### PR TITLE
Reduce re-renders on edit location map

### DIFF
--- a/app/frontend/src/components/EditLocationMap.tsx
+++ b/app/frontend/src/components/EditLocationMap.tsx
@@ -85,6 +85,7 @@ export default function EditLocationMap({
   const isBlank = useRef<boolean>(
     !(initialLocation?.lng || initialLocation?.lat)
   );
+  const locationDisplayRef = useRef<HTMLInputElement>(null);
 
   const onCircleMouseDown = (e: MapMouseEvent | MapTouchEvent) => {
     // Prevent the default map drag behavior.
@@ -300,6 +301,9 @@ export default function EditLocationMap({
             setError={setError}
             setResult={(coordinate, _, simplified) => {
               commit({ address: simplified });
+              if (locationDisplayRef.current) {
+                locationDisplayRef.current.value = simplified;
+              }
               flyToSearch(coordinate);
             }}
           />
@@ -318,6 +322,7 @@ export default function EditLocationMap({
           }}
           error={error !== ""}
           id="display-address"
+          inputRef={locationDisplayRef}
           fullWidth
           variant="standard"
           label={DISPLAY_LOCATION}

--- a/app/frontend/src/components/EditLocationMap.tsx
+++ b/app/frontend/src/components/EditLocationMap.tsx
@@ -108,10 +108,13 @@ export default function EditLocationMap({
 
   const onCircleMove = (e: MapMouseEvent | MapTouchEvent) => {
     const wrapped = e.lngLat.wrap();
-    commit({
-      lat: wrapped.lat,
-      lng: wrapped.lng,
-    });
+    commit(
+      {
+        lat: wrapped.lat,
+        lng: wrapped.lng,
+      },
+      false
+    );
     redrawMap();
   };
 
@@ -146,7 +149,10 @@ export default function EditLocationMap({
     }
   };
 
-  const commit = (updates: Partial<ApproximateLocation>) => {
+  const commit = (
+    updates: Partial<ApproximateLocation>,
+    shouldUpdate = true
+  ) => {
     if (updates.address !== undefined) {
       location.current.address = updates.address;
     }
@@ -159,21 +165,23 @@ export default function EditLocationMap({
       isBlank.current = false;
     }
 
-    if (isBlank.current) {
-      // haven't selected a location yet
-      setError(MAP_IS_BLANK);
-      updateLocation(null);
-    } else if (location.current.lat === 0 && location.current.lng === 0) {
-      // somehow have lat/lng == 0
-      setError(INVALID_COORDINATE);
-      updateLocation(null);
-    } else if (location.current.address === "") {
-      // missing display address
-      setError(DISPLAY_LOCATION_NOT_EMPTY);
-      updateLocation(null);
-    } else {
-      setError("");
-      updateLocation({ ...location.current });
+    if (shouldUpdate) {
+      if (isBlank.current) {
+        // haven't selected a location yet
+        setError(MAP_IS_BLANK);
+        updateLocation(null);
+      } else if (location.current.lat === 0 && location.current.lng === 0) {
+        // somehow have lat/lng == 0
+        setError(INVALID_COORDINATE);
+        updateLocation(null);
+      } else if (location.current.address === "") {
+        // missing display address
+        setError(DISPLAY_LOCATION_NOT_EMPTY);
+        updateLocation(null);
+      } else {
+        setError("");
+        updateLocation({ ...location.current });
+      }
     }
   };
 
@@ -300,7 +308,7 @@ export default function EditLocationMap({
           <MapSearch
             setError={setError}
             setResult={(coordinate, _, simplified) => {
-              commit({ address: simplified });
+              commit({ address: simplified }, false);
               if (locationDisplayRef.current) {
                 locationDisplayRef.current.value = simplified;
               }
@@ -334,7 +342,7 @@ export default function EditLocationMap({
 }
 
 interface RadiusSliderProps {
-  commit(updates: Partial<ApproximateLocation>): void;
+  commit(updates: Partial<ApproximateLocation>, shouldUpdate?: boolean): void;
   initialRadius: number;
   redrawMap(): void;
 }
@@ -355,7 +363,7 @@ function RadiusSlider({ commit, initialRadius, redrawMap }: RadiusSliderProps) {
         max={userLocationMaxRadius}
         onChange={(_, value) => {
           setRadius(value as number);
-          commit({ radius: value as number });
+          commit({ radius: value as number }, false);
           redrawMap();
         }}
         onChangeCommitted={(_, value) => {

--- a/app/frontend/src/components/constants.ts
+++ b/app/frontend/src/components/constants.ts
@@ -9,6 +9,7 @@ export const UPLOAD_PENDING_ERROR =
 export const DISPLAY_LOCATION = "Display location";
 export const INVALID_COORDINATE =
   "Missing coordinates, please select a location with the map above";
+export const LOCATION_ACCURACY = "Location accuracy";
 export const MAP_IS_BLANK =
   "Missing coordinates, start by searching for a location with the map above";
 export const DISPLAY_LOCATION_NOT_EMPTY = "Please fill in a display address";

--- a/app/frontend/src/features/profile/edit/EditProfile.tsx
+++ b/app/frontend/src/features/profile/edit/EditProfile.tsx
@@ -206,6 +206,7 @@ export default function EditProfileForm() {
             />
           </form>
           <Controller
+            defaultValue=""
             name="location"
             control={control}
             render={() => (


### PR DESCRIPTION
Reduces the number of re-renders quite significantly, and scope it to only the components that **needs to be re-render a lot** to a smaller area (i.e. the radius slider). Previously, it was re-rendering on every character change when you update the display location and on every map move.

See before and after video for the difference (excuse the terrible typos :p) - the flashy squares is something from the React DevTools, shows quite nicely where things get re-rendered before/after this change.

**Before**

https://user-images.githubusercontent.com/13669362/114289153-8cd7d580-9a6d-11eb-82fc-cde8a794b7ea.mov



**After**

https://user-images.githubusercontent.com/13669362/114289157-95c8a700-9a6d-11eb-97ee-b359efe95013.mov

