### PR TITLE
Backend/bugfix: fix reply to host requests

### DIFF
--- a/app/backend/src/app.py
+++ b/app/backend/src/app.py
@@ -4,13 +4,11 @@ import sys
 from concurrent import futures
 
 import grpc
-from alembic import command
-from alembic.config import Config
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from couchers import config
-from couchers.db import session_scope
+from couchers.db import apply_migrations, session_scope
 from couchers.interceptors import LoggingInterceptor, UpdateLastActiveTimeInterceptor
 from couchers.models import Base
 from couchers.servicers.api import API
@@ -64,10 +62,7 @@ with session_scope(Session) as session:
 
 logger.info(f"Running DB migrations")
 
-alembic_cfg = Config("alembic.ini")
-# alembic screws up logging config by default, this tells it not to screw it up if being run at startup like this
-alembic_cfg.set_main_option("dont_mess_up_logging", "False")
-command.upgrade(alembic_cfg, "head")
+apply_migrations()
 
 if config.config["ADD_DUMMY_DATA"]:
     add_dummy_data(Session, "src/dummy_data.json")

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -40,8 +40,6 @@ CONFIG_OPTIONS = [
     ("BUG_TOOL_GITHUB_REPO", str),
     ("BUG_TOOL_GITHUB_USERNAME", str),
     ("BUG_TOOL_GITHUB_TOKEN", str),
-    # Whether we should build the database from models or migrations in tests
-    ("TEST_BUILD_DB_FROM_MIGRATIONS", bool, False),
 ]
 
 config = {}

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -40,6 +40,8 @@ CONFIG_OPTIONS = [
     ("BUG_TOOL_GITHUB_REPO", str),
     ("BUG_TOOL_GITHUB_USERNAME", str),
     ("BUG_TOOL_GITHUB_TOKEN", str),
+    # Whether we should build the database from models or migrations in tests
+    ("TEST_BUILD_DB_FROM_MIGRATIONS", bool, False),
 ]
 
 config = {}

--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import os
 import re
 from contextlib import contextmanager
 
@@ -16,10 +17,16 @@ logger = logging.getLogger(__name__)
 
 
 def apply_migrations():
-    alembic_cfg = Config("alembic.ini")
-    # alembic screws up logging config by default, this tells it not to screw it up if being run at startup like this
-    alembic_cfg.set_main_option("dont_mess_up_logging", "False")
-    command.upgrade(alembic_cfg, "head")
+    alembic_dir = os.path.dirname(__file__) + "/../.."
+    cwd = os.getcwd()
+    try:
+        os.chdir(alembic_dir)
+        alembic_cfg = Config("alembic.ini")
+        # alembic screws up logging config by default, this tells it not to screw it up if being run at startup like this
+        alembic_cfg.set_main_option("dont_mess_up_logging", "False")
+        command.upgrade(alembic_cfg, "head")
+    finally:
+        os.chdir(cwd)
 
 
 @contextmanager

--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -3,6 +3,8 @@ import logging
 import re
 from contextlib import contextmanager
 
+from alembic import command
+from alembic.config import Config
 from sqlalchemy.sql import and_, or_
 
 from couchers.crypto import urlsafe_secure_token
@@ -11,6 +13,13 @@ from couchers.utils import now
 from pb import api_pb2
 
 logger = logging.getLogger(__name__)
+
+
+def apply_migrations():
+    alembic_cfg = Config("alembic.ini")
+    # alembic screws up logging config by default, this tells it not to screw it up if being run at startup like this
+    alembic_cfg.set_main_option("dont_mess_up_logging", "False")
+    command.upgrade(alembic_cfg, "head")
 
 
 @contextmanager

--- a/app/backend/src/couchers/migrations/env.py
+++ b/app/backend/src/couchers/migrations/env.py
@@ -10,7 +10,7 @@ from couchers.config import config as couchers_config
 # access to the values within the .ini file in use.
 config = context.config
 
-config.set_main_option("sqlalchemy.url", couchers_config.get("DATABASE_CONNECTION_STRING"))
+config.set_main_option("sqlalchemy.url", couchers_config["DATABASE_CONNECTION_STRING"])
 
 
 # Interpret the config file for Python logging.

