### PR TITLE
fix: map feature doesn't have active styling on slow internet

### DIFF
--- a/app/frontend/src/features/search/SearchPage.tsx
+++ b/app/frontend/src/features/search/SearchPage.tsx
@@ -7,6 +7,7 @@ import maplibregl, { EventData, LngLat, Map as MaplibreMap } from "maplibre-gl";
 import { User } from "proto/api_pb";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { searchRoute } from "routes";
+import { usePrevious } from "utils/hooks";
 
 import SearchResultsList from "./SearchResultsList";
 import { addClusteredUsersToMap, layers } from "./users";
@@ -54,9 +55,13 @@ export default function SearchPage() {
   const theme = useTheme();
 
   const map = useRef<MaplibreMap>();
-  const [selectedResult, setSelectedResult] = useState<number | undefined>(
-    undefined
-  );
+  const [selectedResult, setSelectedResult] = useState<
+    Pick<User.AsObject, "username" | "userId" | "lng" | "lat"> | undefined
+  >(undefined);
+
+  const previousResult = usePrevious(selectedResult);
+
+  const [areClustersLoaded, setAreClustersLoaded] = useState(false);
 
   const showResults = useRef(false);
 
@@ -74,24 +79,6 @@ export default function SearchPage() {
     }
   }, [query, selectedResult, theme.transitions.duration.standard]);
 
