### PR TITLE
Add username into account settings screen

### DIFF
--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -87,6 +87,7 @@ class Account(account_pb2_grpc.AccountServicer):
                     has_password=True,
                 )
             return account_pb2.GetAccountInfoRes(
+                username=user.username,
                 email=user.email,
                 phone=user.phone if user.phone_is_verified() else "",
                 profile_complete=user.has_completed_profile,

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -23,26 +23,24 @@ def _(testconfig):
 
 def test_GetAccountInfo(db, fast_passwords):
     # without password
-    user1, token1 = generate_user(username="funkybot", hashed_password=None, email="funkybot@couchers.invalid")
+    user1, token1 = generate_user(hashed_password=None, email="funkybot@couchers.invalid")
 
     with account_session(token1) as account:
         res = account.GetAccountInfo(empty_pb2.Empty())
         assert res.login_method == account_pb2.GetAccountInfoRes.LoginMethod.MAGIC_LINK
         assert not res.has_password
         assert res.email == "funkybot@couchers.invalid"
-        assert res.username == "funkybot"
+        assert res.username == user1.username
 
     # with password
-    user1, token1 = generate_user(
-        username="funkybot", hashed_password=hash_password(random_hex()), email="user@couchers.invalid"
-    )
+    user1, token1 = generate_user(hashed_password=hash_password(random_hex()), email="user@couchers.invalid")
 
     with account_session(token1) as account:
         res = account.GetAccountInfo(empty_pb2.Empty())
         assert res.login_method == account_pb2.GetAccountInfoRes.LoginMethod.PASSWORD
         assert res.has_password
         assert res.email == "user@couchers.invalid"
-        assert res.username == "funkybot"
+        assert res.username == user1.username
 
 
 def test_GetAccountInfo_regression(db):

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -23,22 +23,26 @@ def _(testconfig):
 
 def test_GetAccountInfo(db, fast_passwords):
     # without password
-    user1, token1 = generate_user(hashed_password=None, email="funkybot@couchers.invalid")
+    user1, token1 = generate_user(username="funkybot", hashed_password=None, email="funkybot@couchers.invalid")
 
     with account_session(token1) as account:
         res = account.GetAccountInfo(empty_pb2.Empty())
         assert res.login_method == account_pb2.GetAccountInfoRes.LoginMethod.MAGIC_LINK
         assert not res.has_password
         assert res.email == "funkybot@couchers.invalid"
+        assert res.username == "funkybot"
 
     # with password
-    user1, token1 = generate_user(hashed_password=hash_password(random_hex()), email="user@couchers.invalid")
+    user1, token1 = generate_user(
+        username="funkybot", hashed_password=hash_password(random_hex()), email="user@couchers.invalid"
+    )
 
     with account_session(token1) as account:
         res = account.GetAccountInfo(empty_pb2.Empty())
         assert res.login_method == account_pb2.GetAccountInfoRes.LoginMethod.PASSWORD
         assert res.has_password
         assert res.email == "user@couchers.invalid"
+        assert res.username == "funkybot"
 
 
 def test_GetAccountInfo_regression(db):

--- a/app/frontend/src/features/auth/Settings.tsx
+++ b/app/frontend/src/features/auth/Settings.tsx
@@ -5,6 +5,7 @@ import PageTitle from "components/PageTitle";
 import ChangeEmail from "features/auth/email/ChangeEmail";
 import { ChangePassword } from "features/auth/password";
 import Timezone from "features/auth/timezone/Timezone";
+import Username from "features/auth/username/Username";
 import { GetAccountInfoRes } from "proto/account_pb";
 
 import { ACCOUNT_SETTINGS, CHANGE_NAME_GENDER, CONTACT } from "./constants";
@@ -28,6 +29,7 @@ export default function Settings() {
         <Alert severity="error">{accountInfoError.message}</Alert>
       ) : (
         <>
+          <Username {...(accountInfo as GetAccountInfoRes.AsObject)} />
           <Timezone {...(accountInfo as GetAccountInfoRes.AsObject)} />
           <ChangeEmail {...(accountInfo as GetAccountInfoRes.AsObject)} />
           <ChangePassword {...(accountInfo as GetAccountInfoRes.AsObject)} />

--- a/app/frontend/src/features/auth/constants.tsx
+++ b/app/frontend/src/features/auth/constants.tsx
@@ -13,7 +13,7 @@ export const TIMEZONE_HELPER =
   "This time and timezone is determined based on your home location. Please report a bug if it is incorrect.";
 
 export const USERNAME_HELPER =
-  "Your username is set when you create your account. There is currently no way to change your username, sorry.";
+  "Your username is set when you create your account.";
 export const YOUR_USERNAME_IS = "Your username is";
 
 export const CHANGE_EMAIL = "Change Email";

--- a/app/frontend/src/features/auth/constants.tsx
+++ b/app/frontend/src/features/auth/constants.tsx
@@ -12,6 +12,10 @@ export const YOUR_LOCAL_TIME_IS =
 export const TIMEZONE_HELPER =
   "This time and timezone is determined based on your home location. Please report a bug if it is incorrect.";
 
+export const USERNAME_HELPER =
+  "Your username is set when you create your account. There is currently no way to change your username, sorry.";
+export const YOUR_USERNAME_IS = "Your username is";
+
 export const CHANGE_EMAIL = "Change Email";
 export const YOUR_EMAIL_IS = "Your email address is currently";
 export const CHANGE_EMAIL_ERROR = "Error changing email: ";

--- a/app/frontend/src/features/auth/email/ChangeEmail.stories.tsx
+++ b/app/frontend/src/features/auth/email/ChangeEmail.stories.tsx
@@ -80,6 +80,7 @@ function setMocks({
         : Promise.resolve({
             hasPassword: loginMethod === GetAccountInfoRes.LoginMethod.PASSWORD,
             loginMethod,
+            username: "tester",
             email: "user@couchers.invalid",
             profileComplete: true,
             phone: "+46701740605",

--- a/app/frontend/src/features/auth/email/ChangeEmail.test.tsx
+++ b/app/frontend/src/features/auth/email/ChangeEmail.test.tsx
@@ -24,6 +24,7 @@ const changeEmailMock = service.account.changeEmail as MockedService<
 const accountInfo = {
   hasPassword: true,
   loginMethod: GetAccountInfoRes.LoginMethod.PASSWORD,
+  username: "tester",
   email: "email@couchers.org",
   profileComplete: true,
   phone: "+46701740605",
@@ -33,6 +34,7 @@ const accountInfo = {
 const accountWithLink = {
   hasPassword: false,
   loginMethod: GetAccountInfoRes.LoginMethod.MAGIC_LINK,
+  username: "tester",
   email: "email@couchers.org",
   profileComplete: true,
   phone: "+46701740605",

--- a/app/frontend/src/features/auth/password/ChangePassword.stories.tsx
+++ b/app/frontend/src/features/auth/password/ChangePassword.stories.tsx
@@ -80,6 +80,7 @@ function setMocks({
         : Promise.resolve({
             hasPassword: loginMethod === GetAccountInfoRes.LoginMethod.PASSWORD,
             loginMethod,
+            username: "tester",
             email: "user@couchers.invalid",
             profileComplete: true,
             phone: "",

--- a/app/frontend/src/features/auth/password/ChangePassword.test.tsx
+++ b/app/frontend/src/features/auth/password/ChangePassword.test.tsx
@@ -26,6 +26,7 @@ const getAccountInfoMock = service.account.getAccountInfo as MockedService<
 const accountWithPassword = {
   hasPassword: true,
   loginMethod: GetAccountInfoRes.LoginMethod.PASSWORD,
+  username: "tester",
   email: "email@couchers.org",
   profileComplete: true,
   phone: "",
@@ -35,6 +36,7 @@ const accountWithPassword = {
 const accountWithLink = {
   hasPassword: false,
   loginMethod: GetAccountInfoRes.LoginMethod.MAGIC_LINK,
+  username: "tester",
   email: "email@couchers.org",
   profileComplete: true,
   phone: "+46701740605",

--- a/app/frontend/src/features/auth/username/Username.tsx
+++ b/app/frontend/src/features/auth/username/Username.tsx
@@ -1,0 +1,16 @@
+import { Typography } from "@material-ui/core";
+import { GetAccountInfoRes } from "proto/account_pb";
+
+import { USERNAME, USERNAME_HELPER, YOUR_USERNAME_IS } from "../constants";
+
+export default function Username(accountInfo: GetAccountInfoRes.AsObject) {
+  return (
+    <>
+      <Typography variant="h2">{USERNAME}</Typography>
+      <Typography variant="body1" paragraph>
+        {YOUR_USERNAME_IS} <b>{accountInfo.username}</b>.
+      </Typography>
+      <Typography variant="body1">{USERNAME_HELPER}</Typography>
+    </>
+  );
+}

--- a/app/proto/account.proto
+++ b/app/proto/account.proto
@@ -62,6 +62,8 @@ message GetAccountInfoRes {
   LoginMethod login_method = 1;
   bool has_password = 2;
 
+  string username = 7;
+
   // user's current email address
   string email = 3;
 


### PR DESCRIPTION
This is a quick fix so we can point users to the account settings where it says very clearly what their username is. This is needed for the community builder form.

**Backend checklist**
- [x] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [ ] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

