### PR TITLE
[MRG] Backend bug escaping variable and user input in emails

### DIFF
--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -188,9 +188,9 @@ def test_report_email(db):
         def mock_send_email(sender_name, sender_email, recipient, subject, plain, html):
             assert recipient == testing_email_address
             assert complaint.author_user.username in plain
-            assert complaint.author_user.username[10:] in html
+            assert complaint.author_user.username in html
             assert complaint.reported_user.username in plain
-            assert complaint.reported_user.username[10:] in html
+            assert complaint.reported_user.username in html
             assert complaint.reason in plain
             assert complaint.reason in html
             assert complaint.description in plain
@@ -232,9 +232,9 @@ def test_host_request_email(db):
             assert recipient == to_user.email
             assert "host request" in subject.lower()
             assert to_user.name in plain
-            assert to_user.name[10:] in html
+            assert to_user.name in html
             assert from_user.name in plain
-            assert from_user.name[10:] in html
+            assert from_user.name in html
             assert from_date in plain
             assert from_date in html
             assert to_date in plain
@@ -280,9 +280,9 @@ def test_friend_request_email(db):
             assert recipient == to_user.email
             assert "friend" in subject.lower()
             assert to_user.name in plain
-            assert to_user.name[10:] in html
+            assert to_user.name in html
             assert from_user.name in plain
-            assert from_user.name[10:] in html
+            assert from_user.name in html
             assert from_user.avatar_url not in plain
             assert from_user.avatar_url in html
             assert f"{config['BASE_URL']}/friends/" in plain

--- a/app/backend/templates/email_base_html.html
+++ b/app/backend/templates/email_base_html.html
@@ -9,7 +9,7 @@
       {% if content %}
       {{ content }}
       {% else %}
-      <p>Sorry, an unknown error occured, please forward this email to <a href="mailto:bugs@couchers.org">bugs@couchers.org</a> so we can investigate further.</p>
+      <p>Sorry, an unknown error occurred, please forward this email to <a href="mailto:bugs@couchers.org">bugs@couchers.org</a> so we can investigate further.</p>
       {% endif %}
       <hr />
       <p>You're receiving this email because you signed up for Couchers.org. If you have any issues, email us at contact@couchers.org.</p>

--- a/app/backend/templates/email_base_plain.md
+++ b/app/backend/templates/email_base_plain.md
@@ -1,7 +1,7 @@
 {% if content %}
 {{ content }}
 {% else %}
-Sorry, an unknown error occured, please forward this email to bugs@couchers.org so we can investigate further.
+Sorry, an unknown error occurred, please forward this email to bugs@couchers.org so we can investigate further.
 {% endif %}
 
 ---

--- a/app/backend/templates/friend_request.md
+++ b/app/backend/templates/friend_request.md
@@ -1,8 +1,8 @@
 {% from "macros.html" import button %}
 
-Hi {{ name_recipient }}!
+<p> Hi {{ name_recipient }}! </p>
 
-You've received a friend request from {{ name_sender }}!
+<p> You've received a friend request from {{ name_sender }}! </p>
 
 {% if html %}
 

--- a/app/backend/templates/host_request.md
+++ b/app/backend/templates/host_request.md
@@ -1,10 +1,10 @@
 {% from "macros.html" import button %}
 
-Hi {{ name_host }}!
+<p> Hi {{ name_host }}! </p>
 
 You've received a host request!
 
-{{ name_guest }} is requesting to stay with you from {{ from_date }} until {{ to_date }}.
+<p> {{ name_guest }} is requesting to stay with you from {{ from_date }} until {{ to_date }}. </p>
 
 {% if html %}
 

--- a/app/backend/templates/login.md
+++ b/app/backend/templates/login.md
@@ -1,5 +1,5 @@
 {% from "macros.html" import button %}
-Hi {{ user.name or "there" }}!
+<p> Hi {{ user.name or "there" }}! </p>
 
 Here's a login link for Couchers.org:
 

--- a/app/backend/templates/message_received.md
+++ b/app/backend/templates/message_received.md
@@ -1,6 +1,6 @@
 {% from "macros.html" import button %}
 
-Hi {{ name_recipient }}!
+<p> Hi {{ name_recipient }}! </p>
 
 You've received a message!
 

--- a/app/backend/templates/report.md
+++ b/app/backend/templates/report.md
@@ -1,10 +1,10 @@
 User Report
 
-Reported by: {{username_author}}
+<p> Reported by: {{username_author}} </p>
 
-Reported User: {{username_reported}}
+<p> Reported User: {{username_reported}} </p>
 
-Reason: {{reason}}
+<p> Reason: {{reason}} </p>
 
 Description:
-{{description}}
+<p> {{description}} </p>


### PR DESCRIPTION
Ready for merge after #212 .

Fixing issue identified by @aapeliv in #215 with the solution I found here:

https://laracasts.com/discuss/channels/laravel/escape-string-parameters-for-markdown-emails

Namely, to escape all strings by putting them inside HTML tags. (I used \<p\> since that was their default already.)