### PR TITLE
Implement auth interceptor using protobuf options

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -5,4 +5,4 @@
 build.sh
 
 # protobuf descriptor sets
-protos.pb
+descriptors.pb

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -3,3 +3,6 @@
 *.prod.env
 # runs deploy.sh with Aapeli's secrets
 build.sh
+
+# protobuf descriptor sets
+protos.pb

--- a/app/backend/src/app.py
+++ b/app/backend/src/app.py
@@ -1,58 +1,16 @@
 import logging
 import signal
 import sys
-from concurrent import futures
 
-import grpc
 import sentry_sdk
 from prometheus_client import start_http_server
 
 from couchers import config
 from couchers.db import apply_migrations, session_scope
-from couchers.interceptors import ErrorSanitizationInterceptor, TracingInterceptor
 from couchers.jobs.worker import start_jobs_scheduler, start_jobs_worker
 from couchers.metrics import main_process_registry
-from couchers.servicers.account import Account
-from couchers.servicers.api import API
-from couchers.servicers.auth import Auth
-from couchers.servicers.blocking import Blocking
-from couchers.servicers.bugs import Bugs
-from couchers.servicers.communities import Communities
-from couchers.servicers.conversations import Conversations
-from couchers.servicers.discussions import Discussions
-from couchers.servicers.events import Events
-from couchers.servicers.gis import GIS
-from couchers.servicers.groups import Groups
-from couchers.servicers.jail import Jail
-from couchers.servicers.media import Media, get_media_auth_interceptor
-from couchers.servicers.pages import Pages
-from couchers.servicers.references import References
-from couchers.servicers.requests import Requests
-from couchers.servicers.resources import Resources
-from couchers.servicers.search import Search
-from couchers.servicers.threads import Threads
+from couchers.server import create_main_server, create_media_server
 from dummy_data import add_dummy_data
-from proto import (
-    account_pb2_grpc,
-    api_pb2_grpc,
-    auth_pb2_grpc,
-    blocking_pb2_grpc,
-    bugs_pb2_grpc,
-    communities_pb2_grpc,
-    conversations_pb2_grpc,
-    discussions_pb2_grpc,
-    events_pb2_grpc,
-    gis_pb2_grpc,
-    groups_pb2_grpc,
-    jail_pb2_grpc,
-    media_pb2_grpc,
-    pages_pb2_grpc,
-    references_pb2_grpc,
-    requests_pb2_grpc,
-    resources_pb2_grpc,
-    search_pb2_grpc,
-    threads_pb2_grpc,
-)
 
 config.check_config()
 
@@ -97,46 +55,11 @@ if config.config["ADD_DUMMY_DATA"]:
 logger.info(f"Starting")
 
 if config.config["ROLE"] in ["api", "all"]:
-    server = grpc.server(
-        futures.ThreadPoolExecutor(64),
-        interceptors=[
-            ErrorSanitizationInterceptor(),
-            TracingInterceptor(),
-            AuthValidatorInterceptor(),
-        ],
-    )
-    server.add_insecure_port("[::]:1751")
-
-    account_pb2_grpc.add_AccountServicer_to_server(Account(), server)
-    api_pb2_grpc.add_APIServicer_to_server(API(), server)
-    auth_pb2_grpc.add_AuthServicer_to_server(Auth(), open_server)
-    blocking_pb2_grpc.add_BlockingServicer_to_server(Blocking(), server)
-    bugs_pb2_grpc.add_BugsServicer_to_server(Bugs(), open_server)
-    communities_pb2_grpc.add_CommunitiesServicer_to_server(Communities(), server)
-    conversations_pb2_grpc.add_ConversationsServicer_to_server(Conversations(), server)
-    discussions_pb2_grpc.add_DiscussionsServicer_to_server(Discussions(), server)
-    events_pb2_grpc.add_EventsServicer_to_server(Events(), server)
-    gis_pb2_grpc.add_GISServicer_to_server(GIS(), server)
-    groups_pb2_grpc.add_GroupsServicer_to_server(Groups(), server)
-    jail_pb2_grpc.add_JailServicer_to_server(Jail(), jailed_server)
-    pages_pb2_grpc.add_PagesServicer_to_server(Pages(), server)
-    references_pb2_grpc.add_ReferencesServicer_to_server(References(), server)
-    requests_pb2_grpc.add_RequestsServicer_to_server(Requests(), server)
-    resources_pb2_grpc.add_ResourcesServicer_to_server(Resources(), open_server)
-    search_pb2_grpc.add_SearchServicer_to_server(Search(), server)
-    threads_pb2_grpc.add_ThreadsServicer_to_server(Threads(), server)
-
+    server = create_main_server(port=1751)
     server.start()
-
-    media_server = grpc.server(
-        futures.ThreadPoolExecutor(8),
-        interceptors=[TracingInterceptor(), get_media_auth_interceptor(config.config["MEDIA_SERVER_BEARER_TOKEN"])],
-    )
-    media_server.add_insecure_port("[::]:1753")
-    media_pb2_grpc.add_MediaServicer_to_server(Media(), media_server)
+    media_server = create_media_server(port=1753)
     media_server.start()
-
-    logger.info(f"Serving on 1751 (secure), 1752 (auth), 1753 (media), and 1754 (jailed)")
+    logger.info(f"Serving on 1751 (secure) and 1753 (media)")
 
 if config.config["ROLE"] in ["scheduler", "all"]:
     scheduler = start_jobs_scheduler()

