### PR TITLE
Disable secure cookies if in dev mode

### DIFF
--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -85,8 +85,9 @@ def create_session_cookie(token, expiry):
     cookie["path"] = "/"
     # send only on requests from first-party domains
     cookie["samesite"] = "Strict"
-    # only HTTPS sites
-    cookie["secure"] = True
+    if not config["DEV"]:
+        # only set cookie on HTTPS sites in production
+        cookie["secure"] = True
     # not accessible from javascript
     cookie["httponly"] = True
 


### PR DESCRIPTION
A small PR for disabling the cookies needing to be secure when in dev mode to prevent issues of it not being set since everything is not served over HTTPS locally.