### PR TITLE
Add couchers logo on unauthenticated pages

### DIFF
--- a/app/frontend/src/features/auth/AuthPage.tsx
+++ b/app/frontend/src/features/auth/AuthPage.tsx
@@ -18,6 +18,7 @@ import DesktopAuthBg from "features/auth/resources/desktop-auth-bg.jpg";
 import MobileAuthBg from "features/auth/resources/mobile-auth-bg.jpg";
 import useAuthStyles from "features/auth/useAuthStyles";
 import { Link } from "react-router-dom";
+import CouchersLogo from "resources/CouchersLogo";
 import { loginRoute, signupRoute } from "routes";
 import makeStyles from "utils/makeStyles";
 
@@ -187,7 +188,10 @@ export default function AuthPage() {
       {/***** DESKTOP ******/}
       <Hidden smDown>
         <header className={authClasses.header}>
-          <div className={authClasses.logo}>{COUCHERS}</div>
+          <div className={authClasses.logoContainer}>
+            <CouchersLogo />
+            <div className={authClasses.logo}>{COUCHERS}</div>
+          </div>
           <nav className={classes.desktopNavigation}>
             <MuiLink
               className={classes.aboutUsLink}

--- a/app/frontend/src/features/auth/login/Login.tsx
+++ b/app/frontend/src/features/auth/login/Login.tsx
@@ -1,10 +1,12 @@
 import { Divider, Hidden, Typography } from "@material-ui/core";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { Link, Redirect, useLocation, useParams } from "react-router-dom";
+import CouchersLogo from "resources/CouchersLogo";
 import makeStyles from "utils/makeStyles";
 
 import Alert from "../../../components/Alert";
 import AuthHeader from "../../../components/AuthHeader";
+import { COUCHERS } from "../../../constants";
 import { signupRoute } from "../../../routes";
 import { useAuthContext } from "../AuthProvider";
 import {
@@ -67,15 +69,6 @@ export default function Login() {
             </Alert>
           )}
           <LoginForm />
-          {/* <Divider>Or</Divider>  not yet available: https://next.material-ui.com/components/dividers/ */}
-          {/* Disabled for beta:
-          <Divider classes={{ root: authClasses.divider }} flexItem />
-          <MuiButton className={classes.facebookButton}>
-            Login with Facebook
-          </MuiButton>
-          <MuiButton className={classes.googleButton}>
-            Login with Google
-          </MuiButton> */}
           <Typography className={classes.signUp}>
             {NO_ACCOUNT_YET + " "}
             <Link className={classes.signUpLink} to={signupRoute}>
@@ -89,7 +82,10 @@ export default function Login() {
       <Hidden smDown>
         <div className={authClasses.page}>
           <header className={authClasses.header}>
-            <div className={authClasses.logo}>Couchers.org</div>
+            <div className={authClasses.logoContainer}>
+              <CouchersLogo />
+              <div className={authClasses.logo}>{COUCHERS}</div>
+            </div>
             <Typography className={classes.signUp}>
               {NO_ACCOUNT_YET + " "}
               <Link className={classes.signUpLink} to={signupRoute}>
@@ -114,15 +110,6 @@ export default function Login() {
                 </Alert>
               )}
               <AuthHeader>{LOGIN_HEADER}</AuthHeader>
-              {/* <Divider>Or</Divider>  not yet available: https://next.material-ui.com/components/dividers/ */}
-              {/*  Disabled for beta:
-              <Divider classes={{ root: authClasses.divider }} flexItem />
-              <MuiButton className={classes.facebookButton}>
-                Login with Facebook
-              </MuiButton>
-              <MuiButton className={classes.googleButton}>
-                Login with Google
-              </MuiButton> */}
               <LoginForm />
             </div>
           </div>

--- a/app/frontend/src/features/auth/signup/Signup.tsx
+++ b/app/frontend/src/features/auth/signup/Signup.tsx
@@ -1,10 +1,12 @@
 import { Divider, Hidden, Typography } from "@material-ui/core";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { Link, Redirect, Route, Switch } from "react-router-dom";
+import CouchersLogo from "resources/CouchersLogo";
 import makeStyles from "utils/makeStyles";
 
 import Alert from "../../../components/Alert";
 import AuthHeader from "../../../components/AuthHeader";
+import { COUCHERS } from "../../../constants";
 import { loginRoute, signupRoute } from "../../../routes";
 import { useAuthContext } from "../AuthProvider";
 import {
@@ -71,16 +73,6 @@ export default function Signup() {
                 </Alert>
               )}
               <EmailForm />
-              {/* <Divider>Or</Divider>  not yet available: https://next.material-ui.com/components/dividers/ */}
-              {/* Hidden for beta: 
-            <Divider classes={{ root: authClasses.divider }} flexItem />
-            <MuiButton className={authClasses.facebookButton}>
-              Sign up with Facebook
-            </MuiButton>
-            <MuiButton className={authClasses.googleButton}>
-              Sign up with Google
-            </MuiButton>
-            */}
               <Typography variant="body1" className={classes.agreement}>
                 {SIGN_UP_AGREEMENT}
               </Typography>
@@ -108,7 +100,10 @@ export default function Signup() {
       <Hidden smDown>
         <div className={authClasses.page}>
           <header className={authClasses.header}>
-            <div className={authClasses.logo}>Couchers.org</div>
+            <div className={authClasses.logoContainer}>
+              <CouchersLogo />
+              <div className={authClasses.logo}>{COUCHERS}</div>
+            </div>
             <Switch>
               <Route exact path={signupRoute}>
                 <Typography className={classes.logIn}>
@@ -142,16 +137,6 @@ export default function Signup() {
                     </Alert>
                   )}
                   <AuthHeader>{SIGN_UP_HEADER}</AuthHeader>
-                  {/* <Divider>Or</Divider>  not yet available: https://next.material-ui.com/components/dividers/ */}
-                  {/* Hidden for beta: 
-            <Divider classes={{ root: authClasses.divider }} flexItem />
-            <MuiButton className={authClasses.facebookButton}>
-              Sign up with Facebook
-            </MuiButton>
-            <MuiButton className={authClasses.googleButton}>
-              Sign up with Google
-            </MuiButton>
-            */}
                   <EmailForm />
                   <Typography variant="body1" className={classes.agreement}>
                     {SIGN_UP_AGREEMENT}

--- a/app/frontend/src/features/auth/useAuthStyles.ts
+++ b/app/frontend/src/features/auth/useAuthStyles.ts
@@ -122,6 +122,10 @@ const useAuthStyles = makeStyles((theme) => ({
     color: theme.palette.secondary.main,
     fontFamily: "'Mansalva', cursive",
     fontSize: "2rem",
+    marginInlineStart: theme.spacing(1.5),
+  },
+  logoContainer: {
+    display: "flex",
   },
   page: {
     alignItems: "center",


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
As in title - namely the couchers logo with the beta badge on the landing page, login page and sign up page.

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on frontend)
If you need help with any of these, please ask :)
--->

**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