--- a/app/backend/src/couchers/descriptor_pool.py
+++ b/app/backend/src/couchers/descriptor_pool.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from google.protobuf import descriptor_pb2, descriptor_pool
 
 
-@functools.cache
+@functools.lru_cache
 def get_descriptor_pool():
     """
     Generates a protocol buffer object descriptor pool which allows looking up info about our proto API, such as options

--- a/app/backend/src/couchers/descriptor_pool.py
+++ b/app/backend/src/couchers/descriptor_pool.py
@@ -14,7 +14,7 @@ def get_descriptor_pool():
     from proto import annotations_pb2
 
     pool = descriptor_pool.DescriptorPool()
-    with open(Path(__file__).parent / ".." / "descriptors.pb", "rb") as descriptor_set_f:
+    with open(Path(__file__).parent / ".." / "proto" / "descriptors.pb", "rb") as descriptor_set_f:
         desc = descriptor_pb2.FileDescriptorSet.FromString(descriptor_set_f.read())
     for file_descriptor in desc.file:
         pool.Add(file_descriptor)

--- a/app/backend/src/couchers/descriptor_pool.py
+++ b/app/backend/src/couchers/descriptor_pool.py
@@ -14,7 +14,7 @@ def get_descriptor_pool():
     from proto import annotations_pb2
 
     pool = descriptor_pool.DescriptorPool()
-    with open(Path(__file__).parent / ".." / "protos.pb", "rb") as descriptor_set_f:
+    with open(Path(__file__).parent / ".." / "descriptors.pb", "rb") as descriptor_set_f:
         desc = descriptor_pb2.FileDescriptorSet.FromString(descriptor_set_f.read())
     for file_descriptor in desc.file:
         pool.Add(file_descriptor)

--- a/app/backend/src/couchers/descriptor_pool.py
+++ b/app/backend/src/couchers/descriptor_pool.py
@@ -11,7 +11,7 @@ def get_descriptor_pool():
     for each servicer, method, or message.
     """
     # this needs to be imported so the annotations are available in the generated pool...
-    from proto import annotations_pb2
+    from proto import annotations_pb2  # noqa
 
     pool = descriptor_pool.DescriptorPool()
     with open(Path(__file__).parent / ".." / "proto" / "descriptors.pb", "rb") as descriptor_set_f:

--- a/app/backend/src/couchers/descriptor_pool.py
+++ b/app/backend/src/couchers/descriptor_pool.py
@@ -1,0 +1,21 @@
+import functools
+from pathlib import Path
+
+from google.protobuf import descriptor_pb2, descriptor_pool
+
+
+@functools.cache
+def get_descriptor_pool():
+    """
+    Generates a protocol buffer object descriptor pool which allows looking up info about our proto API, such as options
+    for each servicer, method, or message.
+    """
+    # this needs to be imported so the annotations are available in the generated pool...
+    from proto import annotations_pb2
+
+    pool = descriptor_pool.DescriptorPool()
+    with open(Path(__file__).parent / ".." / "protos.pb", "rb") as descriptor_set_f:
+        desc = descriptor_pb2.FileDescriptorSet.FromString(descriptor_set_f.read())
+    for file_descriptor in desc.file:
+        pool.Add(file_descriptor)
+    return pool

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -75,7 +75,7 @@ class AuthValidatorInterceptor(grpc.ServerInterceptor):
 
     def intercept_service(self, continuation, handler_call_details):
         method = handler_call_details.method
-        # method is of the form "/org.couchers.api.core/GetUser"
+        # method is of the form "/org.couchers.api.core.API/GetUser"
         _, service_name, method_name = method.split("/")
 
         service_options = self._pool.FindServiceByName(service_name).GetOptions()

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -9,6 +9,7 @@ import sentry_sdk
 
 from couchers import errors
 from couchers.db import session_scope
+from couchers.descriptor_pool import get_descriptor_pool
 from couchers.metrics import servicer_duration_histogram
 from couchers.models import APICall
 from couchers.utils import parse_session_cookie
@@ -17,6 +18,42 @@ from proto import annotations_pb2
 LOG_VERBOSE_PB = "LOG_VERBOSE_PB" in os.environ
 
 logger = logging.getLogger(__name__)
+
+
+def _try_get_and_update_user_details(headers):
+    """
+    Parses the session cookie from headers and tries to get user info corresponding to this session.
+
+    Also updates the user last active time, token last active time, and increments API call count.
+    """
+    token = parse_session_cookie(headers)
+
+    if not token:
+        return None
+
+    with session_scope() as session:
+        result = (
+            session.query(User, UserSession)
+            .join(User, User.id == UserSession.user_id)
+            .filter(UserSession.token == token)
+            .filter(UserSession.is_valid)
+            .one_or_none()
+        )
+
+        if not result:
+            return None
+        else:
+            user, user_session = result
+
+            # update user last active time
+            user.last_active = func.now()
+
+            # let's update the token
+            user_session.last_seen = func.now()
+            user_session.api_calls += 1
+            session.flush()
+
+            return user.id, user.is_jailed, user.is_admin
 
 
 def unauthenticated_handler(message="Unauthorized"):
