### PR TITLE
Switch map style from streets to light

### DIFF
--- a/app/frontend/src/components/Map.tsx
+++ b/app/frontend/src/components/Map.tsx
@@ -77,7 +77,7 @@ export default function Map({
       container: containerRef.current,
       hash: "loc",
       interactive: interactive,
-      style: "mapbox://styles/mapbox/streets-v11",
+      style: "mapbox://styles/mapbox/light-v10",
       transformRequest,
       zoom: initialZoom,
     });


### PR DESCRIPTION
You can see the overlay stuff much better on the light, but there's still enough detail on light to see cities when you're looking more granularly