### PR TITLE
Stop passing sessions around

### DIFF
--- a/app/backend/Dockerfile
+++ b/app/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-buster as base
+FROM python:3.9-buster as base
 
 FROM base as build
 

--- a/app/backend/src/app.py
+++ b/app/backend/src/app.py
@@ -4,11 +4,9 @@ import sys
 from concurrent import futures
 
 import grpc
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 
 from couchers import config
-from couchers.db import apply_migrations, session_scope
+from couchers.db import apply_migrations, session_scope, session_scope_experimental
 from couchers.interceptors import LoggingInterceptor, UpdateLastActiveTimeInterceptor
 from couchers.models import Base
 from couchers.servicers.account import Account
@@ -54,12 +52,9 @@ def log_unhandled_exception(exc_type, exc_value, exc_traceback):
 
 sys.excepthook = log_unhandled_exception
 
-engine = create_engine(config.config["DATABASE_CONNECTION_STRING"], echo=False)
-Session = sessionmaker(bind=engine)
-
 logger.info(f"Checking DB connection")
 
-with session_scope(Session) as session:
+with session_scope() as session:
     res = session.execute("SELECT 42;")
     if list(res) != [(42,)]:
         raise Exception("Failed to connect to DB")
@@ -69,11 +64,11 @@ logger.info(f"Running DB migrations")
 apply_migrations()
 
 if config.config["ADD_DUMMY_DATA"]:
-    add_dummy_data(Session, "src/dummy_data.json")
+    add_dummy_data("src/dummy_data.json")
 
 logger.info(f"Starting")
 
-auth = Auth(Session)
+auth = Auth()
 open_server = grpc.server(futures.ThreadPoolExecutor(2), interceptors=[LoggingInterceptor()])
 open_server.add_insecure_port("[::]:1752")
 auth_pb2_grpc.add_AuthServicer_to_server(auth, open_server)
@@ -84,10 +79,10 @@ jailed_server = grpc.server(
     futures.ThreadPoolExecutor(2), interceptors=[LoggingInterceptor(), auth.get_auth_interceptor(allow_jailed=True)]
 )
 jailed_server.add_insecure_port("[::]:1754")
-jail_pb2_grpc.add_JailServicer_to_server(Jail(Session), jailed_server)
+jail_pb2_grpc.add_JailServicer_to_server(Jail(), jailed_server)
 jailed_server.start()
 
