### PR TITLE
Use an in-memory database for unit tests

### DIFF
--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -18,12 +18,14 @@ from sqlalchemy.orm import sessionmaker
 
 
 @pytest.fixture
-def db(tmp_path):
+def db():
     """
-    Create a temporary SQLite-backed database in a temp directory, and return the Session object.
+    Create a temporary SQLite-backed database in memory, and return the Session object.
     """
-    db_path = tmp_path / "db.sqlite"
-    engine = create_engine(f"sqlite:///{db_path}", echo=False)
+    from sqlalchemy.pool import StaticPool
+    # The elaborate arguments are needed to get multithreaded access
+    engine = create_engine("sqlite://", connect_args={'check_same_thread':False},
+                           poolclass=StaticPool, echo=False)
     Base.metadata.create_all(engine)
     Session = sessionmaker(bind=engine)
 


### PR DESCRIPTION
Speeds up the tests on my machine due to less hammering on the
disk (as shown in iotop).

I guess the same could be achieved with "pragma synchronous = off;"
and file-backed database, but using a :memory: database is easier.

@lucaslcode @aapeliv 