### PR TITLE
Updated add link styling to error page

### DIFF
--- a/app/frontend/src/features/NotFoundPage.tsx
+++ b/app/frontend/src/features/NotFoundPage.tsx
@@ -1,8 +1,9 @@
-import { Box } from "@material-ui/core";
+import { Box, Link as MuiLink } from "@material-ui/core";
 import TextBody from "components/TextBody";
-import React from "react";
+import { DO_YOU_WANT, GO_HOME,NOT_FOUND } from "features/constants";
 import { Link } from "react-router-dom";
 import Graphic from "resources/404graphic.png";
+import { baseRoute } from "routes";
 import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles({
@@ -29,10 +30,11 @@ export default function NotFoundPage() {
         alt="404 Error: Resource Not Found"
         className={classes.graphic}
       ></img>
-      <TextBody>We couldn't find the URL or resource you requested</TextBody>
-      <TextBody>
-        Do you just want to <Link to={`/`}>go home</Link>?
-      </TextBody>
+      <TextBody>{NOT_FOUND}</TextBody>
+      {DO_YOU_WANT}
+      <MuiLink component={Link} to={baseRoute}>
+        {GO_HOME}
+      </MuiLink>
     </Box>
   );
 }

--- a/app/frontend/src/features/constants.ts
+++ b/app/frontend/src/features/constants.ts
@@ -134,3 +134,8 @@ export const BUG_REPORT_SUCCESS =
 
 // Datepicker
 export const CHANGE_DATE = "Change date";
+
+// Not Found Page
+export const NOT_FOUND = "We couldn't find the URL or resource you requested";
+export const DO_YOU_WANT = "Do you just want to ";
+export const GO_HOME = "go home?";


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
CONTINUED FROM: https://github.com/Couchers-org/couchers/pull/1689
Sorry to mess up the pull requests page with another request.
I had to re-clone and start over from the work I had previously done, as I really goofed up the repo.
I added the link styling to the "return to home" button on the NotFoundPage.tsx and updated some of the strings into the constants.ts page.
I was able to run eslint and reformat everything according to spec, and ran tests 

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on frontend)
If you need help with any of these, please ask :)
--->
**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [x] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
