### PR TITLE
Frontend/chore/typecheck unit tests

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -31,7 +31,7 @@
     "eject": "react-scripts eject",
     "format": "prettier --write src/",
     "lint": "eslint src/",
-    "test-ci": "CI=true react-scripts test --coverageReporters=\"text\" --coverageReporters=\"cobertura\" --coverageReporters=\"lcov\" --reporters=\"default\" --reporters=\"jest-junit\" --coverage",
+    "test-ci": "CI=true tsc && react-scripts test --coverageReporters=\"text\" --coverageReporters=\"cobertura\" --coverageReporters=\"lcov\" --reporters=\"default\" --reporters=\"jest-junit\" --coverage",
     "jest": "jest --modulePaths=src",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "NODE_PATH=. build-storybook -s public"

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -34,7 +34,8 @@
     "test-ci": "CI=true tsc && react-scripts test --coverageReporters=\"text\" --coverageReporters=\"cobertura\" --coverageReporters=\"lcov\" --reporters=\"default\" --reporters=\"jest-junit\" --coverage",
     "jest": "jest --modulePaths=src",
     "storybook": "start-storybook -p 6006 -s public",
-    "build-storybook": "NODE_PATH=. build-storybook -s public"
+    "build-storybook": "NODE_PATH=. build-storybook -s public",
+    "tsc": "tsc"
   },
   "eslintConfig": {
     "extends": [

--- a/app/frontend/src/components/Datepicker.test.tsx
+++ b/app/frontend/src/components/Datepicker.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { CHANGE_DATE, SUBMIT } from "features/constants";
 import mockdate from "mockdate";

--- a/app/frontend/src/components/Markdown.test.tsx
+++ b/app/frontend/src/components/Markdown.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+
 import Markdown, { increaseMarkdownHeaderLevel } from "./Markdown";
 
 describe("markdown header level increase", () => {

--- a/app/frontend/src/features/profile/hooks/useUpdateHostingPreferences.test.tsx
+++ b/app/frontend/src/features/profile/hooks/useUpdateHostingPreferences.test.tsx
@@ -3,7 +3,7 @@ import useUpdateHostingPreferences from "features/profile/hooks/useUpdateHosting
 import useCurrentUser from "features/userQueries/useCurrentUser";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { act } from "react-test-renderer";
-import { service } from "service";
+import { HostingPreferenceData, service } from "service";
 import wrapper from "test/hookWrapper";
 import { addDefaultUser } from "test/utils";
 
@@ -12,8 +12,7 @@ const updateHostingPreferenceMock = service.user
   .updateHostingPreference as jest.Mock;
 
 describe("useUpdateHostingPreference hook", () => {
-  const newHostingPreferenceData = {
-    acceptsKids: false,
+  const newHostingPreferenceData: HostingPreferenceData = {
     acceptsPets: false,
     area: "",
     houseRules: "",
@@ -21,20 +20,45 @@ describe("useUpdateHostingPreference hook", () => {
     maxGuests: null,
     smokingAllowed: 1,
     wheelchairAccessible: true,
+    hasPets: false,
+    petDetails: "",
+    hasKids: false,
+    acceptsKids: false,
+    kidDetails: "",
+    hasHousemates: false,
+    housemateDetails: "",
+    smokesAtHome: false,
+    drinkingAllowed: false,
+    drinksAtHome: false,
+    otherHostInfo: "",
+    campingOk: true,
+    parking: true,
+    parkingDetails: 3,
+    sleepingArrangement: 2,
+    sleepingDetails: "",
   };
 
   it("updates the store with the latest user hosting preference", async () => {
     addDefaultUser();
-    const newUserPref = Object.entries(newHostingPreferenceData).reduce(
-      (acc: Record<string, unknown>, [key, value]) => {
-        if (key !== "smokingAllowed") {
-          acc[key] = { value };
-        } else {
-          acc[key] = value;
+
+    const newUserPref = (Object.keys(
+      newHostingPreferenceData
+    ) as (keyof HostingPreferenceData)[]).reduce(
+      (acc, key: keyof HostingPreferenceData) => {
+        switch (key) {
+          case "smokingAllowed":
+          case "parkingDetails":
+          case "sleepingArrangement":
+            acc[key] = newHostingPreferenceData[key];
+            return acc;
+          default:
+            acc[key] = {
+              value: newHostingPreferenceData[key],
+            };
+            return acc;
         }
-        return acc;
       },
-      {}
+      {} as Record<string, unknown>
     );
     updateHostingPreferenceMock.mockResolvedValue(new Empty());
     getUserMock.mockImplementation(() => {

--- a/app/frontend/src/features/profile/hooks/useUpdateUserProfile.test.ts
+++ b/app/frontend/src/features/profile/hooks/useUpdateUserProfile.test.ts
@@ -16,22 +16,39 @@ describe("updateUserProfile action", () => {
     const {
       aboutMe,
       aboutPlace,
+      additionalInformation,
+      avatarUrl,
       radius,
       countriesLivedList,
       countriesVisitedList,
+      education,
       gender,
+      hometown,
+      meetupStatus,
+      myTravels,
       name,
       occupation,
+      pronouns,
+      thingsILike,
     } = defaultUser;
     /* eslint-disable sort-keys */
     const newUserProfileData = {
       // Unchanged data
       aboutMe,
       aboutPlace,
+      additionalInformation,
+      avatarKey: avatarUrl,
       countriesLived: countriesLivedList,
+      education,
       gender,
+      hometown,
+      meetupStatus,
+      myTravels,
       name,
       occupation,
+      pronouns,
+      thingsILike,
+
       // Changed data
       countriesVisited: [...countriesVisitedList, "United States"],
       city: "New York",
@@ -115,6 +132,7 @@ describe("updateUserProfile action", () => {
           countriesLived: ["Ecuador"],
           countriesVisited: defaultUser.countriesVisitedList,
           languages: defaultUser.languagesList,
+          avatarKey: defaultUser.avatarUrl,
         },
         setMutationError: setError,
       })

--- a/app/frontend/src/service/user.test.ts
+++ b/app/frontend/src/service/user.test.ts
@@ -32,6 +32,7 @@ describe("updateProfile", () => {
     pronouns: user.pronouns,
     radius: user.radius,
     thingsILike: user.thingsILike,
+    avatarKey: "",
   };
 
   it("updates the profile correctly when repeated value fields are empty", async () => {


### PR DESCRIPTION
Fixed the typescript errors in tests and changed the `test-ci`script so that CI pipeling fails if tests have typescript errors.

This PR has no affect when running `yarn test` locally.

Adding `tsc` to the `test` script as suggested in facebook/create-react-app#5626 will not fully work with `react-scripts test` and might cause frustration if you have to wait for the entire source code to be typechecked by tsc when you just want to run a single test. Also it would only run tsc a single time. If no typescript errors have been detected, jest will start in watch mode. Meaning that typescript errors added while test script is already running (and watching for file changes) will still go unnoticed.

I've added `tsc` as stand alone script so developers can run it locally with `yarn tsc` as a temporary help to check all files for typescript errors.

#851