### PR TITLE
Fix notification count

### DIFF
--- a/app/frontend/src/components/Navigation/Navigation.tsx
+++ b/app/frontend/src/components/Navigation/Navigation.tsx
@@ -39,7 +39,8 @@ const menu = (data: ReturnType<typeof useNotifications>["data"]) => [
     route: messagesRoute,
     notificationCount:
       (data?.unseenMessageCount ?? 0) +
-      (data?.unseenReceivedHostRequestCount ?? 0),
+      (data?.unseenReceivedHostRequestCount ?? 0) +
+      (data?.unseenSentHostRequestCount ?? 0),
   },
   {
     name: "Search",


### PR DESCRIPTION
Add unseen sent host request count to notifications on Messages

**Frontend checklist**
- [ ] Formatted my code with `yarn format && yarn lint --fix`
- [ ] There are no warnings from `yarn lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [ ] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes
