### PR TITLE
Fix duplicate ID warning for profile text input in console

### DIFF
--- a/app/frontend/src/features/communities/NewGuideForm.tsx
+++ b/app/frontend/src/features/communities/NewGuideForm.tsx
@@ -73,6 +73,7 @@ export default function NewGuideForm() {
             name="content"
             render={({ onChange, value }) => (
               <ProfileMarkdownInput
+                id="content"
                 label="Page content"
                 onChange={onChange}
                 value={value}

--- a/app/frontend/src/features/communities/NewPlaceForm.tsx
+++ b/app/frontend/src/features/communities/NewPlaceForm.tsx
@@ -72,6 +72,7 @@ export default function NewPlaceForm() {
             name="content"
             render={({ onChange, value }) => (
               <ProfileMarkdownInput
+                id="content"
                 label="Place content"
                 onChange={onChange}
                 value={value}

--- a/app/frontend/src/features/profile/ProfileMarkdownInput.tsx
+++ b/app/frontend/src/features/profile/ProfileMarkdownInput.tsx
@@ -10,12 +10,14 @@ const useStyles = makeStyles({
 });
 
 interface ProfileMarkdownInputProps {
+  id: string;
   onChange: (value: string) => void;
   value: string;
   label: string;
 }
 
 export default function ProfileMarkdownInput({
+  id,
   onChange,
   value,
   label,
@@ -27,6 +29,7 @@ export default function ProfileMarkdownInput({
       <Grid container spacing={2}>
         <Grid item xs={12} md={preview ? 6 : 12}>
           <ProfileTextInput
+            id={id}
             label={label}
             rowsMax={5}
             multiline

--- a/app/frontend/src/features/profile/ProfileTextInput.tsx
+++ b/app/frontend/src/features/profile/ProfileTextInput.tsx
@@ -2,14 +2,10 @@ import { TextFieldProps } from "@material-ui/core";
 import TextField from "components/TextField";
 import React from "react";
 
-type ProfileTextInputProps = Omit<TextFieldProps, "margin">;
+interface ProfileTextInputProps extends Omit<TextFieldProps, "margin"> {
+  id: NonNullable<TextFieldProps["id"]>;
+}
 
 export default function ProfileTextInput(props: ProfileTextInputProps) {
-  return (
-    <TextField
-      {...props}
-      margin="normal"
-      id={`profile-text-input-${props.name}`}
-    />
-  );
+  return <TextField {...props} margin="normal" />;
 }

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
@@ -179,6 +179,7 @@ export default function HostingPreferenceForm() {
             }}
           />
           <ProfileTextInput
+            id="area"
             label="Description of your place"
             name="area"
             defaultValue={user.area?.value ?? ""}
@@ -188,6 +189,7 @@ export default function HostingPreferenceForm() {
             className={classes.field}
           />
           <ProfileTextInput
+            id="houseRules"
             label="House rules"
             name="houseRules"
             defaultValue={user.houseRules?.value ?? ""}

--- a/app/frontend/src/features/profile/edit/EditProfile.tsx
+++ b/app/frontend/src/features/profile/edit/EditProfile.tsx
@@ -133,6 +133,7 @@ export default function EditProfileForm() {
         <>
           <form onSubmit={onSubmit}>
             <ProfileTextInput
+              id="name"
               label="Name"
               name="name"
               defaultValue={user.name}
@@ -269,6 +270,7 @@ export default function EditProfileForm() {
               }}
             />
             <ProfileTextInput
+              id="hometown"
               label={HOMETOWN}
               name="hometown"
               defaultValue={user.hometown}
@@ -276,6 +278,7 @@ export default function EditProfileForm() {
               className={classes.field}
             />
             <ProfileTextInput
+              id="occupation"
               label={OCCUPATION}
               name="occupation"
               defaultValue={user.occupation}
@@ -283,6 +286,7 @@ export default function EditProfileForm() {
               className={classes.field}
             />
             <ProfileTextInput
+              id="education"
               label={EDUCATION}
               name="education"
               defaultValue={user.education}
@@ -305,6 +309,7 @@ export default function EditProfileForm() {
               )}
             />
             <ProfileTextInput
+              id="aboutMe"
               label={ABOUT_ME}
               name="aboutMe"
               defaultValue={user.aboutMe}
@@ -314,6 +319,7 @@ export default function EditProfileForm() {
               rows={10}
             />
             <ProfileTextInput
+              id="thingsILike"
               label={HOBBIES}
               name="thingsILike"
               defaultValue={user.thingsILike}
@@ -323,6 +329,7 @@ export default function EditProfileForm() {
               rows={10}
             />
             <ProfileTextInput
+              id="additionalInformation"
               label={ADDITIONAL}
               name="additionalInformation"
               defaultValue={user.additionalInformation}
@@ -332,6 +339,7 @@ export default function EditProfileForm() {
               rows={10}
             />
             <ProfileTextInput
+              id="aboutPlace"
               label={ABOUT_HOME}
               name="aboutPlace"
               defaultValue={user.aboutPlace}


### PR DESCRIPTION
`ProfileTextInput` shouldn't have accepted a hardcoded string as an ID in the first place... 