### PR TITLE
Route org.couchers.resources into the open servicer in envoy

### DIFF
--- a/app/proxy/envoy.yaml
+++ b/app/proxy/envoy.yaml
@@ -28,6 +28,10 @@ static_resources:
                 route:
                   cluster: open_service
                   max_grpc_timeout: 0s
+              - match: { prefix: "/org.couchers.resources" }
+                route:
+                  cluster: open_service
+                  max_grpc_timeout: 0s
               - match: { prefix: "/org.couchers.jail" }
                 route:
                   cluster: jail_service


### PR DESCRIPTION
Closes #1186 (that was a quick issue I opened so I didn't forget)