@@ -34,26 +71,49 @@ class AuthValidatorInterceptor(grpc.ServerInterceptor):
     terminates the call with an UNAUTHENTICATED error code.
     """
 
-    def __init__(self, get_session_for_token, allow_jailed=True):
-        self._get_session_for_token = get_session_for_token
-        self._allow_jailed = allow_jailed
+    def __init__(self):
+        self._pool = get_descriptor_pool()
 
     def intercept_service(self, continuation, handler_call_details):
-        token = parse_session_cookie(dict(handler_call_details.invocation_metadata))
+        method = handler_call_details.method
+        service_name, method_name = method.split("/")
 
-        if not token:
-            return unauthenticated_handler()
+        service_options = self._pool.FindServiceByName(service_name).GetOptions()
+        auth_level = service_options.Extensions[annotations_pb2.auth_level]
 
-        # None or (user_id, jailed)
-        res = self._get_session_for_token(token=token)
+        # if unknown auth level, then it wasn't set and something's wrong
+        if auth_level == annotations_pb2.AUTH_LEVEL_UNKNOWN:
+            raise Exception("Service not annotated with auth_level")
 
+        assert auth_level in [
+            annotations_pb2.AUTH_LEVEL_OPEN,
+            annotations_pb2.AUTH_LEVEL_JAILED,
+            annotations_pb2.AUTH_LEVEL_SECURE,
+            annotations_pb2.AUTH_LEVEL_ADMIN,
+        ]
+
+        res = _try_get_and_update_user_details(dict(handler_call_details.invocation_metadata))
+
+        # if no session was found and this isn't an open service, fail
         if not res:
-            return unauthenticated_handler()
+            if auth_level != annotations_pb2.AUTH_LEVEL_OPEN:
+                return unauthenticated_handler()
+            user_id = None
+            token = None
+        else:
+            # a valid user session was found
+            user_id, is_jailed, is_admin = res
 
-        user_id, jailed = res
+            # if the user is jailed and this is isn't a jailed service, fail
+            if is_jailed and auth_level != annotations_pb2.AUTH_LEVEL_JAILED:
+                return unauthenticated_handler("Permission denied")
 
-        if not self._allow_jailed and jailed:
-            return unauthenticated_handler("Permission denied")
+            # if the user isn't admin but this is an admin service, fail
+            if auth_level == annotations_pb2.AUTH_LEVEL_ADMIN:
+                if not is_admin:
+                    return unauthenticated_handler()
+            else:
+                assert auth_level == annotations_pb2.AUTH_LEVEL_SECURE
 
         handler = continuation(handler_call_details)
         user_aware_function = handler.unary_unary

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -104,8 +104,8 @@ class AuthValidatorInterceptor(grpc.ServerInterceptor):
             # a valid user session was found
             user_id, is_jailed = res
 
-            # if the user is jailed and this is isn't a jailed service, fail
-            if is_jailed and auth_level != annotations_pb2.AUTH_LEVEL_JAILED:
+            # if the user is jailed and this is isn't an open or jailed service, fail
+            if is_jailed and auth_level not in [annotations_pb2.AUTH_LEVEL_OPEN, annotations_pb2.AUTH_LEVEL_JAILED]:
                 return unauthenticated_handler("Permission denied")
 
         handler = continuation(handler_call_details)

--- a/app/backend/src/couchers/server.py
+++ b/app/backend/src/couchers/server.py
@@ -1,0 +1,88 @@
+from concurrent import futures
+
+import grpc
+
+from couchers import config
+from couchers.interceptors import AuthValidatorInterceptor, ErrorSanitizationInterceptor, TracingInterceptor
+from couchers.servicers.account import Account
+from couchers.servicers.api import API
+from couchers.servicers.auth import Auth
+from couchers.servicers.blocking import Blocking
+from couchers.servicers.bugs import Bugs
+from couchers.servicers.communities import Communities
+from couchers.servicers.conversations import Conversations
+from couchers.servicers.discussions import Discussions
+from couchers.servicers.events import Events
+from couchers.servicers.gis import GIS
+from couchers.servicers.groups import Groups
+from couchers.servicers.jail import Jail
+from couchers.servicers.media import Media, get_media_auth_interceptor
+from couchers.servicers.pages import Pages
+from couchers.servicers.references import References
+from couchers.servicers.requests import Requests
+from couchers.servicers.resources import Resources
+from couchers.servicers.search import Search
+from couchers.servicers.threads import Threads
+from proto import (
+    account_pb2_grpc,
+    api_pb2_grpc,
+    auth_pb2_grpc,
+    blocking_pb2_grpc,
+    bugs_pb2_grpc,
+    communities_pb2_grpc,
+    conversations_pb2_grpc,
+    discussions_pb2_grpc,
+    events_pb2_grpc,
+    gis_pb2_grpc,
+    groups_pb2_grpc,
+    jail_pb2_grpc,
+    media_pb2_grpc,
+    pages_pb2_grpc,
+    references_pb2_grpc,
+    requests_pb2_grpc,
+    resources_pb2_grpc,
+    search_pb2_grpc,
+    threads_pb2_grpc,
+)
+
+
+def create_main_server(port, threads=64):
+    server = grpc.server(
+        futures.ThreadPoolExecutor(threads),
+        interceptors=[
+            ErrorSanitizationInterceptor(),
+            TracingInterceptor(),
+            AuthValidatorInterceptor(),
+        ],
+    )
+    server.add_insecure_port(f"[::]:{port}")
+
+    account_pb2_grpc.add_AccountServicer_to_server(Account(), server)
+    api_pb2_grpc.add_APIServicer_to_server(API(), server)
+    auth_pb2_grpc.add_AuthServicer_to_server(Auth(), server)
+    blocking_pb2_grpc.add_BlockingServicer_to_server(Blocking(), server)
+    bugs_pb2_grpc.add_BugsServicer_to_server(Bugs(), server)
+    communities_pb2_grpc.add_CommunitiesServicer_to_server(Communities(), server)
+    conversations_pb2_grpc.add_ConversationsServicer_to_server(Conversations(), server)
+    discussions_pb2_grpc.add_DiscussionsServicer_to_server(Discussions(), server)
+    events_pb2_grpc.add_EventsServicer_to_server(Events(), server)
+    gis_pb2_grpc.add_GISServicer_to_server(GIS(), server)
+    groups_pb2_grpc.add_GroupsServicer_to_server(Groups(), server)
+    jail_pb2_grpc.add_JailServicer_to_server(Jail(), server)
+    pages_pb2_grpc.add_PagesServicer_to_server(Pages(), server)
+    references_pb2_grpc.add_ReferencesServicer_to_server(References(), server)
+    requests_pb2_grpc.add_RequestsServicer_to_server(Requests(), server)
+    resources_pb2_grpc.add_ResourcesServicer_to_server(Resources(), server)
+    search_pb2_grpc.add_SearchServicer_to_server(Search(), server)
+    threads_pb2_grpc.add_ThreadsServicer_to_server(Threads(), server)
+    return server
+
+
+def create_media_server(port, threads=8):
+    media_server = grpc.server(
+        futures.ThreadPoolExecutor(threads),
+        interceptors=[TracingInterceptor(), get_media_auth_interceptor(config.config["MEDIA_SERVER_BEARER_TOKEN"])],
+    )
+    media_server.add_insecure_port(f"[::]:{port}")
+    media_pb2_grpc.add_MediaServicer_to_server(Media(), media_server)
+    return media_server

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -8,7 +8,6 @@ from couchers import errors
 from couchers.constants import TOS_VERSION
 from couchers.crypto import cookiesafe_secure_token, hash_password, verify_password
 from couchers.db import new_login_token, new_password_reset_token, new_signup_token, session_scope
-from couchers.interceptors import AuthValidatorInterceptor
 from couchers.models import LoginToken, PasswordResetToken, SignupToken, User, UserSession
 from couchers.servicers.api import hostingstatus2sql
 from couchers.tasks import send_login_email, send_onboarding_email, send_password_reset_email, send_signup_email
@@ -34,46 +33,6 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
     This class services the Auth service/API.
     """
