### PR TITLE
[MRG] frontend chore/fix: put options back into jest config that shouldn't be removed...

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -100,6 +100,12 @@
     "react-test-renderer": "^16.13.1"
   },
   "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx}",
+      "!**/node_modules/**",
+      "!src/pb/*"
+    ],
+    "resetMocks": true,
     "preset": "ts-jest",
     "testEnvironment": "node",
     "transform": {


### PR DESCRIPTION
As in title.

`resetMocks` is needed so the mocks auto cleans up before each test without us having to manually write it out in all test files. Also we probably want to keep `collectCoverageFrom` for when we set back up test code coverage checks again in future.