### PR TITLE
[WIP] Sort regions alphabetically

### DIFF
--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -375,7 +375,7 @@ class RegionVisited(Base):
     user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
     region_code = Column(ForeignKey("regions.code", deferrable=True), nullable=False)
 
-    user = relationship("User", backref="regions_visited")
+    user = relationship("User", backref=backref("regions_visited", order_by=region_code))
     region = relationship("Region")
 
 
@@ -387,7 +387,7 @@ class RegionLived(Base):
     user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
     region_code = Column(ForeignKey("regions.code", deferrable=True), nullable=False)
 
-    user = relationship("User", backref="regions_lived")
+    user = relationship("User", backref=backref("regions_lived", order_by=region_code))
     region = relationship("Region")
 
 

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -840,8 +840,8 @@ def user_model_to_pb(db_user, session, context):
             api_pb2.LanguageAbility(code=ability.language_code, fluency=fluency2api[ability.fluency])
             for ability in db_user.language_abilities
         ],
-        regions_visited=sorted([region.region_code for region in db_user.regions_visited]),
-        regions_lived=sorted([region.region_code for region in db_user.regions_lived]),
+        regions_visited=[region.region_code for region in db_user.regions_visited],
+        regions_lived=[region.region_code for region in db_user.regions_lived],
         additional_information=db_user.additional_information,
         friends=friends_status,
         pending_friend_request=pending_friend_request,

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -840,8 +840,8 @@ def user_model_to_pb(db_user, session, context):
             api_pb2.LanguageAbility(code=ability.language_code, fluency=fluency2api[ability.fluency])
             for ability in db_user.language_abilities
         ],
-        regions_visited=[region.region_code for region in db_user.regions_visited],
-        regions_lived=[region.region_code for region in db_user.regions_lived],
+        regions_visited=sorted([region.region_code for region in db_user.regions_visited]),
+        regions_lived=sorted([region.region_code for region in db_user.regions_lived]),
         additional_information=db_user.additional_information,
         friends=friends_status,
         pending_friend_request=pending_friend_request,

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -65,8 +65,8 @@ def test_ping(db):
     assert res.user.things_i_like == user.things_i_like
     assert set(language_ability.code for language_ability in res.user.language_abilities) == set(["fin", "fra"])
     assert res.user.about_place == user.about_place
-    assert res.user.regions_visited == ["FIN", "REU"] # tests sort as well
-    assert res.user.regions_lived == ["EST", "FRA"] # tests sort as well
+    assert res.user.regions_visited == ["FIN", "REU"]
+    assert res.user.regions_lived == ["EST", "FRA"]
     assert res.user.additional_information == user.additional_information
 
     assert res.user.friends == api_pb2.User.FriendshipStatus.NA

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -65,8 +65,8 @@ def test_ping(db):
     assert res.user.things_i_like == user.things_i_like
     assert set(language_ability.code for language_ability in res.user.language_abilities) == set(["fin", "fra"])
     assert res.user.about_place == user.about_place
-    assert res.user.regions_visited == ["FIN", "REU"]
-    assert res.user.regions_lived == ["FRA", "EST"]
+    assert res.user.regions_visited == ["FIN", "REU"] # tests sort as well
+    assert res.user.regions_lived == ["EST", "FRA"] # tests sort as well
     assert res.user.additional_information == user.additional_information
 
     assert res.user.friends == api_pb2.User.FriendshipStatus.NA
@@ -240,8 +240,8 @@ def test_update_profile(db):
         assert user_details.language_abilities[0].code == "eng"
         assert user_details.language_abilities[0].fluency == api_pb2.LanguageAbility.Fluency.FLUENCY_FLUENT
         assert user_details.additional_information == "I <3 Couchers"
-        assert set(user_details.regions_visited) == {"CXR", "NAM"}
-        assert set(user_details.regions_lived) == {"USA", "ITA"}
+        assert user_details.regions_visited == ["CXR", "NAM"]
+        assert user_details.regions_lived == ["ITA", "USA"]
 
         # Test unset values
         api.UpdateProfile(

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -240,8 +240,8 @@ def generate_user(*, make_invisible=False, **kwargs):
         session.add(user)
         session.flush()
 
-        session.add(RegionVisited(user_id=user.id, region_code="FIN"))
         session.add(RegionVisited(user_id=user.id, region_code="REU"))
+        session.add(RegionVisited(user_id=user.id, region_code="FIN"))
 
         session.add(RegionLived(user_id=user.id, region_code="FRA"))
         session.add(RegionLived(user_id=user.id, region_code="EST"))


### PR DESCRIPTION
This has been bothering me

Downside: extra work on the backend for every user call [O(n) where n is number of countries ~200, so minimal work, but work nonetheless] for essentially no real gain

Upside: Looks neater and satisfies my OCD

Potential future improvement: Store them sorted in the database. People don't tend to visit new countries *too* often, and it's even rarer that they unvisit them, so one time work per user/insert for permanent sorting. Honestly, every user could have a bit vector of size ~200. Might even be more space efficient than the current built-out model, though would require non-trivial dev work every time a country is added to/removed from existence.


**Backend checklist**
- [ ] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history