### PR TITLE
Discussion part 5: Wrap discussion page around community base

### DIFF
--- a/app/frontend/src/features/communities/CommunityBase.tsx
+++ b/app/frontend/src/features/communities/CommunityBase.tsx
@@ -43,12 +43,14 @@ interface CommunityBaseProps {
     community: Community.AsObject;
     communitySlug?: string;
   }): React.ReactElement;
-  communityId?: string;
+  communityId?: number;
+  defaultTab?: CommunityTab;
 }
 
 export default function CommunityBase({
   children,
   communityId,
+  defaultTab,
 }: CommunityBaseProps) {
   const classes = useCommunityBaseStyles();
 
@@ -61,16 +63,16 @@ export default function CommunityBase({
     isLoading: isCommunityLoading,
     error: communityError,
     data: community,
-  } = useCommunity(+(communityId ?? communityIdFromUrl));
+  } = useCommunity(communityId ?? +communityIdFromUrl);
 
   const history = useHistory();
 
   const { page = "overview" } = useParams<{ page: string }>();
-  const tab = communitySlug
-    ? page in communityTabBarLabels
-      ? (page as CommunityTab)
-      : "overview"
-    : "unselected";
+
+  // Use default tab from prop, otherwise derived state from community URL
+  const tab =
+    defaultTab ??
+    (page in communityTabBarLabels ? (page as CommunityTab) : "overview");
 
   if (!communityId && !communityIdFromUrl)
     return <Alert severity="error">{INVALID_COMMUNITY_ID}</Alert>;

--- a/app/frontend/src/features/communities/CommunityBase.tsx
+++ b/app/frontend/src/features/communities/CommunityBase.tsx
@@ -1,0 +1,129 @@
+import { Breadcrumbs, Link as MuiLink } from "@material-ui/core";
+import { TabContext } from "@material-ui/lab";
+import Alert from "components/Alert";
+import CircularProgress from "components/CircularProgress";
+import TabBar from "components/TabBar";
+import {
+  COMMUNITY_TABS_A11Y_LABEL,
+  communityTabBarLabels,
+  ERROR_LOADING_COMMUNITY,
+  INVALID_COMMUNITY_ID,
+} from "features/communities/constants";
+import { useCommunity } from "features/communities/hooks";
+import { Community } from "pb/communities_pb";
+import { CommunityParent } from "pb/groups_pb";
+import React from "react";
+import { Link, useHistory, useParams } from "react-router-dom";
+import { CommunityTab, routeToCommunity } from "routes";
+import makeStyles from "utils/makeStyles";
+
+import HeaderImage from "./CommunityPage/HeaderImage";
+
+export const useCommunityBaseStyles = makeStyles((theme) => ({
+  root: {
+    marginBottom: theme.spacing(2),
+  },
+  center: {
+    display: "block",
+    marginLeft: "auto",
+    marginRight: "auto",
+  },
+  header: {
+    marginBottom: theme.spacing(1),
+  },
+  breadcrumbs: {
+    "& ol": {
+      justifyContent: "flex-start",
+    },
+  },
+}));
+
+interface CommunityBaseProps {
+  children(communityParams: {
+    community: Community.AsObject;
+    communitySlug?: string;
+  }): React.ReactElement;
+  communityId?: string;
+}
+
+export default function CommunityBase({
+  children,
+  communityId,
+}: CommunityBaseProps) {
+  const classes = useCommunityBaseStyles();
+
+  const { communityId: communityIdFromUrl, communitySlug } = useParams<{
+    communityId: string;
+    communitySlug?: string;
+  }>();
+
+  const {
+    isLoading: isCommunityLoading,
+    error: communityError,
+    data: community,
+  } = useCommunity(+(communityId ?? communityIdFromUrl));
+
+  const history = useHistory();
+
+  const { page = "overview" } = useParams<{ page: string }>();
+  const tab = communitySlug
+    ? page in communityTabBarLabels
+      ? (page as CommunityTab)
+      : "overview"
+    : "unselected";
+
+  if (!communityId && !communityIdFromUrl)
+    return <Alert severity="error">{INVALID_COMMUNITY_ID}</Alert>;
+
+  if (isCommunityLoading)
+    return <CircularProgress className={classes.center} />;
+
+  if (!community || communityError)
+    return (
+      <Alert severity="error">
+        {communityError?.message || ERROR_LOADING_COMMUNITY}
+      </Alert>
+    );
+
+  return (
+    <div className={classes.root}>
+      <HeaderImage community={community} className={classes.header} />
+      <Breadcrumbs aria-label="breadcrumb" className={classes.breadcrumbs}>
+        {community.parentsList
+          .map((parent) => parent.community)
+          .filter(
+            (communityParent): communityParent is CommunityParent.AsObject =>
+              !!communityParent
+          )
+          .map((communityParent) => (
+            <MuiLink
+              component={Link}
+              to={routeToCommunity(
+                communityParent.communityId,
+                communityParent.slug
+              )}
+              key={`breadcrumb-${communityParent?.communityId}`}
+            >
+              {communityParent.name}
+            </MuiLink>
+          ))}
+      </Breadcrumbs>
+      <TabContext value={tab}>
+        <TabBar
+          ariaLabel={COMMUNITY_TABS_A11Y_LABEL}
+          setValue={(newTab) =>
+            history.push(
+              `${routeToCommunity(
+                community.communityId,
+                community.slug,
+                newTab === "overview" ? undefined : newTab
+              )}`
+            )
+          }
+          labels={communityTabBarLabels}
+        />
+      </TabContext>
+      {children({ community, communitySlug })}
+    </div>
+  );
+}

--- a/app/frontend/src/features/communities/CommunityPage/CommunityPage.tsx
+++ b/app/frontend/src/features/communities/CommunityPage/CommunityPage.tsx
@@ -1,61 +1,19 @@
-import { Breadcrumbs, Link as MuiLink, Typography } from "@material-ui/core";
-import { TabContext } from "@material-ui/lab";
-import Alert from "components/Alert";
-import CircularProgress from "components/CircularProgress";
-import TabBar from "components/TabBar";
-import {
-  COMMUNITY_HEADING,
-  COMMUNITY_TABS_A11Y_LABEL,
-  communityTabBarLabels,
-  ERROR_LOADING_COMMUNITY,
-  INVALID_COMMUNITY_ID,
-  MORE_TIPS,
-} from "features/communities/constants";
-import { useCommunity } from "features/communities/hooks";
-import { CommunityParent } from "pb/groups_pb";
-import { useEffect } from "react";
-import {
-  Link,
-  Redirect,
-  Route,
-  Switch,
-  useHistory,
-  useParams,
-} from "react-router-dom";
-import {
-  communityRoute,
-  CommunityTab,
-  routeToCommunity,
-  searchRoute,
-} from "routes";
+import { Link as MuiLink, Typography } from "@material-ui/core";
+import { COMMUNITY_HEADING, MORE_TIPS } from "features/communities/constants";
+import { Link, Redirect, Route, Switch } from "react-router-dom";
+import { communityRoute, routeToCommunity, searchRoute } from "routes";
 import makeStyles from "utils/makeStyles";
 
+import CommunityBase from "../CommunityBase";
 import { DiscussionsListPage, DiscussionsSection } from "../discussions";
 import EventsSection from "./EventsSection";
-import HeaderImage from "./HeaderImage";
 import PlacesSection from "./PlacesSection";
 
 export const useCommunityPageStyles = makeStyles((theme) => ({
-  root: {
-    marginBottom: theme.spacing(2),
-  },
-  center: {
-    display: "block",
-    marginLeft: "auto",
-    marginRight: "auto",
-  },
-  header: {
-    marginBottom: theme.spacing(1),
-  },
   title: {
     marginBottom: 0,
     marginTop: 0,
     ...theme.typography.h1Large,
-  },
-  breadcrumbs: {
-    "& ol": {
-      justifyContent: "flex-start",
-    },
   },
   description: {
     marginBottom: theme.spacing(1),
@@ -111,151 +69,91 @@ export const useCommunityPageStyles = makeStyles((theme) => ({
 export default function CommunityPage() {
   const classes = useCommunityPageStyles();
 
-  const { communityId, communitySlug } = useParams<{
-    communityId: string;
-    communitySlug?: string;
-  }>();
-
-  const {
-    isLoading: isCommunityLoading,
-    error: communityError,
-    data: community,
-  } = useCommunity(+communityId);
-
-  const history = useHistory();
-  useEffect(() => {
-    if (!community) return;
-    if (community.slug !== communitySlug) {
-      // if the address is wrong, redirect to the right place
-      history.replace(routeToCommunity(community.communityId, community.slug));
-    }
-  }, [community, communitySlug, history]);
-
-  const { page = "overview" } = useParams<{ page: string }>();
-  const tab =
-    page in communityTabBarLabels ? (page as CommunityTab) : "overview";
-
-  if (!communityId)
-    return <Alert severity="error">{INVALID_COMMUNITY_ID}</Alert>;
-
-  if (isCommunityLoading)
-    return <CircularProgress className={classes.center} />;
-
-  if (!community || communityError)
-    return (
-      <Alert severity="error">
-        {communityError?.message || ERROR_LOADING_COMMUNITY}
-      </Alert>
-    );
-
   return (
-    <div className={classes.root}>
-      <HeaderImage community={community} className={classes.header} />
-      <Breadcrumbs aria-label="breadcrumb" className={classes.breadcrumbs}>
-        {community.parentsList
-          .map((parent) => parent.community)
-          .filter(
-            (communityParent): communityParent is CommunityParent.AsObject =>
-              !!communityParent
-          )
-          .map((communityParent) => (
-            <MuiLink
-              component={Link}
-              to={routeToCommunity(
-                communityParent.communityId,
-                communityParent.slug
-              )}
-              key={`breadcrumb-${communityParent?.communityId}`}
-            >
-              {communityParent.name}
-            </MuiLink>
-          ))}
-      </Breadcrumbs>
-      <TabContext value={tab}>
-        <TabBar
-          ariaLabel={COMMUNITY_TABS_A11Y_LABEL}
-          setValue={(newTab) =>
-            history.push(
-              `${routeToCommunity(
-                community.communityId,
-                community.slug,
-                newTab === "overview" ? undefined : newTab
-              )}`
-            )
-          }
-          labels={communityTabBarLabels}
-        />
-      </TabContext>
-      <Switch>
-        <Route
-          path={routeToCommunity(community.communityId, community.slug)}
-          exact
-        >
-          <Typography variant="h1" className={classes.title}>
-            {COMMUNITY_HEADING(community.name)}
-          </Typography>
-          <Typography variant="body2" className={classes.description}>
-            {community.description}{" "}
-            <MuiLink component={Link} to="#">
-              {MORE_TIPS}
-            </MuiLink>
-          </Typography>
-        </Route>
-      </Switch>
+    <CommunityBase>
+      {({ community, communitySlug }) => {
+        if (community && community.slug !== communitySlug) {
+          return (
+            <Redirect
+              to={routeToCommunity(community.communityId, community.slug)}
+            />
+          );
+        }
+        return (
+          <>
+            <Switch>
+              <Route
+                path={routeToCommunity(community.communityId, community.slug)}
+                exact
+              >
+                <Typography variant="h1" className={classes.title}>
+                  {COMMUNITY_HEADING(community.name)}
+                </Typography>
+                <Typography variant="body2" className={classes.description}>
+                  {community.description}{" "}
+                  <MuiLink component={Link} to="#">
+                    {MORE_TIPS}
+                  </MuiLink>
+                </Typography>
+              </Route>
+            </Switch>
 
-      <Switch>
-        <Route
-          path={routeToCommunity(
-            community.communityId,
-            community.slug,
-            "find-host"
-          )}
-        >
-          <Redirect to={searchRoute} />
-        </Route>
-        <Route
-          path={routeToCommunity(
-            community.communityId,
-            community.slug,
-            "events"
-          )}
-        >
-          <p>Replace this with full events page</p>
-          <EventsSection community={community} />
-        </Route>
-        <Route
-          path={routeToCommunity(
-            community.communityId,
-            community.slug,
-            "local-points"
-          )}
-        >
-          <p>Local points coming soon</p>
-        </Route>
-        <Route
-          path={routeToCommunity(
-            community.communityId,
-            community.slug,
-            "discussions"
-          )}
-        >
-          <DiscussionsListPage community={community} />
-        </Route>
-        <Route
-          path={routeToCommunity(
-            community.communityId,
-            community.slug,
-            "hangouts"
-          )}
-        >
-          <p>Hangouts coming soon!</p>
-        </Route>
-        <Route path={communityRoute} exact>
-          <EventsSection community={community} />
-          <PlacesSection community={community} />
-          <DiscussionsSection community={community} />
-        </Route>
-      </Switch>
-    </div>
+            <Switch>
+              <Route
+                path={routeToCommunity(
+                  community.communityId,
+                  community.slug,
+                  "find-host"
+                )}
+              >
+                <Redirect to={searchRoute} />
+              </Route>
+              <Route
+                path={routeToCommunity(
+                  community.communityId,
+                  community.slug,
+                  "events"
+                )}
+              >
+                <p>Replace this with full events page</p>
+                <EventsSection community={community} />
+              </Route>
+              <Route
+                path={routeToCommunity(
+                  community.communityId,
+                  community.slug,
+                  "local-points"
+                )}
+              >
+                <p>Local points coming soon</p>
+              </Route>
+              <Route
+                path={routeToCommunity(
+                  community.communityId,
+                  community.slug,
+                  "discussions"
+                )}
+              >
+                <DiscussionsListPage community={community} />
+              </Route>
+              <Route
+                path={routeToCommunity(
+                  community.communityId,
+                  community.slug,
+                  "hangouts"
+                )}
+              >
+                <p>Hangouts coming soon!</p>
+              </Route>
+              <Route path={communityRoute} exact>
+                <EventsSection community={community} />
+                <PlacesSection community={community} />
+                <DiscussionsSection community={community} />
+              </Route>
+            </Switch>
+          </>
+        );
+      }}
+    </CommunityBase>
   );
 }

--- a/app/frontend/src/features/communities/discussions/DiscussionPage.test.tsx
+++ b/app/frontend/src/features/communities/discussions/DiscussionPage.test.tsx
@@ -12,6 +12,7 @@ import { Route, Switch } from "react-router-dom";
 import { discussionBaseRoute, discussionRoute } from "routes";
 import { service } from "service";
 import comments from "test/fixtures/comments.json";
+import community from "test/fixtures/community.json";
 import discussions from "test/fixtures/discussions.json";
 import { getHookWrapperWithClient } from "test/hookWrapper";
 import { getThread, getUser } from "test/serviceMockDefaults";
@@ -41,6 +42,9 @@ jest.mock("components/MarkdownInput");
 
 const getUserMock = service.user.getUser as MockedService<
   typeof service.user.getUser
+>;
+const getCommunityMock = service.communities.getCommunity as MockedService<
+  typeof service.communities.getCommunity
 >;
 const getDiscussionMock = service.discussions.getDiscussion as MockedService<
   typeof service.discussions.getDiscussion
@@ -115,6 +119,7 @@ describe("Discussion page", () => {
 
   beforeEach(() => {
     getUserMock.mockImplementation(getUser);
+    getCommunityMock.mockResolvedValue(community);
     getDiscussionMock.mockResolvedValue(discussions[0]);
     getThreadMock.mockImplementation(getThread);
     postReplyMock.mockResolvedValue({

--- a/app/frontend/src/features/communities/discussions/DiscussionPage.tsx
+++ b/app/frontend/src/features/communities/discussions/DiscussionPage.tsx
@@ -17,6 +17,7 @@ import { service } from "service";
 import { dateFormatter, timestamp2Date } from "utils/date";
 import makeStyles from "utils/makeStyles";
 
+import CommunityBase from "../CommunityBase";
 import { CREATED_AT, PREVIOUS_PAGE, UNKNOWN_USER } from "../constants";
 import CommentTree from "./CommentTree";
 
@@ -81,47 +82,56 @@ export default function DiscussionPage() {
         <CircularProgress />
       ) : (
         discussion && (
-          <div className={classes.root}>
-            <div className={classes.header}>
-              <HeaderButton
-                onClick={() => history.goBack()}
-                aria-label={PREVIOUS_PAGE}
-              >
-                <BackIcon />
-              </HeaderButton>
-              <PageTitle className={classes.discussionTitle}>
-                {discussion.title}
-              </PageTitle>
-            </div>
-            <Markdown
-              className={classes.discussionContent}
-              source={discussion.content}
-            />
-            <div
-              className={classes.creatorContainer}
-              data-testid={CREATOR_TEST_ID}
-            >
-              <Avatar user={discussionCreator} className={classes.avatar} />
-              <div className={classes.creatorDetailsContainer}>
-                {isCreatorLoading ? (
-                  <Skeleton width={100} />
-                ) : (
-                  <Typography variant="body1">
-                    {discussionCreator?.name ?? UNKNOWN_USER}
-                  </Typography>
-                )}
-                {isCreatorLoading ? (
-                  <Skeleton width={100} />
-                ) : (
-                  <Typography variant="body2">
-                    {CREATED_AT}
-                    {dateFormatter.format(timestamp2Date(discussion.created!))}
-                  </Typography>
-                )}
+          <CommunityBase
+            communityId={discussion.ownerCommunityId}
+            defaultTab="discussions"
+          >
+            {() => (
+              <div className={classes.root}>
+                <div className={classes.header}>
+                  <HeaderButton
+                    onClick={() => history.goBack()}
+                    aria-label={PREVIOUS_PAGE}
+                  >
+                    <BackIcon />
+                  </HeaderButton>
+                  <PageTitle className={classes.discussionTitle}>
+                    {discussion.title}
+                  </PageTitle>
+                </div>
+                <Markdown
+                  className={classes.discussionContent}
+                  source={discussion.content}
+                />
+                <div
+                  className={classes.creatorContainer}
+                  data-testid={CREATOR_TEST_ID}
+                >
+                  <Avatar user={discussionCreator} className={classes.avatar} />
+                  <div className={classes.creatorDetailsContainer}>
+                    {isCreatorLoading ? (
+                      <Skeleton width={100} />
+                    ) : (
+                      <Typography variant="body1">
+                        {discussionCreator?.name ?? UNKNOWN_USER}
+                      </Typography>
+                    )}
+                    {isCreatorLoading ? (
+                      <Skeleton width={100} />
+                    ) : (
+                      <Typography variant="body2">
+                        {CREATED_AT}
+                        {dateFormatter.format(
+                          timestamp2Date(discussion.created!)
+                        )}
+                      </Typography>
+                    )}
+                  </div>
+                </div>
+                <CommentTree threadId={discussion.thread!.threadId} />
               </div>
-            </div>
-            <CommentTree threadId={discussion.thread!.threadId} />
-          </div>
+            )}
+          </CommunityBase>
         )
       )}
     </>

--- a/app/frontend/src/test/fixtures/community.json
+++ b/app/frontend/src/test/fixtures/community.json
@@ -17,7 +17,7 @@
     "threadId": 5,
     "title": "Amsterdam community page",
     "content": "Stroopwafels",
-    "photoUrl": "",
+    "photoUrl": "amsterdam.jpg",
     "address": "",
     "editorUserIdsList": [3],
     "canEdit": false,


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
This should be final part for discussion and thus closes #543.

Main changes involve refactoring/splitting the community page into a community base and the rest, so the base can be re-used on the discussion page to include the outer community page styling.

**Desktop**
![Screenshot 2021-05-18 at 01 12 00](https://user-images.githubusercontent.com/13669362/118571526-32b9e680-b776-11eb-81b9-a7f2245a9c7c.png)

**Mobile**
![Screenshot 2021-05-18 at 01 12 26](https://user-images.githubusercontent.com/13669362/118571538-36e60400-b776-11eb-9a27-c2bb32f3de65.png)

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on frontend)
If you need help with any of these, please ask :)
--->
**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
