### PR TITLE
Add manual mock to allow "service" to be imported without "index"

### DIFF
--- a/app/frontend/.storybook/main.js
+++ b/app/frontend/.storybook/main.js
@@ -6,7 +6,7 @@ module.exports = {
     "@storybook/preset-create-react-app",
   ],
   webpackFinal: (config) => {
-    config.resolve.alias["service/index"] = require.resolve(
+    config.resolve.alias["service$"] = require.resolve(
       "../src/stories/__mocks__/service.ts"
     );
     return config;

--- a/app/frontend/src/__mocks__/service.ts
+++ b/app/frontend/src/__mocks__/service.ts
@@ -1,5 +1,3 @@
-import { service } from "../service";
-
 jest.mock("../service");
 
-export { service };
+export * from "../service";

--- a/app/frontend/src/__mocks__/service.ts
+++ b/app/frontend/src/__mocks__/service.ts
@@ -1,0 +1,5 @@
+import { service } from "../service";
+
+jest.mock("../service");
+
+export { service };

--- a/app/frontend/src/components/Comments/CommentBox.tsx
+++ b/app/frontend/src/components/Comments/CommentBox.tsx
@@ -5,7 +5,7 @@ import NewComment from "components/Comments/NewComment";
 import Markdown from "components/Markdown";
 import { Reply } from "pb/threads_pb";
 import React, { useEffect, useState } from "react";
-import { service } from "service/index";
+import { service } from "service";
 
 const useStyles = makeStyles(() => ({
   card: {

--- a/app/frontend/src/features/BugReport.test.tsx
+++ b/app/frontend/src/features/BugReport.test.tsx
@@ -15,8 +15,8 @@ import {
   STEPS,
   SUBMIT,
 } from "features/constants";
+import { service } from "service";
 
-import { service } from "../service";
 import wrapper from "../test/hookWrapper";
 import { addDefaultUser, MockedService } from "../test/utils";
 import BugReport from "./BugReport";

--- a/app/frontend/src/features/BugReport.tsx
+++ b/app/frontend/src/features/BugReport.tsx
@@ -24,7 +24,7 @@ import { Error as GrpcError } from "grpc-web";
 import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useMutation } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 
 export interface BugReportFormData {
   subject: string;

--- a/app/frontend/src/features/auth/email/ChangeEmail.test.tsx
+++ b/app/frontend/src/features/auth/email/ChangeEmail.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   CHANGE_EMAIL,
-  CHANGE_PASSWORD,
   CHECK_EMAIL,
   CURRENT_PASSWORD,
   NEW_EMAIL,
@@ -11,7 +10,7 @@ import {
 import ChangeEmail from "features/auth/email/ChangeEmail";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { GetAccountInfoRes } from "pb/account_pb";
-import { service } from "service/index";
+import { service } from "service";
 import wrapper from "test/hookWrapper";
 import { MockedService } from "test/utils";
 

--- a/app/frontend/src/features/auth/email/ChangeEmail.tsx
+++ b/app/frontend/src/features/auth/email/ChangeEmail.tsx
@@ -9,7 +9,7 @@ import { GetAccountInfoRes } from "pb/account_pb";
 import React from "react";
 import { useForm } from "react-hook-form";
 import { useMutation } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 
 import {
   CHANGE_EMAIL,

--- a/app/frontend/src/features/auth/email/ConfirmChangeEmail.test.tsx
+++ b/app/frontend/src/features/auth/email/ConfirmChangeEmail.test.tsx
@@ -9,7 +9,7 @@ import {
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Route, Switch } from "react-router-dom";
 import { confirmChangeEmailRoute, loginRoute } from "routes";
-import { service } from "service/index";
+import { service } from "service";
 import { getHookWrapperWithClient } from "test/hookWrapper";
 import { MockedService } from "test/utils";
 

--- a/app/frontend/src/features/auth/email/ConfirmChangeEmail.tsx
+++ b/app/frontend/src/features/auth/email/ConfirmChangeEmail.tsx
@@ -12,7 +12,7 @@ import { useEffect } from "react";
 import { useMutation } from "react-query";
 import { Link, useParams } from "react-router-dom";
 import { loginRoute } from "routes";
-import { service } from "service/index";
+import { service } from "service";
 
 export default function ConfirmChangeEmail() {
   const { resetToken } = useParams<{ resetToken?: string }>();

--- a/app/frontend/src/features/auth/jail/Jail.tsx
+++ b/app/frontend/src/features/auth/jail/Jail.tsx
@@ -10,7 +10,7 @@ import { JailInfoRes } from "pb/jail_pb";
 import React, { useEffect, useState } from "react";
 import { Redirect } from "react-router-dom";
 import { loginRoute } from "routes";
-import { service } from "service/index";
+import { service } from "service";
 
 const useStyles = makeStyles((theme) => ({
   bottomMargin: { marginBottom: theme.spacing(4) },

--- a/app/frontend/src/features/auth/jail/LocationSection.tsx
+++ b/app/frontend/src/features/auth/jail/LocationSection.tsx
@@ -1,13 +1,12 @@
 import { Box, makeStyles } from "@material-ui/core";
-import React, { useEffect, useState } from "react";
-import { Controller, useForm } from "react-hook-form";
-
-import Button from "../../../components/Button";
+import Button from "components/Button";
 import EditUserLocationMap, {
   ApproximateLocation,
-} from "../../../components/EditUserLocationMap";
-import TextBody from "../../../components/TextBody";
-import { service } from "../../../service";
+} from "components/EditUserLocationMap";
+import TextBody from "components/TextBody";
+import React, { useEffect, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { service } from "service";
 
 const useStyles = makeStyles({ map: { height: "40vh" } });
 

--- a/app/frontend/src/features/auth/jail/TOSSection.tsx
+++ b/app/frontend/src/features/auth/jail/TOSSection.tsx
@@ -1,9 +1,8 @@
 import { Box } from "@material-ui/core";
+import Button from "components/Button";
+import TOS from "components/TOS";
 import React, { useState } from "react";
-
-import Button from "../../../components/Button";
-import TOS from "../../../components/TOS";
-import { service } from "../../../service";
+import { service } from "service";
 
 interface TOSSectionProps {
   updateJailed: () => void;

--- a/app/frontend/src/features/auth/login/LoginForm.tsx
+++ b/app/frontend/src/features/auth/login/LoginForm.tsx
@@ -15,7 +15,7 @@ import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import { Link, useHistory } from "react-router-dom";
 import { loginPasswordRoute, resetPasswordRoute } from "routes";
-import { service } from "service/index";
+import { service } from "service";
 import { useIsMounted, useSafeState } from "utils/hooks";
 import { sanitizeName } from "utils/validation";
 

--- a/app/frontend/src/features/auth/password/ChangePassword.test.tsx
+++ b/app/frontend/src/features/auth/password/ChangePassword.test.tsx
@@ -6,13 +6,12 @@ import {
   NEW_PASSWORD,
   OLD_PASSWORD,
   PASSWORD_CHANGED,
-  RESET_PASSWORD,
   SUBMIT,
 } from "features/auth/constants";
 import ChangePassword from "features/auth/password/ChangePassword";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { GetAccountInfoRes } from "pb/account_pb";
-import { service } from "service/index";
+import { service } from "service";
 import wrapper from "test/hookWrapper";
 import { MockedService } from "test/utils";
 

--- a/app/frontend/src/features/auth/password/ChangePassword.tsx
+++ b/app/frontend/src/features/auth/password/ChangePassword.tsx
@@ -18,7 +18,7 @@ import { GetAccountInfoRes } from "pb/account_pb";
 import { accountInfoQueryKey } from "queryKeys";
 import { useForm } from "react-hook-form";
 import { useMutation, useQueryClient } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 
 interface ChangePasswordVariables {
   oldPassword?: string;

--- a/app/frontend/src/features/auth/password/CompleteResetPassword.test.tsx
+++ b/app/frontend/src/features/auth/password/CompleteResetPassword.test.tsx
@@ -10,7 +10,7 @@ import {
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Route, Switch } from "react-router-dom";
 import { loginRoute, resetPasswordRoute } from "routes";
-import { service } from "service/index";
+import { service } from "service";
 import { getHookWrapperWithClient } from "test/hookWrapper";
 import { MockedService } from "test/utils";
 

--- a/app/frontend/src/features/auth/password/CompleteResetPassword.tsx
+++ b/app/frontend/src/features/auth/password/CompleteResetPassword.tsx
@@ -12,7 +12,7 @@ import { useEffect } from "react";
 import { useMutation } from "react-query";
 import { Link, useParams } from "react-router-dom";
 import { loginRoute } from "routes";
-import { service } from "service/index";
+import { service } from "service";
 
 export default function CompleteResetPassword() {
   const { resetToken } = useParams<{ resetToken?: string }>();

--- a/app/frontend/src/features/auth/password/ResetPassword.test.tsx
+++ b/app/frontend/src/features/auth/password/ResetPassword.test.tsx
@@ -7,7 +7,7 @@ import {
   SUBMIT,
 } from "features/auth/constants";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
-import { service } from "service/index";
+import { service } from "service";
 import wrapper from "test/hookWrapper";
 import { MockedService } from "test/utils";
 

--- a/app/frontend/src/features/auth/password/ResetPassword.tsx
+++ b/app/frontend/src/features/auth/password/ResetPassword.tsx
@@ -13,7 +13,7 @@ import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Error as GrpcError } from "grpc-web";
 import { useForm } from "react-hook-form";
 import { useMutation } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 
 const useStyles = makeStyles((theme) => ({
   form: {

--- a/app/frontend/src/features/auth/signup/CompleteSignupForm.tsx
+++ b/app/frontend/src/features/auth/signup/CompleteSignupForm.tsx
@@ -24,7 +24,7 @@ import React, { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useHistory, useLocation, useParams } from "react-router-dom";
 import { signupRoute } from "routes";
-import { service } from "service/index";
+import { service } from "service";
 import {
   nameValidationPattern,
   sanitizeName,

--- a/app/frontend/src/features/auth/signup/EmailForm.tsx
+++ b/app/frontend/src/features/auth/signup/EmailForm.tsx
@@ -7,7 +7,7 @@ import useAuthStyles from "features/auth/useAuthStyles";
 import { SignupRes } from "pb/auth_pb";
 import React, { useState } from "react";
 import { useForm } from "react-hook-form";
-import { service } from "service/index";
+import { service } from "service";
 import { sanitizeName } from "utils/validation";
 
 export default function EmailForm() {

--- a/app/frontend/src/features/auth/useAccountInfo.ts
+++ b/app/frontend/src/features/auth/useAccountInfo.ts
@@ -2,7 +2,7 @@ import { Error as GrpcError } from "grpc-web";
 import { GetAccountInfoRes } from "pb/account_pb";
 import { accountInfoQueryKey } from "queryKeys";
 import { useQuery } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 
 export default function useAccountInfo() {
   const accountInfoQuery = useQuery<GetAccountInfoRes.AsObject, GrpcError>(

--- a/app/frontend/src/features/communities/CommunityPage/DiscussionCard.tsx
+++ b/app/frontend/src/features/communities/CommunityPage/DiscussionCard.tsx
@@ -18,7 +18,7 @@ import React, { useMemo } from "react";
 import { useInfiniteQuery } from "react-query";
 import { Link } from "react-router-dom";
 import { routeToDiscussion } from "routes";
-import { service } from "service/index";
+import { service } from "service";
 import { timestamp2Date } from "utils/date";
 import { firstName } from "utils/names";
 import stripMarkdown from "utils/stripMarkdown";

--- a/app/frontend/src/features/communities/DiscussionPage.tsx
+++ b/app/frontend/src/features/communities/DiscussionPage.tsx
@@ -8,7 +8,7 @@ import { Discussion } from "pb/discussions_pb";
 import React, { useEffect, useState } from "react";
 import { useHistory, useParams } from "react-router-dom";
 import { routeToDiscussion } from "routes";
-import { service } from "service/index";
+import { service } from "service";
 
 export default function DiscussionPage() {
   const [loading, setLoading] = useState(false);

--- a/app/frontend/src/features/communities/GroupPage.tsx
+++ b/app/frontend/src/features/communities/GroupPage.tsx
@@ -18,7 +18,7 @@ import {
   routeToGuide,
   routeToPlace,
 } from "routes";
-import { service } from "service/index";
+import { service } from "service";
 
 export default function GroupPage() {
   const [loading, setLoading] = useState(false);

--- a/app/frontend/src/features/communities/NewGuideForm.tsx
+++ b/app/frontend/src/features/communities/NewGuideForm.tsx
@@ -11,7 +11,7 @@ import React from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useMutation } from "react-query";
 import { useHistory } from "react-router-dom";
-import { service } from "service/index";
+import { service } from "service";
 
 type NewGuideInputs = {
   title: string;

--- a/app/frontend/src/features/communities/NewPlaceForm.tsx
+++ b/app/frontend/src/features/communities/NewPlaceForm.tsx
@@ -11,7 +11,7 @@ import React from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useMutation } from "react-query";
 import { useHistory } from "react-router-dom";
-import { service } from "service/index";
+import { service } from "service";
 
 type NewPlaceInputs = {
   title: string;

--- a/app/frontend/src/features/communities/PagePage.tsx
+++ b/app/frontend/src/features/communities/PagePage.tsx
@@ -8,7 +8,7 @@ import { pageURL } from "features/communities/redirect";
 import { Page, PageType } from "pb/pages_pb";
 import React, { useEffect, useState } from "react";
 import { useHistory, useParams } from "react-router-dom";
-import { service } from "service/index";
+import { service } from "service";
 
 export default function PagePage({ pageType }: { pageType: PageType }) {
   const [loading, setLoading] = useState(false);

--- a/app/frontend/src/features/communities/useCommunity.ts
+++ b/app/frontend/src/features/communities/useCommunity.ts
@@ -28,7 +28,7 @@ import {
   useMutation,
   useQuery,
 } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 
 export const useCommunity = (id: number) =>
   useQuery<Community.AsObject, GrpcError>(communityKey(id), () =>

--- a/app/frontend/src/features/connections/friends/AddFriendButton.tsx
+++ b/app/frontend/src/features/connections/friends/AddFriendButton.tsx
@@ -6,7 +6,7 @@ import { ADD_FRIEND, PENDING } from "features/connections/constants";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import React from "react";
 import { useMutation, useQueryClient } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 
 import { SetMutationError } from ".";
 

--- a/app/frontend/src/features/connections/friends/FriendList.test.tsx
+++ b/app/frontend/src/features/connections/friends/FriendList.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
-import { service } from "service/index";
+import { service } from "service";
 import wrapper from "test/hookWrapper";
 import { getUser, listFriends } from "test/serviceMockDefaults";
 import { MockedService } from "test/utils";

--- a/app/frontend/src/features/connections/friends/useCancelFriendRequest.test.ts
+++ b/app/frontend/src/features/connections/friends/useCancelFriendRequest.test.ts
@@ -2,7 +2,7 @@ import { act, renderHook } from "@testing-library/react-hooks";
 import useCancelFriendRequest from "features/connections/friends/useCancelFriendRequest";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { ListFriendRequestsRes } from "pb/api_pb";
-import { service } from "service/index";
+import { service } from "service";
 import { getHookWrapperWithClient } from "test/hookWrapper";
 
 const cancelFriendRequestMock = service.api.cancelFriendRequest as jest.Mock<

--- a/app/frontend/src/features/connections/friends/useCancelFriendRequest.ts
+++ b/app/frontend/src/features/connections/friends/useCancelFriendRequest.ts
@@ -1,8 +1,8 @@
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Error } from "grpc-web";
 import { useMutation, useQueryClient } from "react-query";
+import { service } from "service";
 
-import { service } from "../../../service";
 import { SetMutationError } from ".";
 
 interface CancelFriendRequestVariables {

--- a/app/frontend/src/features/connections/friends/useFriendList.test.tsx
+++ b/app/frontend/src/features/connections/friends/useFriendList.test.tsx
@@ -1,9 +1,9 @@
 import { renderHook } from "@testing-library/react-hooks";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { service } from "service/index";
-import wrapper from "test/hookWrapper";
+import { service } from "service";
 import users from "test/fixtures/users.json";
+import wrapper from "test/hookWrapper";
 import { getUser, listFriends } from "test/serviceMockDefaults";
 import { wait } from "test/utils";
 

--- a/app/frontend/src/features/connections/friends/useFriendList.ts
+++ b/app/frontend/src/features/connections/friends/useFriendList.ts
@@ -1,7 +1,7 @@
 import { Error } from "grpc-web";
 import { User } from "pb/api_pb";
 import { useQueries, useQuery, UseQueryResult } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 
 function useFriendList() {
   const { data: friendIds, error, isLoading } = useQuery<number[], Error>(

--- a/app/frontend/src/features/connections/friends/useFriendRequests.test.tsx
+++ b/app/frontend/src/features/connections/friends/useFriendRequests.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react-hooks";
-import { service } from "service/index";
+import { service } from "service";
 import users from "test/fixtures/users.json";
 import wrapper from "test/hookWrapper";
 import { getUser } from "test/serviceMockDefaults";

--- a/app/frontend/src/features/connections/friends/useFriendRequests.ts
+++ b/app/frontend/src/features/connections/friends/useFriendRequests.ts
@@ -3,7 +3,7 @@ import { Error } from "grpc-web";
 import { FriendRequest } from "pb/api_pb";
 import { friendRequestKey, FriendRequestType } from "queryKeys";
 import { useQuery } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 
 export default function useFriendRequests(
   friendRequestType: FriendRequestType

--- a/app/frontend/src/features/connections/friends/useRespondToFriendRequest.test.tsx
+++ b/app/frontend/src/features/connections/friends/useRespondToFriendRequest.test.tsx
@@ -2,7 +2,7 @@ import { act, renderHook } from "@testing-library/react-hooks";
 import useRespondToFriendRequest from "features/connections/friends/useRespondToFriendRequest";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { ListFriendRequestsRes } from "pb/api_pb";
-import { service } from "service/index";
+import { service } from "service";
 import { getHookWrapperWithClient } from "test/hookWrapper";
 
 const respondToFriendRequestMock = service.api

--- a/app/frontend/src/features/connections/friends/useRespondToFriendRequest.ts
+++ b/app/frontend/src/features/connections/friends/useRespondToFriendRequest.ts
@@ -1,8 +1,8 @@
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Error } from "grpc-web";
 import { useMutation, useQueryClient } from "react-query";
+import { service } from "service";
 
-import { service } from "../../../service";
 import { SetMutationError } from ".";
 
 interface RespondToFriendRequestVariables {

--- a/app/frontend/src/features/messages/Messages.test.tsx
+++ b/app/frontend/src/features/messages/Messages.test.tsx
@@ -5,7 +5,7 @@ import {
   MessagesNotification,
 } from "features/messages/Messages";
 import React from "react";
-import { service } from "service/index";
+import { service } from "service";
 import user from "test/fixtures/defaultUser.json";
 import wrapper from "test/hookWrapper";
 

--- a/app/frontend/src/features/messages/groupchats/AdminsDialog.tsx
+++ b/app/frontend/src/features/messages/groupchats/AdminsDialog.tsx
@@ -26,7 +26,7 @@ import { User } from "pb/api_pb";
 import { GroupChat } from "pb/conversations_pb";
 import React, { useEffect, useState } from "react";
 import { useMutation, useQueryClient } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 
 function AdminListItem({
   groupChatId,

--- a/app/frontend/src/features/messages/groupchats/CreateGroupChat.tsx
+++ b/app/frontend/src/features/messages/groupchats/CreateGroupChat.tsx
@@ -26,7 +26,7 @@ import { User } from "pb/api_pb";
 import React, { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useMutation, useQueryClient } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 
 const useStyles = makeStyles((theme) => ({
   field: {

--- a/app/frontend/src/features/messages/groupchats/GroupChatSettingsDialog.tsx
+++ b/app/frontend/src/features/messages/groupchats/GroupChatSettingsDialog.tsx
@@ -14,7 +14,7 @@ import { GroupChat } from "pb/conversations_pb";
 import React from "react";
 import { useForm } from "react-hook-form";
 import { useMutation, useQueryClient } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 
 interface GroupChatSettingsData {
   title: string;

--- a/app/frontend/src/features/messages/groupchats/GroupChatView.test.tsx
+++ b/app/frontend/src/features/messages/groupchats/GroupChatView.test.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-intersection-observer/test-utils";
 import { Route } from "react-router-dom";
 import { messagesRoute } from "routes";
-import { service } from "service/index";
+import { service } from "service";
 import messageData from "test/fixtures/messages.json";
 import { getHookWrapperWithClient } from "test/hookWrapper";
 import { getGroupChatMessages, getUser } from "test/serviceMockDefaults";

--- a/app/frontend/src/features/messages/groupchats/GroupChatView.tsx
+++ b/app/frontend/src/features/messages/groupchats/GroupChatView.tsx
@@ -32,7 +32,7 @@ import {
   useQueryClient,
 } from "react-query";
 import { useHistory, useParams } from "react-router-dom";
-import { service } from "service/index";
+import { service } from "service";
 
 export const useGroupChatViewStyles = makeStyles((theme) => ({
   footer: {

--- a/app/frontend/src/features/messages/groupchats/GroupChatsTab.tsx
+++ b/app/frontend/src/features/messages/groupchats/GroupChatsTab.tsx
@@ -13,7 +13,7 @@ import React from "react";
 import { useInfiniteQuery } from "react-query";
 import { Link } from "react-router-dom";
 import { routeToGroupChat } from "routes";
-import { service } from "service/index";
+import { service } from "service";
 
 export default function GroupChatsTab() {
   const classes = useMessageListStyles();

--- a/app/frontend/src/features/messages/groupchats/InviteDialog.tsx
+++ b/app/frontend/src/features/messages/groupchats/InviteDialog.tsx
@@ -16,7 +16,7 @@ import { GroupChat } from "pb/conversations_pb";
 import React from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useMutation, useQueryClient } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 
 export default function InviteDialog({
   groupChat,

--- a/app/frontend/src/features/messages/groupchats/LeaveDialog.tsx
+++ b/app/frontend/src/features/messages/groupchats/LeaveDialog.tsx
@@ -1,19 +1,18 @@
 import { DialogProps } from "@material-ui/core";
-import { Empty } from "google-protobuf/google/protobuf/empty_pb";
-import { Error as GrpcError } from "grpc-web";
-import React from "react";
-import { useMutation, useQueryClient } from "react-query";
-
-import Alert from "../../../components/Alert";
-import Button from "../../../components/Button";
+import Alert from "components/Alert";
+import Button from "components/Button";
 import {
   Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
   DialogTitle,
-} from "../../../components/Dialog";
-import { service } from "../../../service";
+} from "components/Dialog";
+import { Empty } from "google-protobuf/google/protobuf/empty_pb";
+import { Error as GrpcError } from "grpc-web";
+import React from "react";
+import { useMutation, useQueryClient } from "react-query";
+import { service } from "service";
 
 export default function MembersDialog({
   groupChatId,

--- a/app/frontend/src/features/messages/surfing/HostRequestView.tsx
+++ b/app/frontend/src/features/messages/surfing/HostRequestView.tsx
@@ -33,7 +33,7 @@ import {
   useQueryClient,
 } from "react-query";
 import { useHistory, useParams } from "react-router-dom";
-import { service } from "service/index";
+import { service } from "service";
 import { firstName } from "utils/names";
 
 export default function HostRequestView() {

--- a/app/frontend/src/features/messages/surfing/NewHostRequest.tsx
+++ b/app/frontend/src/features/messages/surfing/NewHostRequest.tsx
@@ -13,7 +13,7 @@ import { useForm } from "react-hook-form";
 import { useMutation } from "react-query";
 import { useHistory, useParams } from "react-router-dom";
 import { routeToHostRequest } from "routes";
-import { service } from "service/index";
+import { service } from "service";
 import { firstName } from "utils/names";
 import { validateFutureDate } from "utils/validation";
 

--- a/app/frontend/src/features/messages/surfing/SurfingTab.tsx
+++ b/app/frontend/src/features/messages/surfing/SurfingTab.tsx
@@ -12,7 +12,7 @@ import * as React from "react";
 import { useInfiniteQuery } from "react-query";
 import { Link } from "react-router-dom";
 import { routeToHostRequest } from "routes";
-import { service } from "service/index";
+import { service } from "service";
 
 export interface GroupChatListProps extends BoxProps {
   groupChats: Array<GroupChat.AsObject>;

--- a/app/frontend/src/features/profile/actions/ReportUserDialog.tsx
+++ b/app/frontend/src/features/profile/actions/ReportUserDialog.tsx
@@ -14,7 +14,7 @@ import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Error as GrpcError } from "grpc-web";
 import { useForm } from "react-hook-form";
 import { useMutation } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 import type { ReportUserInput } from "service/user";
 
 import {

--- a/app/frontend/src/features/profile/hooks/useUpdateHostingPreferences.test.tsx
+++ b/app/frontend/src/features/profile/hooks/useUpdateHostingPreferences.test.tsx
@@ -3,7 +3,7 @@ import useUpdateHostingPreferences from "features/profile/hooks/useUpdateHosting
 import useCurrentUser from "features/userQueries/useCurrentUser";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { act } from "react-test-renderer";
-import { service } from "service/index";
+import { service } from "service";
 import wrapper from "test/hookWrapper";
 import { addDefaultUser } from "test/utils";
 

--- a/app/frontend/src/features/profile/hooks/useUpdateUserProfile.test.ts
+++ b/app/frontend/src/features/profile/hooks/useUpdateUserProfile.test.ts
@@ -3,7 +3,7 @@ import useUpdateUserProfile from "features/profile/hooks/useUpdateUserProfile";
 import useCurrentUser from "features/userQueries/useCurrentUser";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { act } from "react-test-renderer";
-import { service } from "service/index";
+import { service } from "service";
 import wrapper from "test/hookWrapper";
 import { addDefaultUser } from "test/utils";
 

--- a/app/frontend/src/features/profile/view/ProfilePage.test.tsx
+++ b/app/frontend/src/features/profile/view/ProfilePage.test.tsx
@@ -8,7 +8,7 @@ import userEvent from "@testing-library/user-event";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Route } from "react-router-dom";
 import { profileRoute } from "routes";
-import { service } from "service/index";
+import { service } from "service";
 import { getHookWrapperWithClient } from "test/hookWrapper";
 import { getUser } from "test/serviceMockDefaults";
 import { addDefaultUser, MockedService } from "test/utils";

--- a/app/frontend/src/features/profile/view/References.test.tsx
+++ b/app/frontend/src/features/profile/view/References.test.tsx
@@ -11,7 +11,7 @@ import {
   REFERENCES,
 } from "features/constants";
 import { ReferenceType, User } from "pb/api_pb";
-import { service } from "service/index";
+import { service } from "service";
 import references from "test/fixtures/references.json";
 import users from "test/fixtures/users.json";
 import wrapper from "test/hookWrapper";

--- a/app/frontend/src/features/profile/view/References.tsx
+++ b/app/frontend/src/features/profile/view/References.tsx
@@ -17,7 +17,7 @@ import { GetReferencesRes, User } from "pb/api_pb";
 import { referencesKey } from "queryKeys";
 import React, { useState } from "react";
 import { useQueries, useQuery } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 
 import ReferenceListItem from "./ReferenceListItem";
 

--- a/app/frontend/src/features/search/SearchPage.tsx
+++ b/app/frontend/src/features/search/SearchPage.tsx
@@ -8,7 +8,7 @@ import SearchResult from "features/search/SearchResult";
 import { User } from "pb/api_pb";
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { service } from "service/index";
+import { service } from "service";
 
 export default function SearchPage() {
   const [loading, setLoading] = useState(false);

--- a/app/frontend/src/features/useNotifications.ts
+++ b/app/frontend/src/features/useNotifications.ts
@@ -1,7 +1,7 @@
 import { Error } from "grpc-web";
 import { PingRes } from "pb/api_pb";
 import { useQuery } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 
 import { pingInterval } from "../constants";
 

--- a/app/frontend/src/features/userQueries/useUserByUsername.test.tsx
+++ b/app/frontend/src/features/userQueries/useUserByUsername.test.tsx
@@ -2,7 +2,7 @@ import { renderHook } from "@testing-library/react-hooks";
 import useUserByUsername from "features/userQueries/useUserByUsername";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 import users from "test/fixtures/users.json";
 import { getUser } from "test/serviceMockDefaults";
 

--- a/app/frontend/src/features/userQueries/useUserByUsername.ts
+++ b/app/frontend/src/features/userQueries/useUserByUsername.ts
@@ -6,7 +6,7 @@ import { Error, StatusCode } from "grpc-web";
 import { User } from "pb/api_pb";
 import { useEffect } from "react";
 import { useQuery, useQueryClient } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 
 import { reactQueryRetries } from "../../constants";
 

--- a/app/frontend/src/features/userQueries/useUsers.test.tsx
+++ b/app/frontend/src/features/userQueries/useUsers.test.tsx
@@ -2,7 +2,7 @@ import { act, renderHook } from "@testing-library/react-hooks";
 import useUsers, { useUser } from "features/userQueries/useUsers";
 import React, { useState } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 import users from "test/fixtures/users.json";
 import { getUser } from "test/serviceMockDefaults";
 

--- a/app/frontend/src/features/userQueries/useUsers.ts
+++ b/app/frontend/src/features/userQueries/useUsers.ts
@@ -3,7 +3,7 @@ import { Error } from "grpc-web";
 import { User } from "pb/api_pb";
 import { useCallback, useEffect, useRef } from "react";
 import { useQueries, useQueryClient } from "react-query";
-import { service } from "service/index";
+import { service } from "service";
 import { arrayEq } from "utils/arrayEq";
 
 export default function useUsers(


### PR DESCRIPTION
A small workaround so we can import `service` rather than having to do `service/index`. I think it's worth it given this limitation is imposed by our tests rather than actually the import not working!