### PR TITLE
Fix query name in invalidation logic, issue #798

### DIFF
--- a/app/frontend/src/features/connections/friends/useCancelFriendRequest.test.ts
+++ b/app/frontend/src/features/connections/friends/useCancelFriendRequest.test.ts
@@ -20,7 +20,7 @@ describe("useCancelFriendRequest hook", () => {
   const setMutationError = jest.fn();
 
   beforeEach(() => {
-    client.setQueryData<ListFriendRequestsRes.AsObject>("friendRequestsSent", {
+    client.setQueryData<ListFriendRequestsRes.AsObject>("friendRequests", {
       receivedList: [],
       sentList: [
         {
@@ -52,7 +52,7 @@ describe("useCancelFriendRequest hook", () => {
     await waitForNextUpdate();
     expect(setMutationError).toHaveBeenCalledTimes(1);
     expect(setMutationError).toHaveBeenCalledWith("");
-    expect(client.getQueryState("friendRequestsSent")?.isInvalidated).toBe(
+    expect(client.getQueryState(["friendRequests", {"type":"sent"}])?.isInvalidated).toBe(
       true
     );
   });
@@ -78,7 +78,7 @@ describe("useCancelFriendRequest hook", () => {
     await waitForNextUpdate();
     expect(setMutationError).toHaveBeenCalledTimes(2);
     expect(setMutationError).toHaveBeenLastCalledWith("API error");
-    expect(client.getQueryState("friendRequestsSent")?.isInvalidated).toBe(
+    expect(client.getQueryState(["friendRequests", {"type":"sent"}])?.isInvalidated).toBe(
       false
     );
   });

--- a/app/frontend/src/features/connections/friends/useCancelFriendRequest.test.ts
+++ b/app/frontend/src/features/connections/friends/useCancelFriendRequest.test.ts
@@ -4,6 +4,7 @@ import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { ListFriendRequestsRes } from "pb/api_pb";
 import { service } from "service";
 import { getHookWrapperWithClient } from "test/hookWrapper";
+import { friendRequestKey } from "queryKeys";
 
 const cancelFriendRequestMock = service.api.cancelFriendRequest as jest.Mock<
   ReturnType<typeof service.api.cancelFriendRequest>
@@ -52,7 +53,7 @@ describe("useCancelFriendRequest hook", () => {
     await waitForNextUpdate();
     expect(setMutationError).toHaveBeenCalledTimes(1);
     expect(setMutationError).toHaveBeenCalledWith("");
-    expect(client.getQueryState(["friendRequests", {"type":"sent"}])?.isInvalidated).toBe(
+    expect(client.getQueryState(friendRequestKey("sent"))?.isInvalidated).toBe(
       true
     );
   });
@@ -78,7 +79,7 @@ describe("useCancelFriendRequest hook", () => {
     await waitForNextUpdate();
     expect(setMutationError).toHaveBeenCalledTimes(2);
     expect(setMutationError).toHaveBeenLastCalledWith("API error");
-    expect(client.getQueryState(["friendRequests", {"type":"sent"}])?.isInvalidated).toBe(
+    expect(client.getQueryState(friendRequestKey("sent"))?.isInvalidated).toBe(
       false
     );
   });

--- a/app/frontend/src/features/connections/friends/useCancelFriendRequest.ts
+++ b/app/frontend/src/features/connections/friends/useCancelFriendRequest.ts
@@ -28,7 +28,7 @@ export default function useCancelFriendRequest() {
         setMutationError("");
       },
       onSuccess: (_, { userId }) => {
-        queryClient.invalidateQueries("friendRequestsSent");
+        queryClient.invalidateQueries(["friendRequests", {"type":"sent"}]);
         queryClient.invalidateQueries(["user", userId]);
       },
     }

--- a/app/frontend/src/features/connections/friends/useCancelFriendRequest.ts
+++ b/app/frontend/src/features/connections/friends/useCancelFriendRequest.ts
@@ -2,6 +2,7 @@ import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Error } from "grpc-web";
 import { useMutation, useQueryClient } from "react-query";
 import { service } from "service";
+import { friendRequestKey } from "queryKeys";
 
 import { SetMutationError } from ".";
 
@@ -28,7 +29,7 @@ export default function useCancelFriendRequest() {
         setMutationError("");
       },
       onSuccess: (_, { userId }) => {
-        queryClient.invalidateQueries(["friendRequests", {"type":"sent"}]);
+        queryClient.invalidateQueries(friendRequestKey("sent"));
         queryClient.invalidateQueries(["user", userId]);
       },
     }

--- a/app/frontend/src/features/connections/friends/useRespondToFriendRequest.test.tsx
+++ b/app/frontend/src/features/connections/friends/useRespondToFriendRequest.test.tsx
@@ -4,6 +4,7 @@ import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { ListFriendRequestsRes } from "pb/api_pb";
 import { service } from "service";
 import { getHookWrapperWithClient } from "test/hookWrapper";
+import { friendRequestKey } from "queryKeys";
 
 const respondToFriendRequestMock = service.api
   .respondFriendRequest as jest.Mock<
@@ -57,7 +58,7 @@ describe("useRespondToFriendRequest hook", () => {
     expect(setMutationError).toHaveBeenCalledTimes(1);
     expect(setMutationError).toHaveBeenCalledWith("");
     expect(client.getQueryState("friendIds")?.isInvalidated).toBe(true);
-    expect(client.getQueryState(["friendRequests", {"type":"received"}])?.isInvalidated).toBe(
+    expect(client.getQueryState(friendRequestKey("received"))?.isInvalidated).toBe(
       true
     );
   });
@@ -84,7 +85,7 @@ describe("useRespondToFriendRequest hook", () => {
     expect(setMutationError).toHaveBeenCalledTimes(2);
     expect(setMutationError).toHaveBeenLastCalledWith("API error");
     expect(client.getQueryState("friendIds")?.isInvalidated).toBe(false);
-    expect(client.getQueryState(["friendRequests", {"type":"received"}])?.isInvalidated).toBe(
+    expect(client.getQueryState(friendRequestKey("received"))?.isInvalidated).toBe(
       false
     );
   });

--- a/app/frontend/src/features/connections/friends/useRespondToFriendRequest.test.tsx
+++ b/app/frontend/src/features/connections/friends/useRespondToFriendRequest.test.tsx
@@ -22,7 +22,7 @@ describe("useRespondToFriendRequest hook", () => {
 
   beforeEach(() => {
     client.setQueryData<ListFriendRequestsRes.AsObject>(
-      "friendRequestsReceived",
+      "friendRequests",
       {
         receivedList: [
           {
@@ -57,7 +57,7 @@ describe("useRespondToFriendRequest hook", () => {
     expect(setMutationError).toHaveBeenCalledTimes(1);
     expect(setMutationError).toHaveBeenCalledWith("");
     expect(client.getQueryState("friendIds")?.isInvalidated).toBe(true);
-    expect(client.getQueryState("friendRequestsReceived")?.isInvalidated).toBe(
+    expect(client.getQueryState(["friendRequests", {"type":"received"}])?.isInvalidated).toBe(
       true
     );
   });
@@ -84,7 +84,7 @@ describe("useRespondToFriendRequest hook", () => {
     expect(setMutationError).toHaveBeenCalledTimes(2);
     expect(setMutationError).toHaveBeenLastCalledWith("API error");
     expect(client.getQueryState("friendIds")?.isInvalidated).toBe(false);
-    expect(client.getQueryState("friendRequestsReceived")?.isInvalidated).toBe(
+    expect(client.getQueryState(["friendRequests", {"type":"received"}])?.isInvalidated).toBe(
       false
     );
   });

--- a/app/frontend/src/features/connections/friends/useRespondToFriendRequest.ts
+++ b/app/frontend/src/features/connections/friends/useRespondToFriendRequest.ts
@@ -27,11 +27,11 @@ export default function useRespondToFriendRequest() {
       },
       onMutate: async ({ setMutationError }) => {
         setMutationError("");
-        await queryClient.cancelQueries("friendRequestsReceived");
+        await queryClient.cancelQueries(["friendRequests", {"type":"received"}]);
       },
       onSuccess: () => {
         queryClient.invalidateQueries("friendIds");
-        queryClient.invalidateQueries("friendRequestsReceived");
+        queryClient.invalidateQueries(["friendRequests", {"type":"received"}]);
         queryClient.invalidateQueries("ping");
       },
     }

--- a/app/frontend/src/features/connections/friends/useRespondToFriendRequest.ts
+++ b/app/frontend/src/features/connections/friends/useRespondToFriendRequest.ts
@@ -2,6 +2,7 @@ import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Error } from "grpc-web";
 import { useMutation, useQueryClient } from "react-query";
 import { service } from "service";
+import { friendRequestKey } from "queryKeys";
 
 import { SetMutationError } from ".";
 
@@ -27,11 +28,11 @@ export default function useRespondToFriendRequest() {
       },
       onMutate: async ({ setMutationError }) => {
         setMutationError("");
-        await queryClient.cancelQueries(["friendRequests", {"type":"received"}]);
+        await queryClient.cancelQueries(friendRequestKey("received"));
       },
       onSuccess: () => {
         queryClient.invalidateQueries("friendIds");
-        queryClient.invalidateQueries(["friendRequests", {"type":"received"}]);
+        queryClient.invalidateQueries(friendRequestKey("received"));
         queryClient.invalidateQueries("ping");
       },
     }


### PR DESCRIPTION
After sending a queries to accept/decline income Friends Requests it was tried to invalidate "friendRequestsReceived" and "friendRequestsSent". The problem is that there no such queries and mentioned ones are placed under "friendRequests". So all changes are about this. 