### PR TITLE
Events part 4: event discussion + unhiding join/leave event button

### DIFF
--- a/app/frontend/src/features/communities/discussions/CommentTree.tsx
+++ b/app/frontend/src/features/communities/discussions/CommentTree.tsx
@@ -4,7 +4,7 @@ import Button from "components/Button";
 import hasAtLeastOnePage from "utils/hasAtLeastOnePage";
 import makeStyles from "utils/makeStyles";
 
-import { COMMENTS, LOAD_EARLIER_COMMENTS, NO_COMMENTS } from "../constants";
+import { LOAD_EARLIER_COMMENTS, NO_COMMENTS } from "../constants";
 import { useThread } from "../hooks";
 import Comment from "./Comment";
 import CommentForm from "./CommentForm";
@@ -71,7 +71,6 @@ export default function CommentTree({ threadId }: CommentTreeProps) {
 
   return (
     <>
-      <Typography variant="h2">{COMMENTS}</Typography>
       {commentsError && <Alert severity="error">{commentsError.message}</Alert>}
       {isCommentsLoading ? (
         <CircularProgress />

--- a/app/frontend/src/features/communities/discussions/DiscussionPage.tsx
+++ b/app/frontend/src/features/communities/discussions/DiscussionPage.tsx
@@ -18,7 +18,12 @@ import { dateFormatter, timestamp2Date } from "utils/date";
 import makeStyles from "utils/makeStyles";
 
 import CommunityBase from "../CommunityBase";
-import { CREATED_AT, PREVIOUS_PAGE, UNKNOWN_USER } from "../constants";
+import {
+  COMMENTS,
+  CREATED_AT,
+  PREVIOUS_PAGE,
+  UNKNOWN_USER,
+} from "../constants";
 import CommentTree from "./CommentTree";
 
 const useStyles = makeStyles((theme) => ({
@@ -130,6 +135,7 @@ export default function DiscussionPage() {
                     )}
                   </div>
                 </div>
+                <Typography variant="h2">{COMMENTS}</Typography>
                 <CommentTree threadId={discussion.thread!.threadId} />
               </div>
             )}

--- a/app/frontend/src/features/communities/events/EventCard.test.tsx
+++ b/app/frontend/src/features/communities/events/EventCard.test.tsx
@@ -29,7 +29,9 @@ describe("Event card", () => {
     ).toBeVisible();
     expect(screen.getByText("June 29, 2021 2:37 AM - 3:37 AM")).toBeVisible();
     expect(
-      screen.getByText(getAttendeesCount(firstEvent.goingCount))
+      screen.getByText(
+        getAttendeesCount(firstEvent.goingCount + firstEvent.maybeCount)
+      )
     ).toBeVisible();
     expect(screen.getByText("Be there or be square!")).toBeVisible();
   });
@@ -47,7 +49,9 @@ describe("Event card", () => {
       screen.getByText("June 29, 2021 9:00 PM - June 30, 2021 2:00 AM")
     ).toBeVisible();
     expect(
-      screen.getByText(getAttendeesCount(thirdEvent.goingCount))
+      screen.getByText(
+        getAttendeesCount(thirdEvent.goingCount + thirdEvent.maybeCount)
+      )
     ).toBeVisible();
     expect(screen.getByText(thirdEvent.content)).toBeVisible();
   });
@@ -61,7 +65,9 @@ describe("Event card", () => {
     expect(screen.getByText(VIEW_DETAILS_FOR_LINK)).toBeVisible();
     expect(screen.getByText("June 29, 2021 9:00 PM - 10:00 PM")).toBeVisible();
     expect(
-      screen.getByText(getAttendeesCount(secondEvent.goingCount))
+      screen.getByText(
+        getAttendeesCount(secondEvent.goingCount + secondEvent.maybeCount)
+      )
     ).toBeVisible();
     expect(screen.getByText(secondEvent.content)).toBeVisible();
   });

--- a/app/frontend/src/features/communities/events/EventCard.tsx
+++ b/app/frontend/src/features/communities/events/EventCard.tsx
@@ -141,7 +141,7 @@ export default function EventCard({ event, className }: EventCardProps) {
             <li>
               <AttendeesIcon className={classes.icon} />
               <Typography variant="body1">
-                {getAttendeesCount(event.goingCount)}
+                {getAttendeesCount(event.goingCount + event.maybeCount)}
               </Typography>
             </li>
           </ul>

--- a/app/frontend/src/features/communities/events/EventPage.test.tsx
+++ b/app/frontend/src/features/communities/events/EventPage.test.tsx
@@ -2,7 +2,6 @@ import {
   render,
   screen,
   waitForElementToBeRemoved,
-  within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AttendanceState } from "proto/events_pb";
@@ -210,6 +209,9 @@ describe("Event page", () => {
         attendanceState: 0,
         eventId: 1,
       });
+      // Check that the update doesn't cause the event to be refetched since we should be
+      // using the updated event from mutation
+      expect(getEventMock).toHaveBeenCalledTimes(1);
     });
 
     it("shows an error alert if the attendance state update failed", async () => {

--- a/app/frontend/src/features/communities/events/EventPage.tsx
+++ b/app/frontend/src/features/communities/events/EventPage.tsx
@@ -226,24 +226,24 @@ export default function EventPage() {
                   </Typography>
                 )}
               </div>
-              {process.env.REACT_APP_IS_COMMUNITIES_PART2_ENABLED && (
-                <Button
-                  className={classes.attendanceButton}
-                  loading={isSetEventAttendanceLoading}
-                  onClick={() => setEventAttendance(event.attendanceState)}
-                  variant={
-                    event.attendanceState ===
-                    AttendanceState.ATTENDANCE_STATE_GOING
-                      ? "outlined"
-                      : "contained"
-                  }
-                >
-                  {event.attendanceState ===
+
+              <Button
+                className={classes.attendanceButton}
+                loading={isSetEventAttendanceLoading}
+                onClick={() => setEventAttendance(event.attendanceState)}
+                variant={
+                  event.attendanceState ===
                   AttendanceState.ATTENDANCE_STATE_GOING
-                    ? LEAVE_EVENT
-                    : JOIN_EVENT}
-                </Button>
-              )}
+                    ? "outlined"
+                    : "contained"
+                }
+              >
+                {event.attendanceState ===
+                AttendanceState.ATTENDANCE_STATE_GOING
+                  ? LEAVE_EVENT
+                  : JOIN_EVENT}
+              </Button>
+
               <div className={classes.eventTimeContainer}>
                 <CalendarIcon className={classes.calendarIcon} />
                 <Typography variant="body1">
@@ -257,9 +257,7 @@ export default function EventPage() {
                 <Markdown source={event.content} topHeaderLevel={3} />
               </Card>
               <EventOrganisers eventId={event.eventId} />
-              {process.env.REACT_APP_IS_COMMUNITIES_PART2_ENABLED && (
-                <EventAttendees eventId={event.eventId} />
-              )}
+              <EventAttendees eventId={event.eventId} />
             </div>
             <div className={classes.discussionContainer}>
               <Typography variant="h2">{EVENT_DISCUSSION}</Typography>

--- a/app/frontend/src/features/communities/events/EventPage.tsx
+++ b/app/frontend/src/features/communities/events/EventPage.tsx
@@ -167,7 +167,9 @@ export default function EventPage() {
           eventKey(eventId),
           updatedEvent
         );
-        queryClient.invalidateQueries(eventKey(eventId));
+        queryClient.invalidateQueries(eventKey(eventId), {
+          refetchActive: false,
+        });
         queryClient.invalidateQueries([eventAttendeesBaseKey, eventId]);
       },
     }
@@ -261,7 +263,7 @@ export default function EventPage() {
             </div>
             <div className={classes.discussionContainer}>
               <Typography variant="h2">{EVENT_DISCUSSION}</Typography>
-              <CommentTree threadId={event.threadId} />
+              <CommentTree threadId={event.thread!.threadId} />
             </div>
           </>
         )

--- a/app/frontend/src/features/communities/events/EventPage.tsx
+++ b/app/frontend/src/features/communities/events/EventPage.tsx
@@ -20,8 +20,10 @@ import dayjs from "utils/dayjs";
 import makeStyles from "utils/makeStyles";
 
 import { PREVIOUS_PAGE } from "../constants";
+import CommentTree from "../discussions/CommentTree";
 import {
   details,
+  EVENT_DISCUSSION,
   EVENT_LINK,
   JOIN_EVENT,
   LEAVE_EVENT,
@@ -107,6 +109,9 @@ export const useEventPageStyles = makeStyles((theme) => ({
     "& + &": {
       marginBlockStart: theme.spacing(3),
     },
+  },
+  discussionContainer: {
+    marginBlockEnd: theme.spacing(5),
   },
 }));
 
@@ -255,6 +260,10 @@ export default function EventPage() {
               {process.env.REACT_APP_IS_COMMUNITIES_PART2_ENABLED && (
                 <EventAttendees eventId={event.eventId} />
               )}
+            </div>
+            <div className={classes.discussionContainer}>
+              <Typography variant="h2">{EVENT_DISCUSSION}</Typography>
+              <CommentTree threadId={event.threadId} />
             </div>
           </>
         )

--- a/app/frontend/src/features/communities/events/LongEventCard.test.tsx
+++ b/app/frontend/src/features/communities/events/LongEventCard.test.tsx
@@ -42,7 +42,7 @@ describe("Long event card", () => {
       screen.getByText(firstEvent.offlineInformation?.address!)
     ).toBeVisible();
     expect(screen.getByText("Jun 29, 2021 2:37 AM")).toBeVisible();
-    expect(screen.getByText("10 attendees")).toBeVisible();
+    expect(screen.getByText("12 attendees")).toBeVisible();
 
     const eventImage = screen.getByRole("img", { name: "" });
     expect(eventImage).toBeVisible();

--- a/app/frontend/src/features/communities/events/LongEventCard.tsx
+++ b/app/frontend/src/features/communities/events/LongEventCard.tsx
@@ -122,7 +122,7 @@ export default function LongEventCard({ event }: LongEventCardProps) {
           <div className={classes.attendeesCountContainer}>
             <AttendeesIcon className={classes.icon} />
             <Typography variant="body1">
-              {getAttendeesCount(event.goingCount)}
+              {getAttendeesCount(event.goingCount + event.maybeCount)}
             </Typography>
           </div>
         </div>

--- a/app/frontend/src/features/communities/events/constants.ts
+++ b/app/frontend/src/features/communities/events/constants.ts
@@ -2,6 +2,7 @@ export const ATTENDEES = "Attendees";
 export const details = ({ colon = false }: { colon?: boolean } = {}) =>
   `Details${colon ? ":" : ""}`;
 export const getExtraAvatarCountText = (count: number) => `+${count}`;
+export const EVENT_DISCUSSION = "Event discussion";
 export const EVENTS_EMPTY_STATE = "No events at the moment.";
 export const EVENTS_LABEL = "Events";
 export const EVENT_LINK = "Event link";

--- a/app/frontend/src/test/fixtures/events.json
+++ b/app/frontend/src/test/fixtures/events.json
@@ -13,7 +13,10 @@
     "ownerCommunityId": 2,
     "ownerGroupId": 0,
     "ownerUserId": 0,
-    "threadId": 21,
+    "thread": {
+      "threadId": 21,
+      "numResponses": 0
+    },
     "canEdit": false,
     "canModerate": false,
     "isNext": false,
@@ -45,7 +48,10 @@
     "ownerCommunityId": 2,
     "ownerGroupId": 0,
     "ownerUserId": 0,
-    "threadId": 31,
+    "thread": {
+      "threadId": 31,
+      "numResponses": 0
+    },
     "canEdit": false,
     "canModerate": false,
     "isNext": false,
@@ -75,7 +81,10 @@
     "ownerCommunityId": 2,
     "ownerGroupId": 0,
     "ownerUserId": 0,
-    "threadId": 41,
+    "thread": {
+      "threadId": 41,
+      "numResponses": 0
+    },
     "canEdit": false,
     "canModerate": false,
     "isNext": false,


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
Covers more of #541. Feature in question pretty much in title.

I'm leaving the button as the binary join/leave thing for the first version, as the API currently lists people who are "maybe" going as an attendee and the distinction isn't clear between "going" and "maybe" - i.e. should we include people who said "maybe" in attendees?

**Desktop**
![Screenshot 2021-08-02 at 03 06 18](https://user-images.githubusercontent.com/13669362/127795170-cc0807de-47fd-4212-997b-7d0e0e3e5884.png)

**Mobile**
![Screenshot 2021-08-02 at 03 06 53](https://user-images.githubusercontent.com/13669362/127795188-57180ac1-e40f-404d-9d46-bd3b395b64fd.png)

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on frontend)
If you need help with any of these, please ask :)
--->

**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
