### PR TITLE
Workaround for login/signup styles different in production

### DIFF
--- a/app/frontend/src/AppRoute.tsx
+++ b/app/frontend/src/AppRoute.tsx
@@ -1,6 +1,7 @@
-import { Container, makeStyles } from "@material-ui/core";
+import { Container } from "@material-ui/core";
 import React, { useEffect } from "react";
 import { Redirect, Route, RouteProps } from "react-router-dom";
+import makeStyles from "utils/makeStyles";
 
 import Navigation from "./components/Navigation";
 import { useAuthContext } from "./features/auth/AuthProvider";

--- a/app/frontend/src/components/Alert.tsx
+++ b/app/frontend/src/components/Alert.tsx
@@ -1,10 +1,10 @@
-import { makeStyles } from "@material-ui/core";
 import {
   Alert as MuiAlert,
   AlertProps as MuiAlertProps,
 } from "@material-ui/lab/";
 import classNames from "classnames";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 import { grpcErrorStrings, ObscureGrpcErrorMessages } from "../constants";
 

--- a/app/frontend/src/components/AuthHeader/AuthHeader.tsx
+++ b/app/frontend/src/components/AuthHeader/AuthHeader.tsx
@@ -1,5 +1,6 @@
-import { Divider, Hidden, makeStyles, Typography } from "@material-ui/core";
+import { Divider, Hidden, Typography } from "@material-ui/core";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   divider: {

--- a/app/frontend/src/components/Autocomplete.tsx
+++ b/app/frontend/src/components/Autocomplete.tsx
@@ -1,10 +1,10 @@
-import { makeStyles } from "@material-ui/core";
 import {
   Autocomplete as MuiAutocomplete,
   AutocompleteProps as MuiAutocompleteProps,
 } from "@material-ui/lab";
 import classNames from "classnames";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 import TextField from "./TextField";
 

--- a/app/frontend/src/components/Bar/BarWithHelp.tsx
+++ b/app/frontend/src/components/Bar/BarWithHelp.tsx
@@ -1,6 +1,7 @@
-import { IconButton, makeStyles, Tooltip } from "@material-ui/core";
+import { IconButton, Tooltip } from "@material-ui/core";
 import { HelpIcon } from "components/Icons";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 import ScoreBar from "./ScoreBar";
 

--- a/app/frontend/src/components/Bar/ScoreBar.tsx
+++ b/app/frontend/src/components/Bar/ScoreBar.tsx
@@ -1,10 +1,6 @@
-import {
-  Container,
-  ContainerProps,
-  LinearProgress,
-  makeStyles,
-} from "@material-ui/core";
+import { Container, ContainerProps, LinearProgress } from "@material-ui/core";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 import TextBody from "../TextBody";
 

--- a/app/frontend/src/components/Button/Button.tsx
+++ b/app/frontend/src/components/Button/Button.tsx
@@ -1,12 +1,8 @@
-import {
-  Button as MuiButton,
-  ButtonProps,
-  makeStyles,
-  useTheme,
-} from "@material-ui/core";
+import { Button as MuiButton, ButtonProps , useTheme } from "@material-ui/core";
 import classNames from "classnames";
 import React, { ElementType } from "react";
 import { useIsMounted, useSafeState } from "utils/hooks";
+import makeStyles from "utils/makeStyles";
 
 import CircularProgress from "../CircularProgress";
 

--- a/app/frontend/src/components/Button/Button.tsx
+++ b/app/frontend/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { Button as MuiButton, ButtonProps , useTheme } from "@material-ui/core";
+import { Button as MuiButton, ButtonProps, useTheme } from "@material-ui/core";
 import classNames from "classnames";
 import React, { ElementType } from "react";
 import { useIsMounted, useSafeState } from "utils/hooks";

--- a/app/frontend/src/components/CircularProgress.tsx
+++ b/app/frontend/src/components/CircularProgress.tsx
@@ -1,10 +1,10 @@
 import {
   CircularProgress as MuiCircularProgress,
   CircularProgressProps,
-  makeStyles,
 } from "@material-ui/core";
 import classNames from "classnames";
 import React, { ForwardedRef } from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   root: {},

--- a/app/frontend/src/components/Comments/CommentBox.tsx
+++ b/app/frontend/src/components/Comments/CommentBox.tsx
@@ -1,4 +1,4 @@
-import { Card, makeStyles } from "@material-ui/core";
+import { Card } from "@material-ui/core";
 import Alert from "components/Alert";
 import CircularProgress from "components/CircularProgress";
 import NewComment from "components/Comments/NewComment";
@@ -6,6 +6,7 @@ import Markdown from "components/Markdown";
 import { Reply } from "pb/threads_pb";
 import React, { useEffect, useState } from "react";
 import { service } from "service";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles(() => ({
   card: {

--- a/app/frontend/src/components/Comments/NewComment.tsx
+++ b/app/frontend/src/components/Comments/NewComment.tsx
@@ -1,5 +1,6 @@
-import { Box, Button, Grid, Link, makeStyles } from "@material-ui/core";
+import { Box, Button, Grid, Link } from "@material-ui/core";
 import React, { useState } from "react";
+import makeStyles from "utils/makeStyles";
 
 import Markdown from "../../components/Markdown";
 import TextField from "../../components/TextField";

--- a/app/frontend/src/components/Datepicker.test.tsx
+++ b/app/frontend/src/components/Datepicker.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { CHANGE_DATE, SUBMIT } from "features/constants";
 import mockdate from "mockdate";

--- a/app/frontend/src/components/Dialog.tsx
+++ b/app/frontend/src/components/Dialog.tsx
@@ -9,9 +9,9 @@ import {
   DialogProps,
   DialogTitle as MuiDialogTitle,
   DialogTitleProps,
-  makeStyles,
 } from "@material-ui/core";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   actions: {

--- a/app/frontend/src/components/Divider.tsx
+++ b/app/frontend/src/components/Divider.tsx
@@ -1,4 +1,4 @@
-import { Divider as MuiDivider,  } from "@material-ui/core";
+import { Divider as MuiDivider } from "@material-ui/core";
 import React from "react";
 import makeStyles from "utils/makeStyles";
 

--- a/app/frontend/src/components/Divider.tsx
+++ b/app/frontend/src/components/Divider.tsx
@@ -1,5 +1,6 @@
-import { Divider as MuiDivider, makeStyles } from "@material-ui/core";
+import { Divider as MuiDivider,  } from "@material-ui/core";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/app/frontend/src/components/EditLocationMap.tsx
+++ b/app/frontend/src/components/EditLocationMap.tsx
@@ -1,4 +1,4 @@
-import { BoxProps , Slider, Typography, useTheme } from "@material-ui/core";
+import { BoxProps, Slider, Typography, useTheme } from "@material-ui/core";
 import classNames from "classnames";
 import Map from "components/Map";
 import MapSearch from "components/MapSearch";

--- a/app/frontend/src/components/EditLocationMap.tsx
+++ b/app/frontend/src/components/EditLocationMap.tsx
@@ -1,10 +1,4 @@
-import {
-  BoxProps,
-  makeStyles,
-  Slider,
-  Typography,
-  useTheme,
-} from "@material-ui/core";
+import { BoxProps , Slider, Typography, useTheme } from "@material-ui/core";
 import classNames from "classnames";
 import Map from "components/Map";
 import MapSearch from "components/MapSearch";
@@ -16,6 +10,7 @@ import {
   MapTouchEvent,
 } from "maplibre-gl";
 import React, { useRef, useState } from "react";
+import makeStyles from "utils/makeStyles";
 
 import { userLocationMaxRadius, userLocationMinRadius } from "../constants";
 import {

--- a/app/frontend/src/components/HeaderButton.tsx
+++ b/app/frontend/src/components/HeaderButton.tsx
@@ -1,5 +1,6 @@
-import { IconButton, IconButtonProps, makeStyles } from "@material-ui/core";
+import { IconButton, IconButtonProps } from "@material-ui/core";
 import React, { ReactNode } from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/app/frontend/src/components/HorizontalScroller.tsx
+++ b/app/frontend/src/components/HorizontalScroller.tsx
@@ -1,6 +1,7 @@
-import { Hidden, makeStyles, useMediaQuery, useTheme } from "@material-ui/core";
+import { Hidden, useMediaQuery, useTheme } from "@material-ui/core";
 import classNames from "classnames";
 import React, { ReactNode } from "react";
+import makeStyles from "utils/makeStyles";
 
 import useOnVisibleEffect from "../utils/useOnVisibleEffect";
 import CircularProgress from "./CircularProgress";

--- a/app/frontend/src/components/HostingStatus/HostingStatus.tsx
+++ b/app/frontend/src/components/HostingStatus/HostingStatus.tsx
@@ -1,10 +1,10 @@
-import { makeStyles } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
 import { CouchIcon } from "components/Icons";
 import IconText from "components/IconText";
 import { hostingStatusLabels } from "features/profile/constants";
 import { HostingStatus as THostingStatus } from "pb/api_pb";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles({
   hostingAbilityContainer: {

--- a/app/frontend/src/components/IconButton.tsx
+++ b/app/frontend/src/components/IconButton.tsx
@@ -1,7 +1,8 @@
 import {
   IconButton as MuiIconButton,
   IconButtonProps as MuiIconButtonProps,
- useTheme } from "@material-ui/core";
+  useTheme,
+} from "@material-ui/core";
 import React from "react";
 import makeStyles from "utils/makeStyles";
 

--- a/app/frontend/src/components/IconButton.tsx
+++ b/app/frontend/src/components/IconButton.tsx
@@ -1,10 +1,9 @@
 import {
   IconButton as MuiIconButton,
   IconButtonProps as MuiIconButtonProps,
-  makeStyles,
-  useTheme,
-} from "@material-ui/core";
+ useTheme } from "@material-ui/core";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 import CircularProgress from "./CircularProgress";
 

--- a/app/frontend/src/components/IconText.tsx
+++ b/app/frontend/src/components/IconText.tsx
@@ -1,7 +1,7 @@
-import { makeStyles } from "@material-ui/core";
 import { OverridableComponent } from "@material-ui/core/OverridableComponent";
 import { SvgIconTypeMap } from "@material-ui/core/SvgIcon";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 import TextBody from "./TextBody";
 

--- a/app/frontend/src/components/Map.tsx
+++ b/app/frontend/src/components/Map.tsx
@@ -1,9 +1,9 @@
 import "maplibre-gl/dist/maplibre-gl.css";
 
-import { makeStyles } from "@material-ui/core";
 import classNames from "classnames";
 import mapboxgl, { LngLat, RequestParameters } from "maplibre-gl";
 import { useEffect, useRef } from "react";
+import makeStyles from "utils/makeStyles";
 
 const URL = process.env.REACT_APP_API_BASE_URL;
 

--- a/app/frontend/src/components/MapSearch.tsx
+++ b/app/frontend/src/components/MapSearch.tsx
@@ -1,7 +1,8 @@
-import { Box, IconButton, makeStyles } from "@material-ui/core";
+import { Box, IconButton } from "@material-ui/core";
 import { AutocompleteChangeReason } from "@material-ui/lab/Autocomplete";
 import { LngLat } from "maplibre-gl";
 import React, { useState } from "react";
+import makeStyles from "utils/makeStyles";
 
 import { NominatimPlace, simplifyPlaceDisplayName } from "../utils/nominatim";
 import Autocomplete from "./Autocomplete";

--- a/app/frontend/src/components/Markdown.test.tsx
+++ b/app/frontend/src/components/Markdown.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+
 import Markdown, { increaseMarkdownHeaderLevel } from "./Markdown";
 
 describe("markdown header level increase", () => {

--- a/app/frontend/src/components/Markdown.tsx
+++ b/app/frontend/src/components/Markdown.tsx
@@ -1,8 +1,8 @@
 import "@toast-ui/editor/dist/toastui-editor-viewer.css";
 
-import { makeStyles } from "@material-ui/core";
 import ToastUIViewer from "@toast-ui/editor/dist/toastui-editor-viewer";
 import { useEffect, useRef } from "react";
+import makeStyles from "utils/makeStyles";
 
 interface MarkdownProps {
   source: string;

--- a/app/frontend/src/components/MarkdownInput.tsx
+++ b/app/frontend/src/components/MarkdownInput.tsx
@@ -1,10 +1,10 @@
 import "codemirror/lib/codemirror.css";
 import "@toast-ui/editor/dist/toastui-editor.css";
 
-import { makeStyles } from "@material-ui/core";
 import ToastUIEditor from "@toast-ui/editor";
 import { useEffect, useRef } from "react";
 import { Control, useController } from "react-hook-form";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/app/frontend/src/components/Menu.tsx
+++ b/app/frontend/src/components/Menu.tsx
@@ -1,11 +1,11 @@
 import {
-  makeStyles,
   Menu as MuiMenu,
   MenuItem as MuiMenuItem,
   MenuItemProps,
   MenuProps,
 } from "@material-ui/core";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   item: {

--- a/app/frontend/src/components/Navigation/NavButton.tsx
+++ b/app/frontend/src/components/Navigation/NavButton.tsx
@@ -1,6 +1,7 @@
-import { makeStyles, Typography, TypographyProps } from "@material-ui/core";
+import { Typography, TypographyProps } from "@material-ui/core";
 import { NavLink } from "react-router-dom";
 import { baseRoute, userRoute } from "routes";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   link: {

--- a/app/frontend/src/components/Navigation/Navigation.tsx
+++ b/app/frontend/src/components/Navigation/Navigation.tsx
@@ -5,9 +5,7 @@ import {
   IconButton,
   List,
   ListItem,
-  makeStyles,
-  Toolbar,
-} from "@material-ui/core";
+ Toolbar } from "@material-ui/core";
 import classNames from "classnames";
 import { CloseIcon, MenuIcon } from "components/Icons";
 import { useAuthContext } from "features/auth/AuthProvider";
@@ -23,6 +21,7 @@ import {
   messagesRoute,
   userRoute,
 } from "routes";
+import makeStyles from "utils/makeStyles";
 
 import { COUCHERS, LOG_OUT } from "../../constants";
 import NavButton from "./NavButton";

--- a/app/frontend/src/components/Navigation/Navigation.tsx
+++ b/app/frontend/src/components/Navigation/Navigation.tsx
@@ -5,7 +5,8 @@ import {
   IconButton,
   List,
   ListItem,
- Toolbar } from "@material-ui/core";
+  Toolbar,
+} from "@material-ui/core";
 import classNames from "classnames";
 import { CloseIcon, MenuIcon } from "components/Icons";
 import { useAuthContext } from "features/auth/AuthProvider";

--- a/app/frontend/src/components/NotificationBadge.tsx
+++ b/app/frontend/src/components/NotificationBadge.tsx
@@ -1,5 +1,6 @@
-import { Badge, makeStyles } from "@material-ui/core";
+import { Badge } from "@material-ui/core";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   badge: {

--- a/app/frontend/src/components/PageTitle.tsx
+++ b/app/frontend/src/components/PageTitle.tsx
@@ -1,5 +1,6 @@
-import { makeStyles, Typography, TypographyProps } from "@material-ui/core";
+import { Typography, TypographyProps } from "@material-ui/core";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/app/frontend/src/components/Pill/Pill.tsx
+++ b/app/frontend/src/components/Pill/Pill.tsx
@@ -1,5 +1,6 @@
-import { makeStyles, Typography } from "@material-ui/core";
+import { Typography } from "@material-ui/core";
 import classNames from "classnames";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/app/frontend/src/components/TabBar/TabBar.tsx
+++ b/app/frontend/src/components/TabBar/TabBar.tsx
@@ -1,5 +1,6 @@
-import { makeStyles, Tab } from "@material-ui/core";
+import { Tab } from "@material-ui/core";
 import { TabList } from "@material-ui/lab";
+import makeStyles from "utils/makeStyles";
 
 export const useStyles = makeStyles((theme) => ({
   messagesTab: {

--- a/app/frontend/src/components/TextField.tsx
+++ b/app/frontend/src/components/TextField.tsx
@@ -1,11 +1,8 @@
-import {
-  makeStyles,
-  TextField as MuiTextField,
-  TextFieldProps,
-} from "@material-ui/core";
+import { TextField as MuiTextField, TextFieldProps } from "@material-ui/core";
 import { BaseTextFieldProps } from "@material-ui/core/TextField";
 import classNames from "classnames";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   multiline: {

--- a/app/frontend/src/components/UserSummary.tsx
+++ b/app/frontend/src/components/UserSummary.tsx
@@ -1,15 +1,11 @@
-import {
-  ListItemAvatar,
-  ListItemText,
-  makeStyles,
-  Typography,
-} from "@material-ui/core";
+import { ListItemAvatar, ListItemText , Typography } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
 import Avatar from "components/Avatar";
 import ScoreBar from "components/Bar/ScoreBar";
 import { COMMUNITY_STANDING } from "features/constants";
 import { User } from "pb/api_pb";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 export const useStyles = makeStyles((theme) => ({
   avatar: {

--- a/app/frontend/src/components/UserSummary.tsx
+++ b/app/frontend/src/components/UserSummary.tsx
@@ -1,4 +1,4 @@
-import { ListItemAvatar, ListItemText , Typography } from "@material-ui/core";
+import { ListItemAvatar, ListItemText, Typography } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
 import Avatar from "components/Avatar";
 import ScoreBar from "components/Bar/ScoreBar";

--- a/app/frontend/src/features/BugReport.tsx
+++ b/app/frontend/src/features/BugReport.tsx
@@ -1,10 +1,4 @@
-import {
-  darken,
-  Link,
-  makeStyles,
-  useMediaQuery,
-  useTheme,
-} from "@material-ui/core";
+import { darken, Link , useMediaQuery, useTheme } from "@material-ui/core";
 import Alert from "components/Alert";
 import Button from "components/Button";
 import {
@@ -37,6 +31,7 @@ import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useMutation } from "react-query";
 import { service } from "service";
+import makeStyles from "utils/makeStyles";
 
 export interface BugReportFormData {
   subject: string;

--- a/app/frontend/src/features/BugReport.tsx
+++ b/app/frontend/src/features/BugReport.tsx
@@ -1,4 +1,4 @@
-import { darken, Link , useMediaQuery, useTheme } from "@material-ui/core";
+import { darken, Link, useMediaQuery, useTheme } from "@material-ui/core";
 import Alert from "components/Alert";
 import Button from "components/Button";
 import {

--- a/app/frontend/src/features/NotFoundPage.tsx
+++ b/app/frontend/src/features/NotFoundPage.tsx
@@ -1,8 +1,9 @@
-import { Box, makeStyles } from "@material-ui/core";
+import { Box } from "@material-ui/core";
 import TextBody from "components/TextBody";
 import React from "react";
 import { Link } from "react-router-dom";
 import Graphic from "resources/404graphic.png";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles({
   graphic: {

--- a/app/frontend/src/features/auth/AuthPage.tsx
+++ b/app/frontend/src/features/auth/AuthPage.tsx
@@ -1,4 +1,9 @@
-import { Divider, Hidden, Link as MuiLink , Typography } from "@material-ui/core";
+import {
+  Divider,
+  Hidden,
+  Link as MuiLink,
+  Typography,
+} from "@material-ui/core";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import classNames from "classnames";
 import Button from "components/Button";

--- a/app/frontend/src/features/auth/AuthPage.tsx
+++ b/app/frontend/src/features/auth/AuthPage.tsx
@@ -1,10 +1,4 @@
-import {
-  Divider,
-  Hidden,
-  Link as MuiLink,
-  makeStyles,
-  Typography,
-} from "@material-ui/core";
+import { Divider, Hidden, Link as MuiLink , Typography } from "@material-ui/core";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import classNames from "classnames";
 import Button from "components/Button";
@@ -20,6 +14,7 @@ import MobileAuthBg from "features/auth/resources/mobile-auth-bg.jpg";
 import useAuthStyles from "features/auth/useAuthStyles";
 import { Link } from "react-router-dom";
 import { loginRoute, signupRoute } from "routes";
+import makeStyles from "utils/makeStyles";
 
 import { COUCHERS } from "../../constants";
 

--- a/app/frontend/src/features/auth/jail/Jail.tsx
+++ b/app/frontend/src/features/auth/jail/Jail.tsx
@@ -1,4 +1,4 @@
-import { Backdrop, makeStyles } from "@material-ui/core";
+import { Backdrop } from "@material-ui/core";
 import Alert from "components/Alert";
 import CircularProgress from "components/CircularProgress";
 import PageTitle from "components/PageTitle";
@@ -12,6 +12,7 @@ import React, { useEffect, useState } from "react";
 import { Redirect } from "react-router-dom";
 import { loginRoute } from "routes";
 import { service } from "service";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   bottomMargin: { marginBottom: theme.spacing(4) },

--- a/app/frontend/src/features/auth/login/Login.tsx
+++ b/app/frontend/src/features/auth/login/Login.tsx
@@ -1,6 +1,7 @@
-import { Divider, Hidden, makeStyles, Typography } from "@material-ui/core";
+import { Divider, Hidden, Typography } from "@material-ui/core";
 import React, { useEffect } from "react";
 import { Link, Redirect, useLocation, useParams } from "react-router-dom";
+import makeStyles from "utils/makeStyles";
 
 import Alert from "../../../components/Alert";
 import AuthHeader from "../../../components/AuthHeader";

--- a/app/frontend/src/features/auth/login/LoginForm.tsx
+++ b/app/frontend/src/features/auth/login/LoginForm.tsx
@@ -1,4 +1,9 @@
-import { FormControlLabel, InputLabel , Switch, Typography } from "@material-ui/core";
+import {
+  FormControlLabel,
+  InputLabel,
+  Switch,
+  Typography,
+} from "@material-ui/core";
 import Button from "components/Button";
 import TextBody from "components/TextBody";
 import TextField from "components/TextField";

--- a/app/frontend/src/features/auth/login/LoginForm.tsx
+++ b/app/frontend/src/features/auth/login/LoginForm.tsx
@@ -1,10 +1,4 @@
-import {
-  FormControlLabel,
-  InputLabel,
-  makeStyles,
-  Switch,
-  Typography,
-} from "@material-ui/core";
+import { FormControlLabel, InputLabel , Switch, Typography } from "@material-ui/core";
 import Button from "components/Button";
 import TextBody from "components/TextBody";
 import TextField from "components/TextField";
@@ -17,6 +11,7 @@ import { Link } from "react-router-dom";
 import { resetPasswordRoute } from "routes";
 import { service } from "service";
 import { useIsMounted, useSafeState } from "utils/hooks";
+import makeStyles from "utils/makeStyles";
 import { sanitizeName } from "utils/validation";
 
 const useStyles = makeStyles((theme) => ({

--- a/app/frontend/src/features/auth/password/ResetPassword.tsx
+++ b/app/frontend/src/features/auth/password/ResetPassword.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, Typography } from "@material-ui/core";
+import { Typography } from "@material-ui/core";
 import Alert from "components/Alert";
 import Button from "components/Button";
 import PageTitle from "components/PageTitle";
@@ -14,6 +14,7 @@ import { Error as GrpcError } from "grpc-web";
 import { useForm } from "react-hook-form";
 import { useMutation } from "react-query";
 import { service } from "service";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   form: {

--- a/app/frontend/src/features/auth/signup/CompleteSignupForm.tsx
+++ b/app/frontend/src/features/auth/signup/CompleteSignupForm.tsx
@@ -3,10 +3,7 @@ import {
   FormControlLabel,
   FormHelperText,
   InputLabel,
-  makeStyles,
-  Radio,
-  RadioGroup,
-} from "@material-ui/core";
+ Radio, RadioGroup } from "@material-ui/core";
 import Autocomplete from "components/Autocomplete";
 import Button from "components/Button";
 import CircularProgress from "components/CircularProgress";
@@ -26,6 +23,7 @@ import { Controller, useForm } from "react-hook-form";
 import { useHistory, useLocation, useParams } from "react-router-dom";
 import { signupRoute } from "routes";
 import { service } from "service";
+import makeStyles from "utils/makeStyles";
 import {
   nameValidationPattern,
   sanitizeName,

--- a/app/frontend/src/features/auth/signup/CompleteSignupForm.tsx
+++ b/app/frontend/src/features/auth/signup/CompleteSignupForm.tsx
@@ -3,7 +3,9 @@ import {
   FormControlLabel,
   FormHelperText,
   InputLabel,
- Radio, RadioGroup } from "@material-ui/core";
+  Radio,
+  RadioGroup,
+} from "@material-ui/core";
 import Autocomplete from "components/Autocomplete";
 import Button from "components/Button";
 import CircularProgress from "components/CircularProgress";

--- a/app/frontend/src/features/auth/signup/Signup.tsx
+++ b/app/frontend/src/features/auth/signup/Signup.tsx
@@ -1,6 +1,7 @@
-import { Divider, Hidden, makeStyles, Typography } from "@material-ui/core";
+import { Divider, Hidden, Typography } from "@material-ui/core";
 import React, { useEffect } from "react";
 import { Link, Redirect, Route, Switch } from "react-router-dom";
+import makeStyles from "utils/makeStyles";
 
 import Alert from "../../../components/Alert";
 import AuthHeader from "../../../components/AuthHeader";

--- a/app/frontend/src/features/auth/useAuthStyles.ts
+++ b/app/frontend/src/features/auth/useAuthStyles.ts
@@ -3,43 +3,44 @@ import { makeStyles } from "@material-ui/core";
 import DesktopAuthBg from "./resources/desktop-auth-bg.jpg";
 import MobileAuthBg from "./resources/mobile-auth-bg.jpg";
 
-const useAuthStyles = makeStyles((theme) => ({
-  backgroundBlurImage: {
-    backgroundColor: theme.palette.grey[50],
-    backgroundImage: `url(${MobileAuthBg})`,
-    backgroundPosition: "top center",
-    backgroundRepeat: "no-repeat",
-    backgroundSize: "cover",
-    display: "block",
-    filter: "blur(5px)",
-    height: "100vh",
-    left: 0,
-    opacity: "0.5",
-    position: "fixed",
-    right: 0,
-    zIndex: -1,
-  },
-  button: {
-    marginTop: theme.spacing(4),
-    [theme.breakpoints.up("md")]: {
-      borderRadius: theme.shape.borderRadius / 3,
+const useAuthStyles = makeStyles(
+  (theme) => ({
+    backgroundBlurImage: {
+      backgroundColor: theme.palette.grey[50],
+      backgroundImage: `url(${MobileAuthBg})`,
+      backgroundPosition: "top center",
+      backgroundRepeat: "no-repeat",
+      backgroundSize: "cover",
+      display: "block",
+      filter: "blur(5px)",
+      height: "100vh",
+      left: 0,
+      opacity: "0.5",
+      position: "fixed",
+      right: 0,
+      zIndex: -1,
     },
-  },
-  buttonText: {
-    color: theme.palette.secondary.contrastText,
-    fontWeight: 700,
-  },
-  content: {
-    [theme.breakpoints.up("md")]: {
-      display: "flex",
-      flexDirection: "row",
-      height: "100%",
-      justifyContent: "space-between",
-      margin: "auto",
-      width: theme.breakpoints.values.md,
+    button: {
+      marginTop: theme.spacing(4),
+      [theme.breakpoints.up("md")]: {
+        borderRadius: theme.shape.borderRadius / 3,
+      },
     },
-  },
-  /* disabled for beta:
+    buttonText: {
+      color: theme.palette.secondary.contrastText,
+      fontWeight: 700,
+    },
+    content: {
+      [theme.breakpoints.up("md")]: {
+        display: "flex",
+        flexDirection: "row",
+        height: "100%",
+        justifyContent: "space-between",
+        margin: "auto",
+        width: theme.breakpoints.values.md,
+      },
+    },
+    /* disabled for beta:
   facebookButton: {
     width: "100%",
     height: "40px",
@@ -67,117 +68,119 @@ const useAuthStyles = makeStyles((theme) => ({
     backgroundColor: "#d9472e",
   },
   */
-  divider: {
-    borderTop: `1px solid ${theme.palette.common.white}`,
-    marginLeft: "auto",
-    marginRight: "auto",
-    marginTop: theme.spacing(2),
-    width: "100%",
-    [theme.breakpoints.up("md")]: {
-      borderTop: `1px solid ${theme.palette.text.primary}`,
+    divider: {
+      borderTop: `1px solid ${theme.palette.common.white}`,
+      marginLeft: "auto",
+      marginRight: "auto",
+      marginTop: theme.spacing(2),
+      width: "100%",
+      [theme.breakpoints.up("md")]: {
+        borderTop: `1px solid ${theme.palette.text.primary}`,
+      },
     },
-  },
-  errorMessage: {
-    width: "100%",
-  },
-  feedbackMessage: {
-    textAlign: "center",
-    [theme.breakpoints.up("md")]: {
-      textAlign: "left",
-    },
-  },
-  form: {
-    display: "flex",
-    flexDirection: "column",
-    marginBottom: theme.spacing(5),
-    width: "100%",
-    [theme.breakpoints.up("md")]: {
-      alignItems: "flex-start",
-      marginBottom: 0,
-    },
-  },
-  formField: {
-    marginBottom: theme.spacing(2),
-    width: "100%",
-    [theme.breakpoints.up("md")]: {
-      marginBottom: theme.spacing(4),
-    },
-  },
-  formLabel: {
-    color: theme.palette.text.primary,
-    fontWeight: 700,
-    [theme.breakpoints.up("md")]: {
-      marginBottom: theme.spacing(2),
-    },
-  },
-  formWrapper: {
-    [theme.breakpoints.up("md")]: {
-      backgroundColor: theme.palette.background.default,
-      borderRadius: theme.shape.borderRadius / 3,
-      padding: theme.spacing(5, 8),
-      width: "53%",
-    },
-  },
-  header: {
-    width: "100%",
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "space-between",
-    padding: theme.spacing(2, 4),
-    marginBottom: theme.spacing(2),
-  },
-  introduction: {
-    color: theme.palette.common.white,
-    textAlign: "left",
-    width: "40%",
-    [theme.breakpoints.up("md")]: {
-      marginTop: theme.spacing(10),
-    },
-  },
-  logo: {
-    color: theme.palette.secondary.main,
-    fontFamily: "'Mansalva', cursive",
-    fontSize: "2rem",
-  },
-  page: {
-    alignItems: "center",
-    boxSizing: "border-box",
-    display: "flex",
-    flexDirection: "column",
-    minHeight: "100vh",
-    padding: `${theme.spacing(1, 6)}`,
-    [theme.breakpoints.up("md")]: {
-      alignItems: "flex-start",
-      backgroundImage: `url(${DesktopAuthBg})`,
-      backgroundPosition: "top center",
-      backgroundRepeat: "no-repeat",
-      backgroundSize: "cover",
-      flexDirection: "column",
-      padding: `0 0 ${theme.spacing(6)} 0`,
+    errorMessage: {
       width: "100%",
     },
-  },
-  subtitle: {
-    [theme.breakpoints.up("md")]: {
-      display: "inline-block",
-      marginTop: theme.spacing(4),
-      position: "relative",
+    feedbackMessage: {
+      textAlign: "center",
+      [theme.breakpoints.up("md")]: {
+        textAlign: "left",
+      },
     },
-  },
-  title: {
-    [theme.breakpoints.up("md")]: {
-      fontSize: "2rem",
-      lineHeight: "1.15",
+    form: {
+      display: "flex",
+      flexDirection: "column",
+      marginBottom: theme.spacing(5),
+      width: "100%",
+      [theme.breakpoints.up("md")]: {
+        alignItems: "flex-start",
+        marginBottom: 0,
+      },
+    },
+    formField: {
+      marginBottom: theme.spacing(2),
+      width: "100%",
+      [theme.breakpoints.up("md")]: {
+        marginBottom: theme.spacing(4),
+      },
+    },
+    formLabel: {
+      color: theme.palette.text.primary,
+      fontWeight: 700,
+      [theme.breakpoints.up("md")]: {
+        marginBottom: theme.spacing(2),
+      },
+    },
+    formWrapper: {
+      [theme.breakpoints.up("md")]: {
+        backgroundColor: theme.palette.background.default,
+        borderRadius: theme.shape.borderRadius / 3,
+        padding: theme.spacing(5, 8),
+        width: "53%",
+      },
+    },
+    header: {
+      width: "100%",
+      display: "flex",
+      flexDirection: "row",
+      justifyContent: "space-between",
+      padding: theme.spacing(2, 4),
+      marginBottom: theme.spacing(2),
+    },
+    introduction: {
+      color: theme.palette.common.white,
       textAlign: "left",
+      width: "40%",
+      [theme.breakpoints.up("md")]: {
+        marginTop: theme.spacing(10),
+      },
     },
-  },
-  underline: {
-    borderTop: `5px solid ${theme.palette.primary.main}`,
-    boxShadow: "0px 4px 4px rgba(0, 0, 0, 0.25)",
-    left: theme.spacing(1),
-    position: "absolute",
-    width: "100%",
-  },
-}));
+    logo: {
+      color: theme.palette.secondary.main,
+      fontFamily: "'Mansalva', cursive",
+      fontSize: "2rem",
+    },
+    page: {
+      alignItems: "center",
+      boxSizing: "border-box",
+      display: "flex",
+      flexDirection: "column",
+      minHeight: "100vh",
+      padding: `${theme.spacing(1, 6)}`,
+      [theme.breakpoints.up("md")]: {
+        alignItems: "flex-start",
+        backgroundImage: `url(${DesktopAuthBg})`,
+        backgroundPosition: "top center",
+        backgroundRepeat: "no-repeat",
+        backgroundSize: "cover",
+        flexDirection: "column",
+        padding: `0 0 ${theme.spacing(6)} 0`,
+        width: "100%",
+      },
+    },
+    subtitle: {
+      [theme.breakpoints.up("md")]: {
+        display: "inline-block",
+        marginTop: theme.spacing(4),
+        position: "relative",
+      },
+    },
+    title: {
+      [theme.breakpoints.up("md")]: {
+        fontSize: "2rem",
+        lineHeight: "1.15",
+        textAlign: "left",
+      },
+    },
+    underline: {
+      borderTop: `5px solid ${theme.palette.primary.main}`,
+      boxShadow: "0px 4px 4px rgba(0, 0, 0, 0.25)",
+      left: theme.spacing(1),
+      position: "absolute",
+      width: "100%",
+    },
+  }),
+  { index: 1 }
+);
 
 export default useAuthStyles;

--- a/app/frontend/src/features/auth/useAuthStyles.ts
+++ b/app/frontend/src/features/auth/useAuthStyles.ts
@@ -1,46 +1,45 @@
-import { makeStyles } from "@material-ui/core";
+import makeStyles from "utils/makeStyles";
 
 import DesktopAuthBg from "./resources/desktop-auth-bg.jpg";
 import MobileAuthBg from "./resources/mobile-auth-bg.jpg";
 
-const useAuthStyles = makeStyles(
-  (theme) => ({
-    backgroundBlurImage: {
-      backgroundColor: theme.palette.grey[50],
-      backgroundImage: `url(${MobileAuthBg})`,
-      backgroundPosition: "top center",
-      backgroundRepeat: "no-repeat",
-      backgroundSize: "cover",
-      display: "block",
-      filter: "blur(5px)",
-      height: "100vh",
-      left: 0,
-      opacity: "0.5",
-      position: "fixed",
-      right: 0,
-      zIndex: -1,
+const useAuthStyles = makeStyles((theme) => ({
+  backgroundBlurImage: {
+    backgroundColor: theme.palette.grey[50],
+    backgroundImage: `url(${MobileAuthBg})`,
+    backgroundPosition: "top center",
+    backgroundRepeat: "no-repeat",
+    backgroundSize: "cover",
+    display: "block",
+    filter: "blur(5px)",
+    height: "100vh",
+    left: 0,
+    opacity: "0.5",
+    position: "fixed",
+    right: 0,
+    zIndex: -1,
+  },
+  button: {
+    marginTop: theme.spacing(4),
+    [theme.breakpoints.up("md")]: {
+      borderRadius: theme.shape.borderRadius / 3,
     },
-    button: {
-      marginTop: theme.spacing(4),
-      [theme.breakpoints.up("md")]: {
-        borderRadius: theme.shape.borderRadius / 3,
-      },
+  },
+  buttonText: {
+    color: theme.palette.secondary.contrastText,
+    fontWeight: 700,
+  },
+  content: {
+    [theme.breakpoints.up("md")]: {
+      display: "flex",
+      flexDirection: "row",
+      height: "100%",
+      justifyContent: "space-between",
+      margin: "auto",
+      width: theme.breakpoints.values.md,
     },
-    buttonText: {
-      color: theme.palette.secondary.contrastText,
-      fontWeight: 700,
-    },
-    content: {
-      [theme.breakpoints.up("md")]: {
-        display: "flex",
-        flexDirection: "row",
-        height: "100%",
-        justifyContent: "space-between",
-        margin: "auto",
-        width: theme.breakpoints.values.md,
-      },
-    },
-    /* disabled for beta:
+  },
+  /* disabled for beta:
   facebookButton: {
     width: "100%",
     height: "40px",
@@ -68,119 +67,117 @@ const useAuthStyles = makeStyles(
     backgroundColor: "#d9472e",
   },
   */
-    divider: {
-      borderTop: `1px solid ${theme.palette.common.white}`,
-      marginLeft: "auto",
-      marginRight: "auto",
-      marginTop: theme.spacing(2),
-      width: "100%",
-      [theme.breakpoints.up("md")]: {
-        borderTop: `1px solid ${theme.palette.text.primary}`,
-      },
+  divider: {
+    borderTop: `1px solid ${theme.palette.common.white}`,
+    marginLeft: "auto",
+    marginRight: "auto",
+    marginTop: theme.spacing(2),
+    width: "100%",
+    [theme.breakpoints.up("md")]: {
+      borderTop: `1px solid ${theme.palette.text.primary}`,
     },
-    errorMessage: {
-      width: "100%",
-    },
-    feedbackMessage: {
-      textAlign: "center",
-      [theme.breakpoints.up("md")]: {
-        textAlign: "left",
-      },
-    },
-    form: {
-      display: "flex",
-      flexDirection: "column",
-      marginBottom: theme.spacing(5),
-      width: "100%",
-      [theme.breakpoints.up("md")]: {
-        alignItems: "flex-start",
-        marginBottom: 0,
-      },
-    },
-    formField: {
-      marginBottom: theme.spacing(2),
-      width: "100%",
-      [theme.breakpoints.up("md")]: {
-        marginBottom: theme.spacing(4),
-      },
-    },
-    formLabel: {
-      color: theme.palette.text.primary,
-      fontWeight: 700,
-      [theme.breakpoints.up("md")]: {
-        marginBottom: theme.spacing(2),
-      },
-    },
-    formWrapper: {
-      [theme.breakpoints.up("md")]: {
-        backgroundColor: theme.palette.background.default,
-        borderRadius: theme.shape.borderRadius / 3,
-        padding: theme.spacing(5, 8),
-        width: "53%",
-      },
-    },
-    header: {
-      width: "100%",
-      display: "flex",
-      flexDirection: "row",
-      justifyContent: "space-between",
-      padding: theme.spacing(2, 4),
-      marginBottom: theme.spacing(2),
-    },
-    introduction: {
-      color: theme.palette.common.white,
+  },
+  errorMessage: {
+    width: "100%",
+  },
+  feedbackMessage: {
+    textAlign: "center",
+    [theme.breakpoints.up("md")]: {
       textAlign: "left",
-      width: "40%",
-      [theme.breakpoints.up("md")]: {
-        marginTop: theme.spacing(10),
-      },
     },
-    logo: {
-      color: theme.palette.secondary.main,
-      fontFamily: "'Mansalva', cursive",
-      fontSize: "2rem",
+  },
+  form: {
+    display: "flex",
+    flexDirection: "column",
+    marginBottom: theme.spacing(5),
+    width: "100%",
+    [theme.breakpoints.up("md")]: {
+      alignItems: "flex-start",
+      marginBottom: 0,
     },
-    page: {
-      alignItems: "center",
-      boxSizing: "border-box",
-      display: "flex",
+  },
+  formField: {
+    marginBottom: theme.spacing(2),
+    width: "100%",
+    [theme.breakpoints.up("md")]: {
+      marginBottom: theme.spacing(4),
+    },
+  },
+  formLabel: {
+    color: theme.palette.text.primary,
+    fontWeight: 700,
+    [theme.breakpoints.up("md")]: {
+      marginBottom: theme.spacing(2),
+    },
+  },
+  formWrapper: {
+    [theme.breakpoints.up("md")]: {
+      backgroundColor: theme.palette.background.default,
+      borderRadius: theme.shape.borderRadius / 3,
+      padding: theme.spacing(5, 8),
+      width: "53%",
+    },
+  },
+  header: {
+    width: "100%",
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    padding: theme.spacing(2, 4),
+    marginBottom: theme.spacing(2),
+  },
+  introduction: {
+    color: theme.palette.common.white,
+    textAlign: "left",
+    width: "40%",
+    [theme.breakpoints.up("md")]: {
+      marginTop: theme.spacing(10),
+    },
+  },
+  logo: {
+    color: theme.palette.secondary.main,
+    fontFamily: "'Mansalva', cursive",
+    fontSize: "2rem",
+  },
+  page: {
+    alignItems: "center",
+    boxSizing: "border-box",
+    display: "flex",
+    flexDirection: "column",
+    minHeight: "100vh",
+    padding: `${theme.spacing(1, 6)}`,
+    [theme.breakpoints.up("md")]: {
+      alignItems: "flex-start",
+      backgroundImage: `url(${DesktopAuthBg})`,
+      backgroundPosition: "top center",
+      backgroundRepeat: "no-repeat",
+      backgroundSize: "cover",
       flexDirection: "column",
-      minHeight: "100vh",
-      padding: `${theme.spacing(1, 6)}`,
-      [theme.breakpoints.up("md")]: {
-        alignItems: "flex-start",
-        backgroundImage: `url(${DesktopAuthBg})`,
-        backgroundPosition: "top center",
-        backgroundRepeat: "no-repeat",
-        backgroundSize: "cover",
-        flexDirection: "column",
-        padding: `0 0 ${theme.spacing(6)} 0`,
-        width: "100%",
-      },
-    },
-    subtitle: {
-      [theme.breakpoints.up("md")]: {
-        display: "inline-block",
-        marginTop: theme.spacing(4),
-        position: "relative",
-      },
-    },
-    title: {
-      [theme.breakpoints.up("md")]: {
-        fontSize: "2rem",
-        lineHeight: "1.15",
-        textAlign: "left",
-      },
-    },
-    underline: {
-      borderTop: `5px solid ${theme.palette.primary.main}`,
-      boxShadow: "0px 4px 4px rgba(0, 0, 0, 0.25)",
-      left: theme.spacing(1),
-      position: "absolute",
+      padding: `0 0 ${theme.spacing(6)} 0`,
       width: "100%",
     },
-  }),
-  { index: 1 }
-);
+  },
+  subtitle: {
+    [theme.breakpoints.up("md")]: {
+      display: "inline-block",
+      marginTop: theme.spacing(4),
+      position: "relative",
+    },
+  },
+  title: {
+    [theme.breakpoints.up("md")]: {
+      fontSize: "2rem",
+      lineHeight: "1.15",
+      textAlign: "left",
+    },
+  },
+  underline: {
+    borderTop: `5px solid ${theme.palette.primary.main}`,
+    boxShadow: "0px 4px 4px rgba(0, 0, 0, 0.25)",
+    left: theme.spacing(1),
+    position: "absolute",
+    width: "100%",
+  },
+}));
 
 export default useAuthStyles;

--- a/app/frontend/src/features/auth/useChangeDetailsFormStyles.ts
+++ b/app/frontend/src/features/auth/useChangeDetailsFormStyles.ts
@@ -1,4 +1,4 @@
-import { makeStyles } from "@material-ui/core";
+import makeStyles from "utils/makeStyles";
 
 const useChangeDetailsFormStyles = makeStyles((theme) => ({
   form: {

--- a/app/frontend/src/features/communities/CommunityPage/CommunityPage.tsx
+++ b/app/frontend/src/features/communities/CommunityPage/CommunityPage.tsx
@@ -1,9 +1,4 @@
-import {
-  Breadcrumbs,
-  Link as MuiLink,
-  makeStyles,
-  Typography,
-} from "@material-ui/core";
+import { Breadcrumbs, Link as MuiLink , Typography } from "@material-ui/core";
 import { TabContext } from "@material-ui/lab";
 import Alert from "components/Alert";
 import CircularProgress from "components/CircularProgress";
@@ -33,6 +28,7 @@ import {
   routeToCommunity,
   searchRoute,
 } from "routes";
+import makeStyles from "utils/makeStyles";
 
 import DiscussionsSection from "./DiscussionsSection";
 import EventsSection from "./EventsSection";

--- a/app/frontend/src/features/communities/CommunityPage/CommunityPage.tsx
+++ b/app/frontend/src/features/communities/CommunityPage/CommunityPage.tsx
@@ -1,4 +1,4 @@
-import { Breadcrumbs, Link as MuiLink , Typography } from "@material-ui/core";
+import { Breadcrumbs, Link as MuiLink, Typography } from "@material-ui/core";
 import { TabContext } from "@material-ui/lab";
 import Alert from "components/Alert";
 import CircularProgress from "components/CircularProgress";

--- a/app/frontend/src/features/communities/CommunityPage/DiscussionCard.tsx
+++ b/app/frontend/src/features/communities/CommunityPage/DiscussionCard.tsx
@@ -1,4 +1,9 @@
-import { Card, CardActionArea, CardContent , Typography } from "@material-ui/core";
+import {
+  Card,
+  CardActionArea,
+  CardContent,
+  Typography,
+} from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
 import classNames from "classnames";
 import CircularProgress from "components/CircularProgress";

--- a/app/frontend/src/features/communities/CommunityPage/DiscussionCard.tsx
+++ b/app/frontend/src/features/communities/CommunityPage/DiscussionCard.tsx
@@ -1,10 +1,4 @@
-import {
-  Card,
-  CardActionArea,
-  CardContent,
-  makeStyles,
-  Typography,
-} from "@material-ui/core";
+import { Card, CardActionArea, CardContent , Typography } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
 import classNames from "classnames";
 import CircularProgress from "components/CircularProgress";
@@ -20,6 +14,7 @@ import { Link } from "react-router-dom";
 import { routeToDiscussion } from "routes";
 import { service } from "service";
 import { timestamp2Date } from "utils/date";
+import makeStyles from "utils/makeStyles";
 import { firstName } from "utils/names";
 import stripMarkdown from "utils/stripMarkdown";
 import { timeAgo } from "utils/timeAgo";

--- a/app/frontend/src/features/communities/CommunityPage/DiscussionsSection.tsx
+++ b/app/frontend/src/features/communities/CommunityPage/DiscussionsSection.tsx
@@ -1,4 +1,4 @@
-import { Dialog, DialogContent, makeStyles } from "@material-ui/core";
+import { Dialog, DialogContent } from "@material-ui/core";
 import Alert from "components/Alert";
 import CircularProgress from "components/CircularProgress";
 import NewComment from "components/Comments/NewComment";
@@ -20,6 +20,7 @@ import React, { useState } from "react";
 import { useQueryClient } from "react-query";
 import { Link } from "react-router-dom";
 import { routeToCommunity } from "routes";
+import makeStyles from "utils/makeStyles";
 
 import { useCommunityPageStyles } from "./CommunityPage";
 import DiscussionCard from "./DiscussionCard";

--- a/app/frontend/src/features/communities/CommunityPage/EventCard.tsx
+++ b/app/frontend/src/features/communities/CommunityPage/EventCard.tsx
@@ -3,12 +3,11 @@ import {
   CardActionArea,
   CardContent,
   CardMedia,
-  makeStyles,
-  Typography,
-} from "@material-ui/core";
+ Typography } from "@material-ui/core";
 import React from "react";
 import LinesEllipsis from "react-lines-ellipsis";
 import { Link } from "react-router-dom";
+import makeStyles from "utils/makeStyles";
 
 import {
   CalendarIcon,

--- a/app/frontend/src/features/communities/CommunityPage/EventCard.tsx
+++ b/app/frontend/src/features/communities/CommunityPage/EventCard.tsx
@@ -3,7 +3,8 @@ import {
   CardActionArea,
   CardContent,
   CardMedia,
- Typography } from "@material-ui/core";
+  Typography,
+} from "@material-ui/core";
 import React from "react";
 import LinesEllipsis from "react-lines-ellipsis";
 import { Link } from "react-router-dom";

--- a/app/frontend/src/features/communities/CommunityPage/HeaderImage.tsx
+++ b/app/frontend/src/features/communities/CommunityPage/HeaderImage.tsx
@@ -1,9 +1,9 @@
-import { makeStyles } from "@material-ui/core";
 import classNames from "classnames";
 import Map from "components/Map";
 import { LngLat } from "maplibre-gl";
 import { Community } from "pb/communities_pb";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/app/frontend/src/features/communities/CommunityPage/PlaceCard.tsx
+++ b/app/frontend/src/features/communities/CommunityPage/PlaceCard.tsx
@@ -3,7 +3,9 @@ import {
   CardActionArea,
   CardContent,
   CardMedia,
- useMediaQuery, useTheme } from "@material-ui/core";
+  useMediaQuery,
+  useTheme,
+} from "@material-ui/core";
 import { Page } from "pb/pages_pb";
 import React, { useMemo } from "react";
 import LinesEllipsis from "react-lines-ellipsis";

--- a/app/frontend/src/features/communities/CommunityPage/PlaceCard.tsx
+++ b/app/frontend/src/features/communities/CommunityPage/PlaceCard.tsx
@@ -3,15 +3,13 @@ import {
   CardActionArea,
   CardContent,
   CardMedia,
-  makeStyles,
-  useMediaQuery,
-  useTheme,
-} from "@material-ui/core";
+ useMediaQuery, useTheme } from "@material-ui/core";
 import { Page } from "pb/pages_pb";
 import React, { useMemo } from "react";
 import LinesEllipsis from "react-lines-ellipsis";
 import { Link } from "react-router-dom";
 import { routeToPlace } from "routes";
+import makeStyles from "utils/makeStyles";
 import stripMarkdown from "utils/stripMarkdown";
 
 import placeImagePlaceholder from "./placeImagePlaceholder.svg";

--- a/app/frontend/src/features/communities/CommunityPage/SectionTitle.tsx
+++ b/app/frontend/src/features/communities/CommunityPage/SectionTitle.tsx
@@ -1,5 +1,6 @@
-import { Box, makeStyles, Typography } from "@material-ui/core";
+import { Box, Typography } from "@material-ui/core";
 import React, { ReactNode } from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/app/frontend/src/features/connections/friends/AddFriendButton.tsx
+++ b/app/frontend/src/features/connections/friends/AddFriendButton.tsx
@@ -1,4 +1,3 @@
-import { makeStyles } from "@material-ui/core";
 import classNames from "classnames";
 import Button from "components/Button";
 import { PersonAddIcon } from "components/Icons";
@@ -7,6 +6,7 @@ import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import React from "react";
 import { useMutation, useQueryClient } from "react-query";
 import { service } from "service";
+import makeStyles from "utils/makeStyles";
 
 import { SetMutationError } from ".";
 

--- a/app/frontend/src/features/connections/friends/FriendSummaryView.tsx
+++ b/app/frontend/src/features/connections/friends/FriendSummaryView.tsx
@@ -1,6 +1,6 @@
-import { makeStyles } from "@material-ui/core";
 import UserSummary from "components/UserSummary";
 import { User } from "pb/api_pb";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   friendItem: {

--- a/app/frontend/src/features/connections/friends/FriendTile.tsx
+++ b/app/frontend/src/features/connections/friends/FriendTile.tsx
@@ -1,4 +1,4 @@
-import { Card, CircularProgress , Typography } from "@material-ui/core";
+import { Card, CircularProgress, Typography } from "@material-ui/core";
 import React from "react";
 import makeStyles from "utils/makeStyles";
 

--- a/app/frontend/src/features/connections/friends/FriendTile.tsx
+++ b/app/frontend/src/features/connections/friends/FriendTile.tsx
@@ -1,10 +1,6 @@
-import {
-  Card,
-  CircularProgress,
-  makeStyles,
-  Typography,
-} from "@material-ui/core";
+import { Card, CircularProgress , Typography } from "@material-ui/core";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 import Alert from "../../../components/Alert";
 import TextBody from "../../../components/TextBody";

--- a/app/frontend/src/features/map/MapPage.tsx
+++ b/app/frontend/src/features/map/MapPage.tsx
@@ -1,6 +1,6 @@
-import { makeStyles } from "@material-ui/core";
 import { LngLat, Map as MaplibreMap } from "maplibre-gl";
 import { useHistory, useLocation } from "react-router-dom";
+import makeStyles from "utils/makeStyles";
 
 import Map from "../../components/Map";
 import PageTitle from "../../components/PageTitle";

--- a/app/frontend/src/features/messages/groupchats/MembersDialog.tsx
+++ b/app/frontend/src/features/messages/groupchats/MembersDialog.tsx
@@ -3,7 +3,6 @@ import {
   DialogProps,
   List,
   ListItem,
-  makeStyles,
 } from "@material-ui/core";
 import Avatar from "components/Avatar";
 import Button from "components/Button";
@@ -18,6 +17,7 @@ import useUsers from "features/userQueries/useUsers";
 import { User } from "pb/api_pb";
 import { GroupChat } from "pb/conversations_pb";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 export const useMembersDialogStyles = makeStyles((theme) => ({
   avatar: {

--- a/app/frontend/src/features/messages/messagelist/InfiniteMessageLoader.tsx
+++ b/app/frontend/src/features/messages/messagelist/InfiniteMessageLoader.tsx
@@ -1,4 +1,4 @@
-import { Box, makeStyles } from "@material-ui/core";
+import { Box } from "@material-ui/core";
 import classNames from "classnames";
 import CircularProgress from "components/CircularProgress";
 import useAuthStore from "features/auth/useAuthStore";
@@ -11,6 +11,7 @@ import {
   useLayoutEffect,
   useRef,
 } from "react";
+import makeStyles from "utils/makeStyles";
 import useOnVisibleEffect from "utils/useOnVisibleEffect";
 
 const useStyles = makeStyles((theme) => ({

--- a/app/frontend/src/features/messages/requests/HostRequestStatusIcon.tsx
+++ b/app/frontend/src/features/messages/requests/HostRequestStatusIcon.tsx
@@ -1,9 +1,10 @@
-import { Avatar, AvatarProps, makeStyles } from "@material-ui/core";
+import { Avatar, AvatarProps } from "@material-ui/core";
 import classNames from "classnames";
 import { CheckIcon, CrossIcon, QuestionIcon } from "components/Icons";
 import { HostRequestStatus } from "pb/conversations_pb";
 import { HostRequest } from "pb/requests_pb";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   avatar: {

--- a/app/frontend/src/features/messages/useSendFieldStyles.ts
+++ b/app/frontend/src/features/messages/useSendFieldStyles.ts
@@ -1,4 +1,4 @@
-import { makeStyles } from "@material-ui/core";
+import makeStyles from "utils/makeStyles";
 
 const useSendFieldStyles = makeStyles((theme) => ({
   button: {

--- a/app/frontend/src/features/profile/ProfileTagInput.tsx
+++ b/app/frontend/src/features/profile/ProfileTagInput.tsx
@@ -5,15 +5,13 @@ import {
   fade,
   IconButton,
   InputBase,
-  makeStyles,
-  Popper,
-  Typography,
-} from "@material-ui/core";
+ Popper, Typography } from "@material-ui/core";
 import Autocomplete, {
   AutocompleteCloseReason,
 } from "@material-ui/lab/Autocomplete";
 import { CloseIcon, ExpandMoreIcon } from "components/Icons";
 import React, { useRef, useState } from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) =>
   createStyles({

--- a/app/frontend/src/features/profile/ProfileTagInput.tsx
+++ b/app/frontend/src/features/profile/ProfileTagInput.tsx
@@ -5,7 +5,9 @@ import {
   fade,
   IconButton,
   InputBase,
- Popper, Typography } from "@material-ui/core";
+  Popper,
+  Typography,
+} from "@material-ui/core";
 import Autocomplete, {
   AutocompleteCloseReason,
 } from "@material-ui/lab/Autocomplete";

--- a/app/frontend/src/features/profile/actions/ReportUserDialog.tsx
+++ b/app/frontend/src/features/profile/actions/ReportUserDialog.tsx
@@ -1,4 +1,4 @@
-import { DialogProps, makeStyles } from "@material-ui/core";
+import { DialogProps } from "@material-ui/core";
 import Alert from "components/Alert";
 import Button from "components/Button";
 import {
@@ -16,6 +16,7 @@ import { useForm } from "react-hook-form";
 import { useMutation } from "react-query";
 import { service } from "service";
 import type { ReportUserInput } from "service/user";
+import makeStyles from "utils/makeStyles";
 
 import {
   CANCEL,

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
@@ -1,10 +1,4 @@
-import {
-  Checkbox,
-  FormControl,
-  FormControlLabel,
-  makeStyles,
-  Typography,
-} from "@material-ui/core";
+import { Checkbox, FormControl, FormControlLabel , Typography } from "@material-ui/core";
 import { Autocomplete } from "@material-ui/lab";
 import Alert from "components/Alert";
 import Button from "components/Button";
@@ -57,6 +51,7 @@ import {
 import { useState } from "react";
 import { Controller, useForm, UseFormMethods } from "react-hook-form";
 import { HostingPreferenceData } from "service/index";
+import makeStyles from "utils/makeStyles";
 
 interface HostingPreferenceCheckboxProps {
   className: string;

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
@@ -1,4 +1,9 @@
-import { Checkbox, FormControl, FormControlLabel , Typography } from "@material-ui/core";
+import {
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  Typography,
+} from "@material-ui/core";
 import { Autocomplete } from "@material-ui/lab";
 import Alert from "components/Alert";
 import Button from "components/Button";

--- a/app/frontend/src/features/profile/edit/EditProfile.tsx
+++ b/app/frontend/src/features/profile/edit/EditProfile.tsx
@@ -1,12 +1,4 @@
-import {
-  FormControlLabel,
-  Grid,
-  makeStyles,
-  Radio,
-  RadioGroup,
-  TextField,
-  Typography,
-} from "@material-ui/core";
+import { FormControlLabel, Grid , Radio, RadioGroup, TextField, Typography } from "@material-ui/core";
 import Alert from "components/Alert";
 import AvatarInput from "components/AvatarInput";
 import Button from "components/Button";
@@ -54,6 +46,7 @@ import { Link } from "react-router-dom";
 import { settingsRoute } from "routes";
 import { UpdateUserProfileData } from "service/index";
 import { useIsMounted, useSafeState } from "utils/hooks";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   avatar: {

--- a/app/frontend/src/features/profile/edit/EditProfile.tsx
+++ b/app/frontend/src/features/profile/edit/EditProfile.tsx
@@ -1,4 +1,11 @@
-import { FormControlLabel, Grid , Radio, RadioGroup, TextField, Typography } from "@material-ui/core";
+import {
+  FormControlLabel,
+  Grid,
+  Radio,
+  RadioGroup,
+  TextField,
+  Typography,
+} from "@material-ui/core";
 import Alert from "components/Alert";
 import AvatarInput from "components/AvatarInput";
 import Button from "components/Button";

--- a/app/frontend/src/features/profile/view/About.tsx
+++ b/app/frontend/src/features/profile/view/About.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, Typography } from "@material-ui/core";
+import { Typography } from "@material-ui/core";
 import Divider from "components/Divider";
 import Markdown from "components/Markdown";
 import {
@@ -16,6 +16,7 @@ import {
   RemainingAboutLabels,
 } from "features/user/UserTextAndLabel";
 import { User } from "pb/api_pb";
+import makeStyles from "utils/makeStyles";
 
 interface AboutProps {
   user: User.AsObject;

--- a/app/frontend/src/features/profile/view/Home.tsx
+++ b/app/frontend/src/features/profile/view/Home.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, Typography } from "@material-ui/core";
+import { Typography } from "@material-ui/core";
 import Divider from "components/Divider";
 import LabelAndText from "components/LabelAndText";
 import Markdown from "components/Markdown";
@@ -33,6 +33,7 @@ import booleanConversion, {
 } from "features/profile/constants";
 import { User } from "pb/api_pb";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles(() => ({
   info: {

--- a/app/frontend/src/features/profile/view/Overview.tsx
+++ b/app/frontend/src/features/profile/view/Overview.tsx
@@ -1,4 +1,4 @@
-import { Card, CardActions, makeStyles, Typography } from "@material-ui/core";
+import { Card, CardActions, Typography } from "@material-ui/core";
 import Alert from "components/Alert";
 import Avatar from "components/Avatar";
 import BarWithHelp from "components/Bar/BarWithHelp";
@@ -33,6 +33,7 @@ import {
   editHostingPreferenceRoute,
   editProfileRoute,
 } from "routes";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   card: {

--- a/app/frontend/src/features/profile/view/ProfilePage.tsx
+++ b/app/frontend/src/features/profile/view/ProfilePage.tsx
@@ -1,9 +1,4 @@
-import {
-  Card,
-  CircularProgress,
-  Collapse,
-  makeStyles,
-} from "@material-ui/core";
+import { Card, CircularProgress, Collapse } from "@material-ui/core";
 import { TabContext, TabPanel } from "@material-ui/lab";
 import Alert from "components/Alert";
 import SuccessSnackbar from "components/SuccessSnackbar";
@@ -23,6 +18,7 @@ import useCurrentUser from "features/userQueries/useCurrentUser";
 import useUserByUsername from "features/userQueries/useUserByUsername";
 import { useLayoutEffect, useState } from "react";
 import { useParams } from "react-router-dom";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   detailsCard: {

--- a/app/frontend/src/features/profile/view/ReferenceList.tsx
+++ b/app/frontend/src/features/profile/view/ReferenceList.tsx
@@ -1,6 +1,7 @@
-import { List, makeStyles } from "@material-ui/core";
+import { List } from "@material-ui/core";
 import useUsers from "features/userQueries/useUsers";
 import { ListReferencesRes } from "pb/references_pb";
+import makeStyles from "utils/makeStyles";
 
 import ReferenceListItem from "./ReferenceListItem";
 

--- a/app/frontend/src/features/profile/view/ReferenceListItem.tsx
+++ b/app/frontend/src/features/profile/view/ReferenceListItem.tsx
@@ -1,4 +1,4 @@
-import { ListItem, makeStyles } from "@material-ui/core";
+import { ListItem } from "@material-ui/core";
 import Pill from "components/Pill";
 import TextBody from "components/TextBody";
 import UserSummary from "components/UserSummary";
@@ -6,6 +6,7 @@ import { referenceBadgeLabel } from "features/profile/constants";
 import { User } from "pb/api_pb";
 import { Reference } from "pb/references_pb";
 import { dateTimeFormatter, timestamp2Date } from "utils/date";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   badgesContainer: {

--- a/app/frontend/src/features/profile/view/References.tsx
+++ b/app/frontend/src/features/profile/view/References.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, Select, Typography } from "@material-ui/core";
+import { Select, Typography } from "@material-ui/core";
 import { MenuItem } from "components/Menu";
 import { REFERENCES } from "features/constants";
 import {
@@ -6,6 +6,7 @@ import {
   referencesFilterLabels,
 } from "features/profile/constants";
 import React, { useState } from "react";
+import makeStyles from "utils/makeStyles";
 
 import ReferencesGivenList from "./ReferencesGivenList";
 import ReferencesReceivedList from "./ReferencesReceivedList";

--- a/app/frontend/src/features/profile/view/ReferencesView.tsx
+++ b/app/frontend/src/features/profile/view/ReferencesView.tsx
@@ -1,4 +1,3 @@
-import { makeStyles } from "@material-ui/core";
 import Alert from "components/Alert";
 import Button from "components/Button";
 import CircularProgress from "components/CircularProgress";
@@ -8,6 +7,7 @@ import { Error as GrpcError } from "grpc-web";
 import { ListReferencesRes } from "pb/references_pb";
 import { UseInfiniteQueryResult } from "react-query";
 import hasAtLeastOnePage from "utils/hasAtLeastOnePage";
+import makeStyles from "utils/makeStyles";
 
 import { NO_REFERENCES, SEE_MORE_REFERENCES } from "../constants";
 import ReferenceList from "./ReferenceList";

--- a/app/frontend/src/features/search/SearchBox.tsx
+++ b/app/frontend/src/features/search/SearchBox.tsx
@@ -4,7 +4,6 @@ import {
   Input,
   InputAdornment,
   InputLabel,
-  makeStyles,
 } from "@material-ui/core";
 import SearchIcon from "@material-ui/icons/Search";
 import { SearchQuery } from "features/search/constants";
@@ -12,6 +11,7 @@ import React from "react";
 import { useForm } from "react-hook-form";
 import { useHistory } from "react-router-dom";
 import { routeToSearch } from "routes";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/app/frontend/src/features/search/SearchResult.tsx
+++ b/app/frontend/src/features/search/SearchResult.tsx
@@ -1,4 +1,9 @@
-import { Card, CardActionArea, CardContent , Typography } from "@material-ui/core";
+import {
+  Card,
+  CardActionArea,
+  CardContent,
+  Typography,
+} from "@material-ui/core";
 import { CouchIcon, LocationIcon } from "components/Icons";
 import UserSummary from "components/UserSummary";
 import {

--- a/app/frontend/src/features/search/SearchResult.tsx
+++ b/app/frontend/src/features/search/SearchResult.tsx
@@ -1,10 +1,4 @@
-import {
-  Card,
-  CardActionArea,
-  CardContent,
-  makeStyles,
-  Typography,
-} from "@material-ui/core";
+import { Card, CardActionArea, CardContent , Typography } from "@material-ui/core";
 import { CouchIcon, LocationIcon } from "components/Icons";
 import UserSummary from "components/UserSummary";
 import {
@@ -19,6 +13,7 @@ import {
 import { User } from "pb/api_pb";
 import { Link } from "react-router-dom";
 import { routeToUser } from "routes";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   card: {

--- a/app/frontend/src/features/user/UserGuestbook.tsx
+++ b/app/frontend/src/features/user/UserGuestbook.tsx
@@ -1,6 +1,6 @@
-import { makeStyles } from "@material-ui/core";
 import { User } from "pb/api_pb";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   root: {},

--- a/app/frontend/src/features/user/UserHeader.tsx
+++ b/app/frontend/src/features/user/UserHeader.tsx
@@ -1,4 +1,4 @@
-import { Box, makeStyles, Typography } from "@material-ui/core";
+import { Box, Typography } from "@material-ui/core";
 import Avatar from "components/Avatar";
 import ScoreBar from "components/Bar/ScoreBar";
 import { CouchIcon } from "components/Icons";
@@ -9,6 +9,7 @@ import { hostingStatusLabels } from "features/profile/constants";
 import { User } from "pb/api_pb";
 import React from "react";
 import { timestamp2Date } from "utils/date";
+import makeStyles from "utils/makeStyles";
 import { timeAgo } from "utils/timeAgo";
 
 const useStyles = makeStyles((theme) => ({

--- a/app/frontend/src/features/user/UserPlace.tsx
+++ b/app/frontend/src/features/user/UserPlace.tsx
@@ -1,9 +1,10 @@
-import { makeStyles, Typography } from "@material-ui/core";
+import { Typography } from "@material-ui/core";
 import Markdown from "components/Markdown";
 import TextBody from "components/TextBody";
 import { smokingLocationLabels } from "features/profile/constants";
 import { SmokingLocation, User } from "pb/api_pb";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   hostingPreferenceResponse: {

--- a/app/frontend/src/features/user/UserSection.tsx
+++ b/app/frontend/src/features/user/UserSection.tsx
@@ -1,6 +1,7 @@
-import { CardProps, makeStyles, Typography } from "@material-ui/core";
+import { CardProps, Typography } from "@material-ui/core";
 import classNames from "classnames";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/app/frontend/src/features/user/UserSummary.tsx
+++ b/app/frontend/src/features/user/UserSummary.tsx
@@ -1,10 +1,4 @@
-import {
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
-  makeStyles,
-} from "@material-ui/core";
+import { List, ListItem, ListItemIcon, ListItemText } from "@material-ui/core";
 import {
   CakeIcon,
   LanguageIcon,
@@ -15,6 +9,7 @@ import {
 import UserSection from "features/user/UserSection";
 import { User } from "pb/api_pb";
 import React from "react";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/app/frontend/src/resources/CouchersLogo.tsx
+++ b/app/frontend/src/resources/CouchersLogo.tsx
@@ -1,4 +1,5 @@
-import { makeStyles, SvgIcon, SvgIconProps } from "@material-ui/core";
+import { SvgIcon, SvgIconProps } from "@material-ui/core";
+import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
   logo: {

--- a/app/frontend/src/utils/makeStyles.ts
+++ b/app/frontend/src/utils/makeStyles.ts
@@ -1,0 +1,11 @@
+import { makeStyles as muiMakeStyles } from "@material-ui/core";
+import { Theme as DefaultTheme } from "@material-ui/core/styles/createMuiTheme";
+import { Styles } from "@material-ui/styles/withStyles";
+
+export default function makeStyles<
+  Theme = DefaultTheme,
+  Props extends object = {},
+  ClassKey extends string = string
+>(styles: Styles<Theme, Props, ClassKey>) {
+  return muiMakeStyles(styles, { index: 1 });
+}


### PR DESCRIPTION
Unfortunately this requires manually adding `{index: 1}` to affected styles, so I guess we'll just have to keep an eye out...