### PR TITLE
[WIP/MRG] Backend/feat/no password second email confirmation added test

### DIFF
--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -1,12 +1,10 @@
 import logging
-from datetime import datetime
 
 import grpc
 import pytz
 from google.protobuf import empty_pb2
 from sqlalchemy.sql import func
 
-import couchers
 from couchers import errors
 from couchers.config import config
 from couchers.constants import TOS_VERSION
@@ -430,15 +428,15 @@ class Auth(auth_pb2_grpc.AuthServicer):
             user_with_valid_token_from_old_email = (
                 session.query(User)
                 .filter(User.old_email_token == request.change_email_token)
-                .filter(User.old_email_token_created <= couchers.utils.now())
-                .filter(User.old_email_token_expiry >= couchers.utils.now())
+                .filter(User.old_email_token_created <= now())
+                .filter(User.old_email_token_expiry >= now())
                 .one_or_none()
             )
             user_with_valid_token_from_new_email = (
                 session.query(User)
                 .filter(User.new_email_token == request.change_email_token)
-                .filter(User.new_email_token_created <= couchers.utils.now())
-                .filter(User.new_email_token_expiry >= couchers.utils.now())
+                .filter(User.new_email_token_created <= now())
+                .filter(User.new_email_token_expiry >= now())
                 .one_or_none()
             )
 

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -6,6 +6,7 @@ import pytz
 from google.protobuf import empty_pb2
 from sqlalchemy.sql import func
 
+import couchers
 from couchers import errors
 from couchers.config import config
 from couchers.constants import TOS_VERSION
@@ -429,15 +430,15 @@ class Auth(auth_pb2_grpc.AuthServicer):
             user_with_valid_token_from_old_email = (
                 session.query(User)
                 .filter(User.old_email_token == request.change_email_token)
-                .filter(User.old_email_token_created <= func.now())
-                .filter(User.old_email_token_expiry >= func.now())
+                .filter(User.old_email_token_created <= couchers.utils.now())
+                .filter(User.old_email_token_expiry >= couchers.utils.now())
                 .one_or_none()
             )
             user_with_valid_token_from_new_email = (
                 session.query(User)
                 .filter(User.new_email_token == request.change_email_token)
-                .filter(User.new_email_token_created <= func.now())
-                .filter(User.new_email_token_expiry >= func.now())
+                .filter(User.new_email_token_created <= couchers.utils.now())
+                .filter(User.new_email_token_expiry >= couchers.utils.now())
                 .one_or_none()
             )
 

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -442,7 +442,7 @@ def test_ChangeEmail_tokens_expire(db):
         old_email_token = user.old_email_token
         new_email_token = user.new_email_token
 
-    with patch("couchers.utils.now", two_hours_one_minute_in_future):
+    with patch("couchers.servicers.auth.now", two_hours_one_minute_in_future):
         with auth_api_session() as (auth_api, metadata_interceptor):
             with pytest.raises(grpc.RpcError) as e:
                 auth_api.ConfirmChangeEmail(


### PR DESCRIPTION
Adding a test to check that the tokens successfully expire. Not super thrilled with this solution:
1) I would have preferred to mock func.now(), but couldn't get it to work
2) Would prefer to be able to use now() instead of couchers.utils.now() (and not have to import couchers), but again, couldn't get it to work.

Creating this as a branch to see if anyone else knows how to fix either of the above two issues


**Backend checklist**
- [x] Formatted my code by running `isort . && black .` in `app/backend`
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] All tests pass
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history