### PR TITLE
Fix Date.now to a specific value to fix flaky timeAgo tests

### DIFF
--- a/app/frontend/src/features/BugReport.test.tsx
+++ b/app/frontend/src/features/BugReport.test.tsx
@@ -213,6 +213,7 @@ describe("BugReport", () => {
     });
 
     it("resets error in the bug report dialog when it is being reopened", async () => {
+      jest.spyOn(console, "error").mockReturnValue(undefined);
       reportBugMock.mockRejectedValue(new Error("Bug tool disabled"));
       render(<BugReport />, { wrapper });
       userEvent.click(screen.getByRole("button", { name: "Report a bug" }));

--- a/app/frontend/src/utils/timeAgo.test.ts
+++ b/app/frontend/src/utils/timeAgo.test.ts
@@ -29,6 +29,10 @@ const timeAgoMap = {
   [yearMillis]: "1 year ago",
 };
 
+beforeEach(() => {
+  jest.spyOn(Date, "now").mockReturnValue(1614556800000);
+});
+
 test("timeAgo function", () => {
   Object.keys(timeAgoMap).forEach((key: string) => {
     const now = Date.now();


### PR DESCRIPTION
The [current develop build](https://github.com/Couchers-org/couchers/commit/a4f05ac7925b1f7823b587ed2534e25253f4d9a9) is failing because of these flaky `timeAgo` tests... I started noticing them recently when running locally on my machine too (although still super rare).

My suspicion is that previously, `Date.now` wasn't mocked so it's a variable value depending on the timing of the test, which means very occasionally, we might somehow trigger a calculation (in the milliseconds? 🤷 ) such that `now - millis` isn't actually <= 1 mins...

Mocking `Date.now` and fixing this value to a known one should hopefully fix this.