### PR TITLE
Update group message preview when new messages arrive

### DIFF
--- a/app/frontend/src/features/messages/groupchats/GroupChatsTab.tsx
+++ b/app/frontend/src/features/messages/groupchats/GroupChatsTab.tsx
@@ -16,8 +16,12 @@ import { Link } from "react-router-dom";
 import { routeToGroupChat } from "routes";
 import { service } from "service";
 
+import useNotifications from "../../useNotifications";
+
 export default function GroupChatsTab() {
   const classes = useMessageListStyles();
+  const {data: notifications} = useNotifications();
+  const unseenMessageCount = notifications?.unseenMessageCount;
 
   const {
     data,
@@ -27,7 +31,7 @@ export default function GroupChatsTab() {
     fetchNextPage,
     isFetchingNextPage,
   } = useInfiniteQuery<ListGroupChatsRes.AsObject, GrpcError>(
-    groupChatsListKey,
+    [groupChatsListKey, unseenMessageCount],
     ({ pageParam: lastMessageId }) =>
       service.conversations.listGroupChats(lastMessageId),
     {

--- a/app/frontend/src/features/messages/groupchats/GroupChatsTab.tsx
+++ b/app/frontend/src/features/messages/groupchats/GroupChatsTab.tsx
@@ -36,7 +36,7 @@ export default function GroupChatsTab() {
     fetchNextPage,
     isFetchingNextPage,
   } = useInfiniteQuery<ListGroupChatsRes.AsObject, GrpcError>(
-    [groupChatsListKey],
+    groupChatsListKey,
     ({ pageParam: lastMessageId }) =>
       service.conversations.listGroupChats(lastMessageId),
     {

--- a/app/frontend/src/features/messages/groupchats/GroupChatsTab.tsx
+++ b/app/frontend/src/features/messages/groupchats/GroupChatsTab.tsx
@@ -10,9 +10,10 @@ import useMessageListStyles from "features/messages/useMessageListStyles";
 import { Error as GrpcError } from "grpc-web";
 import { ListGroupChatsRes } from "pb/conversations_pb";
 import { groupChatsListKey } from "queryKeys";
-import React from "react";
+import React, { useEffect } from "react";
 import { useInfiniteQuery } from "react-query";
 import { Link } from "react-router-dom";
+import { queryClient } from "reactQueryClient";
 import { routeToGroupChat } from "routes";
 import { service } from "service";
 
@@ -23,6 +24,10 @@ export default function GroupChatsTab() {
   const {data: notifications} = useNotifications();
   const unseenMessageCount = notifications?.unseenMessageCount;
 
+  useEffect(() => {
+    queryClient.invalidateQueries([groupChatsListKey]);
+  }, [unseenMessageCount]);
+
   const {
     data,
     isLoading,
@@ -31,7 +36,7 @@ export default function GroupChatsTab() {
     fetchNextPage,
     isFetchingNextPage,
   } = useInfiniteQuery<ListGroupChatsRes.AsObject, GrpcError>(
-    [groupChatsListKey, unseenMessageCount],
+    [groupChatsListKey],
     ({ pageParam: lastMessageId }) =>
       service.conversations.listGroupChats(lastMessageId),
     {


### PR DESCRIPTION
Added message count as a dependant key for the `listGroupsChats` query so it'll invalidate when it changes.

This won't work for the hosting/surfing tabs unfortunately because the counts are just the requests sent/received not the message count.

This will close #1004