### PR TITLE
404 Redirect while keeping current URL

### DIFF
--- a/app/frontend/src/AppRoutes.tsx
+++ b/app/frontend/src/AppRoutes.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Redirect, Switch } from "react-router-dom";
+import { Switch } from "react-router-dom";
 
 import AppRoute from "./AppRoute";
 import TOS from "./components/TOS";
@@ -56,7 +56,6 @@ import {
   messagesRoute,
   newGuideRoute,
   newPlaceRoute,
-  notFoundRoute,
   placeRoute,
   profileRoute,
   resetPasswordRoute,
@@ -207,10 +206,9 @@ export default function AppRoutes() {
       {
         // 404 NOT FOUND
       }
-      <AppRoute isPrivate={false} exact path={notFoundRoute}>
+      <AppRoute isPrivate={false}>
         <NotFoundPage />
       </AppRoute>
-      <Redirect from="*" to={notFoundRoute} />
     </Switch>
   );
 }

--- a/app/frontend/src/routes.ts
+++ b/app/frontend/src/routes.ts
@@ -35,7 +35,6 @@ export const mapRoute = "/map";
 export const logoutRoute = "/logout";
 export const connectionsRoute = "/connections";
 export const friendsRoute = `${connectionsRoute}/friends`;
-export const notFoundRoute = "/notfound";
 
 export const userRoute = "/user";
 export const routeToUser = (username: string) => `${profileRoute}/${username}`;


### PR DESCRIPTION
@lucaslcode 

From issue : #753 

I removed the 'exact path' props from 404 Route component and as it is the last it act as a all other routes grabber and still show the 404 page while keeping the URL user entered. 

I then removed the redirect component which became useless with this configuration and after checking for references I also removed 'notFoundRoute export on routes.ts.