### PR TITLE
Make stripe_payment_intent_id unique in invoices table

### DIFF
--- a/app/backend/src/couchers/migrations/versions/e938e80b67a4_make_stripe_payment_intent_id_unique_in_.py
+++ b/app/backend/src/couchers/migrations/versions/e938e80b67a4_make_stripe_payment_intent_id_unique_in_.py
@@ -1,0 +1,22 @@
+"""Make stripe_payment_intent_id unique in invoices table
+
+Revision ID: e938e80b67a4
+Revises: 61b4c6b2df72
+Create Date: 2021-07-22 23:24:50.137340
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e938e80b67a4"
+down_revision = "61b4c6b2df72"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_unique_constraint(op.f("uq_invoices_stripe_payment_intent_id"), "invoices", ["stripe_payment_intent_id"])
+
+
+def downgrade():
+    op.drop_constraint(op.f("uq_invoices_stripe_payment_intent_id"), "invoices", type_="unique")

--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -398,7 +398,7 @@ class Invoice(Base):
 
     amount = Column(Float, nullable=False)
 
-    stripe_payment_intent_id = Column(String, nullable=False)
+    stripe_payment_intent_id = Column(String, nullable=False, unique=True)
     stripe_receipt_url = Column(String, nullable=False)
 
     user = relationship("User", backref="invoices")


### PR DESCRIPTION
This avoids duplicate invoices if stripe delivers webhooks multiple times. Closes #1664.

**Backend checklist**
- [x] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history
