### PR TITLE
add better upload error messages

### DIFF
--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -31,3 +31,14 @@ services:
       - postgres
     links:
       - postgres
+  media:
+    build: media
+    restart: always
+    env_file: media.dev.env
+    volumes:
+      - "./data/media/uploads/:/uploads/"
+    ports:
+      - 5000:5000
+    depends_on:
+      - backend
+

--- a/app/frontend/src/components/ImageInput/ImageInput.test.tsx
+++ b/app/frontend/src/components/ImageInput/ImageInput.test.tsx
@@ -24,7 +24,7 @@ import { assertErrorAlert, mockConsoleError, MockedService } from "test/utils";
 
 import ImageInput from "./ImageInput";
 
-let uploadFileMock = service.api.uploadFile as MockedService<
+const uploadFileMock = service.api.uploadFile as MockedService<
   typeof service.api.uploadFile
 >;
 const submitForm = jest.fn();

--- a/app/frontend/src/components/ImageInput/ImageInput.test.tsx
+++ b/app/frontend/src/components/ImageInput/ImageInput.test.tsx
@@ -3,20 +3,28 @@ import userEvent from "@testing-library/user-event";
 import {
   CANCEL_UPLOAD,
   CONFIRM_UPLOAD,
+  COULDNT_READ_FILE,
   getAvatarLabel,
-  INVALID_FILE,
   SELECT_AN_IMAGE,
   UPLOAD_PENDING_ERROR,
 } from "components/constants";
 import { SUBMIT } from "features/constants";
+import { InitiateMediaUploadRes } from "proto/api_pb";
 import { useForm } from "react-hook-form";
 import { service } from "service";
+import client from "service/client";
+import {
+  IMAGE_TOO_LARGE,
+  INTERNAL_ERROR,
+  SERVER_ERROR,
+} from "service/constants";
 import wrapper from "test/hookWrapper";
-import { MockedService } from "test/utils";
+import { rest, server } from "test/restMock";
+import { assertErrorAlert, mockConsoleError, MockedService } from "test/utils";
 
 import ImageInput from "./ImageInput";
 
-const uploadFileMock = service.api.uploadFile as MockedService<
+let uploadFileMock = service.api.uploadFile as MockedService<
   typeof service.api.uploadFile
 >;
 const submitForm = jest.fn();
@@ -195,7 +203,9 @@ describe.each`
       screen.getByLabelText(SELECT_AN_IMAGE) as HTMLInputElement,
       new File([new Blob(undefined)], "")
     );
-    expect(await screen.findByText(INVALID_FILE)).toBeVisible();
+    expect(
+      await screen.findByText(new RegExp(COULDNT_READ_FILE))
+    ).toBeVisible();
   });
 
   it("displays an error if the upload fails", async () => {
@@ -230,5 +240,97 @@ describe.each`
     expect(
       screen.getByAltText(getAvatarLabel(NAME)).getAttribute("src")
     ).toMatch(/base64/);
+  });
+});
+
+describe("ImageInput http error tests", () => {
+  beforeAll(() => {
+    server.listen();
+  });
+  beforeEach(() => {
+    const View = () => {
+      const { control } = useForm();
+      return (
+        <ImageInput
+          control={control}
+          id="image-input"
+          initialPreviewSrc={MOCK_INITIAL_SRC}
+          name="imageInput"
+          userName={NAME}
+          type="avatar"
+        />
+      );
+    };
+    render(<View />, { wrapper });
+    const uploadFile = jest.requireActual("service").service.api.uploadFile;
+    uploadFileMock.mockImplementation(uploadFile);
+    const initiateMediaUploadMock = jest.spyOn(
+      client.api,
+      "initiateMediaUpload"
+    );
+    initiateMediaUploadMock.mockResolvedValue({
+      getUploadUrl: () => "https://example.com/upload",
+    } as InitiateMediaUploadRes);
+    mockConsoleError();
+  });
+  afterEach(() => {
+    server.resetHandlers();
+  });
+  afterAll(() => {
+    server.close();
+  });
+
+  it("displays the right error if the file is too large", async () => {
+    server.use(
+      rest.post("https://example.com/upload", async (_req, res, ctx) => {
+        return res(ctx.status(413), ctx.text("Payload too large"));
+      })
+    );
+
+    userEvent.upload(
+      screen.getByLabelText(SELECT_AN_IMAGE) as HTMLInputElement,
+      MOCK_FILE
+    );
+
+    expect(await screen.findByLabelText(CONFIRM_UPLOAD)).toBeVisible();
+    userEvent.click(screen.getByLabelText(CONFIRM_UPLOAD));
+
+    await assertErrorAlert(IMAGE_TOO_LARGE);
+  });
+
+  it("displays a general error for server errors", async () => {
+    server.use(
+      rest.post("https://example.com/upload", async (_req, res, ctx) => {
+        return res(ctx.status(500), ctx.text("Internal server error"));
+      })
+    );
+
+    userEvent.upload(
+      screen.getByLabelText(SELECT_AN_IMAGE) as HTMLInputElement,
+      MOCK_FILE
+    );
+
+    expect(await screen.findByLabelText(CONFIRM_UPLOAD)).toBeVisible();
+    userEvent.click(screen.getByLabelText(CONFIRM_UPLOAD));
+
+    await assertErrorAlert(SERVER_ERROR);
+  });
+
+  it("displays an internal error for bad json", async () => {
+    server.use(
+      rest.post("https://example.com/upload", async (_req, res, ctx) => {
+        return res(ctx.status(200), ctx.text("[{bad: 'json'}}]"));
+      })
+    );
+
+    userEvent.upload(
+      screen.getByLabelText(SELECT_AN_IMAGE) as HTMLInputElement,
+      MOCK_FILE
+    );
+
+    expect(await screen.findByLabelText(CONFIRM_UPLOAD)).toBeVisible();
+    userEvent.click(screen.getByLabelText(CONFIRM_UPLOAD));
+
+    await assertErrorAlert(INTERNAL_ERROR);
   });
 });

