### PR TITLE
Use dropdown without auto completion for simple lists in edit hosting preferences form

### DIFF
--- a/app/frontend/src/components/Select.stories.tsx
+++ b/app/frontend/src/components/Select.stories.tsx
@@ -1,0 +1,21 @@
+import { Meta, Story } from "@storybook/react";
+
+import Select from "./Select";
+
+export default {
+  component: Select,
+  title: "Components/Simple/Select",
+} as Meta;
+
+const Template: Story<{ options: string[] }> = ({ options }) => (
+  <Select>
+    {options.map((o) => (
+      <option value={o}>{o}</option>
+    ))}
+  </Select>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  options: ["foo bar", "lorem", "ipsum"],
+};

--- a/app/frontend/src/components/Select.stories.tsx
+++ b/app/frontend/src/components/Select.stories.tsx
@@ -19,3 +19,26 @@ export const Default = Template.bind({});
 Default.args = {
   options: ["foo bar", "lorem", "ipsum"],
 };
+
+const WithDataTemplate: Story<{
+  options: (1 | 2 | 3 | 4)[];
+  value: 1 | 2 | 3 | 4;
+}> = ({ options, value }) => (
+  <Select
+    id="story-select-with-data"
+    data={{
+      1: "label for value 1",
+      2: "label for value 2",
+      3: "label for value 3",
+      4: "label for value 4",
+    }}
+    defaultValue={value}
+    options={options}
+  ></Select>
+);
+
+export const WithData = WithDataTemplate.bind({});
+WithData.args = {
+  options: [1, 3, 4],
+  value: 3,
+};

--- a/app/frontend/src/components/Select.stories.tsx
+++ b/app/frontend/src/components/Select.stories.tsx
@@ -7,26 +7,13 @@ export default {
   title: "Components/Simple/Select",
 } as Meta;
 
