### PR TITLE
Add about and forum into nav bar

### DIFF
--- a/app/frontend/src/components/Navigation/Navigation.tsx
+++ b/app/frontend/src/components/Navigation/Navigation.tsx
@@ -24,7 +24,7 @@ import {
   userRoute,
 } from "routes";
 
-import { COUCHERS, LOG_OUT } from "../../constants";
+import { COUCHERS, LOG_OUT, ABOUT, FORUM } from "../../constants";
 import NavButton from "./NavButton";
 
 const menu = [
@@ -212,6 +212,8 @@ export default function Navigation() {
         <SearchBox />
         <div className={classes.bug}>
           <Hidden smDown>
+            <NavButton route={"https://couchers.org"} label={ABOUT} />
+            <NavButton route={"https://community.couchers.org"} label={FORUM} />
             <NavButton route={logoutRoute} label={LOG_OUT} />
           </Hidden>
           <BugReport />

--- a/app/frontend/src/components/Navigation/Navigation.tsx
+++ b/app/frontend/src/components/Navigation/Navigation.tsx
@@ -17,14 +17,16 @@ import SearchBox from "features/search/SearchBox";
 import React from "react";
 import CouchersLogo from "resources/CouchersLogo";
 import {
+  couchersRoute,
   eventsRoute,
+  forumRoute,
   logoutRoute,
   mapRoute,
   messagesRoute,
   userRoute,
 } from "routes";
 
-import { COUCHERS, LOG_OUT, ABOUT, FORUM } from "../../constants";
+import { ABOUT, COUCHERS, FORUM, LOG_OUT, } from "../../constants";
 import NavButton from "./NavButton";
 
 const menu = [
@@ -124,6 +126,12 @@ export default function Navigation() {
             <NavButton route={route} label={name} labelVariant="h2" />
           </ListItem>
         ))}
+        <ListItem button key="about">
+          <NavButton route={couchersRoute} label={ABOUT} labelVariant="h2" />
+        </ListItem>
+        <ListItem button key="forum">
+          <NavButton route={forumRoute} label={FORUM} labelVariant="h2" />
+        </ListItem>
         <ListItem button key="logout">
           <NavButton route={logoutRoute} label={LOG_OUT} labelVariant="h2" />
         </ListItem>
@@ -212,8 +220,8 @@ export default function Navigation() {
         <SearchBox />
         <div className={classes.bug}>
           <Hidden smDown>
-            <NavButton route={"https://couchers.org"} label={ABOUT} />
-            <NavButton route={"https://community.couchers.org"} label={FORUM} />
+            <NavButton route={couchersRoute} label={ABOUT} />
+            <NavButton route={forumRoute} label={FORUM} />
             <NavButton route={logoutRoute} label={LOG_OUT} />
           </Hidden>
           <BugReport />

--- a/app/frontend/src/constants.ts
+++ b/app/frontend/src/constants.ts
@@ -2,6 +2,8 @@ import { LngLat } from "maplibre-gl";
 
 export const COUCHERS = "Couchers.org";
 export const LOG_OUT = "Log out";
+export const ABOUT = "About";
+export const FORUM = "Forum";
 
 export const userLocationMaxRadius = 2000;
 export const userLocationMinRadius = 50;

--- a/app/frontend/src/routes.ts
+++ b/app/frontend/src/routes.ts
@@ -81,3 +81,6 @@ export const routeToCommunity = (
   slug: string,
   page?: CommunityTab
 ) => `${communityBaseRoute}/${id}/${slug}${page ? `/${page}` : ""}`;
+
+export const couchersRoute = "https://couchers.org";
+export const forumRoute = "https://community.couchers.org";


### PR DESCRIPTION
Added About (https://couchers.org) and Forum (https://community.couchers.org) to navigation bar.

<img width="1440" alt="Screen Shot 2021-04-08 at 10 23 47 PM" src="https://user-images.githubusercontent.com/43279784/114119693-2742e800-98b9-11eb-90e8-7b56bb7c2581.png">

Resolves #939 