### PR TITLE
Clean up bug reporter

### DIFF
--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -21,8 +21,12 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
         repo = config["BUG_TOOL_GITHUB_REPO"]
         auth = (config["BUG_TOOL_GITHUB_USERNAME"], config["BUG_TOOL_GITHUB_TOKEN"])
 
-        with session_scope() as session:
-            username = session.query(User.username).filter(User.id == request.user_id).scalar() or "<unknown>"
+        if context.user_id:
+            with session_scope() as session:
+                username = session.query(User.username).filter(User.id == context.user_id).scalar()
+                user_details = f"{username} ({context.user_id})"
+        else:
+            user_details = "<not logged in>"
 
         issue_title = request.subject
         issue_body = (
@@ -37,7 +41,7 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
             f"Frontend version: {request.frontend_version}\n"
             f"User Agent: {request.user_agent}\n"
             f"Page: {request.page}\n"
-            f"User (spoofable): {username} ({request.user_id})"
+            f"User: {user_details}"
         )
         issue_labels = ["bug tool"]
 

--- a/app/backend/src/tests/test_bugs.py
+++ b/app/backend/src/tests/test_bugs.py
@@ -23,7 +23,6 @@ def test_bugs_disabled():
                 frontend_version="frontend_version",
                 user_agent="user_agent",
                 page="page",
-                user_id=99,
             )
         )
     assert e.value.code() == grpc.StatusCode.UNAVAILABLE
@@ -40,7 +39,7 @@ def test_bugs(db):
                 "body": (
                     "Subject: subject\nDescription:\ndescription\n\nResults:\nresults\n\nBackend version: "
                     + config["VERSION"]
-                    + "\nFrontend version: frontend_version\nUser Agent: user_agent\nPage: page\nUser (spoofable): <unknown> (99)"
+                    + "\nFrontend version: frontend_version\nUser Agent: user_agent\nPage: page\nUser: <not logged in>"
                 ),
                 "labels": ["bug tool"],
             }
@@ -66,7 +65,6 @@ def test_bugs(db):
                         frontend_version="frontend_version",
                         user_agent="user_agent",
                         page="page",
-                        user_id=99,
                     )
                 )
 
@@ -77,7 +75,7 @@ def test_bugs(db):
 def test_bugs_with_user(db):
     user, token = generate_user(username="testing_user")
 
-    with bugs_session() as bugs:
+    with bugs_session(token) as bugs:
 
         def dud_post(url, auth, json):
             assert url == "https://api.github.com/repos/org/repo/issues"
@@ -87,7 +85,7 @@ def test_bugs_with_user(db):
                 "body": (
                     "Subject: subject\nDescription:\ndescription\n\nResults:\nresults\n\nBackend version: "
                     + config["VERSION"]
-                    + "\nFrontend version: frontend_version\nUser Agent: user_agent\nPage: page\nUser (spoofable): testing_user (1)"
+                    + "\nFrontend version: frontend_version\nUser Agent: user_agent\nPage: page\nUser: testing_user (1)"
                 ),
                 "labels": ["bug tool"],
             }
@@ -113,7 +111,6 @@ def test_bugs_with_user(db):
                         frontend_version="frontend_version",
                         user_agent="user_agent",
                         page="page",
-                        user_id=user.id,
                     )
                 )
 
@@ -144,7 +141,6 @@ def test_bugs_fails_on_network_error(db):
                             frontend_version="frontend_version",
                             user_agent="user_agent",
                             page="page",
-                            user_id=99,
                         )
                     )
                 assert e.value.code() == grpc.StatusCode.INTERNAL

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -576,8 +576,11 @@ def events_session(token):
 
 
 @contextmanager
-def bugs_session():
-    channel = FakeChannel()
+def bugs_session(token=None):
+    if token:
+        channel = fake_channel(token)
+    else:
+        channel = FakeChannel()
     bugs_pb2_grpc.add_BugsServicer_to_server(Bugs(), channel)
     yield bugs_pb2_grpc.BugsStub(channel)
 