-servicer = API(Session)
+servicer = API()
 server = grpc.server(
     futures.ThreadPoolExecutor(2),
     interceptors=[
@@ -98,11 +93,11 @@ server = grpc.server(
 )
 server.add_insecure_port("[::]:1751")
 
-account_pb2_grpc.add_AccountServicer_to_server(Account(Session), server)
+account_pb2_grpc.add_AccountServicer_to_server(Account(), server)
 api_pb2_grpc.add_APIServicer_to_server(servicer, server)
-conversations_pb2_grpc.add_ConversationsServicer_to_server(Conversations(Session), server)
-requests_pb2_grpc.add_RequestsServicer_to_server(Requests(Session), server)
-sso_pb2_grpc.add_SSOServicer_to_server(SSO(Session), server)
+conversations_pb2_grpc.add_ConversationsServicer_to_server(Conversations(), server)
+requests_pb2_grpc.add_RequestsServicer_to_server(Requests(), server)
+sso_pb2_grpc.add_SSOServicer_to_server(SSO(), server)
 
 server.start()
 
@@ -111,7 +106,7 @@ media_server = grpc.server(
     interceptors=[LoggingInterceptor(), get_media_auth_interceptor(MEDIA_SERVER_BEARER_TOKEN)],
 )
 media_server.add_insecure_port("[::]:1753")
-media_pb2_grpc.add_MediaServicer_to_server(Media(Session), media_server)
+media_pb2_grpc.add_MediaServicer_to_server(Media(), media_server)
 media_server.start()
 
 logger.info(f"Serving on 1751 (secure), 1752 (auth), 1753 (media), and 1754 (jailed)")

--- a/app/backend/src/app.py
+++ b/app/backend/src/app.py
@@ -6,7 +6,7 @@ from concurrent import futures
 import grpc
 
 from couchers import config
-from couchers.db import apply_migrations, session_scope, session_scope_experimental
+from couchers.db import apply_migrations, session_scope
 from couchers.interceptors import LoggingInterceptor, UpdateLastActiveTimeInterceptor
 from couchers.models import Base
 from couchers.servicers.account import Account

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -40,6 +40,8 @@ CONFIG_OPTIONS = [
     ("BUG_TOOL_GITHUB_REPO", str),
     ("BUG_TOOL_GITHUB_USERNAME", str),
     ("BUG_TOOL_GITHUB_TOKEN", str),
+    # Whether we're in test
+    ("IN_TEST", bool, "0"),
 ]
 
 config = {}
@@ -90,3 +92,5 @@ def check_config():
             raise Exception("Production site must be over HTTPS")
         if not config["ENABLE_EMAIL"]:
             raise Exception("Production site must have email enabled")
+        if config["IN_TEST"]:
+            raise Exception("IN_TEST while not DEV")

--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -43,7 +43,7 @@ def get_engine():
 
 
 @functools.cache
-def get_session():
+def get_session_factory():
     return sessionmaker(bind=get_engine())
 
 

--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from alembic import command
 from alembic.config import Config
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm.session import Session
 from sqlalchemy.pool import NullPool
 from sqlalchemy.sql import and_, or_
 
@@ -42,17 +42,9 @@ def get_engine():
         return create_engine(config.config["DATABASE_CONNECTION_STRING"])
 
 
-@functools.cache
-def get_session_factory():
-    return sessionmaker(bind=get_engine())
-
-
 @contextmanager
 def session_scope():
-    # get factory...
-    factory = get_session_factory()
-    # ...then call it to get session
-    session = factory()
+    session = Session(get_engine())
     try:
         yield session
         session.commit()

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -78,16 +78,13 @@ smokinglocation2api = {
 
 
 class API(api_pb2_grpc.APIServicer):
-    def __init__(self, Session):
-        self._Session = Session
-
     def update_last_active_time(self, user_id):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             user = session.query(User).filter(User.id == user_id).one()
             user.last_active = func.now()
 
     def Ping(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             # auth ought to make sure the user exists
             user = session.query(User).filter(User.id == context.user_id).one()
 
@@ -143,7 +140,7 @@ class API(api_pb2_grpc.APIServicer):
             )
 
     def GetUser(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             user = get_user_by_field(session, request.user)
 
             if not user:
@@ -152,7 +149,7 @@ class API(api_pb2_grpc.APIServicer):
             return user_model_to_pb(user, session, context)
 
     def UpdateProfile(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             user = session.query(User).filter(User.id == context.user_id).one()
 
             if request.HasField("name"):
@@ -265,7 +262,7 @@ class API(api_pb2_grpc.APIServicer):
             return empty_pb2.Empty()
 
     def ListFriends(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             rels = (
                 session.query(FriendRelationship)
                 .filter(
@@ -282,7 +279,7 @@ class API(api_pb2_grpc.APIServicer):
             )
 
     def SendFriendRequest(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             from_user = session.query(User).filter(User.id == context.user_id).one_or_none()
 
             if not from_user:
@@ -307,7 +304,7 @@ class API(api_pb2_grpc.APIServicer):
 
     def ListFriendRequests(self, request, context):
         # both sent and received
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             sent_requests = (
                 session.query(FriendRelationship)
                 .filter(FriendRelationship.from_user_id == context.user_id)
@@ -342,7 +339,7 @@ class API(api_pb2_grpc.APIServicer):
             )
 
     def RespondFriendRequest(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             friend_request = (
                 session.query(FriendRelationship)
                 .filter(FriendRelationship.to_user_id == context.user_id)
@@ -362,7 +359,7 @@ class API(api_pb2_grpc.APIServicer):
             return empty_pb2.Empty()
 
     def CancelFriendRequest(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             friend_request = (
                 session.query(FriendRelationship)
                 .filter(FriendRelationship.from_user_id == context.user_id)
@@ -382,7 +379,7 @@ class API(api_pb2_grpc.APIServicer):
             return empty_pb2.Empty()
 
     def Search(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             users = []
             for user in (
                 session.query(User)
@@ -397,7 +394,7 @@ class API(api_pb2_grpc.APIServicer):
         if context.user_id == request.reported_user_id:
             context.abort(grpc.StatusCode.INVALID_ARGUMENT, errors.CANT_REPORT_SELF)
 
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             reported_user = session.query(User).filter(User.id == request.reported_user_id).one_or_none()
 
             if not reported_user:
@@ -431,7 +428,7 @@ class API(api_pb2_grpc.APIServicer):
             was_safe=request.was_safe,
             rating=request.rating,
         )
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             if not session.query(User).filter(User.id == request.to_user_id).one_or_none():
                 context.abort(grpc.StatusCode.NOT_FOUND, "User not found")
 
@@ -447,7 +444,7 @@ class API(api_pb2_grpc.APIServicer):
         return empty_pb2.Empty()
 
     def GetGivenReferences(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             query = session.query(Reference)
             query = query.filter(Reference.from_user_id == request.from_user_id)
             if request.HasField("type_filter"):
@@ -455,7 +452,7 @@ class API(api_pb2_grpc.APIServicer):
             return paginate_references_result(request, query)
 
     def GetReceivedReferences(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             query = session.query(Reference)
             query = query.filter(Reference.to_user_id == request.to_user_id)
             if request.HasField("type_filter"):
@@ -470,7 +467,7 @@ class API(api_pb2_grpc.APIServicer):
         }
 
         # Filter out already written ones.
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             query = session.query(Reference)
             query = query.filter(Reference.from_user_id == context.user_id)
             query = query.filter(Reference.to_user_id == request.to_user_id)
@@ -486,7 +483,7 @@ class API(api_pb2_grpc.APIServicer):
         created = now()
         expiry = created + timedelta(minutes=20)
 
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             upload = InitiatedUpload(key=key, created=created, expiry=expiry, user_id=context.user_id)
             session.add(upload)
             session.commit()

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -111,11 +111,8 @@ def _add_message_to_subscription(session, subscription, **kwargs):
 
 
 class Conversations(conversations_pb2_grpc.ConversationsServicer):
-    def __init__(self, Session):
-        self._Session = Session
-
     def ListGroupChats(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             # select group chats where you have a subscription, and for each of
             # these, the latest message from them
 
@@ -168,7 +165,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             )
 
     def GetGroupChat(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             result = (
                 session.query(GroupChat, GroupChatSubscription, Message)
                 .join(Message, Message.conversation_id == GroupChatSubscription.group_chat_id)
@@ -198,7 +195,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             )
 
     def GetDirectMessage(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             count = func.count(GroupChatSubscription.id).label("count")
             subquery = (
                 session.query(GroupChatSubscription.group_chat_id)
@@ -245,7 +242,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             )
 
     def GetUpdates(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             results = (
                 session.query(Message)
                 .join(GroupChatSubscription, GroupChatSubscription.group_chat_id == Message.conversation_id)
@@ -270,7 +267,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             )
 
     def GetGroupChatMessages(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             results = (
                 session.query(Message)
                 .join(GroupChatSubscription, GroupChatSubscription.group_chat_id == Message.conversation_id)
@@ -292,7 +289,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             )
 
     def MarkLastSeenGroupChat(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             subscription = (
                 session.query(GroupChatSubscription)
                 .filter(GroupChatSubscription.group_chat_id == request.group_chat_id)
@@ -312,7 +309,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         return empty_pb2.Empty()
 
     def SearchMessages(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             results = (
                 session.query(Message)
                 .join(GroupChatSubscription, GroupChatSubscription.group_chat_id == Message.conversation_id)
@@ -349,7 +346,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         if context.user_id in request.recipient_user_ids:
             context.abort(grpc.StatusCode.INVALID_ARGUMENT, errors.CANT_ADD_SELF)
 
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             if len(request.recipient_user_ids) == 1:
                 # can only have one DM at a time between any two users
                 other_user_id = request.recipient_user_ids[0]
@@ -427,7 +424,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         if request.text == "":
             context.abort(grpc.StatusCode.INVALID_ARGUMENT, errors.INVALID_MESSAGE)
 
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             subscription = (
                 session.query(GroupChatSubscription)
                 .filter(GroupChatSubscription.group_chat_id == request.group_chat_id)
@@ -443,7 +440,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         return empty_pb2.Empty()
 
     def EditGroupChat(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             subscription = (
                 session.query(GroupChatSubscription)
                 .filter(GroupChatSubscription.user_id == context.user_id)
@@ -469,7 +466,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         return empty_pb2.Empty()
 
     def MakeGroupChatAdmin(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             your_subscription = (
                 session.query(GroupChatSubscription)
                 .filter(GroupChatSubscription.group_chat_id == request.group_chat_id)
@@ -510,7 +507,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         return empty_pb2.Empty()
 
     def RemoveGroupChatAdmin(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             your_subscription = (
                 session.query(GroupChatSubscription)
                 .filter(GroupChatSubscription.group_chat_id == request.group_chat_id)
@@ -559,7 +556,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         return empty_pb2.Empty()
 
     def InviteToGroupChat(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             result = (
                 session.query(GroupChatSubscription, GroupChat)
                 .join(GroupChat, GroupChat.conversation_id == GroupChatSubscription.group_chat_id)
@@ -616,7 +613,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         return empty_pb2.Empty()
 
     def LeaveGroupChat(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             subscription = (
                 session.query(GroupChatSubscription)
                 .filter(GroupChatSubscription.group_chat_id == request.group_chat_id)

--- a/app/backend/src/couchers/servicers/jail.py
+++ b/app/backend/src/couchers/servicers/jail.py
@@ -18,10 +18,6 @@ class Jail(jail_pb2_grpc.JailServicer):
     fully active
     """
 
-    def __init__(self, Session):
-        super().__init__()
-        self._Session = Session
-
     def _get_jail_info(self, user):
         res = jail_pb2.JailInfoRes(
             has_not_accepted_tos=user.accepted_tos != 1,
@@ -40,12 +36,12 @@ class Jail(jail_pb2_grpc.JailServicer):
         return res
 
     def JailInfo(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             user = session.query(User).filter(User.id == context.user_id).one()
             return self._get_jail_info(user)
 
     def AcceptTOS(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             user = session.query(User).filter(User.id == context.user_id).one()
 
             if user.accepted_tos == 1 and not request.accept:

--- a/app/backend/src/couchers/servicers/media.py
+++ b/app/backend/src/couchers/servicers/media.py
@@ -21,11 +21,8 @@ def get_media_auth_interceptor(secret_token):
 
 
 class Media(media_pb2_grpc.MediaServicer):
-    def __init__(self, Session):
-        self._Session = Session
-
     def UploadConfirmation(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             upload = (
                 session.query(InitiatedUpload)
                 .filter(InitiatedUpload.key == request.key)

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -56,11 +56,8 @@ def message_to_pb(message: Message):
 
 
 class Requests(requests_pb2_grpc.RequestsServicer):
-    def __init__(self, Session):
-        self._Session = Session
-
     def CreateHostRequest(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             if request.to_user_id == context.user_id:
                 context.abort(grpc.StatusCode.INVALID_ARGUMENT, errors.CANT_REQUEST_SELF)
             # just to check the host exists
@@ -109,7 +106,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             return requests_pb2.CreateHostRequestRes(host_request_id=host_request.conversation_id)
 
     def GetHostRequest(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             host_request = (
                 session.query(HostRequest)
                 .filter(HostRequest.conversation_id == request.host_request_id)
@@ -156,7 +153,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         if request.only_sent and request.only_received:
             context.abort(grpc.StatusCode.INVALID_ARGUMENT, errors.HOST_REQUEST_SENT_OR_RECEIVED)
 
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             pagination = request.number if request.number > 0 else PAGINATION_LENGTH
 
             # By outer joining messages on itself where the second id is bigger, only the highest IDs will have
@@ -231,7 +228,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             )
 
     def RespondHostRequest(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             host_request = (
                 session.query(HostRequest).filter(HostRequest.conversation_id == request.host_request_id).one_or_none()
             )
@@ -328,7 +325,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             return empty_pb2.Empty()
 
     def GetHostRequestMessages(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             host_request = (
                 session.query(HostRequest).filter(HostRequest.conversation_id == request.host_request_id).one_or_none()
             )
@@ -363,7 +360,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
     def SendHostRequestMessage(self, request, context):
         if request.text == "":
             context.abort(grpc.StatusCode.INVALID_ARGUMENT, errors.INVALID_MESSAGE)
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             host_request = (
                 session.query(HostRequest).filter(HostRequest.conversation_id == request.host_request_id).one_or_none()
             )
@@ -404,7 +401,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         if request.only_sent and request.only_received:
             context.abort(grpc.StatusCode.INVALID_ARGUMENT, errors.HOST_REQUEST_SENT_OR_RECEIVED)
 
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             if request.newest_message_id == 0:
                 context.abort(grpc.StatusCode.INVALID_ARGUMENT, errors.INVALID_MESSAGE)
 
@@ -450,7 +447,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             )
 
     def MarkLastSeenHostRequest(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             host_request = (
                 session.query(HostRequest).filter(HostRequest.conversation_id == request.host_request_id).one_or_none()
             )

--- a/app/backend/src/couchers/servicers/sso.py
+++ b/app/backend/src/couchers/servicers/sso.py
@@ -5,7 +5,6 @@ import grpc
 
 from couchers import errors
 from couchers.crypto import base64decode, base64encode, sso_check_hmac, sso_create_hmac
-from couchers.db import session_scope
 from couchers.models import User
 from pb import sso_pb2, sso_pb2_grpc
 
@@ -15,12 +14,9 @@ logger = logging.getLogger(__name__)
 
 
 class SSO(sso_pb2_grpc.SSOServicer):
-    def __init__(self, Session):
-        self._Session = Session
-
     def SSO(self, request, context):
         # Protocol description: https://meta.discourse.org/t/official-single-sign-on-for-discourse-sso/13045
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             sso = request.sso
             sig = request.sig
 

--- a/app/backend/src/couchers/servicers/sso.py
+++ b/app/backend/src/couchers/servicers/sso.py
@@ -5,6 +5,7 @@ import grpc
 
 from couchers import errors
 from couchers.crypto import base64decode, base64encode, sso_check_hmac, sso_create_hmac
+from couchers.db import session_scope
 from couchers.models import User
 from pb import sso_pb2, sso_pb2_grpc
 

--- a/app/backend/src/dummy_data.py
+++ b/app/backend/src/dummy_data.py
@@ -28,10 +28,10 @@ from pb.api_pb2 import HostingStatus
 logger = logging.getLogger(__name__)
 
 
-def add_dummy_data(Session, file_name):
+def add_dummy_data(file_name):
     try:
         logger.info(f"Adding dummy data")
-        with session_scope(Session) as session:
+        with session_scope() as session:
             with open(file_name, "r") as file:
                 data = json.loads(file.read())
 

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -23,9 +23,9 @@ def test_ChangePassword_normal(db, fast_passwords):
     # user has old password and is changing to new password
     old_password = random_hex()
     new_password = random_hex()
-    user, token = generate_user(db, hashed_password=hash_password(old_password))
+    user, token = generate_user(hashed_password=hash_password(old_password))
 
-    with account_session(db, token) as account:
+    with account_session(token) as account:
         with patch("couchers.servicers.account.send_password_changed_email") as mock:
             account.ChangePassword(
                 account_pb2.ChangePasswordReq(
@@ -35,7 +35,7 @@ def test_ChangePassword_normal(db, fast_passwords):
             )
         mock.assert_called_once()
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         updated_user = session.query(User).filter(User.id == user.id).one()
         assert updated_user.hashed_password == hash_password(new_password)
 
@@ -44,9 +44,9 @@ def test_ChangePassword_normal_wrong_password(db, fast_passwords):
     # user has old password and is changing to new password, but used wrong old password
     old_password = random_hex()
     new_password = random_hex()
-    user, token = generate_user(db, hashed_password=hash_password(old_password))
+    user, token = generate_user(hashed_password=hash_password(old_password))
 
-    with account_session(db, token) as account:
+    with account_session(token) as account:
         with pytest.raises(grpc.RpcError) as e:
             account.ChangePassword(
                 account_pb2.ChangePasswordReq(
@@ -57,7 +57,7 @@ def test_ChangePassword_normal_wrong_password(db, fast_passwords):
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
         assert e.value.details() == errors.INVALID_USERNAME_OR_PASSWORD
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         updated_user = session.query(User).filter(User.id == user.id).one()
         assert updated_user.hashed_password == hash_password(old_password)
 
@@ -66,9 +66,9 @@ def test_ChangePassword_normal_no_password(db, fast_passwords):
     # user has old password and is changing to new password, but didn't supply old password
     old_password = random_hex()
     new_password = random_hex()
-    user, token = generate_user(db, hashed_password=hash_password(old_password))
+    user, token = generate_user(hashed_password=hash_password(old_password))
 
-    with account_session(db, token) as account:
+    with account_session(token) as account:
         with pytest.raises(grpc.RpcError) as e:
             account.ChangePassword(
                 account_pb2.ChangePasswordReq(
@@ -78,7 +78,7 @@ def test_ChangePassword_normal_no_password(db, fast_passwords):
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
         assert e.value.details() == errors.MISSING_PASSWORD
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         updated_user = session.query(User).filter(User.id == user.id).one()
         assert updated_user.hashed_password == hash_password(old_password)
 
@@ -86,15 +86,15 @@ def test_ChangePassword_normal_no_password(db, fast_passwords):
 def test_ChangePassword_normal_no_passwords(db, fast_passwords):
     # user has old password and called with empty body
     old_password = random_hex()
-    user, token = generate_user(db, hashed_password=hash_password(old_password))
+    user, token = generate_user(hashed_password=hash_password(old_password))
 
-    with account_session(db, token) as account:
+    with account_session(token) as account:
         with pytest.raises(grpc.RpcError) as e:
             account.ChangePassword(account_pb2.ChangePasswordReq())
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
         assert e.value.details() == errors.MISSING_BOTH_PASSWORDS
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         updated_user = session.query(User).filter(User.id == user.id).one()
         assert updated_user.hashed_password == hash_password(old_password)
 
@@ -102,9 +102,9 @@ def test_ChangePassword_normal_no_passwords(db, fast_passwords):
 def test_ChangePassword_add(db, fast_passwords):
     # user does not have an old password and is adding a new password
     new_password = random_hex()
-    user, token = generate_user(db, hashed_password=None)
+    user, token = generate_user(hashed_password=None)
 
-    with account_session(db, token) as account:
+    with account_session(token) as account:
         with patch("couchers.servicers.account.send_password_changed_email") as mock:
             account.ChangePassword(
                 account_pb2.ChangePasswordReq(
@@ -113,7 +113,7 @@ def test_ChangePassword_add(db, fast_passwords):
             )
         mock.assert_called_once()
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         updated_user = session.query(User).filter(User.id == user.id).one()
         assert updated_user.hashed_password == hash_password(new_password)
 
@@ -121,9 +121,9 @@ def test_ChangePassword_add(db, fast_passwords):
 def test_ChangePassword_add_with_password(db, fast_passwords):
     # user does not have an old password and is adding a new password, but supplied a password
     new_password = random_hex()
-    user, token = generate_user(db, hashed_password=None)
+    user, token = generate_user(hashed_password=None)
 
-    with account_session(db, token) as account:
+    with account_session(token) as account:
         with pytest.raises(grpc.RpcError) as e:
             account.ChangePassword(
                 account_pb2.ChangePasswordReq(
@@ -134,31 +134,31 @@ def test_ChangePassword_add_with_password(db, fast_passwords):
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
         assert e.value.details() == errors.NO_PASSWORD
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         updated_user = session.query(User).filter(User.id == user.id).one()
         assert updated_user.hashed_password == None
 
 
 def test_ChangePassword_add_no_passwords(db, fast_passwords):
     # user does not have an old password and called with empty body
-    user, token = generate_user(db, hashed_password=None)
+    user, token = generate_user(hashed_password=None)
 
-    with account_session(db, token) as account:
+    with account_session(token) as account:
         with pytest.raises(grpc.RpcError) as e:
             account.ChangePassword(account_pb2.ChangePasswordReq())
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
         assert e.value.details() == errors.MISSING_BOTH_PASSWORDS
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         updated_user = session.query(User).filter(User.id == user.id).one()
         assert updated_user.hashed_password == None
 
 
 def test_ChangePassword_remove(db, fast_passwords):
     old_password = random_hex()
-    user, token = generate_user(db, hashed_password=hash_password(old_password))
+    user, token = generate_user(hashed_password=hash_password(old_password))
 
-    with account_session(db, token) as account:
+    with account_session(token) as account:
         with patch("couchers.servicers.account.send_password_changed_email") as mock:
             account.ChangePassword(
                 account_pb2.ChangePasswordReq(
@@ -167,16 +167,16 @@ def test_ChangePassword_remove(db, fast_passwords):
             )
         mock.assert_called_once()
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         updated_user = session.query(User).filter(User.id == user.id).one()
         assert updated_user.hashed_password is None
 
 
 def test_ChangePassword_remove_wrong_password(db, fast_passwords):
     old_password = random_hex()
-    user, token = generate_user(db, hashed_password=hash_password(old_password))
+    user, token = generate_user(hashed_password=hash_password(old_password))
 
-    with account_session(db, token) as account:
+    with account_session(token) as account:
         with pytest.raises(grpc.RpcError) as e:
             account.ChangePassword(
                 account_pb2.ChangePasswordReq(
@@ -186,7 +186,7 @@ def test_ChangePassword_remove_wrong_password(db, fast_passwords):
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
         assert e.value.details() == errors.INVALID_USERNAME_OR_PASSWORD
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         updated_user = session.query(User).filter(User.id == user.id).one()
         assert updated_user.hashed_password == hash_password(old_password)
 
@@ -194,9 +194,9 @@ def test_ChangePassword_remove_wrong_password(db, fast_passwords):
 def test_ChangeEmail_wrong_password(db, fast_passwords):
     password = random_hex()
     new_email = f"{random_hex()}@couchers.org.invalid"
-    user, token = generate_user(db, hashed_password=hash_password(password))
+    user, token = generate_user(hashed_password=hash_password(password))
 
-    with account_session(db, token) as account:
+    with account_session(token) as account:
         with pytest.raises(grpc.RpcError) as e:
             account.ChangeEmail(
                 account_pb2.ChangeEmailReq(
@@ -207,7 +207,7 @@ def test_ChangeEmail_wrong_password(db, fast_passwords):
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
         assert e.value.details() == errors.INVALID_USERNAME_OR_PASSWORD
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         assert (
             session.query(User)
             .filter(User.new_email_token_created <= func.now())
@@ -218,9 +218,9 @@ def test_ChangeEmail_wrong_password(db, fast_passwords):
 def test_ChangeEmail_wrong_email(db, fast_passwords):
     password = random_hex()
     new_email = f"{random_hex()}@couchers.org.invalid"
-    user, token = generate_user(db, hashed_password=hash_password(password))
+    user, token = generate_user(hashed_password=hash_password(password))
 
-    with account_session(db, token) as account:
+    with account_session(token) as account:
         with pytest.raises(grpc.RpcError) as e:
             account.ChangeEmail(
                 account_pb2.ChangeEmailReq(
@@ -231,7 +231,7 @@ def test_ChangeEmail_wrong_email(db, fast_passwords):
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
         assert e.value.details() == errors.INVALID_USERNAME_OR_PASSWORD
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         assert (
             session.query(User)
             .filter(User.new_email_token_created <= func.now())
@@ -242,9 +242,9 @@ def test_ChangeEmail_wrong_email(db, fast_passwords):
 def test_ChangeEmail_invalid_email(db, fast_passwords):
     password = random_hex()
     new_email = f"{random_hex()}@couchers.org.invalid"
-    user, token = generate_user(db, hashed_password=hash_password(password))
+    user, token = generate_user(hashed_password=hash_password(password))
 
-    with account_session(db, token) as account:
+    with account_session(token) as account:
         with pytest.raises(grpc.RpcError) as e:
             account.ChangeEmail(
                 account_pb2.ChangeEmailReq(
@@ -255,7 +255,7 @@ def test_ChangeEmail_invalid_email(db, fast_passwords):
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
         assert e.value.details() == errors.INVALID_EMAIL
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         assert (
             session.query(User)
             .filter(User.new_email_token_created <= func.now())
@@ -266,10 +266,10 @@ def test_ChangeEmail_invalid_email(db, fast_passwords):
 def test_ChangeEmail_email_in_use(db, fast_passwords):
     password = random_hex()
     new_email = f"{random_hex()}@couchers.org.invalid"
-    user, token = generate_user(db, hashed_password=hash_password(password))
-    user2, token2 = generate_user(db, hashed_password=hash_password(password))
+    user, token = generate_user(hashed_password=hash_password(password))
+    user2, token2 = generate_user(hashed_password=hash_password(password))
 
-    with account_session(db, token) as account:
+    with account_session(token) as account:
         with pytest.raises(grpc.RpcError) as e:
             account.ChangeEmail(
                 account_pb2.ChangeEmailReq(
@@ -280,7 +280,7 @@ def test_ChangeEmail_email_in_use(db, fast_passwords):
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
         assert e.value.details() == errors.INVALID_EMAIL
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         assert (
             session.query(User)
             .filter(User.new_email_token_created <= func.now())
@@ -291,9 +291,9 @@ def test_ChangeEmail_email_in_use(db, fast_passwords):
 def test_ChangeEmail_no_change(db, fast_passwords):
     password = random_hex()
     new_email = f"{random_hex()}@couchers.org.invalid"
-    user, token = generate_user(db, hashed_password=hash_password(password))
+    user, token = generate_user(hashed_password=hash_password(password))
 
-    with account_session(db, token) as account:
+    with account_session(token) as account:
         with pytest.raises(grpc.RpcError) as e:
             account.ChangeEmail(
                 account_pb2.ChangeEmailReq(
@@ -304,7 +304,7 @@ def test_ChangeEmail_no_change(db, fast_passwords):
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
         assert e.value.details() == errors.INVALID_EMAIL
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         assert (
             session.query(User)
             .filter(User.new_email_token_created <= func.now())
@@ -315,9 +315,9 @@ def test_ChangeEmail_no_change(db, fast_passwords):
 def test_ChangeEmail_wrong_token(db, fast_passwords):
     password = random_hex()
     new_email = f"{random_hex()}@couchers.org.invalid"
-    user, token = generate_user(db, hashed_password=hash_password(password))
+    user, token = generate_user(hashed_password=hash_password(password))
 
-    with account_session(db, token) as account:
+    with account_session(token) as account:
         account.ChangeEmail(
             account_pb2.ChangeEmailReq(
                 password=wrappers_pb2.StringValue(value=password),
@@ -325,7 +325,7 @@ def test_ChangeEmail_wrong_token(db, fast_passwords):
             )
         )
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         user_updated = (
             session.query(User)
             .filter(User.id == user.id)
@@ -336,7 +336,7 @@ def test_ChangeEmail_wrong_token(db, fast_passwords):
 
         token = user_updated.new_email_token
 
-    with auth_api_session(db) as auth_api:
+    with auth_api_session() as auth_api:
         with pytest.raises(grpc.RpcError) as e:
             res = auth_api.CompleteChangeEmail(
                 auth_pb2.CompleteChangeEmailReq(
@@ -346,7 +346,7 @@ def test_ChangeEmail_wrong_token(db, fast_passwords):
         assert e.value.code() == grpc.StatusCode.UNAUTHENTICATED
         assert e.value.details() == errors.INVALID_TOKEN
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         user_updated2 = session.query(User).filter(User.id == user.id).one()
         assert user_updated2.email == user.email
 
@@ -354,9 +354,9 @@ def test_ChangeEmail_wrong_token(db, fast_passwords):
 def test_ChangeEmail(db, fast_passwords):
     password = random_hex()
     new_email = f"{random_hex()}@couchers.org.invalid"
-    user, token = generate_user(db, hashed_password=hash_password(password))
+    user, token = generate_user(hashed_password=hash_password(password))
 
-    with account_session(db, token) as account:
+    with account_session(token) as account:
         account.ChangeEmail(
             account_pb2.ChangeEmailReq(
                 password=wrappers_pb2.StringValue(value=password),
@@ -364,7 +364,7 @@ def test_ChangeEmail(db, fast_passwords):
             )
         )
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         user_updated = (
             session.query(User)
             .filter(User.id == user.id)
@@ -375,21 +375,21 @@ def test_ChangeEmail(db, fast_passwords):
 
         token = user_updated.new_email_token
 
-    with auth_api_session(db) as auth_api:
+    with auth_api_session() as auth_api:
         res = auth_api.CompleteChangeEmail(
             auth_pb2.CompleteChangeEmailReq(
                 change_email_token=token,
             )
         )
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         user_updated2 = session.query(User).filter(User.id == user.id).one()
         assert user_updated2.email == new_email
         assert user_updated2.new_email is None
         assert user_updated2.new_email_token is None
 
     # check there's no valid tokens left
-    with session_scope(db) as session:
+    with session_scope() as session:
         assert (
             session.query(User)
             .filter(User.new_email_token_created <= func.now())

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -17,9 +17,9 @@ def _(testconfig):
 
 
 def test_ping(db):
-    user, token = generate_user(db, "tester")
+    user, token = generate_user("tester")
 
-    with real_api_session(db, token) as api:
+    with real_api_session(token) as api:
         res = api.Ping(api_pb2.PingReq())
 
     assert res.user.user_id == user.id
@@ -54,10 +54,10 @@ def test_ping(db):
 
 
 def test_get_user(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
 
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=user2.username))
         assert res.user_id == user2.id
         assert res.username == user2.username
@@ -65,9 +65,9 @@ def test_get_user(db):
 
 
 def test_update_profile(db):
-    user, token = generate_user(db)
+    user, token = generate_user()
 
-    with api_session(db, token) as api:
+    with api_session(token) as api:
         with pytest.raises(grpc.RpcError) as e:
             api.UpdateProfile(api_pb2.UpdateProfileReq(name=wrappers_pb2.StringValue(value="  ")))
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
@@ -103,26 +103,26 @@ def test_update_profile(db):
 
 
 def test_pending_friend_request_count(db):
-    user1, token1 = generate_user(db, "user1")
-    user2, token2 = generate_user(db, "user2")
-    user3, token3 = generate_user(db, "user3")
+    user1, token1 = generate_user("user1")
+    user2, token2 = generate_user("user2")
+    user3, token3 = generate_user("user3")
 
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         res = api.Ping(api_pb2.PingReq())
         assert res.pending_friend_request_count == 0
 
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         res = api.Ping(api_pb2.PingReq())
         assert res.pending_friend_request_count == 0
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user2.id))
         res = api.Ping(api_pb2.PingReq())
         assert res.pending_friend_request_count == 0
 
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         res = api.Ping(api_pb2.PingReq())
         assert res.pending_friend_request_count == 1
 
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         # check it's there
         res = api.ListFriendRequests(empty_pb2.Empty())
         assert len(res.sent) == 0
@@ -141,12 +141,12 @@ def test_pending_friend_request_count(db):
 
 
 def test_friend_request_flow(db):
-    user1, token1 = generate_user(db, "user1")
-    user2, token2 = generate_user(db, "user2")
-    user3, token3 = generate_user(db, "user3")
+    user1, token1 = generate_user("user1")
+    user2, token2 = generate_user("user2")
+    user3, token3 = generate_user("user3")
 
     # send friend request from user1 to user2
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user2.id))
 
         # check it went through
@@ -157,7 +157,7 @@ def test_friend_request_flow(db):
         assert res.sent[0].state == api_pb2.FriendRequest.FriendRequestStatus.PENDING
         assert res.sent[0].user_id == user2.id
 
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         # check it's there
         res = api.ListFriendRequests(empty_pb2.Empty())
         assert len(res.sent) == 0
@@ -181,7 +181,7 @@ def test_friend_request_flow(db):
         assert len(res.user_ids) == 1
         assert res.user_ids[0] == user1.id
 
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         # check it's gone
         res = api.ListFriendRequests(empty_pb2.Empty())
         assert len(res.sent) == 0
@@ -194,11 +194,11 @@ def test_friend_request_flow(db):
 
 
 def test_cant_friend_request_twice(db):
-    user1, token1 = generate_user(db, "user1")
-    user2, token2 = generate_user(db, "user2")
+    user1, token1 = generate_user("user1")
+    user2, token2 = generate_user("user2")
 
     # send friend request from user1 to user2
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user2.id))
 
         with pytest.raises(grpc.RpcError):
@@ -206,32 +206,32 @@ def test_cant_friend_request_twice(db):
 
 
 def test_cant_friend_request_pending(db):
-    user1, token1 = generate_user(db, "user1")
-    user2, token2 = generate_user(db, "user2")
-    user3, token3 = generate_user(db, "user3")
+    user1, token1 = generate_user("user1")
+    user2, token2 = generate_user("user2")
+    user3, token3 = generate_user("user3")
 
     # send friend request from user1 to user2
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user2.id))
 
-    with api_session(db, token2) as api, pytest.raises(grpc.RpcError):
+    with api_session(token2) as api, pytest.raises(grpc.RpcError):
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user1.id))
 
 
 def test_ListFriends(db):
-    user1, token1 = generate_user(db, "user1")
-    user2, token2 = generate_user(db, "user2")
-    user3, token3 = generate_user(db, "user3")
+    user1, token1 = generate_user("user1")
+    user2, token2 = generate_user("user2")
+    user3, token3 = generate_user("user3")
 
     # send friend request from user1 to user2 and user3
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user2.id))
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user3.id))
 
-    with api_session(db, token3) as api:
+    with api_session(token3) as api:
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user2.id))
 
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         res = api.ListFriendRequests(empty_pb2.Empty())
         assert len(res.received) == 2
 
@@ -257,7 +257,7 @@ def test_ListFriends(db):
         assert user1.id in res.user_ids
         assert user3.id in res.user_ids
 
-    with api_session(db, token3) as api:
+    with api_session(token3) as api:
         res = api.ListFriends(empty_pb2.Empty())
         assert len(res.user_ids) == 1
         assert user2.id in res.user_ids
@@ -274,7 +274,7 @@ def test_ListFriends(db):
         assert user1.id in res.user_ids
         assert user2.id in res.user_ids
 
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         res = api.ListFriends(empty_pb2.Empty())
         assert len(res.user_ids) == 2
         assert user2.id in res.user_ids
@@ -282,22 +282,22 @@ def test_ListFriends(db):
 
 
 def test_mutual_friends(db):
-    user1, token1 = generate_user(db, "user1")
-    user2, token2 = generate_user(db, "user2")
-    user3, token3 = generate_user(db, "user3")
-    user4, token4 = generate_user(db, "user4")
-    user5, token5 = generate_user(db, "user5")
+    user1, token1 = generate_user("user1")
+    user2, token2 = generate_user("user2")
+    user3, token3 = generate_user("user3")
+    user4, token4 = generate_user("user4")
+    user5, token5 = generate_user("user5")
 
     # arrange friends like this: 1<->2, 1<->3, 1<->4, 1<->5, 3<->2, 3<->4,
     # 2<->5 pending
     # so 1 and 2 should have mutual friend 3 only
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user2.id))
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user3.id))
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user4.id))
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user5.id))
 
-    with api_session(db, token3) as api:
+    with api_session(token3) as api:
         res = api.ListFriendRequests(empty_pb2.Empty())
         assert res.received[0].user_id == user1.id
         fr_id = res.received[0].friend_request_id
@@ -305,13 +305,13 @@ def test_mutual_friends(db):
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user2.id))
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user4.id))
 
-    with api_session(db, token5) as api:
+    with api_session(token5) as api:
         res = api.ListFriendRequests(empty_pb2.Empty())
         assert res.received[0].user_id == user1.id
         fr_id = res.received[0].friend_request_id
         api.RespondFriendRequest(api_pb2.RespondFriendRequestReq(friend_request_id=fr_id, accept=True))
 
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         res = api.ListFriendRequests(empty_pb2.Empty())
         assert res.received[0].user_id == user1.id
         fr_id = res.received[0].friend_request_id
@@ -320,7 +320,7 @@ def test_mutual_friends(db):
         fr_id = res.received[1].friend_request_id
         api.RespondFriendRequest(api_pb2.RespondFriendRequestReq(friend_request_id=fr_id, accept=True))
 
-    with api_session(db, token4) as api:
+    with api_session(token4) as api:
         res = api.ListFriendRequests(empty_pb2.Empty())
         assert res.received[0].user_id == user1.id
         fr_id = res.received[0].friend_request_id
@@ -330,23 +330,23 @@ def test_mutual_friends(db):
         api.RespondFriendRequest(api_pb2.RespondFriendRequestReq(friend_request_id=fr_id, accept=True))
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user5.id))
 
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=str(user2.username)))
         assert len(res.mutual_friends) == 1
         assert res.mutual_friends[0].user_id == user3.id
 
     # and other way around same
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=str(user1.username)))
         assert len(res.mutual_friends) == 1
         assert res.mutual_friends[0].user_id == user3.id
 
 
 def test_CancelFriendRequest(db):
-    user1, token1 = generate_user(db, "user1")
-    user2, token2 = generate_user(db, "user2")
+    user1, token1 = generate_user("user1")
+    user2, token2 = generate_user("user2")
 
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user2.id))
 
         res = api.ListFriendRequests(empty_pb2.Empty())
@@ -360,17 +360,17 @@ def test_CancelFriendRequest(db):
 
 
 def test_reject_friend_request(db):
-    user1, token1 = generate_user(db, "user1")
-    user2, token2 = generate_user(db, "user2")
+    user1, token1 = generate_user("user1")
+    user2, token2 = generate_user("user2")
 
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user2.id))
 
         res = api.ListFriendRequests(empty_pb2.Empty())
         assert res.sent[0].state == api_pb2.FriendRequest.FriendRequestStatus.PENDING
         assert res.sent[0].user_id == user2.id
 
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         res = api.ListFriendRequests(empty_pb2.Empty())
         assert res.received[0].state == api_pb2.FriendRequest.FriendRequestStatus.PENDING
         assert res.received[0].user_id == user1.id
@@ -389,7 +389,7 @@ def test_reject_friend_request(db):
         res = api.ListFriends(empty_pb2.Empty())
         assert len(res.user_ids) == 0
 
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         # check it's gone
         res = api.ListFriendRequests(empty_pb2.Empty())
         assert len(res.sent) == 0
@@ -408,12 +408,12 @@ def test_reject_friend_request(db):
 
 
 def test_search(db):
-    user1, token1 = generate_user(db, "user1")
-    user2, token2 = generate_user(db, "user2")
-    user3, token3 = generate_user(db, "user3")
-    user4, token4 = generate_user(db, "user4")
+    user1, token1 = generate_user("user1")
+    user2, token2 = generate_user("user2")
+    user3, token3 = generate_user("user3")
+    user4, token4 = generate_user("user4")
 
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         res = api.Search(api_pb2.SearchReq(query="user"))
         assert len(res.users) == 4
 
@@ -422,53 +422,53 @@ def test_search(db):
 
 
 def test_mutual_friends_self(db):
-    user1, token1 = generate_user(db, "user1")
-    user2, token2 = generate_user(db, "user2")
-    user3, token3 = generate_user(db, "user3")
-    user4, token4 = generate_user(db, "user4")
+    user1, token1 = generate_user("user1")
+    user2, token2 = generate_user("user2")
+    user3, token3 = generate_user("user3")
+    user4, token4 = generate_user("user4")
 
-    make_friends(db, user1, user2)
-    make_friends(db, user2, user3)
-    make_friends(db, user1, user4)
+    make_friends(user1, user2)
+    make_friends(user2, user3)
+    make_friends(user1, user4)
 
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=user3.username))
         assert len(res.mutual_friends) == 1
         assert res.mutual_friends[0].user_id == user2.id
 
-    with api_session(db, token3) as api:
+    with api_session(token3) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=user1.username))
         assert len(res.mutual_friends) == 1
         assert res.mutual_friends[0].user_id == user2.id
 
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=user1.username))
         assert len(res.mutual_friends) == 0
 
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=user2.username))
         assert len(res.mutual_friends) == 0
 
-    with api_session(db, token3) as api:
+    with api_session(token3) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=user3.username))
         assert len(res.mutual_friends) == 0
 
-    with api_session(db, token4) as api:
+    with api_session(token4) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=user4.username))
         assert len(res.mutual_friends) == 0
 
 
 def test_reporting(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
 
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         res = api.Report(
             api_pb2.ReportReq(reported_user_id=user2.id, reason="reason text", description="description text")
         )
     assert isinstance(res, empty_pb2.Empty)
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         entries = session.query(Complaint).all()
 
         assert len(entries) == 1
@@ -479,27 +479,27 @@ def test_reporting(db):
 
     # Test that reporting oneself and reporting nonexisting user fails
     report_req = api_pb2.ReportReq(reported_user_id=user1.id, reason="foo", description="bar")
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         with pytest.raises(grpc.RpcError) as e:
             api.Report(report_req)
     assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
 
     report_req = api_pb2.ReportReq(reported_user_id=0x7FFFFFFFFFFFFFFF, reason="foo", description="bar")
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         with pytest.raises(grpc.RpcError) as e:
             api.Report(report_req)
     assert e.value.code() == grpc.StatusCode.NOT_FOUND
 
 
 def test_references(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
 
     alltypes = set([api_pb2.ReferenceType.FRIEND, api_pb2.ReferenceType.HOSTED, api_pb2.ReferenceType.SURFED])
     # write all three reference types
     for typ in alltypes:
         req = api_pb2.WriteReferenceReq(to_user_id=user2.id, reference_type=typ, text="kinda weird sometimes")
-        with api_session(db, token1) as api:
+        with api_session(token1) as api:
             res = api.WriteReference(req)
         assert isinstance(res, empty_pb2.Empty)
 
@@ -507,7 +507,7 @@ def test_references(db):
     seen_types = set()
     for i in range(3):
         req = api_pb2.GetGivenReferencesReq(from_user_id=user1.id, number=1, start_at=i)
-        with api_session(db, token1) as api:
+        with api_session(token1) as api:
             res = api.GetGivenReferences(req)
         assert res.total_matches == 3
         assert len(res.references) == 1
@@ -523,7 +523,7 @@ def test_references(db):
     seen_types = set()
     for i in range(3):
         req = api_pb2.GetReceivedReferencesReq(to_user_id=user2.id, number=1, start_at=i)
-        with api_session(db, token1) as api:
+        with api_session(token1) as api:
             res = api.GetReceivedReferences(req)
         assert res.total_matches == 3
         assert len(res.references) == 1
@@ -535,17 +535,17 @@ def test_references(db):
     assert seen_types == alltypes
 
     # Check available types
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         res = api.AvailableWriteReferenceTypes(api_pb2.AvailableWriteReferenceTypesReq(to_user_id=user2.id))
     assert res.reference_types == []
 
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         res = api.AvailableWriteReferenceTypes(api_pb2.AvailableWriteReferenceTypesReq(to_user_id=user1.id))
     assert set(res.reference_types) == alltypes
 
     # Forbidden to write a second reference of the same type
     req = api_pb2.WriteReferenceReq(to_user_id=user2.id, reference_type=api_pb2.ReferenceType.HOSTED, text="ok")
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         with pytest.raises(grpc.RpcError) as e:
             api.WriteReference(req)
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
@@ -554,19 +554,19 @@ def test_references(db):
     req = api_pb2.WriteReferenceReq(
         to_user_id=0x7FFFFFFFFFFFFFFF, reference_type=api_pb2.ReferenceType.HOSTED, text="ok"
     )
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         with pytest.raises(grpc.RpcError) as e:
             api.WriteReference(req)
         assert e.value.code() == grpc.StatusCode.NOT_FOUND
 
     # yourself
     req = api_pb2.WriteReferenceReq(to_user_id=user1.id, reference_type=api_pb2.ReferenceType.HOSTED, text="ok")
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         with pytest.raises(grpc.RpcError) as e:
             api.WriteReference(req)
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
 
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         # test the number of references in GetUser and Ping
         res = api.GetUser(api_pb2.GetUserReq(user=user2.username))
         assert res.num_references == 3
@@ -576,10 +576,10 @@ def test_references(db):
 
 
 def test_hosting_preferences(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
 
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=user2.username))
         assert not res.HasField("max_guests")
         assert not res.HasField("multiple_groups")
@@ -601,7 +601,7 @@ def test_hosting_preferences(db):
             )
         )
 
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=user1.username))
         assert res.max_guests.value == 3
         assert not res.HasField("multiple_groups")
@@ -614,7 +614,7 @@ def test_hosting_preferences(db):
         assert not res.HasField("area")
         assert res.house_rules.value == "RULES!"
 
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         # test unsetting
         api.UpdateProfile(
             api_pb2.UpdateProfileReq(

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -15,29 +15,29 @@ def _(testconfig):
 
 
 def test_UsernameValid(db):
-    with auth_api_session(db) as auth_api:
+    with auth_api_session() as auth_api:
         assert auth_api.UsernameValid(auth_pb2.UsernameValidReq(username="test")).valid
 
-    with auth_api_session(db) as auth_api:
+    with auth_api_session() as auth_api:
         assert not auth_api.UsernameValid(auth_pb2.UsernameValidReq(username="")).valid
 
 
 def test_basic_signup(db):
-    with auth_api_session(db) as auth_api:
+    with auth_api_session() as auth_api:
         reply = auth_api.Signup(auth_pb2.SignupReq(email="a@b.com"))
     assert reply.next_step == auth_pb2.SignupRes.SignupStep.SENT_SIGNUP_EMAIL
 
     # read out the signup token directly from the database for now
-    with session_scope(db) as session:
+    with session_scope() as session:
         entry = session.query(SignupToken).filter(SignupToken.email == "a@b.com").one_or_none()
         signup_token = entry.token
 
-    with auth_api_session(db) as auth_api:
+    with auth_api_session() as auth_api:
         reply = auth_api.SignupTokenInfo(auth_pb2.SignupTokenInfoReq(signup_token=signup_token))
 
     assert reply.email == "a@b.com"
 
-    with auth_api_session(db) as auth_api:
+    with auth_api_session() as auth_api:
         reply = auth_api.CompleteSignup(
             auth_pb2.CompleteSignupReq(
                 signup_token=signup_token,
@@ -56,66 +56,66 @@ def test_basic_login(db):
     # Create our test user using signup
     test_basic_signup(db)
 
-    with auth_api_session(db) as auth_api:
+    with auth_api_session() as auth_api:
         reply = auth_api.Login(auth_pb2.LoginReq(user="frodo"))
     assert reply.next_step == auth_pb2.LoginRes.LoginStep.SENT_LOGIN_EMAIL
 
     # backdoor to find login token
-    with session_scope(db) as session:
+    with session_scope() as session:
         entry = session.query(LoginToken).one_or_none()
         login_token = entry.token
 
-    with auth_api_session(db) as auth_api:
+    with auth_api_session() as auth_api:
         reply = auth_api.CompleteTokenLogin(auth_pb2.CompleteTokenLoginReq(login_token=login_token))
     assert isinstance(reply.token, str)
     session_token = reply.token
 
     # log out
-    with auth_api_session(db) as auth_api:
+    with auth_api_session() as auth_api:
         reply = auth_api.Deauthenticate(auth_pb2.DeAuthReq(token=session_token))
 
 
 def test_login_tokens_invalidate_after_use(db):
     test_basic_signup(db)
-    with auth_api_session(db) as auth_api:
+    with auth_api_session() as auth_api:
         reply = auth_api.Login(auth_pb2.LoginReq(user="frodo"))
     assert reply.next_step == auth_pb2.LoginRes.LoginStep.SENT_LOGIN_EMAIL
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         login_token = session.query(LoginToken).one_or_none().token
 
-    with auth_api_session(db) as auth_api:
+    with auth_api_session() as auth_api:
         session_token = auth_api.CompleteTokenLogin(auth_pb2.CompleteTokenLoginReq(login_token=login_token)).token
 
-    with auth_api_session(db) as auth_api, pytest.raises(grpc.RpcError):
+    with auth_api_session() as auth_api, pytest.raises(grpc.RpcError):
         # check we can't login again
         auth_api.CompleteTokenLogin(auth_pb2.CompleteTokenLoginReq(login_token=login_token))
 
 
 def test_banned_user(db):
     test_basic_signup(db)
-    with auth_api_session(db) as auth_api:
+    with auth_api_session() as auth_api:
         reply = auth_api.Login(auth_pb2.LoginReq(user="frodo"))
     assert reply.next_step == auth_pb2.LoginRes.LoginStep.SENT_LOGIN_EMAIL
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         login_token = session.query(LoginToken).one_or_none().token
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         session.query(User).one().is_banned = True
 
-    with auth_api_session(db) as auth_api:
+    with auth_api_session() as auth_api:
         with pytest.raises(grpc.RpcError):
             auth_api.CompleteTokenLogin(auth_pb2.CompleteTokenLoginReq(login_token=login_token))
 
 
 def test_invalid_token(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
 
     wrong_token = random_hex(32)
 
-    with real_api_session(db, wrong_token) as api, pytest.raises(grpc.RpcError) as e:
+    with real_api_session(wrong_token) as api, pytest.raises(grpc.RpcError) as e:
         res = api.GetUser(api_pb2.GetUserReq(user=user2.username))
 
     assert e.value.code() == grpc.StatusCode.UNAUTHENTICATED
@@ -123,37 +123,37 @@ def test_invalid_token(db):
 
 
 def test_password_reset(db, fast_passwords):
-    user, token = generate_user(db, hashed_password=hash_password("mypassword"))
+    user, token = generate_user(hashed_password=hash_password("mypassword"))
 
-    with auth_api_session(db) as auth_api:
+    with auth_api_session() as auth_api:
         res = auth_api.ResetPassword(
             auth_pb2.ResetPasswordReq(
                 user=user.username,
             )
         )
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         token = session.query(PasswordResetToken).one_or_none().token
 
-    with auth_api_session(db) as auth_api:
+    with auth_api_session() as auth_api:
         res = auth_api.CompletePasswordReset(auth_pb2.CompletePasswordResetReq(password_reset_token=token))
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         user = session.query(User).one()
         assert user.hashed_password is None
 
 
 def test_password_reset_no_such_user(db):
-    user, token = generate_user(db)
+    user, token = generate_user()
 
-    with auth_api_session(db) as auth_api:
+    with auth_api_session() as auth_api:
         res = auth_api.ResetPassword(
             auth_pb2.ResetPasswordReq(
                 user="nonexistentuser",
             )
         )
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         res = session.query(PasswordResetToken).one_or_none()
 
     assert res is None
@@ -161,24 +161,24 @@ def test_password_reset_no_such_user(db):
 
 def test_password_reset_invalid_token(db, fast_passwords):
     password = random_hex()
-    user, token = generate_user(db, hashed_password=hash_password(password))
+    user, token = generate_user(hashed_password=hash_password(password))
 
-    with auth_api_session(db) as auth_api:
+    with auth_api_session() as auth_api:
         res = auth_api.ResetPassword(
             auth_pb2.ResetPasswordReq(
                 user=user.username,
             )
         )
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         token = session.query(PasswordResetToken).one_or_none().token
 
-    with auth_api_session(db) as auth_api, pytest.raises(grpc.RpcError) as e:
+    with auth_api_session() as auth_api, pytest.raises(grpc.RpcError) as e:
         res = auth_api.CompletePasswordReset(auth_pb2.CompletePasswordResetReq(password_reset_token="wrongtoken"))
     assert e.value.code() == grpc.StatusCode.UNAUTHENTICATED
     assert e.value.details() == errors.INVALID_TOKEN
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         user = session.query(User).one()
         assert user.hashed_password == hash_password(password)
 

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -16,14 +16,14 @@ def _(testconfig):
 
 
 def test_list_group_chats(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
 
-    make_friends(db, user2, user1)
-    make_friends(db, user1, user3)
+    make_friends(user2, user1)
+    make_friends(user1, user3)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         # no threads initially
         res = c.ListGroupChats(conversations_pb2.ListGroupChatsReq())
         assert len(res.group_chats) == 0
@@ -44,27 +44,27 @@ def test_list_group_chats(db):
         assert len(res.group_chats) == 2
         assert res.no_more
 
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         res = c.ListGroupChats(conversations_pb2.ListGroupChatsReq())
         assert len(res.group_chats) == 2
         assert res.no_more
 
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         res = c.ListGroupChats(conversations_pb2.ListGroupChatsReq())
         assert len(res.group_chats) == 1
         assert res.no_more
 
 
 def test_list_empty_group_chats(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
 
-    make_friends(db, user1, user3)
-    make_friends(db, user2, user1)
-    make_friends(db, user2, user3)
+    make_friends(user1, user3)
+    make_friends(user2, user1)
+    make_friends(user2, user3)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         res = c.ListGroupChats(conversations_pb2.ListGroupChatsReq())
         assert len(res.group_chats) == 0
 
@@ -75,7 +75,7 @@ def test_list_empty_group_chats(db):
         assert len(res.group_chats) == 2
         assert res.no_more
 
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         res = c.ListGroupChats(conversations_pb2.ListGroupChatsReq())
         assert len(res.group_chats) == 2
         assert res.no_more
@@ -86,7 +86,7 @@ def test_list_empty_group_chats(db):
         assert len(res.group_chats) == 3
         assert res.no_more
 
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         res = c.ListGroupChats(conversations_pb2.ListGroupChatsReq())
         assert len(res.group_chats) == 2
         assert res.no_more
@@ -94,19 +94,19 @@ def test_list_empty_group_chats(db):
 
 def test_list_group_chats_ordering(db):
     # user is member of 5 group chats, order them correctly
-    user, token = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
-    user4, token4 = generate_user(db)
+    user, token = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
+    user4, token4 = generate_user()
 
-    make_friends(db, user2, user)
-    make_friends(db, user2, user3)
-    make_friends(db, user2, user4)
-    make_friends(db, user3, user)
-    make_friends(db, user3, user4)
-    make_friends(db, user, user4)
+    make_friends(user2, user)
+    make_friends(user2, user3)
+    make_friends(user2, user4)
+    make_friends(user3, user)
+    make_friends(user3, user4)
+    make_friends(user, user4)
 
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         res = c.CreateGroupChat(
             conversations_pb2.CreateGroupChatReq(
                 recipient_user_ids=[user.id], title=wrappers_pb2.StringValue(value="Chat 0")
@@ -126,7 +126,7 @@ def test_list_group_chats_ordering(db):
         )
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=res.group_chat_id, text="Test message"))
 
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         res = c.CreateGroupChat(
             conversations_pb2.CreateGroupChatReq(
                 recipient_user_ids=[user.id, user2.id, user4.id], title=wrappers_pb2.StringValue(value="Chat 3")
@@ -134,7 +134,7 @@ def test_list_group_chats_ordering(db):
         )
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=res.group_chat_id, text="Test message"))
 
-    with conversations_session(db, token) as c:
+    with conversations_session(token) as c:
         res = c.CreateGroupChat(
             conversations_pb2.CreateGroupChatReq(
                 recipient_user_ids=[user2.id, user3.id, user4.id], title=wrappers_pb2.StringValue(value="Chat 4")
@@ -171,19 +171,19 @@ def test_list_group_chats_ordering_after_left(db):
     # user is member to 4 group chats, and has left one.
     # The one user left has the most recent message, but user left before then,
     # this should display as e.g. 3rd most recent depending on last message when they were in the chat
-    user, token = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
-    user4, token4 = generate_user(db)
+    user, token = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
+    user4, token4 = generate_user()
 
-    make_friends(db, user2, user)
-    make_friends(db, user2, user3)
-    make_friends(db, user2, user4)
-    make_friends(db, user3, user)
-    make_friends(db, user3, user4)
-    make_friends(db, user, user4)
+    make_friends(user2, user)
+    make_friends(user2, user3)
+    make_friends(user2, user4)
+    make_friends(user3, user)
+    make_friends(user3, user4)
+    make_friends(user, user4)
 
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         res = c.CreateGroupChat(
             conversations_pb2.CreateGroupChatReq(
                 recipient_user_ids=[user.id], title=wrappers_pb2.StringValue(value="Chat 0")
@@ -205,7 +205,7 @@ def test_list_group_chats_ordering_after_left(db):
         chat2_id = res.group_chat_id
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=chat2_id, text="Test message"))
 
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         res = c.CreateGroupChat(
             conversations_pb2.CreateGroupChatReq(
                 recipient_user_ids=[user.id, user2.id, user4.id], title=wrappers_pb2.StringValue(value="Chat 3")
@@ -213,7 +213,7 @@ def test_list_group_chats_ordering_after_left(db):
         )
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=res.group_chat_id, text="Test message"))
 
-    with conversations_session(db, token) as c:
+    with conversations_session(token) as c:
         res = c.CreateGroupChat(
             conversations_pb2.CreateGroupChatReq(
                 recipient_user_ids=[user2.id, user3.id, user4.id], title=wrappers_pb2.StringValue(value="Chat 4")
@@ -224,11 +224,11 @@ def test_list_group_chats_ordering_after_left(db):
         # leave chat
         c.LeaveGroupChat(conversations_pb2.LeaveGroupChatReq(group_chat_id=left_chat_id))
 
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=chat2_id, text="Test message"))
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=left_chat_id, text="Test message"))
 
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         # other user sends a message to that chat
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=left_chat_id, text="Another test message"))
         res = c.ListGroupChats(conversations_pb2.ListGroupChatsReq())
@@ -239,7 +239,7 @@ def test_list_group_chats_ordering_after_left(db):
         assert res.group_chats[3].title == "Chat 3"
         assert res.group_chats[4].title == "Chat 0"
 
-    with conversations_session(db, token) as c:
+    with conversations_session(token) as c:
         # we can't see the new message since we left before it was sent
         res = c.ListGroupChats(conversations_pb2.ListGroupChatsReq())
         assert len(res.group_chats) == 5
@@ -251,13 +251,13 @@ def test_list_group_chats_ordering_after_left(db):
 
 
 def test_get_group_chat_messages(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
 
-    make_friends(db, user1, user2)
+    make_friends(user1, user2)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         # create some threads with messages
         res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id]))
         group_chat_id = res.group_chat_id
@@ -274,23 +274,23 @@ def test_get_group_chat_messages(db):
         assert res.messages[2].WhichOneof("content") == "chat_created"
 
     # test that another user can't access the thread
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         res = c.GetGroupChatMessages(conversations_pb2.GetGroupChatMessagesReq(group_chat_id=group_chat_id))
         assert len(res.messages) == 0
 
 
 def test_get_group_chat_messages_pagination(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    make_friends(db, user1, user2)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    make_friends(user1, user2)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id]))
         group_chat_id = res.group_chat_id
         for i in range(30):
             c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text=str(i)))
 
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         res = c.GetGroupChatMessages(conversations_pb2.GetGroupChatMessagesReq(group_chat_id=group_chat_id))
         # pagination
         assert len(res.messages) == 20
@@ -309,16 +309,16 @@ def test_get_group_chat_messages_pagination(db):
 
 
 def test_get_group_chat_messages_joined_left(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
-    user4, token4 = generate_user(db)
-    make_friends(db, user1, user2)
-    make_friends(db, user1, user3)
-    make_friends(db, user1, user4)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
+    user4, token4 = generate_user()
+    make_friends(user1, user2)
+    make_friends(user1, user3)
+    make_friends(user1, user4)
     start_time = now()
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id, user4.id]))
         group_chat_id = res.group_chat_id
 
@@ -334,7 +334,7 @@ def test_get_group_chat_messages_joined_left(db):
         # created + 10 normal + invited + normal
         assert len(res.messages) == 13
 
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         # can only see last message after invited
         res = c.GetGroupChatMessages(conversations_pb2.GetGroupChatMessagesReq(group_chat_id=group_chat_id))
         # joined + normal
@@ -343,7 +343,7 @@ def test_get_group_chat_messages_joined_left(db):
 
         c.LeaveGroupChat(conversations_pb2.LeaveGroupChatReq(group_chat_id=group_chat_id))
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="11"))
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="12"))
 
@@ -352,7 +352,7 @@ def test_get_group_chat_messages_joined_left(db):
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="13"))
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="14"))
 
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         # can only see last message after invited
         res = c.GetGroupChatMessages(conversations_pb2.GetGroupChatMessagesReq(group_chat_id=group_chat_id))
         # joined + normal + left + invite + 2 normal
@@ -366,14 +366,14 @@ def test_get_group_chat_messages_joined_left(db):
 
 
 def test_get_group_chat_info(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
 
-    make_friends(db, user1, user2)
-    make_friends(db, user3, user1)
+    make_friends(user1, user2)
+    make_friends(user3, user1)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         # create some threads with messages
         res = c.CreateGroupChat(
             conversations_pb2.CreateGroupChatReq(
@@ -407,15 +407,15 @@ def test_get_group_chat_info(db):
 
 
 def test_get_group_chat_info_denied(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
-    user4, token4 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
+    user4, token4 = generate_user()
 
-    make_friends(db, user1, user2)
-    make_friends(db, user3, user1)
+    make_friends(user1, user2)
+    make_friends(user3, user1)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         # create a group chat with messages
         res = c.CreateGroupChat(
             conversations_pb2.CreateGroupChatReq(
@@ -425,23 +425,23 @@ def test_get_group_chat_info_denied(db):
         group_chat_id = res.group_chat_id
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message 1"))
 
-    with conversations_session(db, token4) as c:
+    with conversations_session(token4) as c:
         with pytest.raises(grpc.RpcError) as e:
             res = c.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=group_chat_id))
         assert e.value.code() == grpc.StatusCode.NOT_FOUND
 
 
 def test_get_group_chat_info_left(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
-    user4, token4 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
+    user4, token4 = generate_user()
 
-    make_friends(db, user1, user2)
-    make_friends(db, user3, user1)
-    make_friends(db, user1, user4)
+    make_friends(user1, user2)
+    make_friends(user3, user1)
+    make_friends(user1, user4)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         # create a group chat with messages
         res = c.CreateGroupChat(
             conversations_pb2.CreateGroupChatReq(
@@ -451,13 +451,13 @@ def test_get_group_chat_info_left(db):
         group_chat_id = res.group_chat_id
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message 1"))
 
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         c.LeaveGroupChat(conversations_pb2.LeaveGroupChatReq(group_chat_id=group_chat_id))
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         c.InviteToGroupChat(conversations_pb2.InviteToGroupChatReq(group_chat_id=group_chat_id, user_id=user4.id))
 
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         # this user left when user4 wasn't a member,
         # so the returned members should be user1, user2, and user3 only
         res = c.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=group_chat_id))
@@ -469,12 +469,12 @@ def test_get_group_chat_info_left(db):
 
 
 def test_edit_group_chat(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
-    make_friends(db, user1, user2)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
+    make_friends(user1, user2)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         # create some threads with messages
         res = c.CreateGroupChat(
             conversations_pb2.CreateGroupChatReq(
@@ -495,7 +495,7 @@ def test_edit_group_chat(db):
         assert not res.only_admins_invite
 
     # make sure non-admin is not allowed to modify
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         with pytest.raises(grpc.RpcError) as e:
             c.EditGroupChat(
                 conversations_pb2.EditGroupChatReq(
@@ -507,7 +507,7 @@ def test_edit_group_chat(db):
         assert e.value.code() == grpc.StatusCode.PERMISSION_DENIED
 
     # make sure non-recipient is not allowed to modify
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         with pytest.raises(grpc.RpcError) as e:
             c.EditGroupChat(
                 conversations_pb2.EditGroupChatReq(
@@ -520,15 +520,15 @@ def test_edit_group_chat(db):
 
 
 def test_make_remove_group_chat_admin(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
 
-    make_friends(db, user1, user2)
-    make_friends(db, user1, user3)
-    make_friends(db, user2, user3)
+    make_friends(user1, user2)
+    make_friends(user1, user3)
+    make_friends(user2, user3)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         # create some threads with messages
         res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id, user3.id]))
         group_chat_id = res.group_chat_id
@@ -549,19 +549,19 @@ def test_make_remove_group_chat_admin(db):
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
         assert e.value.details() == errors.ALREADY_ADMIN
 
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         res = c.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=group_chat_id))
         assert user1.id in res.admin_user_ids
         assert user2.id in res.admin_user_ids
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         c.RemoveGroupChatAdmin(conversations_pb2.RemoveGroupChatAdminReq(group_chat_id=group_chat_id, user_id=user2.id))
 
         res = c.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=group_chat_id))
         assert user1.id in res.admin_user_ids
         assert not user2.id in res.admin_user_ids
 
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         # shouldn't be able to make admin if not admin
         with pytest.raises(grpc.RpcError) as e:
             c.MakeGroupChatAdmin(conversations_pb2.MakeGroupChatAdminReq(group_chat_id=group_chat_id, user_id=user3.id))
@@ -569,13 +569,13 @@ def test_make_remove_group_chat_admin(db):
 
 
 def test_send_message(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
-    make_friends(db, user1, user2)
-    make_friends(db, user1, user3)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
+    make_friends(user1, user2)
+    make_friends(user1, user3)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id]))
         group_chat_id = res.group_chat_id
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message 1"))
@@ -585,32 +585,32 @@ def test_send_message(db):
         assert res.messages[0].author_user_id == user1.id
 
     # can't send message if not in chat
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         with pytest.raises(grpc.RpcError) as e:
             c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message 2"))
         assert e.value.code() == grpc.StatusCode.NOT_FOUND
 
 
 def test_leave_invite_to_group_chat(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
-    user4, token4 = generate_user(db)
-    user5, token5 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
+    user4, token4 = generate_user()
+    user5, token5 = generate_user()
 
-    make_friends(db, user1, user2)
-    make_friends(db, user1, user3)
-    make_friends(db, user1, user5)
-    make_friends(db, user2, user3)
-    make_friends(db, user4, user3)
+    make_friends(user1, user2)
+    make_friends(user1, user3)
+    make_friends(user1, user5)
+    make_friends(user2, user3)
+    make_friends(user4, user3)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id, user5.id]))
         group_chat_id = res.group_chat_id
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message 1"))
 
     # other user not in chat
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         with pytest.raises(grpc.RpcError) as e:
             res = c.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=group_chat_id))
         assert e.value.code() == grpc.StatusCode.NOT_FOUND
@@ -623,7 +623,7 @@ def test_leave_invite_to_group_chat(db):
             res = c.LeaveGroupChat(conversations_pb2.LeaveGroupChatReq(group_chat_id=group_chat_id))
         assert e.value.code() == grpc.StatusCode.NOT_FOUND
 
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         res = c.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=group_chat_id))
         assert not user3.id in res.member_user_ids
 
@@ -635,7 +635,7 @@ def test_leave_invite_to_group_chat(db):
         assert e.value.code() == grpc.StatusCode.PERMISSION_DENIED
         c.LeaveGroupChat(conversations_pb2.LeaveGroupChatReq(group_chat_id=group_chat_id))
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         # can't invite non-friend
         with pytest.raises(grpc.RpcError) as e:
             c.InviteToGroupChat(conversations_pb2.InviteToGroupChatReq(group_chat_id=group_chat_id, user_id=user4.id))
@@ -655,7 +655,7 @@ def test_leave_invite_to_group_chat(db):
             )
         )
 
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         c.InviteToGroupChat(conversations_pb2.InviteToGroupChatReq(group_chat_id=group_chat_id, user_id=user2.id))
         res = c.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=group_chat_id))
         assert user2.id in res.member_user_ids
@@ -666,30 +666,30 @@ def test_group_chats_with_messages_before_join(db):
     If user 1 and 2 have a group chat and send messages, then add user 3; user 3
     should still see the group chat!
     """
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
-    user4, token4 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
+    user4, token4 = generate_user()
 
-    make_friends(db, user1, user2)
-    make_friends(db, user1, user3)
-    make_friends(db, user2, user3)
-    make_friends(db, user1, user4)
+    make_friends(user1, user2)
+    make_friends(user1, user3)
+    make_friends(user2, user3)
+    make_friends(user1, user4)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id, user4.id]))
         group_chat_id = res.group_chat_id
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message 1"))
 
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message 2"))
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message 3"))
 
         c.InviteToGroupChat(conversations_pb2.InviteToGroupChatReq(group_chat_id=group_chat_id, user_id=user3.id))
 
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         # should work
         c.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=group_chat_id))
 
@@ -698,15 +698,15 @@ def test_group_chats_with_messages_before_join(db):
 
 
 def test_invite_to_dm(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
 
-    make_friends(db, user1, user2)
-    make_friends(db, user1, user3)
-    make_friends(db, user2, user3)
+    make_friends(user1, user2)
+    make_friends(user1, user3)
+    make_friends(user2, user3)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id]))
         group_chat_id = res.group_chat_id
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message 1"))
@@ -719,15 +719,15 @@ def test_invite_to_dm(db):
 
 
 def test_sole_admin_leaves(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
 
-    make_friends(db, user1, user2)
-    make_friends(db, user1, user3)
-    make_friends(db, user2, user3)
+    make_friends(user1, user2)
+    make_friends(user1, user3)
+    make_friends(user2, user3)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id, user3.id]))
         group_chat_id = res.group_chat_id
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message 1"))
@@ -738,26 +738,26 @@ def test_sole_admin_leaves(db):
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
         assert e.value.details() == errors.LAST_ADMIN_CANT_LEAVE
 
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         c.LeaveGroupChat(conversations_pb2.LeaveGroupChatReq(group_chat_id=group_chat_id))
 
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         c.LeaveGroupChat(conversations_pb2.LeaveGroupChatReq(group_chat_id=group_chat_id))
 
     # sole admin can leave when last in chat
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         c.LeaveGroupChat(conversations_pb2.LeaveGroupChatReq(group_chat_id=group_chat_id))
 
 
 def test_search_messages(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
 
-    make_friends(db, user1, user2)
-    make_friends(db, user1, user3)
+    make_friends(user1, user2)
+    make_friends(user1, user3)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         # create some threads with messages
         res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id]))
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=res.group_chat_id, text="Test message 1"))
@@ -774,22 +774,22 @@ def test_search_messages(db):
         assert len(res.results) == 0
 
     # outside user doesn't get results
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         res = c.SearchMessages(conversations_pb2.SearchMessagesReq(query="Test message"))
         assert len(res.results) == 0
 
 
 def test_search_messages_left_joined(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
-    user4, token4 = generate_user(db)
-    make_friends(db, user1, user2)
-    make_friends(db, user1, user3)
-    make_friends(db, user1, user4)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
+    user4, token4 = generate_user()
+    make_friends(user1, user2)
+    make_friends(user1, user3)
+    make_friends(user1, user4)
     start_time = now()
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id, user4.id]))
         group_chat_id = res.group_chat_id
         for i in range(10):
@@ -801,7 +801,7 @@ def test_search_messages_left_joined(db):
 
         assert len(res.results) == 11
 
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         # can only see last message after invited
         res = c.SearchMessages(conversations_pb2.SearchMessagesReq(query="Test message"))
 
@@ -810,14 +810,14 @@ def test_search_messages_left_joined(db):
 
         c.LeaveGroupChat(conversations_pb2.LeaveGroupChatReq(group_chat_id=group_chat_id))
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message 11"))
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message 12"))
         c.InviteToGroupChat(conversations_pb2.InviteToGroupChatReq(group_chat_id=group_chat_id, user_id=user3.id))
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message 13"))
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message 14"))
 
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         # can only see last message after invited
         res = c.SearchMessages(conversations_pb2.SearchMessagesReq(query="Test message"))
         assert len(res.results) == 3
@@ -827,15 +827,15 @@ def test_search_messages_left_joined(db):
 
 
 def test_admin_behaviour(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
 
-    make_friends(db, user1, user2)
-    make_friends(db, user1, user3)
-    make_friends(db, user2, user3)
+    make_friends(user1, user2)
+    make_friends(user1, user3)
+    make_friends(user2, user3)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         gcid = c.CreateGroupChat(
             conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id, user3.id])
         ).group_chat_id
@@ -845,7 +845,7 @@ def test_admin_behaviour(db):
         assert user1.id in res.admin_user_ids
         assert user2.id in res.admin_user_ids
 
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         with pytest.raises(grpc.RpcError) as e:
             c.MakeGroupChatAdmin(conversations_pb2.MakeGroupChatAdminReq(group_chat_id=gcid, user_id=user3.id))
         assert e.value.code() == grpc.StatusCode.PERMISSION_DENIED
@@ -857,7 +857,7 @@ def test_admin_behaviour(db):
         assert user1.id in res.admin_user_ids
         assert user2.id in res.admin_user_ids
 
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         c.MakeGroupChatAdmin(conversations_pb2.MakeGroupChatAdminReq(group_chat_id=gcid, user_id=user3.id))
         res = c.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=gcid))
         assert len(res.admin_user_ids) == 3
@@ -871,7 +871,7 @@ def test_admin_behaviour(db):
         assert user2.id in res.admin_user_ids
         assert user3.id in res.admin_user_ids
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         with pytest.raises(grpc.RpcError):
             c.MakeGroupChatAdmin(conversations_pb2.MakeGroupChatAdminReq(group_chat_id=gcid, user_id=user1.id))
         with pytest.raises(grpc.RpcError):
@@ -883,14 +883,14 @@ def test_admin_behaviour(db):
         assert user2.id in res.admin_user_ids
         assert user3.id in res.admin_user_ids
 
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         # can demote self if there are other admins
         c.RemoveGroupChatAdmin(conversations_pb2.RemoveGroupChatAdminReq(group_chat_id=gcid, user_id=user2.id))
         res = c.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=gcid))
         assert len(res.admin_user_ids) == 1
         assert user3.id in res.admin_user_ids
 
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         with pytest.raises(grpc.RpcError) as e:
             c.RemoveGroupChatAdmin(conversations_pb2.RemoveGroupChatAdminReq(group_chat_id=gcid, user_id=user3.id))
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
@@ -909,30 +909,30 @@ def test_admin_behaviour(db):
 
         c.LeaveGroupChat(conversations_pb2.LeaveGroupChatReq(group_chat_id=gcid))
 
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         c.LeaveGroupChat(conversations_pb2.LeaveGroupChatReq(group_chat_id=gcid))
 
     # last participant must be admin but can leave to orphan chat
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         c.LeaveGroupChat(conversations_pb2.LeaveGroupChatReq(group_chat_id=gcid))
 
 
 def test_last_seen(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
 
-    make_friends(db, user1, user2)
-    make_friends(db, user1, user3)
-    make_friends(db, user2, user3)
+    make_friends(user1, user2)
+    make_friends(user1, user3)
+    make_friends(user2, user3)
 
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         # this is just here to mess up any issues we get if we pretend there's only one group chat ever
         gcid_distraction = c.CreateGroupChat(
             conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id, user1.id])
         ).group_chat_id
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         gcid = c.CreateGroupChat(
             conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id, user3.id])
         ).group_chat_id
@@ -956,7 +956,7 @@ def test_last_seen(db):
         res = c.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=gcid))
         assert res.unseen_message_count == 0
 
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         res = c.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=gcid))
         # created + 6 normal
         assert res.unseen_message_count == 7
@@ -976,7 +976,7 @@ def test_last_seen(db):
         res = c.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=gcid))
         assert res.unseen_message_count == 0
 
-    with conversations_session(db, token3) as c:
+    with conversations_session(token3) as c:
         res = c.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=gcid))
         # created + 7 normal
         assert res.unseen_message_count == 8
@@ -988,15 +988,15 @@ def test_last_seen(db):
 
 
 def test_one_dm_per_pair(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
 
-    make_friends(db, user1, user2)
-    make_friends(db, user1, user3)
-    make_friends(db, user2, user3)
+    make_friends(user1, user2)
+    make_friends(user1, user3)
+    make_friends(user2, user3)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         # create DM with user 2
         res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id]))
         assert res.is_dm
