### PR TITLE
Hosting request emails

### DIFF
--- a/app/backend/src/couchers/jobs/definitions.py
+++ b/app/backend/src/couchers/jobs/definitions.py
@@ -31,5 +31,5 @@ SCHEDULE = [
     (BackgroundJobType.send_message_notifications, timedelta(minutes=3)),
     (BackgroundJobType.send_onboarding_emails, timedelta(hours=1)),
     (BackgroundJobType.add_users_to_email_list, timedelta(hours=6)),
-    (BackgroundJobType.send_request_notifications, timedelta(seconds=15)),
+    (BackgroundJobType.send_request_notifications, timedelta(minutes=3)),
 ]

--- a/app/backend/src/couchers/jobs/definitions.py
+++ b/app/backend/src/couchers/jobs/definitions.py
@@ -9,6 +9,7 @@ from couchers.jobs.handlers import (
     process_send_email,
     process_send_message_notifications,
     process_send_onboarding_emails,
+    process_send_request_notifications,
 )
 from couchers.models import BackgroundJobType
 from pb.internal import jobs_pb2
@@ -21,6 +22,7 @@ JOBS = {
     BackgroundJobType.send_message_notifications: (empty_pb2.Empty, process_send_message_notifications),
     BackgroundJobType.send_onboarding_emails: (empty_pb2.Empty, process_send_onboarding_emails),
     BackgroundJobType.add_users_to_email_list: (empty_pb2.Empty, process_add_users_to_email_list),
+    BackgroundJobType.send_request_notifications: (empty_pb2.Empty, process_send_request_notifications),
 }
 
 SCHEDULE = [
@@ -29,4 +31,5 @@ SCHEDULE = [
     (BackgroundJobType.send_message_notifications, timedelta(minutes=3)),
     (BackgroundJobType.send_onboarding_emails, timedelta(hours=1)),
     (BackgroundJobType.add_users_to_email_list, timedelta(hours=6)),
+    (BackgroundJobType.send_request_notifications, timedelta(seconds=15)),
 ]

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -12,7 +12,16 @@ from couchers import config, email, urls
 from couchers.db import session_scope
 from couchers.email.dev import print_dev_email
 from couchers.email.smtp import send_smtp_email
-from couchers.models import GroupChat, GroupChatSubscription, LoginToken, Message, MessageType, SignupToken, User
+from couchers.models import (
+    GroupChat,
+    GroupChatSubscription,
+    HostRequest,
+    LoginToken,
+    Message,
+    MessageType,
+    SignupToken,
+    User,
+)
 from couchers.tasks import send_onboarding_email
 from couchers.utils import now
 
@@ -115,6 +124,69 @@ def process_send_message_notifications(payload):
                         (group_chat, latest_message, count) for group_chat, latest_message, count in unseen_messages
                     ],
                     "group_chats_link": urls.messages_link(),
