### PR TITLE
Add grpc web dev tools

### DIFF
--- a/app/frontend/src/service/client.ts
+++ b/app/frontend/src/service/client.ts
@@ -38,17 +38,19 @@ const apis = {
   jail: new JailPromiseClient(URL, null, opts),
 };
 
-// @ts-ignore
-const grpcWebTools = window.__GRPCWEB_DEVTOOLS__ || (() => {});
+if (process.env.NODE_ENV === "development") {
+  // @ts-ignore
+  const grpcWebTools = window.__GRPCWEB_DEVTOOLS__ || (() => {});
 
-grpcWebTools([
-  apis.api,
-  apis.bugs,
-  apis.sso,
-  apis.conversations,
-  apis.auth,
-  apis.requests,
-  apis.jail,
-]);
+  grpcWebTools([
+    apis.api,
+    apis.bugs,
+    apis.sso,
+    apis.conversations,
+    apis.auth,
+    apis.requests,
+    apis.jail,
+  ]);
+}
 
 export default apis;

--- a/app/frontend/src/service/client.ts
+++ b/app/frontend/src/service/client.ts
@@ -38,4 +38,17 @@ const apis = {
   jail: new JailPromiseClient(URL, null, opts),
 };
 
+// @ts-ignore
+const grpcWebTools = window.__GRPCWEB_DEVTOOLS__ || (() => {});
+
+grpcWebTools([
+  apis.api,
+  apis.bugs,
+  apis.sso,
+  apis.conversations,
+  apis.auth,
+  apis.requests,
+  apis.jail,
+]);
+
 export default apis;

--- a/app/vue/src/api.ts
+++ b/app/vue/src/api.ts
@@ -47,3 +47,18 @@ export const authClient = new AuthPromiseClient(URL)
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 export const requestsClient = new RequestsPromiseClient(URL, null, opts) as RequestsPromiseClient
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const grpcWebTools = window.__GRPCWEB_DEVTOOLS__ || (() => {})
+
+grpcWebTools([
+  client,
+  jailClient,
+  bugsClient,
+  SSOclient,
+  conversations,
+  authClient,
+  requestsClient,
+])

--- a/app/vue/src/api.ts
+++ b/app/vue/src/api.ts
@@ -48,17 +48,18 @@ export const authClient = new AuthPromiseClient(URL)
 // @ts-ignore
 export const requestsClient = new RequestsPromiseClient(URL, null, opts) as RequestsPromiseClient
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const grpcWebTools = window.__GRPCWEB_DEVTOOLS__ || (() => {})
-
-grpcWebTools([
-  client,
-  jailClient,
-  bugsClient,
-  SSOclient,
-  conversations,
-  authClient,
-  requestsClient,
-])
+if (process.env.NODE_ENV === "development") {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  const grpcWebTools = window.__GRPCWEB_DEVTOOLS__ || (() => {})
+  grpcWebTools([
+    client,
+    jailClient,
+    bugsClient,
+    SSOclient,
+    conversations,
+    authClient,
+    requestsClient,
+  ])
+}


### PR DESCRIPTION
I found this great dev tool, it shows you the requests in a "JSON-like" way, works on FF and Chrome:

https://github.com/SafetyCulture/grpc-web-devtools

Screenshot:

<img width="738" alt="Screen Shot 2020-12-04 at 9 20 57 am" src="https://user-images.githubusercontent.com/2975660/101174751-492e1480-3612-11eb-9fb6-4e4e89011808.png">

Do we want this? Any downsides? We can of course add a config var to enable/disable?