### PR TITLE
Require python>3.8 instead of 3.9

### DIFF
--- a/app/backend/Dockerfile
+++ b/app/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-buster as base
+FROM python:3.8-buster as base
 
 RUN apt-get update && apt-get install -y libgeos-c1v5
 

--- a/app/backend/readme.md
+++ b/app/backend/readme.md
@@ -25,7 +25,7 @@ docker-compose -f docker-compose.test.yml up postgres_tests
 3. Create a virtual environment and install the requirements.
 
 ```sh
-virtualenv venv -p python3.9
+virtualenv venv -p python3.8
 pip install -r requirements.txt
 ```
 

--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -47,7 +47,7 @@ def apply_migrations():
         os.chdir(cwd)
 
 
-@functools.cache
+@functools.lru_cache
 def _get_base_engine():
     if config.config["IN_TEST"]:
         return create_engine(config.config["DATABASE_CONNECTION_STRING"], poolclass=NullPool)

--- a/app/backend/src/couchers/resources.py
+++ b/app/backend/src/couchers/resources.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 resources_folder = Path(__file__).parent / ".." / ".." / "resources"
 
 
-@functools.cache
+@functools.lru_cache
 def get_terms_of_service():
     """
     Get the latest terms of service
@@ -21,7 +21,7 @@ def get_terms_of_service():
         return f.read()
 
 
-@functools.cache
+@functools.lru_cache
 def get_region_dict():
     """
     Get list of allowed regions as a dictionary of {alpha3: name}.
@@ -37,7 +37,7 @@ def region_is_allowed(code):
     return code in get_region_dict()
 
 
-@functools.cache
+@functools.lru_cache
 def get_language_dict():
     """
     Get list of allowed languages as a dictionary of {code: name}.


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
It is just silly to depend on a too new Python just to use functools.cache instead of functools.cache_lru. Use a Python that is installed by default in stable distros.

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on frontend)
If you need help with any of these, please ask :)
--->
**Backend checklist**
- [x] Formatted my code by running `isort . && black .` in `app/backend`
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] All tests pass
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
