### PR TITLE
Include profile pic/remove username in connections page

### DIFF
--- a/app/frontend/src/components/TabBar/TabBar.stories.tsx
+++ b/app/frontend/src/components/TabBar/TabBar.stories.tsx
@@ -1,5 +1,6 @@
+import { TabContext } from "@material-ui/lab";
 import { Meta, Story } from "@storybook/react";
-import React from "react";
+import { useState } from "react";
 
 import NotificationBadge from "../NotificationBadge";
 import TabBar, { TabBarProps } from "./TabBar";
@@ -16,11 +17,16 @@ const labels = {
   surfing: "Surfing",
 };
 
-type PartialLabels = Partial<typeof labels>;
+type Labels = Partial<typeof labels>;
 
-const Template: Story<TabBarProps<PartialLabels>> = (args) => (
-  <TabBar {...args} />
-);
+const Template: Story<TabBarProps<Labels>> = (args) => {
+  const [currentTab, setCurrentTab] = useState(args.value);
+  return (
+    <TabContext value={currentTab}>
+      <TabBar {...args} setValue={setCurrentTab} />
+    </TabContext>
+  );
+};
 
 export const SimpleLabel = Template.bind({});
 SimpleLabel.args = {
@@ -28,7 +34,6 @@ SimpleLabel.args = {
     meet: "Meet",
     surfing: "Surfing",
   },
-  setValue: () => {},
   value: "meet",
 };
 
@@ -38,7 +43,6 @@ LabelWithBadge.args = {
     all: <NotificationBadge count={10}>All</NotificationBadge>,
     surfing: "Surfing",
   },
-  setValue: () => {},
   value: "all",
 };
 
@@ -48,6 +52,5 @@ HighCountBadge.args = {
     all: <NotificationBadge count={100}>All</NotificationBadge>,
     surfing: "Surfing",
   },
-  setValue: () => {},
   value: "all",
 };