-
-    def get_auth_interceptor(self, allow_jailed):
-        """
-        Returns an auth interceptor.
-
-        By adding this interceptor to a service, all requests to that service will require a bearer authorization with a valid session from the Auth service.
-
-        The user_id will be available in the RPC context through context.user_id.
-        """
-        return AuthValidatorInterceptor(self.get_session_for_token, allow_jailed)
-
-    def get_session_for_token(self, token):
-        """
-        Returns None if the session token is not valid, and (user_id, jailed) corresponding to the session token otherwise.
-
-        Also updates the user last active time, token last active time, and increments API call count.
-        """
-        with session_scope() as session:
-            result = (
-                session.query(User, UserSession)
-                .join(User, User.id == UserSession.user_id)
-                .filter(UserSession.token == token)
-                .filter(UserSession.is_valid)
-                .one_or_none()
-            )
-
-            if not result:
-                return None
-            else:
-                user, user_session = result
-
-                # update user last active time
-                user.last_active = func.now()
-
-                # let's update the token
-                user_session.last_seen = func.now()
-                user_session.api_calls += 1
-                session.flush()
-
-                return user.id, user.is_jailed
 
     def _create_session(self, context, session, user, long_lived):
         """

--- a/app/backend/src/tests/test_app.py
+++ b/app/backend/src/tests/test_app.py
@@ -1,8 +1,7 @@
-import grpc
 import pytest
 
 from couchers.server import create_main_server, create_media_server
-from tests.test_fixtures import testconfig
+from tests.test_fixtures import testconfig  # noqa
 
 
 @pytest.fixture(autouse=True)

--- a/app/backend/src/tests/test_app.py
+++ b/app/backend/src/tests/test_app.py
@@ -1,0 +1,19 @@
+import grpc
+import pytest
+
+from couchers.server import create_main_server, create_media_server
+from tests.test_fixtures import testconfig
+
+
+@pytest.fixture(autouse=True)
+def _(testconfig):
+    pass
+
+
+def test_create_servers():
+    server = create_main_server(port=1751)
+    media_server = create_media_server(port=1753)
+    server.start()
+    media_server.start()
+    server.stop(None).wait()
+    media_server.stop(None).wait()

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -435,8 +435,7 @@ def real_jail_session(token):
     with futures.ThreadPoolExecutor(1) as executor:
         server = grpc.server(executor, interceptors=[AuthValidatorInterceptor()])
         port = server.add_secure_port("localhost:0", grpc.local_server_credentials())
-        servicer = Jail()
-        jail_pb2_grpc.add_JailServicer_to_server(servicer, server)
+        jail_pb2_grpc.add_JailServicer_to_server(Jail(), server)
         server.start()
 
         call_creds = grpc.metadata_call_credentials(CookieMetadataPlugin(token))

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -449,8 +449,7 @@ def real_jail_session(token):
 
 
 def fake_channel(token):
-    headers = {"cookie": f"couchers-sesh={token}"}
-    user_id, jailed = _try_get_and_update_user_details(headers)
+    user_id, jailed = _try_get_and_update_user_details(token)
     return FakeChannel(user_id=user_id)
 
 

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -13,6 +13,7 @@ from couchers.config import config
 from couchers.constants import TOS_VERSION
 from couchers.crypto import random_hex
 from couchers.db import get_engine, session_scope
+from couchers.interceptors import AuthValidatorInterceptor, _try_get_and_update_user_details
 from couchers.models import (
     Base,
     FriendRelationship,
@@ -410,13 +411,10 @@ def real_api_session(token):
     """
     Create an API for testing, using TCP sockets, uses the token for auth
     """
-    auth_interceptor = Auth().get_auth_interceptor(allow_jailed=False)
-
     with futures.ThreadPoolExecutor(1) as executor:
-        server = grpc.server(executor, interceptors=[auth_interceptor])
+        server = grpc.server(executor, interceptors=[AuthValidatorInterceptor()])
         port = server.add_secure_port("localhost:0", grpc.local_server_credentials())
-        servicer = API()
-        api_pb2_grpc.add_APIServicer_to_server(servicer, server)
+        api_pb2_grpc.add_APIServicer_to_server(API(), server)
         server.start()
 
         call_creds = grpc.metadata_call_credentials(CookieMetadataPlugin(token))
@@ -434,10 +432,8 @@ def real_jail_session(token):
     """
     Create a Jail service for testing, using TCP sockets, uses the token for auth
     """
-    auth_interceptor = Auth().get_auth_interceptor(allow_jailed=True)
-
     with futures.ThreadPoolExecutor(1) as executor:
-        server = grpc.server(executor, interceptors=[auth_interceptor])
+        server = grpc.server(executor, interceptors=[AuthValidatorInterceptor()])
         port = server.add_secure_port("localhost:0", grpc.local_server_credentials())
         servicer = Jail()
         jail_pb2_grpc.add_JailServicer_to_server(servicer, server)
@@ -454,7 +450,8 @@ def real_jail_session(token):
 
 
 def fake_channel(token):
-    user_id, jailed = Auth().get_session_for_token(token)
+    headers = {"cookie": f"couchers-sesh={token}"}
+    user_id, jailed = _try_get_and_update_user_details(headers)
     return FakeChannel(user_id=user_id)
 
 

--- a/app/generate_protos.sh
+++ b/app/generate_protos.sh
@@ -11,7 +11,7 @@ find proto -name '*.proto' | protoc -I proto \
   --plugin=protoc-gen-grpc_python=$(which grpc_python_plugin) \
   --include_imports --include_source_info \
   \
-  --descriptor_set_out proto/protos.pb \
+  --descriptor_set_out proto/descriptors.pb \
   \
   --python_out=backend/src/proto \
   --grpc_python_out=backend/src/proto \
@@ -25,8 +25,8 @@ find proto -name '*.proto' | protoc -I proto \
   $(xargs)
 
 # protoc only allows passing --descriptor_set_out once...
-cp proto/protos.pb proxy/protos.pb
-cp proto/protos.pb backend/src/protos.pb
+cp proto/descriptors.pb proxy/descriptors.pb
+cp proto/descriptors.pb backend/src/descriptors.pb
 
 # create internal backend protos
 (cd backend && find proto -name '*.proto' | protoc -I proto \

--- a/app/generate_protos.sh
+++ b/app/generate_protos.sh
@@ -26,7 +26,7 @@ find proto -name '*.proto' | protoc -I proto \
 
 # protoc only allows passing --descriptor_set_out once...
 cp proto/descriptors.pb proxy/descriptors.pb
-cp proto/descriptors.pb backend/src/descriptors.pb
+cp proto/descriptors.pb backend/src/proto/descriptors.pb
 
 # create internal backend protos
 (cd backend && find proto -name '*.proto' | protoc -I proto \

--- a/app/generate_protos.sh
+++ b/app/generate_protos.sh
@@ -11,7 +11,7 @@ find proto -name '*.proto' | protoc -I proto \
   --plugin=protoc-gen-grpc_python=$(which grpc_python_plugin) \
   --include_imports --include_source_info \
   \
-  --descriptor_set_out proxy/protos.pb \
+  --descriptor_set_out proto/protos.pb \
   \
   --python_out=backend/src/proto \
   --grpc_python_out=backend/src/proto \
@@ -23,6 +23,10 @@ find proto -name '*.proto' | protoc -I proto \
   --grpc-web_out="import_style=commonjs+dts,mode=grpcweb:frontend/src/proto" \
   \
   $(xargs)
+
+# protoc only allows passing --descriptor_set_out once...
+cp proto/protos.pb proxy/protos.pb
+cp proto/protos.pb backend/src/protos.pb
 
 # create internal backend protos
 (cd backend && find proto -name '*.proto' | protoc -I proto \

--- a/app/proto/account.proto
+++ b/app/proto/account.proto
@@ -2,14 +2,13 @@ syntax = "proto3";
 
 package org.couchers.api.account;
 
-import "google/protobuf/wrappers.proto";
 import "google/protobuf/empty.proto";
+import "google/protobuf/wrappers.proto";
 
 import "annotations.proto";
 
 service Account {
-  // This is a secure service: a user needs to be authenticated and not jailed to call functions here, refer to
-  // auth.proto and jail.proto
+  option (auth_level) = AUTH_LEVEL_SECURE;
 
   // account management APIs
   rpc GetAccountInfo(google.protobuf.Empty) returns (GetAccountInfoRes) {

--- a/app/proto/annotations.proto
+++ b/app/proto/annotations.proto
@@ -6,3 +6,21 @@ extend google.protobuf.FieldOptions {
   // whether the field is sensitive and should not be logged
   bool sensitive = 50000;
 }
+
+enum AuthLevel {
+  // error
+  AUTH_LEVEL_UNKNOWN = 0;
+  // accessible to all
+  AUTH_LEVEL_OPEN = 1;
+  // accessible to users who need to finish some things to get into the app
+  AUTH_LEVEL_JAILED = 2;
+  // accessible to all signed in users
+  AUTH_LEVEL_SECURE = 3;
+  // accessible to superusers/admins only
+  AUTH_LEVEL_ADMIN = 4;
+}
+
+extend google.protobuf.ServiceOptions {
+  // the auth level required to access this service, one of
+  AuthLevel auth_level = 50001;
+}

--- a/app/proto/annotations.proto
+++ b/app/proto/annotations.proto
@@ -16,8 +16,6 @@ enum AuthLevel {
   AUTH_LEVEL_JAILED = 2;
   // accessible to all signed in users
   AUTH_LEVEL_SECURE = 3;
-  // accessible to superusers/admins only
-  AUTH_LEVEL_ADMIN = 4;
 }
 
 extend google.protobuf.ServiceOptions {

--- a/app/proto/api.proto
+++ b/app/proto/api.proto
@@ -2,13 +2,14 @@ syntax = "proto3";
 
 package org.couchers.api.core;
 
+import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
-import "google/protobuf/empty.proto";
+
+import "annotations.proto";
 
 service API {
-  // This is a secure service: a user needs to be authenticated and not jailed to call functions here, refer to
-  // auth.proto and jail.proto
+  option (auth_level) = AUTH_LEVEL_SECURE;
 
   rpc Ping(PingReq) returns (PingRes) {
     // Pings the server for updates and basic user info

--- a/app/proto/auth.proto
+++ b/app/proto/auth.proto
@@ -5,11 +5,10 @@ package org.couchers.auth;
 import "google/protobuf/empty.proto";
 
 import "annotations.proto";
-
 import "api.proto";
 
 service Auth {
-  // This is an open service, no authentication is needed
+  option (auth_level) = AUTH_LEVEL_OPEN;
 
   /*
   Authentication API

--- a/app/proto/blocking.proto
+++ b/app/proto/blocking.proto
@@ -4,9 +4,10 @@ package org.couchers.blocking;
 
 import "google/protobuf/empty.proto";
 
+import "annotations.proto";
+
 service Blocking {
-  // This is a secure service: a user needs to be authenticated and not jailed to call functions here, refer to
-  // auth.proto and jail.proto
+  option (auth_level) = AUTH_LEVEL_SECURE;
 
   rpc BlockUser(BlockUserReq) returns (google.protobuf.Empty);
 

--- a/app/proto/bugs.proto
+++ b/app/proto/bugs.proto
@@ -4,8 +4,10 @@ package org.couchers.bugs;
 
 import "google/protobuf/empty.proto";
 
+import "annotations.proto";
+
 service Bugs {
-  // This is an open service, no authentication is needed
+  option (auth_level) = AUTH_LEVEL_OPEN;
 
   rpc Version(google.protobuf.Empty) returns (VersionInfo) {
     // Returns backend version info

--- a/app/proto/communities.proto
+++ b/app/proto/communities.proto
@@ -5,13 +5,13 @@ package org.couchers.api.communities;
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 
+import "annotations.proto";
 import "discussions.proto";
 import "groups.proto";
 import "pages.proto";
 
 service Communities {
-  // This is a secure service: a user needs to be authenticated and not jailed to call functions here, refer to
-  // auth.proto and jail.proto
+  option (auth_level) = AUTH_LEVEL_SECURE;
 
   rpc GetCommunity(GetCommunityReq) returns (Community) {
     // Get info about a Community

--- a/app/proto/conversations.proto
+++ b/app/proto/conversations.proto
@@ -2,13 +2,14 @@ syntax = "proto3";
 
 package org.couchers.api.conversations;
 
+import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
-import "google/protobuf/empty.proto";
+
+import "annotations.proto";
 
 service Conversations {
-  // This is a secure service: a user needs to be authenticated and not jailed to call functions here, refer to
-  // auth.proto and jail.proto
+  option (auth_level) = AUTH_LEVEL_SECURE;
 
   rpc ListGroupChats(ListGroupChatsReq) returns (ListGroupChatsRes) {
     // Retrieves list of group chats (ordered by last message), paginated

--- a/app/proto/discussions.proto
+++ b/app/proto/discussions.proto
@@ -4,11 +4,11 @@ package org.couchers.api.discussions;
 
 import "google/protobuf/timestamp.proto";
 
+import "annotations.proto";
 import "threads.proto";
 
 service Discussions {
-  // This is a secure service: a user needs to be authenticated and not jailed to call functions here, refer to
-  // auth.proto and jail.proto
+  option (auth_level) = AUTH_LEVEL_SECURE;
 
   rpc CreateDiscussion(CreateDiscussionReq) returns (Discussion) {
     // Create a new discussion

--- a/app/proto/events.proto
+++ b/app/proto/events.proto
@@ -6,9 +6,10 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
+import "annotations.proto";
+
 service Events {
-  // This is a secure service: a user needs to be authenticated and not jailed to call functions here, refer to
-  // auth.proto and jail.proto
+  option (auth_level) = AUTH_LEVEL_SECURE;
 
   rpc CreateEvent(CreateEventReq) returns (Event) {
     // Creates an event, only one instance, add more with ScheduleEvent

--- a/app/proto/gis.proto
+++ b/app/proto/gis.proto
@@ -6,9 +6,10 @@ import "google/api/annotations.proto";
 import "google/api/httpbody.proto";
 import "google/protobuf/empty.proto";
 
+import "annotations.proto";
+
 service GIS {
-  // This is a secure service: a user needs to be authenticated and not jailed to call functions here, refer to
-  // auth.proto and jail.proto
+  option (auth_level) = AUTH_LEVEL_SECURE;
 
   rpc GetUsers(google.protobuf.Empty) returns (google.api.HttpBody) {
     option (google.api.http) = {

--- a/app/proto/groups.proto
+++ b/app/proto/groups.proto
@@ -5,12 +5,12 @@ package org.couchers.api.groups;
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 
+import "annotations.proto";
 import "discussions.proto";
 import "pages.proto";
 
 service Groups {
-  // This is a secure service: a user needs to be authenticated and not jailed to call functions here, refer to
-  // auth.proto and jail.proto
+  option (auth_level) = AUTH_LEVEL_SECURE;
 
   rpc GetGroup(GetGroupReq) returns (Group) {
     // Get info about a group

--- a/app/proto/jail.proto
+++ b/app/proto/jail.proto
@@ -4,8 +4,10 @@ package org.couchers.jail;
 
 import "google/protobuf/empty.proto";
 
+import "annotations.proto";
+
 service Jail {
-  // This is a secure service but allows jailed users access.
+  option (auth_level) = AUTH_LEVEL_JAILED;
 
   /*
   Jail API

--- a/app/proto/pages.proto
+++ b/app/proto/pages.proto
@@ -5,11 +5,11 @@ package org.couchers.api.pages;
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
+import "annotations.proto";
 import "threads.proto";
 
 service Pages {
-  // This is a secure service: a user needs to be authenticated and not jailed to call functions here, refer to
-  // auth.proto and jail.proto
+  option (auth_level) = AUTH_LEVEL_SECURE;
 
   rpc CreatePlace(CreatePlaceReq) returns (Page) {
     // Creates a place

--- a/app/proto/references.proto
+++ b/app/proto/references.proto
@@ -5,9 +5,10 @@ package org.couchers.api.references;
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 
+import "annotations.proto";
+
 service References {
-  // This is a secure service: a user needs to be authenticated and not jailed to call functions here, refer to
-  // auth.proto and jail.proto
+  option (auth_level) = AUTH_LEVEL_SECURE;
 
   rpc ListReferences(ListReferencesReq) returns (ListReferencesRes) {
     // Returns a paginated list of references satisfying some filtering criterion

--- a/app/proto/requests.proto
+++ b/app/proto/requests.proto
@@ -2,14 +2,14 @@ syntax = "proto3";
 
 package org.couchers.api.requests;
 
-import "google/protobuf/timestamp.proto";
 import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
 
+import "annotations.proto";
 import "conversations.proto";
 
 service Requests {
-  // This is a secure service: a user needs to be authenticated and not jailed to call functions here, refer to
-  // auth.proto and jail.proto
+  option (auth_level) = AUTH_LEVEL_SECURE;
 
   rpc CreateHostRequest(CreateHostRequestReq) returns (CreateHostRequestRes);
 

--- a/app/proto/resources.proto
+++ b/app/proto/resources.proto
@@ -4,8 +4,10 @@ package org.couchers.resources;
 
 import "google/protobuf/empty.proto";
 
+import "annotations.proto";
+
 service Resources {
-  // This is an open service, no authentication is needed
+  option (auth_level) = AUTH_LEVEL_OPEN;
 
   // This API contains general resources needed by frontends and managed by the backend team
 

--- a/app/proto/search.proto
+++ b/app/proto/search.proto
@@ -5,14 +5,14 @@ package org.couchers.api.search;
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
+import "annotations.proto";
 import "api.proto";
 import "communities.proto";
 import "groups.proto";
 import "pages.proto";
 
 service Search {
-  // This is a secure service: a user needs to be authenticated and not jailed to call functions here, refer to
-  // auth.proto and jail.proto
+  option (auth_level) = AUTH_LEVEL_SECURE;
 
   rpc Search(SearchReq) returns (SearchRes) {
     // Search all content

--- a/app/proto/threads.proto
+++ b/app/proto/threads.proto
@@ -4,9 +4,10 @@ package org.couchers.api.threads;
 
 import "google/protobuf/timestamp.proto";
 
+import "annotations.proto";
+
 service Threads {
-  // This is a secure service: a user needs to be authenticated and not jailed to call functions here, refer to
-  // auth.proto and jail.proto
+  option (auth_level) = AUTH_LEVEL_SECURE;
 
   // Discussion threads are organized as a tree with maximum three levels depth:
   // thread1

--- a/app/proxy/.gitignore
+++ b/app/proxy/.gitignore
@@ -1,1 +1,0 @@
-protos.pb

--- a/app/proxy/Dockerfile
+++ b/app/proxy/Dockerfile
@@ -1,7 +1,7 @@
 FROM envoyproxy/envoy:v1.18.3
 
 COPY ./envoy.yaml /etc/envoy/envoy.yaml
-COPY ./protos.pb /tmp/envoy/protos.pb
+COPY ./descriptors.pb /tmp/envoy/descriptors.pb
 
 EXPOSE 8888
 EXPOSE 9901

--- a/app/proxy/envoy.yaml
+++ b/app/proxy/envoy.yaml
@@ -29,7 +29,7 @@ static_resources:
                       in building the next-generation couch surfing platform with us, or if you're
                       just interested in API access, please contact us through https://couchers.org
                       or come help out on GitHub at https://github.com/Couchers-org.
-              - match: { prefix: "/org.couchers.auth" }
+              - match: { prefix: "/" }
                 route:
                   cluster: couchers_service
                   max_stream_duration:

--- a/app/proxy/envoy.yaml
+++ b/app/proxy/envoy.yaml
@@ -31,32 +31,6 @@ static_resources:
                       or come help out on GitHub at https://github.com/Couchers-org.
               - match: { prefix: "/org.couchers.auth" }
                 route:
-                  cluster: open_service
-                  max_stream_duration:
-                    grpc_timeout_header_max: 0s
-              - match: { prefix: "/org.couchers.bugs" }
-                route:
-                  cluster: open_service
-                  max_stream_duration:
-                    grpc_timeout_header_max: 0s
-              - match: { prefix: "/org.couchers.resources" }
-                route:
-                  cluster: open_service
-                  max_stream_duration:
-                    grpc_timeout_header_max: 0s
-              - match: { prefix: "/org.couchers.jail" }
-                route:
-                  cluster: jail_service
-                  max_stream_duration:
-                    grpc_timeout_header_max: 0s
-              - match: { prefix: "/org.couchers.api" }
-                route:
-                  cluster: couchers_service
-                  max_stream_duration:
-                    grpc_timeout_header_max: 0s
-              # json transcoded stuff
-              - match: { prefix: "/org.couchers.json" }
-                route:
                   cluster: couchers_service
                   max_stream_duration:
                     grpc_timeout_header_max: 0s
@@ -129,34 +103,6 @@ static_resources:
       - lb_endpoints:
         - endpoint:
             address: { socket_address: { address: backend, port_value: 1751 }}
-    typed_extension_protocol_options:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicit_http_config:
-          http2_protocol_options: {}
-  - name: open_service
-    connect_timeout: 0.25s
-    type: logical_dns
-    load_assignment:
-      cluster_name: open_service
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address: { socket_address: { address: backend, port_value: 1752 }}
-    typed_extension_protocol_options:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicit_http_config:
-          http2_protocol_options: {}
-  - name: jail_service
-    connect_timeout: 0.25s
-    type: logical_dns
-    load_assignment:
-      cluster_name: jail_service
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address: { socket_address: { address: backend, port_value: 1754 }}
     typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/app/proxy/envoy.yaml
+++ b/app/proxy/envoy.yaml
@@ -84,7 +84,7 @@ static_resources:
           - name: envoy.filters.http.grpc_json_transcoder
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder
-              proto_descriptor: "/tmp/envoy/protos.pb"
+              proto_descriptor: "/tmp/envoy/descriptors.pb"
               services: ["org.couchers.json.GIS"]
               print_options:
                 add_whitespace: true


### PR DESCRIPTION
This uses protobuf `option`s to describe the auth level for each service instead of having them as comments and then syncing the comments with the multi-server system.

I know this won't run as is; and it's missing tests. I wanted to seek out opinions before I put a lot of time into tests and fixing the rest of everything to work with this.

Pros:
* `.proto`s are the source of truth for required auth level, which reduces
* Only need to have the server listening on one port instead of one for each auth level
* Much easier to implement new auth levels (such as `admin`, implemented here)
* Can do more complicated auth/interceptor annotations; e.g. per-method, or other per-service/method interceptor things
* Potentially allows frontends to attach their own logic to services depending on annotations

Cons:
* Silly protobuf ~~reflection~~ descriptor stuff
* Need to have a generated `DescriptorFileSet` proto in backend too (but we already do codegen, etc; so I don't think this is big)

I've got to say: I do personally think these protobuf annotations/options are pretty nifty...

Missing:
* ~~Add `is_admin` (superuser) field to `User`~~ removed from this PR
* ~~Fix envoy proxy to use single-port thing~~
* Add tests

**Backend checklist**
- [x] Formatted my code by running `isort . && black .` in `app/backend`
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] All tests pass
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history