### PR TITLE
fix: lowercases usernames/emails before sending to backend

### DIFF
--- a/app/frontend/src/features/auth/constants.tsx
+++ b/app/frontend/src/features/auth/constants.tsx
@@ -87,7 +87,7 @@ export const SIGN_UP_REDIRECT =
 export const SIGN_UP_TOS_ACCEPT = "I Accept the Terms of Service.";
 export const SIGN_UP_TOS_TEXT = "To continue, please read and accept the ";
 export const SIGN_UP_USERNAME_ERROR =
-  "Username can only have lowercase letters, numbers or _, starting with a letter.";
+  "Username can only have numbers or _, starting with a letter.";
 export const CONTINUE = "Continue";
 export const SUBMIT = "Submit";
 export const TERMS_OF_SERVICE = "Terms of Service";

--- a/app/frontend/src/features/auth/email/ChangeEmail.test.tsx
+++ b/app/frontend/src/features/auth/email/ChangeEmail.test.tsx
@@ -136,6 +136,26 @@ describe("ChangeEmail", () => {
       // Also check form has been cleared
       expect(screen.getByLabelText(NEW_EMAIL)).not.toHaveValue();
     });
+
+    it("changes the user's email successfully if the user has provided an email with non-lowercase characters", async () => {
+      userEvent.type(
+        await screen.findByLabelText(NEW_EMAIL),
+        "tesT@eXaMple.cOm"
+      );
+      userEvent.click(screen.getByRole("button", { name: SUBMIT }));
+
+      const successAlert = await screen.findByRole("alert");
+      expect(successAlert).toBeVisible();
+      expect(successAlert).toHaveTextContent(CHECK_EMAIL);
+      expect(changeEmailMock).toHaveBeenCalledTimes(1);
+      expect(changeEmailMock).toHaveBeenCalledWith(
+        "test@example.com",
+        undefined
+      );
+
+      // Also check form has been cleared
+      expect(screen.getByLabelText(NEW_EMAIL)).not.toHaveValue();
+    });
   });
 
   it("shows an error alert if the change password request failed", async () => {

--- a/app/frontend/src/features/auth/email/ChangeEmail.tsx
+++ b/app/frontend/src/features/auth/email/ChangeEmail.tsx
@@ -8,6 +8,7 @@ import { GetAccountInfoRes } from "proto/account_pb";
 import { useForm } from "react-hook-form";
 import { useMutation } from "react-query";
 import { service } from "service";
+import { lowercaseAndTrimField } from "utils/validation";
 
 import {
   CHANGE_EMAIL,
@@ -35,7 +36,7 @@ export default function ChangeEmail(accountInfo: GetAccountInfoRes.AsObject) {
     reset: resetForm,
   } = useForm<ChangeEmailFormData>();
   const onSubmit = handleSubmit(({ currentPassword, newEmail }) => {
-    changeEmail({ currentPassword, newEmail });
+    changeEmail({ currentPassword, newEmail: lowercaseAndTrimField(newEmail) });
   });
 
   const {

--- a/app/frontend/src/features/auth/signup/AccountForm.test.tsx
+++ b/app/frontend/src/features/auth/signup/AccountForm.test.tsx
@@ -115,6 +115,28 @@ describe("AccountForm", () => {
       });
     });
 
+    it("lowercases the username before submitting", async () => {
+      const usernameField = screen.getByLabelText(USERNAME);
+      userEvent.clear(usernameField);
+      userEvent.type(usernameField, "TeSt");
+      userEvent.click(screen.getByRole("button", { name: SIGN_UP }));
+
+      await waitFor(() => {
+        expect(signupFlowAccountMock).toHaveBeenCalledWith({
+          flowToken: "token",
+          username: "test",
+          birthdate: "1990-01-01",
+          gender: "Woman",
+          acceptTOS: true,
+          hostingStatus: HostingStatus.HOSTING_STATUS_CAN_HOST,
+          city: "test city, test country",
+          lat: 1,
+          lng: 2,
+          radius: 5,
+        });
+      });
+    });
+
     it("fails on incorrect/blank username", async () => {
       const field = screen.getByLabelText(USERNAME);
       userEvent.clear(field);

--- a/app/frontend/src/features/auth/signup/AccountForm.tsx
+++ b/app/frontend/src/features/auth/signup/AccountForm.tsx
@@ -133,7 +133,10 @@ export default function AccountForm() {
 
   const submit = handleSubmit(
     (data: SignupAccountInputs) => {
-      mutation.mutate({ ...data, username: data.username.toLowerCase() });
+      mutation.mutate({
+        ...data,
+        username: lowercaseAndTrimField(data.username),
+      });
     },
     () => {
       //location won't focus on error, so scroll to the top
@@ -179,7 +182,7 @@ export default function AccountForm() {
               required: USERNAME_REQUIRED,
               validate: async (username: string) => {
                 const valid = await service.auth.validateUsername(
-                  username.toLowerCase()
+                  lowercaseAndTrimField(username)
                 );
                 return valid || USERNAME_TAKEN;
               },

--- a/app/frontend/src/features/auth/signup/AccountForm.tsx
+++ b/app/frontend/src/features/auth/signup/AccountForm.tsx
@@ -133,7 +133,7 @@ export default function AccountForm() {
 
   const submit = handleSubmit(
     (data: SignupAccountInputs) => {
-      mutation.mutate(data);
+      mutation.mutate({ ...data, username: data.username.toLowerCase() });
     },
     () => {
       //location won't focus on error, so scroll to the top
@@ -177,8 +177,10 @@ export default function AccountForm() {
                 value: usernameValidationPattern,
               },
               required: USERNAME_REQUIRED,
-              validate: async (username) => {
-                const valid = await service.auth.validateUsername(username);
+              validate: async (username: string) => {
+                const valid = await service.auth.validateUsername(
+                  username.toLowerCase()
+                );
                 return valid || USERNAME_TAKEN;
               },
             });

--- a/app/frontend/src/utils/validation.ts
+++ b/app/frontend/src/utils/validation.ts
@@ -2,7 +2,7 @@
 export const nameValidationPattern = /\S+/;
 export const usernameValidationPattern = /^[a-z][0-9a-z_]*[a-z0-9]$/i;
 export const emailValidationPattern =
-  /^[0-9a-z][0-9a-z\-_+.]*@([0-9a-z-]+\.)*[0-9a-z-]+\.[a-z]{2,}$/;
+  /^[0-9a-z][0-9a-z\-_+.]*@([0-9a-z-]+\.)*[0-9a-z-]+\.[a-z]{2,}$/i;
 
 export function validatePastDate(stringDate: string) {
   const date = new Date(stringDate);

--- a/app/frontend/src/utils/validation.ts
+++ b/app/frontend/src/utils/validation.ts
@@ -1,6 +1,6 @@
 // taken from backend
 export const nameValidationPattern = /\S+/;
-export const usernameValidationPattern = /^[a-z][0-9a-z_]*[a-z0-9]$/;
+export const usernameValidationPattern = /^[a-z][0-9a-z_]*[a-z0-9]$/i;
 export const emailValidationPattern =
   /^[0-9a-z][0-9a-z\-_+.]*@([0-9a-z-]+\.)*[0-9a-z-]+\.[a-z]{2,}$/;
 


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
Closes #1657. Closes #1728. Lowercasing as the user type requires more code changes (making the input specifically into a controlled component) and not sure it's worth it if lowercasing at submission also works.

Updated error message and validation regexp so it doesn't say the username can only have lowercase letter anymore.
![Screenshot 2021-07-25 at 17 59 34](https://user-images.githubusercontent.com/13669362/126907210-2eda59c5-194b-4b26-a1ae-0e71f7a97801.png)


<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on frontend)
If you need help with any of these, please ask :)
--->

**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
