### PR TITLE
Make profile card go full width on mobile screens

### DIFF
--- a/app/frontend/src/AppRoute.tsx
+++ b/app/frontend/src/AppRoute.tsx
@@ -67,7 +67,11 @@ export default function AppRoute({
                 [classes.fullscreenContainer]: variant === "full-screen",
                 [classes.standardContainer]: variant === "standard",
               })}
-              maxWidth={variant === "full-screen" ? false : undefined}
+              maxWidth={
+                variant === "full-screen" || variant === "full-width"
+                  ? false
+                  : undefined
+              }
             >
               {isJailed ? (
                 <Redirect to={jailRoute} />

--- a/app/frontend/src/AppRoute.tsx
+++ b/app/frontend/src/AppRoute.tsx
@@ -1,4 +1,5 @@
 import { Container } from "@material-ui/core";
+import classNames from "classnames";
 import ErrorBoundary from "components/ErrorBoundary";
 import { useEffect } from "react";
 import { Redirect, Route, RouteProps } from "react-router-dom";
@@ -23,17 +24,21 @@ export const useStyles = makeStyles((theme) => ({
     paddingLeft: theme.spacing(2),
     paddingRight: theme.spacing(2),
   },
+  fullWidthContainer: {
+    paddingLeft: 0,
+    paddingRight: 0,
+  },
 }));
 
 interface AppRouteProps extends RouteProps {
   isPrivate: boolean;
-  isFullscreen?: boolean;
+  variant?: "standard" | "full-screen" | "full-width";
 }
 
 export default function AppRoute({
   children,
   isPrivate,
-  isFullscreen = false,
+  variant = "standard",
   ...otherProps
 }: AppRouteProps) {
   const { authState, authActions } = useAuthContext();
@@ -54,12 +59,11 @@ export default function AppRoute({
         <>
           {isAuthenticated ? (
             <Container
-              className={
-                isFullscreen
-                  ? classes.fullscreenContainer
-                  : classes.standardContainer
-              }
-              maxWidth={isFullscreen ? false : undefined}
+              className={classNames({
+                [classes.standardContainer]:
+                  variant === "standard" || variant === "full-width",
+                [classes.fullWidthContainer]: variant === "full-width",
+              })}
             >
               {isJailed ? (
                 <Redirect to={jailRoute} />
@@ -82,16 +86,29 @@ export default function AppRoute({
       )}
     />
   ) : (
-    <Container
-      className={
-        isFullscreen ? classes.fullscreenContainer : classes.standardContainer
-      }
-      maxWidth={isFullscreen ? false : undefined}
-    >
-      <Route
-        {...otherProps}
-        render={() => <ErrorBoundary>{children}</ErrorBoundary>}
-      />
-    </Container>
+    <>
+      {variant === "full-screen" || variant === "full-width" ? (
+        <Container
+          className={classNames({
+            [classes.fullscreenContainer]: variant === "full-screen",
+            [classes.fullWidthContainer]: variant === "full-width",
+          })}
+          maxWidth={false}
+        >
+          <Route
+            {...otherProps}
+            render={() => <ErrorBoundary>{children}</ErrorBoundary>}
+          />
+        </Container>
+      ) : (
+        <Container className={classes.standardContainer}>
+          <Navigation />
+          <Route
+            {...otherProps}
+            render={() => <ErrorBoundary>{children}</ErrorBoundary>}
+          />
+        </Container>
+      )}
+    </>
   );
 }

--- a/app/frontend/src/AppRoute.tsx
+++ b/app/frontend/src/AppRoute.tsx
@@ -27,6 +27,7 @@ export const useStyles = makeStyles((theme) => ({
     paddingRight: theme.spacing(2),
   },
   fullWidthContainer: {
+    margin: "0 auto",
     paddingLeft: 0,
     paddingRight: 0,
   },

--- a/app/frontend/src/AppRoute.tsx
+++ b/app/frontend/src/AppRoute.tsx
@@ -14,13 +14,15 @@ export const useStyles = makeStyles((theme) => ({
     margin: "0 auto",
     padding: 0,
   },
-  standardContainer: {
+  nonFullScreenStyles: {
     height: "100%",
     [theme.breakpoints.up("md")]: {
       paddingBottom: 0,
       paddingTop: theme.shape.navPaddingDesktop,
     },
     paddingTop: theme.shape.navPaddingMobile,
+  },
+  standardContainer: {
     paddingLeft: theme.spacing(2),
     paddingRight: theme.spacing(2),
   },
@@ -60,16 +62,18 @@ export default function AppRoute({
           {isAuthenticated ? (
             <Container
               className={classNames({
-                [classes.standardContainer]:
-                  variant === "standard" || variant === "full-width",
+                [classes.nonFullScreenStyles]: variant !== "full-screen",
                 [classes.fullWidthContainer]: variant === "full-width",
+                [classes.fullscreenContainer]: variant === "full-screen",
+                [classes.standardContainer]: variant === "standard",
               })}
+              maxWidth={variant === "full-screen" ? false : undefined}
             >
               {isJailed ? (
                 <Redirect to={jailRoute} />
               ) : (
                 <>
-                  <Navigation />
+                  {variant !== "full-screen" && <Navigation />}
                   <ErrorBoundary>{children}</ErrorBoundary>
                 </>
               )}
@@ -86,29 +90,20 @@ export default function AppRoute({
       )}
     />
   ) : (
-    <>
-      {variant === "full-screen" || variant === "full-width" ? (
-        <Container
-          className={classNames({
-            [classes.fullscreenContainer]: variant === "full-screen",
-            [classes.fullWidthContainer]: variant === "full-width",
-          })}
-          maxWidth={false}
-        >
-          <Route
-            {...otherProps}
-            render={() => <ErrorBoundary>{children}</ErrorBoundary>}
-          />
-        </Container>
-      ) : (
-        <Container className={classes.standardContainer}>
-          <Navigation />
-          <Route
-            {...otherProps}
-            render={() => <ErrorBoundary>{children}</ErrorBoundary>}
-          />
-        </Container>
-      )}
-    </>
+    <Container
+      className={classNames({
+        [classes.nonFullScreenStyles]: variant !== "full-screen",
+        [classes.fullscreenContainer]: variant === "full-screen",
+        [classes.fullWidthContainer]: variant === "full-width",
+        [classes.standardContainer]: variant === "standard",
+      })}
+      maxWidth={variant === "full-screen" ? false : undefined}
+    >
+      {variant !== "full-screen" && <Navigation />}
+      <Route
+        {...otherProps}
+        render={() => <ErrorBoundary>{children}</ErrorBoundary>}
+      />
+    </Container>
   );
 }

--- a/app/frontend/src/AppRoutes.tsx
+++ b/app/frontend/src/AppRoutes.tsx
@@ -68,7 +68,7 @@ export default function AppRoutes() {
       }
       <AppRoute
         isPrivate={isAuthenticated}
-        isFullscreen={!isAuthenticated}
+        variant={!isAuthenticated ? "full-screen" : "standard"}
         exact
         path={baseRoute}
       >
@@ -76,20 +76,25 @@ export default function AppRoutes() {
       </AppRoute>
       <AppRoute
         isPrivate={false}
-        isFullscreen
+        variant="full-screen"
         path={`${loginRoute}/:urlToken?`}
       >
         <Login />
       </AppRoute>
       <AppRoute
         isPrivate={false}
-        isFullscreen
+        variant="full-screen"
         path={`${signupRoute}/:urlToken?`}
       >
         <Signup />
       </AppRoute>
 
-      <AppRoute isPrivate={false} isFullscreen exact path={resetPasswordRoute}>
+      <AppRoute
+        isPrivate={false}
+        variant="full-screen"
+        exact
+        path={resetPasswordRoute}
+      >
         <ResetPassword />
       </AppRoute>
       <AppRoute
@@ -105,7 +110,7 @@ export default function AppRoutes() {
       >
         <ConfirmChangeEmail />
       </AppRoute>
-      <AppRoute isPrivate={false} path={tosRoute}>
+      <AppRoute variant="full-screen" isPrivate={false} path={tosRoute}>
         <TOS />
       </AppRoute>
       <AppRoute isPrivate path={settingsRoute}>
@@ -121,7 +126,12 @@ export default function AppRoutes() {
       {
         // CONTRIBUTE
       }
-      <AppRoute isPrivate={false} isFullscreen exact path={contributeRoute}>
+      <AppRoute
+        isPrivate={false}
+        variant="full-screen"
+        exact
+        path={contributeRoute}
+      >
         <Contribute />
       </AppRoute>
 
@@ -134,7 +144,7 @@ export default function AppRoutes() {
       <AppRoute isPrivate path={editHostingPreferenceRoute}>
         <EditHostingPreference />
       </AppRoute>
-      <AppRoute isPrivate path={`${userRoute}/:username?`}>
+      <AppRoute variant="full-width" isPrivate path={`${userRoute}/:username?`}>
         <ProfilePage />
       </AppRoute>
       <AppRoute isPrivate path={`${connectionsRoute}/:type?`}>

--- a/app/frontend/src/AppRoutes.tsx
+++ b/app/frontend/src/AppRoutes.tsx
@@ -169,7 +169,7 @@ export default function AppRoutes() {
       {
         // SEARCH
       }
-      <AppRoute isPrivate isFullscreen={true} path={`${searchRoute}/:query?`}>
+      <AppRoute isPrivate variant="full-width" path={`${searchRoute}/:query?`}>
         <SearchPage />
       </AppRoute>
 

--- a/app/frontend/src/features/profile/view/ProfilePage.tsx
+++ b/app/frontend/src/features/profile/view/ProfilePage.tsx
@@ -41,8 +41,10 @@ const useStyles = makeStyles((theme) => ({
   root: {
     paddingTop: theme.spacing(3),
     [theme.breakpoints.up("md")]: {
-      paddingTop: 0,
       display: "flex",
+      maxWidth: theme.breakpoints.values.lg,
+      margin: "0 auto",
+      paddingTop: 0,
     },
   },
   tabPanel: {

--- a/app/frontend/src/features/search/SearchPage.tsx
+++ b/app/frontend/src/features/search/SearchPage.tsx
@@ -20,11 +20,9 @@ const useStyles = makeStyles((theme) => ({
     alignContent: "stretch",
     flexDirection: "column-reverse",
     height: `calc(100vh - ${theme.shape.navPaddingMobile})`,
-    marginTop: theme.shape.navPaddingMobile,
     [theme.breakpoints.up("md")]: {
       flexDirection: "row",
       height: `calc(100vh - ${theme.shape.navPaddingDesktop})`,
-      marginTop: theme.shape.navPaddingDesktop,
     },
   },
   mapContainer: {


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
As requested by Itsi in the frontend chat, so now on mobile screen it looks like this:

![Screenshot 2021-05-02 at 00 28 38](https://user-images.githubusercontent.com/13669362/116952313-451a2780-ac82-11eb-9a97-135e71a0ceee.png)


<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on frontend)
If you need help with any of these, please ask :)
--->

**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
