### PR TITLE
fix: make allowCsv=false the default for ProfileTagInput

### DIFF
--- a/app/frontend/src/features/profile/ProfileTagInput.tsx
+++ b/app/frontend/src/features/profile/ProfileTagInput.tsx
@@ -125,7 +125,7 @@ export default function ProfileTagInput({
   options,
   label,
   id,
-  allowCsv = true,
+  allowCsv = false,
   className,
 }: ProfileTagInputProps) {
   const classes = useStyles();

--- a/app/frontend/src/features/profile/ProfileTagInput.tsx
+++ b/app/frontend/src/features/profile/ProfileTagInput.tsx
@@ -125,7 +125,6 @@ export default function ProfileTagInput({
   options,
   label,
   id,
-  allowCsv = false,
   className,
 }: ProfileTagInputProps) {
   const classes = useStyles();
@@ -210,17 +209,7 @@ export default function ProfileTagInput({
               // For some reason I came across situations when there were undefined values in this array.
               newValue = newValue.filter((element) => element !== undefined);
 
-              if (allowCsv) {
-                const lastIndex = newValue.length - 1;
-                const latestEntry = newValue[lastIndex];
-                const previousEntries = newValue.slice(0, lastIndex);
-                uniqueValues = new Set([
-                  ...previousEntries,
-                  ...latestEntry.split(",").map((value) => value.trim()),
-                ]);
-              } else {
-                uniqueValues = new Set(newValue);
-              }
+              uniqueValues = new Set(newValue);
             } else {
               uniqueValues = new Set([]);
             }


### PR DESCRIPTION
Disable csv functionality in the ProfileTagInput component so that we wont try to split inputs that contain a comma into two separate values.

Since the only place where this component was used is on the Edit Profile page, I have changed the default. This looks more future proof so we don't run into this bug again when we start using this component on other pages where the options have not been cleared from commas.


Fixes #1818

**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [ ] All tests pass
I have some failed tests regarding to the event page and datepicker, something broke on develop branch?
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