-  /*
-
-  const handlePlaceClick = (ev: any) => {
-    const properties = ev.features[0].properties as {
-      id: number;
-      slug: string;
-    };
-    history.push(routeToPlace(properties.id, properties.slug), location.state);
-  };
-
-  const handleGuideClick = (ev: any) => {
-    const properties = ev.features[0].properties as {
-      id: number;
-      slug: string;
-    };
-    history.push(routeToGuide(properties.id, properties.slug), location.state);
-  };*/
-
   const flyToUser = useCallback((user: Pick<User.AsObject, "lng" | "lat">) => {
     map.current?.stop();
     map.current?.easeTo({
@@ -99,47 +86,31 @@ export default function SearchPage() {
     });
   }, []);
 
-  const handleResultClick = useCallback(
-    (user?: Pick<User.AsObject, "username" | "userId" | "lng" | "lat">) => {
-      //if undefined, unset
-      if (!user) {
-        if (selectedResult) {
-          //unset the old feature selection on the map for styling
-          map.current?.setFeatureState(
-            { source: "clustered-users", id: selectedResult },
-            { selected: false }
-          );
-          setSelectedResult(undefined);
-        }
-        return;
-      }
-
-      //always fly to user as the user may have panned the map
-      flyToUser(user);
-
-      //make a new selection if it has changed
-      if (selectedResult !== user.userId) {
-        if (selectedResult) {
-          //unset the old feature selection on the map for styling
-          map.current?.setFeatureState(
-            { source: "clustered-users", id: selectedResult },
-            { selected: false }
-          );
-        }
-        //set the new selection
+  useEffect(() => {
+    if (previousResult) {
+      //unset the old feature selection on the map for styling
+      areClustersLoaded &&
         map.current?.setFeatureState(
-          { source: "clustered-users", id: user.userId },
+          { source: "clustered-users", id: previousResult.userId },
+          { selected: false }
+        );
+    }
+
+    if (selectedResult) {
+      //update the map
+      flyToUser(selectedResult);
+      areClustersLoaded &&
+        map.current?.setFeatureState(
+          { source: "clustered-users", id: selectedResult.userId },
           { selected: true }
         );
-        setSelectedResult(user.userId);
-        document
-          .getElementById(`search-result-${user.userId}`)
-          ?.scrollIntoView({ behavior: "smooth" });
-        return;
-      }
-    },
-    [selectedResult, flyToUser]
-  );
+
+      //update result list
+      document
+        .getElementById(`search-result-${selectedResult.userId}`)
+        ?.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [selectedResult, areClustersLoaded, previousResult, flyToUser]);
 
   const handleMapUserClick = useCallback(
     (
@@ -154,17 +125,31 @@ export default function SearchPage() {
       const username = props.username;
       const userId = props.id;
       const [lng, lat] = geom.coordinates;
-      handleResultClick({ username, userId, lng, lat });
+      setSelectedResult({ username, userId, lng, lat });
     },
-    [handleResultClick]
+    []
   );
+
+  //detect when map data has been initially loaded
+  const handleMapSourceData = useCallback(() => {
+    if (
+      map.current &&
+      map.current.getSource("clustered-users") &&
+      map.current.isSourceLoaded("clustered-users")
+    ) {
+      setAreClustersLoaded(true);
+
+      // unbind the event
+      map.current.off("sourcedata", handleMapSourceData);
+    }
+  }, []);
 
   useEffect(() => {
     if (!map.current) return;
     const handleMapClickAway = (e: EventData) => {
       //defaultPrevented is true when a map feature has been clicked
       if (!e.defaultPrevented) {
-        handleResultClick(undefined);
+        setSelectedResult(undefined);
       }
     };
 
@@ -176,10 +161,13 @@ export default function SearchPage() {
     );
     map.current.on("click", handleMapClickAway);
 
+    map.current.on("sourcedata", handleMapSourceData);
+
     return () => {
       if (!map.current) return;
 
       //unbind event handlers for map events
+      map.current.off("sourcedata", handleMapSourceData);
       map.current.off("click", handleMapClickAway);
       map.current.off(
         "click",
@@ -187,14 +175,11 @@ export default function SearchPage() {
         handleMapUserClick
       );
     };
-  }, [handleResultClick, handleMapUserClick]);
+  }, [handleMapUserClick, handleMapSourceData]);
 
   const initializeMap = (newMap: MaplibreMap) => {
     map.current = newMap;
     newMap.on("load", () => {
-      //addCommunitiesToMap(newMap);
-      //addPlacesToMap(newMap);
-      //addGuidesToMap(newMap);
       addClusteredUsersToMap(newMap);
     });
   };
@@ -204,10 +189,10 @@ export default function SearchPage() {
       <div className={classes.container}>
         <Hidden smDown>
           <SearchResultsList
-            handleResultClick={handleResultClick}
+            handleResultClick={setSelectedResult}
             handleMapUserClick={handleMapUserClick}
             map={map}
-            selectedResult={selectedResult}
+            selectedResult={selectedResult?.userId}
             searchFilters={searchFilters}
           />
         </Hidden>
@@ -218,10 +203,10 @@ export default function SearchPage() {
             className={classes.mobileCollapse}
           >
             <SearchResultsList
-              handleResultClick={handleResultClick}
+              handleResultClick={setSelectedResult}
               handleMapUserClick={handleMapUserClick}
               map={map}
-              selectedResult={selectedResult}
+              selectedResult={selectedResult?.userId}
               searchFilters={searchFilters}
             />
           </Collapse>

--- a/app/frontend/src/utils/hooks.ts
+++ b/app/frontend/src/utils/hooks.ts
@@ -4,6 +4,7 @@ import {
   MutableRefObject,
   SetStateAction,
   useCallback,
+  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -104,4 +105,12 @@ const useGeocodeQuery = () => {
   return { isLoading, error, results, query };
 };
 
-export { useGeocodeQuery, useIsMounted, useSafeState };
+function usePrevious<T>(value: T) {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref.current;
+}
+
+export { useGeocodeQuery, useIsMounted, usePrevious, useSafeState };


### PR DESCRIPTION
Moved logic from handeResultClick callback function into a useEffect
hook so it can listen to map state changes (areClustersLoaded) and
wait for executing any map related code untill the map is loaded.

This way we can be sure that the feature of the selected user will
always be styled as active. No matter if the result was clicked before
or after the map data was loaded.

There was no need to disable the button 'show user on map'. You can click them whenever you want and you'll see the user on the map once the map is loaded.

fixes #1846

**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass 
   except datepicker test
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

