### PR TITLE
fixed messages sending notification email

### DIFF
--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -115,13 +115,8 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             host_request.status = HostRequestStatus.pending
             host_request.from_last_seen_message_id = message.id
             session.add(host_request)
-
-            host_request = (
-                session.query(HostRequest)
-                .filter(HostRequest.conversation_id == conversation.id)
-                .filter(or_(HostRequest.from_user_id == context.user_id, HostRequest.to_user_id == host.id))
-                .one_or_none()
-            )
+            session.flush()
+            
             send_host_request_email(host_request)
 
             return requests_pb2.CreateHostRequestRes(host_request_id=host_request.conversation_id)

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -116,6 +116,14 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             host_request.from_last_seen_message_id = message.id
             session.add(host_request)
 
+            host_request = (
+                session.query(HostRequest)
+                .filter(HostRequest.conversation_id == conversation.id)
+                .filter(or_(HostRequest.from_user_id == context.user_id, HostRequest.to_user_id == host.id))
+                .one_or_none()
+            )
+            send_host_request_email(host_request)
+
             return requests_pb2.CreateHostRequestRes(host_request_id=host_request.conversation_id)
 
     def GetHostRequest(self, request, context):
@@ -145,8 +153,6 @@ class Requests(requests_pb2_grpc.RequestsServicer):
                 .limit(1)
                 .one()
             )
-
-            send_host_request_email(host_request)
 
             return requests_pb2.HostRequest(
                 host_request_id=host_request.conversation_id,


### PR DESCRIPTION
Viewing host request messages no longer sends a notification email. 

Moved the send email function call from GetHostRequest to CreateHostRequest. The send email function requires the host request to have a to_user attribute which is only populated after the host request is added to the database so the host request object is fetched again after it is added to the database. Not sure if this is the cleanest method.