### PR TITLE
Fix jail not loading

### DIFF
--- a/app/frontend/src/AppRoutes.tsx
+++ b/app/frontend/src/AppRoutes.tsx
@@ -5,8 +5,6 @@ import Home from "./features/Home";
 import Messages from "./features/messages/index";
 import Logout from "./features/auth/Logout";
 import Signup from "./features/auth/signup/Signup";
-import { useDispatch, useSelector } from "react-redux";
-import { RootState } from "./reducers";
 import { authError } from "./features/auth/authSlice";
 import {
   EditProfilePage,
@@ -17,6 +15,7 @@ import UserPage from "./features/userPage/UserPage";
 import SearchPage from "./features/search/SearchPage";
 import Jail from "./features/auth/jail/Jail";
 import TOS from "./components/TOS";
+import { useAppDispatch, useTypedSelector } from "./store";
 
 export const loginRoute = "/login";
 export const loginPasswordRoute = `${loginRoute}/password`;
@@ -64,9 +63,9 @@ export default function AppRoutes() {
       <PrivateRoute path={`${searchRoute}/:query?`}>
         <SearchPage />
       </PrivateRoute>
-      <PrivateRoute path={jailRoute}>
+      <Route path={jailRoute}>
         <Jail />
-      </PrivateRoute>
+      </Route>
       <PrivateRoute exact path="/">
         <Home />
       </PrivateRoute>
@@ -78,13 +77,11 @@ export default function AppRoutes() {
 }
 
 const PrivateRoute = ({ children, ...otherProps }: RouteProps) => {
-  const dispatch = useDispatch();
-  const isAuthenticated = useSelector<RootState, boolean>(
+  const dispatch = useAppDispatch();
+  const isAuthenticated = useTypedSelector(
     (state) => state.auth.authToken !== null
   );
-  const isJailed = useSelector<RootState, boolean>(
-    (state) => state.auth.jailed
-  );
+  const isJailed = useTypedSelector((state) => state.auth.jailed);
   useEffect(() => {
     if (!isAuthenticated) {
       dispatch(authError("Please log in."));

--- a/app/frontend/src/AppRoutes.tsx
+++ b/app/frontend/src/AppRoutes.tsx
@@ -69,9 +69,9 @@ export default function AppRoutes() {
       <PrivateRoute exact path="/">
         <Home />
       </PrivateRoute>
-      <PrivateRoute exact path={logoutRoute}>
+      <Route exact path={logoutRoute}>
         <Logout />
-      </PrivateRoute>
+      </Route>
     </Switch>
   );
 }

--- a/app/frontend/src/components/Navigation/Navigation.tsx
+++ b/app/frontend/src/components/Navigation/Navigation.tsx
@@ -94,7 +94,7 @@ const useStyles = makeStyles((theme) => ({
 export default function Navigation() {
   const classes = useStyles();
 
-  const user = useTypedSelector((state) => state.auth.user);
+  const authToken = useTypedSelector((state) => state.auth.authToken);
 
   return (
     <AppBar
@@ -137,7 +137,7 @@ export default function Navigation() {
             </Button>
           ))}
           <Hidden smDown>
-            {user && (
+            {authToken && (
               <Button
                 classes={{
                   root: classes.item,

--- a/app/frontend/src/features/auth/Logout.tsx
+++ b/app/frontend/src/features/auth/Logout.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { logout } from "./authSlice";
 import { useAppDispatch } from "../../store";
 import { Redirect } from "react-router-dom";

--- a/app/frontend/src/features/auth/Logout.tsx
+++ b/app/frontend/src/features/auth/Logout.tsx
@@ -1,6 +1,9 @@
+import React from "react";
 import { useEffect } from "react";
 import { logout } from "./authSlice";
 import { useAppDispatch } from "../../store";
+import { Redirect } from "react-router-dom";
+import { loginRoute } from "../../AppRoutes";
 
 export default function Logout() {
   const dispatch = useAppDispatch();
@@ -9,5 +12,5 @@ export default function Logout() {
     dispatch(logout());
   });
 
-  return null;
+  return <Redirect to={loginRoute} />;
 }

--- a/app/frontend/src/features/auth/jail/Jail.tsx
+++ b/app/frontend/src/features/auth/jail/Jail.tsx
@@ -1,6 +1,7 @@
 import { Backdrop, makeStyles } from "@material-ui/core";
 import React, { useEffect, useState } from "react";
 import { Redirect } from "react-router-dom";
+import { loginRoute } from "../../../AppRoutes";
 import Alert from "../../../components/Alert";
 import CircularProgress from "../../../components/CircularProgress";
 import PageTitle from "../../../components/PageTitle";
@@ -22,6 +23,9 @@ export default function Jail() {
   const isJailed = useTypedSelector((state) => state.auth.jailed);
   const authError = useTypedSelector((state) => state.auth.error);
   const authLoading = useTypedSelector((state) => state.auth.loading);
+  const isAuthenticated = useTypedSelector(
+    (state) => state.auth.authToken !== null
+  );
 
   const [loading, setLoading] = useState(false);
   const [jailInfo, setJailInfo] = useState<null | JailInfoRes.AsObject>(null);
@@ -39,6 +43,8 @@ export default function Jail() {
   const updateJailed = () => {
     dispatch(updateJailStatus());
   };
+
+  if (!isAuthenticated) return <Redirect to={loginRoute} />;
 
   return (
     <>


### PR DESCRIPTION
Closes #373 

This was due to the Route component in PrivateRoute changing from using children to the render pro. Before this, I didn't realise putting jail in a private route had a stray Redirect to itself, since the rest was being rendered anyway.