--- a/app/frontend/src/components/TabBar/TabBar.tsx
+++ b/app/frontend/src/components/TabBar/TabBar.tsx
@@ -1,12 +1,15 @@
-import { Tab, Tabs } from "@material-ui/core";
+import { Tab } from "@material-ui/core";
+import { TabList } from "@material-ui/lab";
 
 export interface TabBarProps<T extends Record<string, React.ReactNode>> {
-  value: keyof T;
-  setValue: (value: keyof T) => void;
+  ariaLabel: string;
   labels: T;
+  setValue: (value: keyof T) => void;
+  value: keyof T;
 }
 
 export default function TabBar<T extends Record<string, React.ReactNode>>({
+  ariaLabel,
   value,
   setValue,
   labels,
@@ -15,7 +18,8 @@ export default function TabBar<T extends Record<string, React.ReactNode>>({
     setValue(newValue);
   };
   return (
-    <Tabs
+    <TabList
+      aria-label={ariaLabel}
       value={value as any}
       onChange={handleChange}
       indicatorColor="primary"
@@ -26,6 +30,6 @@ export default function TabBar<T extends Record<string, React.ReactNode>>({
       {Object.entries(labels).map(([value, label]) => (
         <Tab key={value} label={label} value={value} />
       ))}
-    </Tabs>
+    </TabList>
   );
 }

--- a/app/frontend/src/components/UserSummary.tsx
+++ b/app/frontend/src/components/UserSummary.tsx
@@ -36,10 +36,15 @@ export const useStyles = makeStyles((theme) => ({
 
 interface UserSummaryProps {
   children?: React.ReactNode;
+  headlineComponent?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
   user?: User.AsObject;
 }
 
-export default function UserSummary({ children, user }: UserSummaryProps) {
+export default function UserSummary({
+  children,
+  headlineComponent = "h2",
+  user,
+}: UserSummaryProps) {
   const classes = useStyles();
   return (
     <div className={classes.root}>
@@ -54,7 +59,11 @@ export default function UserSummary({ children, user }: UserSummaryProps) {
         className={classes.titleAndBarContainer}
         disableTypography
         primary={
-          <Typography variant="h2" className={classes.title}>
+          <Typography
+            component={headlineComponent}
+            variant="h2"
+            className={classes.title}
+          >
             {!user ? <Skeleton /> : `${user.name}, ${user.age}, ${user.city}`}
           </Typography>
         }

--- a/app/frontend/src/features/connections/ConnectionsPage.tsx
+++ b/app/frontend/src/features/connections/ConnectionsPage.tsx
@@ -7,6 +7,7 @@ import PageTitle from "../../components/PageTitle";
 import TabBar from "../../components/TabBar";
 import { connectionsRoute } from "../../routes";
 import useNotifications from "../useNotifications";
+import { CONNECTIONS, FRIENDS } from "./constants";
 import { FriendsTab } from "./friends";
 
 function FriendsNotification() {
@@ -14,7 +15,7 @@ function FriendsNotification() {
 
   return (
     <NotificationBadge count={data?.pendingFriendRequestCount}>
-      Friends
+      {FRIENDS}
     </NotificationBadge>
   );
 }
@@ -32,7 +33,7 @@ function ConnectionsPage() {
 
   return (
     <>
-      <PageTitle>My Connections</PageTitle>
+      <PageTitle>{CONNECTIONS}</PageTitle>
       <TabContext value={connectionType}>
         <TabBar
           value={connectionType}

--- a/app/frontend/src/features/connections/ConnectionsPage.tsx
+++ b/app/frontend/src/features/connections/ConnectionsPage.tsx
@@ -36,6 +36,7 @@ function ConnectionsPage() {
       <PageTitle>{CONNECTIONS}</PageTitle>
       <TabContext value={connectionType}>
         <TabBar
+          ariaLabel="Tabs for different connection types"
           value={connectionType}
           setValue={(newType) =>
             history.push(

--- a/app/frontend/src/features/connections/constants.ts
+++ b/app/frontend/src/features/connections/constants.ts
@@ -1,4 +1,7 @@
 export const ADD_FRIEND = "Add friend";
+export const CONNECTIONS = "My connections";
+export const FRIENDS = "Friends";
+
 export const FRIEND_LIST_TITLE = "Your friends";
 export const FRIEND_REQUESTS = "Friend requests";
 export const FRIEND_REQUESTS_SENT = "Friend requests you sent";

--- a/app/frontend/src/features/connections/friends/FriendList.test.tsx
+++ b/app/frontend/src/features/connections/friends/FriendList.test.tsx
@@ -37,12 +37,12 @@ describe("FriendList", () => {
 
     // First friend
     expect(
-      firstFriend.getByRole("link", { name: "Funny Dog @funnydog" })
+      firstFriend.getByRole("heading", { name: /Funny Dog/ })
     ).toBeVisible();
 
     // Second friend
     expect(
-      secondFriend.getByRole("link", { name: "Funny Kid @funnykid" })
+      secondFriend.getByRole("heading", { name: /Funny Kid/ })
     ).toBeVisible();
   });
 

--- a/app/frontend/src/features/connections/friends/FriendSummaryView.tsx
+++ b/app/frontend/src/features/connections/friends/FriendSummaryView.tsx
@@ -1,15 +1,9 @@
-import { makeStyles, Typography } from "@material-ui/core";
-import TextBody from "components/TextBody";
+import { makeStyles } from "@material-ui/core";
+import UserSummary from "components/UserSummary";
 import { User } from "pb/api_pb";
-import React from "react";
-import { Link } from "react-router-dom";
-import { routeToUser } from "routes";
 
 const useStyles = makeStyles((theme) => ({
   friendItem: {
-    alignItems: "center",
-    display: "flex",
-    justifyContent: "space-between",
     padding: `0 ${theme.spacing(1)}`,
   },
   friendLink: {
@@ -33,12 +27,7 @@ function FriendSummaryView({ children, friend }: FriendSummaryViewProps) {
 
   return friend ? (
     <div className={classes.friendItem} data-testid={FRIEND_ITEM_TEST_ID}>
-      <Link className={classes.friendLink} to={routeToUser(friend.username)}>
-        <Typography component="h3" variant="h2">
-          {friend.name}
-        </Typography>
-        <TextBody>@{friend.username}</TextBody>
-      </Link>
+      <UserSummary user={friend} />
       {children}
     </div>
   ) : null;

--- a/app/frontend/src/features/connections/friends/FriendSummaryView.tsx
+++ b/app/frontend/src/features/connections/friends/FriendSummaryView.tsx
@@ -27,7 +27,7 @@ function FriendSummaryView({ children, friend }: FriendSummaryViewProps) {
 
   return friend ? (
     <div className={classes.friendItem} data-testid={FRIEND_ITEM_TEST_ID}>
-      <UserSummary user={friend} />
+      <UserSummary headlineComponent="h3" user={friend} />
       {children}
     </div>
   ) : null;

--- a/app/frontend/src/features/connections/friends/FriendTile.tsx
+++ b/app/frontend/src/features/connections/friends/FriendTile.tsx
@@ -1,5 +1,4 @@
 import {
-  Box,
   Card,
   CircularProgress,
   makeStyles,
@@ -16,8 +15,8 @@ const useStyles = makeStyles((theme) => ({
     margin: `0 auto ${theme.spacing(1)}`,
   },
   container: {
-    "& > :last-child": {
-      marginBottom: theme.spacing(1),
+    "& > *": {
+      marginBottom: theme.spacing(2),
     },
   },
   errorAlert: {
@@ -53,7 +52,7 @@ function FriendTile({
 
   return (
     <Card>
-      <Box className={classes.container}>
+      <div className={classes.container}>
         <Typography className={classes.header} variant="h2">
           {title}
         </Typography>
@@ -71,7 +70,7 @@ function FriendTile({
             {noDataMessage}
           </TextBody>
         )}
-      </Box>
+      </div>
     </Card>
   );
 }

--- a/app/frontend/src/features/messages/Messages.tsx
+++ b/app/frontend/src/features/messages/Messages.tsx
@@ -1,3 +1,4 @@
+import { TabContext } from "@material-ui/lab";
 import * as React from "react";
 import { Route, Switch, useHistory, useParams } from "react-router-dom";
 
@@ -70,12 +71,14 @@ export default function Messages() {
   const header = (
     <>
       <PageTitle>Messages</PageTitle>
-      <TabBar
-        ariaLabel="Tabs for different message types"
-        value={messageType}
-        setValue={(newType) => history.push(`${messagesRoute}/${newType}`)}
-        labels={labels}
-      />
+      <TabContext value={messageType}>
+        <TabBar
+          ariaLabel="Tabs for different message types"
+          value={messageType}
+          setValue={(newType) => history.push(`${messagesRoute}/${newType}`)}
+          labels={labels}
+        />
+      </TabContext>
     </>
   );
 

--- a/app/frontend/src/features/messages/Messages.tsx
+++ b/app/frontend/src/features/messages/Messages.tsx
@@ -71,6 +71,7 @@ export default function Messages() {
     <>
       <PageTitle>Messages</PageTitle>
       <TabBar
+        ariaLabel="Tabs for different message types"
         value={messageType}
         setValue={(newType) => history.push(`${messagesRoute}/${newType}`)}
         labels={labels}

--- a/app/frontend/src/features/profile/view/ProfilePage.tsx
+++ b/app/frontend/src/features/profile/view/ProfilePage.tsx
@@ -77,7 +77,7 @@ export default function ProfilePage() {
                 value={currentTab}
                 setValue={setCurrentTab}
                 labels={SECTION_LABELS}
-                aria-label="tabs for user's details"
+                ariaLabel="tabs for user's details"
               />
               <TabPanel classes={{ root: classes.tabPanel }} value="about">
                 <About user={user} />


### PR DESCRIPTION
Literally swapping what's on the friends list to re-use the existing `UserSummary` component for this. Achieves the "remove username" and "show profile photo" in one. Since there aren't any designs for this, I thought this is the easiest way to do this and also for maintaining visual consistency. Thoughts?

Closes #761

**Web**
![Screenshot 2021-03-16 at 00 34 04](https://user-images.githubusercontent.com/13669362/111238682-744fd900-85ef-11eb-8929-5694c42cc518.png)

**Mobile Web**
![Screenshot 2021-03-16 at 00 34 29](https://user-images.githubusercontent.com/13669362/111238707-80d43180-85ef-11eb-9f0a-4a551fe84b88.png)
