### PR TITLE
Add schedule to run enforce community memberships

### DIFF
--- a/app/backend/src/couchers/jobs/definitions.py
+++ b/app/backend/src/couchers/jobs/definitions.py
@@ -4,6 +4,7 @@ from google.protobuf import empty_pb2
 
 from couchers.jobs.handlers import (
     process_add_users_to_email_list,
+    process_enforce_community_membership,
     process_purge_login_tokens,
     process_purge_signup_tokens,
     process_send_email,
@@ -23,6 +24,7 @@ JOBS = {
     BackgroundJobType.send_onboarding_emails: (empty_pb2.Empty, process_send_onboarding_emails),
     BackgroundJobType.add_users_to_email_list: (empty_pb2.Empty, process_add_users_to_email_list),
     BackgroundJobType.send_request_notifications: (empty_pb2.Empty, process_send_request_notifications),
+    BackgroundJobType.enforce_community_membership: (empty_pb2.Empty, process_enforce_community_membership),
 }
 
 SCHEDULE = [
@@ -32,4 +34,5 @@ SCHEDULE = [
     (BackgroundJobType.send_onboarding_emails, timedelta(hours=1)),
     (BackgroundJobType.add_users_to_email_list, timedelta(hours=6)),
     (BackgroundJobType.send_request_notifications, timedelta(minutes=3)),
+    (BackgroundJobType.enforce_community_membership, timedelta(minutes=15)),
 ]

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -22,7 +22,7 @@ from couchers.models import (
     SignupToken,
     User,
 )
-from couchers.tasks import send_onboarding_email
+from couchers.tasks import enforce_community_memberships, send_onboarding_email
 from couchers.utils import now
 
 logger = logging.getLogger(__name__)
@@ -265,3 +265,7 @@ def process_add_users_to_email_list(payload):
             session.commit()
         else:
             raise Exception("Failed to add users to mailing list")
+
+
+def process_enforce_community_membership(payload):
+    enforce_community_memberships()

--- a/app/backend/src/couchers/migrations/versions/d3cee8207c3d_enforce_community_membership_background_.py
+++ b/app/backend/src/couchers/migrations/versions/d3cee8207c3d_enforce_community_membership_background_.py
@@ -1,0 +1,24 @@
+"""enforce_community_membership_background_job
+
+Revision ID: d3cee8207c3d
+Revises: 3b8d963e0b7d
+Create Date: 2021-06-05 11:24:10.551584
+
+"""
+import geoalchemy2
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d3cee8207c3d"
+down_revision = "3b8d963e0b7d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TYPE backgroundjobtype ADD VALUE 'enforce_community_membership'")
+
+
+def downgrade():
+    pass

--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -1476,7 +1476,7 @@ class BackgroundJobType(enum.Enum):
     # payload: google.protobuf.Empty
     send_request_notifications = 7
     # payload: google.protobuf.Empty
-    enforce_community_membership = 7
+    enforce_community_membership = 8
 
 
 class BackgroundJobState(enum.Enum):

--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -1475,6 +1475,8 @@ class BackgroundJobType(enum.Enum):
     add_users_to_email_list = 6
     # payload: google.protobuf.Empty
     send_request_notifications = 7
+    # payload: google.protobuf.Empty
+    enforce_community_membership = 7
 
 
 class BackgroundJobState(enum.Enum):

--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -1462,21 +1462,21 @@ class Reply(Base):
 
 class BackgroundJobType(enum.Enum):
     # payload: jobs.SendEmailPayload
-    send_email = 1
+    send_email = enum.auto()
     # payload: google.protobuf.Empty
-    purge_login_tokens = 2
+    purge_login_tokens = enum.auto()
     # payload: google.protobuf.Empty
-    purge_signup_tokens = 3
+    purge_signup_tokens = enum.auto()
     # payload: google.protobuf.Empty
-    send_message_notifications = 4
+    send_message_notifications = enum.auto()
     # payload: google.protobuf.Empty
-    send_onboarding_emails = 5
+    send_onboarding_emails = enum.auto()
     # payload: google.protobuf.Empty
-    add_users_to_email_list = 6
+    add_users_to_email_list = enum.auto()
     # payload: google.protobuf.Empty
-    send_request_notifications = 7
+    send_request_notifications = enum.auto()
     # payload: google.protobuf.Empty
-    enforce_community_membership = 8
+    enforce_community_membership = enum.auto()
 
 
 class BackgroundJobState(enum.Enum):

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -101,6 +101,15 @@ def test_purge_login_tokens(db):
         assert session.query(BackgroundJob).filter(BackgroundJob.state != BackgroundJobState.completed).count() == 0
 
 
+def test_enforce_community_memberships(db):
+    queue_job(BackgroundJobType.enforce_community_membership, empty_pb2.Empty())
+    process_job()
+
+    with session_scope() as session:
+        assert session.query(BackgroundJob).filter(BackgroundJob.state == BackgroundJobState.completed).count() == 1
+        assert session.query(BackgroundJob).filter(BackgroundJob.state != BackgroundJobState.completed).count() == 0
+
+
 def test_purge_signup_tokens(db):
     with auth_api_session() as (auth_api, metadata_interceptor):
         reply = auth_api.Signup(auth_pb2.SignupReq(email="a@b.com"))


### PR DESCRIPTION
Add schedule to run 'enforce_community_memberships' every 15 minutes.
closes #1335

- [ x] Formatted my code by running `isort . && black .` in `app/backend`
- [ x] Added tests for any new code or added a regression test if fixing a bug
- [ x ] All tests pass
- [x ] Run the backend locally and it works
- [ x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

