### PR TITLE
Install geos in backend docker

### DIFF
--- a/app/backend/Dockerfile
+++ b/app/backend/Dockerfile
@@ -14,7 +14,7 @@ FROM base
 
 COPY --from=build /usr/local/bin/entr /usr/local/bin/entr
 
-RUN apt-get update && apt-get install -y libgeos-dev
+RUN apt-get update && apt-get install -y libgeos-c1v5
 
 WORKDIR /app
 

--- a/app/backend/Dockerfile
+++ b/app/backend/Dockerfile
@@ -14,6 +14,8 @@ FROM base
 
 COPY --from=build /usr/local/bin/entr /usr/local/bin/entr
 
+RUN apt-get update && apt-get install -y libgeos-dev
+
 WORKDIR /app
 
 COPY requirements.txt /app

--- a/app/backend/src/couchers/servicers/jail.py
+++ b/app/backend/src/couchers/servicers/jail.py
@@ -55,7 +55,7 @@ class Jail(jail_pb2_grpc.JailServicer):
             return self._get_jail_info(user)
 
     def SetLocation(self, request, context):
-        with session_scope(self._Session) as session:
+        with session_scope() as session:
             user = session.query(User).filter(User.id == context.user_id).one()
 
             user.city = request.city

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -65,10 +65,10 @@ def test_ping(db):
 
 def test_coords(db):
     # make them have not added a location
-    user1, token1 = generate_user(db, geom=None, geom_radius=None)
-    user2, token2 = generate_user(db)
+    user1, token1 = generate_user(geom=None, geom_radius=None)
+    user2, token2 = generate_user()
 
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         res = api.Ping(api_pb2.PingReq())
         assert res.user.city == user2.city
         lat, lng = user2.coordinates
@@ -76,14 +76,14 @@ def test_coords(db):
         assert res.user.lng == lng
         assert res.user.radius == user2.geom_radius
 
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=user1.username))
         assert res.city == user1.city
         assert res.lat == 0.0
         assert res.lng == 0.0
         assert res.radius == 0.0
 
-    with real_jail_session(db, token1) as jail:
+    with real_jail_session(token1) as jail:
         res = jail.JailInfo(empty_pb2.Empty())
         assert res.jailed
         assert res.has_not_added_location
@@ -104,7 +104,7 @@ def test_coords(db):
         assert not res.jailed
         assert not res.has_not_added_location
 
-    with api_session(db, token2) as api:
+    with api_session(token2) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=user1.username))
         assert res.city == "New York City"
         assert res.lat == 40.7812

--- a/app/backend/src/tests/test_jail.py
+++ b/app/backend/src/tests/test_jail.py
@@ -126,9 +126,9 @@ def test_AcceptTOS(db):
 
 def test_SetLocation(db):
     # make them have not added a location
-    user1, token1 = generate_user(db, geom=None, geom_radius=None)
+    user1, token1 = generate_user(geom=None, geom_radius=None)
 
-    with real_jail_session(db, token1) as jail:
+    with real_jail_session(token1) as jail:
         res = jail.JailInfo(empty_pb2.Empty())
         assert res.jailed
         assert res.has_not_added_location

--- a/app/vue/src/components/EditableLocation.vue
+++ b/app/vue/src/components/EditableLocation.vue
@@ -58,7 +58,9 @@
             label="Display address (shown to other users)"
           ></v-text-field>
 
-          Drag the markers to indicate what will be shown to other users.
+          Drag the red marker (and adjust the radius) to indicate what will be
+          shown to other users. (The red marker shows the address you searched
+          for).
 
           <div style="height: 350px">
             <MglMap

--- a/app/vue/src/components/EditableLocation.vue
+++ b/app/vue/src/components/EditableLocation.vue
@@ -59,7 +59,7 @@
           ></v-text-field>
 
           Drag the red marker (and adjust the radius) to indicate what will be
-          shown to other users. (The red marker shows the address you searched
+          shown to other users. (The blue marker shows the address you searched
           for).
 
           <div style="height: 350px">


### PR DESCRIPTION
PyPI is missing the `Shapely` binary wheels, so it falls back to a build from source, which then needs this lib