### PR TITLE
Update Envoy config to v3 from v2

### DIFF
--- a/app/nginx/sites-enabled/api.conf
+++ b/app/nginx/sites-enabled/api.conf
@@ -9,17 +9,6 @@ server {
     ssl_certificate /certs/live/{API_DOMAIN}/fullchain.pem;
     ssl_certificate_key /certs/live/{API_DOMAIN}/privkey.pem;
 
-    location = / {
-        add_header Content-Type text/plain;
-
-        set $msg "This is the API for the Couchers.org app. If you're interested in helping out in building the";
-        set $msg "${msg} next-generation couch surfing platform with us, or if you're just interested in API access,";
-        set $msg "${msg} please contact us through https://couchers.org or come help out on GitHub at";
-        set $msg "${msg} https://github.com/Couchers-org.\n";
-
-        return 200 $msg;
-    }
-
     location / {
         proxy_http_version 1.1;
         proxy_pass http://envoy:8888;

--- a/app/proxy/envoy.yaml
+++ b/app/proxy/envoy.yaml
@@ -20,6 +20,15 @@ static_resources:
             - name: local_service
               domains: ["*"]
               routes:
+              - match: { path: "/" }
+                direct_response:
+                  status: 200
+                  body:
+                    inline_string: |-
+                      This is the API for the Couchers.org app. If you're interested in helping out
+                      in building the next-generation couch surfing platform with us, or if you're
+                      just interested in API access, please contact us through https://couchers.org
+                      or come help out on GitHub at https://github.com/Couchers-org.
               - match: { prefix: "/org.couchers.auth" }
                 route:
                   cluster: open_service

--- a/app/proxy/envoy.yaml
+++ b/app/proxy/envoy.yaml
@@ -1,8 +1,3 @@
-admin:
-  access_log_path: /tmp/admin_access.log
-  address:
-    socket_address: { address: 0.0.0.0, port_value: 9901 }
-
 static_resources:
   listeners:
   - name: listener_0
@@ -11,9 +6,14 @@ static_resources:
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
-        config:
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
+          access_log:
+          - name: envoy.access_loggers.stdout
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
           route_config:
             name: local_route
             virtual_hosts:
@@ -23,28 +23,34 @@ static_resources:
               - match: { prefix: "/org.couchers.auth" }
                 route:
                   cluster: open_service
-                  max_grpc_timeout: 0s
+                  max_stream_duration:
+                    grpc_timeout_header_max: 0s
               - match: { prefix: "/org.couchers.bugs" }
                 route:
                   cluster: open_service
-                  max_grpc_timeout: 0s
+                  max_stream_duration:
+                    grpc_timeout_header_max: 0s
               - match: { prefix: "/org.couchers.resources" }
                 route:
                   cluster: open_service
-                  max_grpc_timeout: 0s
+                  max_stream_duration:
+                    grpc_timeout_header_max: 0s
               - match: { prefix: "/org.couchers.jail" }
                 route:
                   cluster: jail_service
-                  max_grpc_timeout: 0s
+                  max_stream_duration:
+                    grpc_timeout_header_max: 0s
               - match: { prefix: "/org.couchers.api" }
                 route:
                   cluster: couchers_service
-                  max_grpc_timeout: 0s
+                  max_stream_duration:
+                    grpc_timeout_header_max: 0s
               # json transcoded stuff
               - match: { prefix: "/org.couchers.json" }
                 route:
                   cluster: couchers_service
-                  max_grpc_timeout: 0s
+                  max_stream_duration:
+                    grpc_timeout_header_max: 0s
               cors:
                 allow_origin_string_match:
                 # main site
@@ -60,6 +66,7 @@ static_resources:
                 max_age: "1728000"
                 allow_credentials: true
                 expose_headers: grpc-status,grpc-message,set-cookie
+                allow_credentials: true
           http_filters:
           - name: envoy.filters.http.grpc_web
           - name: envoy.filters.http.grpc_json_transcoder
@@ -78,18 +85,42 @@ static_resources:
   - name: couchers_service
     connect_timeout: 0.25s
     type: logical_dns
-    http2_protocol_options: {}
-    lb_policy: round_robin
-    hosts: [{ socket_address: { address: backend, port_value: 1751 }}]
+    load_assignment:
+      cluster_name: couchers_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address: { socket_address: { address: backend, port_value: 1751 }}
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
   - name: open_service
     connect_timeout: 0.25s
     type: logical_dns
-    http2_protocol_options: {}
-    lb_policy: round_robin
-    hosts: [{ socket_address: { address: backend, port_value: 1752 }}]
+    load_assignment:
+      cluster_name: open_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address: { socket_address: { address: backend, port_value: 1752 }}
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
   - name: jail_service
     connect_timeout: 0.25s
     type: logical_dns
-    http2_protocol_options: {}
-    lb_policy: round_robin
-    hosts: [{ socket_address: { address: backend, port_value: 1754 }}]
+    load_assignment:
+      cluster_name: jail_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address: { socket_address: { address: backend, port_value: 1754 }}
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}

--- a/app/proxy/envoy.yaml
+++ b/app/proxy/envoy.yaml
@@ -76,6 +76,35 @@ static_resources:
                 allow_credentials: true
                 expose_headers: grpc-status,grpc-message,set-cookie
                 allow_credentials: true
+            response_headers_to_add:
+              - header:
+                  key: x-help-wanted
+                  value: Come help build the next generation platform for couch surfers at https://github.com/Couchers-org
+                append: false
+              - header:
+                  key: strict-transport-security
+                  value: max-age=15552000; includeSubdomains; preload
+                append: false
+              - header:
+                  key: referrer-policy
+                  value: origin-when-cross-origin
+                append: false
+              - header:
+                  key: x-content-type
+                  value: Options "nosniff"
+                append: false
+              - header:
+                  key: x-frame-options
+                  value: DENY
+                append: false
+              - header:
+                  key: x-xss-protection
+                  value: 1; mode=block
+                append: false
+              - header:
+                  key: x-fact
+                  value: Kilroy was here.
+                append: false
           http_filters:
           - name: envoy.filters.http.grpc_web
           - name: envoy.filters.http.grpc_json_transcoder


### PR DESCRIPTION
I'm trying to push as much out from nginx into envoy.

On the app side: this now only leaves nginx to do TLS termination.