### PR TITLE
Default profile headings

### DIFF
--- a/app/frontend/src/components/Markdown.tsx
+++ b/app/frontend/src/components/Markdown.tsx
@@ -15,16 +15,14 @@ const useStyles = makeStyles((theme) => ({
   root: {
     fontSize: theme.typography.fontSize,
     fontFamily: theme.typography.fontFamily,
-    "& h1": {
+    "& h1, & h2, & h3, & h4, & h5, & h6": {
       borderBottom: "none",
       paddingBottom: 0,
-      ...theme.typography.h1,
+      marginBottom: 0,
+      marginTop: theme.spacing(2),
     },
-    "& h2": {
-      borderBottom: "none",
-      paddingBottom: 0,
-      ...theme.typography.h2,
-    },
+    "& h1": theme.typography.h1,
+    "& h2": theme.typography.h2,
     "& h3": theme.typography.h3,
     "& h4": theme.typography.h4,
     "& h5": theme.typography.h5,

--- a/app/frontend/src/components/Markdown.tsx
+++ b/app/frontend/src/components/Markdown.tsx
@@ -17,10 +17,12 @@ const useStyles = makeStyles((theme) => ({
     fontFamily: theme.typography.fontFamily,
     "& h1": {
       borderBottom: "none",
+      paddingBottom: 0,
       ...theme.typography.h1,
     },
     "& h2": {
       borderBottom: "none",
+      paddingBottom: 0,
       ...theme.typography.h2,
     },
     "& h3": theme.typography.h3,

--- a/app/frontend/src/components/MarkdownInput.tsx
+++ b/app/frontend/src/components/MarkdownInput.tsx
@@ -14,10 +14,8 @@ const useStyles = makeStyles((theme) => ({
       "& h1, & h2, & h3, & h4, & h5, & h6": {
         borderBottom: "none",
         paddingBottom: 0,
-        marginBottom: theme.spacing(1),
-        "&:not(:first-of-type)": {
-          marginTop: theme.spacing(3),
-        },
+        marginBottom: 0,
+        marginTop: theme.spacing(2),
       },
       "& h1": {
         ...theme.typography.h1,

--- a/app/frontend/src/components/MarkdownInput.tsx
+++ b/app/frontend/src/components/MarkdownInput.tsx
@@ -11,12 +11,18 @@ const useStyles = makeStyles((theme) => ({
     "& .tui-editor-contents": {
       fontSize: theme.typography.fontSize,
       fontFamily: theme.typography.fontFamily,
-      "& h1": {
+      "& h1, & h2, & h3, & h4, & h5, & h6": {
         borderBottom: "none",
+        paddingBottom: 0,
+        marginBottom: theme.spacing(1),
+        "&:not(:first-of-type)": {
+          marginTop: theme.spacing(3),
+        },
+      },
+      "& h1": {
         ...theme.typography.h1,
       },
       "& h2": {
-        borderBottom: "none",
         ...theme.typography.h2,
       },
       "& h3": theme.typography.h3,

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.test.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.test.tsx
@@ -1,4 +1,8 @@
-import { render, screen, within } from "@testing-library/react";
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Route, Switch } from "react-router-dom";
@@ -10,6 +14,7 @@ import { getUser } from "test/serviceMockDefaults";
 
 import { addDefaultUser, MockedService } from "../../../test/utils";
 import {
+  ABOUT_HOME,
   ACCEPT_SMOKING,
   HOSTING_PREFERENCES,
   PARKING_DETAILS,
@@ -65,22 +70,12 @@ describe("EditHostingPreference", () => {
   });
 
   it(`should not submit the default headings for the '${ABOUT_HOME}'section`, async () => {
-    jest.isolateModules(() => {
-      getUserMock.mockImplementation(async (user) => ({
-        ...(await getUser(user)),
-        aboutPlace: "",
-      }));
-      jest.unmock("components/MarkdownInput");
-      const EditHostingPreference = require("./EditHostingPreference").default;
-      renderPage(EditHostingPreference);
-    });
-
-    const aboutMyHomeField = within(await screen.findByLabelText(ABOUT_HOME));
-    expect(
-      aboutMyHomeField.getByRole("heading", {
-        name: "What I can share with guests",
-      })
-    ).toBeVisible();
+    getUserMock.mockImplementation(async (user) => ({
+      ...(await getUser(user)),
+      aboutPlace: "",
+    }));
+    renderPage();
+    await waitForElementToBeRemoved(screen.getByRole("progressbar"));
 
     userEvent.click(screen.getByRole("button", { name: SAVE }));
     await screen.findByTestId("user-profile");
@@ -91,7 +86,7 @@ describe("EditHostingPreference", () => {
         aboutPlace: "",
       })
     );
-  }, 20000);
+  });
 
   it("should display the users hosting preferences", async () => {
     renderPage();

--- a/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
@@ -57,6 +57,8 @@ import { Controller, useForm, UseFormMethods } from "react-hook-form";
 import { HostingPreferenceData } from "service";
 import makeStyles from "utils/makeStyles";
 
+import { DEFAULT_ABOUT_HOME_HEADINGS } from "./constants";
+
 interface HostingPreferenceCheckboxProps {
   className: string;
   defaultValue: boolean;
@@ -141,7 +143,13 @@ export default function HostingPreferenceForm() {
     resetUpdate();
     updateHostingPreferences(
       {
-        preferenceData: data,
+        preferenceData: {
+          ...data,
+          aboutPlace:
+            data.aboutPlace === DEFAULT_ABOUT_HOME_HEADINGS
+              ? ""
+              : data.aboutPlace,
+        },
         setMutationError: setErrorMessage,
       },
       {
@@ -268,7 +276,7 @@ export default function HostingPreferenceForm() {
             id="aboutPlace"
             label={ABOUT_HOME}
             name="aboutPlace"
-            defaultValue={user.aboutPlace}
+            defaultValue={user.aboutPlace || DEFAULT_ABOUT_HOME_HEADINGS}
             control={control}
             className={classes.field}
           />

--- a/app/frontend/src/features/profile/edit/EditProfile.test.tsx
+++ b/app/frontend/src/features/profile/edit/EditProfile.test.tsx
@@ -1,0 +1,104 @@
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HOBBIES, SAVE, WHO } from "features/constants";
+import { Empty } from "google-protobuf/google/protobuf/empty_pb";
+import { Route, Switch } from "react-router-dom";
+import { editProfileRoute, userRoute } from "routes";
+import { service } from "service";
+import { getHookWrapperWithClient } from "test/hookWrapper";
+import { getUser } from "test/serviceMockDefaults";
+import { addDefaultUser } from "test/utils";
+
+jest.mock("components/Map", () => () => "map");
+
+const getUserMock = service.user.getUser as jest.MockedFunction<
+  typeof service.user.getUser
+>;
+const updateProfileMock = service.user.updateProfile as jest.MockedFunction<
+  typeof service.user.updateProfile
+>;
+
+const renderPage = (Component: () => JSX.Element) => {
+  const { wrapper } = getHookWrapperWithClient({
+    initialRouterEntries: [`${editProfileRoute}`],
+  });
+
+  render(
+    <Switch>
+      <Route path={editProfileRoute}>
+        <Component />
+      </Route>
+      <Route path={userRoute}>
+        <h1 data-testid="user-profile">Mock Profile Page</h1>
+      </Route>
+    </Switch>,
+    { wrapper }
+  );
+};
+
+describe("Edit profile", () => {
+  beforeEach(() => {
+    addDefaultUser();
+    getUserMock.mockImplementation(getUser);
+    updateProfileMock.mockResolvedValue(new Empty());
+  });
+
+  it("should redirect to the user profile page after a successful update", async () => {
+    jest.isolateModules(() => {
+      jest.mock("components/MarkdownInput");
+      const EditProfile = require("./EditProfile").default;
+      renderPage(EditProfile);
+    });
+    await waitForElementToBeRemoved(screen.getByRole("progressbar"));
+
+    userEvent.click(screen.getByRole("button", { name: SAVE }));
+
+    expect(await screen.findByTestId("user-profile")).toBeInTheDocument();
+  });
+
+  it(`should not submit the default headings for the '${WHO}' and '${HOBBIES}' sections`, async () => {
+    jest.isolateModules(() => {
+      jest.unmock("components/MarkdownInput");
+      getUserMock.mockImplementation(async (user) => ({
+        ...(await getUser(user)),
+        aboutMe: "",
+        thingsILike: "",
+      }));
+      const EditProfile = require("./EditProfile").default;
+      renderPage(EditProfile);
+    });
+    await waitForElementToBeRemoved(screen.getByRole("progressbar"));
+
+    const whoIAmTextField = within(screen.getByLabelText(WHO));
+    const hobbiesTextField = within(screen.getByLabelText(HOBBIES));
+    [
+      "Current mission",
+      "Why I use Couchers",
+      "My favourite travel story",
+    ].forEach((heading) => {
+      expect(
+        whoIAmTextField.getByRole("heading", { name: heading })
+      ).toBeVisible();
+    });
+    ["Art", "Books", "Movies", "Music"].forEach((heading) => {
+      expect(
+        hobbiesTextField.getByRole("heading", { name: heading })
+      ).toBeVisible();
+    });
+
+    userEvent.click(screen.getByRole("button", { name: SAVE }));
+    await screen.findByTestId("user-profile");
+    expect(updateProfileMock).toHaveBeenCalledTimes(1);
+    expect(updateProfileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        aboutMe: "",
+        thingsILike: "",
+      })
+    );
+  }, 20000);
+});

--- a/app/frontend/src/features/profile/edit/EditProfile.tsx
+++ b/app/frontend/src/features/profile/edit/EditProfile.tsx
@@ -48,6 +48,11 @@ import { UpdateUserProfileData } from "service/index";
 import { useIsMounted, useSafeState } from "utils/hooks";
 import makeStyles from "utils/makeStyles";
 
+import {
+  DEFAULT_ABOUT_ME_HEADINGS,
+  DEFAULT_HOBBIES_HEADINGS,
+} from "./constants";
+
 const useStyles = makeStyles((theme) => ({
   avatar: {
     width: 120,
@@ -146,7 +151,15 @@ export default function EditProfileForm() {
       resetUpdate();
       updateUserProfile(
         {
-          profileData: data,
+          profileData: {
+            ...data,
+            aboutMe:
+              data.aboutMe === DEFAULT_ABOUT_ME_HEADINGS ? "" : data.aboutMe,
+            thingsILike:
+              data.thingsILike === DEFAULT_HOBBIES_HEADINGS
+                ? ""
+                : data.thingsILike,
+          },
           setMutationError: setErrorMessage,
         },
         {
@@ -373,7 +386,7 @@ export default function EditProfileForm() {
               id="aboutMe"
               label={WHO}
               name="aboutMe"
-              defaultValue={user.aboutMe}
+              defaultValue={user.aboutMe || DEFAULT_ABOUT_ME_HEADINGS}
               control={control}
               className={classes.field}
             />
@@ -381,7 +394,7 @@ export default function EditProfileForm() {
               id="thingsILike"
               label={HOBBIES}
               name="thingsILike"
-              defaultValue={user.thingsILike}
+              defaultValue={user.thingsILike || DEFAULT_HOBBIES_HEADINGS}
               control={control}
               className={classes.field}
             />

--- a/app/frontend/src/features/profile/edit/EditProfilePage.test.tsx
+++ b/app/frontend/src/features/profile/edit/EditProfilePage.test.tsx
@@ -7,13 +7,13 @@ import userEvent from "@testing-library/user-event";
 import { HOBBIES, SAVE, WHO } from "features/constants";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Route, Switch } from "react-router-dom";
-import { editProfileRoute, userRoute } from "routes";
+import { editUserRoute, userBaseRoute, userRoute } from "routes";
 import { service } from "service";
 import { getHookWrapperWithClient } from "test/hookWrapper";
 import { getUser } from "test/serviceMockDefaults";
 import { addDefaultUser } from "test/utils";
 
-import EditProfile from "./EditProfile";
+import EditProfilePage from "./EditProfilePage";
 
 jest.mock("components/Map", () => () => "map");
 jest.mock("components/MarkdownInput");
@@ -27,13 +27,13 @@ const updateProfileMock = service.user.updateProfile as jest.MockedFunction<
 
 const renderPage = () => {
   const { wrapper } = getHookWrapperWithClient({
-    initialRouterEntries: [`${editProfileRoute}`],
+    initialRouterEntries: [`${userBaseRoute}/edit`],
   });
 
   render(
     <Switch>
-      <Route path={editProfileRoute}>
-        <EditProfile />
+      <Route path={editUserRoute}>
+        <EditProfilePage />
       </Route>
       <Route path={userRoute}>
         <h1 data-testid="user-profile">Mock Profile Page</h1>
@@ -77,5 +77,5 @@ describe("Edit profile", () => {
         thingsILike: "",
       })
     );
-  }, 20000);
+  });
 });

--- a/app/frontend/src/features/profile/edit/constants.ts
+++ b/app/frontend/src/features/profile/edit/constants.ts
@@ -15,3 +15,5 @@ export const DEFAULT_HOBBIES_HEADINGS = `# Art
 # Music
 
 `;
+
+export const DEFAULT_ABOUT_HOME_HEADINGS = "# What I can share with guests";

--- a/app/frontend/src/features/profile/edit/constants.ts
+++ b/app/frontend/src/features/profile/edit/constants.ts
@@ -1,0 +1,17 @@
+export const DEFAULT_ABOUT_ME_HEADINGS = `# Current mission
+
+# Why I use Couchers
+
+# My favourite travel story
+
+`;
+
+export const DEFAULT_HOBBIES_HEADINGS = `# Art
+
+# Books
+
+# Movies
+
+# Music
+
+`;

--- a/app/frontend/src/features/profile/edit/constants.ts
+++ b/app/frontend/src/features/profile/edit/constants.ts
@@ -1,19 +1,21 @@
 export const DEFAULT_ABOUT_ME_HEADINGS = `# Current mission
-
+<br>
 # Why I use Couchers
-
+<br>
 # My favourite travel story
-
+<br>
 `;
 
 export const DEFAULT_HOBBIES_HEADINGS = `# Art
-
+<br>
 # Books
-
+<br>
 # Movies
-
+<br>
 # Music
-
+<br>
 `;
 
-export const DEFAULT_ABOUT_HOME_HEADINGS = "# What I can share with guests";
+export const DEFAULT_ABOUT_HOME_HEADINGS = `# What I can share with guests
+<br>
+`;

--- a/app/frontend/src/routes.ts
+++ b/app/frontend/src/routes.ts
@@ -17,7 +17,7 @@ export const signupRoute = "/signup";
 
 // user
 
-const userBaseRoute = "/user";
+export const userBaseRoute = "/user";
 export type UserTab = "about" | "home" | "references" | "favorites" | "photos";
 export type EditUserTab = Extract<UserTab, "about" | "home">;
 


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
Closes #1246 

The headings in #410 seems a bit outdated? I chose the ones that made the most sense for the sections we got now.

This is what it looks like if the "Who I am" / "What I do in my free time" fields are empty:

![Screenshot 2021-05-24 at 02 42 32](https://user-images.githubusercontent.com/13669362/119285365-cdfd0100-bc39-11eb-9b7d-c5080a6a0b7f.png)

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on frontend)
If you need help with any of these, please ask :)
--->


**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