@@ -1019,7 +1019,7 @@ def test_one_dm_per_pair(db):
         res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id, user3.id]))
         assert not res.is_dm
 
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         # can create DM with user 3
         res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user3.id]))
         assert res.is_dm
@@ -1031,15 +1031,15 @@ def test_one_dm_per_pair(db):
 
 
 def test_GetDirectMessage(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
 
-    make_friends(db, user1, user2)
-    make_friends(db, user1, user3)
-    make_friends(db, user2, user3)
+    make_friends(user1, user2)
+    make_friends(user1, user3)
+    make_friends(user2, user3)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         # no group chat with user 2
         with pytest.raises(grpc.RpcError) as e:
             res = c.GetDirectMessage(conversations_pb2.GetDirectMessageReq(user_id=user2.id))
@@ -1067,7 +1067,7 @@ def test_GetDirectMessage(db):
         res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id, user3.id]))
         assert not res.is_dm
 
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         # can create DM with user 3
         res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user3.id]))
         assert res.is_dm
@@ -1079,23 +1079,23 @@ def test_GetDirectMessage(db):
 
 
 def test_total_unseen(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
 
     # distractions
-    user4, token4 = generate_user(db)
+    user4, token4 = generate_user()
 
-    make_friends(db, user1, user2)
-    make_friends(db, user1, user3)
-    make_friends(db, user2, user3)
+    make_friends(user1, user2)
+    make_friends(user1, user3)
+    make_friends(user2, user3)
 
     # distractions
-    make_friends(db, user1, user4)
+    make_friends(user1, user4)
 
     start_time = now()
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         # distractions
         gcid_distraction = c.CreateGroupChat(
             conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user4.id])
