### PR TITLE
[MRG] Skip half of the tests now when migrations are proved equal to models

### DIFF
--- a/app/backend/src/tests/test_communities.py
+++ b/app/backend/src/tests/test_communities.py
@@ -22,10 +22,10 @@ from pb import communities_pb2, discussions_pb2, pages_pb2
 from tests.test_fixtures import (
     communities_session,
     db,
-    db_impl,
     discussions_session,
     generate_user,
     pages_session,
+    recreate_database,
     testconfig,
 )
 
@@ -186,8 +186,8 @@ def get_group_id(session, group_name):
 
 
 @pytest.fixture(scope="class")
-def testing_communities(request):
-    db_impl()
+def testing_communities():
+    recreate_database()
     user1, token1 = generate_user(username="user1", geom=create_1d_point(1), geom_radius=0.1)
     user2, token2 = generate_user(username="user2", geom=create_1d_point(2), geom_radius=0.1)
     user3, token3 = generate_user(username="user3", geom=create_1d_point(3), geom_radius=0.1)

--- a/app/backend/src/tests/test_communities.py
+++ b/app/backend/src/tests/test_communities.py
@@ -185,9 +185,9 @@ def get_group_id(session, group_name):
     return session.query(Cluster).filter(~Cluster.is_official_cluster).filter(Cluster.name == group_name).one().id
 
 
-@pytest.fixture(params=["models", "migrations"], scope="class")
+@pytest.fixture(scope="class")
 def testing_communities(request):
-    db_impl(request.param)
+    db_impl()
     user1, token1 = generate_user(username="user1", geom=create_1d_point(1), geom_radius=0.1)
     user2, token2 = generate_user(username="user2", geom=create_1d_point(2), geom_radius=0.1)
     user3, token3 = generate_user(username="user3", geom=create_1d_point(3), geom_radius=0.1)

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -68,7 +68,7 @@ def create_schema_from_models():
     Base.metadata.create_all(get_engine())
 
 
-def db_impl():
+def recreate_database():
     """
     Connect to a running Postgres database, build it using metadata.create_all()
     """
@@ -89,7 +89,7 @@ def db():
     Pytest fixture to connect to a running Postgres database and build it using metadata.create_all()
     """
 
-    db_impl()
+    recreate_database()
 
 
 def generate_user(*_, **kwargs):

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -11,7 +11,7 @@ from sqlalchemy import or_
 
 from couchers.config import config
 from couchers.crypto import random_hex
-from couchers.db import apply_migrations, get_engine, session_scope
+from couchers.db import get_engine, session_scope
 from couchers.models import Base, FriendRelationship, FriendStatus, User
 from couchers.servicers.account import Account
 from couchers.servicers.api import API
@@ -68,37 +68,28 @@ def create_schema_from_models():
     Base.metadata.create_all(get_engine())
 
 
-def db_impl(param):
+def db_impl():
     """
-    Connect to a running Postgres database
-
-    param tells whether the db should be built from alembic migrations or using metadata.create_all()
+    Connect to a running Postgres database, build it using metadata.create_all()
     """
 
     # running in non-UTC catches some timezone errors
-    # os.environ["TZ"] = "Etc/UTC"
     os.environ["TZ"] = "America/New_York"
 
     # drop everything currently in the database
     drop_all()
 
-    if param == "migrations":
-        # rebuild it with alembic migrations
-        apply_migrations()
-    else:
-        # create everything from the current models, not incrementally through migrations
-        create_schema_from_models()
+    # create everything from the current models, not incrementally through migrations
+    create_schema_from_models()
 
 
-@pytest.fixture(params=["migrations", "models"])
-def db(request):
+@pytest.fixture()
+def db():
     """
-    Pytest fixture to connect to a running Postgres database.
-
-    request.param tells whether the db should be built from alembic migrations or using metadata.create_all()
+    Pytest fixture to connect to a running Postgres database and build it using metadata.create_all()
     """
 
-    db_impl(request.param)
+    db_impl()
 
 
 def generate_user(*_, **kwargs):


### PR DESCRIPTION
Skip running all other migration tests after a specific test for migrations was merged in https://github.com/Couchers-org/couchers/pull/885 .

Closes #391