### PR TITLE
fix: sanitizing name/email before submitting it to backend

### DIFF
--- a/app/frontend/src/features/auth/email/ChangeEmailPage.test.tsx
+++ b/app/frontend/src/features/auth/email/ChangeEmailPage.test.tsx
@@ -91,6 +91,35 @@ describe("ChangeEmailPage", () => {
       expect(screen.getByLabelText("Current password")).not.toHaveValue();
       expect(screen.getByLabelText("New email")).not.toHaveValue();
     });
+
+    it("submits sanitized email to the backend if user uses uppercase characters or adds whitespaces at the start/end", async () => {
+      render(<ChangeEmailPage />, { wrapper });
+
+      userEvent.type(
+        await screen.findByLabelText("Current password"),
+        "password"
+      );
+      userEvent.type(
+        screen.getByLabelText("New email"),
+        "   tEst@examPle.Com   "
+      );
+      userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+      const successAlert = await screen.findByRole("alert");
+      expect(successAlert).toBeVisible();
+      expect(successAlert).toHaveTextContent(
+        "Your email change has been received. Check your new email to complete the change."
+      );
+      expect(changeEmailMock).toHaveBeenCalledTimes(1);
+      expect(changeEmailMock).toHaveBeenCalledWith(
+        "test@example.com",
+        "password"
+      );
+
+      // Also check form has been cleared
+      expect(screen.getByLabelText("Current password")).not.toHaveValue();
+      expect(screen.getByLabelText("New email")).not.toHaveValue();
+    });
   });
 
   describe("if the user does not have a password", () => {
@@ -117,6 +146,31 @@ describe("ChangeEmailPage", () => {
         await screen.findByLabelText("New email"),
         "test@example.com"
       );
+      userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+      const successAlert = await screen.findByRole("alert");
+      expect(successAlert).toBeVisible();
+      expect(successAlert).toHaveTextContent(
+        "Your email change has been received. Check your new email to complete the change."
+      );
+      expect(changeEmailMock).toHaveBeenCalledTimes(1);
+      expect(changeEmailMock).toHaveBeenCalledWith(
+        "test@example.com",
+        undefined
+      );
+
+      // Also check form has been cleared
+      expect(screen.getByLabelText("New email")).not.toHaveValue();
+    });
+
+    it("submits sanitized email to the backend if user uses uppercase characters or adds whitespaces at the start/end", async () => {
+      render(<ChangeEmailPage />, { wrapper });
+
+      userEvent.type(
+        await screen.findByLabelText("New email"),
+        "  tesT@eXample.cOm  "
+      );
+
       userEvent.click(screen.getByRole("button", { name: "Submit" }));
 
       const successAlert = await screen.findByRole("alert");

--- a/app/frontend/src/features/auth/email/ChangeEmailPage.tsx
+++ b/app/frontend/src/features/auth/email/ChangeEmailPage.tsx
@@ -3,6 +3,7 @@ import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Error as GrpcError } from "grpc-web";
 import { useForm } from "react-hook-form";
 import { useMutation } from "react-query";
+import { sanitizeName } from "utils/validation";
 
 import Alert from "../../../components/Alert";
 import Button from "../../../components/Button";
@@ -29,7 +30,8 @@ export default function ChangeEmailPage() {
     reset: resetForm,
   } = useForm<ChangeEmailFormData>();
   const onSubmit = handleSubmit(({ currentPassword, newEmail }) => {
-    changeEmail({ currentPassword, newEmail });
+    const sanitizedEmail = sanitizeName(newEmail);
+    changeEmail({ currentPassword, newEmail: sanitizedEmail });
   });
 
   const {

--- a/app/frontend/src/features/auth/login/LoginForm.tsx
+++ b/app/frontend/src/features/auth/login/LoginForm.tsx
@@ -17,6 +17,7 @@ import { Link, useHistory } from "react-router-dom";
 import { loginPasswordRoute, resetPasswordRoute } from "routes";
 import { service } from "service/index";
 import { useIsMounted, useSafeState } from "utils/hooks";
+import { sanitizeName } from "utils/validation";
 
 const useStyles = makeStyles((theme) => ({
   loginOptions: {
@@ -46,7 +47,8 @@ export default function UsernameForm() {
       setLoading(true);
       authActions.clearError();
       try {
-        const next = await service.auth.checkUsername(data.username);
+        const sanitizedUsername = sanitizeName(data.username);
+        const next = await service.auth.checkUsername(sanitizedUsername);
         switch (next) {
           case LoginRes.LoginStep.INVALID_USER:
             authActions.authError("Couldn't find that user.");
@@ -64,7 +66,7 @@ export default function UsernameForm() {
 
         if (!loginWithLink) {
           authActions.passwordLogin({
-            username: data.username,
+            username: sanitizedUsername,
             password: data.password,
           });
         }

--- a/app/frontend/src/features/auth/signup/CompleteSignupForm.tsx
+++ b/app/frontend/src/features/auth/signup/CompleteSignupForm.tsx
@@ -25,6 +25,7 @@ import { signupRoute } from "routes";
 import { service } from "service/index";
 import {
   nameValidationPattern,
+  sanitizeName,
   usernameValidationPattern,
   validatePastDate,
 } from "utils/validation";
@@ -106,7 +107,7 @@ export default function CompleteSignup() {
 
     authActions.signup({
       signupToken: urlToken,
-      username: data.username,
+      username: sanitizeName(data.username),
       name: data.name,
       city: data.city,
       location: data.location,

--- a/app/frontend/src/features/auth/signup/EmailForm.tsx
+++ b/app/frontend/src/features/auth/signup/EmailForm.tsx
@@ -8,6 +8,7 @@ import { SignupRes } from "pb/auth_pb";
 import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import { service } from "service/index";
+import { sanitizeName } from "utils/validation";
 
 export default function EmailForm() {
   const { authActions } = useAuthContext();
@@ -25,7 +26,8 @@ export default function EmailForm() {
     setLoading(true);
     authActions.clearError();
     try {
-      const next = await service.auth.createEmailSignup(email);
+      const sanitizedEmail = sanitizeName(email);
+      const next = await service.auth.createEmailSignup(sanitizedEmail);
       switch (next) {
         case SignupRes.SignupStep.EMAIL_EXISTS:
           authActions.authError("That email is already in use.");

--- a/app/frontend/src/utils/validation.ts
+++ b/app/frontend/src/utils/validation.ts
@@ -11,3 +11,7 @@ export function validateFutureDate(stringDate: string) {
   const date = new Date(stringDate);
   return !isNaN(date.getTime()) && date >= new Date();
 }
+
+export function sanitizeName(name: string) {
+  return name.trim().toLowerCase();
+}


### PR DESCRIPTION
Closes https://github.com/Couchers-org/couchers/issues/258

Let me know if there are other places we should do this. Also this function is used for sanitizing both email and login, couldn't come up with a better name, feel free to suggest sth better ;) 

Do we display username somewhere? Does it make sense to display it the way user entered it during sign up (capitalized or not)?