### PR TITLE
Fix bouncy scrolling on mobile web

### DIFF
--- a/app/frontend/src/components/EditUserLocationMap.tsx
+++ b/app/frontend/src/components/EditUserLocationMap.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles({
   root: {
     height: 200,
     position: "relative",
-    width: 400,
+    maxWidth: 400,
   },
 });
 

--- a/app/frontend/src/features/map/MapPage.tsx
+++ b/app/frontend/src/features/map/MapPage.tsx
@@ -7,14 +7,22 @@ import PageTitle from "../../components/PageTitle";
 import { routeToGuide, routeToPlace, routeToUser } from "../../routes";
 import { addClusteredUsersToMap } from "./clusteredUsers";
 import { addCommunitiesToMap } from "./communities";
+import { MAP_PAGE } from "./constants";
 import { addGuidesToMap } from "./guides";
 import { addPlacesToMap } from "./places";
 
 const useStyles = makeStyles((theme) => ({
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    height: `calc(100vh - ${theme.shape.navPaddingMobile})`,
+    paddingBlockEnd: theme.spacing(2),
+    [theme.breakpoints.up("md")]: {
+      height: `calc(100vh - ${theme.shape.navPaddingDesktop})`,
+    },
+  },
   root: {
     border: "1px solid black",
-    height: "80vh",
-    maxWidth: "100vw",
   },
 }));
 
@@ -56,8 +64,8 @@ export default function MapPage() {
   };
 
   return (
-    <>
-      <PageTitle>MapPage</PageTitle>
+    <div className={classes.container}>
+      <PageTitle>{MAP_PAGE}</PageTitle>
       <Map
         initialZoom={1}
         initialCenter={new LngLat(0, 0)}
@@ -65,6 +73,6 @@ export default function MapPage() {
         postMapInitialize={initializeMap}
         className={classes.root}
       />
-    </>
+    </div>
   );
 }

--- a/app/frontend/src/features/map/constants.ts
+++ b/app/frontend/src/features/map/constants.ts
@@ -1,0 +1,1 @@
+export const MAP_PAGE = "Map page";

--- a/app/frontend/src/features/messages/Messages.tsx
+++ b/app/frontend/src/features/messages/Messages.tsx
@@ -1,5 +1,4 @@
 import { TabContext } from "@material-ui/lab";
-import * as React from "react";
 import { Route, Switch, useHistory, useParams } from "react-router-dom";
 
 import NotificationBadge from "../../components/NotificationBadge";
@@ -16,6 +15,7 @@ import {
   surfingRequestsRoute,
 } from "../../routes";
 import useNotifications from "../useNotifications";
+import { MESSAGES } from "./constants";
 import GroupChatsTab from "./groupchats/GroupChatsTab";
 import GroupChatView from "./groupchats/GroupChatView";
 import HostRequestView from "./surfing/HostRequestView";
@@ -70,7 +70,7 @@ export default function Messages() {
 
   const header = (
     <>
-      <PageTitle>Messages</PageTitle>
+      <PageTitle>{MESSAGES}</PageTitle>
       <TabContext value={messageType}>
         <TabBar
           ariaLabel="Tabs for different message types"

--- a/app/frontend/src/features/messages/constants.ts
+++ b/app/frontend/src/features/messages/constants.ts
@@ -15,6 +15,7 @@ export const ERROR_USER_LOAD = "(User load error)";
 export const FRIENDS = "Friends";
 export const LOAD_MORE = "Load more";
 export const MARK_LAST_SEEN_TIMEOUT = 500;
+export const MESSAGES = "Messages";
 export const NEW_CHAT = "Create a new chat";
 export const NEW_GROUP_CHAT = "Create group chat";
 export const NO_GROUP_CHAT = "No group chats yet";

--- a/app/frontend/src/features/messages/useMessageListStyles.ts
+++ b/app/frontend/src/features/messages/useMessageListStyles.ts
@@ -9,8 +9,7 @@ const useMessageListStyles = makeStyles((theme) => ({
     textDecoration: "none",
   },
   list: {
-    //margin won't go on the right, so make the width longer
-    width: `calc(100% + ${theme.spacing(4)})`,
+    width: "100%",
   },
   listItem: {
     marginInline: `-${theme.spacing(2)}`,


### PR DESCRIPTION
Considering I can just about reproduce this on mobile Chrome (Firefox works fine for me on Android even without this fix...), fixing the map overflow on the edit profile page seems to have done the trick.

Might be good to have an iPhone user to check and see how it behaves on Safari too? 🤷 

Fixes #817