### PR TITLE
chore: remove now redundant service mock workaround

### DIFF
--- a/app/frontend/src/__mocks__/service.ts
+++ b/app/frontend/src/__mocks__/service.ts
@@ -1,3 +1,0 @@
-jest.mock("../service");
-
-export * from "../service";


### PR DESCRIPTION
Turns out this was not needed after all, and was just a bad stopgap solution to hide the fact it was the Storybook mock that was causing weird behaviours and it just so happen to be loaded after it which was not great...

Let's see if CI agrees too...