### PR TITLE
No longer need to save profile to update avatar

### DIFF
--- a/app/frontend/src/components/ImageInput/ImageInput.tsx
+++ b/app/frontend/src/components/ImageInput/ImageInput.tsx
@@ -70,6 +70,7 @@ interface ImageInputProps {
   id: string;
   initialPreviewSrc?: string;
   name: string;
+  onSuccess?(data: ImageInputValues): Promise<void>;
 }
 
 interface AvatarInputProps extends ImageInputProps {
@@ -100,11 +101,12 @@ export function ImageInput(props: AvatarInputProps | RectImgInputProps) {
         ? service.api.uploadFile(file)
         : Promise.reject(new Error(NO_VALID_FILE)),
     {
-      onSuccess: (data: ImageInputValues) => {
+      onSuccess: async (data: ImageInputValues) => {
         field.onChange(data.key);
         setImageUrl(data.thumbnail_url);
         confirmedUpload.current = data;
         setFile(null);
+        await props.onSuccess?.(data);
       },
     }
   );

--- a/app/frontend/src/features/profile/edit/EditProfile.tsx
+++ b/app/frontend/src/features/profile/edit/EditProfile.tsx
@@ -46,7 +46,7 @@ import useCurrentUser from "features/userQueries/useCurrentUser";
 import { HostingStatus, LanguageAbility, MeetupStatus } from "proto/api_pb";
 import React, { useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { UpdateUserProfileData } from "service/index";
+import { service, UpdateUserProfileData } from "service/index";
 import { useIsMounted, useSafeState } from "utils/hooks";
 import makeStyles from "utils/makeStyles";
 
@@ -216,6 +216,9 @@ export default function EditProfileForm() {
               initialPreviewSrc={user.avatarUrl}
               userName={user.name}
               type="avatar"
+              onSuccess={async (data) => {
+                await service.user.updateAvatar(data.key);
+              }}
             />
             <ProfileTextInput
               id="name"

--- a/app/frontend/src/service/user.ts
+++ b/app/frontend/src/service/user.ts
@@ -192,6 +192,12 @@ export async function updateProfile(
   return client.api.updateProfile(req);
 }
 
+export function updateAvatar(avatarKey: string) {
+  const req = new UpdateProfileReq();
+  req.setAvatarKey(new NullableStringValue().setValue(avatarKey));
+  return client.api.updateProfile(req);
+}
+
 export function updateHostingPreference(preferences: HostingPreferenceData) {
   const req = new UpdateProfileReq();
 


### PR DESCRIPTION
Hopefully this will close the rest of the image issues by eliminating the need to save the form after changing the profile pic

I did not actually see if it works yet but the tests did!

**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [x] Added tests where relevant
- [ ] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
