### PR TITLE
Fix broken logout

### DIFF
--- a/app/frontend/src/features/auth/useAuthStore.ts
+++ b/app/frontend/src/features/auth/useAuthStore.ts
@@ -133,8 +133,8 @@ export default function useAuthStore() {
         setLoading(true);
         try {
           await service.user.logout();
-          setUserId(null);
           setAuthenticated(false);
+          setUserId(null);
         } catch (e) {
           setError(e.message);
         }


### PR DESCRIPTION
Setting the authenticated state to false first, which kicks the users out, before waiting for the next re-render to clear the user, seems to be the easiest fix to the problem.