### PR TITLE
Fix version string

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,7 +52,7 @@ build:proxy:
   stage: build
   script:
     - docker pull $PROXY_RELEASE_TAG || true
-    - docker build --build-arg version=$PROXY_TAG --cache-from $PROXY_RELEASE_TAG -t $PROXY_TAG app/proxy/
+    - docker build --build-arg version=$SLUG --cache-from $PROXY_RELEASE_TAG -t $PROXY_TAG app/proxy/
     - docker push $PROXY_TAG
   rules:
     - if: $CI_COMMIT_BRANCH == $RELEASE_BRANCH
@@ -67,7 +67,7 @@ build:nginx:
   stage: build
   script:
     - docker pull $NGINX_RELEASE_TAG || true
-    - docker build --build-arg version=$NGINX_TAG --cache-from $NGINX_RELEASE_TAG -t $NGINX_TAG app/nginx/
+    - docker build --build-arg version=$SLUG --cache-from $NGINX_RELEASE_TAG -t $NGINX_TAG app/nginx/
     - docker push $NGINX_TAG
   rules:
     - if: $CI_COMMIT_BRANCH == $RELEASE_BRANCH
@@ -82,7 +82,7 @@ build:backend:
   stage: build
   script:
     - docker pull $BACKEND_RELEASE_TAG || true
-    - docker build --build-arg version=$BACKEND_TAG --cache-from $BACKEND_RELEASE_TAG -t $BACKEND_TAG app/backend/
+    - docker build --build-arg version=$SLUG --cache-from $BACKEND_RELEASE_TAG -t $BACKEND_TAG app/backend/
     - docker push $BACKEND_TAG
   rules:
     - if: $CI_COMMIT_BRANCH == $RELEASE_BRANCH
@@ -97,7 +97,7 @@ build:media:
   stage: build
   script:
     - docker pull $MEDIA_RELEASE_TAG || true
-    - docker build --build-arg version=$MEDIA_TAG --cache-from $MEDIA_RELEASE_TAG -t $MEDIA_TAG app/media/
+    - docker build --build-arg version=$SLUG --cache-from $MEDIA_RELEASE_TAG -t $MEDIA_TAG app/media/
     - docker push $MEDIA_TAG
   rules:
     - if: $CI_COMMIT_BRANCH == $RELEASE_BRANCH
@@ -112,7 +112,7 @@ build:frontend:
   stage: build
   script:
     - docker pull $FRONTEND_RELEASE_TAG || true
-    - docker build --build-arg version=$FRONTEND_TAG --cache-from $FRONTEND_RELEASE_TAG -t $FRONTEND_TAG app/frontend/
+    - docker build --build-arg version=$SLUG --cache-from $FRONTEND_RELEASE_TAG -t $FRONTEND_TAG app/frontend/
     - docker push $FRONTEND_TAG
     # creates a new docker container (docker create returns the container name), and copies the /app folder to the host
     - mkdir -p artifacts && docker cp $(docker create $FRONTEND_TAG):/app/build artifacts/frontend
@@ -132,7 +132,7 @@ build:vue:
   stage: build
   script:
     - docker pull $VUE_RELEASE_TAG || true
-    - docker build --build-arg version=$VUE_TAG --cache-from $VUE_RELEASE_TAG -t $VUE_TAG app/vue/
+    - docker build --build-arg version=$SLUG --cache-from $VUE_RELEASE_TAG -t $VUE_TAG app/vue/
     - docker push $VUE_TAG
     # creates a new docker container (docker create returns the container name), and copies the /app folder to the host
     - mkdir -p artifacts && docker cp $(docker create $VUE_TAG):/app/dist artifacts/vue


### PR DESCRIPTION
Use $SLUG for version instead of $SERVICE_TAG

The latter starts with `registry.gitlab.com/couchers/couchers/backend:`, which we don't want, $SLUG is just `develop-839cb682`, or similar.
