### PR TITLE
fix default headings persisting

### DIFF
--- a/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
+++ b/app/frontend/src/features/profile/edit/EditHostingPreference.tsx
@@ -145,10 +145,9 @@ export default function HostingPreferenceForm() {
       {
         preferenceData: {
           ...data,
-          aboutPlace:
-            data.aboutPlace === DEFAULT_ABOUT_HOME_HEADINGS
-              ? ""
-              : data.aboutPlace,
+          aboutPlace: DEFAULT_ABOUT_HOME_HEADINGS.includes(data.aboutPlace)
+            ? ""
+            : data.aboutPlace,
         },
         setMutationError: setErrorMessage,
       },

--- a/app/frontend/src/features/profile/edit/EditProfile.tsx
+++ b/app/frontend/src/features/profile/edit/EditProfile.tsx
@@ -174,12 +174,12 @@ export default function EditProfileForm() {
                 fluency: LanguageAbility.Fluency.FLUENCY_FLUENT,
               })),
             },
-            aboutMe:
-              data.aboutMe === DEFAULT_ABOUT_ME_HEADINGS ? "" : data.aboutMe,
-            thingsILike:
-              data.thingsILike === DEFAULT_HOBBIES_HEADINGS
-                ? ""
-                : data.thingsILike,
+            aboutMe: DEFAULT_ABOUT_ME_HEADINGS.includes(data.aboutMe)
+              ? ""
+              : data.aboutMe,
+            thingsILike: DEFAULT_HOBBIES_HEADINGS.includes(data.thingsILike)
+              ? ""
+              : data.thingsILike,
           },
           setMutationError: setErrorMessage,
         },


### PR DESCRIPTION
closes #1356 
Visual editor seems to strip `<br>` and \n at the end of the content, so the strings didn't match.
Unfortunately we can't test for this since we mock out the visual editor

@aapeliv you can probably clean these from the db (a bit dangerous though :P)



<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
