### PR TITLE
Deleted this once, but it survived in some branch and snuck back in

### DIFF
--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -661,21 +661,6 @@ def test_ListMutualFriends(db):
         assert mutual_friends[0].user_id == user3.id
 
 
-def test_mutual_friends_from_user_proto_message(db):
-    user1, token1 = generate_user()
-    user2, token2 = generate_user()
-    user3, token3 = generate_user()
-    user4, token4 = generate_user()
-    make_friends(user1, user2)
-    make_friends(user1, user3)
-    make_friends(user4, user2)
-    make_friends(user4, user3)
-
-    with api_session(token1) as api:
-        mutual_friends = api.ListMutualFriends(api_pb2.ListMutualFriendsReq(user_id=user4.id)).mutual_friends
-        assert len(mutual_friends) == 2
-
-
 def test_mutual_friends_self(db):
     user1, token1 = generate_user()
     user2, token2 = generate_user()


### PR DESCRIPTION
I wrote this test specifically to test mutual friends when grabbed in the protobuffs. Mutual friends have since been removed from the user message protobuff

**Backend checklist**
- [ ] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] All tests pass
- [ ] Run the backend locally and it works