@@ -1113,22 +1113,22 @@ def test_total_unseen(db):
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=gcid_distraction, text=f"distraction..."))
 
     # messages are automatically marked as seen when you send a new message
-    with api_session(db, token1) as api:
+    with api_session(token1) as api:
         assert api.Ping(api_pb2.PingReq()).unseen_message_count == 0
 
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         # chat created + 6 normal messages
         assert api.Ping(api_pb2.PingReq()).unseen_message_count == 7
 
     # now leave chat with user2
-    with conversations_session(db, token2) as c:
+    with conversations_session(token2) as c:
         c.LeaveGroupChat(conversations_pb2.LeaveGroupChatReq(group_chat_id=gcid))
 
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         # seen messages becomes 0 when leaving
         assert api.Ping(api_pb2.PingReq()).unseen_message_count == 0
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         # distractions
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=gcid_distraction, text=f"distraction..."))
 
@@ -1139,11 +1139,11 @@ def test_total_unseen(db):
         # distractions
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=gcid_distraction, text=f"distraction..."))
 
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         # seen messages becomes 0 when leaving
         assert api.Ping(api_pb2.PingReq()).unseen_message_count == 0
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         # add user 2 back
         c.InviteToGroupChat(conversations_pb2.InviteToGroupChatReq(group_chat_id=gcid, user_id=user2.id))
 
