### PR TITLE
Add polyfill for older browsers to stop frontend erroring on use of flatMap

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -83,7 +83,7 @@
   ],
   "browserslist": {
     "production": [
-      ">0.2%",
+      ">0.1%",
       "not dead",
       "not op_mini all"
     ],

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -17,6 +17,7 @@
     "grpc-web": "^1.2.1",
     "maplibre-gl": "^1.15.2",
     "react": "^17.0.2",
+    "react-app-polyfill": "^2.0.0",
     "react-dom": "^17.0.2",
     "react-error-boundary": "^3.1.3",
     "react-gtm-module": "^2.0.11",

--- a/app/frontend/src/index.tsx
+++ b/app/frontend/src/index.tsx
@@ -1,3 +1,4 @@
+import "react-app-polyfill/stable";
 import "./index.css";
 
 import * as Sentry from "@sentry/react";

--- a/app/frontend/yarn.lock
+++ b/app/frontend/yarn.lock
@@ -4988,9 +4988,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001173:
-  version "1.0.30001179"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001179.tgz#b0803883b4471a6c62066fb1752756f8afc699c8"
-  integrity sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==
+  version "1.0.30001251"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz"
+  integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
I was seeing a few `c.data.pages.flatMap is not a function` errors on Sentry and noticed that they are all from users from using older versions of Safari... this polyfill should hopefully fix it. It only gets applied to [browsers who don't support the function already using the `browserslist` config](https://create-react-app.dev/docs/supported-browsers-features/)

Closes #1823

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on frontend)
If you need help with any of these, please ask :)
--->

**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
