### PR TITLE
[WIP] Backend/feat/simplifying queries

### DIFF
--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -298,3 +298,12 @@ def all_blocked_or_blocking_users(user_id):
             user_block.blocking_user_id if user_block.blocking_user_id != user_id else user_block.blocked_user_id
             for user_block in relevant_user_blocks
         ]
+
+
+def filter_users_for_visibility_and_blocks(query, requesting_user_id, user_id_column, user_table=User):
+    relevant_blocks = all_blocked_or_blocking_users(requesting_user_id)
+    return (
+        query.join(user_table, user_table.id == user_id_column)
+        .filter(user_table.is_visible)
+        .filter(~user_table.id.in_(relevant_blocks))
+    )

--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -324,3 +324,8 @@ def check_target_user_found(user_id, context):
             context.abort(grpc.StatusCode.NOT_FOUND, errors.USER_NOT_FOUND)
 
         return user
+
+
+def filter_user_table(query, requesting_user_id, table=User):
+    relevant_blocks = all_blocked_or_blocking_users(requesting_user_id)
+    return query.filter(table.is_visible).filter(~table.id.in_(relevant_blocks))

--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -301,8 +301,11 @@ def all_blocked_or_blocking_users(user_id):
         ]
 
 
-def filter_users_for_visibility_and_blocks(query, requesting_user_id, user_id_column, user_table=User):
-    relevant_blocks = all_blocked_or_blocking_users(requesting_user_id)
+def filter_users_for_visibility_and_blocks(
+    query, requesting_user_id, user_id_column, user_table=User, relevant_blocks=None
+):
+    if not relevant_blocks:
+        relevant_blocks = all_blocked_or_blocking_users(requesting_user_id)
     return (
         query.join(user_table, user_table.id == user_id_column)
         .filter(user_table.is_visible)
@@ -310,9 +313,11 @@ def filter_users_for_visibility_and_blocks(query, requesting_user_id, user_id_co
     )
 
 
-def check_target_user_found(user_id, context):
-    with session_scope() as session:
+def check_target_user_found(user_id, context, relevant_blocks=None):
+    if not relevant_blocks:
         relevant_blocks = all_blocked_or_blocking_users(context.user_id)
+
+    with session_scope() as session:
         user = (
             session.query(User)
             .filter(User.is_visible)
@@ -326,6 +331,7 @@ def check_target_user_found(user_id, context):
         return user
 
 
-def filter_user_table(query, requesting_user_id, table=User):
-    relevant_blocks = all_blocked_or_blocking_users(requesting_user_id)
+def filter_user_table(query, requesting_user_id, table=User, relevant_blocks=None):
+    if not relevant_blocks:
+        relevant_blocks = all_blocked_or_blocking_users(requesting_user_id)
     return query.filter(table.is_visible).filter(~table.id.in_(relevant_blocks))

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import aliased
 from sqlalchemy.sql import and_, func, or_
 
 from couchers import errors
-from couchers.db import all_blocked_or_blocking_users, session_scope
+from couchers.db import all_blocked_or_blocking_users, filter_users_for_visibility_and_blocks, session_scope
 from couchers.models import Conversation, HostRequest, HostRequestStatus, Message, MessageType, User
 from couchers.tasks import send_host_request_email
 from couchers.utils import Timestamp_from_datetime, date_to_api, now, parse_date, today_in_timezone
@@ -277,19 +277,22 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         to_users = aliased(User)
 
         with session_scope() as session:
-            relevant_blocks = all_blocked_or_blocking_users(context.user_id)
+            host_request = session.query(HostRequest)
 
-            host_request = (
-                session.query(HostRequest)
-                .join(from_users, from_users.id == HostRequest.from_user_id)
-                .join(to_users, to_users.id == HostRequest.to_user_id)
-                .filter(from_users.is_visible)
-                .filter(to_users.is_visible)
-                .filter(~from_users.id.in_(relevant_blocks))
-                .filter(~to_users.id.in_(relevant_blocks))
-                .filter(HostRequest.conversation_id == request.host_request_id)
-                .one_or_none()
+            host_request = filter_users_for_visibility_and_blocks(
+                query=host_request,
+                requesting_user_id=context.user_id,
+                user_id_column=HostRequest.to_user_id,
+                user_table=from_users,
             )
+            host_request = filter_users_for_visibility_and_blocks(
+                query=host_request,
+                requesting_user_id=context.user_id,
+                user_id_column=HostRequest.from_user_id,
+                user_table=to_users,
+            )
+
+            host_request = host_request.filter(HostRequest.conversation_id == request.host_request_id).one_or_none()
 
             if not host_request:
                 context.abort(grpc.StatusCode.NOT_FOUND, errors.HOST_REQUEST_NOT_FOUND)


### PR DESCRIPTION
Here are three different approaches for standardizing block/visibility filters

Commit 1) Method for joining the user table to any given query and filtering in the process

Commit 2) Standardizing the common queries

Commit 3) Method for filtering user table post-join

I'm partial to 2. Easy to use, very beginner friendly for any of the normal queries and most queries will be covered.

I suspect you'll be partial to 3 if any.

Big downside of 1 & 3 is having to get userblocks every time you query the User table. Could pass it in as an optional parameter (commit 4), but that further complicates the process.