### PR TITLE
Fix up form flashing on load if it's already been filled

### DIFF
--- a/app/frontend/src/features/contributorForm/ContributorForm.tsx
+++ b/app/frontend/src/features/contributorForm/ContributorForm.tsx
@@ -88,6 +88,7 @@ export default function ContributorForm() {
   const { authState } = useAuthContext();
 
   const [alreadyFilled, setAlreadyFilled] = useState(false);
+  const [loadingFilled, setLoadingFilled] = useState(authState.authenticated);
 
   const {
     control,
@@ -114,6 +115,7 @@ export default function ContributorForm() {
       setValue("gender", data.gender);
       setValue("location", data.location);
       setAlreadyFilled(data.filledContributorForm);
+      setLoadingFilled(false);
     },
   });
 
@@ -163,7 +165,7 @@ export default function ContributorForm() {
     }
   };
 
-  return loading || authState.loading || queryLoading ? (
+  return loading || authState.loading || queryLoading || loadingFilled ? (
     <CircularProgress />
   ) : (
     <>

--- a/app/frontend/src/queryKeys.ts
+++ b/app/frontend/src/queryKeys.ts
@@ -1,5 +1,7 @@
 import { ReferenceType } from "pb/references_pb";
 
+export const contributorFormInfoQueryKey = "contributorFormInfo";
+
 export const accountInfoQueryKey = "accountInfo";
 
 export const communityKey = (id: number) => ["community", id];


### PR DESCRIPTION
If you've already filled in the form, then it'll flash on the screen before turning into the "You've already filled in the contributor form." message.

It's because after the query succeeds, loading stops, but `setFormFilled` is called only moments later in the `onSuccess` function... I didn't catch it earlier because it was fast before the preview being deployed in Sydney.

This is not a very neat way of doing it, open to other approaches.