### PR TITLE
paragraphs in messages

### DIFF
--- a/app/frontend/src/features/messages/messagelist/MessageView.tsx
+++ b/app/frontend/src/features/messages/messagelist/MessageView.tsx
@@ -51,6 +51,7 @@ const useStyles = makeStyles((theme) => ({
     paddingBottom: theme.spacing(1),
     paddingTop: 0,
     overflowWrap: "break-word",
+    whiteSpace: "pre-wrap",
   },
   name: {
     ...theme.typography.body2,


### PR DESCRIPTION
closes #1334

the components which display messages was updated with the right white-space css set

after:
<img width="1045" alt="Screen Shot 2021-06-24 at 2 24 00 PM" src="https://user-images.githubusercontent.com/12307897/123314519-b0e97580-d4f8-11eb-9263-74d6367094d7.png">

before:
<img width="1042" alt="Screen Shot 2021-06-24 at 2 24 32 PM" src="https://user-images.githubusercontent.com/12307897/123314479-a62ee080-d4f8-11eb-935f-f32499b692f7.png">
 

**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [ ] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

