### PR TITLE
API keys

### DIFF
--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -217,7 +217,8 @@ class TracingInterceptor(grpc.ServerInterceptor):
                 finished = perf_counter_ns()
                 duration = (finished - start) / 1e6  # ms
                 user_id = getattr(context, "user_id", None)
-                self._store_log(method, None, duration, user_id, request, res, None)
+                is_api_key = getattr(context, "is_api_key", None)
+                self._store_log(method, None, duration, user_id, is_api_key, request, res, None)
                 self._observe_in_histogram(method, "", "", duration)
             except Exception as e:
                 finished = perf_counter_ns()

--- a/app/backend/src/couchers/migrations/versions/61b4c6b2df72_add_api_keys.py
+++ b/app/backend/src/couchers/migrations/versions/61b4c6b2df72_add_api_keys.py
@@ -1,0 +1,29 @@
+"""Add API keys
+
+Revision ID: 61b4c6b2df72
+Revises: f77ccd92eb4d
+Create Date: 2021-07-22 13:50:58.948747
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "61b4c6b2df72"
+down_revision = "f77ccd92eb4d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "api_calls",
+        sa.Column("is_api_key", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        schema="logging",
+    )
+    op.add_column("sessions", sa.Column("is_api_key", sa.Boolean(), server_default=sa.text("false"), nullable=False))
+
+
+def downgrade():
+    op.drop_column("sessions", "is_api_key")
+    op.drop_column("api_calls", "is_api_key", schema="logging")

--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -648,6 +648,13 @@ class UserSession(Base):
 
     user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
 
+    # sessions are either "api keys" or "session cookies", otherwise identical
+    # an api key is put in the authorization header (e.g. "authorization: Bearer <token>")
+    # a session cookie is set in the "couchers-sesh" cookie (e.g. "cookie: couchers-sesh=<token>")
+    # when a session is created, it's fixed as one or the other for security reasons
+    # for api keys to be useful, they should be long lived and have a long expiry
+    is_api_key = Column(Boolean, nullable=False, server_default=text("false"))
+
     # whether it's a long-lived or short-lived session
     long_lived = Column(Boolean, nullable=False)
 
@@ -1776,6 +1783,9 @@ class APICall(Base):
     __table_args__ = {"schema": "logging"}
 
     id = Column(BigInteger, primary_key=True)
+
+    # whether the call was made using an api key or session cookies
+    is_api_key = Column(Boolean, nullable=False, server_default=text("false"))
 
     # backend version (normally e.g. develop-31469e3), allows us to figure out which proto definitions were used
     # note that `default` is a python side default, not hardcoded into DB schema

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from datetime import timedelta
 
 import grpc
 from shapely.geometry import shape
@@ -8,8 +9,10 @@ from couchers import errors
 from couchers.db import session_scope
 from couchers.helpers.clusters import create_cluster, create_node
 from couchers.models import User
+from couchers.servicers.auth import create_session
 from couchers.servicers.communities import community_to_pb
 from couchers.sql import couchers_select as select
+from couchers.tasks import send_api_key_email
 from proto import admin_pb2, admin_pb2_grpc
 
 logger = logging.getLogger(__name__)
@@ -56,6 +59,17 @@ class Admin(admin_pb2_grpc.AdminServicer):
             if not user:
                 context.abort(grpc.StatusCode.NOT_FOUND, errors.USER_NOT_FOUND)
             user.is_deleted = True
+            return _user_to_details(user)
+
+    def CreateApiKey(self, request, context):
+        with session_scope() as session:
+            user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
+            if not user:
+                context.abort(grpc.StatusCode.NOT_FOUND, errors.USER_NOT_FOUND)
+            token, expiry = create_session(
+                context, session, user, long_lived=True, is_api_key=True, duration=timedelta(days=365)
+            )
+            send_api_key_email(session, user, token, expiry)
             return _user_to_details(user)
 
     def CreateCommunity(self, request, context):

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -416,7 +416,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
     def Deauthenticate(self, request, context):
         """
