### PR TITLE
Fix search in area

### DIFF
--- a/app/backend/src/couchers/servicers/search.py
+++ b/app/backend/src/couchers/servicers/search.py
@@ -390,12 +390,14 @@ class Search(search_pb2_grpc.SearchServicer):
                 query = query.filter(User.camping_ok == camping_ok.value)
 
             if request.HasField("search_in_area"):
-                # EPSG4326 measures distance in meters
+                # EPSG4326 measures distance in decimal degress
                 # we want to check whether two circles overlap, so check if the distance between their centers is less
-                # than the sum of their radii
+                # than the sum of their radii, divided by 111111 m ~= 1 degree
                 search_point = create_coordinate(request.search_in_area.lat, request.search_in_area.lng)
                 query = query.filter(
-                    func.ST_DWithin(User.geom, search_point, User.geom_radius + request.search_in_area.radius)
+                    func.ST_DWithin(
+                        User.geom, search_point, (User.geom_radius + request.search_in_area.radius) / 111111
+                    )
                 )
             if request.HasField("search_in_community_id"):
                 # could do a join here as well, but this is just simpler

--- a/app/backend/src/couchers/servicers/search.py
+++ b/app/backend/src/couchers/servicers/search.py
@@ -392,7 +392,7 @@ class Search(search_pb2_grpc.SearchServicer):
             if request.HasField("search_in_area"):
                 # EPSG4326 measures distance in decimal degress
                 # we want to check whether two circles overlap, so check if the distance between their centers is less
-                # than the sum of their radii, divided by 111111 m ~= 1 degree
+                # than the sum of their radii, divided by 111111 m ~= 1 degree (at the equator)
                 search_point = create_coordinate(request.search_in_area.lat, request.search_in_area.lng)
                 query = query.filter(
                     func.ST_DWithin(

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -3,6 +3,7 @@ import pytest
 
 from couchers import errors
 from couchers.db import session_scope
+from couchers.utils import create_coordinate
 from pb import search_pb2
 from tests.test_communities import get_community_id, get_group_id, get_user_id_and_token, testing_communities
 from tests.test_fixtures import db, generate_user, groups_session, search_session, testconfig
@@ -44,3 +45,34 @@ def test_UserSearch(testing_communities):
     with search_session(token) as api:
         res = api.UserSearch(search_pb2.UserSearchReq())
         assert len(res.results) > 0
+
+
+def test_regression_search_in_area(db):
+    """
+    Makes sure search_in_area works.
+
+    At the equator/prime meridian intersection (0,0), one degree is roughly 111 km.
+    """
+
+    # outside
+    user1, token1 = generate_user(geom=create_coordinate(1, 0), geom_radius=100)
+    # outside
+    user2, token2 = generate_user(geom=create_coordinate(0, 1), geom_radius=100)
+    # inside
+    user3, token3 = generate_user(geom=create_coordinate(0.1, 0), geom_radius=100)
+    # inside
+    user4, token4 = generate_user(geom=create_coordinate(0, 0.1), geom_radius=100)
+    # outside
+    user5, token5 = generate_user(geom=create_coordinate(10, 10), geom_radius=100)
+
+    with search_session(token5) as api:
+        res = api.UserSearch(
+            search_pb2.UserSearchReq(
+                search_in_area=search_pb2.Area(
+                    lat=0,
+                    lng=0,
+                    radius=100000,
+                )
+            )
+        )
+        assert [result.user.user_id for result in res.results] == [user3.id, user4.id]


### PR DESCRIPTION
Closes #1158. I got the units mixed up.

This does an approximation of 1 degree = 111 111 m, which technically only holds at the equator, and gets worse as one approaches the poles. This is because postgis does the computation in a cartesian plane.

**Backend checklist**
- [x] Formatted my code by running `isort . && black .` in `app/backend`
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history
