### PR TITLE
Remove gender from update profile.

### DIFF
--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -175,11 +175,7 @@ class API(api_pb2_grpc.APIServicer):
 
             return user_model_to_pb(user, session, context)
 
-    def UpdateProfile(self, request, context):
-        # users can't change gender themselves to avoid filter evasion
-        if request.HasField("gender"):
-            context.abort(grpc.StatusCode.PERMISSION_DENIED, errors.CANT_CHANGE_GENDER)
-
+    def UpdateProfile(self, request, context):        
         with session_scope() as session:
             user = session.query(User).filter(User.id == context.user_id).one()
 

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -158,11 +158,6 @@ def test_update_profile(db):
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
         assert e.value.details() == errors.INVALID_COORDINATE
 
-        # changing gender shouldn't be allowed
-        with pytest.raises(grpc.RpcError) as e:
-            api.UpdateProfile(api_pb2.UpdateProfileReq(gender=wrappers_pb2.StringValue(value="newgender")))
-        assert e.value.code() == grpc.StatusCode.PERMISSION_DENIED
-
         api.UpdateProfile(
             api_pb2.UpdateProfileReq(
                 name=wrappers_pb2.StringValue(value="New name"),

--- a/app/pb/api.proto
+++ b/app/pb/api.proto
@@ -248,9 +248,7 @@ message UpdateProfileReq {
   google.protobuf.DoubleValue lng = 23;
   google.protobuf.DoubleValue radius = 24; // metres
 
-  NullableStringValue avatar_key = 25; // result from media server
-
-  google.protobuf.StringValue gender = 3;
+  NullableStringValue avatar_key = 25; // result from media server  
   NullableStringValue pronouns = 101;
   NullableStringValue occupation = 4;
   NullableStringValue education = 102;  // CommonMark without images


### PR DESCRIPTION
Fixes #918 

- Remove gender reference in api.proto
- Remove permission denied check (since no more gender in request) in api.py