### PR TITLE
[MRG] Fetch existing logger instead of using top level logger

### DIFF
--- a/app/backend/src/app.py
+++ b/app/backend/src/app.py
@@ -17,7 +17,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 logging.basicConfig(format="%(asctime)s.%(msecs)03d: %(process)d: %(message)s", datefmt="%F %T", level=logging.INFO)
-logging.info(f"Starting")
+logger = logging.getLogger(__name__)
+logger.info(f"Starting")
 
 engine = create_engine("sqlite:///db.sqlite", echo=False)
 Base.metadata.create_all(engine)
@@ -43,7 +44,7 @@ sso_pb2_grpc.add_SSOServicer_to_server(SSO(Session), server)
 conversations_pb2_grpc.add_ConversationsServicer_to_server(Conversations(Session), server)
 server.start()
 
-logging.info(f"Serving on 1751 and 1752 (auth)")
+logger.info(f"Serving on 1751 and 1752 (auth)")
 
 server.wait_for_termination()
 auth_server.wait_for_termination()

--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -9,6 +9,7 @@ from couchers.models import (FriendRelationship, FriendStatus, LoginToken,
 from pb import api_pb2
 from sqlalchemy.sql import and_, or_
 
+logger = logging.getLogger(__name__)
 
 @contextmanager
 def session_scope(Session):
@@ -62,16 +63,16 @@ def get_user_by_field(session, field):
     Returns the user based on any of those three
     """
     if is_valid_user_id(field):
-        logging.debug(f"Field matched to type user id")
+        logger.debug(f"Field matched to type user id")
         return session.query(User).filter(User.id == field).one_or_none()
     elif is_valid_username(field):
-        logging.debug(f"Field matched to type username")
+        logger.debug(f"Field matched to type username")
         return session.query(User).filter(User.username == field).one_or_none()
     elif is_valid_email(field):
-        logging.debug(f"Field matched to type email")
+        logger.debug(f"Field matched to type email")
         return session.query(User).filter(User.email == field).one_or_none()
     else:
-        logging.debug(f"Field {field=}, didn't match any known types")
+        logger.debug(f"Field {field=}, didn't match any known types")
         return None
 
 def new_signup_token(session, email, hours=2):

--- a/app/backend/src/couchers/interceptors/__init__.py
+++ b/app/backend/src/couchers/interceptors/__init__.py
@@ -14,6 +14,8 @@ from .grpcext import intercept_server
 
 LOG_VERBOSE_PB = os.environ.get("LOG_VERBOSE_PB", None) is not None
 
+logger = logging.getLogger(__name__)
+
 # pylint:disable=abstract-method
 class _AuthInterceptorServicerContext(grpc.ServicerContext):
     def __init__(self, servicer_context, user_id):
@@ -100,17 +102,17 @@ class _AuthValidatorInterceptor(grpcext.UnaryServerInterceptor, grpcext.StreamSe
 class LoggingInterceptor(grpcext.UnaryServerInterceptor):
     def intercept_unary(self, request, servicer_context, server_info, handler):
         if LOG_VERBOSE_PB:
-            logging.info(f"Got request: {server_info.full_method}. Request: {request}")
+            logger.info(f"Got request: {server_info.full_method}. Request: {request}")
         else:
-            logging.info(f"Got request: {server_info.full_method}")
+            logger.info(f"Got request: {server_info.full_method}")
         start = perf_counter_ns()
         res = handler(request, servicer_context)
         finished = perf_counter_ns()
         duration = (finished-start) / 1e9
         if LOG_VERBOSE_PB:
-            logging.info(f"Finished request (in {duration} s): {server_info.full_method}. Response: {res}")
+            logger.info(f"Finished request (in {duration} s): {server_info.full_method}. Response: {res}")
         else:
-            logging.info(f"Finished request (in {duration} s): {server_info.full_method}")
+            logger.info(f"Finished request (in {duration} s): {server_info.full_method}")
         return res
 
 

--- a/app/backend/src/couchers/servicers/sso.py
+++ b/app/backend/src/couchers/servicers/sso.py
@@ -11,6 +11,8 @@ from pb import sso_pb2, sso_pb2_grpc
 
 logging.basicConfig(format="%(asctime)s.%(msecs)03d: %(process)d: %(message)s", datefmt="%F %T", level=logging.DEBUG)
 
+logger = logging.getLogger(__name__)
+
 class SSO(sso_pb2_grpc.SSOServicer):
     def __init__(self, Session):
         self._Session = Session
@@ -21,7 +23,7 @@ class SSO(sso_pb2_grpc.SSOServicer):
             sso = request.sso
             sig = request.sig
 
-            logging.info(f"Doing SSO login for {context.user_id=}, {sso=}, {sig=}")
+            logger.info(f"Doing SSO login for {context.user_id=}, {sso=}, {sig=}")
 
             # TODO: secrets management, this is from sso-test instance
             hmac_sec = "b26c7ff6aa391b6a2ba2c0ad18cc6eae40c1a72e5355f86b7b35a4200b514709"
@@ -33,7 +35,7 @@ class SSO(sso_pb2_grpc.SSOServicer):
             decoded_sso = base64decode(unquote(sso))
             parsed_query_string = parse_qs(decoded_sso)
 
-            logging.info(f"SSO {parsed_query_string=}")
+            logger.info(f"SSO {parsed_query_string=}")
 
             nonce = parsed_query_string["nonce"][0]
             return_sso_url = parsed_query_string["return_sso_url"][0]
@@ -49,7 +51,7 @@ class SSO(sso_pb2_grpc.SSOServicer):
                 #"admin": False
             }
 
-            logging.info(f"SSO {payload=}")
+            logger.info(f"SSO {payload=}")
 
             encoded_payload = base64encode(urlencode(payload))
             payload_sig = sso_create_hmac(encoded_payload, hmac_sec)
@@ -60,6 +62,6 @@ class SSO(sso_pb2_grpc.SSOServicer):
             })
 
             redirect_url = f"{return_sso_url}?{query_string}"
-            logging.info(f"SSO {redirect_url=}")
+            logger.info(f"SSO {redirect_url=}")
 
             return sso_pb2.SSORes(redirect_url=redirect_url)

--- a/app/backend/src/couchers/tasks.py
+++ b/app/backend/src/couchers/tasks.py
@@ -1,13 +1,14 @@
 import logging
 
+logger = logger.getLogger(__name__)
 
 def send_login_email(user, token, expiry_text):
-    logging.info(f"Pretending to send login email to {user=}:")
-    logging.info(f"Email for {user.username=} to {user.email=}")
-    logging.info(f"Token: {token=} ({token.created=}, {token.expiry=}) ({expiry_text=})")
-    logging.info(f"Link is: http://localhost:8080/login/{token.token}")
+    logger.info(f"Pretending to send login email to {user=}:")
+    logger.info(f"Email for {user.username=} to {user.email=}")
+    logger.info(f"Token: {token=} ({token.created=}, {token.expiry=}) ({expiry_text=})")
+    logger.info(f"Link is: http://localhost:8080/login/{token.token}")
 
 def send_signup_email(email, token, expiry_text):
-    logging.info(f"Pretending to send signup email to {email=}:")
-    logging.info(f"Token: {token=} ({token.created=}, {token.expiry=}) ({expiry_text=})")
-    logging.info(f"Link is: http://localhost:8080/signup/{token.token}")
+    logger.info(f"Pretending to send signup email to {email=}:")
+    logger.info(f"Token: {token=} ({token.created=}, {token.expiry=}) ({expiry_text=})")
+    logger.info(f"Link is: http://localhost:8080/signup/{token.token}")

--- a/app/backend/src/dummy_data.py
+++ b/app/backend/src/dummy_data.py
@@ -11,10 +11,11 @@ from couchers.utils import Timestamp_from_datetime
 from dateutil import parser
 from sqlalchemy.exc import IntegrityError
 
+logger = logging.getLogger(__name__)
 
 def add_dummy_data(Session, file_name):
     try:
-        logging.info(f"Adding dummy data")
+        logger.info(f"Adding dummy data")
         with session_scope(Session) as session:
             with open(file_name, "r") as file:
                 data = json.loads(file.read())
@@ -92,4 +93,4 @@ def add_dummy_data(Session, file_name):
 
 
     except IntegrityError as e:
-        logging.error("Failed to insert dummy data, is it already inserted?")
+        logger.error("Failed to insert dummy data, is it already inserted?")


### PR DESCRIPTION
Made a change to fetch the existing logger instance instead of using the top level one. This allows you better ability to filter for log messages because you don't lose information about the module that was the call site.