### PR TITLE
Added functionality to clear profile picture

### DIFF
--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -212,7 +212,10 @@ class API(api_pb2_grpc.APIServicer):
                 user.geom_radius = request.radius.value
 
             if request.HasField("avatar_key"):
-                user.avatar_key = request.avatar_key.value
+                if request.avatar_key.is_null:
+                    user.avatar_key = None
+                else:
+                    user.avatar_key = request.avatar_key.value
 
             if request.HasField("gender"):
                 user.gender = request.gender.value

--- a/app/pb/api.proto
+++ b/app/pb/api.proto
@@ -264,7 +264,7 @@ message UpdateProfileReq {
   google.protobuf.DoubleValue lng = 23;
   google.protobuf.DoubleValue radius = 24; // metres
 
-  google.protobuf.StringValue avatar_key = 25; // result from media server
+  NullableStringValue avatar_key = 25; // result from media server
 
   google.protobuf.StringValue gender = 3;
   NullableStringValue pronouns = 101;


### PR DESCRIPTION
Fixes #731 

Makes the user avatar nullable when updating a user profile which will allow the picture to be cleared.