--- a/app/frontend/src/features/ReportButton.test.tsx
+++ b/app/frontend/src/features/ReportButton.test.tsx
@@ -23,7 +23,7 @@ import {
 import { service } from "service";
 
 import wrapper from "../test/hookWrapper";
-import { addDefaultUser, MockedService, wait } from "../test/utils";
+import { MockedService, wait } from "../test/utils";
 import ReportButton from "./ReportButton";
 
 const reportBugMock = service.bugs.reportBug as MockedService<
@@ -201,14 +201,11 @@ describe("ReportButton", () => {
         "#1"
       );
       expect(reportBugMock).toHaveBeenCalledTimes(1);
-      expect(reportBugMock).toHaveBeenCalledWith(
-        {
-          description: "Log in is broken",
-          results: "",
-          subject: "Broken log in",
-        },
-        null
-      );
+      expect(reportBugMock).toHaveBeenCalledWith({
+        description: "Log in is broken",
+        results: "",
+        subject: "Broken log in",
+      });
     });
 
     it("submits the bug report successfully if everything has been filled in", async () => {
@@ -225,37 +222,11 @@ describe("ReportButton", () => {
       await waitFor(() => {
         expect(reportBugMock).toHaveBeenCalledTimes(1);
       });
-      expect(reportBugMock).toHaveBeenCalledWith(
-        {
-          description: "Log in is broken",
-          results: "Log in didn't work, and I expected it to work",
-          subject: "Broken log in",
-        },
-        null
-      );
-    });
-
-    it("submits the bug report with a user ID if there is an authenticated user", async () => {
-      addDefaultUser();
-      render(<ReportButton />, { wrapper });
-      userEvent.click(screen.getByRole("button", { name: REPORT }));
-      userEvent.click(screen.getByRole("button", { name: REPORT_BUG_BUTTON }));
-      await fillInAndSubmitReportButton(
-        subjectFieldLabel,
-        descriptionFieldLabel
-      );
-
-      await waitFor(() => {
-        expect(reportBugMock).toHaveBeenCalledTimes(1);
+      expect(reportBugMock).toHaveBeenCalledWith({
+        description: "Log in is broken",
+        results: "Log in didn't work, and I expected it to work",
+        subject: "Broken log in",
       });
-      expect(reportBugMock).toHaveBeenCalledWith(
-        {
-          description: "Log in is broken",
-          results: "",
-          subject: "Broken log in",
-        },
-        1
-      );
     });
 
     it("shows an error alert if the bug report failed to submit", async () => {

--- a/app/frontend/src/features/ReportButton.tsx
+++ b/app/frontend/src/features/ReportButton.tsx
@@ -17,7 +17,6 @@ import {
 import { BugIcon } from "components/Icons";
 import Snackbar from "components/Snackbar";
 import TextField from "components/TextField";
-import { useAuthContext } from "features/auth/AuthProvider";
 import {
   BUG_DESCRIPTION_HELPER,
   BUG_DESCRIPTION_NAME,
@@ -37,7 +36,7 @@ import {
 } from "features/constants";
 import { Error as GrpcError } from "grpc-web";
 import { ReportBugRes } from "proto/bugs_pb";
-import React, { useState } from "react";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useMutation } from "react-query";
 import { service } from "service";
@@ -91,7 +90,6 @@ export default function ReportButton({
     handleSubmit,
     reset: resetForm,
   } = useForm<BugReportFormData>();
-  const userId = useAuthContext().authState.userId;
   const {
     data: bug,
     error,
@@ -99,7 +97,7 @@ export default function ReportButton({
     mutate: reportBug,
     reset: resetMutation,
   } = useMutation<ReportBugRes.AsObject, GrpcError, BugReportFormData>(
-    (formData) => service.bugs.reportBug(formData, userId),
+    (formData) => service.bugs.reportBug(formData),
     {
       onSuccess: () => {
         setIsOpen(false);

--- a/app/frontend/src/service/bugs.ts
+++ b/app/frontend/src/service/bugs.ts
@@ -2,10 +2,11 @@ import { BugReportFormData } from "features/ReportButton";
 import { ReportBugReq } from "proto/bugs_pb";
 import client from "service/client";
 
-export async function reportBug(
-  { description, results, subject }: BugReportFormData,
-  userId: number | null
-) {
+export async function reportBug({
+  description,
+  results,
+  subject,
+}: BugReportFormData) {
   const req = new ReportBugReq();
 
   req.setSubject(subject);
@@ -14,7 +15,6 @@ export async function reportBug(
   req.setFrontendVersion(process.env.REACT_APP_VERSION);
   req.setUserAgent(navigator.userAgent);
   req.setPage(window.location.href);
-  req.setUserId(Number(userId));
 
   const res = await client.bugs.reportBug(req);
   return res.toObject();

--- a/app/proto/bugs.proto
+++ b/app/proto/bugs.proto
@@ -30,7 +30,6 @@ message ReportBugReq {
   string frontend_version = 5;
   string user_agent = 6;
   string page = 7;
-  int64 user_id = 8;
 }
 
 message ReportBugRes {


### PR DESCRIPTION
The new auth interceptor validates the user id if the cookie is present, so the username is no longer spoofable. This uses that info and cleans up the bug reporter in the process.

**Backend checklist**
- [ ] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Frontend checklist**
- [ ] Formatted my code with `yarn format && yarn lint --fix`
- [ ] There are no warnings from `yarn lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [ ] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
