### PR TITLE
Change email + updates to change password

### DIFF
--- a/app/frontend/src/AppRoutes.tsx
+++ b/app/frontend/src/AppRoutes.tsx
@@ -3,6 +3,7 @@ import { Redirect, Route, RouteProps, Switch } from "react-router-dom";
 
 import TOS from "./components/TOS";
 import { useAuthContext } from "./features/auth/AuthProvider";
+import ChangeEmailPage from "./features/auth/email/ChangeEmailPage";
 import Jail from "./features/auth/jail/Jail";
 import Login from "./features/auth/login/Login";
 import Logout from "./features/auth/Logout";
@@ -32,6 +33,7 @@ import SearchPage from "./features/search/SearchPage";
 import UserPage from "./features/userPage/UserPage";
 import { PageType } from "./pb/pages_pb";
 import {
+  changeEmailRoute,
   changePasswordRoute,
   communityRoute,
   connectionsRoute,
@@ -72,9 +74,12 @@ export default function AppRoutes() {
       <Route exact path={`${resetPasswordRoute}/:resetToken`}>
         <CompleteResetPasswordPage />
       </Route>
-      <Route path={changePasswordRoute}>
+      <PrivateRoute path={changePasswordRoute}>
         <ChangePasswordPage />
-      </Route>
+      </PrivateRoute>
+      <PrivateRoute path={changeEmailRoute}>
+        <ChangeEmailPage />
+      </PrivateRoute>
       <Route path={tosRoute}>
         <TOS />
       </Route>

--- a/app/frontend/src/AppRoutes.tsx
+++ b/app/frontend/src/AppRoutes.tsx
@@ -4,6 +4,7 @@ import { Redirect, Route, RouteProps, Switch } from "react-router-dom";
 import TOS from "./components/TOS";
 import { useAuthContext } from "./features/auth/AuthProvider";
 import ChangeEmailPage from "./features/auth/email/ChangeEmailPage";
+import ConfirmChangeEmailPage from "./features/auth/email/ConfirmChangeEmailPage";
 import Jail from "./features/auth/jail/Jail";
 import Login from "./features/auth/login/Login";
 import Logout from "./features/auth/Logout";
@@ -36,6 +37,7 @@ import {
   changeEmailRoute,
   changePasswordRoute,
   communityRoute,
+  confirmChangeEmailRoute,
   connectionsRoute,
   discussionRoute,
   editHostingPreferenceRoute,
@@ -74,15 +76,18 @@ export default function AppRoutes() {
       <Route exact path={`${resetPasswordRoute}/:resetToken`}>
         <CompleteResetPasswordPage />
       </Route>
+      <Route path={`${confirmChangeEmailRoute}/:resetToken`}>
+        <ConfirmChangeEmailPage />
+      </Route>
+      <Route path={tosRoute}>
+        <TOS />
+      </Route>
       <PrivateRoute path={changePasswordRoute}>
         <ChangePasswordPage />
       </PrivateRoute>
       <PrivateRoute path={changeEmailRoute}>
         <ChangeEmailPage />
       </PrivateRoute>
-      <Route path={tosRoute}>
-        <TOS />
-      </Route>
       <PrivateRoute path={mapRoute}>
         <MapPage />
       </PrivateRoute>

--- a/app/frontend/src/features/auth/email/ChangeEmailPage.test.tsx
+++ b/app/frontend/src/features/auth/email/ChangeEmailPage.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Empty } from "google-protobuf/google/protobuf/empty_pb";
+
+import { GetAccountInfoRes } from "../../../pb/account_pb";
+import { service } from "../../../service";
+import wrapper from "../../../test/hookWrapper";
+import { MockedService } from "../../../test/utils";
+import ChangeEmailPage from "./ChangeEmailPage";
+
+const getAccountInfoMock = service.account.getAccountInfo as MockedService<
+  typeof service.account.getAccountInfo
+>;
+const changeEmailMock = service.account.changeEmail as MockedService<
+  typeof service.account.changeEmail
+>;
+
+describe("ChangeEmailPage", () => {
+  beforeEach(() => {
+    changeEmailMock.mockResolvedValue(new Empty());
+  });
+
+  describe("if the user has a password", () => {
+    beforeEach(() => {
+      getAccountInfoMock.mockResolvedValue({
+        hasPassword: true,
+        loginMethod: GetAccountInfoRes.LoginMethod.PASSWORD,
+      });
+    });
+
+    it("shows the full change email form", async () => {
+      render(<ChangeEmailPage />, { wrapper });
+
+      expect(
+        screen.getByRole("heading", { name: "Change email" })
+      ).toBeVisible();
+      expect(await screen.findByLabelText("Current password")).toBeVisible();
+      expect(screen.getByLabelText("New email")).toBeVisible();
+      expect(screen.getByRole("button", { name: "Submit" })).toBeVisible();
+    });
+
+    it("does not try to submit the form if the user didn't provide their old password", async () => {
+      render(<ChangeEmailPage />, { wrapper });
+
+      userEvent.type(
+        await screen.findByLabelText("New email"),
+        "test@example.com"
+      );
+      userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+      await waitFor(() => {
+        expect(changeEmailMock).not.toHaveBeenCalled();
+      });
+    });
+
+    it("does not try to submit the form if the user didn't provide a new email", async () => {
+      render(<ChangeEmailPage />, { wrapper });
+
+      userEvent.type(
+        await screen.findByLabelText("Current password"),
+        "password"
+      );
+      userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+      await waitFor(() => {
+        expect(changeEmailMock).not.toHaveBeenCalled();
+      });
+    });
+
+    it("changes the user's email successfully if all required fields have been filled in", async () => {
+      render(<ChangeEmailPage />, { wrapper });
+
+      userEvent.type(
+        await screen.findByLabelText("Current password"),
+        "password"
+      );
+      userEvent.type(screen.getByLabelText("New email"), "test@example.com");
+      userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+      const successAlert = await screen.findByRole("alert");
+      expect(successAlert).toBeVisible();
+      expect(successAlert).toHaveTextContent(
+        "Your email change has been received. Check your new email to complete the change."
+      );
+      expect(changeEmailMock).toHaveBeenCalledTimes(1);
+      expect(changeEmailMock).toHaveBeenCalledWith(
+        "test@example.com",
+        "password"
+      );
+    });
+  });
+
+  describe("if the user does not have a password", () => {
+    beforeEach(() => {
+      getAccountInfoMock.mockResolvedValue({
+        hasPassword: false,
+        loginMethod: GetAccountInfoRes.LoginMethod.MAGIC_LINK,
+      });
+    });
+
+    it("does not show the current password field", async () => {
+      render(<ChangeEmailPage />, { wrapper });
+
+      expect(await screen.findByLabelText("New email")).toBeVisible();
+      expect(
+        screen.queryByLabelText("Current password")
+      ).not.toBeInTheDocument();
+    });
+
+    it("changes the user's email successfully if the user has provided a new email", async () => {
+      render(<ChangeEmailPage />, { wrapper });
+
+      userEvent.type(
+        await screen.findByLabelText("New email"),
+        "test@example.com"
+      );
+      userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+      const successAlert = await screen.findByRole("alert");
+      expect(successAlert).toBeVisible();
+      expect(successAlert).toHaveTextContent(
+        "Your email change has been received. Check your new email to complete the change."
+      );
+      expect(changeEmailMock).toHaveBeenCalledTimes(1);
+      expect(changeEmailMock).toHaveBeenCalledWith(
+        "test@example.com",
+        undefined
+      );
+    });
+
+    it("shows an error alert if the change password request failed", async () => {
+      jest.spyOn(console, "error").mockReturnValue(undefined);
+      changeEmailMock.mockRejectedValue(new Error("Invalid email"));
+      render(<ChangeEmailPage />, { wrapper });
+
+      userEvent.type(
+        await screen.findByLabelText("New email"),
+        "test@example.com"
+      );
+      userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+      const errorAlert = await screen.findByRole("alert");
+      expect(errorAlert).toBeVisible();
+      expect(errorAlert).toHaveTextContent("Invalid email");
+      expect(
+        screen.queryByText(/Your email change has been received/i)
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/app/frontend/src/features/auth/email/ChangeEmailPage.test.tsx
+++ b/app/frontend/src/features/auth/email/ChangeEmailPage.test.tsx
@@ -87,6 +87,10 @@ describe("ChangeEmailPage", () => {
         "test@example.com",
         "password"
       );
+
+      // Also check form has been cleared
+      expect(screen.getByLabelText("Current password")).not.toHaveValue();
+      expect(screen.getByLabelText("New email")).not.toHaveValue();
     });
   });
 
@@ -126,6 +130,9 @@ describe("ChangeEmailPage", () => {
         "test@example.com",
         undefined
       );
+
+      // Also check form has been cleared
+      expect(screen.getByLabelText("New email")).not.toHaveValue();
     });
 
     it("shows an error alert if the change password request failed", async () => {

--- a/app/frontend/src/features/auth/email/ChangeEmailPage.tsx
+++ b/app/frontend/src/features/auth/email/ChangeEmailPage.tsx
@@ -24,6 +24,15 @@ export default function ChangeEmailPage() {
   const isMdOrWider = useMediaQuery(theme.breakpoints.up("md"));
 
   const {
+    handleSubmit,
+    register,
+    reset: resetForm,
+  } = useForm<ChangeEmailFormData>();
+  const onSubmit = handleSubmit(({ currentPassword, newEmail }) => {
+    changeEmail({ currentPassword, newEmail });
+  });
+
+  const {
     data: accountInfo,
     error: accountInfoError,
     isLoading: isAccountInfoLoading,
@@ -36,13 +45,13 @@ export default function ChangeEmailPage() {
     mutate: changeEmail,
   } = useMutation<Empty, GrpcError, ChangeEmailFormData>(
     ({ currentPassword, newEmail }) =>
-      service.account.changeEmail(newEmail, currentPassword)
+      service.account.changeEmail(newEmail, currentPassword),
+    {
+      onSuccess: () => {
+        resetForm();
+      },
+    }
   );
-
-  const { handleSubmit, register } = useForm<ChangeEmailFormData>();
-  const onSubmit = handleSubmit(({ currentPassword, newEmail }) => {
-    changeEmail({ currentPassword, newEmail });
-  });
 
   return (
     <>

--- a/app/frontend/src/features/auth/email/ChangeEmailPage.tsx
+++ b/app/frontend/src/features/auth/email/ChangeEmailPage.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, useMediaQuery, useTheme } from "@material-ui/core";
+import { useMediaQuery, useTheme } from "@material-ui/core";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Error as GrpcError } from "grpc-web";
 import { useForm } from "react-hook-form";
@@ -11,17 +11,7 @@ import PageTitle from "../../../components/PageTitle";
 import TextField from "../../../components/TextField";
 import { service } from "../../../service";
 import useAccountInfo from "../useAccountInfo";
-
-const useStyles = makeStyles((theme) => ({
-  form: {
-    "& > * + *": {
-      marginBlockStart: theme.spacing(1),
-    },
-  },
-  infoText: {
-    marginBlockEnd: theme.spacing(1),
-  },
-}));
+import useChangeDetailsFormStyles from "../useChangeDetailsFormStyles";
 
 interface ChangeEmailFormData {
   newEmail: string;
@@ -29,7 +19,7 @@ interface ChangeEmailFormData {
 }
 
 export default function ChangeEmailPage() {
-  const classes = useStyles();
+  const classes = useChangeDetailsFormStyles();
   const theme = useTheme();
   const isMdOrWider = useMediaQuery(theme.breakpoints.up("md"));
 

--- a/app/frontend/src/features/auth/email/ChangeEmailPage.tsx
+++ b/app/frontend/src/features/auth/email/ChangeEmailPage.tsx
@@ -1,0 +1,97 @@
+import { makeStyles, useMediaQuery, useTheme } from "@material-ui/core";
+import { Empty } from "google-protobuf/google/protobuf/empty_pb";
+import { Error as GrpcError } from "grpc-web";
+import { useForm } from "react-hook-form";
+import { useMutation } from "react-query";
+
+import Alert from "../../../components/Alert";
+import Button from "../../../components/Button";
+import CircularProgress from "../../../components/CircularProgress";
+import PageTitle from "../../../components/PageTitle";
+import TextField from "../../../components/TextField";
+import { service } from "../../../service";
+import useAccountInfo from "../useAccountInfo";
+
+const useStyles = makeStyles((theme) => ({
+  form: {
+    "& > * + *": {
+      marginBlockStart: theme.spacing(1),
+    },
+  },
+  infoText: {
+    marginBlockEnd: theme.spacing(1),
+  },
+}));
+
+interface ChangeEmailFormData {
+  newEmail: string;
+  currentPassword?: string;
+}
+
+export default function ChangeEmailPage() {
+  const classes = useStyles();
+  const theme = useTheme();
+  const isMdOrWider = useMediaQuery(theme.breakpoints.up("md"));
+
+  const {
+    data: accountInfo,
+    error: accountInfoError,
+    isLoading: isAccountInfoLoading,
+  } = useAccountInfo();
+
+  const { error, isLoading, isSuccess, mutate: changeEmail } = useMutation<
+    Empty,
+    GrpcError,
+    ChangeEmailFormData
+  >(({ currentPassword, newEmail }) =>
+    service.account.changeEmail(newEmail, currentPassword)
+  );
+
+  const { handleSubmit, register } = useForm<ChangeEmailFormData>();
+  const onSubmit = handleSubmit(({ currentPassword, newEmail }) => {
+    changeEmail({ currentPassword, newEmail });
+  });
+
+  return (
+    <>
+      <PageTitle>Change email</PageTitle>
+      {isAccountInfoLoading ? (
+        <CircularProgress />
+      ) : accountInfoError ? (
+        <Alert severity="error">{accountInfoError.message}</Alert>
+      ) : (
+        <>
+          {error && <Alert severity="error">{error.message}</Alert>}
+          {isSuccess && (
+            <Alert severity="success">
+              Your email change has been received. Check your new email to
+              complete the change.
+            </Alert>
+          )}
+          <form className={classes.form} onSubmit={onSubmit}>
+            {accountInfo && accountInfo.hasPassword && (
+              <TextField
+                id="currentPassword"
+                inputRef={register({ required: true })}
+                label="Current password"
+                name="currentPassword"
+                type="password"
+                fullWidth={!isMdOrWider}
+              />
+            )}
+            <TextField
+              id="newEmail"
+              inputRef={register({ required: true })}
+              label="New email"
+              name="newEmail"
+              fullWidth={!isMdOrWider}
+            />
+            <Button fullWidth={!isMdOrWider} loading={isLoading} type="submit">
+              Submit
+            </Button>
+          </form>
+        </>
+      )}
+    </>
+  );
+}

--- a/app/frontend/src/features/auth/email/ChangeEmailPage.tsx
+++ b/app/frontend/src/features/auth/email/ChangeEmailPage.tsx
@@ -29,12 +29,14 @@ export default function ChangeEmailPage() {
     isLoading: isAccountInfoLoading,
   } = useAccountInfo();
 
-  const { error, isLoading, isSuccess, mutate: changeEmail } = useMutation<
-    Empty,
-    GrpcError,
-    ChangeEmailFormData
-  >(({ currentPassword, newEmail }) =>
-    service.account.changeEmail(newEmail, currentPassword)
+  const {
+    error: changeEmailError,
+    isLoading: isChangeEmailLoading,
+    isSuccess: isChangeEmailSuccess,
+    mutate: changeEmail,
+  } = useMutation<Empty, GrpcError, ChangeEmailFormData>(
+    ({ currentPassword, newEmail }) =>
+      service.account.changeEmail(newEmail, currentPassword)
   );
 
   const { handleSubmit, register } = useForm<ChangeEmailFormData>();
@@ -51,8 +53,10 @@ export default function ChangeEmailPage() {
         <Alert severity="error">{accountInfoError.message}</Alert>
       ) : (
         <>
-          {error && <Alert severity="error">{error.message}</Alert>}
-          {isSuccess && (
+          {changeEmailError && (
+            <Alert severity="error">{changeEmailError.message}</Alert>
+          )}
+          {isChangeEmailSuccess && (
             <Alert severity="success">
               Your email change has been received. Check your new email to
               complete the change.
@@ -76,7 +80,11 @@ export default function ChangeEmailPage() {
               name="newEmail"
               fullWidth={!isMdOrWider}
             />
-            <Button fullWidth={!isMdOrWider} loading={isLoading} type="submit">
+            <Button
+              fullWidth={!isMdOrWider}
+              loading={isChangeEmailLoading}
+              type="submit"
+            >
               Submit
             </Button>
           </form>

--- a/app/frontend/src/features/auth/email/ConfirmChangeEmailPage.test.tsx
+++ b/app/frontend/src/features/auth/email/ConfirmChangeEmailPage.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Empty } from "google-protobuf/google/protobuf/empty_pb";
+import { Route, Switch } from "react-router-dom";
+
+import { confirmChangeEmailRoute, loginRoute } from "../../../routes";
+import { service } from "../../../service";
+import { getHookWrapperWithClient } from "../../../test/hookWrapper";
+import { MockedService } from "../../../test/utils";
+import ConfirmChangeEmailPage from "./ConfirmChangeEmailPage";
+
+const completeChangeEmailMock = service.account
+  .completeChangeEmail as MockedService<
+  typeof service.account.completeChangeEmail
+>;
+
+function renderPage() {
+  const { wrapper } = getHookWrapperWithClient({
+    initialRouterEntries: [`${confirmChangeEmailRoute}/Em4iLR3seTtok3n`],
+  });
+
+  render(
+    <Switch>
+      <Route path={`${confirmChangeEmailRoute}/:resetToken`}>
+        <ConfirmChangeEmailPage />
+      </Route>
+      <Route path={loginRoute}>Log in page</Route>
+    </Switch>,
+    { wrapper }
+  );
+}
+
+describe("ConfirmChangeEmailPage", () => {
+  it("shows the loading state on initial load", async () => {
+    completeChangeEmailMock.mockImplementation(() => new Promise(() => void 0));
+    renderPage();
+
+    expect(
+      await screen.findByText("Email change in progress...")
+    ).toBeVisible();
+  });
+
+  describe("when the change email completes successfully", () => {
+    beforeEach(() => {
+      completeChangeEmailMock.mockResolvedValue(new Empty());
+      renderPage();
+    });
+
+    it("shows the success alert", async () => {
+      const successAlert = await screen.findByRole("alert");
+      expect(successAlert).toBeVisible();
+      expect(successAlert).toHaveTextContent(
+        "Your email has been changed successfully!"
+      );
+      expect(completeChangeEmailMock).toHaveBeenCalledTimes(1);
+      expect(completeChangeEmailMock).toHaveBeenLastCalledWith(
+        "Em4iLR3seTtok3n"
+      );
+    });
+
+    it("shows a link that takes you to the login page when clicked", async () => {
+      userEvent.click(
+        await screen.findByRole("link", { name: "Click here to login" })
+      );
+
+      expect(await screen.findByText("Log in page")).toBeInTheDocument();
+    });
+  });
+
+  it("shows an error alert if the reset password process failed to complete", async () => {
+    jest.spyOn(console, "error").mockReturnValue(undefined);
+    completeChangeEmailMock.mockRejectedValue(new Error("Invalid token"));
+    renderPage();
+
+    const errorAlert = await screen.findByRole("alert");
+    expect(errorAlert).toBeVisible();
+    expect(errorAlert).toHaveTextContent("Error changing email: Invalid token");
+  });
+});

--- a/app/frontend/src/features/auth/email/ConfirmChangeEmailPage.tsx
+++ b/app/frontend/src/features/auth/email/ConfirmChangeEmailPage.tsx
@@ -9,30 +9,30 @@ import Alert from "../../../components/Alert";
 import { loginRoute } from "../../../routes";
 import { service } from "../../../service";
 
-export default function CompleteResetPasswordPage() {
+export default function ConfirmChangeEmailPage() {
   const { resetToken } = useParams<{ resetToken?: string }>();
 
   const {
     error,
     isLoading,
     isSuccess,
-    mutate: completePasswordReset,
+    mutate: completeChangeEmail,
   } = useMutation<Empty, GrpcError, string>((resetToken) =>
-    service.account.completePasswordReset(resetToken)
+    service.account.completeChangeEmail(resetToken)
   );
 
   useEffect(() => {
     if (resetToken) {
-      completePasswordReset(resetToken);
+      completeChangeEmail(resetToken);
     }
-  }, [completePasswordReset, resetToken]);
+  }, [completeChangeEmail, resetToken]);
 
   return isLoading ? (
-    <Typography variant="body1">Password reset in progress...</Typography>
+    <Typography variant="body1">Email change in progress...</Typography>
   ) : isSuccess ? (
     <>
       <Alert severity="success">
-        Your password has been reset successfully!
+        Your email has been changed successfully!
       </Alert>
       <Typography variant="body1" component={Link} to={loginRoute}>
         Click here to login
@@ -40,7 +40,7 @@ export default function CompleteResetPasswordPage() {
     </>
   ) : (
     error && (
-      <Alert severity="error">Error resetting password: {error.message}</Alert>
+      <Alert severity="error">Error changing email: {error.message}</Alert>
     )
   );
 }

--- a/app/frontend/src/features/auth/password/ChangePasswordPage.test.tsx
+++ b/app/frontend/src/features/auth/password/ChangePasswordPage.test.tsx
@@ -84,6 +84,11 @@ describe("ChangePasswordPage", () => {
         "old_password",
         "new_password"
       );
+
+      // Also check form has been cleared
+      expect(screen.getByLabelText("Old password")).not.toHaveValue();
+      expect(screen.getByLabelText("New password")).not.toHaveValue();
+      expect(screen.getByLabelText("Confirm password")).not.toHaveValue();
     });
 
     it("clears the user password successfully if no new password has been given", async () => {
@@ -102,6 +107,11 @@ describe("ChangePasswordPage", () => {
       );
       expect(changePasswordMock).toHaveBeenCalledTimes(1);
       expect(changePasswordMock).toHaveBeenCalledWith("old_password", "");
+
+      // Also check form has been cleared
+      expect(screen.getByLabelText("Old password")).not.toHaveValue();
+      expect(screen.getByLabelText("New password")).not.toHaveValue();
+      expect(screen.getByLabelText("Confirm password")).not.toHaveValue();
     });
   });
 
@@ -153,6 +163,10 @@ describe("ChangePasswordPage", () => {
         undefined,
         "new_password"
       );
+
+      // Also check form has been cleared
+      expect(screen.getByLabelText("New password")).not.toHaveValue();
+      expect(screen.getByLabelText("Confirm password")).not.toHaveValue();
     });
 
     it("shows an error alert if the change password request failed", async () => {

--- a/app/frontend/src/features/auth/password/ChangePasswordPage.test.tsx
+++ b/app/frontend/src/features/auth/password/ChangePasswordPage.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 
+import { GetAccountInfoRes } from "../../../pb/account_pb";
 import { service } from "../../../service";
 import wrapper from "../../../test/hookWrapper";
 import { MockedService } from "../../../test/utils";
@@ -10,95 +11,170 @@ import ChangePasswordPage from "./ChangePasswordPage";
 const changePasswordMock = service.account.changePassword as MockedService<
   typeof service.account.changePassword
 >;
+const getAccountInfoMock = service.account.getAccountInfo as MockedService<
+  typeof service.account.getAccountInfo
+>;
 
 describe("ChangePasswordPage", () => {
   beforeEach(() => {
     changePasswordMock.mockResolvedValue(new Empty());
   });
 
-  it("does not show the old password field if the user does not have a password", async () => {
-    // TODO: trigger getAccountInfo mock to return no password when queried when new API gets merged
-    render(<ChangePasswordPage />, { wrapper });
+  describe("if the user has a password", () => {
+    beforeEach(() => {
+      getAccountInfoMock.mockResolvedValue({
+        hasPassword: true,
+        loginMethod: GetAccountInfoRes.LoginMethod.PASSWORD,
+      });
+    });
 
-    // Assert old password field doesn't show up
+    it("shows the full change password form", async () => {
+      render(<ChangePasswordPage />, { wrapper });
+
+      expect(
+        screen.getByRole("heading", { name: "Change password" })
+      ).toBeVisible();
+      expect(await screen.findByLabelText("Old password")).toBeVisible();
+      expect(screen.getByLabelText("New password")).toBeVisible();
+      expect(screen.getByLabelText("Confirm password")).toBeVisible();
+      expect(screen.getByRole("button", { name: "Submit" })).toBeVisible();
+    });
+
+    it("does not try to submit the form if the user doesn't provide its old password", async () => {
+      render(<ChangePasswordPage />, { wrapper });
+
+      userEvent.click(await screen.findByRole("button", { name: "Submit" }));
+
+      await waitFor(() => {
+        expect(changePasswordMock).not.toHaveBeenCalled();
+      });
+    });
+
+    it("does not try to submit the form if the new and confirm password values don't match", async () => {
+      render(<ChangePasswordPage />, { wrapper });
+
+      userEvent.type(await screen.findByLabelText("New password"), "password");
+      userEvent.type(screen.getByLabelText("Confirm password"), "password1");
+      userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+      expect(
+        await screen.findByText(/This does not match the new password/i)
+      ).toBeVisible();
+      expect(changePasswordMock).not.toHaveBeenCalled();
+    });
+
+    it("updates the user's password successfully if a new password has been given", async () => {
+      render(<ChangePasswordPage />, { wrapper });
+
+      userEvent.type(
+        await screen.findByLabelText("Old password"),
+        "old_password"
+      );
+      userEvent.type(screen.getByLabelText("New password"), "new_password");
+      userEvent.type(screen.getByLabelText("Confirm password"), "new_password");
+      userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+      const successAlert = await screen.findByRole("alert");
+      expect(successAlert).toBeVisible();
+      expect(successAlert).toHaveTextContent(
+        "Your password change has been processed. Check your email for confirmation."
+      );
+      expect(changePasswordMock).toHaveBeenCalledTimes(1);
+      expect(changePasswordMock).toHaveBeenCalledWith(
+        "old_password",
+        "new_password"
+      );
+    });
+
+    it("clears the user password successfully if no new password has been given", async () => {
+      render(<ChangePasswordPage />, { wrapper });
+
+      userEvent.type(
+        await screen.findByLabelText("Old password"),
+        "old_password"
+      );
+      userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+      const successAlert = await screen.findByRole("alert");
+      expect(successAlert).toBeVisible();
+      expect(successAlert).toHaveTextContent(
+        "Your password change has been processed. Check your email for confirmation."
+      );
+      expect(changePasswordMock).toHaveBeenCalledTimes(1);
+      expect(changePasswordMock).toHaveBeenCalledWith("old_password", "");
+    });
   });
 
-  it("shows the full change password form if the user has a password", async () => {
-    render(<ChangePasswordPage />, { wrapper });
+  describe("if the user does not have a password", () => {
+    beforeEach(() => {
+      getAccountInfoMock.mockResolvedValue({
+        hasPassword: false,
+        loginMethod: GetAccountInfoRes.LoginMethod.MAGIC_LINK,
+      });
+    });
 
-    expect(
-      screen.getByRole("heading", { name: "Change password" })
-    ).toBeVisible();
-    expect(screen.getByLabelText("Old password")).toBeVisible();
-    expect(screen.getByLabelText("New password")).toBeVisible();
-    expect(screen.getByLabelText("Confirm password")).toBeVisible();
-    expect(screen.getByRole("button", { name: "Submit" })).toBeVisible();
-  });
+    it("does not show the old password field", async () => {
+      render(<ChangePasswordPage />, { wrapper });
 
-  it("does not try to submit the form if the new and confirm password values don't match", async () => {
-    render(<ChangePasswordPage />, { wrapper });
+      // Wait for new password field/form to show up first, otherwise old password not visible is always
+      // gonna be true
+      expect(await screen.findByLabelText("New password")).toBeVisible();
+      expect(screen.queryByLabelText("Old password")).not.toBeInTheDocument();
+    });
 
-    userEvent.type(screen.getByLabelText("New password"), "password");
-    userEvent.type(screen.getByLabelText("Confirm password"), "password1");
-    userEvent.click(screen.getByRole("button", { name: "Submit" }));
+    // When user doesn't have an old password, new password becomes a required field
+    it("does not try to submit the form if the user doesn't provide a new password", async () => {
+      render(<ChangePasswordPage />, { wrapper });
 
-    expect(
-      await screen.findByText(/This does not match the new password/i)
-    ).toBeVisible();
-    expect(changePasswordMock).not.toHaveBeenCalled();
-  });
+      userEvent.click(await screen.findByRole("button", { name: "Submit" }));
 
-  it("submits the change password request successfully", async () => {
-    render(<ChangePasswordPage />, { wrapper });
+      await waitFor(() => {
+        expect(changePasswordMock).not.toHaveBeenCalled();
+      });
+    });
 
-    userEvent.type(screen.getByLabelText("New password"), "new_password");
-    userEvent.type(screen.getByLabelText("Confirm password"), "new_password");
-    userEvent.click(screen.getByRole("button", { name: "Submit" }));
+    it("submits the change password request successfully if a new password has been given", async () => {
+      render(<ChangePasswordPage />, { wrapper });
 
-    const successAlert = await screen.findByRole("alert");
-    expect(successAlert).toBeVisible();
-    expect(successAlert).toHaveTextContent(
-      "Your password change has been processed. Check your email for confirmation."
-    );
-    expect(changePasswordMock).toHaveBeenCalledTimes(1);
-    expect(changePasswordMock).toHaveBeenCalledWith("", "new_password");
-  });
+      userEvent.type(
+        await screen.findByLabelText("New password"),
+        "new_password"
+      );
+      userEvent.type(screen.getByLabelText("Confirm password"), "new_password");
+      userEvent.click(screen.getByRole("button", { name: "Submit" }));
 
-  it("submits the change password request successfully with an old password if one is given", async () => {
-    render(<ChangePasswordPage />, { wrapper });
+      const successAlert = await screen.findByRole("alert");
+      expect(successAlert).toBeVisible();
+      expect(successAlert).toHaveTextContent(
+        "Your password change has been processed. Check your email for confirmation."
+      );
+      expect(changePasswordMock).toHaveBeenCalledTimes(1);
+      expect(changePasswordMock).toHaveBeenCalledWith(
+        undefined,
+        "new_password"
+      );
+    });
 
-    userEvent.type(screen.getByLabelText("Old password"), "old_password");
-    userEvent.type(screen.getByLabelText("New password"), "new_password");
-    userEvent.type(screen.getByLabelText("Confirm password"), "new_password");
-    userEvent.click(screen.getByRole("button", { name: "Submit" }));
+    it("shows an error alert if the change password request failed", async () => {
+      jest.spyOn(console, "error").mockReturnValue(undefined);
+      changePasswordMock.mockRejectedValue(
+        new Error("The password is insecure")
+      );
+      render(<ChangePasswordPage />, { wrapper });
 
-    const successAlert = await screen.findByRole("alert");
-    expect(successAlert).toBeVisible();
-    expect(successAlert).toHaveTextContent(
-      "Your password change has been processed. Check your email for confirmation."
-    );
-    expect(changePasswordMock).toHaveBeenCalledTimes(1);
-    expect(changePasswordMock).toHaveBeenCalledWith(
-      "old_password",
-      "new_password"
-    );
-  });
+      userEvent.type(
+        await screen.findByLabelText("New password"),
+        "new_password"
+      );
+      userEvent.type(screen.getByLabelText("Confirm password"), "new_password");
+      userEvent.click(screen.getByRole("button", { name: "Submit" }));
 
-  it("shows an error alert if the change password request failed", async () => {
-    jest.spyOn(console, "error").mockReturnValue(undefined);
-    changePasswordMock.mockRejectedValue(new Error("The password is insecure"));
-    render(<ChangePasswordPage />, { wrapper });
-
-    userEvent.type(screen.getByLabelText("Old password"), "old_password");
-    userEvent.type(screen.getByLabelText("New password"), "new_password");
-    userEvent.type(screen.getByLabelText("Confirm password"), "new_password");
-    userEvent.click(screen.getByRole("button", { name: "Submit" }));
-
-    const errorAlert = await screen.findByRole("alert");
-    expect(errorAlert).toBeVisible();
-    expect(errorAlert).toHaveTextContent("The password is insecure");
-    expect(
-      screen.queryByText(/Your password change has been processed/i)
-    ).not.toBeInTheDocument();
+      const errorAlert = await screen.findByRole("alert");
+      expect(errorAlert).toBeVisible();
+      expect(errorAlert).toHaveTextContent("The password is insecure");
+      expect(
+        screen.queryByText(/Your password change has been processed/i)
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/app/frontend/src/features/auth/password/ChangePasswordPage.tsx
+++ b/app/frontend/src/features/auth/password/ChangePasswordPage.tsx
@@ -34,11 +34,12 @@ export default function ChangePasswordPage() {
     error: accountInfoError,
     isLoading: isAccountInfoLoading,
   } = useAccountInfo();
-  const { error, isLoading, isSuccess, mutate: changePassword } = useMutation<
-    Empty,
-    GrpcError,
-    ChangePasswordVariables
-  >(
+  const {
+    error: changePasswordError,
+    isLoading: isChangePasswordLoading,
+    isSuccess: isChangePasswordSuccess,
+    mutate: changePassword,
+  } = useMutation<Empty, GrpcError, ChangePasswordVariables>(
     ({ oldPassword, newPassword }) =>
       service.account.changePassword(oldPassword, newPassword),
     {
@@ -69,8 +70,10 @@ export default function ChangePasswordPage() {
         <Alert severity="error">{accountInfoError.message}</Alert>
       ) : (
         <>
-          {error && <Alert severity="error">{error.message}</Alert>}
-          {isSuccess && (
+          {changePasswordError && (
+            <Alert severity="error">{changePasswordError.message}</Alert>
+          )}
+          {isChangePasswordSuccess && (
             <Alert severity="success">
               Your password change has been processed. Check your email for
               confirmation.
@@ -113,7 +116,11 @@ export default function ChangePasswordPage() {
               type="password"
               helperText={errors.passwordConfirmation?.message}
             />
-            <Button fullWidth={!isMdOrWider} loading={isLoading} type="submit">
+            <Button
+              fullWidth={!isMdOrWider}
+              loading={isChangePasswordLoading}
+              type="submit"
+            >
               Submit
             </Button>
           </form>

--- a/app/frontend/src/features/auth/password/ChangePasswordPage.tsx
+++ b/app/frontend/src/features/auth/password/ChangePasswordPage.tsx
@@ -1,9 +1,4 @@
-import {
-  makeStyles,
-  Typography,
-  useMediaQuery,
-  useTheme,
-} from "@material-ui/core";
+import { Typography, useMediaQuery, useTheme } from "@material-ui/core";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Error as GrpcError } from "grpc-web";
 import { useForm } from "react-hook-form";
@@ -17,6 +12,7 @@ import TextField from "../../../components/TextField";
 import { accountInfoQueryKey } from "../../../queryKeys";
 import { service } from "../../../service";
 import useAccountInfo from "../useAccountInfo";
+import useChangeDetailsFormStyles from "../useChangeDetailsFormStyles";
 
 interface ChangePasswordVariables {
   oldPassword?: string;
@@ -27,19 +23,8 @@ interface ChangePasswordFormData extends ChangePasswordVariables {
   passwordConfirmation?: string;
 }
 
-const useStyles = makeStyles((theme) => ({
-  form: {
-    "& > * + *": {
-      marginBlockStart: theme.spacing(1),
-    },
-  },
-  infoText: {
-    marginBlockEnd: theme.spacing(1),
-  },
-}));
-
 export default function ChangePasswordPage() {
-  const classes = useStyles();
+  const classes = useChangeDetailsFormStyles();
   const theme = useTheme();
   const isMdOrWider = useMediaQuery(theme.breakpoints.up("md"));
 

--- a/app/frontend/src/features/auth/password/ChangePasswordPage.tsx
+++ b/app/frontend/src/features/auth/password/ChangePasswordPage.tsx
@@ -28,6 +28,19 @@ export default function ChangePasswordPage() {
   const theme = useTheme();
   const isMdOrWider = useMediaQuery(theme.breakpoints.up("md"));
 
+  const {
+    errors,
+    getValues,
+    handleSubmit,
+    reset: resetForm,
+    register,
+  } = useForm<ChangePasswordFormData>({
+    mode: "onBlur",
+  });
+  const onSubmit = handleSubmit(({ oldPassword, newPassword }) => {
+    changePassword({ oldPassword, newPassword });
+  });
+
   const queryClient = useQueryClient();
   const {
     data: accountInfo,
@@ -45,21 +58,10 @@ export default function ChangePasswordPage() {
     {
       onSuccess: () => {
         queryClient.invalidateQueries(accountInfoQueryKey);
+        resetForm();
       },
     }
   );
-
-  const {
-    errors,
-    getValues,
-    handleSubmit,
-    register,
-  } = useForm<ChangePasswordFormData>({
-    mode: "onBlur",
-  });
-  const onSubmit = handleSubmit(({ oldPassword, newPassword }) => {
-    changePassword({ oldPassword, newPassword });
-  });
 
   return (
     <>

--- a/app/frontend/src/features/auth/password/ChangePasswordPage.tsx
+++ b/app/frontend/src/features/auth/password/ChangePasswordPage.tsx
@@ -7,13 +7,16 @@ import {
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Error as GrpcError } from "grpc-web";
 import { useForm } from "react-hook-form";
-import { useMutation } from "react-query";
+import { useMutation, useQueryClient } from "react-query";
 
 import Alert from "../../../components/Alert";
 import Button from "../../../components/Button";
+import CircularProgress from "../../../components/CircularProgress";
 import PageTitle from "../../../components/PageTitle";
 import TextField from "../../../components/TextField";
+import { accountInfoQueryKey } from "../../../queryKeys";
 import { service } from "../../../service";
+import useAccountInfo from "../useAccountInfo";
 
 interface ChangePasswordVariables {
   oldPassword?: string;
@@ -40,6 +43,26 @@ export default function ChangePasswordPage() {
   const theme = useTheme();
   const isMdOrWider = useMediaQuery(theme.breakpoints.up("md"));
 
+  const queryClient = useQueryClient();
+  const {
+    data: accountInfo,
+    error: accountInfoError,
+    isLoading: isAccountInfoLoading,
+  } = useAccountInfo();
+  const { error, isLoading, isSuccess, mutate: changePassword } = useMutation<
+    Empty,
+    GrpcError,
+    ChangePasswordVariables
+  >(
+    ({ oldPassword, newPassword }) =>
+      service.account.changePassword(oldPassword, newPassword),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(accountInfoQueryKey);
+      },
+    }
+  );
+
   const {
     errors,
     getValues,
@@ -48,15 +71,6 @@ export default function ChangePasswordPage() {
   } = useForm<ChangePasswordFormData>({
     mode: "onBlur",
   });
-
-  const { error, isLoading, isSuccess, mutate: changePassword } = useMutation<
-    Empty,
-    GrpcError,
-    ChangePasswordVariables
-  >(({ oldPassword, newPassword }) =>
-    service.account.changePassword(oldPassword, newPassword)
-  );
-
   const onSubmit = handleSubmit(({ oldPassword, newPassword }) => {
     changePassword({ oldPassword, newPassword });
   });
@@ -64,52 +78,62 @@ export default function ChangePasswordPage() {
   return (
     <>
       <PageTitle>Change password</PageTitle>
-      {error && <Alert severity="error">{error.message}</Alert>}
-      {isSuccess && (
-        <Alert severity="success">
-          Your password change has been processed. Check your email for
-          confirmation.
-        </Alert>
-      )}
-      <Typography className={classes.infoText} variant="body1">
-        Please enter a new password, or leave the "New password" and "Confirm
-        password" fields blank to unset your password.
-      </Typography>
-      <form className={classes.form} onSubmit={onSubmit}>
-        <TextField
-          id="oldPassword"
-          inputRef={register}
-          label="Old password"
-          name="oldPassword"
-          type="password"
-          fullWidth={!isMdOrWider}
-        />
+      {isAccountInfoLoading ? (
+        <CircularProgress />
+      ) : accountInfoError ? (
+        <Alert severity="error">{accountInfoError.message}</Alert>
+      ) : (
+        <>
+          {error && <Alert severity="error">{error.message}</Alert>}
+          {isSuccess && (
+            <Alert severity="success">
+              Your password change has been processed. Check your email for
+              confirmation.
+            </Alert>
+          )}
+          <Typography className={classes.infoText} variant="body1">
+            Please enter a new password, or leave the "New password" and
+            "Confirm password" fields blank to unset your password.
+          </Typography>
+          <form className={classes.form} onSubmit={onSubmit}>
+            {accountInfo && accountInfo.hasPassword && (
+              <TextField
+                id="oldPassword"
+                inputRef={register({ required: true })}
+                label="Old password"
+                name="oldPassword"
+                type="password"
+                fullWidth={!isMdOrWider}
+              />
+            )}
 
-        <TextField
-          id="newPassword"
-          inputRef={register}
-          label="New password"
-          name="newPassword"
-          type="password"
-          fullWidth={!isMdOrWider}
-        />
-        <TextField
-          id="passwordConfirmation"
-          inputRef={register({
-            validate: (value) =>
-              value === getValues("newPassword") ||
-              "This does not match the new password you typed above",
-          })}
-          label="Confirm password"
-          name="passwordConfirmation"
-          fullWidth={!isMdOrWider}
-          type="password"
-          helperText={errors.passwordConfirmation?.message}
-        />
-        <Button loading={isLoading} type="submit">
-          Submit
-        </Button>
-      </form>
+            <TextField
+              id="newPassword"
+              inputRef={register({ required: !accountInfo?.hasPassword })}
+              label="New password"
+              name="newPassword"
+              type="password"
+              fullWidth={!isMdOrWider}
+            />
+            <TextField
+              id="passwordConfirmation"
+              inputRef={register({
+                validate: (value) =>
+                  value === getValues("newPassword") ||
+                  "This does not match the new password you typed above",
+              })}
+              label="Confirm password"
+              name="passwordConfirmation"
+              fullWidth={!isMdOrWider}
+              type="password"
+              helperText={errors.passwordConfirmation?.message}
+            />
+            <Button fullWidth={!isMdOrWider} loading={isLoading} type="submit">
+              Submit
+            </Button>
+          </form>
+        </>
+      )}
     </>
   );
 }

--- a/app/frontend/src/features/auth/password/CompleteResetPasswordPage.test.tsx
+++ b/app/frontend/src/features/auth/password/CompleteResetPasswordPage.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Route, Switch } from "react-router-dom";
 
-import { loginRoute, resetPasswordRoute } from "../../../AppRoutes";
+import { loginRoute, resetPasswordRoute } from "../../../routes";
 import { service } from "../../../service";
 import { getHookWrapperWithClient } from "../../../test/hookWrapper";
 import { MockedService } from "../../../test/utils";
@@ -70,6 +70,7 @@ describe("CompleteResetPasswordPage", () => {
   });
 
   it("shows an error alert if the reset password process failed to complete", async () => {
+    jest.spyOn(console, "error").mockReturnValue(undefined);
     completePasswordResetMock.mockRejectedValue(new Error("Invalid token"));
     renderPage();
 

--- a/app/frontend/src/features/auth/useAccountInfo.ts
+++ b/app/frontend/src/features/auth/useAccountInfo.ts
@@ -1,0 +1,15 @@
+import { Error as GrpcError } from "grpc-web";
+import { useQuery } from "react-query";
+
+import { GetAccountInfoRes } from "../../pb/account_pb";
+import { accountInfoQueryKey } from "../../queryKeys";
+import { service } from "../../service";
+
+export default function useAccountInfo() {
+  const accountInfoQuery = useQuery<GetAccountInfoRes.AsObject, GrpcError>(
+    accountInfoQueryKey,
+    () => service.account.getAccountInfo()
+  );
+
+  return accountInfoQuery;
+}

--- a/app/frontend/src/features/auth/useChangeDetailsFormStyles.ts
+++ b/app/frontend/src/features/auth/useChangeDetailsFormStyles.ts
@@ -1,0 +1,14 @@
+import { makeStyles } from "@material-ui/core";
+
+const useChangeDetailsFormStyles = makeStyles((theme) => ({
+  form: {
+    "& > * + *": {
+      marginBlockStart: theme.spacing(1),
+    },
+  },
+  infoText: {
+    marginBlockEnd: theme.spacing(1),
+  },
+}));
+
+export default useChangeDetailsFormStyles;

--- a/app/frontend/src/features/profile/ProfilePage.tsx
+++ b/app/frontend/src/features/profile/ProfilePage.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 
 import PageTitle from "../../components/PageTitle";
 import {
+  changeEmailRoute,
   changePasswordRoute,
   editHostingPreferenceRoute,
   editProfileRoute,
@@ -40,6 +41,13 @@ export default function ProfilePage() {
           to={editHostingPreferenceRoute}
         >
           Edit my place
+        </ListItem>
+        <ListItem
+          className={classes.linkStyle}
+          component={Link}
+          to={changeEmailRoute}
+        >
+          Change my email
         </ListItem>
         <ListItem
           className={classes.linkStyle}

--- a/app/frontend/src/queryKeys.ts
+++ b/app/frontend/src/queryKeys.ts
@@ -1,0 +1,1 @@
+export const accountInfoQueryKey = "accountInfo";

--- a/app/frontend/src/routes.ts
+++ b/app/frontend/src/routes.ts
@@ -3,6 +3,7 @@ export const loginPasswordRoute = `${loginRoute}/password`;
 export const resetPasswordRoute = "/password-reset";
 export const changePasswordRoute = "/change-password";
 export const changeEmailRoute = "/change-email";
+export const confirmChangeEmailRoute = "/confirm-email";
 
 export const signupRoute = "/signup";
 export const profileRoute = "/profile";

--- a/app/frontend/src/routes.ts
+++ b/app/frontend/src/routes.ts
@@ -2,6 +2,7 @@ export const loginRoute = "/login";
 export const loginPasswordRoute = `${loginRoute}/password`;
 export const resetPasswordRoute = "/password-reset";
 export const changePasswordRoute = "/change-password";
+export const changeEmailRoute = "/change-email";
 
 export const signupRoute = "/signup";
 export const profileRoute = "/profile";

--- a/app/frontend/src/service/account.ts
+++ b/app/frontend/src/service/account.ts
@@ -1,8 +1,18 @@
+import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { StringValue } from "google-protobuf/google/protobuf/wrappers_pb";
 
-import { ChangePasswordReq } from "../pb/account_pb";
-import { CompletePasswordResetReq, ResetPasswordReq } from "../pb/auth_pb";
+import { ChangeEmailReq, ChangePasswordReq } from "../pb/account_pb";
+import {
+  CompleteChangeEmailReq,
+  CompletePasswordResetReq,
+  ResetPasswordReq,
+} from "../pb/auth_pb";
 import client from "./client";
+
+export async function getAccountInfo() {
+  const res = await client.account.getAccountInfo(new Empty());
+  return res.toObject();
+}
 
 export function resetPassword(userId: string) {
   const req = new ResetPasswordReq();
@@ -26,4 +36,20 @@ export function changePassword(oldPassword?: string, newPassword?: string) {
   }
 
   return client.account.changePassword(req);
+}
+
+export function changeEmail(newEmail: string, currentPassword?: string) {
+  const req = new ChangeEmailReq();
+  req.setNewEmail(newEmail);
+  if (currentPassword) {
+    req.setPassword(new StringValue().setValue(currentPassword));
+  }
+
+  return client.account.changeEmail(req);
+}
+
+export function completeChangeEmail(resetToken: string) {
+  const req = new CompleteChangeEmailReq();
+  req.setChangeEmailToken(resetToken);
+  return client.auth.completeChangeEmail(req);
 }


### PR DESCRIPTION
Updated change password form to use the new `getAccountInfo` API to hide the "old password" field if the user doesn't have one. Also realised I didn't wrap it in a `PrivateRoute` for that in the last PR, so fixed that in this too.

Also did the same for the change email form.