### PR TITLE
Fix "display location" instructive text not moving when autofilled

### DIFF
--- a/app/frontend/src/components/EditLocationMap.test.tsx
+++ b/app/frontend/src/components/EditLocationMap.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import MapUI from "components/Map";
+import mapboxgl from "maplibre-gl";
+import { useEffect } from "react";
+import { server } from "test/restMock";
+
+import { DISPLAY_LOCATION, SEARCH_FOR_LOCATION } from "./constants";
+import EditLocationMap from "./EditLocationMap";
+
+jest.mock("components/Map");
+jest.mock("maplibre-gl");
+
+const getCanvasMock = mapboxgl.Map.prototype.getCanvas as jest.Mock;
+const MapMock = MapUI as jest.Mock;
+const wrapMock = mapboxgl.LngLat.prototype.wrap as jest.Mock;
+const getSourceMock = mapboxgl.Map.prototype.getSource as jest.Mock;
+
+describe("Edit location map", () => {
+  beforeEach(() => {
+    getCanvasMock.mockImplementation(() => ({
+      style: {
+        set cursor(value: string) {},
+      },
+    }));
+    getSourceMock.mockImplementation(() => {
+      return {
+        setData: jest.fn(),
+      };
+    });
+
+    wrapMock.mockReturnThis();
+
+    MapMock.mockImplementation(({ postMapInitialize }) => {
+      useEffect(() => {
+        postMapInitialize?.(new mapboxgl.Map());
+      });
+      return <div>Map</div>;
+    });
+  });
+
+  beforeAll(() => {
+    server.listen();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  describe("The 'Display Location' label", () => {
+    it("is not shrunk when the location is empty", async () => {
+      render(
+        <EditLocationMap
+          initialLocation={{
+            address: "",
+            lat: 1,
+            lng: 2,
+            radius: 100,
+          }}
+          updateLocation={jest.fn()}
+        />
+      );
+      expect(screen.getByText(DISPLAY_LOCATION)).toHaveAttribute(
+        "data-shrink",
+        "false"
+      );
+    });
+
+    it("is shrunk when there is a default location", async () => {
+      render(
+        <EditLocationMap
+          initialLocation={{
+            address: "test location",
+            lat: 1,
+            lng: 2,
+            radius: 100,
+          }}
+          updateLocation={jest.fn()}
+        />
+      );
+      expect(screen.getByText(DISPLAY_LOCATION)).toHaveAttribute(
+        "data-shrink",
+        "true"
+      );
+    });
+
+    it("is shrunk again when being populated from a search result", async () => {
+      const updateLocation = jest.fn();
+      render(
+        <EditLocationMap
+          initialLocation={{
+            address: "",
+            lat: 1,
+            lng: 2,
+            radius: 100,
+          }}
+          updateLocation={updateLocation}
+        />
+      );
+
+      userEvent.type(screen.getByLabelText(SEARCH_FOR_LOCATION), "test{enter}");
+      userEvent.click(
+        await screen.findByRole("option", { name: "test city, test country" })
+      );
+
+      expect(screen.getByText(DISPLAY_LOCATION)).toHaveAttribute(
+        "data-shrink",
+        "true"
+      );
+      expect(screen.getByLabelText(DISPLAY_LOCATION)).toHaveValue(
+        "test city, test country"
+      );
+      expect(updateLocation).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/app/frontend/src/components/EditLocationMap.tsx
+++ b/app/frontend/src/components/EditLocationMap.tsx
@@ -86,6 +86,9 @@ export default function EditLocationMap({
     !(initialLocation?.lng || initialLocation?.lat)
   );
   const locationDisplayRef = useRef<HTMLInputElement>(null);
+  const [shrinkLabel, setShrinkLabel] = useState(
+    location.current.address !== ""
+  );
 
   const onCircleMouseDown = (e: MapMouseEvent | MapTouchEvent) => {
     // Prevent the default map drag behavior.
@@ -177,9 +180,11 @@ export default function EditLocationMap({
       } else if (location.current.address === "") {
         // missing display address
         setError(DISPLAY_LOCATION_NOT_EMPTY);
+        setShrinkLabel(false);
         updateLocation(null);
       } else {
         setError("");
+        setShrinkLabel(true);
         updateLocation({ ...location.current });
       }
     }
@@ -311,6 +316,7 @@ export default function EditLocationMap({
               commit({ address: simplified }, false);
               if (locationDisplayRef.current) {
                 locationDisplayRef.current.value = simplified;
+                setShrinkLabel(true);
               }
               flyToSearch(coordinate);
             }}
@@ -331,6 +337,7 @@ export default function EditLocationMap({
           error={error !== ""}
           id="display-address"
           inputRef={locationDisplayRef}
+          InputLabelProps={{ shrink: shrinkLabel }}
           fullWidth
           variant="standard"
           label={DISPLAY_LOCATION}


### PR DESCRIPTION
Closes #1102

<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->


<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on frontend)
If you need help with any of these, please ask :)
--->

**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
