### PR TITLE
make the service layer ignorant about the rest of the front-end

### DIFF
--- a/app/frontend/src/features/profile/UserInfoForm.tsx
+++ b/app/frontend/src/features/profile/UserInfoForm.tsx
@@ -6,8 +6,9 @@ import { Controller, useForm } from "react-hook-form";
 import Alert from "../../components/Alert";
 import Button from "../../components/Button";
 import TextField from "../../components/TextField";
+import { ProfileFormData } from "../../service/user";
 import ProfileTextInput from "./ProfileTextInput";
-import { ProfileFormData, updateUserProfile } from "./index";
+import { updateUserProfile } from "./index";
 import { useAppDispatch, useTypedSelector } from "../../store";
 
 const useStyles = makeStyles({

--- a/app/frontend/src/features/profile/actions.ts
+++ b/app/frontend/src/features/profile/actions.ts
@@ -1,8 +1,8 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
-import { ProfileFormData } from "./index";
 import { service } from "../../service";
 import { User } from "../../pb/api_pb";
 import { RootState } from "../../reducers";
+import { ProfileFormData } from "../../service/user";
 
 export const updateUserProfile = createAsyncThunk<
   User.AsObject,

--- a/app/frontend/src/features/profile/index.ts
+++ b/app/frontend/src/features/profile/index.ts
@@ -2,10 +2,3 @@ import { ProtoToJsTypes } from "../../utils/types";
 import { UpdateProfileReq } from "../../pb/api_pb";
 
 export * from "./actions";
-
-type RequiredUpdateProfileReq = Required<UpdateProfileReq.AsObject>;
-export type ProfileFormData = {
-  [K in keyof RequiredUpdateProfileReq]: ProtoToJsTypes<
-    RequiredUpdateProfileReq[K]
-  >;
-};

--- a/app/frontend/src/features/profile/index.ts
+++ b/app/frontend/src/features/profile/index.ts
@@ -1,4 +1,1 @@
-import { ProtoToJsTypes } from "../../utils/types";
-import { UpdateProfileReq } from "../../pb/api_pb";
-
 export * from "./actions";

--- a/app/frontend/src/index.tsx
+++ b/app/frontend/src/index.tsx
@@ -2,14 +2,10 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
-import "./index.css";
-import { persistor, store } from "./store";
-import * as api from "./service/api";
-
 import App from "./App";
+import "./index.css";
 import * as serviceWorker from "./serviceWorker";
-
-api.setGetToken(() => store.getState().auth.authToken);
+import { persistor, store } from "./store";
 
 const root = document.getElementById("root") as HTMLElement;
 ReactDOM.render(

--- a/app/frontend/src/index.tsx
+++ b/app/frontend/src/index.tsx
@@ -4,9 +4,12 @@ import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
 import "./index.css";
 import { persistor, store } from "./store";
+import * as api from "./service/api";
 
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
+
+api.setGetToken(() => store.getState().auth.authToken);
 
 const root = document.getElementById("root") as HTMLElement;
 ReactDOM.render(

--- a/app/frontend/src/service/api.ts
+++ b/app/frontend/src/service/api.ts
@@ -1,14 +1,10 @@
-import { AuthPromiseClient } from "../pb/auth_grpc_web_pb";
 import { APIPromiseClient } from "../pb/api_grpc_web_pb";
+import { AuthPromiseClient } from "../pb/auth_grpc_web_pb";
 import { BugsPromiseClient } from "../pb/bugs_grpc_web_pb";
 import { ConversationsPromiseClient } from "../pb/conversations_grpc_web_pb";
 import { RequestsPromiseClient } from "../pb/requests_grpc_web_pb";
 import { SSOPromiseClient } from "../pb/sso_grpc_web_pb";
-
-let getToken = () => "";
-export function setGetToken(newGetToken: () => string) {
-  getToken = newGetToken;
-}
+import { store } from "../store";
 
 const URL = process.env.REACT_APP_API_BASE_URL;
 
@@ -17,7 +13,8 @@ class AuthInterceptor {
     const authorizationHeader = request.getMetadata().authorization;
 
     if (!authorizationHeader) {
-      request.getMetadata().authorization = `Bearer ${getToken()}`;
+      const { authToken } = store.getState().auth;
+      request.getMetadata().authorization = `Bearer ${authToken}`;
     }
     return invoker(request);
   }

--- a/app/frontend/src/service/api.ts
+++ b/app/frontend/src/service/api.ts
@@ -5,7 +5,10 @@ import { ConversationsPromiseClient } from "../pb/conversations_grpc_web_pb";
 import { RequestsPromiseClient } from "../pb/requests_grpc_web_pb";
 import { SSOPromiseClient } from "../pb/sso_grpc_web_pb";
 
-import { store } from "../store";
+let getToken = () => "";
+export function setGetToken(newGetToken: () => string) {
+  getToken = newGetToken;
+}
 
 const URL = process.env.REACT_APP_API_BASE_URL;
 
@@ -14,8 +17,7 @@ class AuthInterceptor {
     const authorizationHeader = request.getMetadata().authorization;
 
     if (!authorizationHeader) {
-      const { authToken } = store.getState().auth;
-      request.getMetadata().authorization = `Bearer ${authToken}`;
+      request.getMetadata().authorization = `Bearer ${getToken()}`;
     }
     return invoker(request);
   }

--- a/app/frontend/src/service/auth.ts
+++ b/app/frontend/src/service/auth.ts
@@ -7,7 +7,7 @@ import {
 import client from "./api";
 import { ServiceMap } from "./index";
 
-const serviceMap: ServiceMap = {
+const serviceMap = {
   checkUsername: async (username: string) => {
     const req = new LoginReq();
     req.setUser(username);

--- a/app/frontend/src/service/auth.ts
+++ b/app/frontend/src/service/auth.ts
@@ -1,35 +1,40 @@
-import client from "./api";
 import {
   LoginReq,
   SignupReq,
   SignupTokenInfoReq,
   UsernameValidReq,
 } from "../pb/auth_pb";
+import client from "./api";
+import { ServiceMap } from "./index";
 
-export const checkUsername = async (username: string) => {
-  const req = new LoginReq();
-  req.setUser(username);
-  const res = await client.auth.login(req);
-  return res.getNextStep();
+const serviceMap: ServiceMap = {
+  checkUsername: async (username: string) => {
+    const req = new LoginReq();
+    req.setUser(username);
+    const res = await client.auth.login(req);
+    return res.getNextStep();
+  },
+
+  createEmailSignup: async (email: string) => {
+    const req = new SignupReq();
+    req.setEmail(email);
+    const res = await client.auth.signup(req);
+    return res.getNextStep();
+  },
+
+  getSignupEmail: async (signupToken: string) => {
+    const req = new SignupTokenInfoReq();
+    req.setSignupToken(signupToken);
+    const res = await client.auth.signupTokenInfo(req);
+    return res.getEmail();
+  },
+
+  validateUsername: async (username: string) => {
+    const req = new UsernameValidReq();
+    req.setUsername(username);
+    const res = await client.auth.usernameValid(req);
+    return res.getValid();
+  },
 };
 
-export const createEmailSignup = async (email: string) => {
-  const req = new SignupReq();
-  req.setEmail(email);
-  const res = await client.auth.signup(req);
-  return res.getNextStep();
-};
-
-export const getSignupEmail = async (signupToken: string) => {
-  const req = new SignupTokenInfoReq();
-  req.setSignupToken(signupToken);
-  const res = await client.auth.signupTokenInfo(req);
-  return res.getEmail();
-};
-
-export const validateUsername = async (username: string) => {
-  const req = new UsernameValidReq();
-  req.setUsername(username);
-  const res = await client.auth.usernameValid(req);
-  return res.getValid();
-};
+export default serviceMap;

--- a/app/frontend/src/service/auth.ts
+++ b/app/frontend/src/service/auth.ts
@@ -6,34 +6,30 @@ import {
 } from "../pb/auth_pb";
 import client from "./api";
 
-const serviceMap = {
-  checkUsername: async (username: string) => {
-    const req = new LoginReq();
-    req.setUser(username);
-    const res = await client.auth.login(req);
-    return res.getNextStep();
-  },
+export async function checkUsername(username: string) {
+  const req = new LoginReq();
+  req.setUser(username);
+  const res = await client.auth.login(req);
+  return res.getNextStep();
+}
 
-  createEmailSignup: async (email: string) => {
-    const req = new SignupReq();
-    req.setEmail(email);
-    const res = await client.auth.signup(req);
-    return res.getNextStep();
-  },
+export async function createEmailSignup(email: string) {
+  const req = new SignupReq();
+  req.setEmail(email);
+  const res = await client.auth.signup(req);
+  return res.getNextStep();
+}
 
-  getSignupEmail: async (signupToken: string) => {
-    const req = new SignupTokenInfoReq();
-    req.setSignupToken(signupToken);
-    const res = await client.auth.signupTokenInfo(req);
-    return res.getEmail();
-  },
+export async function getSignupEmail(signupToken: string) {
+  const req = new SignupTokenInfoReq();
+  req.setSignupToken(signupToken);
+  const res = await client.auth.signupTokenInfo(req);
+  return res.getEmail();
+}
 
-  validateUsername: async (username: string) => {
-    const req = new UsernameValidReq();
-    req.setUsername(username);
-    const res = await client.auth.usernameValid(req);
-    return res.getValid();
-  },
-};
-
-export default serviceMap;
+export async function validateUsername(username: string) {
+  const req = new UsernameValidReq();
+  req.setUsername(username);
+  const res = await client.auth.usernameValid(req);
+  return res.getValid();
+}

--- a/app/frontend/src/service/auth.ts
+++ b/app/frontend/src/service/auth.ts
@@ -5,7 +5,6 @@ import {
   UsernameValidReq,
 } from "../pb/auth_pb";
 import client from "./api";
-import { ServiceMap } from "./index";
 
 const serviceMap = {
   checkUsername: async (username: string) => {

--- a/app/frontend/src/service/index.ts
+++ b/app/frontend/src/service/index.ts
@@ -15,7 +15,7 @@ export function mockService() {
   for (name in service) {
     const serviceMap = service[name];
     for (const serviceName in serviceMap) {
-      serviceMap[serviceName] = () => {
+      (serviceMap as any)[serviceName] = () => {
         console.warn(
           `Service method '${name}.${serviceName}' is called. You should probably mock it.`
         );

--- a/app/frontend/src/service/index.ts
+++ b/app/frontend/src/service/index.ts
@@ -1,6 +1,6 @@
-import * as auth from "./auth";
-import * as search from "./search";
-import * as user from "./user";
+import auth from "./auth";
+import search from "./search";
+import user from "./user";
 
 export const service = {
   search,
@@ -8,12 +8,17 @@ export const service = {
   auth,
 };
 
-export function mockService(record: Record<string, any> = service) {
-  for (const name in record) {
-    if (typeof record[name] === "function") {
-      record[name] = jest.fn();
-    } else {
-      mockService(record[name]);
+export type ServiceMap = Record<string, (...args: any[]) => Promise<any>>;
+
+export function mockService(serviceMaps: Record<string, ServiceMap> = service) {
+  for (const name in serviceMaps) {
+    for (const serviceName in serviceMaps[name]) {
+      serviceMaps[name][serviceName] = () => {
+        console.warn(
+          `Service method '${name}.${serviceName}' is called. You should probably mock it.`
+        );
+        return Promise.resolve();
+      };
     }
   }
 }

--- a/app/frontend/src/service/index.ts
+++ b/app/frontend/src/service/index.ts
@@ -8,8 +8,6 @@ export const service = {
   auth,
 } as const;
 
-export type ServiceMap = Record<string, (...args: any[]) => Promise<any>>;
-
 export function mockService() {
   let name: keyof typeof service;
   for (name in service) {

--- a/app/frontend/src/service/index.ts
+++ b/app/frontend/src/service/index.ts
@@ -1,24 +1,9 @@
-import auth from "./auth";
-import search from "./search";
-import user from "./user";
+import * as auth from "./auth";
+import * as search from "./search";
+import * as user from "./user";
 
 export const service = {
   search,
   user,
   auth,
 } as const;
-
-export function mockService() {
-  let name: keyof typeof service;
-  for (name in service) {
-    const serviceMap = service[name];
-    for (const serviceName in serviceMap) {
-      (serviceMap as any)[serviceName] = () => {
-        console.warn(
-          `Service method '${name}.${serviceName}' is called. You should probably mock it.`
-        );
-        return Promise.resolve();
-      };
-    }
-  }
-}

--- a/app/frontend/src/service/index.ts
+++ b/app/frontend/src/service/index.ts
@@ -6,14 +6,16 @@ export const service = {
   search,
   user,
   auth,
-};
+} as const;
 
 export type ServiceMap = Record<string, (...args: any[]) => Promise<any>>;
 
-export function mockService(serviceMaps: Record<string, ServiceMap> = service) {
-  for (const name in serviceMaps) {
-    for (const serviceName in serviceMaps[name]) {
-      serviceMaps[name][serviceName] = () => {
+export function mockService() {
+  let name: keyof typeof service;
+  for (name in service) {
+    const serviceMap = service[name];
+    for (const serviceName in serviceMap) {
+      serviceMap[serviceName] = () => {
         console.warn(
           `Service method '${name}.${serviceName}' is called. You should probably mock it.`
         );

--- a/app/frontend/src/service/search.ts
+++ b/app/frontend/src/service/search.ts
@@ -1,22 +1,18 @@
 import { SearchReq, User } from "../pb/api_pb";
 import client from "./api";
 
-const serviceMap = {
-  /**
-   * Perform a search and return a list of users.
-   *
-   * @param {string} query
-   * @returns {Promise<User.AsObject[]>}
-   */
-  search: async (query: string): Promise<User.AsObject[]> => {
-    const req = new SearchReq();
-    req.setQuery(query);
+/**
+ * Perform a search and return a list of users.
+ *
+ * @param {string} query
+ * @returns {Promise<User.AsObject[]>}
+ */
+export async function search(query: string): Promise<User.AsObject[]> {
+  const req = new SearchReq();
+  req.setQuery(query);
 
-    const response = await client.api.search(req);
-    const users = response.getUsersList();
+  const response = await client.api.search(req);
+  const users = response.getUsersList();
 
-    return users.map((user) => user.toObject());
-  },
-};
-
-export default serviceMap;
+  return users.map((user) => user.toObject());
+}

--- a/app/frontend/src/service/search.ts
+++ b/app/frontend/src/service/search.ts
@@ -1,6 +1,5 @@
 import { SearchReq, User } from "../pb/api_pb";
 import client from "./api";
-import { ServiceMap } from "./index";
 
 const serviceMap = {
   /**

--- a/app/frontend/src/service/search.ts
+++ b/app/frontend/src/service/search.ts
@@ -2,7 +2,7 @@ import { SearchReq, User } from "../pb/api_pb";
 import client from "./api";
 import { ServiceMap } from "./index";
 
-const serviceMap: ServiceMap = {
+const serviceMap = {
   /**
    * Perform a search and return a list of users.
    *

--- a/app/frontend/src/service/search.ts
+++ b/app/frontend/src/service/search.ts
@@ -1,18 +1,23 @@
-import client from "./api";
 import { SearchReq, User } from "../pb/api_pb";
+import client from "./api";
+import { ServiceMap } from "./index";
 
-/**
- * Perform a search and return a list of users.
- *
- * @param {string} query
- * @returns {Promise<User.AsObject[]>}
- */
-export const search = async (query: string): Promise<User.AsObject[]> => {
-  const req = new SearchReq();
-  req.setQuery(query);
+const serviceMap: ServiceMap = {
+  /**
+   * Perform a search and return a list of users.
+   *
+   * @param {string} query
+   * @returns {Promise<User.AsObject[]>}
+   */
+  search: async (query: string): Promise<User.AsObject[]> => {
+    const req = new SearchReq();
+    req.setQuery(query);
 
-  const response = await client.api.search(req);
-  const users = response.getUsersList();
+    const response = await client.api.search(req);
+    const users = response.getUsersList();
 
-  return users.map((user) => user.toObject());
+    return users.map((user) => user.toObject());
+  },
 };
+
+export default serviceMap;

--- a/app/frontend/src/service/user.ts
+++ b/app/frontend/src/service/user.ts
@@ -34,7 +34,7 @@ export type SignupArguments = {
   hostingStatus: HostingStatus;
 };
 
-const serviceMap: ServiceMap = {
+const serviceMap = {
   /**
    * Login user using password and returns session token
    *

--- a/app/frontend/src/service/user.ts
+++ b/app/frontend/src/service/user.ts
@@ -33,145 +33,146 @@ export type SignupArguments = {
   hostingStatus: HostingStatus;
 };
 
-const serviceMap = {
-  /**
-   * Login user using password and returns session token
-   *
-   * @param {string} username
-   * @param {string} password
-   * @returns {Promise<string>}
-   */
-  passwordLogin: async (
-    username: string,
-    password: string
-  ): Promise<string> => {
-    const req = new AuthReq();
-    req.setUser(username);
-    req.setPassword(password);
+/**
+ * Login user using password and returns session token
+ *
+ * @param {string} username
+ * @param {string} password
+ * @returns {Promise<string>}
+ */
+export async function passwordLogin(
+  username: string,
+  password: string
+): Promise<string> {
+  const req = new AuthReq();
+  req.setUser(username);
+  req.setPassword(password);
 
-    const response = await client.auth.authenticate(req);
-    const token = response.getToken();
+  const response = await client.auth.authenticate(req);
+  const token = response.getToken();
 
-    return token;
-  },
+  return token;
+}
 
-  /**
-   * Login user using a login token and returns session token
-   *
-   * @param {string} token
-   * @returns {Promise<string>}
-   */
-  tokenLogin: async (loginToken: string): Promise<string> => {
-    const req = new CompleteTokenLoginReq();
-    req.setLoginToken(loginToken);
+/**
+ * Login user using a login token and returns session token
+ *
+ * @param {string} token
+ * @returns {Promise<string>}
+ */
+export async function tokenLogin(loginToken: string): Promise<string> {
+  const req = new CompleteTokenLoginReq();
+  req.setLoginToken(loginToken);
 
-    const response = await client.auth.completeTokenLogin(req);
-    const token = response.getToken();
+  const response = await client.auth.completeTokenLogin(req);
+  const token = response.getToken();
 
-    return token;
-  },
+  return token;
+}
 
-  /**
-   * Returns User record of logged in user
-   *
-   * @returns {Promise<User.AsObject>}
-   */
-  getCurrentUser: async (token?: string): Promise<User.AsObject> => {
-    const req = new PingReq();
+/**
+ * Returns User record of logged in user
+ *
+ * @returns {Promise<User.AsObject>}
+ */
+export async function getCurrentUser(token?: string): Promise<User.AsObject> {
+  const req = new PingReq();
 
-    const response = await client.api.ping(
-      req,
-      token ? { authorization: `Bearer ${token}` } : undefined
-    );
+  const response = await client.api.ping(
+    req,
+    token ? { authorization: `Bearer ${token}` } : undefined
+  );
 
-    return response.getUser()!.toObject();
-  },
+  return response.getUser()!.toObject();
+}
 
-  /**
-   * Returns User record by Username or id
-   *
-   * @param {string} user
-   * @param {string} token
-   * @returns {Promise<User.AsObject>}
-   */
-  getUser: async (user: string, token?: string): Promise<User.AsObject> => {
-    const userReq = new GetUserReq();
-    userReq.setUser(user || "");
+/**
+ * Returns User record by Username or id
+ *
+ * @param {string} user
+ * @param {string} token
+ * @returns {Promise<User.AsObject>}
+ */
+export async function getUser(
+  user: string,
+  token?: string
+): Promise<User.AsObject> {
+  const userReq = new GetUserReq();
+  userReq.setUser(user || "");
 
-    const response = await client.api.getUser(
-      userReq,
-      token ? { authorization: `Bearer ${token}` } : undefined
-    );
+  const response = await client.api.getUser(
+    userReq,
+    token ? { authorization: `Bearer ${token}` } : undefined
+  );
 
-    return response.toObject();
-  },
+  return response.toObject();
+}
 
-  /**
-   * Updates user
-   *
-   * @param {User.AsObject} reqObject
-   * @returns {Promise<Empty>}
-   */
-  updateProfile: async (reqObject: ProfileFormData): Promise<Empty> => {
-    const req = new UpdateProfileReq();
+/**
+ * Updates user
+ *
+ * @param {User.AsObject} reqObject
+ * @returns {Promise<Empty>}
+ */
+export async function updateProfile(
+  reqObject: ProfileFormData
+): Promise<Empty> {
+  const req = new UpdateProfileReq();
 
-    const name = new wrappers.StringValue().setValue(reqObject.name);
-    const city = new wrappers.StringValue().setValue(reqObject.city);
-    const gender = new wrappers.StringValue().setValue(reqObject.gender);
-    const occupation = new NullableStringValue().setValue(reqObject.occupation);
-    const languages = new RepeatedStringValue()
-      .setValueList(reqObject.languages)
-      .setExists(!!reqObject.languages);
-    const aboutMe = new NullableStringValue().setValue(reqObject.aboutMe);
-    const aboutPlace = new NullableStringValue().setValue(reqObject.aboutPlace);
-    const countriesVisited = new RepeatedStringValue()
-      .setValueList(reqObject.countriesVisited)
-      .setExists(!!reqObject.countriesVisited);
-    const countriesLived = new RepeatedStringValue()
-      .setValueList(reqObject.countriesLived)
-      .setExists(!!reqObject.countriesLived);
+  const name = new wrappers.StringValue().setValue(reqObject.name);
+  const city = new wrappers.StringValue().setValue(reqObject.city);
+  const gender = new wrappers.StringValue().setValue(reqObject.gender);
+  const occupation = new NullableStringValue().setValue(reqObject.occupation);
+  const languages = new RepeatedStringValue()
+    .setValueList(reqObject.languages)
+    .setExists(!!reqObject.languages);
+  const aboutMe = new NullableStringValue().setValue(reqObject.aboutMe);
+  const aboutPlace = new NullableStringValue().setValue(reqObject.aboutPlace);
+  const countriesVisited = new RepeatedStringValue()
+    .setValueList(reqObject.countriesVisited)
+    .setExists(!!reqObject.countriesVisited);
+  const countriesLived = new RepeatedStringValue()
+    .setValueList(reqObject.countriesLived)
+    .setExists(!!reqObject.countriesLived);
 
-    req
-      .setName(name)
-      .setCity(city)
-      .setGender(gender)
-      .setOccupation(occupation)
-      .setLanguages(languages)
-      .setAboutMe(aboutMe)
-      .setAboutPlace(aboutPlace)
-      .setCountriesVisited(countriesVisited)
-      .setCountriesLived(countriesLived);
+  req
+    .setName(name)
+    .setCity(city)
+    .setGender(gender)
+    .setOccupation(occupation)
+    .setLanguages(languages)
+    .setAboutMe(aboutMe)
+    .setAboutPlace(aboutPlace)
+    .setCountriesVisited(countriesVisited)
+    .setCountriesLived(countriesLived);
 
-    return client.api.updateProfile(req);
-  },
+  return client.api.updateProfile(req);
+}
 
-  /**
-   * Completes the signup process
-   *
-   * @param {SignupArguments} signup arguments
-   * @returns {Promise<string>} session token
-   */
-  completeSignup: async ({
-    signupToken,
-    username,
-    name,
-    city,
-    birthdate,
-    gender,
-    hostingStatus,
-  }: SignupArguments) => {
-    const req = new CompleteSignupReq();
-    req.setSignupToken(signupToken);
-    req.setUsername(username);
-    req.setName(name);
-    req.setCity(city);
-    req.setBirthdate(birthdate);
-    req.setGender(gender);
-    req.setHostingStatus(hostingStatus);
+/**
+ * Completes the signup process
+ *
+ * @param {SignupArguments} signup arguments
+ * @returns {Promise<string>} session token
+ */
+export async function completeSignup({
+  signupToken,
+  username,
+  name,
+  city,
+  birthdate,
+  gender,
+  hostingStatus,
+}: SignupArguments) {
+  const req = new CompleteSignupReq();
+  req.setSignupToken(signupToken);
+  req.setUsername(username);
+  req.setName(name);
+  req.setCity(city);
+  req.setBirthdate(birthdate);
+  req.setGender(gender);
+  req.setHostingStatus(hostingStatus);
 
-    const res = await client.auth.completeSignup(req);
-    return res.getToken();
-  },
-};
-
-export default serviceMap;
+  const res = await client.auth.completeSignup(req);
+  return res.getToken();
+}

--- a/app/frontend/src/service/user.ts
+++ b/app/frontend/src/service/user.ts
@@ -16,7 +16,6 @@ import {
 } from "../pb/auth_pb";
 import { ProtoToJsTypes } from "../utils/types";
 import client from "./api";
-import { ServiceMap } from "./index";
 
 type RequiredUpdateProfileReq = Required<UpdateProfileReq.AsObject>;
 export type ProfileFormData = {

--- a/app/frontend/src/service/user.ts
+++ b/app/frontend/src/service/user.ts
@@ -1,140 +1,29 @@
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import wrappers from "google-protobuf/google/protobuf/wrappers_pb";
-import client from "./api";
 import {
   GetUserReq,
+  HostingStatus,
+  NullableStringValue,
   PingReq,
+  RepeatedStringValue,
   UpdateProfileReq,
   User,
-  NullableStringValue,
-  RepeatedStringValue,
-  HostingStatus,
 } from "../pb/api_pb";
 import {
   AuthReq,
-  CompleteTokenLoginReq,
   CompleteSignupReq,
+  CompleteTokenLoginReq,
 } from "../pb/auth_pb";
-import { ProfileFormData } from "../features/profile";
+import { ProtoToJsTypes } from "../utils/types";
+import client from "./api";
+import { ServiceMap } from "./index";
 
-/**
- * Login user using password and returns session token
- *
- * @param {string} username
- * @param {string} password
- * @returns {Promise<string>}
- */
-export const passwordLogin = async (
-  username: string,
-  password: string
-): Promise<string> => {
-  const req = new AuthReq();
-  req.setUser(username);
-  req.setPassword(password);
-
-  const response = await client.auth.authenticate(req);
-  const token = response.getToken();
-
-  return token;
+type RequiredUpdateProfileReq = Required<UpdateProfileReq.AsObject>;
+export type ProfileFormData = {
+  [K in keyof RequiredUpdateProfileReq]: ProtoToJsTypes<
+    RequiredUpdateProfileReq[K]
+  >;
 };
-
-/**
- * Login user using a login token and returns session token
- *
- * @param {string} token
- * @returns {Promise<string>}
- */
-export const tokenLogin = async (loginToken: string): Promise<string> => {
-  const req = new CompleteTokenLoginReq();
-  req.setLoginToken(loginToken);
-
-  const response = await client.auth.completeTokenLogin(req);
-  const token = response.getToken();
-
-  return token;
-};
-
-/**
- * Returns User record of logged in user
- *
- * @returns {Promise<User.AsObject>}
- */
-export const getCurrentUser = async (
-  token?: string
-): Promise<User.AsObject> => {
-  const req = new PingReq();
-
-  const response = await client.api.ping(
-    req,
-    token ? { authorization: `Bearer ${token}` } : undefined
-  );
-
-  return response.getUser()!.toObject();
-};
-
-/**
- * Returns User record by Username or id
- *
- * @param {string} user
- * @param {string} token
- * @returns {Promise<User.AsObject>}
- */
-export const getUser = async (
-  user: string,
-  token?: string
-): Promise<User.AsObject> => {
-  const userReq = new GetUserReq();
-  userReq.setUser(user || "");
-
-  const response = await client.api.getUser(
-    userReq,
-    token ? { authorization: `Bearer ${token}` } : undefined
-  );
-
-  return response.toObject();
-};
-
-/**
- * Updates user
- *
- * @param {User.AsObject} reqObject
- * @returns {Promise<Empty>}
- */
-export const updateProfile = async (
-  reqObject: ProfileFormData
-): Promise<Empty> => {
-  const req = new UpdateProfileReq();
-
-  const name = new wrappers.StringValue().setValue(reqObject.name);
-  const city = new wrappers.StringValue().setValue(reqObject.city);
-  const gender = new wrappers.StringValue().setValue(reqObject.gender);
-  const occupation = new NullableStringValue().setValue(reqObject.occupation);
-  const languages = new RepeatedStringValue()
-    .setValueList(reqObject.languages)
-    .setExists(!!reqObject.languages);
-  const aboutMe = new NullableStringValue().setValue(reqObject.aboutMe);
-  const aboutPlace = new NullableStringValue().setValue(reqObject.aboutPlace);
-  const countriesVisited = new RepeatedStringValue()
-    .setValueList(reqObject.countriesVisited)
-    .setExists(!!reqObject.countriesVisited);
-  const countriesLived = new RepeatedStringValue()
-    .setValueList(reqObject.countriesLived)
-    .setExists(!!reqObject.countriesLived);
-
-  req
-    .setName(name)
-    .setCity(city)
-    .setGender(gender)
-    .setOccupation(occupation)
-    .setLanguages(languages)
-    .setAboutMe(aboutMe)
-    .setAboutPlace(aboutPlace)
-    .setCountriesVisited(countriesVisited)
-    .setCountriesLived(countriesLived);
-
-  return client.api.updateProfile(req);
-};
-
 export type SignupArguments = {
   signupToken: string;
   username: string;
@@ -145,30 +34,145 @@ export type SignupArguments = {
   hostingStatus: HostingStatus;
 };
 
-/**
- * Completes the signup process
- *
- * @param {SignupArguments} signup arguments
- * @returns {Promise<string>} session token
- */
-export const completeSignup = async ({
-  signupToken,
-  username,
-  name,
-  city,
-  birthdate,
-  gender,
-  hostingStatus,
-}: SignupArguments) => {
-  const req = new CompleteSignupReq();
-  req.setSignupToken(signupToken);
-  req.setUsername(username);
-  req.setName(name);
-  req.setCity(city);
-  req.setBirthdate(birthdate);
-  req.setGender(gender);
-  req.setHostingStatus(hostingStatus);
+const serviceMap: ServiceMap = {
+  /**
+   * Login user using password and returns session token
+   *
+   * @param {string} username
+   * @param {string} password
+   * @returns {Promise<string>}
+   */
+  passwordLogin: async (
+    username: string,
+    password: string
+  ): Promise<string> => {
+    const req = new AuthReq();
+    req.setUser(username);
+    req.setPassword(password);
 
-  const res = await client.auth.completeSignup(req);
-  return res.getToken();
+    const response = await client.auth.authenticate(req);
+    const token = response.getToken();
+
+    return token;
+  },
+
+  /**
+   * Login user using a login token and returns session token
+   *
+   * @param {string} token
+   * @returns {Promise<string>}
+   */
+  tokenLogin: async (loginToken: string): Promise<string> => {
+    const req = new CompleteTokenLoginReq();
+    req.setLoginToken(loginToken);
+
+    const response = await client.auth.completeTokenLogin(req);
+    const token = response.getToken();
+
+    return token;
+  },
+
+  /**
+   * Returns User record of logged in user
+   *
+   * @returns {Promise<User.AsObject>}
+   */
+  getCurrentUser: async (token?: string): Promise<User.AsObject> => {
+    const req = new PingReq();
+
+    const response = await client.api.ping(
+      req,
+      token ? { authorization: `Bearer ${token}` } : undefined
+    );
+
+    return response.getUser()!.toObject();
+  },
+
+  /**
+   * Returns User record by Username or id
+   *
+   * @param {string} user
+   * @param {string} token
+   * @returns {Promise<User.AsObject>}
+   */
+  getUser: async (user: string, token?: string): Promise<User.AsObject> => {
+    const userReq = new GetUserReq();
+    userReq.setUser(user || "");
+
+    const response = await client.api.getUser(
+      userReq,
+      token ? { authorization: `Bearer ${token}` } : undefined
+    );
+
+    return response.toObject();
+  },
+
+  /**
+   * Updates user
+   *
+   * @param {User.AsObject} reqObject
+   * @returns {Promise<Empty>}
+   */
+  updateProfile: async (reqObject: ProfileFormData): Promise<Empty> => {
+    const req = new UpdateProfileReq();
+
+    const name = new wrappers.StringValue().setValue(reqObject.name);
+    const city = new wrappers.StringValue().setValue(reqObject.city);
+    const gender = new wrappers.StringValue().setValue(reqObject.gender);
+    const occupation = new NullableStringValue().setValue(reqObject.occupation);
+    const languages = new RepeatedStringValue()
+      .setValueList(reqObject.languages)
+      .setExists(!!reqObject.languages);
+    const aboutMe = new NullableStringValue().setValue(reqObject.aboutMe);
+    const aboutPlace = new NullableStringValue().setValue(reqObject.aboutPlace);
+    const countriesVisited = new RepeatedStringValue()
+      .setValueList(reqObject.countriesVisited)
+      .setExists(!!reqObject.countriesVisited);
+    const countriesLived = new RepeatedStringValue()
+      .setValueList(reqObject.countriesLived)
+      .setExists(!!reqObject.countriesLived);
+
+    req
+      .setName(name)
+      .setCity(city)
+      .setGender(gender)
+      .setOccupation(occupation)
+      .setLanguages(languages)
+      .setAboutMe(aboutMe)
+      .setAboutPlace(aboutPlace)
+      .setCountriesVisited(countriesVisited)
+      .setCountriesLived(countriesLived);
+
+    return client.api.updateProfile(req);
+  },
+
+  /**
+   * Completes the signup process
+   *
+   * @param {SignupArguments} signup arguments
+   * @returns {Promise<string>} session token
+   */
+  completeSignup: async ({
+    signupToken,
+    username,
+    name,
+    city,
+    birthdate,
+    gender,
+    hostingStatus,
+  }: SignupArguments) => {
+    const req = new CompleteSignupReq();
+    req.setSignupToken(signupToken);
+    req.setUsername(username);
+    req.setName(name);
+    req.setCity(city);
+    req.setBirthdate(birthdate);
+    req.setGender(gender);
+    req.setHostingStatus(hostingStatus);
+
+    const res = await client.auth.completeSignup(req);
+    return res.getToken();
+  },
 };
+
+export default serviceMap;


### PR DESCRIPTION
By removing imports from rest of front-end into service layer.
In order to 
prevent cyclic dependencies while mocking
make the code more maintainable and readable