### PR TITLE
Frontend chore: clean up lint warnings

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "CI=true react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "format": "prettier --write src/",
@@ -49,6 +49,7 @@
           "@typescript-eslint/no-unused-vars": [
             "warn",
             {
+              "argsIgnorePattern": "theme",
               "varsIgnorePattern": "classes|useStyles"
             }
           ]

--- a/app/frontend/src/components/Map.tsx
+++ b/app/frontend/src/components/Map.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from "react";
 import { Box, BoxProps, makeStyles } from "@material-ui/core";
 import classNames from "classnames";
 import "mapbox-gl/dist/mapbox-gl.css";
-import mapboxgl, { LngLat, ResourceType, RequestParameters } from "mapbox-gl";
+import mapboxgl, { LngLat, RequestParameters } from "mapbox-gl";
 
 const URL = process.env.REACT_APP_API_BASE_URL;
 
@@ -53,10 +53,7 @@ export default function Map({
 
   Those APIs will return an error if the session cookie is not set as these APIs are secure and not public.
   */
-  const transformRequest = (
-    url: string,
-    resourceType: ResourceType
-  ): RequestParameters => {
+  const transformRequest = (url: string): RequestParameters => {
     if (url.startsWith(URL)) {
       return {
         url,

--- a/app/frontend/src/components/ScoreBar.tsx
+++ b/app/frontend/src/components/ScoreBar.tsx
@@ -1,4 +1,4 @@
-import React, { ReactChildren } from "react";
+import React from "react";
 import {
   Container,
   ContainerProps,

--- a/app/frontend/src/features/profile/ProfileTagInput.tsx
+++ b/app/frontend/src/features/profile/ProfileTagInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useRef } from "react";
 import {
   Checkbox,
   IconButton,


### PR DESCRIPTION
As in title.

Also made the build command blocking if there are any linting warnings/errors, making the build step the equivalent of running linting and build in one. The idea is that hopefully this should encourage us to address them rather than ignore them, so they are actually useful to catch bugs early on during development.