### PR TITLE
Add next.couchershq.org to CORS allowlist for API

### DIFF
--- a/app/proxy/envoy.yaml
+++ b/app/proxy/envoy.yaml
@@ -50,6 +50,7 @@ static_resources:
                 # main site
                 - exact: https://app.couchers.org
                 # deploy preview sites
+                - exact: https://next.couchershq.org
                 - suffix: .preview.couchershq.org
                 # react
                 - exact: http://127.0.0.1:3000


### PR DESCRIPTION
I've created a new site, https://next.couchershq.org that's the same as https://develop--frontend.preview.couchershq.org but easier to point non-technical folks to who still need to poke around on the staging area. This adds it to the allowlist to allow requests from there for CORS.