--- a/app/backend/src/couchers/migrations/versions/95c58503e9c0_fix_message_type_enum.py
+++ b/app/backend/src/couchers/migrations/versions/95c58503e9c0_fix_message_type_enum.py
@@ -1,0 +1,23 @@
+"""Fix message type enum
+
+Revision ID: 95c58503e9c0
+Revises: 3c0f67ff3ea2
+Create Date: 2020-11-21 11:57:37.853004
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "95c58503e9c0"
+down_revision = "3c0f67ff3ea2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TYPE messagetype ADD VALUE 'host_request_status_changed';")
+
+
+def downgrade():
+    raise Exception("I can't drop the 'host_request_status_changed' value from 'messagetype' enum.")

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -31,7 +31,7 @@ from pb import (
 )
 
 
-@pytest.fixture(params=[False, True])
+@pytest.fixture(params=["migrations", "models"])
 def db(request):
     """
     Connect to a running Postgres database, and return the Session object.
@@ -43,7 +43,7 @@ def db(request):
     # drop everything currently in the database
     engine.execute("DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
 
-    if request.param:
+    if request.param == "migrations":
         # rebuild it with alembic migrations
         apply_migrations()
     else:

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -32,18 +32,18 @@ from pb import (
 
 
 @pytest.fixture(params=[False, True])
-def db(build_db_from_migration):
+def db(request):
     """
     Connect to a running Postgres database, and return the Session object.
 
-    build_db_from_migration tells whether the db should be built from alembic migrations or using metadata.create_all()
+    request.params tells whether the db should be built from alembic migrations or using metadata.create_all()
     """
     engine = create_engine(config["DATABASE_CONNECTION_STRING"], poolclass=NullPool)
 
     # drop everything currently in the database
     engine.execute("DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
 
-    if build_db_from_migration:
+    if request.params:
         # rebuild it with alembic migrations
         apply_migrations()
     else:

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -41,8 +41,12 @@ def db():
     # drop everything currently in the database
     engine.execute("DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
 
-    # rebuild it with alembic migrations
-    apply_migrations()
+    if config["TEST_BUILD_DB_FROM_MIGRATIONS"]:
+        # rebuild it with alembic migrations
+        apply_migrations()
+    else:
+        # create everything from the current models, not incrementally through migrations
+        Base.metadata.create_all(engine)
 
     return sessionmaker(bind=engine)
 

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -36,14 +36,14 @@ def db(request):
     """
     Connect to a running Postgres database, and return the Session object.
 
-    request.params tells whether the db should be built from alembic migrations or using metadata.create_all()
+    request.param tells whether the db should be built from alembic migrations or using metadata.create_all()
     """
     engine = create_engine(config["DATABASE_CONNECTION_STRING"], poolclass=NullPool)
 
     # drop everything currently in the database
     engine.execute("DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
 
-    if request.params:
+    if request.param:
         # rebuild it with alembic migrations
         apply_migrations()
     else:

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -5,8 +5,6 @@ from unittest.mock import patch
 
 import grpc
 import pytest
-from alembic import command
-from alembic.config import Config
 from sqlalchemy import create_engine
 from sqlalchemy.event import listen, remove
 from sqlalchemy.orm import sessionmaker

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -31,17 +31,19 @@ from pb import (
 )
 
 
-@pytest.fixture
-def db():
+@pytest.fixture(params=[False, True])
+def db(build_db_from_migration):
     """
     Connect to a running Postgres database, and return the Session object.
+
+    build_db_from_migration tells whether the db should be built from alembic migrations or using metadata.create_all()
     """
     engine = create_engine(config["DATABASE_CONNECTION_STRING"], poolclass=NullPool)
 
     # drop everything currently in the database
     engine.execute("DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
 
-    if config["TEST_BUILD_DB_FROM_MIGRATIONS"]:
+    if build_db_from_migration:
         # rebuild it with alembic migrations
         apply_migrations()
     else:


### PR DESCRIPTION
Closes #281 

The database enum `messagetype` was missing the `host_request_status_changed` value.

This does two things:
* Use alembic migrations within tests to catch broken migrations
* Adds a migration that adds this value to the enum