-        Removes an active session.
+        Removes an active cookie session.
         """
         token = parse_session_cookie(dict(context.invocation_metadata()))
         logger.info(f"Deauthenticate(token={token})")

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -39,69 +39,75 @@ def _auth_res(user):
     return auth_pb2.AuthRes(jailed=user.is_jailed, user_id=user.id)
 
 
+def create_session(context, session, user, long_lived, is_api_key=False, duration=None):
+    """
+    Creates a session for the given user and returns the token and expiry.
+
+    You need to give an active DB session as nested sessions don't really
+    work here due to the active User object.
+
+    Will abort the API calling context if the user is banned from logging in.
+
+    You can set the cookie on the client (if `is_api_key=False`) with
+
+    ```py3
+    token, expiry = create_session(...)
+    context.send_initial_metadata([("set-cookie", create_session_cookie(token, expiry)),])
+    ```
+    """
+    if user.is_banned:
+        context.abort(grpc.StatusCode.FAILED_PRECONDITION, errors.ACCOUNT_SUSPENDED)
+
+    # just double check
+    assert not user.is_deleted
+
+    token = cookiesafe_secure_token()
+
+    headers = dict(context.invocation_metadata())
+
+    user_session = UserSession(
+        token=token,
+        user=user,
+        long_lived=long_lived,
+        ip_address=headers.get("x-forwarded-for"),
+        user_agent=headers.get("user-agent"),
+        is_api_key=is_api_key,
+    )
+    if duration:
+        user_session.created = now()
+        user_session.expiry = user_session.created + duration
+
+    session.add(user_session)
+    session.commit()
+
+    logger.debug(f"Handing out {token=} to {user=}")
+    return token, user_session.expiry
+
+
+def delete_session(token):
+    """
+    Deletes the given session (practically logging the user out)
+
+    Returns True if the session was found, False otherwise.
+    """
+    with session_scope() as session:
+        user_session = session.execute(
+            select(UserSession).where(UserSession.token == token).where(UserSession.is_valid)
+        ).scalar_one_or_none()
+        if user_session:
+            user_session.deleted = func.now()
+            session.commit()
+            return True
+        else:
+            return False
+
+
 class Auth(auth_pb2_grpc.AuthServicer):
     """
     The Auth servicer.
 
     This class services the Auth service/API.
     """
-
-    def _create_session(self, context, session, user, long_lived):
-        """
-        Creates a session for the given user and returns the token and expiry.
-
-        You need to give an active DB session as nested sessions don't really
-        work here due to the active User object.
-
-        Will abort the API calling context if the user is banned from logging in.
-
-        You can set the cookie on the client with
-
-        ```py3
-        token, expiry = self._create_session(...)
-        context.send_initial_metadata([("set-cookie", create_session_cookie(token, expiry)),])
-        ```
-        """
-        if user.is_banned:
-            context.abort(grpc.StatusCode.FAILED_PRECONDITION, errors.ACCOUNT_SUSPENDED)
-
-        # just double check
-        assert not user.is_deleted
-
-        token = cookiesafe_secure_token()
-
-        headers = dict(context.invocation_metadata())
-
-        user_session = UserSession(
-            token=token,
-            user=user,
-            long_lived=long_lived,
-            ip_address=headers.get("x-forwarded-for"),
-            user_agent=headers.get("user-agent"),
-        )
-
-        session.add(user_session)
-        session.commit()
-
-        logger.debug(f"Handing out {token=} to {user=}")
-        return token, user_session.expiry
-
-    def _delete_session(self, token):
-        """
-        Deletes the given session (practically logging the user out)
-
-        Returns True if the session was found, False otherwise.
-        """
-        with session_scope() as session:
-            user_session = session.execute(
-                select(UserSession).where(UserSession.token == token).where(UserSession.is_valid)
-            ).scalar_one_or_none()
-            if user_session:
-                user_session.deleted = func.now()
-                session.commit()
-                return True
-            else:
-                return False
 
     def _username_available(self, username):
         """
@@ -291,7 +297,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
                 send_onboarding_email(user, email_number=1)
 