--- a/app/frontend/src/components/ImageInput/ImageInput.tsx
+++ b/app/frontend/src/components/ImageInput/ImageInput.tsx
@@ -7,8 +7,9 @@ import CircularProgress from "components/CircularProgress";
 import {
   CANCEL_UPLOAD,
   CONFIRM_UPLOAD,
+  COULDNT_READ_FILE,
   getAvatarLabel,
-  INVALID_FILE,
+  NO_VALID_FILE,
   SELECT_AN_IMAGE,
   UPLOAD_PENDING_ERROR,
 } from "components/constants";
@@ -97,7 +98,7 @@ export function ImageInput(props: AvatarInputProps | RectImgInputProps) {
     () =>
       file
         ? service.api.uploadFile(file)
-        : Promise.reject(new Error(INVALID_FILE)),
+        : Promise.reject(new Error(NO_VALID_FILE)),
     {
       onSuccess: (data: ImageInputValues) => {
         field.onChange(data.key);
@@ -130,8 +131,8 @@ export function ImageInput(props: AvatarInputProps | RectImgInputProps) {
       });
       setImageUrl(base64);
       setFile(file);
-    } catch {
-      setReaderError(INVALID_FILE);
+    } catch (e) {
+      setReaderError(`${COULDNT_READ_FILE}: ${e.message}`);
     }
   };
 
@@ -157,7 +158,7 @@ export function ImageInput(props: AvatarInputProps | RectImgInputProps) {
         <input
           aria-label={SELECT_AN_IMAGE}
           className={classes.input}
-          accept="image/*"
+          accept="image/jpeg,image/png,image/gif"
           id={id}
           type="file"
           onChange={handleChange}

--- a/app/frontend/src/components/constants.ts
+++ b/app/frontend/src/components/constants.ts
@@ -1,7 +1,8 @@
 export const CANCEL_UPLOAD = "Cancel upload";
 export const CONFIRM_UPLOAD = "Confirm upload";
 export const getAvatarLabel = (name: string) => `${name}'s profile picture`;
-export const INVALID_FILE = "Invalid file.";
+export const COULDNT_READ_FILE = "Couldn't read file";
+export const NO_VALID_FILE = "Didn't have a valid file to send";
 export const SELECT_AN_IMAGE = "Select an image";
 export const UPLOAD_PENDING_ERROR =
   "Confirm or cancel the picture upload before saving.";

--- a/app/frontend/src/service/api.ts
+++ b/app/frontend/src/service/api.ts
@@ -5,7 +5,12 @@ import {
   RespondFriendRequestReq,
   SendFriendRequestReq,
 } from "proto/api_pb";
-import { FETCH_FAILED, INVALID_IMAGE } from "service/constants";
+import {
+  FETCH_FAILED,
+  IMAGE_TOO_LARGE,
+  INTERNAL_ERROR,
+  SERVER_ERROR,
+} from "service/constants";
 
 import client from "./client";
 
@@ -74,9 +79,17 @@ export async function uploadFile(file: File): Promise<ImageInputValues> {
     throw new Error(FETCH_FAILED);
   });
 
+  if (!uploadResponse.ok) {
+    if (uploadResponse.status === 413) {
+      throw new Error(IMAGE_TOO_LARGE);
+    } else {
+      throw new Error(`${SERVER_ERROR}: ${uploadResponse.statusText}`);
+    }
+  }
+
   const responseJson = await uploadResponse.json().catch((e) => {
     console.error(e);
-    throw new Error(INVALID_IMAGE);
+    throw new Error(`${INTERNAL_ERROR}: ${e.message}`);
   });
   return {
     ...responseJson,

--- a/app/frontend/src/service/api.ts
+++ b/app/frontend/src/service/api.ts
@@ -79,12 +79,10 @@ export async function uploadFile(file: File): Promise<ImageInputValues> {
     throw new Error(FETCH_FAILED);
   });
 
-  if (!uploadResponse.ok) {
-    if (uploadResponse.status === 413) {
-      throw new Error(IMAGE_TOO_LARGE);
-    } else {
-      throw new Error(`${SERVER_ERROR}: ${uploadResponse.statusText}`);
-    }
+  if (uploadResponse.status === 413) {
+    throw new Error(IMAGE_TOO_LARGE);
+  } else if (!uploadResponse.ok) {
+    throw new Error(`${SERVER_ERROR}: ${uploadResponse.statusText}`);
   }
 
   const responseJson = await uploadResponse.json().catch((e) => {

--- a/app/frontend/src/service/constants.ts
+++ b/app/frontend/src/service/constants.ts
@@ -1,3 +1,5 @@
 export const FETCH_FAILED =
   "Couldn't connect to the server. Please check your Internet connection or try again later.";
-export const INVALID_IMAGE = "Invalid image.";
+export const IMAGE_TOO_LARGE = "Image size was too large";
+export const INTERNAL_ERROR = "Internal error";
+export const SERVER_ERROR = "Server error";


### PR DESCRIPTION
Closes #948 
May solve other image problems by specifying image/jpeg and other mime types, which might prevent devices trying to use HEIF files. Even if they are supported in the backend, they can't be displayed in the frontend so might have been causing the errors.

However I couldn't reproduce anything myself so not sure. In any case errors will be much more descriptive now.

**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [x] Added tests where relevant
- [x] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