+                },
+            )
+
+
+def process_send_request_notifications(payload):
+    """
+    Sends out email notifications for unseen messages in host requests (as surfer or host)
+    """
+    logger.info(f"Sending out email notifications for unseen messages in host requests")
+
+    with session_scope() as session:
+        # select all host requests that have unseen messages then get list of unique users from there
+        # requests where this user is surfing
+        surfing_reqs = (
+            session.query(User, HostRequest, func.max(Message.id))
+            .join(HostRequest, HostRequest.from_user_id == User.id)
+            .join(Message, Message.conversation_id == HostRequest.conversation_id)
+            .filter(Message.id > HostRequest.from_last_seen_message_id)
+            .filter(Message.id > User.last_notified_request_message_id)
+            .filter(Message.time < now() - timedelta(minutes=5))
+            .filter(Message.message_type == MessageType.text)
+            .group_by(User, HostRequest)
+            .all()
+        )
+
+        # where this user is hosting
+        hosting_reqs = (
+            session.query(User, HostRequest, func.max(Message.id))
+            .join(HostRequest, HostRequest.to_user_id == User.id)
+            .join(Message, Message.conversation_id == HostRequest.conversation_id)
+            .filter(Message.id > HostRequest.to_last_seen_message_id)
+            .filter(Message.id > User.last_notified_request_message_id)
+            .filter(Message.time < now() - timedelta(minutes=5))
+            .filter(Message.message_type == MessageType.text)
+            .group_by(User, HostRequest)
+            .all()
+        )
+
+        for user, host_request, max_message_id in surfing_reqs:
+            user.last_notified_request_message_id = max(user.last_notified_request_message_id, max_message_id)
+            session.commit()
+
+            email.enqueue_email_from_template(
+                user.email,
+                "unseen_message_guest",
+                template_args={
+                    "user": user,
+                    "host_request": host_request,
+                    "host_request_link": urls.host_request_link_guest(),
+                },
+            )
+
+        for user, host_request, max_message_id in hosting_reqs:
+            user.last_notified_request_message_id = max(user.last_notified_request_message_id, max_message_id)
+            session.commit()
+
+            email.enqueue_email_from_template(
+                user.email,
+                "unseen_message_host",
+                template_args={
+                    "user": user,
+                    "host_request": host_request,
+                    "host_request_link": urls.host_request_link_host(),
                 },
             )
 

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -135,7 +135,6 @@ def process_send_request_notifications(payload):
     logger.info(f"Sending out email notifications for unseen messages in host requests")
 
     with session_scope() as session:
-        # select all host requests that have unseen messages then get list of unique users from there
         # requests where this user is surfing
         surfing_reqs = (
             session.query(User, HostRequest, func.max(Message.id))

--- a/app/backend/src/couchers/migrations/versions/584f70c6a0d4_add_host_request_message_bg_job.py
+++ b/app/backend/src/couchers/migrations/versions/584f70c6a0d4_add_host_request_message_bg_job.py
@@ -1,0 +1,28 @@
+"""Add host request message bg job
+
+Revision ID: 584f70c6a0d4
+Revises: 763e0bd674a5
+Create Date: 2021-05-26 14:43:43.079500
+
+"""
+import geoalchemy2
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "584f70c6a0d4"
+down_revision = "763e0bd674a5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "users",
+        sa.Column("last_notified_request_message_id", sa.BigInteger(), server_default=sa.text("0"), nullable=False),
+    )
+    op.execute("ALTER TYPE backgroundjobtype ADD VALUE 'send_request_notifications'")
+
+
+def downgrade():
+    pass

--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -117,6 +117,8 @@ class User(Base):
 
     # id of the last message that they received a notification about
     last_notified_message_id = Column(BigInteger, nullable=False, default=0)
+    # same as above for host requests
+    last_notified_request_message_id = Column(BigInteger, nullable=False, server_default=text("0"))
 
     # display name
     name = Column(String, nullable=False)
@@ -1377,6 +1379,8 @@ class BackgroundJobType(enum.Enum):
     send_onboarding_emails = 5
     # payload: google.protobuf.Empty
     add_users_to_email_list = 6
+    # payload: google.protobuf.Empty
+    send_request_notifications = 7
 
 
 class BackgroundJobState(enum.Enum):

--- a/app/backend/src/couchers/tasks.py
+++ b/app/backend/src/couchers/tasks.py
@@ -54,8 +54,6 @@ def send_report_email(complaint):
 
 
 def send_new_host_request_email(host_request):
-    host_request_link = urls.host_request_link()
-
     logger.info(f"Sending host request email to {host_request.to_user=}:")
     logger.info(f"Host request sent by {host_request.from_user}")
     logger.info(f"Email for {host_request.to_user.username=} sent to {host_request.to_user.email=}")
