### PR TITLE
Add contributor form into app

### DIFF
--- a/app/backend/src/couchers/migrations/versions/723394ace6b5_add_filled_contributor_form_to_user.py
+++ b/app/backend/src/couchers/migrations/versions/723394ace6b5_add_filled_contributor_form_to_user.py
@@ -1,0 +1,24 @@
+"""Add filled_contributor_form to user
+
+Revision ID: 723394ace6b5
+Revises: 27a2782784d0
+Create Date: 2021-04-11 11:48:11.170484
+
+"""
+import geoalchemy2
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "723394ace6b5"
+down_revision = "27a2782784d0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("users", sa.Column("filled_contributor_form", sa.Boolean(), server_default="false", nullable=False))
+
+
+def downgrade():
+    op.drop_column("users", "filled_contributor_form")

--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -176,6 +176,8 @@ class User(Base):
     camping_ok = Column(Boolean, nullable=True)
 
     accepted_tos = Column(Integer, nullable=False, default=0)
+    # whether the user has yet filled in the contributor form
+    filled_contributor_form = Column(Boolean, nullable=False, server_default="false")
 
     # for changing their email
     new_email = Column(String, nullable=True)

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -136,6 +136,7 @@ class Account(account_pb2_grpc.AccountServicer):
             return account_pb2.GetContributorFormInfoRes(
                 filled_contributor_form=user.filled_contributor_form,
                 username=user.username,
+                name=user.name,
                 email=user.email,
                 age=user.age,
                 gender=user.gender,

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -128,3 +128,22 @@ class Account(account_pb2_grpc.AccountServicer):
             send_email_changed_confirmation_email(user, token, expiry_text)
             # session autocommit
         return empty_pb2.Empty()
+
+    def GetContributorFormInfo(self, request, context):
+        with session_scope() as session:
+            user = session.query(User).filter(User.id == context.user_id).one()
+
+            return account_pb2.GetContributorFormInfoRes(
+                filled_contributor_form=user.filled_contributor_form,
+                username=user.username,
+                email=user.email,
+                age=user.age,
+                gender=user.gender,
+                location=user.city,
+            )
+
+    def MarkContributorFormFilled(self, request, context):
+        with session_scope() as session:
+            user = session.query(User).filter(User.id == context.user_id).one()
+            user.filled_contributor_form = request.filled_contributor_form
+        return empty_pb2.Empty()

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -477,3 +477,36 @@ def test_ChangeEmail(db, fast_passwords):
             .filter(User.new_email_token_created <= func.now())
             .filter(User.new_email_token_expiry >= func.now())
         ).count() == 0
+
+
+def test_contributor_form(db):
+    user, token = generate_user()
+
+    with account_session(token) as account:
+        res = account.GetContributorFormInfo(empty_pb2.Empty())
+        assert not res.filled_contributor_form
+        assert res.username == user.username
+        assert res.email == user.email
+        assert res.age == user.age
+        assert res.gender == user.gender
+        assert res.location == user.city
+
+        account.MarkContributorFormFilled(account_pb2.MarkContributorFormFilledReq(filled_contributor_form=True))
+
+        res = account.GetContributorFormInfo(empty_pb2.Empty())
+        assert res.filled_contributor_form
+        assert res.username == user.username
+        assert res.email == user.email
+        assert res.age == user.age
+        assert res.gender == user.gender
+        assert res.location == user.city
+
+        account.MarkContributorFormFilled(account_pb2.MarkContributorFormFilledReq(filled_contributor_form=False))
+
+        res = account.GetContributorFormInfo(empty_pb2.Empty())
+        assert not res.filled_contributor_form
+        assert res.username == user.username
+        assert res.email == user.email
+        assert res.age == user.age
+        assert res.gender == user.gender
+        assert res.location == user.city

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -486,6 +486,7 @@ def test_contributor_form(db):
         res = account.GetContributorFormInfo(empty_pb2.Empty())
         assert not res.filled_contributor_form
         assert res.username == user.username
+        assert res.name == user.name
         assert res.email == user.email
         assert res.age == user.age
         assert res.gender == user.gender
@@ -496,6 +497,7 @@ def test_contributor_form(db):
         res = account.GetContributorFormInfo(empty_pb2.Empty())
         assert res.filled_contributor_form
         assert res.username == user.username
+        assert res.name == user.name
         assert res.email == user.email
         assert res.age == user.age
         assert res.gender == user.gender
@@ -506,6 +508,7 @@ def test_contributor_form(db):
         res = account.GetContributorFormInfo(empty_pb2.Empty())
         assert not res.filled_contributor_form
         assert res.username == user.username
+        assert res.name == user.name
         assert res.email == user.email
         assert res.age == user.age
         assert res.gender == user.gender

--- a/app/frontend/src/AppRoutes.tsx
+++ b/app/frontend/src/AppRoutes.tsx
@@ -1,5 +1,6 @@
 import PageTitle from "components/PageTitle";
 import TextBody from "components/TextBody";
+import Contribute from "features/Contribute";
 import React from "react";
 import { Switch } from "react-router-dom";
 
