### PR TITLE
frontend chore: set up dependabot to check for package updates automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/app/frontend"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Given how quickly JS packages update and experience from current work projects on how painful it is to upgrade things when you don't keep on top, having a bot to check this for us should make this a bit easier.

According [to this page](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates), this should just work once the config is committed there so let's give it a try?