### PR TITLE
[MRG] Properly escape slugify in the migration take 2

### DIFF
--- a/app/backend/src/couchers/migrations/versions/2d656b6ad999_fix_slugify.py
+++ b/app/backend/src/couchers/migrations/versions/2d656b6ad999_fix_slugify.py
@@ -23,7 +23,7 @@ def upgrade():
     # e.g. slugify('Detta är ett test!') -> detta-ar-ett-test
     op.execute(
         r"""
-    REPLACE FUNCTION slugify("text" TEXT)
+    CREATE OR REPLACE FUNCTION slugify("text" TEXT)
     RETURNS TEXT AS $$
     SELECT regexp_replace(
       regexp_replace(

--- a/app/backend/src/couchers/migrations/versions/2d656b6ad999_fix_slugify.py
+++ b/app/backend/src/couchers/migrations/versions/2d656b6ad999_fix_slugify.py
@@ -30,7 +30,7 @@ def upgrade():
         substring(
           regexp_replace(
             lower(unaccent("text")),
-            '[^a-z0-9_]+', '-', 'gi'
+            '[^a-z0-9]+', '-', 'gi'
           ) from 0 for 64
         ), '-$', ''
       ), '^-', ''

--- a/app/backend/src/couchers/migrations/versions/2d656b6ad999_fix_slugify.py
+++ b/app/backend/src/couchers/migrations/versions/2d656b6ad999_fix_slugify.py
@@ -30,10 +30,10 @@ def upgrade():
         substring(
           regexp_replace(
             lower(unaccent("text")),
-            '[^a-z0-9\\-_]+', '-', 'gi'
+            '[^a-z0-9_]+', '-', 'gi'
           ) from 0 for 64
-        ), '\-+$', ''
-      ), '^\-', ''
+        ), '-$', ''
+      ), '^-', ''
     );
     $$ LANGUAGE SQL STRICT IMMUTABLE;
     """

--- a/app/backend/src/couchers/migrations/versions/2d656b6ad999_fix_slugify.py
+++ b/app/backend/src/couchers/migrations/versions/2d656b6ad999_fix_slugify.py
@@ -1,0 +1,44 @@
+"""Fix slugify
+
+Revision ID: 2d656b6ad999
+Revises: 723394ace6b5
+Create Date: 2021-04-25 15:43:19.995784
+
+"""
+import geoalchemy2
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2d656b6ad999"
+down_revision = "723394ace6b5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # slugify takes an arbitrary piece of text and turns it into a "slug" by replacing occurences of non-alphanumber
+    # characters with dashes, truncating, and then cleaning that up. We attempt to turn non-ascii characters to close
+    # ascii characters with unaccent. Slugs are useful in URLs, giving users a preview yet being URL "nice".
+    # e.g. slugify('Detta är ett test!') -> detta-ar-ett-test
+    op.execute(
+        r"""
+    REPLACE FUNCTION slugify("text" TEXT)
+    RETURNS TEXT AS $$
+    SELECT regexp_replace(
+      regexp_replace(
+        substring(
+          regexp_replace(
+            lower(unaccent("text")),
+            '[^a-z0-9\\-_]+', '-', 'gi'
+          ) from 0 for 64
+        ), '\-+$', ''
+      ), '^\-', ''
+    );
+    $$ LANGUAGE SQL STRICT IMMUTABLE;
+    """
+    )
+
+
+def downgrade():
+    pass

--- a/app/backend/src/tests/slugify.sql
+++ b/app/backend/src/tests/slugify.sql
@@ -9,7 +9,7 @@ SELECT regexp_replace(
     substring(
       regexp_replace(
         lower(unaccent("text")),
-        '[^a-z0-9_]+', '-', 'gi'
+        '[^a-z0-9]+', '-', 'gi'
       ) from 0 for 64
     ), '-$', ''
   ), '^-', ''

--- a/app/backend/src/tests/slugify.sql
+++ b/app/backend/src/tests/slugify.sql
@@ -9,9 +9,9 @@ SELECT regexp_replace(
     substring(
       regexp_replace(
         lower(unaccent("text")),
-        '[^a-z0-9\-_]+', '-', 'gi'
+        '[^a-z0-9_]+', '-', 'gi'
       ) from 0 for 64
-    ), '\-+$', ''
-  ), '^\-', ''
+    ), '-$', ''
+  ), '^-', ''
 );
 $$ LANGUAGE SQL STRICT IMMUTABLE;

--- a/app/backend/src/tests/test_pages.py
+++ b/app/backend/src/tests/test_pages.py
@@ -177,7 +177,7 @@ def test_create_page_place(db):
         time_before = now()
         res = api.CreatePlace(
             pages_pb2.CreatePlaceReq(
-                title="dummy title",
+                title="dummy !#¤%&/-*' title",
                 content="dummy content",
                 address="dummy address",
                 location=pages_pb2.Coordinate(
@@ -187,7 +187,7 @@ def test_create_page_place(db):
             )
         )
 
-        assert res.title == "dummy title"
+        assert res.title == "dummy !#¤%&/-*' title"
         assert res.type == pages_pb2.PAGE_TYPE_PLACE
         assert res.content == "dummy content"
         assert res.address == "dummy address"


### PR DESCRIPTION
So that it treats dash as a punctation character. Re-applies #1130