-const Template: Story<{ options: string[] }> = ({ options }) => (
-  <Select id="story-select">
-    {options.map((o) => (
-      <option value={o}>{o}</option>
-    ))}
-  </Select>
-);
-
-export const Default = Template.bind({});
-Default.args = {
-  options: ["foo bar", "lorem", "ipsum"],
-};
-
-const WithDataTemplate: Story<{
+const Template: Story<{
   options: (1 | 2 | 3 | 4)[];
   value: 1 | 2 | 3 | 4;
 }> = ({ options, value }) => (
   <Select
     id="story-select-with-data"
-    data={{
+    optionLabelMap={{
       1: "label for value 1",
       2: "label for value 2",
       3: "label for value 3",
@@ -37,8 +24,8 @@ const WithDataTemplate: Story<{
   ></Select>
 );
 
-export const WithData = WithDataTemplate.bind({});
-WithData.args = {
+export const Default = Template.bind({});
+Default.args = {
   options: [1, 3, 4],
   value: 3,
 };

--- a/app/frontend/src/components/Select.stories.tsx
+++ b/app/frontend/src/components/Select.stories.tsx
@@ -8,7 +8,7 @@ export default {
 } as Meta;
 
 const Template: Story<{ options: string[] }> = ({ options }) => (
-  <Select>
+  <Select id="story-select">
     {options.map((o) => (
       <option value={o}>{o}</option>
     ))}

--- a/app/frontend/src/components/Select.tsx
+++ b/app/frontend/src/components/Select.tsx
@@ -5,7 +5,7 @@ import {
   SelectProps,
 } from "@material-ui/core";
 import classnames from "classnames";
-import React, { useMemo } from "react";
+import React from "react";
 import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
@@ -36,21 +36,6 @@ export default function Select<T extends Record<string | number, string>>({
 }) {
   const classes = useStyles();
 
-  const SelectOptions = useMemo(
-    () => () => {
-      return (
-        <>
-          {options.map((option) => (
-            <option value={option} key={option}>
-              {optionLabelMap[option]}
-            </option>
-          ))}
-        </>
-      );
-    },
-    [options, optionLabelMap]
-  );
-
   return (
     <FormControl
       variant={variant}
@@ -67,7 +52,11 @@ export default function Select<T extends Record<string | number, string>>({
           id,
         }}
       >
-        <SelectOptions />
+        {options.map((option) => (
+          <option value={option} key={option}>
+            {optionLabelMap[option]}
+          </option>
+        ))}
       </MuiSelect>
     </FormControl>
   );

--- a/app/frontend/src/components/Select.tsx
+++ b/app/frontend/src/components/Select.tsx
@@ -1,0 +1,53 @@
+import {
+  FormControl,
+  InputLabel,
+  Select as MuiSelect,
+  SelectProps,
+} from "@material-ui/core";
+import classnames from "classnames";
+import React from "react";
+import makeStyles from "utils/makeStyles";
+
+const useStyles = makeStyles((theme) => ({
+  formControl: {
+    "& .MuiOutlinedInput-root": {
+      borderRadius: theme.shape.borderRadius * 3,
+    },
+    "& .MuiInputBase-input": {
+      height: "auto",
+    },
+    display: "block",
+  },
+}));
+
+export default function Select({
+  id,
+  children,
+  className,
+  label,
+  variant = "outlined",
+  ...otherProps
+}: SelectProps) {
+  const classes = useStyles();
+  return (
+    <FormControl
+      variant={variant}
+      id={id}
+      className={classnames(className, classes.formControl)}
+      margin="normal"
+    >
+      <InputLabel htmlFor={id}>{label}</InputLabel>
+      <MuiSelect
+        native
+        label={label}
+        {...otherProps}
+        inputProps={{
+          name: id,
+          id,
+        }}
+      >
+        {children}
+      </MuiSelect>
+    </FormControl>
+  );
+}

--- a/app/frontend/src/components/Select.tsx
+++ b/app/frontend/src/components/Select.tsx
@@ -27,12 +27,13 @@ export default function Select({
   label,
   variant = "outlined",
   ...otherProps
-}: SelectProps) {
+}: SelectProps & {
+  id: string;
+}) {
   const classes = useStyles();
   return (
     <FormControl
       variant={variant}
-      id={id}
       className={classnames(className, classes.formControl)}
       margin="normal"
     >

--- a/app/frontend/src/components/Select.tsx
+++ b/app/frontend/src/components/Select.tsx
@@ -26,9 +26,11 @@ export default function Select({
   className,
   label,
   variant = "outlined",
+  options,
   ...otherProps
 }: SelectProps & {
   id: string;
+  options?: { label: string; value: string | number }[];
 }) {
   const classes = useStyles();
   return (
@@ -47,6 +49,12 @@ export default function Select({
           id,
         }}
       >
+        {options &&
+          options.map(({ value, label }) => (
+            <option value={value} key={value}>
+              {label}
+            </option>
+          ))}
         {children}
       </MuiSelect>
     </FormControl>

--- a/app/frontend/src/components/Select.tsx
+++ b/app/frontend/src/components/Select.tsx
@@ -5,7 +5,7 @@ import {
   SelectProps,
 } from "@material-ui/core";
 import classnames from "classnames";
-import React from "react";
+import React, { useMemo } from "react";
 import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
@@ -20,40 +20,36 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function Select<
-  T extends { [key: string]: string } | { [key: number]: string }
->({
+export default function Select<T extends Record<string | number, string>>({
   id,
-  children,
   className,
-  data,
+  optionLabelMap,
   label,
   variant = "outlined",
   options,
   ...otherProps
-}: SelectProps & {
+}: Omit<SelectProps, "children"> & {
   id: string;
-  options?: Extract<keyof T, string | number>[];
+  options: Extract<keyof T, string | number>[];
   value?: T extends undefined ? string | number : keyof T;
-  data?: T;
+  optionLabelMap: T;
 }) {
   const classes = useStyles();
 
-  const SelectOptions = () => {
-    if (!options || !data) {
-      return null;
-    }
-
-    return (
-      <>
-        {options.map((option) => (
-          <option value={option} key={option}>
-            {data[option]}
-          </option>
-        ))}
-      </>
-    );
-  };
+  const SelectOptions = useMemo(
+    () => () => {
+      return (
+        <>
+          {options.map((option) => (
+            <option value={option} key={option}>
+              {optionLabelMap[option]}
+            </option>
+          ))}
+        </>
+      );
+    },
+    [options, optionLabelMap]
+  );
 
   return (
     <FormControl
@@ -72,7 +68,6 @@ export default function Select<
         }}
       >
         <SelectOptions />
-        {children}
       </MuiSelect>
     </FormControl>
   );

--- a/app/frontend/src/components/Select.tsx
+++ b/app/frontend/src/components/Select.tsx
@@ -20,19 +20,41 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function Select({
+export default function Select<
+  T extends { [key: string]: string } | { [key: number]: string }
+>({
   id,
   children,
   className,
+  data,
   label,
   variant = "outlined",
   options,
   ...otherProps
 }: SelectProps & {
   id: string;
-  options?: { label: string; value: string | number }[];
+  options?: Extract<keyof T, string | number>[];
+  value?: T extends undefined ? string | number : keyof T;
+  data?: T;
 }) {
   const classes = useStyles();
+
+  const SelectOptions = () => {
+    if (!options || !data) {
+      return null;
+    }
+
+    return (
+      <>
+        {options.map((option) => (
+          <option value={option} key={option}>
+            {data[option]}
+          </option>
+        ))}
+      </>
+    );
+  };
+
   return (
     <FormControl
       variant={variant}
@@ -49,12 +71,7 @@ export default function Select({
           id,
         }}
       >
-        {options &&
-          options.map(({ value, label }) => (
-            <option value={value} key={value}>
-              {label}
-            </option>
-          ))}
+        <SelectOptions />
         {children}
       </MuiSelect>
     </FormControl>

--- a/app/frontend/src/components/TextField.tsx
+++ b/app/frontend/src/components/TextField.tsx
@@ -27,7 +27,6 @@ interface AccessibleTextFieldProps extends BaseTextFieldProps {
 }
 
 export default function TextField({
-  id,
   className,
   variant = "outlined",
   ...otherProps
@@ -37,7 +36,6 @@ export default function TextField({
     <MuiTextField
       {...otherProps}
       variant={variant}
-      id={id}
       className={classNames(classes.root, className, {
         [classes.multiline]: otherProps.multiline,
       })}

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.test.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.test.tsx
@@ -8,13 +8,7 @@ import { getHookWrapperWithClient } from "test/hookWrapper";
 import { getUser } from "test/serviceMockDefaults";
 
 import { addDefaultUser, MockedService } from "../../../test/utils";
-import {
-  ACCEPT_SMOKING,
-  HOSTING_PREFERENCES,
-  PARKING_DETAILS,
-  SAVE,
-  SPACE,
-} from "../../constants";
+import { ACCEPT_SMOKING, HOSTING_PREFERENCES, PARKING_DETAILS, SAVE, SPACE } from "../../constants";
 import EditHostingPreference from "./EditHostingPreference";
 
 jest.mock("components/MarkdownInput");
@@ -66,15 +60,15 @@ describe("EditHostingPreference", () => {
     await screen.findByText(HOSTING_PREFERENCES);
 
     expect(
-      (await screen.findByLabelText(ACCEPT_SMOKING)) as HTMLSelectElement
+      screen.getByLabelText(ACCEPT_SMOKING) as HTMLSelectElement,
     ).toHaveValue("1");
 
     expect(
-      (await screen.findByLabelText(PARKING_DETAILS)) as HTMLSelectElement
+      screen.getByLabelText(PARKING_DETAILS) as HTMLSelectElement,
     ).toHaveValue("3");
 
     expect(
-      (await screen.findByLabelText(SPACE)) as HTMLSelectElement
+      screen.getByLabelText(SPACE) as HTMLSelectElement,
     ).toHaveValue("2");
   });
 });

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.test.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.test.tsx
@@ -8,7 +8,13 @@ import { getHookWrapperWithClient } from "test/hookWrapper";
 import { getUser } from "test/serviceMockDefaults";
 
 import { addDefaultUser, MockedService } from "../../../test/utils";
-import { SAVE } from "../../constants";
+import {
+  ACCEPT_SMOKING,
+  HOSTING_PREFERENCES,
+  PARKING_DETAILS,
+  SAVE,
+  SPACE,
+} from "../../constants";
 import EditHostingPreference from "./EditHostingPreference";
 
 jest.mock("components/MarkdownInput");
@@ -41,7 +47,7 @@ const renderPage = () => {
 
 describe("EditHostingPreference", () => {
   beforeEach(() => {
-    addDefaultUser();
+    addDefaultUser(1);
     getUserMock.mockImplementation(getUser);
     updateHostingPreferenceMock.mockResolvedValue(new Empty());
   });
@@ -53,4 +59,22 @@ describe("EditHostingPreference", () => {
 
     expect(await screen.findByTestId("user-profile")).toBeInTheDocument();
   }, 20000);
+
+  it("should display the users hosting preferences", async () => {
+    renderPage();
+
+    await screen.findByText(HOSTING_PREFERENCES);
+
+    expect(
+      (await screen.findByLabelText(ACCEPT_SMOKING)) as HTMLSelectElement
+    ).toHaveValue("1");
+
+    expect(
+      (await screen.findByLabelText(PARKING_DETAILS)) as HTMLSelectElement
+    ).toHaveValue("3");
+
+    expect(
+      (await screen.findByLabelText(SPACE)) as HTMLSelectElement
+    ).toHaveValue("2");
+  });
 });

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.test.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.test.tsx
@@ -8,7 +8,13 @@ import { getHookWrapperWithClient } from "test/hookWrapper";
 import { getUser } from "test/serviceMockDefaults";
 
 import { addDefaultUser, MockedService } from "../../../test/utils";
-import { ACCEPT_SMOKING, HOSTING_PREFERENCES, PARKING_DETAILS, SAVE, SPACE } from "../../constants";
+import {
+  ACCEPT_SMOKING,
+  HOSTING_PREFERENCES,
+  PARKING_DETAILS,
+  SAVE,
+  SPACE,
+} from "../../constants";
 import EditHostingPreference from "./EditHostingPreference";
 
 jest.mock("components/MarkdownInput");
@@ -60,15 +66,13 @@ describe("EditHostingPreference", () => {
     await screen.findByText(HOSTING_PREFERENCES);
 
     expect(
-      screen.getByLabelText(ACCEPT_SMOKING) as HTMLSelectElement,
+      screen.getByLabelText(ACCEPT_SMOKING) as HTMLSelectElement
     ).toHaveValue("1");
 
     expect(
-      screen.getByLabelText(PARKING_DETAILS) as HTMLSelectElement,
+      screen.getByLabelText(PARKING_DETAILS) as HTMLSelectElement
     ).toHaveValue("3");
 
-    expect(
-      screen.getByLabelText(SPACE) as HTMLSelectElement,
-    ).toHaveValue("2");
+    expect(screen.getByLabelText(SPACE) as HTMLSelectElement).toHaveValue("2");
   });
 });

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
@@ -9,6 +9,7 @@ import Alert from "components/Alert";
 import Button from "components/Button";
 import CircularProgress from "components/CircularProgress";
 import PageTitle from "components/PageTitle";
+import Select from "components/Select";
 import {
   ABOUT_HOME,
   ACCEPT_CAMPING,
@@ -53,7 +54,7 @@ import {
   SleepingArrangement,
   SmokingLocation,
 } from "pb/api_pb";
-import { useState } from "react";
+import React, { useState } from "react";
 import { Controller, useForm, UseFormMethods } from "react-hook-form";
 import { HostingPreferenceData } from "service";
 import makeStyles from "utils/makeStyles";
@@ -95,6 +96,7 @@ const useStyles = makeStyles((theme) => ({
     paddingTop: theme.spacing(1),
   },
   field: {
+    display: "block",
     [theme.breakpoints.up("md")]: {
       "& > .MuiInputBase-root": {
         width: 400,
@@ -250,31 +252,25 @@ export default function HostingPreferenceForm() {
             defaultValue={user.smokingAllowed}
             name="smokingAllowed"
             render={({ onChange }) => (
-              <Autocomplete
-                disableClearable={false}
-                defaultValue={user.smokingAllowed}
-                forcePopupIcon
-                freeSolo={false}
-                getOptionLabel={(option) => smokingLocationLabels[option]}
-                multiple={false}
-                options={[
+              <Select
+                defaultValue={user.smokingAllowed || SmokingLocation.SMOKING_LOCATION_UNKNOWN}
+                onChange={onChange}
+                label={ACCEPT_SMOKING}
+                name="smokingAllowed"
+                className={classes.field}
+              >
+                {[
+                  SmokingLocation.SMOKING_LOCATION_UNKNOWN,
                   SmokingLocation.SMOKING_LOCATION_YES,
                   SmokingLocation.SMOKING_LOCATION_WINDOW,
                   SmokingLocation.SMOKING_LOCATION_OUTSIDE,
                   SmokingLocation.SMOKING_LOCATION_NO,
-                ]}
-                onChange={(e, value) =>
-                  onChange(value ?? SmokingLocation.SMOKING_LOCATION_UNKNOWN)
-                }
-                renderInput={(params) => (
-                  <ProfileTextInput
-                    {...params}
-                    label={ACCEPT_SMOKING}
-                    name="smokingAllowed"
-                    className={classes.field}
-                  />
-                )}
-              />
+                ].map((o) => (
+                  <option value={o} key={o}>
+                    {smokingLocationLabels[o]}
+                  </option>
+                ))}
+              </Select>
             )}
           />
           <ProfileMarkdownInput
@@ -287,37 +283,27 @@ export default function HostingPreferenceForm() {
           />
           <Controller
             control={control}
-            defaultValue={user.sleepingArrangement}
+            defaultValue={user.sleepingArrangement || SleepingArrangement.SLEEPING_ARRANGEMENT_UNKNOWN}
             name="sleepingArrangement"
             render={({ onChange }) => (
-              <Autocomplete
-                disableClearable={false}
-                defaultValue={user.sleepingArrangement}
-                forcePopupIcon
-                freeSolo={false}
-                getOptionLabel={(option) => sleepingArrangementLabels[option]}
-                multiple={false}
-                options={[
+              <Select
+                onChange={onChange}
+                name="sleepingArrangement"
+                label={SLEEPING_ARRANGEMENT}
+                className={classes.field}
+              >
+                {[
+                  SleepingArrangement.SLEEPING_ARRANGEMENT_UNKNOWN,
                   SleepingArrangement.SLEEPING_ARRANGEMENT_PRIVATE,
                   SleepingArrangement.SLEEPING_ARRANGEMENT_COMMON,
                   SleepingArrangement.SLEEPING_ARRANGEMENT_SHARED_ROOM,
                   SleepingArrangement.SLEEPING_ARRANGEMENT_SHARED_SPACE,
-                ]}
-                onChange={(e, value) =>
-                  onChange(
-                    value ??
-                      SleepingArrangement.SLEEPING_ARRANGEMENT_UNSPECIFIED
-                  )
-                }
-                renderInput={(params) => (
-                  <ProfileTextInput
-                    {...params}
-                    label={SPACE}
-                    name="sleepingArrangement"
-                    className={classes.field}
-                  />
-                )}
-              />
+                ].map((o) => (
+                  <option value={o} key={o}>
+                    {sleepingArrangementLabels[o]}
+                  </option>
+                ))}
+              </Select>
             )}
           />
           <div className={classes.checkboxContainer}>
@@ -388,36 +374,29 @@ export default function HostingPreferenceForm() {
               />
               <Controller
                 control={control}
-                defaultValue={user.parkingDetails}
+                defaultValue={user.parkingDetails || ParkingDetails.PARKING_DETAILS_UNKNOWN}
                 name="parkingDetails"
                 render={({ onChange }) => (
-                  <Autocomplete
-                    disableClearable={false}
+                  <Select
+                    variant="outlined"
+                    native
+                    label={PARKING_DETAILS}
                     defaultValue={user.parkingDetails}
-                    forcePopupIcon
-                    freeSolo={false}
-                    getOptionLabel={(option) => parkingDetailsLabels[option]}
-                    multiple={false}
-                    options={[
+                    onChange={onChange}
+                    className={classes.field}
+                  >
+                    {[
+                      ParkingDetails.PARKING_DETAILS_UNKNOWN,
                       ParkingDetails.PARKING_DETAILS_FREE_ONSITE,
                       ParkingDetails.PARKING_DETAILS_FREE_OFFSITE,
                       ParkingDetails.PARKING_DETAILS_PAID_ONSITE,
                       ParkingDetails.PARKING_DETAILS_PAID_OFFSITE,
-                    ]}
-                    onChange={(e, value) =>
-                      onChange(
-                        value ?? ParkingDetails.PARKING_DETAILS_UNSPECIFIED
-                      )
-                    }
-                    renderInput={(params) => (
-                      <ProfileTextInput
-                        {...params}
-                        label={PARKING_DETAILS}
-                        name="parkingDetails"
-                        className={classes.field}
-                      />
-                    )}
-                  />
+                    ].map((parkingDetail) => (
+                      <option value={parkingDetail} key={parkingDetail}>
+                        {parkingDetailsLabels[parkingDetail]}
+                      </option>
+                    ))}
+                  </Select>
                 )}
               />
             </div>

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
@@ -256,7 +256,7 @@ export default function HostingPreferenceForm() {
                 defaultValue={user.smokingAllowed || SmokingLocation.SMOKING_LOCATION_UNKNOWN}
                 onChange={onChange}
                 label={ACCEPT_SMOKING}
-                name="smokingAllowed"
+                id="smokingAllowed"
                 className={classes.field}
               >
                 {[
@@ -288,7 +288,7 @@ export default function HostingPreferenceForm() {
             render={({ onChange }) => (
               <Select
                 onChange={onChange}
-                name="sleepingArrangement"
+                id="sleepingArrangement"
                 label={SPACE}
                 className={classes.field}
               >
@@ -384,6 +384,7 @@ export default function HostingPreferenceForm() {
                     defaultValue={user.parkingDetails}
                     onChange={onChange}
                     className={classes.field}
+                    id="parkingDetails"
                   >
                     {[
                       ParkingDetails.PARKING_DETAILS_UNKNOWN,

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
@@ -259,19 +259,44 @@ export default function HostingPreferenceForm() {
                 className={classes.field}
                 value={value}
                 id="smokingAllowed"
-              >
-                {[
-                  SmokingLocation.SMOKING_LOCATION_UNKNOWN,
-                  SmokingLocation.SMOKING_LOCATION_YES,
-                  SmokingLocation.SMOKING_LOCATION_WINDOW,
-                  SmokingLocation.SMOKING_LOCATION_OUTSIDE,
-                  SmokingLocation.SMOKING_LOCATION_NO,
-                ].map((o) => (
-                  <option value={o} key={o}>
-                    {smokingLocationLabels[o]}
-                  </option>
-                ))}
-              </Select>
+                options={[
+                  {
+                    value: SmokingLocation.SMOKING_LOCATION_UNKNOWN,
+                    label:
+                      smokingLocationLabels[
+                        SmokingLocation.SMOKING_LOCATION_UNKNOWN
+                      ],
+                  },
+                  {
+                    value: SmokingLocation.SMOKING_LOCATION_YES,
+                    label:
+                      smokingLocationLabels[
+                        SmokingLocation.SMOKING_LOCATION_YES
+                      ],
+                  },
+                  {
+                    value: SmokingLocation.SMOKING_LOCATION_WINDOW,
+                    label:
+                      smokingLocationLabels[
+                        SmokingLocation.SMOKING_LOCATION_WINDOW
+                      ],
+                  },
+                  {
+                    value: SmokingLocation.SMOKING_LOCATION_OUTSIDE,
+                    label:
+                      smokingLocationLabels[
+                        SmokingLocation.SMOKING_LOCATION_OUTSIDE
+                      ],
+                  },
+                  {
+                    value: SmokingLocation.SMOKING_LOCATION_NO,
+                    label:
+                      smokingLocationLabels[
+                        SmokingLocation.SMOKING_LOCATION_NO
+                      ],
+                  },
+                ]}
+              />
             )}
           />
           <ProfileMarkdownInput
@@ -296,19 +321,45 @@ export default function HostingPreferenceForm() {
                 label={SPACE}
                 className={classes.field}
                 value={value}
-              >
-                {[
-                  SleepingArrangement.SLEEPING_ARRANGEMENT_UNKNOWN,
-                  SleepingArrangement.SLEEPING_ARRANGEMENT_PRIVATE,
-                  SleepingArrangement.SLEEPING_ARRANGEMENT_COMMON,
-                  SleepingArrangement.SLEEPING_ARRANGEMENT_SHARED_ROOM,
-                  SleepingArrangement.SLEEPING_ARRANGEMENT_SHARED_SPACE,
-                ].map((o) => (
-                  <option value={o} key={o}>
-                    {sleepingArrangementLabels[o]}
-                  </option>
-                ))}
-              </Select>
+                options={[
+                  {
+                    value: SleepingArrangement.SLEEPING_ARRANGEMENT_UNKNOWN,
+                    label:
+                      sleepingArrangementLabels[
+                        SleepingArrangement.SLEEPING_ARRANGEMENT_UNKNOWN
+                      ],
+                  },
+                  {
+                    value: SleepingArrangement.SLEEPING_ARRANGEMENT_PRIVATE,
+                    label:
+                      sleepingArrangementLabels[
+                        SleepingArrangement.SLEEPING_ARRANGEMENT_PRIVATE
+                      ],
+                  },
+                  {
+                    value: SleepingArrangement.SLEEPING_ARRANGEMENT_COMMON,
+                    label:
+                      sleepingArrangementLabels[
+                        SleepingArrangement.SLEEPING_ARRANGEMENT_COMMON
+                      ],
+                  },
+                  {
+                    value: SleepingArrangement.SLEEPING_ARRANGEMENT_SHARED_ROOM,
+                    label:
+                      sleepingArrangementLabels[
+                        SleepingArrangement.SLEEPING_ARRANGEMENT_SHARED_ROOM
+                      ],
+                  },
+                  {
+                    value:
+                      SleepingArrangement.SLEEPING_ARRANGEMENT_SHARED_SPACE,
+                    label:
+                      sleepingArrangementLabels[
+                        SleepingArrangement.SLEEPING_ARRANGEMENT_SHARED_SPACE
+                      ],
+                  },
+                ]}
+              />
             )}
           />
           <div className={classes.checkboxContainer}>
@@ -390,19 +441,44 @@ export default function HostingPreferenceForm() {
                     className={classes.field}
                     value={value}
                     id="parkingDetails"
-                  >
-                    {[
-                      ParkingDetails.PARKING_DETAILS_UNKNOWN,
-                      ParkingDetails.PARKING_DETAILS_FREE_ONSITE,
-                      ParkingDetails.PARKING_DETAILS_FREE_OFFSITE,
-                      ParkingDetails.PARKING_DETAILS_PAID_ONSITE,
-                      ParkingDetails.PARKING_DETAILS_PAID_OFFSITE,
-                    ].map((parkingDetail) => (
-                      <option value={parkingDetail} key={parkingDetail}>
-                        {parkingDetailsLabels[parkingDetail]}
-                      </option>
-                    ))}
-                  </Select>
+                    options={[
+                      {
+                        value: ParkingDetails.PARKING_DETAILS_UNKNOWN,
+                        label:
+                          parkingDetailsLabels[
+                            ParkingDetails.PARKING_DETAILS_UNKNOWN
+                          ],
+                      },
+                      {
+                        value: ParkingDetails.PARKING_DETAILS_FREE_ONSITE,
+                        label:
+                          parkingDetailsLabels[
+                            ParkingDetails.PARKING_DETAILS_FREE_ONSITE
+                          ],
+                      },
+                      {
+                        value: ParkingDetails.PARKING_DETAILS_FREE_OFFSITE,
+                        label:
+                          parkingDetailsLabels[
+                            ParkingDetails.PARKING_DETAILS_FREE_OFFSITE
+                          ],
+                      },
+                      {
+                        value: ParkingDetails.PARKING_DETAILS_PAID_ONSITE,
+                        label:
+                          parkingDetailsLabels[
+                            ParkingDetails.PARKING_DETAILS_PAID_ONSITE
+                          ],
+                      },
+                      {
+                        value: ParkingDetails.PARKING_DETAILS_PAID_OFFSITE,
+                        label:
+                          parkingDetailsLabels[
+                            ParkingDetails.PARKING_DETAILS_PAID_OFFSITE
+                          ],
+                      },
+                    ]}
+                  />
                 )}
               />
             </div>

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
@@ -289,7 +289,7 @@ export default function HostingPreferenceForm() {
               <Select
                 onChange={onChange}
                 name="sleepingArrangement"
-                label={SLEEPING_ARRANGEMENT}
+                label={SPACE}
                 className={classes.field}
               >
                 {[

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
@@ -54,7 +54,7 @@ import {
   SleepingArrangement,
   SmokingLocation,
 } from "pb/api_pb";
-import React, { useState } from "react";
+import { useState } from "react";
 import { Controller, useForm, UseFormMethods } from "react-hook-form";
 import { HostingPreferenceData } from "service";
 import makeStyles from "utils/makeStyles";
@@ -96,7 +96,6 @@ const useStyles = makeStyles((theme) => ({
     paddingTop: theme.spacing(1),
   },
   field: {
-    display: "block",
     [theme.breakpoints.up("md")]: {
       "& > .MuiInputBase-root": {
         width: 400,
@@ -249,15 +248,17 @@ export default function HostingPreferenceForm() {
           />
           <Controller
             control={control}
-            defaultValue={user.smokingAllowed}
+            defaultValue={
+              user.smokingAllowed || SmokingLocation.SMOKING_LOCATION_UNKNOWN
+            }
             name="smokingAllowed"
-            render={({ onChange }) => (
+            render={({ onChange, value }) => (
               <Select
-                defaultValue={user.smokingAllowed || SmokingLocation.SMOKING_LOCATION_UNKNOWN}
                 onChange={onChange}
                 label={ACCEPT_SMOKING}
-                id="smokingAllowed"
                 className={classes.field}
+                value={value}
+                id="smokingAllowed"
               >
                 {[
                   SmokingLocation.SMOKING_LOCATION_UNKNOWN,
@@ -283,14 +284,18 @@ export default function HostingPreferenceForm() {
           />
           <Controller
             control={control}
-            defaultValue={user.sleepingArrangement || SleepingArrangement.SLEEPING_ARRANGEMENT_UNKNOWN}
+            defaultValue={
+              user.sleepingArrangement ||
+              SleepingArrangement.SLEEPING_ARRANGEMENT_UNKNOWN
+            }
             name="sleepingArrangement"
-            render={({ onChange }) => (
+            render={({ onChange, value }) => (
               <Select
                 onChange={onChange}
                 id="sleepingArrangement"
                 label={SPACE}
                 className={classes.field}
+                value={value}
               >
                 {[
                   SleepingArrangement.SLEEPING_ARRANGEMENT_UNKNOWN,
@@ -374,16 +379,16 @@ export default function HostingPreferenceForm() {
               />
               <Controller
                 control={control}
-                defaultValue={user.parkingDetails || ParkingDetails.PARKING_DETAILS_UNKNOWN}
+                defaultValue={
+                  user.parkingDetails || ParkingDetails.PARKING_DETAILS_UNKNOWN
+                }
                 name="parkingDetails"
-                render={({ onChange }) => (
+                render={({ onChange, value }) => (
                   <Select
-                    variant="outlined"
-                    native
                     label={PARKING_DETAILS}
-                    defaultValue={user.parkingDetails}
                     onChange={onChange}
                     className={classes.field}
+                    value={value}
                     id="parkingDetails"
                   >
                     {[

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
@@ -266,7 +266,7 @@ export default function HostingPreferenceForm() {
                   SmokingLocation.SMOKING_LOCATION_WINDOW,
                   SmokingLocation.SMOKING_LOCATION_YES,
                 ]}
-                data={smokingLocationLabels}
+                optionLabelMap={smokingLocationLabels}
               />
             )}
           />
@@ -299,7 +299,7 @@ export default function HostingPreferenceForm() {
                   SleepingArrangement.SLEEPING_ARRANGEMENT_SHARED_ROOM,
                   SleepingArrangement.SLEEPING_ARRANGEMENT_SHARED_SPACE,
                 ]}
-                data={sleepingArrangementLabels}
+                optionLabelMap={sleepingArrangementLabels}
               />
             )}
           />
@@ -389,7 +389,7 @@ export default function HostingPreferenceForm() {
                       ParkingDetails.PARKING_DETAILS_PAID_ONSITE,
                       ParkingDetails.PARKING_DETAILS_PAID_OFFSITE,
                     ]}
-                    data={parkingDetailsLabels}
+                    optionLabelMap={parkingDetailsLabels}
                   />
                 )}
               />

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
@@ -260,42 +260,13 @@ export default function HostingPreferenceForm() {
                 value={value}
                 id="smokingAllowed"
                 options={[
-                  {
-                    value: SmokingLocation.SMOKING_LOCATION_UNKNOWN,
-                    label:
-                      smokingLocationLabels[
-                        SmokingLocation.SMOKING_LOCATION_UNKNOWN
-                      ],
-                  },
-                  {
-                    value: SmokingLocation.SMOKING_LOCATION_YES,
-                    label:
-                      smokingLocationLabels[
-                        SmokingLocation.SMOKING_LOCATION_YES
-                      ],
-                  },
-                  {
-                    value: SmokingLocation.SMOKING_LOCATION_WINDOW,
-                    label:
-                      smokingLocationLabels[
-                        SmokingLocation.SMOKING_LOCATION_WINDOW
-                      ],
-                  },
-                  {
-                    value: SmokingLocation.SMOKING_LOCATION_OUTSIDE,
-                    label:
-                      smokingLocationLabels[
-                        SmokingLocation.SMOKING_LOCATION_OUTSIDE
-                      ],
-                  },
-                  {
-                    value: SmokingLocation.SMOKING_LOCATION_NO,
-                    label:
-                      smokingLocationLabels[
-                        SmokingLocation.SMOKING_LOCATION_NO
-                      ],
-                  },
+                  SmokingLocation.SMOKING_LOCATION_UNKNOWN,
+                  SmokingLocation.SMOKING_LOCATION_NO,
+                  SmokingLocation.SMOKING_LOCATION_OUTSIDE,
+                  SmokingLocation.SMOKING_LOCATION_WINDOW,
+                  SmokingLocation.SMOKING_LOCATION_YES,
                 ]}
+                data={smokingLocationLabels}
               />
             )}
           />
@@ -322,43 +293,13 @@ export default function HostingPreferenceForm() {
                 className={classes.field}
                 value={value}
                 options={[
-                  {
-                    value: SleepingArrangement.SLEEPING_ARRANGEMENT_UNKNOWN,
-                    label:
-                      sleepingArrangementLabels[
-                        SleepingArrangement.SLEEPING_ARRANGEMENT_UNKNOWN
-                      ],
-                  },
-                  {
-                    value: SleepingArrangement.SLEEPING_ARRANGEMENT_PRIVATE,
-                    label:
-                      sleepingArrangementLabels[
-                        SleepingArrangement.SLEEPING_ARRANGEMENT_PRIVATE
-                      ],
-                  },
-                  {
-                    value: SleepingArrangement.SLEEPING_ARRANGEMENT_COMMON,
-                    label:
-                      sleepingArrangementLabels[
-                        SleepingArrangement.SLEEPING_ARRANGEMENT_COMMON
-                      ],
-                  },
-                  {
-                    value: SleepingArrangement.SLEEPING_ARRANGEMENT_SHARED_ROOM,
-                    label:
-                      sleepingArrangementLabels[
-                        SleepingArrangement.SLEEPING_ARRANGEMENT_SHARED_ROOM
-                      ],
-                  },
-                  {
-                    value:
-                      SleepingArrangement.SLEEPING_ARRANGEMENT_SHARED_SPACE,
-                    label:
-                      sleepingArrangementLabels[
-                        SleepingArrangement.SLEEPING_ARRANGEMENT_SHARED_SPACE
-                      ],
-                  },
+                  SleepingArrangement.SLEEPING_ARRANGEMENT_UNKNOWN,
+                  SleepingArrangement.SLEEPING_ARRANGEMENT_PRIVATE,
+                  SleepingArrangement.SLEEPING_ARRANGEMENT_COMMON,
+                  SleepingArrangement.SLEEPING_ARRANGEMENT_SHARED_ROOM,
+                  SleepingArrangement.SLEEPING_ARRANGEMENT_SHARED_SPACE,
                 ]}
+                data={sleepingArrangementLabels}
               />
             )}
           />
@@ -442,42 +383,13 @@ export default function HostingPreferenceForm() {
                     value={value}
                     id="parkingDetails"
                     options={[
-                      {
-                        value: ParkingDetails.PARKING_DETAILS_UNKNOWN,
-                        label:
-                          parkingDetailsLabels[
-                            ParkingDetails.PARKING_DETAILS_UNKNOWN
-                          ],
-                      },
-                      {
-                        value: ParkingDetails.PARKING_DETAILS_FREE_ONSITE,
-                        label:
-                          parkingDetailsLabels[
-                            ParkingDetails.PARKING_DETAILS_FREE_ONSITE
-                          ],
-                      },
-                      {
-                        value: ParkingDetails.PARKING_DETAILS_FREE_OFFSITE,
-                        label:
-                          parkingDetailsLabels[
-                            ParkingDetails.PARKING_DETAILS_FREE_OFFSITE
-                          ],
-                      },
-                      {
-                        value: ParkingDetails.PARKING_DETAILS_PAID_ONSITE,
-                        label:
-                          parkingDetailsLabels[
-                            ParkingDetails.PARKING_DETAILS_PAID_ONSITE
-                          ],
-                      },
-                      {
-                        value: ParkingDetails.PARKING_DETAILS_PAID_OFFSITE,
-                        label:
-                          parkingDetailsLabels[
-                            ParkingDetails.PARKING_DETAILS_PAID_OFFSITE
-                          ],
-                      },
+                      ParkingDetails.PARKING_DETAILS_UNKNOWN,
+                      ParkingDetails.PARKING_DETAILS_FREE_ONSITE,
+                      ParkingDetails.PARKING_DETAILS_FREE_OFFSITE,
+                      ParkingDetails.PARKING_DETAILS_PAID_ONSITE,
+                      ParkingDetails.PARKING_DETAILS_PAID_OFFSITE,
                     ]}
+                    data={parkingDetailsLabels}
                   />
                 )}
               />


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

Closes #1268 

Sleeping arrangement (or 'private space'), smoking location and parking details fields on the edit hosting preferences form now no longer allow typing text with autocompletion.

These fields now display the valid options in a dropdown (MUI select component)

Users may have 0 (unspecified) or 1 (unknown) as value for these fields. 
Before this issue, this would log warnings in the console because they were not listed as an option for the autocomplete control.

I have now added the unknown (ask me) option to the dropdown for each of these fields.
If the value of the user was 0 (unspecified) it will fallback in the UI to 1 (unknown) and be saved as 1 (unknown) if the user would submit the form.

The user may now also change a previous saved value to 'ask me'.

If this is not the expected behavior, please let me know.

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on frontend)
If you need help with any of these, please ask :)
--->

**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [x] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
