### PR TITLE
Backend/bugfix/birthdate in past

### DIFF
--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -201,11 +201,11 @@ class Auth(auth_pb2_grpc.AuthServicer):
             if not signup_token:
                 context.abort(grpc.StatusCode.NOT_FOUND, errors.INVALID_TOKEN)
 
-			# check birthdate validity (YYYY-MM-DD format and in the past)
+            # check birthdate validity (YYYY-MM-DD format and in the past)
             try:
                 birthdate = datetime.fromisoformat(request.birthdate)
-				if birthdate >= datetime.now():
-            	    context.abort(grpc.StatusCode.INVALID_ARGUMENT, errors.INVALID_BIRTHDATE)
+                if birthdate >= datetime.now():
+                    context.abort(grpc.StatusCode.INVALID_ARGUMENT, errors.INVALID_BIRTHDATE)
             except ValueError:
                 context.abort(grpc.StatusCode.INVALID_ARGUMENT, errors.INVALID_BIRTHDATE)
 

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -38,7 +38,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
         """
         Returns an auth interceptor.
 
-        By adding this interceptor to a service, all requests to that service will require an bearer authorization with a valid session from the Auth service.
+        By adding this interceptor to a service, all requests to that service will require a bearer authorization with a valid session from the Auth service.
 
         The user_id will be available in the RPC context through context.user_id.
         """

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -204,9 +204,9 @@ class Auth(auth_pb2_grpc.AuthServicer):
             # check birthdate validity (YYYY-MM-DD format and in the past)
             try:
                 birthdate = datetime.fromisoformat(request.birthdate)
-                if birthdate >= datetime.now():
-                    context.abort(grpc.StatusCode.INVALID_ARGUMENT, errors.INVALID_BIRTHDATE)
             except ValueError:
+                context.abort(grpc.StatusCode.INVALID_ARGUMENT, errors.INVALID_BIRTHDATE)
+            if utc.localize(birthdate) >= now():
                 context.abort(grpc.StatusCode.INVALID_ARGUMENT, errors.INVALID_BIRTHDATE)
 
             # check email again

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -2,6 +2,7 @@ import logging
 from datetime import datetime
 
 import grpc
+import pytz
 from google.protobuf import empty_pb2
 from sqlalchemy.sql import func
 
@@ -206,7 +207,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 birthdate = datetime.fromisoformat(request.birthdate)
             except ValueError:
                 context.abort(grpc.StatusCode.INVALID_ARGUMENT, errors.INVALID_BIRTHDATE)
-            if utc.localize(birthdate) >= now():
+            if pytz.UTC.localize(birthdate) >= now():
                 context.abort(grpc.StatusCode.INVALID_ARGUMENT, errors.INVALID_BIRTHDATE)
 
             # check email again

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -201,9 +201,11 @@ class Auth(auth_pb2_grpc.AuthServicer):
             if not signup_token:
                 context.abort(grpc.StatusCode.NOT_FOUND, errors.INVALID_TOKEN)
 
-            # should be in YYYY-MM-DD format
+			# check birthdate validity (YYYY-MM-DD format and in the past)
             try:
                 birthdate = datetime.fromisoformat(request.birthdate)
+				if birthdate >= datetime.now():
+            	    context.abort(grpc.StatusCode.INVALID_ARGUMENT, errors.INVALID_BIRTHDATE)
             except ValueError:
                 context.abort(grpc.StatusCode.INVALID_ARGUMENT, errors.INVALID_BIRTHDATE)
 

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -257,7 +257,7 @@ def test_signup_invalid_birthdate(db):
                 username="frodo",
                 name="Räksmörgås",
                 city="Minas Tirith",
-                birthdate="9999-12-31", # arbitrary future birthdate
+                birthdate="9999-12-31",  # arbitrary future birthdate
                 gender="Robot",
                 hosting_status=api_pb2.HOSTING_STATUS_CAN_HOST,
             )


### PR DESCRIPTION
Modified **auth.py** to now also check that the birthdate entered upon sign up is in the past.

Retained the same form of try/except that was previously only used to check the form of the birthdate. This makes sense to me because the `is_valid_date()` function simply yields **True/False**. Invoking this function, checking for **True**, and then converting the string to a **datetime** instance is less straightforward than simply trying to convert the string to a **datetime** instance (especially since the **datetime** instance is needed by the database in the valid case).

Note: my code does not account for timezones. I prioritized simplicity and readability over this level of accuracy.

Note: also fixed a typo in a comment for unrelated code, since the comment is used to generate documentation.