### PR TITLE
Change dialog styling to use mui stuff

### DIFF
--- a/app/frontend/src/components/Dialog.tsx
+++ b/app/frontend/src/components/Dialog.tsx
@@ -29,24 +29,6 @@ const useStyles = makeStyles((theme) => ({
   contentText: {
     padding: theme.spacing(2),
   },
-  dialog: {
-    padding: 0,
-    "& .MuiDialog-scrollPaper": {
-      display: "flex",
-      flexDirection: "column",
-      justifyContent: "start",
-      [theme.breakpoints.down("sm")]: {
-        alignItems: "inherit",
-      },
-
-      "& .MuiDialog-paper": {
-        width: "25%",
-        [theme.breakpoints.down("sm")]: {
-          width: "80%",
-        },
-      },
-    },
-  },
   title: {
     "& > h2": theme.typography.h2,
     "&:not(:nth-child(1))": {
@@ -63,8 +45,7 @@ export interface AccessibleDialogProps extends Omit<DialogProps, "className"> {
 }
 
 export function Dialog(props: AccessibleDialogProps) {
-  const classes = useStyles();
-  return <MuiDialog {...props} className={classes.dialog} />;
+  return <MuiDialog {...props} fullWidth maxWidth="sm" />;
 }
 
 export function DialogActions(props: Omit<DialogActionsProps, "className">) {


### PR DESCRIPTION
Before:

<img width="1680" alt="Screen Shot 2021-04-07 at 6 51 35 pm" src="https://user-images.githubusercontent.com/2975660/113944489-97c30980-97d2-11eb-9bb6-9947ce61db87.png">
<img width="1680" alt="Screen Shot 2021-04-07 at 6 51 41 pm" src="https://user-images.githubusercontent.com/2975660/113944492-98f43680-97d2-11eb-8660-a09698ecc355.png">
<img width="906" alt="Screen Shot 2021-04-07 at 6 53 21 pm" src="https://user-images.githubusercontent.com/2975660/113944507-9db8ea80-97d2-11eb-9262-ca7ddd952e88.png">

After:

<img width="1680" alt="Screen Shot 2021-04-07 at 6 52 12 pm" src="https://user-images.githubusercontent.com/2975660/113944518-a3163500-97d2-11eb-92b8-4ec3f7b94c45.png">
<img width="1680" alt="Screen Shot 2021-04-07 at 6 52 21 pm" src="https://user-images.githubusercontent.com/2975660/113944528-a6112580-97d2-11eb-975f-0f7770f13c41.png">
<img width="910" alt="Screen Shot 2021-04-07 at 6 53 33 pm" src="https://user-images.githubusercontent.com/2975660/113944532-a7dae900-97d2-11eb-8659-d9f1c81540e0.png">
