### PR TITLE
Fix weird gaps on connections page

### DIFF
--- a/app/frontend/src/features/auth/useAuthStyles.ts
+++ b/app/frontend/src/features/auth/useAuthStyles.ts
@@ -1,7 +1,6 @@
 import makeStyles from "utils/makeStyles";
 
 import DesktopAuthBg from "./resources/desktop-auth-bg.jpg";
-import MobileAuthBg from "./resources/mobile-auth-bg.jpg";
 
 const useAuthStyles = makeStyles((theme) => ({
   button: {

--- a/app/frontend/src/features/connections/friends/FriendsTab.tsx
+++ b/app/frontend/src/features/connections/friends/FriendsTab.tsx
@@ -1,25 +1,33 @@
 import { Grid } from "@material-ui/core";
-import React from "react";
+import makeStyles from "utils/makeStyles";
 
 import FriendList from "./FriendList";
 import FriendRequestsReceived from "./FriendRequestsReceived";
 import FriendRequestsSent from "./FriendRequestsSent";
 
+export const useStyles = makeStyles(() => ({
+  gridItem: {
+    "& > div": {
+      height: "100%",
+    },
+  },
+}));
+
 function FriendsTab() {
+  const classes = useStyles();
+
   return (
-    <>
-      <Grid container spacing={2}>
-        <Grid item xs={12} md={6}>
-          <FriendList />
-        </Grid>
-        <Grid item xs={12} md={6}>
-          <FriendRequestsReceived />
-        </Grid>
-        <Grid item xs={12} md={6}>
-          <FriendRequestsSent />
-        </Grid>
+    <Grid container spacing={2}>
+      <Grid item xs={12} md={6} className={classes.gridItem}>
+        <FriendList />
       </Grid>
-    </>
+      <Grid item xs={12} md={6} className={classes.gridItem}>
+        <FriendRequestsReceived />
+      </Grid>
+      <Grid item xs={12} md={6} className={classes.gridItem}>
+        <FriendRequestsSent />
+      </Grid>
+    </Grid>
   );
 }
 


### PR DESCRIPTION
A quick fix for [#1090](https://github.com/Couchers-org/couchers/issues/1090) by 100% height to child divs means that they take the height of their respective row, whether on mobile or desktop

![image](https://user-images.githubusercontent.com/60824744/115732107-97ed0880-a37f-11eb-9a24-8d29e91180df.png)
![image](https://user-images.githubusercontent.com/60824744/115732154-a20f0700-a37f-11eb-8c24-b71b7878ed9e.png)

I'm not sure having friends and requests on the same tab is the best idea, because eventually you'll have way more friends and it'll look really awkward
![image](https://user-images.githubusercontent.com/60824744/115732499-f31efb00-a37f-11eb-960a-24a58c2936c9.png)

The design suggests having Recently Added and Friend Requests as separate tabs (which I'm guessing are the same as our Sent/Received sections), but I couldn't figure out how to do that, and figured it's not the highest priority to spend too much time digging around