### PR TITLE
[MRG] Add DeleteAccount to backend

### DIFF
--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -266,3 +266,16 @@ class Account(account_pb2_grpc.AccountServicer):
             user.phone_verification_attempts = 0
 
         return empty_pb2.Empty()
+
+    def DeleteAccount(self, request, context):
+        """
+        Cannot be used to delete any account, except for the user's own
+
+        Extensive checking should be confirmed by the frontend
+        """
+        with session_scope() as session:
+            user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+            user.is_deleted = True
+            session.commit()
+
+        return empty_pb2.Empty()

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -835,3 +835,14 @@ def test_contributor_form(db):
         assert res.age == user.age
         assert res.gender == user.gender
         assert res.location == user.city
+
+
+def test_DeleteAccount(db):
+    user, token = generate_user()
+
+    with account_session(token) as account:
+        account.DeleteAccount(empty_pb2.Empty())
+
+    with session_scope() as session:
+        updated_user = session.execute(select(User).where(User.id == user.id)).scalar_one()
+        assert updated_user.is_deleted


### PR DESCRIPTION
My thinking is that the front end should verify the identity before requesting account deletion and that a request only adds in a possibility of passing in the wrong information. However, it would be trivial to add a request with username and a check that `request.username.lower() == user.username.lower()`

**Backend checklist**
- [x] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history