### PR TITLE
Move api_calls to a different schema and don't back it up

### DIFF
--- a/app/backend/src/couchers/migrations/versions/45e7e0254963_move_api_calls_to_logging_schema.py
+++ b/app/backend/src/couchers/migrations/versions/45e7e0254963_move_api_calls_to_logging_schema.py
@@ -15,10 +15,10 @@ depends_on = None
 
 
 def upgrade():
-    op.execute("CREATE SCHEMA logging")
+    op.execute("CREATE SCHEMA IF NOT EXISTS logging")
     op.execute("ALTER TABLE api_calls SET SCHEMA logging")
 
 
 def downgrade():
     op.execute("ALTER TABLE api_calls SET SCHEMA public")
-    op.execute("DROP SCHEMA logging")
+    op.execute("DROP SCHEMA IF EXISTS logging")

--- a/app/backend/src/couchers/migrations/versions/45e7e0254963_move_api_calls_to_logging_schema.py
+++ b/app/backend/src/couchers/migrations/versions/45e7e0254963_move_api_calls_to_logging_schema.py
@@ -1,0 +1,24 @@
+"""Move api_calls to logging schema
+
+Revision ID: 45e7e0254963
+Revises: 5e89dd9ef181
+Create Date: 2021-06-25 09:06:24.763694
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "45e7e0254963"
+down_revision = "5e89dd9ef181"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("CREATE SCHEMA logging")
+    op.execute("ALTER TABLE api_calls SET SCHEMA logging")
+
+
+def downgrade():
+    op.execute("ALTER TABLE api_calls SET SCHEMA public")
+    op.execute("DROP SCHEMA logging")

--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -1618,6 +1618,7 @@ class APICall(Base):
     """
 
     __tablename__ = "api_calls"
+    __table_args__ = {"schema": "logging"}
 
     id = Column(BigInteger, primary_key=True)
 

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -73,7 +73,7 @@ def drop_all():
         # pg_trgm is required for trigram based search
         # btree_gist is required for gist-based exclusion constraints
         session.execute(
-            "DROP SCHEMA public CASCADE; CREATE SCHEMA public; CREATE EXTENSION postgis; CREATE EXTENSION pg_trgm; CREATE EXTENSION btree_gist;"
+            "DROP SCHEMA public CASCADE; DROP SCHEMA IF EXISTS logging CASCADE; CREATE SCHEMA public; CREATE SCHEMA logging; CREATE EXTENSION postgis; CREATE EXTENSION pg_trgm; CREATE EXTENSION btree_gist;"
         )
 
 

--- a/app/deployment/backup.sh
+++ b/app/deployment/backup.sh
@@ -16,7 +16,8 @@ docker_image=${DB_DOCKER_IMAGE:-"postgis/postgis:13-3.1"}
 echo "Backing up database..."
 # --net=host is required so we can hit localhost from inside the container
 # really not sure what's wrong with aws cli not getting env vars the normal way
-docker run --net=host $docker_image pg_dump $DATABASE_CONNECTION_STRING \
+# only dump `public` schema
+docker run --net=host $docker_image pg_dump -n public $DATABASE_CONNECTION_STRING \
   | gzip \
   | AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
     aws s3 cp - s3://$AWS_BACKUP_BUCKET_NAME/db/dump-$(date +%s).sql.gz \


### PR DESCRIPTION
Closes #1313.

I've decided not to move these to a different database for now. That would come with more pain of migrations, and a mess in local and prod dev environments. Instead, we can put them in a different schema and eventually move them to a different [tablespace](https://www.postgresql.org/docs/current/manage-ag-tablespaces.html) if we want them on different media.

**Backend checklist**
- [x] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history
