### PR TITLE
fix: lower cache time for username2Id query

### DIFF
--- a/app/frontend/src/features/userQueries/constants.ts
+++ b/app/frontend/src/features/userQueries/constants.ts
@@ -1,3 +1,3 @@
 export const expiryMilliseconds = 1000 * 60 * 5;
-export const username2IdStaleTime = 30 * 24 * 60 * 60 * 1000;
+export const username2IdStaleTime = 14 * 24 * 60 * 60 * 1000;
 export const userStaleTime = 10 * 60 * 1000;

--- a/app/frontend/src/reactQueryClient.tsx
+++ b/app/frontend/src/reactQueryClient.tsx
@@ -21,7 +21,7 @@ export const queryClient = new QueryClient({
   },
 });
 
-persistWithLocalStorage(queryClient);
+persistWithLocalStorage(queryClient, { maxAge: 14 * 24 * 60 * 60 * 1000 });
 interface ReactQueryClientProviderProps {
   children: React.ReactNode;
 }


### PR DESCRIPTION
Lowers the cache time to 14 days so the cache doesn't get incorrectly garbage collected due to 32-bit number overflow before - see https://github.com/tannerlinsley/react-query/issues/1646. 25 days was still just over the 2^31 ms and I think 2 weeks is still long enough tbh. 

Also increased the localStorage maxAge to the same amount, otherwise this stable cache will get removed on hydration after 24 hours (the default `maxAge` value in the `persist-localstorage` plugin) regardless of cache time's value.
