### PR TITLE
nav bar color switched

### DIFF
--- a/app/frontend/src/components/Navigation/useNavLinkStyles.tsx
+++ b/app/frontend/src/components/Navigation/useNavLinkStyles.tsx
@@ -10,7 +10,7 @@ export const useNavLinkStyles = makeStyles((theme) => ({
     padding: theme.spacing(1, 1.5),
   },
   selected: {
-    color: theme.palette.secondary.dark,
+    color: theme.palette.secondary.main,
   },
   label: {
     alignSelf: "center",


### PR DESCRIPTION
this PR is to resolve issue #1041 I changed the color of the navigation text to match that of Couchers.org wordmark by switching the color to the secondary.main color rather than the secondary.dark