### PR TITLE
Fix bug where user can't erase full address

### DIFF
--- a/app/frontend/src/components/EditLocationMap.tsx
+++ b/app/frontend/src/components/EditLocationMap.tsx
@@ -185,12 +185,7 @@ export default function EditLocationMap({
         updateLocation(null);
       } else {
         setError("");
-        updateLocation({
-          address: location.current.address,
-          lat: location.current.lat,
-          lng: location.current.lng,
-          radius: location.current.radius,
-        });
+        updateLocation({ ...location.current });
       }
     }
 

--- a/app/frontend/src/components/EditLocationMap.tsx
+++ b/app/frontend/src/components/EditLocationMap.tsx
@@ -158,15 +158,15 @@ export default function EditLocationMap({
     updates: Partial<ApproximateLocation>,
     update: boolean = true
   ) => {
-    if (updates.address) {
-      location.current.address = updates.address;
+    if ("address" in updates) {
+      location.current.address = updates.address!;
     }
-    if (updates.radius && !exact) {
-      location.current.radius = updates.radius;
+    if ("radius" in updates && !exact) {
+      location.current.radius = updates.radius!;
     }
-    if (updates.lat && updates.lng) {
-      location.current.lat = updates.lat;
-      location.current.lng = updates.lng;
+    if ("lat" in updates && "lng" in updates) {
+      location.current.lat = updates.lat!;
+      location.current.lng = updates.lng!;
       isBlank.current = false;
     }
 
@@ -184,8 +184,8 @@ export default function EditLocationMap({
         setError(DISPLAY_LOCATION_NOT_EMPTY);
         updateLocation(null);
       } else {
-        updateLocation(location.current);
         setError("");
+        updateLocation(location.current);
       }
     }
 

--- a/app/frontend/src/components/EditLocationMap.tsx
+++ b/app/frontend/src/components/EditLocationMap.tsx
@@ -185,7 +185,12 @@ export default function EditLocationMap({
         updateLocation(null);
       } else {
         setError("");
-        updateLocation(location.current);
+        updateLocation({
+          address: location.current.address,
+          lat: location.current.lat,
+          lng: location.current.lng,
+          radius: location.current.radius,
+        });
       }
     }
 

--- a/app/frontend/src/components/EditLocationMap.tsx
+++ b/app/frontend/src/components/EditLocationMap.tsx
@@ -158,15 +158,15 @@ export default function EditLocationMap({
     updates: Partial<ApproximateLocation>,
     update: boolean = true
   ) => {
-    if ("address" in updates) {
-      location.current.address = updates.address!;
+    if (updates.address !== undefined) {
+      location.current.address = updates.address;
     }
-    if ("radius" in updates && !exact) {
-      location.current.radius = updates.radius!;
+    if (updates.radius !== undefined && !exact) {
+      location.current.radius = updates.radius;
     }
-    if ("lat" in updates && "lng" in updates) {
-      location.current.lat = updates.lat!;
-      location.current.lng = updates.lng!;
+    if (updates.lat !== undefined && updates.lng !== undefined) {
+      location.current.lat = updates.lat;
+      location.current.lng = updates.lng;
       isBlank.current = false;
     }
 


### PR DESCRIPTION
If you'd try to erase the whole address, it wouldn't work because `updates.address` was falsey. This fixes it and seems to be a more reliable way in general, so also updated the others.

Closes #1028 