### PR TITLE
Remove coordinates in guide data that was breaking the dummy_data script

### DIFF
--- a/app/backend/src/data/dummy_communities.json
+++ b/app/backend/src/data/dummy_communities.json
@@ -267,8 +267,7 @@
       "owner": "Sydney",
       "title": "A Guide to Sightseeing in Sydney",
       "creator": "itsi",
-      "content": "# A Guide to Sightseeing in Sydney\n\nEmpty for now.",
-      "coordinate": [151.197933, -33.851041]
+      "content": "# A Guide to Sightseeing in Sydney\n\nEmpty for now."
     },
     {
       "owner": "Sydney",


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

As in title. Before this change I was getting this error:

```
(psycopg2.errors.CheckViolation) new row for relation "page_versions" violates check constraint "ck_page_versions_geom_iff_address"
backend_1   | DETAIL:  Failing row contains (72, 172, 2, A Guide to Sightseeing in Sydney, # A Guide to Sightseeing in Sydney
```

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on frontend)
If you need help with any of these, please ask :)
--->
**Backend checklist**
- [ ] Formatted my code by running `isort . && black .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