@@ -65,7 +63,7 @@ def send_new_host_request_email(host_request):
         "host_request",
         template_args={
             "host_request": host_request,
-            "host_request_link": host_request_link,
+            "host_request_link": urls.host_request_link_host(),
         },
     )
 
@@ -79,7 +77,7 @@ def send_host_request_accepted_email_to_guest(host_request):
         "host_request_accepted_guest",
         template_args={
             "host_request": host_request,
-            "host_request_link": urls.host_request_link(),
+            "host_request_link": urls.host_request_link_guest(),
         },
     )
 
@@ -93,7 +91,7 @@ def send_host_request_rejected_email_to_guest(host_request):
         "host_request_rejected_guest",
         template_args={
             "host_request": host_request,
-            "host_request_link": urls.host_request_link(),
+            "host_request_link": urls.host_request_link_guest(),
         },
     )
 
@@ -107,7 +105,7 @@ def send_host_request_confirmed_email_to_host(host_request):
         "host_request_confirmed_host",
         template_args={
             "host_request": host_request,
-            "host_request_link": urls.host_request_link(),
+            "host_request_link": urls.host_request_link_host(),
         },
     )
 
@@ -121,7 +119,7 @@ def send_host_request_cancelled_email_to_host(host_request):
         "host_request_cancelled_host",
         template_args={
             "host_request": host_request,
-            "host_request_link": urls.host_request_link(),
+            "host_request_link": urls.host_request_link_host(),
         },
     )
 

--- a/app/backend/src/couchers/tasks.py
+++ b/app/backend/src/couchers/tasks.py
@@ -5,7 +5,7 @@ from sqlalchemy.sql import func
 from couchers import email, urls
 from couchers.config import config
 from couchers.db import session_scope
-from couchers.models import ClusterRole, ClusterSubscription, Node, User
+from couchers.models import ClusterRole, ClusterSubscription, HostRequestStatus, Node, User
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,7 @@ def send_report_email(complaint):
     )
 
 
-def send_host_request_email(host_request):
+def send_new_host_request_email(host_request):
     host_request_link = urls.host_request_link()
 
     logger.info(f"Sending host request email to {host_request.to_user=}:")
@@ -66,6 +66,62 @@ def send_host_request_email(host_request):
         template_args={
             "host_request": host_request,
             "host_request_link": host_request_link,
+        },
+    )
+
+
+def send_host_request_accepted_email_to_guest(host_request):
+    logger.info(f"Sending host request accepted email to guest: {host_request.from_user=}:")
+    logger.info(f"Email for {host_request.from_user.username=} sent to {host_request.from_user.email=}")
+
+    email.enqueue_email_from_template(
+        host_request.from_user.email,
+        "host_request_accepted_guest",
+        template_args={
+            "host_request": host_request,
+            "host_request_link": urls.host_request_link(),
+        },
+    )
+
+
+def send_host_request_rejected_email_to_guest(host_request):
+    logger.info(f"Sending host request rejected email to guest: {host_request.from_user=}:")
+    logger.info(f"Email for {host_request.from_user.username=} sent to {host_request.from_user.email=}")
+
+    email.enqueue_email_from_template(
+        host_request.from_user.email,
+        "host_request_rejected_guest",
+        template_args={
+            "host_request": host_request,
+            "host_request_link": urls.host_request_link(),
+        },
+    )
+
+
+def send_host_request_confirmed_email_to_host(host_request):
+    logger.info(f"Sending host request confirmed email to host: {host_request.to_user=}:")
+    logger.info(f"Email for {host_request.to_user.username=} sent to {host_request.to_user.email=}")
+
+    email.enqueue_email_from_template(
+        host_request.to_user.email,
+        "host_request_confirmed_host",
+        template_args={
+            "host_request": host_request,
+            "host_request_link": urls.host_request_link(),
+        },
+    )
+
+
+def send_host_request_cancelled_email_to_host(host_request):
+    logger.info(f"Sending host request cancelled email to host: {host_request.to_user=}:")
+    logger.info(f"Email for {host_request.to_user.username=} sent to {host_request.to_user.email=}")
+
+    email.enqueue_email_from_template(
+        host_request.to_user.email,
+        "host_request_cancelled_host",
+        template_args={
+            "host_request": host_request,
+            "host_request_link": urls.host_request_link(),
         },
     )
 

