### PR TITLE
Set default notification badge styling for small devices

### DIFF
--- a/app/frontend/src/components/NotificationBadge.tsx
+++ b/app/frontend/src/components/NotificationBadge.tsx
@@ -3,8 +3,10 @@ import React from "react";
 
 const useStyles = makeStyles((theme) => ({
   badge: {
-    right: theme.spacing(-3),
-    top: "50%",
+    [theme.breakpoints.up("sm")]: {
+      right: theme.spacing(-3),
+      top: "50%",
+    },
   },
 }));
 

--- a/app/frontend/src/components/NotificationBadge.tsx
+++ b/app/frontend/src/components/NotificationBadge.tsx
@@ -3,10 +3,8 @@ import React from "react";
 
 const useStyles = makeStyles((theme) => ({
   badge: {
-    [theme.breakpoints.up("sm")]: {
-      right: theme.spacing(-3),
-      top: "50%",
-    },
+    right: theme.spacing(-3),
+    top: "50%",
   },
 }));
 

--- a/app/frontend/src/components/TabBar/TabBar.tsx
+++ b/app/frontend/src/components/TabBar/TabBar.tsx
@@ -1,5 +1,14 @@
-import { Tab } from "@material-ui/core";
+import { makeStyles, Tab } from "@material-ui/core";
 import { TabList } from "@material-ui/lab";
+
+export const useStyles = makeStyles((theme) => ({
+  messagesTab: {
+    [theme.breakpoints.down("sm")]: {
+      overflow: "visible",
+      margin: `0 ${theme.spacing(2)}`,
+    },
+  },
+}));
 
 export interface TabBarProps<T extends Record<string, React.ReactNode>> {
   ariaLabel: string;
@@ -14,6 +23,7 @@ export default function TabBar<T extends Record<string, React.ReactNode>>({
   setValue,
   labels,
 }: TabBarProps<T>) {
+  const classes = useStyles();
   const handleChange = (event: any, newValue: keyof T) => {
     setValue(newValue);
   };
@@ -28,7 +38,12 @@ export default function TabBar<T extends Record<string, React.ReactNode>>({
       variant="scrollable"
     >
       {Object.entries(labels).map(([value, label]) => (
-        <Tab key={value} label={label} value={value} />
+        <Tab
+          key={value}
+          label={label}
+          value={value}
+          className={classes.messagesTab}
+        />
       ))}
     </TabList>
   );


### PR DESCRIPTION
Issue [#815](https://github.com/Couchers-org/couchers/issues/815).

Currently with default styling on small devices, but can change if we want to increase the tabsize instead. Images here:
https://github.com/Couchers-org/couchers/issues/815#issuecomment-802022033