### PR TITLE
Frontend fix: export non-anon object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode
+.idea

--- a/app/frontend/.gitignore
+++ b/app/frontend/.gitignore
@@ -23,5 +23,3 @@ yarn-debug.log*
 yarn-error.log*
 
 src/pb/**
-.vscode
-.idea

--- a/app/frontend/src/service/api.ts
+++ b/app/frontend/src/service/api.ts
@@ -27,11 +27,18 @@ const opts = {
   streamInterceptors: [interceptor],
 };
 
-export default {
+const apis = {
+  // @ts-ignore
   api: new APIPromiseClient(URL, null, opts),
+  // @ts-ignore
   bugs: new BugsPromiseClient(URL, null, opts),
+  // @ts-ignore
   sso: new SSOPromiseClient(URL, null, opts),
+  // @ts-ignore
   conversations: new ConversationsPromiseClient(URL, null, opts),
   auth: new AuthPromiseClient(URL),
+  // @ts-ignore
   requests: new RequestsPromiseClient(URL, null, opts),
 };
+
+export default apis;


### PR DESCRIPTION
Without this, the app is unsurprisingly not compiling as the TS types for the generated clients are wrong for the `opts` parameter.