--- a/app/backend/src/couchers/urls.py
+++ b/app/backend/src/couchers/urls.py
@@ -30,8 +30,12 @@ def password_reset_link(password_reset_token):
     return f"{config['BASE_URL']}/password-reset/{password_reset_token}"
 
 
-def host_request_link():
+def host_request_link_host():
     return f"{config['BASE_URL']}/messages/hosting/"
+
+
+def host_request_link_guest():
+    return f"{config['BASE_URL']}/messages/surfing/"
 
 
 def messages_link():

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -18,8 +18,8 @@ from couchers.models import (
 )
 from couchers.tasks import (
     send_friend_request_email,
-    send_host_request_email,
     send_login_email,
+    send_new_host_request_email,
     send_report_email,
     send_signup_email,
 )
@@ -132,7 +132,7 @@ def test_host_request_email(db):
         session.add(host_request)
 
         with patch("couchers.email.queue_email") as mock:
-            send_host_request_email(host_request)
+            send_new_host_request_email(host_request)
 
         assert mock.call_count == 1
         (sender_name, sender_email, recipient, subject, plain, html), _ = mock.call_args

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -66,7 +66,6 @@ def create_host_request(
     )
     session.add(host_request)
     session.commit()
-    # send_new_host_request_email(host_request)
     return host_request.conversation_id
 
 

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -66,7 +66,7 @@ def create_host_request(
     )
     session.add(host_request)
     session.commit()
-    # send_host_request_email(host_request)
+    # send_new_host_request_email(host_request)
     return host_request.conversation_id
 
 

--- a/app/backend/templates/host_request_accepted_guest.md
+++ b/app/backend/templates/host_request_accepted_guest.md
@@ -1,0 +1,25 @@
+---
+subject: "{{ escape(host_request.to_user.name) }} accepted your hosting request!"
+---
+
+{% from "macros.html" import button %}
+
+Hi {{ escape(host_request.from_user.name) }},
+
+{{ escape(host_request.to_user.name) }} accepted your hosting request!
+
+Check it out here:
+
+{% if html %}
+
+{{ button("Host Requests", host_request_link) }}
+
+Alternatively, click the following link: <{{ host_request_link }}>.
+
+{% else %}
+<{{ host_request_link }}>
+{% endif %}
+
+Thanks for using Couchers!
+
+The Couchers.org team

--- a/app/backend/templates/host_request_accepted_guest.md
+++ b/app/backend/templates/host_request_accepted_guest.md
@@ -6,7 +6,7 @@ subject: "{{ escape(host_request.to_user.name) }} accepted your hosting request!
 
 Hi {{ escape(host_request.from_user.name) }},
 
-{{ escape(host_request.to_user.name) }} accepted your hosting request!
+{{ escape(host_request.to_user.name) }} accepted your hosting request from {{ host_request.from_date }} until {{ host_request.to_date }}!
 
 Check it out here:
 

--- a/app/backend/templates/host_request_cancelled_host.md
+++ b/app/backend/templates/host_request_cancelled_host.md
@@ -6,7 +6,7 @@ subject: "{{ escape(host_request.from_user.name) }} cancelled their hosting requ
 
 Hi {{ escape(host_request.to_user.name) }},
 
-{{ escape(host_request.from_user.name) }} cancelled their hosting request.
+{{ escape(host_request.from_user.name) }} cancelled their hosting request from {{ host_request.from_date }} until {{ host_request.to_date }}.
 
 Check it out here:
 

