### PR TITLE
Reduce massive gap between logo and couchers.org logo text

### DIFF
--- a/app/frontend/src/components/Navigation/Navigation.tsx
+++ b/app/frontend/src/components/Navigation/Navigation.tsx
@@ -76,6 +76,9 @@ const useStyles = makeStyles((theme) => ({
     fontWeight: "bold",
     paddingLeft: theme.spacing(1),
   },
+  logoText: {
+    marginInlineStart: theme.spacing(3),
+  },
   gutters: {
     [theme.breakpoints.up("md")]: {
       paddingLeft: theme.spacing(3),
@@ -208,7 +211,9 @@ export default function Navigation() {
           </Hidden>
           <CouchersLogo />
           <Hidden smDown>
-            <div className={authClasses.logo}>{COUCHERS}</div>
+            <div className={classNames(authClasses.logo, classes.logoText)}>
+              {COUCHERS}
+            </div>
           </Hidden>
           <Hidden smDown>
             <div className={classes.flex}>

--- a/app/frontend/src/resources/CouchersLogo.tsx
+++ b/app/frontend/src/resources/CouchersLogo.tsx
@@ -2,6 +2,10 @@ import { Chip, SvgIcon, SvgIconProps } from "@material-ui/core";
 import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
+  root: {
+    display: "flex",
+    position: "relative",
+  },
   logo: {
     fill: theme.palette.secondary.main,
     height: theme.typography.pxToRem(50),
@@ -9,17 +13,15 @@ const useStyles = makeStyles((theme) => ({
   },
   sticker: {
     fontSize: "0.8rem",
-    position: "relative",
-    left: "-1.8rem",
-    top: "-1.2rem",
-    transform: "rotate(15deg)",
+    position: "absolute",
+    transform: `rotate(15deg) translate(1.25rem, -0.625rem)`,
   },
 }));
 
 export default function CouchersLogo(props: SvgIconProps) {
   const classes = useStyles();
   return (
-    <>
+    <div className={classes.root}>
       <SvgIcon
         {...props}
         className={classes.logo}
@@ -52,6 +54,6 @@ export default function CouchersLogo(props: SvgIconProps) {
         className={classes.sticker}
         label="Beta"
       />
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
As in title - the massive gap caused by the rotated chip taking up space when it doesn't need to was annoying me. Here's what it looks like now:
![Screenshot 2021-05-18 at 00 55 23](https://user-images.githubusercontent.com/13669362/118570276-bfaf7080-b773-11eb-94c1-ebd4bc64d42f.png)

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on frontend)
If you need help with any of these, please ask :)
--->
**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