@@ -1154,20 +1154,20 @@ def test_total_unseen(db):
         # distractions
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=gcid_distraction, text=f"distraction..."))
 
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         # joined + 12 normal
         assert api.Ping(api_pb2.PingReq()).unseen_message_count == 13
 
 
 def test_regression_ListGroupChats_pagination(db):
-    user1, token1 = generate_user(db)
-    user2, token2 = generate_user(db)
-    user3, token3 = generate_user(db)
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
 
-    make_friends(db, user1, user2)
-    make_friends(db, user1, user3)
+    make_friends(user1, user2)
+    make_friends(user1, user3)
 
-    with conversations_session(db, token1) as c:
+    with conversations_session(token1) as c:
         # tuples of (group_chat_id, message_id)
         group_chat_and_message_ids = []
         for i in range(50):

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -31,11 +31,11 @@ def _(testconfig):
 
 
 def test_login_email(db):
-    user, api_token = generate_user(db)
+    user, api_token = generate_user()
 
     message_id = random_hex(64)
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         login_token, expiry_text = new_login_token(session, user)
 
         @create_autospec
@@ -53,12 +53,12 @@ def test_login_email(db):
 
 
 def test_signup_email(db):
-    user, api_token = generate_user(db)
+    user, api_token = generate_user()
 
     request_email = f"{random_hex(12)}@couchers.org.invalid"
     message_id = random_hex(64)
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         token, expiry_text = new_signup_token(session, request_email)
 
         @create_autospec
