### PR TITLE
Fix broken edit hosting preference test

### DIFF
--- a/app/frontend/src/features/profile/edit/EditHostingPreference.test.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.test.tsx
@@ -44,11 +44,11 @@ describe("EditHostingPreference", () => {
     updateHostingPreferenceMock.mockResolvedValue(new Empty());
   });
 
-  it("should redirect to Profile route after successful update", async () => {
+  it("should redirect to the user profile route after successful update", async () => {
     renderPage();
 
     userEvent.click(await screen.findByRole("button", { name: SAVE }));
 
     expect(await screen.findByTestId("user-profile")).toBeInTheDocument();
-  });
+  }, 20000);
 });

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.test.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.test.tsx
@@ -8,7 +8,7 @@ import { getHookWrapperWithClient } from "test/hookWrapper";
 import { getUser } from "test/serviceMockDefaults";
 
 import { addDefaultUser, MockedService } from "../../../test/utils";
-import { HOSTING_PREFERENCES, SAVE } from "../../constants";
+import { SAVE } from "../../constants";
 import EditHostingPreference from "./EditHostingPreference";
 
 const getUserMock = service.user.getUser as MockedService<
@@ -30,11 +30,11 @@ const renderPage = () => {
 
   render(
     <Switch>
-      <Route exact path={userRoute}>
-        <MockProfileComponent />
-      </Route>
-      <Route exact path={editHostingPreferenceRoute}>
+      <Route path={editHostingPreferenceRoute}>
         <EditHostingPreference />
+      </Route>
+      <Route path={userRoute}>
+        <MockProfileComponent />
       </Route>
     </Switch>,
     { wrapper }
@@ -51,14 +51,8 @@ describe("EditHostingPreference", () => {
   it("should redirect to Profile route after successful update", async () => {
     renderPage();
 
-    expect(
-      await screen.findByRole("heading", { name: HOSTING_PREFERENCES })
-    ).toBeInTheDocument();
+    userEvent.click(await screen.findByRole("button", { name: SAVE }));
 
-    // Need to fill in the required fields in the form before submitting...
-
-    // userEvent.click(await screen.findByRole("button", { name: SAVE }));
-
-    // expect(await screen.findByTestId("user-profile")).toBeInTheDocument();
+    expect(await screen.findByTestId("user-profile")).toBeInTheDocument();
   });
 });

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.test.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.test.tsx
@@ -1,42 +1,64 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Route, Switch } from "react-router-dom";
-import { userRoute } from "routes";
+import { editHostingPreferenceRoute, userRoute } from "routes";
 import { service } from "service";
-import wrapper from "test/hookWrapper";
+import { getHookWrapperWithClient } from "test/hookWrapper";
 import { getUser } from "test/serviceMockDefaults";
 
 import { addDefaultUser, MockedService } from "../../../test/utils";
-import { SAVE } from "../../constants";
+import { HOSTING_PREFERENCES, SAVE } from "../../constants";
 import EditHostingPreference from "./EditHostingPreference";
 
-const mockProfilePage = "Mock Profile Page";
 const getUserMock = service.user.getUser as MockedService<
   typeof service.user.getUser
 >;
-const MockProfileComponent = () => <div title={mockProfilePage} />;
+const updateHostingPreferenceMock = service.user
+  .updateHostingPreference as MockedService<
+  typeof service.user.updateHostingPreference
+>;
+
+const MockProfileComponent = () => (
+  <div data-testid="user-profile">Mock Profile Page</div>
+);
+
+const renderPage = () => {
+  const { wrapper } = getHookWrapperWithClient({
+    initialRouterEntries: [`${editHostingPreferenceRoute}`],
+  });
+
+  render(
+    <Switch>
+      <Route exact path={userRoute}>
+        <MockProfileComponent />
+      </Route>
+      <Route exact path={editHostingPreferenceRoute}>
+        <EditHostingPreference />
+      </Route>
+    </Switch>,
+    { wrapper }
+  );
+};
 
 describe("EditHostingPreference", () => {
   beforeEach(() => {
-    getUserMock.mockImplementation(getUser);
     addDefaultUser();
+    getUserMock.mockImplementation(getUser);
+    updateHostingPreferenceMock.mockResolvedValue(new Empty());
   });
 
-  it.skip("should redirect to Profile route after successful update", async () => {
-    render(
-      <Switch>
-        <Route path={userRoute}>
-          <MockProfileComponent />
-        </Route>
-        <Route>
-          <EditHostingPreference />
-        </Route>
-      </Switch>,
-      { wrapper }
-    );
+  it("should redirect to Profile route after successful update", async () => {
+    renderPage();
 
-    userEvent.click(await screen.findByRole("button", { name: SAVE }));
+    expect(
+      await screen.findByRole("heading", { name: HOSTING_PREFERENCES })
+    ).toBeInTheDocument();
 
-    expect(await screen.findByTitle(mockProfilePage)).toBeInTheDocument();
+    // Need to fill in the required fields in the form before submitting...
+
+    // userEvent.click(await screen.findByRole("button", { name: SAVE }));
+
+    // expect(await screen.findByTestId("user-profile")).toBeInTheDocument();
   });
 });

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.test.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.test.tsx
@@ -19,10 +19,6 @@ const updateHostingPreferenceMock = service.user
   typeof service.user.updateHostingPreference
 >;
 
-const MockProfileComponent = () => (
-  <div data-testid="user-profile">Mock Profile Page</div>
-);
-
 const renderPage = () => {
   const { wrapper } = getHookWrapperWithClient({
     initialRouterEntries: [`${editHostingPreferenceRoute}`],
@@ -34,7 +30,7 @@ const renderPage = () => {
         <EditHostingPreference />
       </Route>
       <Route path={userRoute}>
-        <MockProfileComponent />
+        <h1 data-testid="user-profile">Mock Profile Page</h1>
       </Route>
     </Switch>,
     { wrapper }

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
@@ -55,7 +55,7 @@ import {
 } from "pb/api_pb";
 import { useState } from "react";
 import { Controller, useForm, UseFormMethods } from "react-hook-form";
-import { HostingPreferenceData } from "service/index";
+import { HostingPreferenceData } from "service";
 import makeStyles from "utils/makeStyles";
 
 interface HostingPreferenceCheckboxProps {

--- a/app/frontend/src/features/profile/hooks/useUpdateHostingPreferences.ts
+++ b/app/frontend/src/features/profile/hooks/useUpdateHostingPreferences.ts
@@ -3,7 +3,7 @@ import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { useMutation, useQueryClient } from "react-query";
 import { useHistory } from "react-router-dom";
 import { userRoute } from "routes";
-import { HostingPreferenceData, service } from "service/index";
+import { HostingPreferenceData, service } from "service";
 import { SetMutationError } from "utils/types";
 
 interface UpdateHostingPreferencesVariables {

--- a/app/frontend/src/setupTests.ts
+++ b/app/frontend/src/setupTests.ts
@@ -17,6 +17,7 @@ afterEach(() => {
 });
 
 Element.prototype.scroll = () => {};
+window.scroll = jest.fn();
 
 declare global {
   var defaultUser: typeof user;

--- a/app/frontend/src/utils/hooks.ts
+++ b/app/frontend/src/utils/hooks.ts
@@ -3,7 +3,7 @@ import {
   MutableRefObject,
   SetStateAction,
   useCallback,
-  useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -11,7 +11,7 @@ import {
 function useIsMounted() {
   const isMounted = useRef(false);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     isMounted.current = true;
     return () => {
       isMounted.current = false;

--- a/app/frontend/yarn.lock
+++ b/app/frontend/yarn.lock
@@ -2792,11 +2792,6 @@
   resolved "https://registry.yarnpkg.com/@types/braces/-/braces-3.0.0.tgz#7da1c0d44ff1c7eb660a36ec078ea61ba7eb42cb"
   integrity sha512-TbH79tcyi9FHwbyboOKeRachRq63mSuWYXOflsNO9ZyE5ClQ/JaozNKl+aWUq87qPNsXasXxi2AbgfwIJ+8GQw==
 
-"@types/classnames@^2.2.11":
-  version "2.2.11"
-  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.11.tgz#2521cc86f69d15c5b90664e4829d84566052c1cf"
-  integrity sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw==
-
 "@types/codemirror@0.0.71":
   version "0.0.71"
   resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-0.0.71.tgz#861f1bcb3100c0a064567c5400f2981cf4ae8ca7"


### PR DESCRIPTION
This is a bit weird, since if you run the test in interactive mode, it'd say it's failed temporarily and then eventually passes 🤔 
but looks like the main thing that broke it was using `window.scroll` on `EditHostingPreference` since jsdom doesn't support it.