### PR TITLE
Removes the 'build: nginx' line from the prod docker-compose file

### DIFF
--- a/app/docker-compose.prod.yml
+++ b/app/docker-compose.prod.yml
@@ -49,7 +49,6 @@ services:
   nginx:
     image: registry.gitlab.com/couchers/couchers/nginx
     restart: always
-    build: nginx
     env_file: nginx.prod.env
     volumes:
       - "./data/certs/:/certs/"


### PR DESCRIPTION
It should use the pre-built container from GitLab instead of building it locally.

Closes #400.