@@ -75,9 +75,9 @@ def test_signup_email(db):
 
 
 def test_report_email(db):
-    with session_scope(db):
-        user_author, api_token_author = generate_user(db)
-        user_reported, api_token_reported = generate_user(db)
+    with session_scope():
+        user_author, api_token_author = generate_user()
+        user_reported, api_token_reported = generate_user()
 
         complaint = Complaint(
             author_user=user_author, reported_user=user_reported, reason=random_hex(64), description=random_hex(256)
@@ -106,9 +106,9 @@ def test_report_email(db):
 
 
 def test_host_request_email(db):
-    with session_scope(db) as session:
-        from_user, api_token_from = generate_user(db)
-        to_user, api_token_to = generate_user(db)
+    with session_scope() as session:
+        from_user, api_token_from = generate_user()
+        to_user, api_token_to = generate_user()
         from_date = "2020-01-01"
         to_date = "2020-01-05"
 
@@ -155,7 +155,7 @@ def test_host_request_email(db):
 
 
 def test_message_received_email(db):
-    user, api_token = generate_user(db)
+    user, api_token = generate_user()
 
     message_id = random_hex(64)
 
@@ -174,9 +174,9 @@ def test_message_received_email(db):
 
 
 def test_friend_request_email(db):
-    with session_scope(db) as session:
-        from_user, api_token_from = generate_user(db)
-        to_user, api_token_to = generate_user(db)
+    with session_scope() as session:
+        from_user, api_token_from = generate_user()
+        to_user, api_token_to = generate_user()
         friend_relationship = FriendRelationship(from_user=from_user, to_user=to_user, status=FriendStatus.pending)
 
         message_id = random_hex(64)
@@ -208,9 +208,9 @@ def test_email_patching_fails(db):
     printing function was called instead, this makes sure the patching is
     actually done
     """
-    with session_scope(db) as session:
-        from_user, api_token_from = generate_user(db)
-        to_user, api_token_to = generate_user(db)
+    with session_scope() as session:
+        from_user, api_token_from = generate_user()
+        to_user, api_token_to = generate_user()
         friend_relationship = FriendRelationship(from_user=from_user, to_user=to_user, status=FriendStatus.pending)
 
         patched_msg = random_hex(64)

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -8,7 +8,6 @@ import grpc
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.event import listen, remove
-from sqlalchemy.orm import sessionmaker
 
 from couchers.config import config
 from couchers.crypto import random_hex

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -9,11 +9,10 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.event import listen, remove
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import NullPool
 
 from couchers.config import config
 from couchers.crypto import random_hex
-from couchers.db import apply_migrations, session_scope
+from couchers.db import apply_migrations, get_engine, session_scope
 from couchers.models import Base, FriendRelationship, FriendStatus, User
 from couchers.servicers.account import Account
 from couchers.servicers.api import API
@@ -48,22 +47,21 @@ def db(request):
     # os.environ["TZ"] = "Etc/UTC"
     os.environ["TZ"] = "America/New_York"
 
-    engine = create_engine(config["DATABASE_CONNECTION_STRING"], poolclass=NullPool)
-
     # drop everything currently in the database
-    engine.execute("DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
+    with session_scope() as session:
+        session.execute("DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
 
     if request.param == "migrations":
         # rebuild it with alembic migrations
         apply_migrations()
     else:
         # create everything from the current models, not incrementally through migrations
-        Base.metadata.create_all(engine)
+        Base.metadata.create_all(get_engine())
 
-    return sessionmaker(bind=engine)
+    yield
 
 
-def generate_user(db, *_, **kwargs):
+def generate_user(*_, **kwargs):
     """
     Create a new user, return session token
 
@@ -71,9 +69,9 @@ def generate_user(db, *_, **kwargs):
 
     Use this most of the time
     """
-    auth = Auth(db)
+    auth = Auth()
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         # default args
         username = "test_user_" + random_hex(16)
         user_opts = {
@@ -118,8 +116,8 @@ def generate_user(db, *_, **kwargs):
     return user, token
 
 
-def make_friends(db, user1, user2):
-    with session_scope(db) as session:
+def make_friends(user1, user2):
+    with session_scope() as session:
         friend_relationship = FriendRelationship(
             from_user_id=user1.id,
             to_user_id=user2.id,
@@ -171,37 +169,37 @@ class FakeChannel:
 
 
 @contextmanager
-def auth_api_session(db):
+def auth_api_session():
     """
     Create an Auth API for testing
     """
     channel = FakeChannel()
-    auth_pb2_grpc.add_AuthServicer_to_server(Auth(db), channel)
+    auth_pb2_grpc.add_AuthServicer_to_server(Auth(), channel)
     yield auth_pb2_grpc.AuthStub(channel)
 
 
 @contextmanager
-def api_session(db, token):
+def api_session(token):
     """
     Create an API for testing, uses the token for auth
     """
-    user_id, jailed = Auth(db).get_session_for_token(token)
+    user_id, jailed = Auth().get_session_for_token(token)
     channel = FakeChannel(user_id=user_id)
-    api_pb2_grpc.add_APIServicer_to_server(API(db), channel)
+    api_pb2_grpc.add_APIServicer_to_server(API(), channel)
     yield api_pb2_grpc.APIStub(channel)
 
 
 @contextmanager
-def real_api_session(db, token):
+def real_api_session(token):
     """
     Create an API for testing, using TCP sockets, uses the token for auth
     """
-    auth_interceptor = Auth(db).get_auth_interceptor(allow_jailed=False)
+    auth_interceptor = Auth().get_auth_interceptor(allow_jailed=False)
 
     with futures.ThreadPoolExecutor(1) as executor:
         server = grpc.server(executor, interceptors=[auth_interceptor])
         port = server.add_secure_port("localhost:0", grpc.local_server_credentials())
-        servicer = API(db)
+        servicer = API()
         api_pb2_grpc.add_APIServicer_to_server(servicer, server)
         server.start()
 
@@ -216,16 +214,16 @@ def real_api_session(db, token):
 
 
 @contextmanager
-def real_jail_session(db, token):
+def real_jail_session(token):
     """
     Create a Jail service for testing, using TCP sockets, uses the token for auth
     """
-    auth_interceptor = Auth(db).get_auth_interceptor(allow_jailed=True)
+    auth_interceptor = Auth().get_auth_interceptor(allow_jailed=True)
 
     with futures.ThreadPoolExecutor(1) as executor:
         server = grpc.server(executor, interceptors=[auth_interceptor])
         port = server.add_secure_port("localhost:0", grpc.local_server_credentials())
-        servicer = Jail(db)
+        servicer = Jail()
         jail_pb2_grpc.add_JailServicer_to_server(servicer, server)
         server.start()
 
@@ -240,37 +238,37 @@ def real_jail_session(db, token):
 
 
 @contextmanager
-def conversations_session(db, token):
+def conversations_session(token):
     """
     Create a Conversations API for testing, uses the token for auth
     """
-    user_id, jailed = Auth(db).get_session_for_token(token)
+    user_id, jailed = Auth().get_session_for_token(token)
     channel = FakeChannel(user_id=user_id)
-    conversations_pb2_grpc.add_ConversationsServicer_to_server(Conversations(db), channel)
+    conversations_pb2_grpc.add_ConversationsServicer_to_server(Conversations(), channel)
     yield conversations_pb2_grpc.ConversationsStub(channel)
 
 
 @contextmanager
-def requests_session(db, token):
+def requests_session(token):
     """
     Create a Requests API for testing, uses the token for auth
     """
-    auth_interceptor = Auth(db).get_auth_interceptor(allow_jailed=False)
-    user_id, jailed = Auth(db).get_session_for_token(token)
+    auth_interceptor = Auth().get_auth_interceptor(allow_jailed=False)
+    user_id, jailed = Auth().get_session_for_token(token)
     channel = FakeChannel(user_id=user_id)
-    requests_pb2_grpc.add_RequestsServicer_to_server(Requests(db), channel)
+    requests_pb2_grpc.add_RequestsServicer_to_server(Requests(), channel)
     yield requests_pb2_grpc.RequestsStub(channel)
 
 
 @contextmanager
-def account_session(db, token):
+def account_session(token):
     """
     Create a Account API for testing, uses the token for auth
     """
-    auth_interceptor = Auth(db).get_auth_interceptor(allow_jailed=False)
-    user_id, jailed = Auth(db).get_session_for_token(token)
+    auth_interceptor = Auth().get_auth_interceptor(allow_jailed=False)
+    user_id, jailed = Auth().get_session_for_token(token)
     channel = FakeChannel(user_id=user_id)
-    account_pb2_grpc.add_AccountServicer_to_server(Account(db), channel)
+    account_pb2_grpc.add_AccountServicer_to_server(Account(), channel)
     yield account_pb2_grpc.AccountStub(channel)
 
 
@@ -282,7 +280,7 @@ def bugs_session():
 
 
 @contextmanager
-def media_session(db, bearer_token):
+def media_session(bearer_token):
     """
     Create a fresh Media API for testing, uses the bearer token for media auth
     """
@@ -291,7 +289,7 @@ def media_session(db, bearer_token):
     with futures.ThreadPoolExecutor(1) as executor:
         server = grpc.server(executor, interceptors=[media_auth_interceptor])
         port = server.add_secure_port("localhost:0", grpc.local_server_credentials())
-        servicer = Media(db)
+        servicer = Media()
         media_pb2_grpc.add_MediaServicer_to_server(servicer, server)
         server.start()
 
@@ -310,6 +308,8 @@ def testconfig():
     prevconfig = config.copy()
     config.clear()
     config.update(prevconfig)
+
+    config["IN_TEST"] = True
 
     config["DEV"] = True
     config["VERSION"] = "testing_version"

--- a/app/backend/src/tests/test_media.py
+++ b/app/backend/src/tests/test_media.py
@@ -17,11 +17,11 @@ def _(testconfig):
 
 
 def test_media_upload(db):
-    user, token = generate_user(db, "tester")
+    user, token = generate_user("tester")
 
     media_bearer_token = random_hex(32)
 
-    with api_session(db, token) as api:
+    with api_session(token) as api:
         res = api.InitiateMediaUpload(empty_pb2.Empty())
 
     params = parse_qs(urlparse(res.upload_url).query)
@@ -34,10 +34,10 @@ def test_media_upload(db):
 
     req = media_pb2.UploadConfirmationReq(key=key, filename=filename)
 
-    with media_session(db, media_bearer_token) as media:
+    with media_session(media_bearer_token) as media:
         res = media.UploadConfirmation(req)
 
-    with session_scope(db) as session:
+    with session_scope() as session:
         # make sure it exists
         upload = session.query(InitiatedUpload).filter(InitiatedUpload.key == key).one()
 

--- a/app/media/Dockerfile
+++ b/app/media/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-buster
+FROM python:3.9-buster
 
 RUN apt-get update && apt-get install -y libvips42
 


### PR DESCRIPTION
This stops us from passing these session factories around. I think it's a good idea: it's not really a state you should be keeping and propagating downstream, it's just a resource (which is nicely encapsulated with the context manager).