--- a/app/backend/templates/host_request_cancelled_host.md
+++ b/app/backend/templates/host_request_cancelled_host.md
@@ -1,0 +1,25 @@
+---
+subject: "{{ escape(host_request.from_user.name) }} cancelled their hosting request"
+---
+
+{% from "macros.html" import button %}
+
+Hi {{ escape(host_request.to_user.name) }},
+
+{{ escape(host_request.from_user.name) }} cancelled their hosting request.
+
+Check it out here:
+
+{% if html %}
+
+{{ button("Host Requests", host_request_link) }}
+
+Alternatively, click the following link: <{{ host_request_link }}>.
+
+{% else %}
+<{{ host_request_link }}>
+{% endif %}
+
+Thanks for using Couchers!
+
+The Couchers.org team

--- a/app/backend/templates/host_request_confirmed_host.md
+++ b/app/backend/templates/host_request_confirmed_host.md
@@ -1,0 +1,25 @@
+---
+subject: "{{ escape(host_request.from_user.name) }} confirmed their hosting request!"
+---
+
+{% from "macros.html" import button %}
+
+Hi {{ escape(host_request.to_user.name) }},
+
+{{ escape(host_request.from_user.name) }} just confirmed their hosting request!
+
+Check it out here:
+
+{% if html %}
+
+{{ button("Host Requests", host_request_link) }}
+
+Alternatively, click the following link: <{{ host_request_link }}>.
+
+{% else %}
+<{{ host_request_link }}>
+{% endif %}
+
+Thanks for using Couchers!
+
+The Couchers.org team

--- a/app/backend/templates/host_request_confirmed_host.md
+++ b/app/backend/templates/host_request_confirmed_host.md
@@ -6,7 +6,7 @@ subject: "{{ escape(host_request.from_user.name) }} confirmed their hosting requ
 
 Hi {{ escape(host_request.to_user.name) }},
 
-{{ escape(host_request.from_user.name) }} just confirmed their hosting request!
+{{ escape(host_request.from_user.name) }} just confirmed their hosting request from {{ host_request.from_date }} until {{ host_request.to_date }}!
 
 Check it out here:
 

--- a/app/backend/templates/host_request_rejected_guest.md
+++ b/app/backend/templates/host_request_rejected_guest.md
@@ -6,7 +6,7 @@ subject: "{{ escape(host_request.to_user.name) }} rejected your hosting request"
 
 Hi {{ escape(host_request.from_user.name) }},
 
-{{ escape(host_request.to_user.name) }} rejected your hosting request :/
+{{ escape(host_request.to_user.name) }} rejected your hosting request from {{ host_request.from_date }} until {{ host_request.to_date }} :/
 
 Check it out here:
 

--- a/app/backend/templates/host_request_rejected_guest.md
+++ b/app/backend/templates/host_request_rejected_guest.md
@@ -1,0 +1,25 @@
+---
+subject: "{{ escape(host_request.to_user.name) }} rejected your hosting request"
+---
+
+{% from "macros.html" import button %}
+
+Hi {{ escape(host_request.from_user.name) }},
+
+{{ escape(host_request.to_user.name) }} rejected your hosting request :/
+
+Check it out here:
+
+{% if html %}
+
+{{ button("Host Requests", host_request_link) }}
+
+Alternatively, click the following link: <{{ host_request_link }}>.
+
+{% else %}
+<{{ host_request_link }}>
+{% endif %}
+
+Thanks for using Couchers!
+
+The Couchers.org team

--- a/app/backend/templates/unseen_message_guest.md
+++ b/app/backend/templates/unseen_message_guest.md
@@ -6,7 +6,7 @@ subject: "{{ escape(host_request.to_user.name) }} wrote a message in your hostin
 
 Hi {{ escape(user.name) }}!
 
-You have an unseen message from {{ escape(host_request.to_user.name) }} regarding your hosting request.
+You have an unseen message from {{ escape(host_request.to_user.name) }} regarding your hosting request from {{ host_request.from_date }} until {{ host_request.to_date }}.
 
 Check it out here:
 

