### PR TITLE
[MRG] Check that all opened filedescriptors by tests are also closed

### DIFF
--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -5,6 +5,7 @@ isort
 Jinja2
 markdown2
 protobuf
+psutil
 psycopg2-binary
 pynacl
 pytest

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -8,11 +8,19 @@ from couchers.db import session_scope
 from couchers.models import Complaint
 from couchers.utils import to_aware_datetime
 from pb import api_pb2
-from tests.test_fixtures import api_session, db, generate_user, make_friends, real_api_session, testconfig
+from tests.test_fixtures import (
+    api_session,
+    check_fd_leak,
+    db,
+    generate_user,
+    make_friends,
+    real_api_session,
+    testconfig,
+)
 
 
 @pytest.fixture(autouse=True)
-def _(testconfig):
+def _(testconfig, check_fd_leak):
     pass
 
 

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -8,11 +8,11 @@ from couchers.crypto import random_hex
 from couchers.db import session_scope
 from couchers.models import Base, LoginToken, SignupToken, User
 from pb import api_pb2, auth_pb2, auth_pb2_grpc, bugs_pb2_grpc
-from tests.test_fixtures import auth_api_session, db, generate_user, real_api_session, testconfig
+from tests.test_fixtures import auth_api_session, check_fd_leak, db, generate_user, real_api_session, testconfig
 
 
 @pytest.fixture(autouse=True)
-def _(testconfig):
+def _(testconfig, check_fd_leak):
     pass
 
 

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -7,11 +7,19 @@ from google.protobuf import empty_pb2, wrappers_pb2
 from couchers import errors
 from couchers.models import User
 from pb import api_pb2, conversations_pb2
-from tests.test_fixtures import api_session, conversations_session, db, generate_user, make_friends, testconfig
+from tests.test_fixtures import (
+    api_session,
+    check_fd_leak,
+    conversations_session,
+    db,
+    generate_user,
+    make_friends,
+    testconfig,
+)
 
 
 @pytest.fixture(autouse=True)
-def _(testconfig):
+def _(testconfig, check_fd_leak):
     pass
 
 

--- a/app/backend/src/tests/test_media.py
+++ b/app/backend/src/tests/test_media.py
@@ -8,11 +8,11 @@ from couchers.crypto import random_hex
 from couchers.db import session_scope
 from couchers.models import InitiatedUpload, User
 from pb import api_pb2, media_pb2
-from tests.test_fixtures import api_session, db, generate_user, media_session, testconfig
+from tests.test_fixtures import api_session, check_fd_leak, db, generate_user, media_session, testconfig
 
 
 @pytest.fixture(autouse=True)
-def _(testconfig):
+def _(testconfig, check_fd_leak):
     pass
 
 

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -10,11 +10,19 @@ from couchers import errors
 from couchers.db import session_scope
 from couchers.models import Conversation, HostRequest, HostRequestStatus, Message, MessageType
 from pb import api_pb2, conversations_pb2, requests_pb2
-from tests.test_fixtures import api_session, db, generate_user, make_friends, requests_session, testconfig
+from tests.test_fixtures import (
+    api_session,
+    check_fd_leak,
+    db,
+    generate_user,
+    make_friends,
+    requests_session,
+    testconfig,
+)
 
 
 @pytest.fixture(autouse=True)
-def _(testconfig):
+def _(testconfig, check_fd_leak):
     pass
 
 


### PR DESCRIPTION
Disables the connection pool so that each test get a clean state and
don't risk hitting the connection limit of the postgres server.