### PR TITLE
[MRG] frontend chore: relax no-unused-vars ESLint check to ignore "classes"

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -26,6 +26,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "format": "prettier --write src/",
+    "lint": "eslint src/",
     "test-travis": "NODE_ENV=test && react-scripts test --coverage --watchAll=false",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public"
@@ -36,6 +37,21 @@
       "prettier",
       "prettier/@typescript-eslint",
       "prettier/react"
+    ],
+    "overrides": [
+      {
+        "files": [
+          "**/*.ts?(x)"
+        ],
+        "rules": {
+          "@typescript-eslint/no-unused-vars": [
+            "warn",
+            {
+              "varsIgnorePattern": "classes"
+            }
+          ]
+        }
+      }
     ]
   },
   "eslintIgnore": [


### PR DESCRIPTION
A small PR to relax the no unused variable check on any variable named "classes", since we (kinda?) agreed that we're ok with leaving `const classes = useStyles()` in components even if there's no custom styles for the component yet in `makeStyles`. Makes it easier for us to create "good first issues" ticket in future for those who just wants to do styling without modifying the code too much themselves.

Also added a lint command in `package.json` that could be used in CI/CD in future, or locally for those who don't use VSCode/ESLint plugin