--- a/app/backend/templates/unseen_message_guest.md
+++ b/app/backend/templates/unseen_message_guest.md
@@ -1,0 +1,23 @@
+---
+subject: "{{ escape(host_request.to_user.name) }} wrote a message in your hosting request"
+---
+
+{% from "macros.html" import button %}
+
+Hi {{ escape(user.name) }}!
+
+You have an unseen message from {{ escape(host_request.to_user.name) }} regarding your hosting request.
+
+Check it out here:
+
+{% if html %}
+
+{{ button("Host Requests", host_request_link) }}
+
+Alternatively, click the following link: <{{ host_request_link }}>.
+
+{% else %}
+<{{ host_request_link }}>
+{% endif %}
+
+The Couchers.org team

--- a/app/backend/templates/unseen_message_host.md
+++ b/app/backend/templates/unseen_message_host.md
@@ -1,0 +1,23 @@
+---
+subject: "{{ escape(host_request.from_user.name) }} wrote a message in their hosting request"
+---
+
+{% from "macros.html" import button %}
+
+Hi {{ escape(user.name) }}!
+
+You have an unseen message from {{ escape(host_request.from_user.name) }} regarding their hosting request.
+
+Check it out here:
+
+{% if html %}
+
+{{ button("Host Requests", host_request_link) }}
+
+Alternatively, click the following link: <{{ host_request_link }}>.
+
+{% else %}
+<{{ host_request_link }}>
+{% endif %}
+
+The Couchers.org team

--- a/app/backend/templates/unseen_message_host.md
+++ b/app/backend/templates/unseen_message_host.md
@@ -6,7 +6,7 @@ subject: "{{ escape(host_request.from_user.name) }} wrote a message in their hos
 
 Hi {{ escape(user.name) }}!
 
-You have an unseen message from {{ escape(host_request.from_user.name) }} regarding their hosting request.
+You have an unseen message from {{ escape(host_request.from_user.name) }} regarding their hosting request from {{ host_request.from_date }} until {{ host_request.to_date }}.
 
 Check it out here:
 

--- a/app/backend/templates/unseen_messages.md
+++ b/app/backend/templates/unseen_messages.md
@@ -6,7 +6,7 @@ subject: "You have {{ total_unseen_message_count }} unseen messages in {{ unseen
 
 Hi {{ escape(user.name) }}!
 
-You've unseen messages on Couchers.org, here's the latest:
+You have unseen messages on Couchers.org, here's the latest:
 
 {% for group_chat, latest_message, count in unseen_messages[:5] %}
 {% if group_chat.title %}

--- a/docs/urls.md
+++ b/docs/urls.md
@@ -9,7 +9,18 @@ This file also describes URLs included in all emails that is sent by
 the couchers server. For more information, see discussion in
 https://github.com/Couchers-org/couchers/issues/501 .
 
-## Sydney example
+## Core features
+
+### Messaging/requests
+
+* Messages overview: `/messages`
+* All group chats: `/messages/chats`
+* Group chat: `/messages/chats/{group chat id}`
+* All surfing requests (i.e. requests sent by us): `/messages/surfing`
+* All hosting requests (i.e. requests received by us): `/messages/hosting`
+* Request (surfing or hosting): `/messages/request/{host request id}`
+
+## Sydney example for community features
 
 Title: Sydney
 Explanation: Page for the Sydney Community
@@ -45,5 +56,3 @@ Navigation: Australia > East Coast Hitchhikers
 
 Title: User's profile
 URL: https://couchers.org/user/denvercoder9
-
-


### PR DESCRIPTION
Implements emails for when hosting requests change state and when they get messages.

Closes #915, but more of a stopgap before we get a full push notification system built.


**Backend checklist**
- [x] Formatted my code by running `isort . && black .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history
