### PR TITLE
Migration tests pg_dump fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -149,7 +149,12 @@ test:backend:
   variables:
     POSTGRES_PASSWORD: c765064a49d18a95
     DATABASE_CONNECTION_STRING: "postgresql://postgres:c765064a49d18a95@postgres/postgres"
-    PG_DUMP: "docker run postgis/postgis:13-3.0 pg_dump"
+  before_script:
+    # install latest postgres from their repos to get pg_dump compatible with postgres 13
+    - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+    - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+    - sudo apt-get update
+    - sudo apt-get -y install postgresql
   script:
     - cd /app && pytest --junitxml=junit.xml --cov=src src
   after_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -154,7 +154,7 @@ test:backend:
     - sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
     - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
     - apt-get update
-    - apt-get -y install postgresql
+    - apt-get -y install postgresql-client
   script:
     - cd /app && pytest --junitxml=junit.xml --cov=src src
   after_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,10 +151,10 @@ test:backend:
     DATABASE_CONNECTION_STRING: "postgresql://postgres:c765064a49d18a95@postgres/postgres"
   before_script:
     # install latest postgres from their repos to get pg_dump compatible with postgres 13
-    - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-    - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-    - sudo apt-get update
-    - sudo apt-get -y install postgresql
+    - sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+    - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+    - apt-get update
+    - apt-get -y install postgresql
   script:
     - cd /app && pytest --junitxml=junit.xml --cov=src src
   after_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,7 +151,7 @@ test:backend:
     DATABASE_CONNECTION_STRING: "postgresql://postgres:c765064a49d18a95@postgres/postgres"
   before_script:
     # install latest postgres from their repos to get pg_dump compatible with postgres 13
-    - sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+    - sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
     - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
     - apt-get update
     - apt-get -y install postgresql


### PR DESCRIPTION
Installs the latest (version 13) postgresql-client package in the backend test container so `pg_dump` works.

@kalvdans: this is just on top of your current PR, feel free to merge if you want it in!