### PR TITLE
Password change messages

### DIFF
--- a/app/frontend/src/AppRoute.tsx
+++ b/app/frontend/src/AppRoute.tsx
@@ -9,7 +9,7 @@ import Navigation from "./components/Navigation";
 import { useAuthContext } from "./features/auth/AuthProvider";
 import { jailRoute, loginRoute } from "./routes";
 
-export const useStyles = makeStyles((theme) => ({
+export const useAppRouteStyles = makeStyles((theme) => ({
   fullscreenContainer: {
     margin: "0 auto",
     padding: 0,
@@ -52,7 +52,7 @@ export default function AppRoute({
     }
   });
 
-  const classes = useStyles();
+  const classes = useAppRouteStyles();
 
   return isPrivate ? (
     <Route

--- a/app/frontend/src/AppRoutes.tsx
+++ b/app/frontend/src/AppRoutes.tsx
@@ -103,6 +103,7 @@ export default function AppRoutes() {
       </AppRoute>
       <AppRoute
         isPrivate={false}
+        variant="full-screen"
         exact
         path={`${resetPasswordRoute}/:resetToken`}
       >

--- a/app/frontend/src/features/auth/constants.tsx
+++ b/app/frontend/src/features/auth/constants.tsx
@@ -11,11 +11,7 @@ export const CHANGE_EMAIL_ERROR = "Error changing email: ";
 export const CHANGE_EMAIL_PROGRESS = "Email change in progress...";
 export const CHANGE_EMAIL_SUCCESS = "Your email has been changed successfully!";
 export const CHANGE_NAME_GENDER = "Change Name / Gender";
-export const CHANGE_PASSWORD = "Change Password";
-export const CHANGE_PASSWORD_ERROR = "Error changing password: ";
-export const CHANGE_PASSWORD_PROGRESS = "Password reset in progress...";
-export const CHANGE_PASSWORD_SUCCESS =
-  "Your password has been reset successfully!";
+export const CHANGE_PASSWORD = "Change password";
 export const CHECK_EMAIL =
   "Your email change has been received. Check your new email to complete the change.";
 export const CLICK_LOGIN = "Click here to log in";
@@ -47,10 +43,13 @@ export const NO_ACCOUNT_YET = "No account yet?";
 export const NON_BINARY = "Non-binary";
 export const OLD_PASSWORD = "Old password";
 export const PASSWORD_CHANGED =
-  "Your password has been reset and a notification was sent to your email. You can now sign in without a password.";
+  "Your new password has been set and a notification was sent to your email.";
 export const RESET_PASSWORD = "Reset password";
+export const RESET_PASSWORD_ERROR = "Error resetting password: ";
 export const RESET_PASSWORD_LINK =
   "Check your email for a reset password link!";
+export const RESET_PASSWORD_SUCCESS =
+  "Your password has been reset successfully! You will now be emailed a magic link when you log in with your username or email.";
 export const SIGN_UP = "Sign up";
 export const SIGN_UP_AGREEMENT =
   "By signing up, you agree with the T&Cs of using the platform and confirm to adhere to our Code of Conduct.";

--- a/app/frontend/src/features/auth/password/ChangePassword.test.tsx
+++ b/app/frontend/src/features/auth/password/ChangePassword.test.tsx
@@ -6,6 +6,7 @@ import {
   NEW_PASSWORD,
   OLD_PASSWORD,
   PASSWORD_CHANGED,
+  RESET_PASSWORD_SUCCESS,
   SUBMIT,
 } from "features/auth/constants";
 import ChangePassword from "features/auth/password/ChangePassword";
@@ -111,7 +112,7 @@ describe("ChangePassword", () => {
 
       const successAlert = await screen.findByRole("alert");
       expect(successAlert).toBeVisible();
-      expect(successAlert).toHaveTextContent(PASSWORD_CHANGED);
+      expect(successAlert).toHaveTextContent(RESET_PASSWORD_SUCCESS);
       expect(changePasswordMock).toHaveBeenCalledTimes(1);
       expect(changePasswordMock).toHaveBeenCalledWith("old_password", "");
 

--- a/app/frontend/src/features/auth/password/ChangePassword.tsx
+++ b/app/frontend/src/features/auth/password/ChangePassword.tsx
@@ -9,6 +9,7 @@ import {
   NEW_PASSWORD,
   OLD_PASSWORD,
   PASSWORD_CHANGED,
+  RESET_PASSWORD_SUCCESS,
   SUBMIT,
 } from "features/auth/constants";
 import useChangeDetailsFormStyles from "features/auth/useChangeDetailsFormStyles";
@@ -55,6 +56,7 @@ export default function ChangePassword(
     isLoading: isChangePasswordLoading,
     isSuccess: isChangePasswordSuccess,
     mutate: changePassword,
+    variables: changePasswordVariables,
   } = useMutation<Empty, GrpcError, ChangePasswordVariables>(
     ({ oldPassword, newPassword }) =>
       service.account.changePassword(oldPassword, newPassword),
@@ -73,7 +75,11 @@ export default function ChangePassword(
         <Alert severity="error">{changePasswordError.message}</Alert>
       )}
       {isChangePasswordSuccess && (
-        <Alert severity="success">{PASSWORD_CHANGED}</Alert>
+        <Alert severity="success">
+          {changePasswordVariables?.newPassword
+            ? PASSWORD_CHANGED
+            : RESET_PASSWORD_SUCCESS}
+        </Alert>
       )}
       <form className={classes.form} onSubmit={onSubmit}>
         {accountInfo && accountInfo.hasPassword && (

--- a/app/frontend/src/features/auth/password/CompleteResetPassword.test.tsx
+++ b/app/frontend/src/features/auth/password/CompleteResetPassword.test.tsx
@@ -1,11 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
-  CHANGE_PASSWORD_ERROR,
-  CHANGE_PASSWORD_PROGRESS,
-  CHANGE_PASSWORD_SUCCESS,
   CLICK_LOGIN,
   LOGIN_PAGE,
+  RESET_PASSWORD_ERROR,
+  RESET_PASSWORD_SUCCESS,
 } from "features/auth/constants";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Route, Switch } from "react-router-dom";
@@ -44,7 +43,7 @@ describe("CompleteResetPassword", () => {
     );
     renderPage();
 
-    expect(await screen.findByText(CHANGE_PASSWORD_PROGRESS)).toBeVisible();
+    expect(await screen.findByRole("progressbar")).toBeVisible();
   });
 
   describe("when the reset password completes successfully", () => {
@@ -56,7 +55,7 @@ describe("CompleteResetPassword", () => {
     it("shows the success alert", async () => {
       const successAlert = await screen.findByRole("alert");
       expect(successAlert).toBeVisible();
-      expect(successAlert).toHaveTextContent(CHANGE_PASSWORD_SUCCESS);
+      expect(successAlert).toHaveTextContent(RESET_PASSWORD_SUCCESS);
       expect(completePasswordResetMock).toHaveBeenCalledTimes(1);
       expect(completePasswordResetMock).toHaveBeenLastCalledWith(
         "P4w0rdR3seTtok3n"
@@ -78,7 +77,7 @@ describe("CompleteResetPassword", () => {
     const errorAlert = await screen.findByRole("alert");
     expect(errorAlert).toBeVisible();
     expect(errorAlert).toHaveTextContent(
-      `${CHANGE_PASSWORD_ERROR}Invalid token`
+      `${RESET_PASSWORD_ERROR}Invalid token`
     );
   });
 });

--- a/app/frontend/src/features/auth/password/CompleteResetPassword.tsx
+++ b/app/frontend/src/features/auth/password/CompleteResetPassword.tsx
@@ -1,4 +1,8 @@
-import { CircularProgress, Container, Typography } from "@material-ui/core";
+import {
+  CircularProgress,
+  Container,
+  Link as MuiLink,
+} from "@material-ui/core";
 import { useAppRouteStyles } from "AppRoute";
 import Alert from "components/Alert";
 import {
@@ -41,9 +45,9 @@ export default function CompleteResetPassword() {
       ) : isSuccess ? (
         <>
           <Alert severity="success">{RESET_PASSWORD_SUCCESS}</Alert>
-          <Typography variant="body1" component={Link} to={loginRoute}>
+          <MuiLink variant="body1" component={Link} to={loginRoute}>
             {CLICK_LOGIN}
-          </Typography>
+          </MuiLink>
         </>
       ) : error ? (
         <Alert severity="error">

--- a/app/frontend/src/features/auth/password/CompleteResetPassword.tsx
+++ b/app/frontend/src/features/auth/password/CompleteResetPassword.tsx
@@ -1,10 +1,10 @@
-import { Typography } from "@material-ui/core";
+import { CircularProgress, Container, Typography } from "@material-ui/core";
+import { useAppRouteStyles } from "AppRoute";
 import Alert from "components/Alert";
 import {
-  CHANGE_PASSWORD_ERROR,
-  CHANGE_PASSWORD_PROGRESS,
-  CHANGE_PASSWORD_SUCCESS,
   CLICK_LOGIN,
+  RESET_PASSWORD_ERROR,
+  RESET_PASSWORD_SUCCESS,
 } from "features/auth/constants";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Error as GrpcError } from "grpc-web";
@@ -15,6 +15,8 @@ import { loginRoute } from "routes";
 import { service } from "service";
 
 export default function CompleteResetPassword() {
+  const classes = useAppRouteStyles();
+
   const { resetToken } = useParams<{ resetToken?: string }>();
 
   const {
@@ -32,20 +34,24 @@ export default function CompleteResetPassword() {
     }
   }, [completePasswordReset, resetToken]);
 
-  return isLoading ? (
-    <Typography variant="body1">{CHANGE_PASSWORD_PROGRESS}</Typography>
-  ) : isSuccess ? (
-    <>
-      <Alert severity="success">{CHANGE_PASSWORD_SUCCESS}</Alert>
-      <Typography variant="body1" component={Link} to={loginRoute}>
-        {CLICK_LOGIN}
-      </Typography>
-    </>
-  ) : (
-    error && (
-      <Alert severity="error">
-        {`${CHANGE_PASSWORD_ERROR}${error.message}`}
-      </Alert>
-    )
+  return (
+    <Container className={classes.standardContainer}>
+      {isLoading ? (
+        <CircularProgress />
+      ) : isSuccess ? (
+        <>
+          <Alert severity="success">{RESET_PASSWORD_SUCCESS}</Alert>
+          <Typography variant="body1" component={Link} to={loginRoute}>
+            {CLICK_LOGIN}
+          </Typography>
+        </>
+      ) : error ? (
+        <Alert severity="error">
+          {`${RESET_PASSWORD_ERROR}${error.message}`}
+        </Alert>
+      ) : (
+        ""
+      )}
+    </Container>
   );
 }


### PR DESCRIPTION
closes #1402 
fix password change messages
make password reset complete page fullscreen because it was trying to call 'Ping' and causing unauthenticated logout


**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
