### PR TITLE
Fix broken frontend build

### DIFF
--- a/app/frontend/src/features/communities/PagePage.tsx
+++ b/app/frontend/src/features/communities/PagePage.tsx
@@ -54,7 +54,7 @@ export default function PagePage({ pageType }: { pageType: PageType }) {
             Owner:{" "}
             {page.ownerUserId !== 0
               ? "user " + page.ownerUserId
-              : "cluster " + page.ownerClusterId}
+              : "cluster " + page.ownerGroupId}
           </p>
           <p>
             Last edited at {page.lastEdited?.seconds} by {page.lastEditorUserId}


### PR DESCRIPTION
Since `page.ownerClusterId` has been renamed to `page.ownerGroupId` in the generated js protos and the frontend didn't get updated to pick up this change