### PR TITLE
Frontend: stop test coverage from including files in the pb folder

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -31,7 +31,7 @@
     "eject": "react-scripts eject",
     "format": "prettier --write src/",
     "lint": "eslint src/",
-    "test-ci": "NODE_ENV=test && react-scripts test --coverageReporters=\"text\" --coverageReporters=\"cobertura\" --coverageReporters=\"lcov\" --reporters=\"default\" --reporters=\"jest-junit\" --coverage --watchAll=false",
+    "test-ci": "CI=true react-scripts test --coverageReporters=\"text\" --coverageReporters=\"cobertura\" --coverageReporters=\"lcov\" --reporters=\"default\" --reporters=\"jest-junit\" --coverage",
     "jest": "jest",
     "storybook": "NODE_PATH=. start-storybook -p 6006 -s public",
     "build-storybook": "NODE_PATH=. build-storybook -s public"
@@ -110,7 +110,7 @@
     "collectCoverageFrom": [
       "src/**/*.{ts,tsx}",
       "!**/node_modules/**",
-      "!src/pb/*"
+      "!src/pb/**"
     ],
     "resetMocks": true
   },


### PR DESCRIPTION
A small PR to fix this following error I've been noticing in CI:

```
Failed to collect coverage from /app/src/pb/google/api/http_pb.d.ts
ERROR: /app/src/pb/google/api/http_pb.d.ts: Namespace not marked type-only declare. Non-declarative namespaces are only supported experimentally in Babel. To enable and review caveats see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
```

because the glob pattern didn't correctly exclude the pb files.