@@ -35,6 +36,7 @@ import {
   communityRoute,
   confirmChangeEmailRoute,
   connectionsRoute,
+  contributeRoute,
   discussionRoute,
   editHostingPreferenceRoute,
   editProfileRoute,
@@ -119,6 +121,13 @@ export default function AppRoutes() {
       </AppRoute>
       <AppRoute isPrivate={false} exact path={logoutRoute}>
         <Logout />
+      </AppRoute>
+
+      {
+        // CONTRIBUTE
+      }
+      <AppRoute isPrivate={false} isFullscreen exact path={contributeRoute}>
+        <Contribute />
       </AppRoute>
 
       {

--- a/app/frontend/src/features/Contribute.tsx
+++ b/app/frontend/src/features/Contribute.tsx
@@ -1,0 +1,103 @@
+import { makeStyles, Typography } from "@material-ui/core";
+import { LOGIN } from "features/auth/constants";
+import DesktopAuthBg from "features/auth/resources/desktop-auth-bg.jpg";
+import { Link } from "react-router-dom";
+import { loginRoute } from "routes";
+
+import { COUCHERS } from "../constants";
+import ContributorForm, {
+  CONTRIBUTE,
+  FILL_IN_THE_FORM,
+  JOIN_THE_TEAM,
+} from "./contributorForm";
+
+const useStyles = makeStyles((theme) => ({
+  bg: {
+    height: "100%",
+    width: "100%",
+    backgroundColor: theme.palette.common.white,
+    // backgroundAttachment: "scroll, local",
+    backgroundPosition: "top center",
+    backgroundRepeat: "no-repeat",
+    backgroundImage: `url(${DesktopAuthBg})`,
+    backgroundSize: "cover",
+    position: "fixed",
+    zIndex: -1000,
+  },
+  page: {
+    boxSizing: "border-box",
+    display: "flex",
+    height: "100vh",
+    alignItems: "flex-start",
+    flexDirection: "column",
+    padding: 0,
+    width: "100%",
+  },
+  content: {
+    flexDirection: "column",
+    height: "100%",
+    margin: "0 auto",
+  },
+  nav: {
+    display: "flex",
+  },
+  link: {
+    borderRadius: theme.shape.borderRadius / 3,
+    color: theme.palette.common.white,
+    fontSize: "1.25rem",
+    fontWeight: 500,
+    textAlign: "center",
+    padding: theme.spacing(1, 2),
+  },
+  loginLink: {
+    border: `1px solid ${theme.palette.primary.main}`,
+    marginRight: theme.spacing(3),
+  },
+  formWrapper: {
+    backgroundColor: theme.palette.background.default,
+    borderRadius: theme.shape.borderRadius / 3,
+    padding: theme.spacing(5, 3),
+  },
+  header: {
+    width: "100%",
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    padding: theme.spacing(2, 4),
+    marginBottom: theme.spacing(2),
+  },
+  logo: {
+    color: theme.palette.secondary.main,
+    fontFamily: "'Mansalva', cursive",
+    fontSize: "2rem",
+  },
+}));
+
+export default function Contribute() {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.page}>
+      <div className={classes.bg} />
+      <header className={classes.header}>
+        <div className={classes.logo}>{COUCHERS}</div>
+        <nav className={classes.nav}>
+          <Link
+            to={loginRoute}
+            className={`${classes.link} ${classes.loginLink}`}
+          >
+            {LOGIN}
+          </Link>
+        </nav>
+      </header>
+      <div className={classes.content}>
+        <div className={classes.formWrapper}>
+          <Typography variant="h1">{CONTRIBUTE}</Typography>
+          <Typography variant="subtitle1">{JOIN_THE_TEAM}</Typography>
+          <p>{FILL_IN_THE_FORM}</p>
+          <ContributorForm />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/features/Contribute.tsx
+++ b/app/frontend/src/features/Contribute.tsx
@@ -5,11 +5,7 @@ import { Link } from "react-router-dom";
 import { loginRoute } from "routes";
 
 import { COUCHERS } from "../constants";
-import ContributorForm, {
-  CONTRIBUTE,
-  FILL_IN_THE_FORM,
-  JOIN_THE_TEAM,
-} from "./contributorForm";
+import ContributorForm, { CONTRIBUTE, JOIN_THE_TEAM } from "./contributorForm";
 
 const useStyles = makeStyles((theme) => ({
   bg: {
@@ -94,7 +90,6 @@ export default function Contribute() {
         <div className={classes.formWrapper}>
           <Typography variant="h1">{CONTRIBUTE}</Typography>
           <Typography variant="subtitle1">{JOIN_THE_TEAM}</Typography>
-          <p>{FILL_IN_THE_FORM}</p>
           <ContributorForm />
         </div>
       </div>

--- a/app/frontend/src/features/Contribute.tsx
+++ b/app/frontend/src/features/Contribute.tsx
@@ -12,7 +12,6 @@ const useStyles = makeStyles((theme) => ({
     height: "100%",
     width: "100%",
     backgroundColor: theme.palette.common.white,
-    // backgroundAttachment: "scroll, local",
     backgroundPosition: "top center",
     backgroundRepeat: "no-repeat",
     backgroundImage: `url(${DesktopAuthBg})`,
@@ -38,7 +37,7 @@ const useStyles = makeStyles((theme) => ({
     display: "flex",
   },
   link: {
-    borderRadius: theme.shape.borderRadius / 3,
+    borderRadius: theme.shape.borderRadius,
     color: theme.palette.common.white,
     fontSize: "1.25rem",
     fontWeight: 500,
@@ -51,7 +50,7 @@ const useStyles = makeStyles((theme) => ({
   },
   formWrapper: {
     backgroundColor: theme.palette.background.default,
-    borderRadius: theme.shape.borderRadius / 3,
+    borderRadius: theme.shape.borderRadius,
     padding: theme.spacing(5, 3),
   },
   header: {

--- a/app/frontend/src/features/Home.tsx
+++ b/app/frontend/src/features/Home.tsx
@@ -20,6 +20,12 @@ import {
 } from "features/constants";
 import React from "react";
 
+import ContributorForm, {
+  CONTRIBUTE,
+  FILL_IN_THE_FORM,
+  JOIN_THE_TEAM,
+} from "./contributorForm";
+
 export default function Home() {
   return (
     <>
@@ -30,10 +36,10 @@ export default function Home() {
         <br /> {WELCOME_DESCRIPTION_2}
       </Typography>
       <Divider />
-      <Typography variant="h1">{FEATURES}</Typography>
+      <Typography variant="h2">{FEATURES}</Typography>
       <Typography variant="body1">{FEATURES_DESCRIPTION}</Typography>
       <Divider />
-      <Typography variant="h1">{BUGS}</Typography>
+      <Typography variant="h2">{BUGS}</Typography>
       <Typography variant="body1">
         {BUGS_DESCRIPTION_1}
         <br />
@@ -45,7 +51,7 @@ export default function Home() {
         {BUGS_DESCRIPTION_3}
       </Typography>
       <Divider />
-      <Typography variant="h1">{HELP}</Typography>
+      <Typography variant="h2">{HELP}</Typography>
       <Typography variant="body1">
         {HELP_DESCRIPTION_1}
         <Link href={SIGN_UP_LINK} target="_blank">
@@ -53,6 +59,11 @@ export default function Home() {
         </Link>
         {HELP_DESCRIPTION_2}
       </Typography>
+      <Divider />
+      <Typography variant="h2">{CONTRIBUTE}</Typography>
+      <Typography variant="subtitle2">{JOIN_THE_TEAM}</Typography>
+      <p>{FILL_IN_THE_FORM}</p>
+      <ContributorForm />
     </>
   );
 }

--- a/app/frontend/src/features/Home.tsx
+++ b/app/frontend/src/features/Home.tsx
@@ -9,22 +9,13 @@ import {
   COMMUNITY_FORUM_LINK,
   FEATURES,
   FEATURES_DESCRIPTION,
-  HELP,
-  HELP_DESCRIPTION_1,
-  HELP_DESCRIPTION_2,
-  SIGN_UP,
-  SIGN_UP_LINK,
   WELCOME,
   WELCOME_DESCRIPTION_1,
   WELCOME_DESCRIPTION_2,
 } from "features/constants";
 import React from "react";
 
-import ContributorForm, {
-  CONTRIBUTE,
-  FILL_IN_THE_FORM,
-  JOIN_THE_TEAM,
-} from "./contributorForm";
+import ContributorForm, { CONTRIBUTE, JOIN_THE_TEAM } from "./contributorForm";
 
 export default function Home() {
   return (
@@ -51,18 +42,8 @@ export default function Home() {
         {BUGS_DESCRIPTION_3}
       </Typography>
       <Divider />
-      <Typography variant="h2">{HELP}</Typography>
-      <Typography variant="body1">
-        {HELP_DESCRIPTION_1}
-        <Link href={SIGN_UP_LINK} target="_blank">
-          {SIGN_UP}
-        </Link>
-        {HELP_DESCRIPTION_2}
-      </Typography>
-      <Divider />
       <Typography variant="h2">{CONTRIBUTE}</Typography>
       <Typography variant="subtitle2">{JOIN_THE_TEAM}</Typography>
-      <p>{FILL_IN_THE_FORM}</p>
       <ContributorForm />
     </>
   );

--- a/app/frontend/src/features/constants.ts
+++ b/app/frontend/src/features/constants.ts
@@ -149,13 +149,6 @@ export const COMMUNITY_FORUM_LINK = "https://community.couchers.org/";
 export const FEATURES = "Features";
 export const FEATURES_DESCRIPTION =
   "We're working on a few more things before we launch, such as events, forums and community pages, as well as improved designs, and we'll let you know as those get released.";
-export const HELP = "Help out";
-export const HELP_DESCRIPTION_1 =
-  "If you're interested in helping out on this project, we'd love for you to ";
-export const HELP_DESCRIPTION_2 =
-  "! We are looking for people with all kinds of experience to help us build this amazing product.";
-export const SIGN_UP = "sign up";
-export const SIGN_UP_LINK = "https://couchers.org/signup";
 export const WELCOME = "Welcome to Couchers.org!";
 export const WELCOME_DESCRIPTION_1 = `We're in the process of building out the platform, so we appreciate your patience as we create new 
   features.`;

--- a/app/frontend/src/features/contributorForm/ContributorForm.tsx
+++ b/app/frontend/src/features/contributorForm/ContributorForm.tsx
@@ -1,0 +1,318 @@
+import {
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  FormLabel,
+  makeStyles,
+  Radio,
+  RadioGroup,
+} from "@material-ui/core";
+import classNames from "classnames";
+import Alert from "components/Alert";
+import Button from "components/Button";
+import CircularProgress from "components/CircularProgress";
+import TextField from "components/TextField";
+import { useAuthContext } from "features/auth/AuthProvider";
+import { useUser } from "features/userQueries/useUsers";
+import React, { useEffect, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+
+import {
+  AGE,
+  CONTRIBUTE_LABEL,
+  CONTRIBUTE_OPTIONS,
+  CONTRIBUTE_REQUIRED,
+  EMAIL,
+  EMAIL_REQUIRED,
+  EXPERIENCE_HELPER,
+  EXPERIENCE_LABEL,
+  EXPERTISE_HELPER,
+  EXPERTISE_LABEL,
+  FEATURES_HELPER,
+  FEATURES_LABEL,
+  GENDER,
+  GENDER_OPTIONS,
+  IDEAS_HELPER,
+  IDEAS_LABEL,
+  LOCATION_HELPER,
+  LOCATION_LABEL,
+  NAME,
+  NAME_REQUIRED,
+  QUESTIONS_OPTIONAL,
+  SUBMIT,
+} from "./constants";
+
+type ContributorInputs = {
+  name: string;
+  // doubles as username for logged in users
+  email: string;
+  contribute: string;
+  ideas: string;
+  features: string;
+  age: string;
+  gender: string;
+  location: string;
+  experience: string;
+  develop: string;
+  expertise: string;
+};
+
+type FormResponse = {
+  success: boolean;
+};
+
+const useStyles = makeStyles((theme) => ({
+  genderRadio: {
+    display: "flex",
+    flexDirection: "row",
+  },
+  hidden: {
+    display: "none",
+  },
+}));
+
+export default function ContributorForm() {
+  const { authState } = useAuthContext();
+
+  const { data: user, isLoading: userIsLoading } = useUser(
+    authState.userId ?? 0
+  );
+  const hasUser = !!user;
+
+  const {
+    control,
+    register,
+    handleSubmit,
+    setValue,
+    errors,
+  } = useForm<ContributorInputs>({
+    defaultValues: {},
+    mode: "onBlur",
+    shouldUnregister: false,
+  });
+
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  const classes = useStyles();
+
+  useEffect(() => {
+    if (!userIsLoading && user) {
+      // hard to get email from backend since it's not part of the normal User object
+      setValue("email", user.username);
+      setValue("name", user.name);
+      setValue("age", user.age);
+      setValue("gender", user.gender);
+      setValue("location", user.city);
+    }
+  }, [userIsLoading, setValue, user]);
+
+  const submit = handleSubmit(async (data: ContributorInputs) => {
+    setError("");
+    setLoading(true);
+
+    try {
+      const response = await fetch(
+        "https://ja4o9uz9u3.execute-api.us-east-1.amazonaws.com/form_handler",
+        {
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json;charset=UTF-8",
+          },
+          mode: "cors",
+          method: "POST",
+          body: JSON.stringify(data),
+        }
+      );
+      const result = (await response.json()) as FormResponse;
+      if (result.success) {
+        setSuccess(true);
+      } else {
+        setError("An unknown error occured");
+      }
+    } catch (e) {
+      setError(e.message);
+    }
+    setLoading(false);
+  });
+
+  return (
+    <>
+      {loading || userIsLoading ? (
+        <CircularProgress />
+      ) : (
+        <>
+          {success ? (
+            <>Thank you, we may be in touch soon</>
+          ) : (
+            <form onSubmit={submit}>
+              {error && <Alert severity="error">{error}</Alert>}
+              <TextField
+                id="name"
+                label={NAME}
+                variant="standard"
+                margin="normal"
+                fullWidth
+                name="name"
+                inputRef={register({
+                  required: NAME_REQUIRED,
+                })}
+                helperText={errors?.name?.message ?? " "}
+                error={!!errors?.name?.message}
+                className={classNames({ [classes.hidden]: hasUser })}
+              />
+              <TextField
+                id="email"
+                label={EMAIL}
+                variant="standard"
+                margin="normal"
+                fullWidth
+                name="email"
+                inputRef={register({
+                  required: EMAIL_REQUIRED,
+                })}
+                helperText={errors?.email?.message ?? " "}
+                error={!!errors?.email?.message}
+                className={classNames({ [classes.hidden]: hasUser })}
+              />
+              <Controller
+                id="contribute"
+                control={control}
+                name="contribute"
+                defaultValue=""
+                rules={{ required: CONTRIBUTE_REQUIRED }}
+                render={({ onChange }) => (
+                  <FormControl>
+                    <FormLabel>{CONTRIBUTE_LABEL}</FormLabel>
+                    <RadioGroup
+                      aria-label="contribute"
+                      name="contribute-radio"
+                      onChange={onChange}
+                    >
+                      {CONTRIBUTE_OPTIONS.map((opt) => (
+                        <FormControlLabel
+                          key={opt}
+                          value={opt}
+                          control={<Radio />}
+                          label={opt}
+                        />
+                      ))}
+                    </RadioGroup>
+                    <FormHelperText error={!!errors?.contribute?.message}>
+                      {errors?.contribute?.message ?? " "}
+                    </FormHelperText>
+                  </FormControl>
+                )}
+              />
+              <p>{QUESTIONS_OPTIONAL}</p>
+              <TextField
+                inputRef={register}
+                id="ideas"
+                margin="normal"
+                name="ideas"
+                label={IDEAS_LABEL}
+                helperText={IDEAS_HELPER}
+                fullWidth
+                multiline
+                rows={4}
+                rowsMax={6}
+              />
+              <TextField
+                inputRef={register}
+                id="features"
+                margin="normal"
+                name="features"
+                label={FEATURES_LABEL}
+                helperText={FEATURES_HELPER}
+                fullWidth
+                multiline
+                rows={4}
+                rowsMax={6}
+              />
+              <TextField
+                inputRef={register}
+                id="age"
+                type="number"
+                margin="normal"
+                name="age"
+                label={AGE}
+                fullWidth
+                className={classNames({ [classes.hidden]: hasUser })}
+              />
+              <Controller
+                id="gender"
+                control={control}
+                name="gender"
+                render={({ onChange }) => (
+                  <FormControl
+                    className={classNames({ [classes.hidden]: hasUser })}
+                  >
+                    <FormLabel component="legend">{GENDER}</FormLabel>
+                    <RadioGroup
+                      className={classes.genderRadio}
+                      aria-label="gender"
+                      name="gender-radio"
+                      onChange={onChange}
+                    >
+                      {GENDER_OPTIONS.map((opt) => (
+                        <FormControlLabel
+                          key={opt}
+                          value={opt}
+                          control={<Radio />}
+                          label={opt}
+                        />
+                      ))}
+                    </RadioGroup>
+                  </FormControl>
+                )}
+              />
+              <TextField
+                inputRef={register}
+                id="location"
+                margin="normal"
+                name="location"
+                label={LOCATION_LABEL}
+                helperText={LOCATION_HELPER}
+                fullWidth
+                className={classNames({ [classes.hidden]: hasUser })}
+              />
+              <TextField
+                inputRef={register}
+                id="experience"
+                margin="normal"
+                name="experience"
+                label={EXPERIENCE_LABEL}
+                helperText={EXPERIENCE_HELPER}
+                fullWidth
+                multiline
+                rows={4}
+                rowsMax={6}
+              />
+              <TextField
+                inputRef={register}
+                id="expertise"
+                margin="normal"
+                name="expertise"
+                label={EXPERTISE_LABEL}
+                helperText={EXPERTISE_HELPER}
+                fullWidth
+                multiline
+                rows={4}
+                rowsMax={6}
+              />
+              <Button
+                classes={{}}
+                onClick={submit}
+                type="submit"
+                loading={loading}
+              >
+                {SUBMIT}
+              </Button>
+            </form>
+          )}
+        </>
+      )}
+    </>
+  );
+}

--- a/app/frontend/src/features/contributorForm/ContributorForm.tsx
+++ b/app/frontend/src/features/contributorForm/ContributorForm.tsx
@@ -8,6 +8,7 @@ import {
   makeStyles,
   Radio,
   RadioGroup,
+  Typography,
 } from "@material-ui/core";
 import classNames from "classnames";
 import Alert from "components/Alert";
@@ -24,6 +25,7 @@ import { service } from "service";
 import {
   AGE,
   ALREADY_FILLED_IN,
+  CONTRIBUTE_ARIA_LABEL,
   CONTRIBUTE_LABEL,
   CONTRIBUTE_OPTIONS,
   CONTRIBUTE_REQUIRED,
@@ -38,6 +40,7 @@ import {
   FILL_IN_AGAIN,
   FILL_IN_THE_FORM,
   GENDER,
+  GENDER_ARIA_LABEL,
   GENDER_OPTIONS,
   IDEAS_HELPER,
   IDEAS_LABEL,
@@ -76,9 +79,6 @@ const useStyles = makeStyles((theme) => ({
   genderRadio: {
     display: "flex",
     flexDirection: "row",
-  },
-  hidden: {
-    display: "none",
   },
 }));
 
@@ -166,218 +166,200 @@ export default function ContributorForm() {
     }
   };
 
-  return (
+  return loading || authState.loading ? (
+    <CircularProgress />
+  ) : (
     <>
-      {loading || authState.loading ? (
-        <CircularProgress />
-      ) : (
+      {filled ? (
         <>
-          {filled ? (
+          <Typography variant="body1">{ALREADY_FILLED_IN}</Typography>
+          <Button onClick={() => setFilled(false)}>{FILL_IN_AGAIN}</Button>
+        </>
+      ) : success ? (
+        <>
+          <Typography variant="body1">{SUCCESS_MSG}</Typography>
+          {!authState.authenticated && (
             <>
-              <p>{ALREADY_FILLED_IN}</p>
-              <Button onClick={() => setFilled(false)}>{FILL_IN_AGAIN}</Button>
-            </>
-          ) : (
-            <>
-              {success ? (
-                <>
-                  <p>{SUCCESS_MSG}</p>
-                  {!authState.authenticated && (
-                    <>
-                      <p>{PLEASE_SIGN_UP}</p>
-                      <Button component={Link} to={signupRoute}>
-                        {SIGN_UP}
-                      </Button>
-                    </>
-                  )}
-                </>
-              ) : (
-                <form onSubmit={submit}>
-                  <p>{FILL_IN_THE_FORM}</p>
-                  {!authState.authenticated && (
-                    <>
-                      <Button component={Link} to={signupRoute}>
-                        {SIGN_UP}
-                      </Button>
-                      <p>{YOU_CAN_ALSO}</p>
-                    </>
-                  )}
-                  {error && <Alert severity="error">{error}</Alert>}
-                  {!authState.authenticated && (
-                    <>
-                      <TextField
-                        id="name"
-                        label={NAME}
-                        variant="standard"
-                        margin="normal"
-                        fullWidth
-                        name="name"
-                        inputRef={register({
-                          required: NAME_REQUIRED,
-                        })}
-                        helperText={errors?.name?.message ?? " "}
-                        error={!!errors?.name?.message}
-                      />
-                      <TextField
-                        id="email"
-                        label={EMAIL}
-                        variant="standard"
-                        margin="normal"
-                        fullWidth
-                        name="email"
-                        inputRef={register({
-                          required: EMAIL_REQUIRED,
-                        })}
-                        helperText={errors?.email?.message ?? " "}
-                        error={!!errors?.email?.message}
-                        className={classNames({
-                          [classes.hidden]: authState.authenticated,
-                        })}
-                      />
-                    </>
-                  )}
-                  <Controller
-                    id="contribute"
-                    control={control}
-                    name="contribute"
-                    defaultValue=""
-                    rules={{ required: CONTRIBUTE_REQUIRED }}
-                    render={({ onChange, value }) => (
-                      <FormControl>
-                        <FormLabel>{CONTRIBUTE_LABEL}</FormLabel>
-                        <FormGroup aria-label="contribute">
-                          {CONTRIBUTE_OPTIONS.map(({ name, description }) => (
-                            <FormControlLabel
-                              key={name}
-                              value={name}
-                              control={
-                                <Checkbox
-                                  checked={value.includes(name)}
-                                  onChange={() =>
-                                    toggleCheckbox(name, value, onChange)
-                                  }
-                                  name={name}
-                                />
-                              }
-                              label={description}
-                            />
-                          ))}
-                        </FormGroup>
-                        <FormHelperText error={!!errors?.contribute?.message}>
-                          {errors?.contribute?.message ?? " "}
-                        </FormHelperText>
-                      </FormControl>
-                    )}
-                  />
-                  <p>{QUESTIONS_OPTIONAL}</p>
-                  <TextField
-                    inputRef={register}
-                    id="ideas"
-                    margin="normal"
-                    name="ideas"
-                    label={IDEAS_LABEL}
-                    helperText={IDEAS_HELPER}
-                    fullWidth
-                    multiline
-                    rows={4}
-                    rowsMax={6}
-                  />
-                  <TextField
-                    inputRef={register}
-                    id="features"
-                    margin="normal"
-                    name="features"
-                    label={FEATURES_LABEL}
-                    helperText={FEATURES_HELPER}
-                    fullWidth
-                    multiline
-                    rows={4}
-                    rowsMax={6}
-                  />
-                  {!authState.authenticated && (
-                    <>
-                      <TextField
-                        inputRef={register}
-                        id="age"
-                        type="number"
-                        margin="normal"
-                        name="age"
-                        label={AGE}
-                        fullWidth
-                      />
-                      <Controller
-                        id="gender"
-                        control={control}
-                        name="gender"
-                        render={({ onChange }) => (
-                          <FormControl>
-                            <FormLabel component="legend">{GENDER}</FormLabel>
-                            <RadioGroup
-                              className={classes.genderRadio}
-                              aria-label="gender"
-                              name="gender-radio"
-                              onChange={onChange}
-                            >
-                              {GENDER_OPTIONS.map((opt) => (
-                                <FormControlLabel
-                                  key={opt}
-                                  value={opt}
-                                  control={<Radio />}
-                                  label={opt}
-                                />
-                              ))}
-                            </RadioGroup>
-                          </FormControl>
-                        )}
-                      />
-                      <TextField
-                        inputRef={register}
-                        id="location"
-                        margin="normal"
-                        name="location"
-                        label={LOCATION_LABEL}
-                        helperText={LOCATION_HELPER}
-                        fullWidth
-                      />
-                    </>
-                  )}
-                  <TextField
-                    inputRef={register}
-                    id="experience"
-                    margin="normal"
-                    name="experience"
-                    label={EXPERIENCE_LABEL}
-                    helperText={EXPERIENCE_HELPER}
-                    fullWidth
-                    multiline
-                    rows={4}
-                    rowsMax={6}
-                  />
-                  <TextField
-                    inputRef={register}
-                    id="expertise"
-                    margin="normal"
-                    name="expertise"
-                    label={EXPERTISE_LABEL}
-                    helperText={EXPERTISE_HELPER}
-                    fullWidth
-                    multiline
-                    rows={4}
-                    rowsMax={6}
-                  />
-                  <Button
-                    classes={{}}
-                    onClick={submit}
-                    type="submit"
-                    loading={loading}
-                  >
-                    {SUBMIT}
-                  </Button>
-                </form>
-              )}
+              <Typography variant="body1">{PLEASE_SIGN_UP}</Typography>
+              <Button component={Link} to={signupRoute}>
+                {SIGN_UP}
+              </Button>
             </>
           )}
         </>
+      ) : (
+        <form onSubmit={submit}>
+          <Typography variant="body1">{FILL_IN_THE_FORM}</Typography>
+          {!authState.authenticated && (
+            <>
+              <Button component={Link} to={signupRoute}>
+                {SIGN_UP}
+              </Button>
+              <Typography variant="body1">{YOU_CAN_ALSO}</Typography>
+            </>
+          )}
+          {error && <Alert severity="error">{error}</Alert>}
+          {!authState.authenticated && (
+            <>
+              <TextField
+                id="name"
+                label={NAME}
+                variant="standard"
+                margin="normal"
+                fullWidth
+                name="name"
+                inputRef={register({
+                  required: NAME_REQUIRED,
+                })}
+                helperText={errors?.name?.message ?? " "}
+                error={!!errors?.name?.message}
+              />
+              <TextField
+                id="email"
+                label={EMAIL}
+                variant="standard"
+                margin="normal"
+                fullWidth
+                name="email"
+                inputRef={register({
+                  required: EMAIL_REQUIRED,
+                })}
+                helperText={errors?.email?.message ?? " "}
+                error={!!errors?.email?.message}
+              />
+            </>
+          )}
+          <Controller
+            id="contribute"
+            control={control}
+            name="contribute"
+            defaultValue=""
+            rules={{ required: CONTRIBUTE_REQUIRED }}
+            render={({ onChange, value }) => (
+              <FormControl>
+                <FormLabel>{CONTRIBUTE_LABEL}</FormLabel>
+                <FormGroup aria-label={CONTRIBUTE_ARIA_LABEL}>
+                  {CONTRIBUTE_OPTIONS.map(({ name, description }) => (
+                    <FormControlLabel
+                      key={name}
+                      value={name}
+                      control={
+                        <Checkbox
+                          checked={value.includes(name)}
+                          onChange={() => toggleCheckbox(name, value, onChange)}
+                          name={name}
+                        />
+                      }
+                      label={description}
+                    />
+                  ))}
+                </FormGroup>
+                <FormHelperText error={!!errors?.contribute?.message}>
+                  {errors?.contribute?.message ?? " "}
+                </FormHelperText>
+              </FormControl>
+            )}
+          />
+          <Typography variant="body1">{QUESTIONS_OPTIONAL}</Typography>
+          <TextField
+            inputRef={register}
+            id="ideas"
+            margin="normal"
+            name="ideas"
+            label={IDEAS_LABEL}
+            helperText={IDEAS_HELPER}
+            fullWidth
+            multiline
+            rows={4}
+            rowsMax={6}
+          />
+          <TextField
+            inputRef={register}
+            id="features"
+            margin="normal"
+            name="features"
+            label={FEATURES_LABEL}
+            helperText={FEATURES_HELPER}
+            fullWidth
+            multiline
+            rows={4}
+            rowsMax={6}
+          />
+          {!authState.authenticated && (
+            <>
+              <TextField
+                inputRef={register}
+                id="age"
+                type="number"
+                margin="normal"
+                name="age"
+                label={AGE}
+                fullWidth
+              />
+              <Controller
+                id="gender"
+                control={control}
+                name="gender"
+                render={({ onChange }) => (
+                  <FormControl>
+                    <FormLabel component="legend">{GENDER}</FormLabel>
+                    <RadioGroup
+                      className={classes.genderRadio}
+                      aria-label={GENDER_ARIA_LABEL}
+                      name="gender-radio"
+                      onChange={onChange}
+                    >
+                      {GENDER_OPTIONS.map((opt) => (
+                        <FormControlLabel
+                          key={opt}
+                          value={opt}
+                          control={<Radio />}
+                          label={opt}
+                        />
+                      ))}
+                    </RadioGroup>
+                  </FormControl>
+                )}
+              />
+              <TextField
+                inputRef={register}
+                id="location"
+                margin="normal"
+                name="location"
+                label={LOCATION_LABEL}
+                helperText={LOCATION_HELPER}
+                fullWidth
+              />
+            </>
+          )}
+          <TextField
+            inputRef={register}
+            id="experience"
+            margin="normal"
+            name="experience"
+            label={EXPERIENCE_LABEL}
+            helperText={EXPERIENCE_HELPER}
+            fullWidth
+            multiline
+            rows={4}
+            rowsMax={6}
+          />
+          <TextField
+            inputRef={register}
+            id="expertise"
+            margin="normal"
+            name="expertise"
+            label={EXPERTISE_LABEL}
+            helperText={EXPERTISE_HELPER}
+            fullWidth
+            multiline
+            rows={4}
+            rowsMax={6}
+          />
+          <Button onClick={submit} type="submit" loading={loading}>
+            {SUBMIT}
+          </Button>
+        </form>
       )}
     </>
   );

--- a/app/frontend/src/features/contributorForm/ContributorForm.tsx
+++ b/app/frontend/src/features/contributorForm/ContributorForm.tsx
@@ -1,6 +1,8 @@
 import {
+  Checkbox,
   FormControl,
   FormControlLabel,
+  FormGroup,
   FormHelperText,
   FormLabel,
   makeStyles,
@@ -103,7 +105,6 @@ export default function ContributorForm() {
 
   useEffect(() => {
     if (authState.authenticated) {
-      console.log("auth'd");
       (async () => {
         const info = await service.account.getContributorFormInfo();
         setValue("username", info.username);
@@ -151,6 +152,19 @@ export default function ContributorForm() {
     }
     setLoading(false);
   });
+
+  const toggleCheckbox = (
+    option: string,
+    contribute: string,
+    setContribute: (s: string) => void
+  ) => {
+    const currentChoices = contribute.split(",").filter((v) => !!v);
+    if (currentChoices.includes(option)) {
+      setContribute(currentChoices.filter((opt) => opt !== option).join(","));
+    } else {
+      setContribute(currentChoices.concat(option).join(","));
+    }
+  };
 
   return (
     <>
@@ -228,23 +242,27 @@ export default function ContributorForm() {
                     name="contribute"
                     defaultValue=""
                     rules={{ required: CONTRIBUTE_REQUIRED }}
-                    render={({ onChange }) => (
+                    render={({ onChange, value }) => (
                       <FormControl>
                         <FormLabel>{CONTRIBUTE_LABEL}</FormLabel>
-                        <RadioGroup
-                          aria-label="contribute"
-                          name="contribute-radio"
-                          onChange={onChange}
-                        >
-                          {CONTRIBUTE_OPTIONS.map((opt) => (
+                        <FormGroup aria-label="contribute">
+                          {CONTRIBUTE_OPTIONS.map(({ name, description }) => (
                             <FormControlLabel
-                              key={opt}
-                              value={opt}
-                              control={<Radio />}
-                              label={opt}
+                              key={name}
+                              value={name}
+                              control={
+                                <Checkbox
+                                  checked={value.includes(name)}
+                                  onChange={() =>
+                                    toggleCheckbox(name, value, onChange)
+                                  }
+                                  name={name}
+                                />
+                              }
+                              label={description}
                             />
                           ))}
-                        </RadioGroup>
+                        </FormGroup>
                         <FormHelperText error={!!errors?.contribute?.message}>
                           {errors?.contribute?.message ?? " "}
                         </FormHelperText>

--- a/app/frontend/src/features/contributorForm/ContributorForm.tsx
+++ b/app/frontend/src/features/contributorForm/ContributorForm.tsx
@@ -130,7 +130,7 @@ export default function ContributorForm() {
         body: JSON.stringify(data),
       }
     );
-    return (await response.json()) as FormResponse;
+    return response.json();
   };
 
   const {

--- a/app/frontend/src/features/contributorForm/ContributorForm.tsx
+++ b/app/frontend/src/features/contributorForm/ContributorForm.tsx
@@ -13,12 +13,13 @@ import Button from "components/Button";
 import CircularProgress from "components/CircularProgress";
 import TextField from "components/TextField";
 import { useAuthContext } from "features/auth/AuthProvider";
-import { useUser } from "features/userQueries/useUsers";
 import React, { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
+import { service } from "service";
 
 import {
   AGE,
+  ALREADY_FILLED_IN,
   CONTRIBUTE_LABEL,
   CONTRIBUTE_OPTIONS,
   CONTRIBUTE_REQUIRED,
@@ -30,6 +31,7 @@ import {
   EXPERTISE_LABEL,
   FEATURES_HELPER,
   FEATURES_LABEL,
+  FILL_IN_AGAIN,
   GENDER,
   GENDER_OPTIONS,
   IDEAS_HELPER,
@@ -40,11 +42,12 @@ import {
   NAME_REQUIRED,
   QUESTIONS_OPTIONAL,
   SUBMIT,
+  SUCCESS_MSG,
 } from "./constants";
 
 type ContributorInputs = {
+  username?: string;
   name: string;
-  // doubles as username for logged in users
   email: string;
   contribute: string;
   ideas: string;
@@ -72,12 +75,13 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function ContributorForm() {
+  const classes = useStyles();
   const { authState } = useAuthContext();
 
-  const { data: user, isLoading: userIsLoading } = useUser(
-    authState.userId ?? 0
-  );
-  const hasUser = !!user;
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [success, setSuccess] = useState(false);
+  const [filled, setFilled] = useState(false);
 
   const {
     control,
@@ -91,22 +95,24 @@ export default function ContributorForm() {
     shouldUnregister: false,
   });
 
-  const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [success, setSuccess] = useState(false);
-
-  const classes = useStyles();
-
   useEffect(() => {
-    if (!userIsLoading && user) {
-      // hard to get email from backend since it's not part of the normal User object
-      setValue("email", user.username);
-      setValue("name", user.name);
-      setValue("age", user.age);
-      setValue("gender", user.gender);
-      setValue("location", user.city);
+    if (authState.authenticated) {
+      console.log("auth'd");
+      (async () => {
+        const info = await service.account.getContributorFormInfo();
+        setValue("username", info.username);
+        setValue("name", info.name);
+        setValue("email", info.email);
+        setValue("age", info.age);
+        setValue("gender", info.gender);
+        setValue("location", info.location);
+        setFilled(info.filledContributorForm);
+        setLoading(false);
+      })();
+    } else {
+      setLoading(false);
     }
-  }, [userIsLoading, setValue, user]);
+  }, [authState, setLoading, setValue, setFilled]);
 
   const submit = handleSubmit(async (data: ContributorInputs) => {
     setError("");
@@ -127,6 +133,9 @@ export default function ContributorForm() {
       );
       const result = (await response.json()) as FormResponse;
       if (result.success) {
+        if (authState.authenticated) {
+          await service.account.markContributorFormFilled();
+        }
         setSuccess(true);
       } else {
         setError("An unknown error occured");
@@ -139,177 +148,191 @@ export default function ContributorForm() {
 
   return (
     <>
-      {loading || userIsLoading ? (
+      {loading || authState.loading ? (
         <CircularProgress />
       ) : (
         <>
-          {success ? (
-            <>Thank you, we may be in touch soon</>
+          {filled ? (
+            <>
+              <p>{ALREADY_FILLED_IN}</p>
+              <Button onClick={() => setFilled(false)}>{FILL_IN_AGAIN}</Button>
+            </>
           ) : (
-            <form onSubmit={submit}>
-              {error && <Alert severity="error">{error}</Alert>}
-              <TextField
-                id="name"
-                label={NAME}
-                variant="standard"
-                margin="normal"
-                fullWidth
-                name="name"
-                inputRef={register({
-                  required: NAME_REQUIRED,
-                })}
-                helperText={errors?.name?.message ?? " "}
-                error={!!errors?.name?.message}
-                className={classNames({ [classes.hidden]: hasUser })}
-              />
-              <TextField
-                id="email"
-                label={EMAIL}
-                variant="standard"
-                margin="normal"
-                fullWidth
-                name="email"
-                inputRef={register({
-                  required: EMAIL_REQUIRED,
-                })}
-                helperText={errors?.email?.message ?? " "}
-                error={!!errors?.email?.message}
-                className={classNames({ [classes.hidden]: hasUser })}
-              />
-              <Controller
-                id="contribute"
-                control={control}
-                name="contribute"
-                defaultValue=""
-                rules={{ required: CONTRIBUTE_REQUIRED }}
-                render={({ onChange }) => (
-                  <FormControl>
-                    <FormLabel>{CONTRIBUTE_LABEL}</FormLabel>
-                    <RadioGroup
-                      aria-label="contribute"
-                      name="contribute-radio"
-                      onChange={onChange}
-                    >
-                      {CONTRIBUTE_OPTIONS.map((opt) => (
-                        <FormControlLabel
-                          key={opt}
-                          value={opt}
-                          control={<Radio />}
-                          label={opt}
-                        />
-                      ))}
-                    </RadioGroup>
-                    <FormHelperText error={!!errors?.contribute?.message}>
-                      {errors?.contribute?.message ?? " "}
-                    </FormHelperText>
-                  </FormControl>
-                )}
-              />
-              <p>{QUESTIONS_OPTIONAL}</p>
-              <TextField
-                inputRef={register}
-                id="ideas"
-                margin="normal"
-                name="ideas"
-                label={IDEAS_LABEL}
-                helperText={IDEAS_HELPER}
-                fullWidth
-                multiline
-                rows={4}
-                rowsMax={6}
-              />
-              <TextField
-                inputRef={register}
-                id="features"
-                margin="normal"
-                name="features"
-                label={FEATURES_LABEL}
-                helperText={FEATURES_HELPER}
-                fullWidth
-                multiline
-                rows={4}
-                rowsMax={6}
-              />
-              <TextField
-                inputRef={register}
-                id="age"
-                type="number"
-                margin="normal"
-                name="age"
-                label={AGE}
-                fullWidth
-                className={classNames({ [classes.hidden]: hasUser })}
-              />
-              <Controller
-                id="gender"
-                control={control}
-                name="gender"
-                render={({ onChange }) => (
-                  <FormControl
-                    className={classNames({ [classes.hidden]: hasUser })}
+            <>
+              {success ? (
+                <>{SUCCESS_MSG}</>
+              ) : (
+                <form onSubmit={submit}>
+                  {error && <Alert severity="error">{error}</Alert>}
+                  {!authState.authenticated && (
+                    <>
+                      <TextField
+                        id="name"
+                        label={NAME}
+                        variant="standard"
+                        margin="normal"
+                        fullWidth
+                        name="name"
+                        inputRef={register({
+                          required: NAME_REQUIRED,
+                        })}
+                        helperText={errors?.name?.message ?? " "}
+                        error={!!errors?.name?.message}
+                      />
+                      <TextField
+                        id="email"
+                        label={EMAIL}
+                        variant="standard"
+                        margin="normal"
+                        fullWidth
+                        name="email"
+                        inputRef={register({
+                          required: EMAIL_REQUIRED,
+                        })}
+                        helperText={errors?.email?.message ?? " "}
+                        error={!!errors?.email?.message}
+                        className={classNames({
+                          [classes.hidden]: authState.authenticated,
+                        })}
+                      />
+                    </>
+                  )}
+                  <Controller
+                    id="contribute"
+                    control={control}
+                    name="contribute"
+                    defaultValue=""
+                    rules={{ required: CONTRIBUTE_REQUIRED }}
+                    render={({ onChange }) => (
+                      <FormControl>
+                        <FormLabel>{CONTRIBUTE_LABEL}</FormLabel>
+                        <RadioGroup
+                          aria-label="contribute"
+                          name="contribute-radio"
+                          onChange={onChange}
+                        >
+                          {CONTRIBUTE_OPTIONS.map((opt) => (
+                            <FormControlLabel
+                              key={opt}
+                              value={opt}
+                              control={<Radio />}
+                              label={opt}
+                            />
+                          ))}
+                        </RadioGroup>
+                        <FormHelperText error={!!errors?.contribute?.message}>
+                          {errors?.contribute?.message ?? " "}
+                        </FormHelperText>
+                      </FormControl>
+                    )}
+                  />
+                  <p>{QUESTIONS_OPTIONAL}</p>
+                  <TextField
+                    inputRef={register}
+                    id="ideas"
+                    margin="normal"
+                    name="ideas"
+                    label={IDEAS_LABEL}
+                    helperText={IDEAS_HELPER}
+                    fullWidth
+                    multiline
+                    rows={4}
+                    rowsMax={6}
+                  />
+                  <TextField
+                    inputRef={register}
+                    id="features"
+                    margin="normal"
+                    name="features"
+                    label={FEATURES_LABEL}
+                    helperText={FEATURES_HELPER}
+                    fullWidth
+                    multiline
+                    rows={4}
+                    rowsMax={6}
+                  />
+                  {!authState.authenticated && (
+                    <>
+                      <TextField
+                        inputRef={register}
+                        id="age"
+                        type="number"
+                        margin="normal"
+                        name="age"
+                        label={AGE}
+                        fullWidth
+                      />
+                      <Controller
+                        id="gender"
+                        control={control}
+                        name="gender"
+                        render={({ onChange }) => (
+                          <FormControl>
+                            <FormLabel component="legend">{GENDER}</FormLabel>
+                            <RadioGroup
+                              className={classes.genderRadio}
+                              aria-label="gender"
+                              name="gender-radio"
+                              onChange={onChange}
+                            >
+                              {GENDER_OPTIONS.map((opt) => (
+                                <FormControlLabel
+                                  key={opt}
+                                  value={opt}
+                                  control={<Radio />}
+                                  label={opt}
+                                />
+                              ))}
+                            </RadioGroup>
+                          </FormControl>
+                        )}
+                      />
+                      <TextField
+                        inputRef={register}
+                        id="location"
+                        margin="normal"
+                        name="location"
+                        label={LOCATION_LABEL}
+                        helperText={LOCATION_HELPER}
+                        fullWidth
+                      />
+                    </>
+                  )}
+                  <TextField
+                    inputRef={register}
+                    id="experience"
+                    margin="normal"
+                    name="experience"
+                    label={EXPERIENCE_LABEL}
+                    helperText={EXPERIENCE_HELPER}
+                    fullWidth
+                    multiline
+                    rows={4}
+                    rowsMax={6}
+                  />
+                  <TextField
+                    inputRef={register}
+                    id="expertise"
+                    margin="normal"
+                    name="expertise"
+                    label={EXPERTISE_LABEL}
+                    helperText={EXPERTISE_HELPER}
+                    fullWidth
+                    multiline
+                    rows={4}
+                    rowsMax={6}
+                  />
+                  <Button
+                    classes={{}}
+                    onClick={submit}
+                    type="submit"
+                    loading={loading}
                   >
-                    <FormLabel component="legend">{GENDER}</FormLabel>
-                    <RadioGroup
-                      className={classes.genderRadio}
-                      aria-label="gender"
-                      name="gender-radio"
-                      onChange={onChange}
-                    >
-                      {GENDER_OPTIONS.map((opt) => (
-                        <FormControlLabel
-                          key={opt}
-                          value={opt}
-                          control={<Radio />}
-                          label={opt}
-                        />
-                      ))}
-                    </RadioGroup>
-                  </FormControl>
-                )}
-              />
-              <TextField
-                inputRef={register}
-                id="location"
-                margin="normal"
-                name="location"
-                label={LOCATION_LABEL}
-                helperText={LOCATION_HELPER}
-                fullWidth
-                className={classNames({ [classes.hidden]: hasUser })}
-              />
-              <TextField
-                inputRef={register}
-                id="experience"
-                margin="normal"
-                name="experience"
-                label={EXPERIENCE_LABEL}
-                helperText={EXPERIENCE_HELPER}
-                fullWidth
-                multiline
-                rows={4}
-                rowsMax={6}
-              />
-              <TextField
-                inputRef={register}
-                id="expertise"
-                margin="normal"
-                name="expertise"
-                label={EXPERTISE_LABEL}
-                helperText={EXPERTISE_HELPER}
-                fullWidth
-                multiline
-                rows={4}
-                rowsMax={6}
-              />
-              <Button
-                classes={{}}
-                onClick={submit}
-                type="submit"
-                loading={loading}
-              >
-                {SUBMIT}
-              </Button>
-            </form>
+                    {SUBMIT}
+                  </Button>
+                </form>
+              )}
+            </>
           )}
         </>
       )}

--- a/app/frontend/src/features/contributorForm/ContributorForm.tsx
+++ b/app/frontend/src/features/contributorForm/ContributorForm.tsx
@@ -15,6 +15,8 @@ import TextField from "components/TextField";
 import { useAuthContext } from "features/auth/AuthProvider";
 import React, { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
+import { Link } from "react-router-dom";
+import { signupRoute } from "routes";
 import { service } from "service";
 
 import {
@@ -32,6 +34,7 @@ import {
   FEATURES_HELPER,
   FEATURES_LABEL,
   FILL_IN_AGAIN,
+  FILL_IN_THE_FORM,
   GENDER,
   GENDER_OPTIONS,
   IDEAS_HELPER,
@@ -40,9 +43,12 @@ import {
   LOCATION_LABEL,
   NAME,
   NAME_REQUIRED,
+  PLEASE_SIGN_UP,
   QUESTIONS_OPTIONAL,
+  SIGN_UP,
   SUBMIT,
   SUCCESS_MSG,
+  YOU_CAN_ALSO,
 } from "./constants";
 
 type ContributorInputs = {
@@ -160,9 +166,28 @@ export default function ContributorForm() {
           ) : (
             <>
               {success ? (
-                <>{SUCCESS_MSG}</>
+                <>
+                  <p>{SUCCESS_MSG}</p>
+                  {!authState.authenticated && (
+                    <>
+                      <p>{PLEASE_SIGN_UP}</p>
+                      <Button component={Link} to={signupRoute}>
+                        {SIGN_UP}
+                      </Button>
+                    </>
+                  )}
+                </>
               ) : (
                 <form onSubmit={submit}>
+                  <p>{FILL_IN_THE_FORM}</p>
+                  {!authState.authenticated && (
+                    <>
+                      <Button component={Link} to={signupRoute}>
+                        {SIGN_UP}
+                      </Button>
+                      <p>{YOU_CAN_ALSO}</p>
+                    </>
+                  )}
                   {error && <Alert severity="error">{error}</Alert>}
                   {!authState.authenticated && (
                     <>

--- a/app/frontend/src/features/contributorForm/constants.ts
+++ b/app/frontend/src/features/contributorForm/constants.ts
@@ -1,0 +1,70 @@
+export const CONTRIBUTE = "Sign up to contribute to Couchers.org";
+export const JOIN_THE_TEAM =
+  "Join the worldwide team of couch-surfers bringing this community-run platform to life";
+export const FILL_IN_THE_FORM =
+  "Fill in the form below to tell us your experience, ideas, and expertise. We'll keep you in the loop as we make progress on this exciting project!";
+
+export const YOUR_DETAILS = "Your details";
+export const BASICS = "The basics about you";
+
+export const NAME = "Name";
+export const NAME_REQUIRED = "Name required";
+export const EMAIL = "Email";
+export const EMAIL_REQUIRED = "Email required";
+export const CONTRIBUTE_LABEL =
+  "How you like to help in creating Couchers.org?";
+export const CONTRIBUTE_REQUIRED = "This field is required";
+export const CONTRIBUTE_OPTIONS = [
+  "Design (graphic/UI/UX)",
+  "Development, mobile (iOS/Android)",
+  "Development, backend (python/gRPC/postgres)",
+  "Development, web (TS/React)",
+  "Marketing",
+  "Community organizer (events, moderation, outreach, etc)",
+  "Blog writing",
+];
+export const NEXT = "Next";
+export const DETAILS_SUBMITTED =
+  "Your basic details will be submitted when you press Next";
+
+export const BIT_MORE = "A bit more about you";
+export const FEEL_FREE =
+  "Feel free to fill out the form below and tell us a bit more about yourself and what you think we should concentrate on.";
+export const QUESTIONS_OPTIONAL = "All questions below are optional.";
+
+export const IDEAS_LABEL =
+  "Please share any ideas you have that would improve the couch-surfing experience for you and for the community.";
+export const IDEAS_HELPER =
+  "Feel free to describe any problems you've had or experienced with other platforms, and what you'd like to see done about them.";
+
+export const FEATURES_LABEL =
+  "What feature would you like implemented first, and why? How could we make that feature as good as possible for your particular use?";
+export const FEATURES_HELPER =
+  "Do you care about hosting or surfing? Events or hangouts? Wish there was a better messaging system? Do you like mobile apps or prefer to use a computer?";
+
+export const AGE = "Age";
+export const GENDER = "Gender";
+export const GENDER_OPTIONS = ["Female", "Male", "Non-binary"];
+export const LOCATION_LABEL = "Country and city";
+export const LOCATION_HELPER =
+  "Maybe you can help us grow Couchers in your city?";
+
+export const EXPERIENCE_LABEL =
+  "Briefly describe your experience as a couch-surfer.";
+export const EXPERIENCE_HELPER =
+  "How many times you've surfed, hosted, and used other features of similar platforms. Have you been part of communities? Anything else you'd like to tell us.";
+
+export const HELP_GROW_COUCHERS =
+  "Would you like to help in developing or growing Couchers.org?";
+export const HELP_GROW_COUCHERS_OPTIONS = ["Yes", "Maybe", "No"];
+
+export const EXPERTISE_LABEL =
+  "What kinds of expertise do you have that could help us build and grow this platform? Feel free to share a link to your portfolio, github, linkedin or anything else.";
+export const EXPERTISE_HELPER =
+  "Have technical or community/non-profit experience? Anything else you think could get us moving forward?";
+
+export const THANK_YOU = "Thank you!";
+export const APPRECIATE_YOUR_TIME =
+  "We appreciate you taking the time to help us build Couchers.org";
+
+export const SUBMIT = "Submit";

--- a/app/frontend/src/features/contributorForm/constants.ts
+++ b/app/frontend/src/features/contributorForm/constants.ts
@@ -4,6 +4,10 @@ export const JOIN_THE_TEAM =
 export const FILL_IN_THE_FORM =
   "Fill in the form below to tell us your experience, ideas, and expertise. We'll keep you in the loop as we make progress on this exciting project!";
 
+export const ALREADY_FILLED_IN =
+  "You've already filled in the contributor form. Thanks! If you'd like to fill it in again, please click the below button.";
+export const FILL_IN_AGAIN = "Fill the form in again";
+
 export const YOUR_DETAILS = "Your details";
 export const BASICS = "The basics about you";
 
@@ -63,8 +67,7 @@ export const EXPERTISE_LABEL =
 export const EXPERTISE_HELPER =
   "Have technical or community/non-profit experience? Anything else you think could get us moving forward?";
 
-export const THANK_YOU = "Thank you!";
-export const APPRECIATE_YOUR_TIME =
-  "We appreciate you taking the time to help us build Couchers.org";
+export const SUCCESS_MSG =
+  "Thank you. We appreciate you taking the time to help us build Couchers.org!";
 
 export const SUBMIT = "Submit";

--- a/app/frontend/src/features/contributorForm/constants.ts
+++ b/app/frontend/src/features/contributorForm/constants.ts
@@ -3,13 +3,12 @@ export const JOIN_THE_TEAM =
   "Join the worldwide team of couch-surfers bringing this community-run platform to life";
 export const FILL_IN_THE_FORM =
   "Fill in the form below to tell us your experience, ideas, and expertise. We'll keep you in the loop as we make progress on this exciting project!";
+export const YOU_CAN_ALSO =
+  "You can also sign up or log in first and fill in this form on the dashboard. That way you don't need to enter your basic details again!";
 
 export const ALREADY_FILLED_IN =
   "You've already filled in the contributor form. Thanks! If you'd like to fill it in again, please click the below button.";
 export const FILL_IN_AGAIN = "Fill the form in again";
-
-export const YOUR_DETAILS = "Your details";
-export const BASICS = "The basics about you";
 
 export const NAME = "Name";
 export const NAME_REQUIRED = "Name required";
@@ -27,14 +26,9 @@ export const CONTRIBUTE_OPTIONS = [
   "Community organizer (events, moderation, outreach, etc)",
   "Blog writing",
 ];
-export const NEXT = "Next";
-export const DETAILS_SUBMITTED =
-  "Your basic details will be submitted when you press Next";
 
-export const BIT_MORE = "A bit more about you";
-export const FEEL_FREE =
-  "Feel free to fill out the form below and tell us a bit more about yourself and what you think we should concentrate on.";
-export const QUESTIONS_OPTIONAL = "All questions below are optional.";
+export const QUESTIONS_OPTIONAL =
+  "All questions below are optional. Please fill them in to tell us a bit more about yourself and what you think we should concentrate on.";
 
 export const IDEAS_LABEL =
   "Please share any ideas you have that would improve the couch-surfing experience for you and for the community.";
@@ -58,16 +52,15 @@ export const EXPERIENCE_LABEL =
 export const EXPERIENCE_HELPER =
   "How many times you've surfed, hosted, and used other features of similar platforms. Have you been part of communities? Anything else you'd like to tell us.";
 
-export const HELP_GROW_COUCHERS =
-  "Would you like to help in developing or growing Couchers.org?";
-export const HELP_GROW_COUCHERS_OPTIONS = ["Yes", "Maybe", "No"];
-
 export const EXPERTISE_LABEL =
   "What kinds of expertise do you have that could help us build and grow this platform? Feel free to share a link to your portfolio, github, linkedin or anything else.";
 export const EXPERTISE_HELPER =
   "Have technical or community/non-profit experience? Anything else you think could get us moving forward?";
 
+export const SUBMIT = "Submit";
+
 export const SUCCESS_MSG =
   "Thank you. We appreciate you taking the time to help us build Couchers.org!";
 
-export const SUBMIT = "Submit";
+export const PLEASE_SIGN_UP = "Please continue by signing up for the app.";
+export const SIGN_UP = "Sign up for the app";

--- a/app/frontend/src/features/contributorForm/constants.ts
+++ b/app/frontend/src/features/contributorForm/constants.ts
@@ -18,13 +18,34 @@ export const CONTRIBUTE_LABEL =
   "How you like to help in creating Couchers.org?";
 export const CONTRIBUTE_REQUIRED = "This field is required";
 export const CONTRIBUTE_OPTIONS = [
-  "Design (graphic/UI/UX)",
-  "Development, mobile (iOS/Android)",
-  "Development, backend (python/gRPC/postgres)",
-  "Development, web (TS/React)",
-  "Marketing",
-  "Community organizer (events, moderation, outreach, etc)",
-  "Blog writing",
+  {
+    name: "design",
+    description: "Design (graphic/UI/UX)",
+  },
+  {
+    name: "mobile",
+    description: "Development, mobile (iOS/Android)",
+  },
+  {
+    name: "backend",
+    description: "Development, backend (python/gRPC/postgres)",
+  },
+  {
+    name: "web",
+    description: "Development, web (TS/React)",
+  },
+  {
+    name: "marketing",
+    description: "Marketing",
+  },
+  {
+    name: "community",
+    description: "Community organizer (events, moderation, outreach, etc)",
+  },
+  {
+    name: "blog",
+    description: "Blog writing",
+  },
 ];
 
 export const QUESTIONS_OPTIONAL =

--- a/app/frontend/src/features/contributorForm/constants.ts
+++ b/app/frontend/src/features/contributorForm/constants.ts
@@ -47,6 +47,7 @@ export const CONTRIBUTE_OPTIONS = [
     description: "Blog writing",
   },
 ];
+export const CONTRIBUTE_ARIA_LABEL = "contribute";
 
 export const QUESTIONS_OPTIONAL =
   "All questions below are optional. Please fill them in to tell us a bit more about yourself and what you think we should concentrate on.";
@@ -64,6 +65,7 @@ export const FEATURES_HELPER =
 export const AGE = "Age";
 export const GENDER = "Gender";
 export const GENDER_OPTIONS = ["Female", "Male", "Non-binary"];
+export const GENDER_ARIA_LABEL = "gender";
 export const LOCATION_LABEL = "Country and city";
 export const LOCATION_HELPER =
   "Maybe you can help us grow Couchers in your city?";

--- a/app/frontend/src/features/contributorForm/index.ts
+++ b/app/frontend/src/features/contributorForm/index.ts
@@ -1,0 +1,2 @@
+export { CONTRIBUTE, FILL_IN_THE_FORM, JOIN_THE_TEAM } from "./constants";
+export { default } from "./ContributorForm";

--- a/app/frontend/src/features/contributorForm/index.ts
+++ b/app/frontend/src/features/contributorForm/index.ts
@@ -1,2 +1,3 @@
-export { CONTRIBUTE, FILL_IN_THE_FORM, JOIN_THE_TEAM } from "./constants";
+// depending on the page the form is on, we want to style these differently, so leave up to the embedding page
+export { CONTRIBUTE, JOIN_THE_TEAM } from "./constants";
 export { default } from "./ContributorForm";

--- a/app/frontend/src/routes.ts
+++ b/app/frontend/src/routes.ts
@@ -1,5 +1,7 @@
 export const baseRoute = "/";
 
+export const contributeRoute = "/contribute";
+
 export const loginRoute = "/login";
 export const resetPasswordRoute = "/password-reset";
 export const settingsRoute = "/account-settings";

--- a/app/frontend/src/service/account.ts
+++ b/app/frontend/src/service/account.ts
@@ -1,6 +1,10 @@
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { StringValue } from "google-protobuf/google/protobuf/wrappers_pb";
-import { ChangeEmailReq, ChangePasswordReq } from "pb/account_pb";
+import {
+  ChangeEmailReq,
+  ChangePasswordReq,
+  MarkContributorFormFilledReq,
+} from "pb/account_pb";
 import {
   CompleteChangeEmailReq,
   CompletePasswordResetReq,
@@ -51,4 +55,15 @@ export function completeChangeEmail(resetToken: string) {
   const req = new CompleteChangeEmailReq();
   req.setChangeEmailToken(resetToken);
   return client.auth.completeChangeEmail(req);
+}
+
+export async function getContributorFormInfo() {
+  const res = await client.account.getContributorFormInfo(new Empty());
+  return res.toObject();
+}
+
+export async function markContributorFormFilled() {
+  const req = new MarkContributorFormFilledReq();
+  req.setFilledContributorForm(true);
+  await client.account.markContributorFormFilled(req);
 }

--- a/app/pb/account.proto
+++ b/app/pb/account.proto
@@ -65,10 +65,11 @@ message GetContributorFormInfoRes {
   bool filled_contributor_form = 1;
 
   string username = 2;
-  string email = 3;
-  uint32 age = 4;
-  string gender = 5;
-  string location = 6;
+  string name = 3;
+  string email = 4;
+  uint32 age = 5;
+  string gender = 6;
+  string location = 7;
 }
 
 message MarkContributorFormFilledReq {

--- a/app/pb/account.proto
+++ b/app/pb/account.proto
@@ -23,6 +23,14 @@ service Account {
     // we will send and email saying the email changed to the old email, and confirmation email to the new email
     // Raises INVALID_ARGUMENT if password is too small or too large or insecure or wrong or not supplied.
   }
+
+  rpc GetContributorFormInfo(google.protobuf.Empty) returns (GetContributorFormInfoRes) {
+    // Returns info related to filling out the contributor form
+  }
+
+  rpc MarkContributorFormFilled(MarkContributorFormFilledReq) returns (google.protobuf.Empty) {
+    // Marks the contributor form as filled
+  }
 }
 
 message GetAccountInfoRes {
@@ -51,4 +59,18 @@ message ChangePasswordReq {
 message ChangeEmailReq {
   google.protobuf.StringValue password = 1;
   string new_email = 2;
+}
+
+message GetContributorFormInfoRes {
+  bool filled_contributor_form = 1;
+
+  string username = 2;
+  string email = 3;
+  uint32 age = 4;
+  string gender = 5;
+  string location = 6;
+}
+
+message MarkContributorFormFilledReq {
+  bool filled_contributor_form = 1;
 }

--- a/site/pages/signup.vue
+++ b/site/pages/signup.vue
@@ -120,7 +120,7 @@
           </div>
         </div>
         <div class="field">
-          <label class="label">What kinds of expertise do you have that could help us build and grow this platform?&#13;&#10;Feel free to share a link to your portfolio, github, linkedin or anything else.</label>
+          <label class="label">What kinds of expertise do you have that could help us build and grow this platform? Feel free to share a link to your portfolio, github, linkedin or anything else.</label>
           <div class="control">
             <textarea class="textarea" placeholder="" v-model="expertise"></textarea>
           </div>


### PR DESCRIPTION
There's a shared component, which is embedded on the dashboard. The backend tracks whether logged in users have filled in the form or not. Form submissions are sent to an AWS lambda function. I've also added a non-logged in route `/contribute` for those who have not signed up (for whatever reason?). Several form inputs are hidden and filled in automatically if the user is signed in.

* ~~Itsi would like the radio group to be turned into a set of checkboxes, but that's a lot of effort~~
* ~~Add a separate username field + lambda func tweaks~~
* ~~Would be good to get the user's email into the form so the form backend can email the person~~
* Needs some tweaks in the AWS lambda functions: email needs to be updated to reflect current situation, and emails to us need to be updated to include username.

It'd be great to eventually move the lambda function concoction into the backend, but that can come later.
