### PR TITLE
Redirect to profile page after update hosting preference

### DIFF
--- a/app/frontend/src/features/profile/edit/EditHostingPreference.test.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Route, Switch } from "react-router-dom";
+import { profileRoute } from "routes";
+import { service } from "service";
+import wrapper from "test/hookWrapper";
+import { getUser } from "test/serviceMockDefaults";
+
+import { addDefaultUser, MockedService } from "../../../test/utils";
+import { SAVE } from "../../constants";
+import EditHostingPreference from "./EditHostingPreference";
+
+const mockProfilePage = "Mock Profile Page";
+const getUserMock = service.user.getUser as MockedService<
+  typeof service.user.getUser
+>;
+const MockProfileComponent = () => <div title={mockProfilePage} />;
+
+describe("EditHostingPreference", () => {
+  beforeEach(() => {
+    getUserMock.mockImplementation(getUser);
+    addDefaultUser();
+  });
+
+  it("should redirect to Profile route after successful update", async () => {
+    render(
+      <Switch>
+        <Route path={profileRoute}>
+          <MockProfileComponent />
+        </Route>
+        <Route>
+          <EditHostingPreference />
+        </Route>
+      </Switch>,
+      { wrapper }
+    );
+
+    userEvent.click(await screen.findByRole("button", { name: SAVE }));
+
+    expect(await screen.findByTitle(mockProfilePage)).toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/features/profile/hooks/useUpdateHostingPreferences.ts
+++ b/app/frontend/src/features/profile/hooks/useUpdateHostingPreferences.ts
@@ -1,6 +1,8 @@
 import { useAuthContext } from "features/auth/AuthProvider";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { useMutation, useQueryClient } from "react-query";
+import { useHistory } from "react-router-dom";
+import { profileRoute } from "routes";
 import { HostingPreferenceData, service } from "service/index";
 import { SetMutationError } from "utils/types";
 
@@ -11,6 +13,7 @@ interface UpdateHostingPreferencesVariables {
 
 export default function useUpdateHostingPreferences() {
   const queryClient = useQueryClient();
+  const history = useHistory();
   const userId = useAuthContext().authState.userId;
   const { mutate: updateHostingPreferences, status, reset } = useMutation<
     Empty,
@@ -28,6 +31,7 @@ export default function useUpdateHostingPreferences() {
       },
       onSuccess: () => {
         queryClient.invalidateQueries(["user", userId]);
+        history.push(profileRoute);
       },
     }
   );


### PR DESCRIPTION
**Saving changes on Edit Home and Edit Profile is inconsistent**

Made both Edit Home and Edit Profile flow consistent by redirected to Profile page.
 
Issue: [#862](https://github.com/Couchers-org/couchers/issues/862l)


@aapeliv, I raised the MR but I can't select reviewers or assignees. Please do the needful. 
