### PR TITLE
fix: split two env variables into separate lines

### DIFF
--- a/app/frontend/.env.development
+++ b/app/frontend/.env.development
@@ -1,5 +1,6 @@
 REACT_APP_API_BASE_URL=http://localhost:8888
 REACT_APP_IS_POST_BETA_ENABLED=true
 REACT_APP_MAPBOX_KEY = "pk.eyJ1IjoiY291Y2hlcnMiLCJhIjoiY2tpYzY4eHd2MGVpcTJ0bGdhdGhvbHhlbiJ9.u5zvDeFE9H8itTK_dNp7Pg"
-REACT_APP_NOMINATIM_URL="https://nominatim.openstreetmap.org/"REACT_APP_TILE_URL="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+REACT_APP_NOMINATIM_URL="https://nominatim.openstreetmap.org/"
+REACT_APP_TILE_URL="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
 REACT_APP_TILE_ATTRIBUTION="Map data &copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors"


### PR DESCRIPTION
Had some problems with map data fetching due to this.