-                token, expiry = self._create_session(context, session, user, False)
+                token, expiry = create_session(context, session, user, False)
                 context.send_initial_metadata(
                     [
                         ("set-cookie", create_session_cookie(token, expiry)),
@@ -368,7 +374,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 session.commit()
 
                 # create a session
-                token, expiry = self._create_session(context, session, user, False)
+                token, expiry = create_session(context, session, user, False)
                 context.send_initial_metadata(
                     [
                         ("set-cookie", create_session_cookie(token, expiry)),
@@ -397,7 +403,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 if verify_password(user.hashed_password, request.password):
                     logger.debug(f"Right password")
                     # correct password
-                    token, expiry = self._create_session(context, session, user, request.remember_device)
+                    token, expiry = create_session(context, session, user, request.remember_device)
                     context.send_initial_metadata(
                         [
                             ("set-cookie", create_session_cookie(token, expiry)),
@@ -423,7 +429,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
         # if we had a token, try to remove the session
         if token:
-            self._delete_session(token)
+            delete_session(token)
 
         # set the cookie to an empty string and expire immediately, should remove it from the browser
         context.send_initial_metadata(

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -74,8 +74,7 @@ def create_session(context, session, user, long_lived, is_api_key=False, duratio
         is_api_key=is_api_key,
     )
     if duration:
-        user_session.created = now()
-        user_session.expiry = user_session.created + duration
+        user_session.expiry = func.now() + duration
 
     session.add(user_session)
     session.commit()

--- a/app/backend/src/couchers/tasks.py
+++ b/app/backend/src/couchers/tasks.py
@@ -55,6 +55,13 @@ def send_login_email(session, user):
     return login_token
 
 
+def send_api_key_email(session, user, token, expiry):
+    logger.info(f"Sending API key email to {user=}:")
+    email.enqueue_email_from_template(
+        user.email, "api_key", template_args={"user": user, "token": token, "expiry": expiry}
+    )
+
+
 def send_password_reset_email(session, user):
     password_reset_token = PasswordResetToken(
         token=urlsafe_secure_token(), user=user, expiry=now() + timedelta(hours=2)

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -208,6 +208,20 @@ def parse_session_cookie(headers):
     return cookie.value
 
 
+def parse_api_key(headers):
+    """
+    Returns a bearer token (API key) from the `authorization` header, or None if invalid/not present
+    """
+    if "authorization" not in headers:
+        return None
+
+    authorization = headers["authorization"]
+    if not authorization.startswith("Bearer "):
+        return None
+
+    return authorization[7:]
+
+
 def remove_duplicates_retain_order(list_):
     out = []
     for item in list_:

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -199,12 +199,16 @@ def test_CreateApiKey(db):
             == 0
         )
 
-        with patch("couchers.email.enqueue_email_from_template") as mock:
-            with _admin_session(super_token) as api:
-                res = api.CreateApiKey(admin_pb2.CreateApiKeyReq(user=normal_user.username))
+    with patch("couchers.email.enqueue_email_from_template") as mock:
+        with _admin_session(super_token) as api:
+            res = api.CreateApiKey(admin_pb2.CreateApiKeyReq(user=normal_user.username))
 
+    with session_scope() as session:
         api_key = session.execute(
-            select(UserSession).where(UserSession.is_api_key == True).where(UserSession.user_id == normal_user.id)
+            select(UserSession)
+            .where(UserSession.is_valid)
+            .where(UserSession.is_api_key == True)
+            .where(UserSession.user_id == normal_user.id)
         ).scalar_one()
 
         assert mock.called_once_with(

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
@@ -18,6 +19,7 @@ from couchers.models import (
     Upload,
 )
 from couchers.tasks import (
+    send_api_key_email,
     send_email_changed_confirmation_to_new_email,
     send_email_changed_confirmation_to_old_email,
     send_email_changed_notification_email,
@@ -28,6 +30,7 @@ from couchers.tasks import (
     send_report_email,
     send_signup_email,
 )
+from couchers.utils import now
 from tests.test_fixtures import db, generate_user, testconfig  # noqa
 
 
@@ -306,5 +309,30 @@ def test_password_reset_email(db):
         assert unique_string in html
         assert f"{config['BASE_URL']}/password-reset/{password_reset_token.token}" in plain
         assert f"{config['BASE_URL']}/password-reset/{password_reset_token.token}" in html
+        assert "support@couchers.org" in plain
+        assert "support@couchers.org" in html
+
+
+def test_api_key_email(db):
+    user, api_token = generate_user()
+
+    token = random_hex(64)
+    expiry = now() + timedelta(days=90)
+
+    with session_scope() as session:
+        with patch("couchers.email.queue_email") as mock:
+            send_api_key_email(session, user, token, expiry)
+
+        assert mock.call_count == 1
+        (sender_name, sender_email, recipient, subject, plain, html), _ = mock.call_args
+        assert recipient == user.email
+        assert "api key" in subject.lower()
+        assert token in plain
+        assert token in html
+        assert str(expiry) in plain
+        assert str(expiry) in html
+        unique_string = "We've issued you with the following API key:"
+        assert unique_string in plain
+        assert unique_string in html
         assert "support@couchers.org" in plain
         assert "support@couchers.org" in html

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -482,7 +482,7 @@ def real_jail_session(token):
 
 
 def fake_channel(token):
-    user_id, jailed, is_superuser = _try_get_and_update_user_details(token)
+    user_id, jailed, is_superuser = _try_get_and_update_user_details(token, is_api_key=False)
     return FakeChannel(user_id=user_id)
 
 

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -30,7 +30,7 @@ from couchers.models import (
 )
 from couchers.servicers.account import Account
 from couchers.servicers.api import API
-from couchers.servicers.auth import Auth
+from couchers.servicers.auth import Auth, create_session
 from couchers.servicers.blocking import Blocking
 from couchers.servicers.bugs import Bugs
 from couchers.servicers.communities import Communities
@@ -260,7 +260,7 @@ def generate_user(*, make_invisible=False, **kwargs):
             def invocation_metadata(self):
                 return {}
 
-        token, _ = auth._create_session(_DummyContext(), session, user, False)
+        token, _ = create_session(_DummyContext(), session, user, False)
 
         # deleted user aborts session creation, hence this follows and necessitates a second commit
         if make_invisible:

--- a/app/backend/templates/api_key.md
+++ b/app/backend/templates/api_key.md
@@ -15,6 +15,10 @@ You recently requested an API key for Couchers.org. We've issued you with the fo
 
 The token expires at {% if html %}<code>{{ expiry }}</code>{% else %}`{{ expiry }}`{% endif %}.
 
-Please remember to abide by our Terms of Service, our Community Guidelines, and other policies while using our APIs. All access is logged analyzed, and we may terminate your access if you abuse our service. For any questions, please contact us at {{ support_email(html)|couchers_safe }}.
+This token is unique to your account; do not share it with anyone, it gives complete access to your account, and you are reponsible for any actions taken using this API key.
+
+Please remember to abide by our Terms of Service, our Community Guidelines, and other policies while using our APIs. All access is logged and analyzed, and we may terminate your access or account if you abuse the service.
+
+For any questions, please contact us at {{ support_email(html)|couchers_safe }}.
 
 The Couchers.org team

--- a/app/backend/templates/api_key.md
+++ b/app/backend/templates/api_key.md
@@ -1,0 +1,20 @@
+---
+subject: "Your API key for Couchers.org"
+---
+
+{% from "macros.html" import button, link, support_email %}
+Hi {{ user.name|couchers_escape }},
+
+You recently requested an API key for Couchers.org. We've issued you with the following API key:
+
+{% if html %}
+<code>{{ token }}</code>
+{% else %}
+{{ token }}
+{% endif %}
+
+The token expires at {% if html %}<code>{{ expiry }}</code>{% else %}`{{ expiry }}`{% endif %}.
+
+Please remember to abide by our Terms of Service, our Community Guidelines, and other policies while using our APIs. All access is logged analyzed, and we may terminate your access if you abuse our service. For any questions, please contact us at {{ support_email(html)|couchers_safe }}.
+
+The Couchers.org team

--- a/app/client/src/couchers/client.py
+++ b/app/client/src/couchers/client.py
@@ -1,64 +1,26 @@
-import http.cookies
-
 import grpc
 
-from couchers.proto import auth_pb2, auth_pb2_grpc
 from couchers.services import get_all_stubs
 
 DEFAULT_SERVER_ADDRESS = "api.couchers.org:8443"
 
 
-class _CookieCreds:
-    def __init__(self, cookie_name, cookie_value):
-        self.cookie_name = cookie_name
-        self.cookie_value = cookie_value
+def get_client(api_key, server_address=DEFAULT_SERVER_ADDRESS, disable_tls=False):
+    """
+    Given an API key returns a client object.
 
-    def __call__(self, context, callback):
-        callback((("cookie", f"{self.cookie_name}={self.cookie_value}"),), None)
+    `disable_tls` connects to the server insecurely. This only works on localhost, thanks to gRPC.
 
-
-class _MetadataKeeperInterceptor(grpc.UnaryUnaryClientInterceptor):
-    def __init__(self):
-        self.latest_headers = {}
-
-    def intercept_unary_unary(self, continuation, client_call_details, request):
-        call = continuation(client_call_details, request)
-        self.latest_headers = dict(call.initial_metadata())
-        return call
-
-
-def get_api_key(username, password, server_address, disable_tls):
-    with create_channel(None, server_address, disable_tls) as channel:
-        metadata_interceptor = _MetadataKeeperInterceptor()
-        channel = grpc.intercept_channel(channel, metadata_interceptor)
-        auth = auth_pb2_grpc.AuthStub(channel)
-        auth.Authenticate(auth_pb2.AuthReq(user=username, password=password))
-        return http.cookies.SimpleCookie(metadata_interceptor.latest_headers["set-cookie"])["couchers-sesh"].value
-
-
-def create_channel(api_key, server_address, disable_tls):
+    Returns a new class with attributes corresponding to each stub, with attributes such as `account`, corresponding to
+    an account gRPC stub.
+    """
     if disable_tls:
         creds = grpc.local_channel_credentials()
     else:
         creds = grpc.ssl_channel_credentials()
 
-    if api_key:
-        cookie_creds = grpc.metadata_call_credentials(_CookieCreds("couchers-sesh", api_key))
-        creds = grpc.composite_channel_credentials(creds, cookie_creds)
+    creds = grpc.composite_channel_credentials(creds, grpc.access_token_call_credentials(api_key))
 
-    return grpc.secure_channel(server_address, creds)
-
-
-def get_client(username, password, server_address=DEFAULT_SERVER_ADDRESS, disable_tls=False):
-    """
-    Given username and password (the user must have a password set), returns a client object.
-
-    `disable_tls` connects to the server insecurely. This only works on localhost.
-
-    Returns a new class with attributes corresponding to each stub, with attributes such as `account`, corresponding to
-    an account gRPC stub.
-    """
-    api_key = get_api_key(username, password, server_address, disable_tls)
-    channel = create_channel(api_key, server_address, disable_tls)
+    channel = grpc.secure_channel(server_address, creds)
     stubs = get_all_stubs(channel)
     return type("__Client", (), stubs)

--- a/app/proto/admin.proto
+++ b/app/proto/admin.proto
@@ -16,6 +16,11 @@ service Admin {
 
   rpc DeleteUser(DeleteUserReq) returns (UserDetails) {}
 
+  rpc CreateApiKey(CreateApiKeyReq) returns (CreateApiKeyRes) {
+    // Create an API key for a user. For security, we don't return the API key to the admin calling this API, rather
+    // it's sent to the user in an email
+  }
+
   rpc CreateCommunity(CreateCommunityReq) returns (org.couchers.api.communities.Community) {}
 }
 
@@ -50,6 +55,13 @@ message DeleteUserReq {
   // username, email, or user id
   string user = 1;
 }
+
+message CreateApiKeyReq {
+  // username, email, or user id
+  string user = 1;
+}
+
+message CreateApiKeyRes {}
 
 message CreateCommunityReq {
   string name = 1;


### PR DESCRIPTION
As discussed in backend meeting two weeks ago, implements API keys for admin usage and possibly something else in the future. Closes #1681 and fixes #1658.

**Backend checklist**
- [x] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] All tests pass
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history