### PR TITLE
fix: pin pytest version

### DIFF
--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -7,7 +7,7 @@ markdown2
 protobuf
 psycopg2-binary
 pynacl
-pytest
+pytest==4.6
 pytest-cov
 pytest-pythonpath
 python-dateutil


### PR DESCRIPTION
When installing dependencies with python 3.8.1 I got `ERROR: pytest-cov 2.10.1 has requirement pytest>=4.6, but you'll have pytest 3.8.2 which is incompatible.` Also its' just good practice: https://nvie.com/posts/pin-your-packages

I would make a PR pinning the rest of them but I'm not sure which versions to pin (latest?). Also maybe there is a reason they are unpinned.