### PR TITLE
Events part 6: edit event page

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -33,11 +33,11 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "CI=true react-scripts build",
-    "test": "react-scripts test",
+    "test": "TZ=UTC react-scripts test",
     "eject": "react-scripts eject",
     "format": "prettier --write src/*",
     "lint": "eslint src/",
-    "test-ci": "tsc && CI=true react-scripts test --coverageReporters=\"text\" --coverageReporters=\"cobertura\" --coverageReporters=\"lcov\" --reporters=\"default\" --reporters=\"jest-junit\" --coverage",
+    "test-ci": "tsc && CI=true TZ=UTC react-scripts test --coverageReporters=\"text\" --coverageReporters=\"cobertura\" --coverageReporters=\"lcov\" --reporters=\"default\" --reporters=\"jest-junit\" --coverage",
     "jest": "jest --modulePaths=src",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "NODE_PATH=. build-storybook -s public",

--- a/app/frontend/src/AppRoutes.tsx
+++ b/app/frontend/src/AppRoutes.tsx
@@ -2,12 +2,12 @@ import PageTitle from "components/PageTitle";
 import TextBody from "components/TextBody";
 import EditCommunityInfoPage from "features/communities/EditCommunityInfoPage";
 import CreateEventPage from "features/communities/events/CreateEventPage";
+import EditEventPage from "features/communities/events/EditEventPage";
 import EventPage from "features/communities/events/EventPage";
 import ContributePage from "features/ContributePage";
 import Donations from "features/donations/Donations";
 import EditProfilePage from "features/profile/edit/EditProfilePage";
 import UserPage from "features/profile/view/UserPage";
-import React from "react";
 import { Switch } from "react-router-dom";
 
 import AppRoute from "./AppRoute";
@@ -44,6 +44,7 @@ import {
   discussionRoute,
   donationsRoute,
   editCommunityPageRoute,
+  editEventRoute,
   editProfileRoute,
   eventRoute,
   eventsRoute,
@@ -200,6 +201,9 @@ export default function AppRoutes() {
       </AppRoute>
       <AppRoute isPrivate path={newEventRoute}>
         <CreateEventPage />
+      </AppRoute>
+      <AppRoute isPrivate path={editEventRoute}>
+        <EditEventPage />
       </AppRoute>
       <AppRoute isPrivate path={eventRoute}>
         <EventPage />

--- a/app/frontend/src/features/communities/events/CreateEventPage.test.tsx
+++ b/app/frontend/src/features/communities/events/CreateEventPage.test.tsx
@@ -23,6 +23,14 @@ const createEventMock = service.events.createEvent as jest.MockedFunction<
 >;
 
 describe("Create event page", () => {
+  beforeAll(() => {
+    server.listen();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
   beforeEach(() => {
     createEventMock.mockResolvedValue(events[0]);
     jest.useFakeTimers("modern");
@@ -71,6 +79,76 @@ describe("Create event page", () => {
     // Verifies that success re-directs user
     expect(screen.getByTestId("event-page")).toBeInTheDocument();
   });
+
+  it("creates on offline event with no route state correctly", async () => {
+    renderPageWithState();
+
+    userEvent.type(screen.getByLabelText(TITLE), "Test event");
+    // msw server response doesn't work with fake timers on, so turn it off temporarily
+    jest.useRealTimers();
+    userEvent.type(screen.getByLabelText(LOCATION), "tes{enter}");
+    userEvent.click(
+      await screen.findByText("test city, test county, test country")
+    );
+    userEvent.type(screen.getByLabelText(EVENT_DETAILS), "sick social!");
+
+    // Now we got our location, turn fake timers back on so the default date we got earlier from the "current"
+    // date would pass form validation
+    jest.useFakeTimers("modern");
+    jest.setSystemTime(new Date("2021-08-01 00:00"));
+    userEvent.click(screen.getByRole("button", { name: CREATE }));
+
+    await waitFor(() => {
+      expect(createEventMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(createEventMock).toHaveBeenCalledWith({
+      isOnline: false,
+      lat: 2,
+      lng: 1,
+      address: "test city, test county, test country",
+      title: "Test event",
+      content: "sick social!",
+      photoKey: "",
+      startTime: new Date("2021-08-01 01:00"),
+      endTime: new Date("2021-08-01 02:00"),
+    });
+  });
+
+  it("creates on offline event with route state correctly", async () => {
+    jest.useFakeTimers("modern");
+    jest.setSystemTime(new Date("2021-08-01 00:00"));
+    renderPageWithState({ communityId: 99 });
+
+    userEvent.type(screen.getByLabelText(TITLE), "Test event");
+    jest.useRealTimers();
+    userEvent.type(screen.getByLabelText(LOCATION), "tes{enter}");
+    userEvent.click(
+      await screen.findByText("test city, test county, test country")
+    );
+    userEvent.type(screen.getByLabelText(EVENT_DETAILS), "sick social!");
+
+    jest.useFakeTimers("modern");
+    jest.setSystemTime(new Date("2021-08-01 00:00"));
+    userEvent.click(screen.getByRole("button", { name: CREATE }));
+
+    await waitFor(() => {
+      expect(createEventMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(createEventMock).toHaveBeenCalledWith({
+      isOnline: false,
+      lat: 2,
+      lng: 1,
+      address: "test city, test county, test country",
+      title: "Test event",
+      content: "sick social!",
+      photoKey: "",
+      startTime: new Date("2021-08-01 01:00"),
+      endTime: new Date("2021-08-01 02:00"),
+      parentCommunityId: 99,
+    });
+  });
 });
 
 function renderPageWithState(state?: { communityId: number }) {
@@ -94,74 +172,3 @@ function renderPageWithState(state?: { communityId: number }) {
     { wrapper }
   );
 }
-
-describe("Create event page (offline events)", () => {
-  beforeAll(() => {
-    server.listen();
-  });
-
-  afterAll(() => {
-    server.close();
-  });
-
-  beforeEach(() => {
-    createEventMock.mockResolvedValue(events[0]);
-  });
-
-  it("creates on offline event with no route state correctly", async () => {
-    renderPageWithState();
-
-    userEvent.type(screen.getByLabelText(TITLE), "Test event");
-    userEvent.type(screen.getByLabelText(LOCATION), "tes{enter}");
-    userEvent.click(
-      await screen.findByText("test city, test county, test country")
-    );
-    userEvent.type(screen.getByLabelText(EVENT_DETAILS), "sick social!");
-    userEvent.click(screen.getByRole("button", { name: CREATE }));
-
-    await waitFor(() => {
-      expect(createEventMock).toHaveBeenCalledTimes(1);
-    });
-
-    expect(createEventMock).toHaveBeenCalledWith({
-      isOnline: false,
-      lat: 2,
-      lng: 1,
-      address: "test city, test county, test country",
-      title: "Test event",
-      content: "sick social!",
-      photoKey: "",
-      startTime: expect.any(Date),
-      endTime: expect.any(Date),
-    });
-  });
-
-  it("creates on offline event with route state correctly", async () => {
-    renderPageWithState({ communityId: 99 });
-
-    userEvent.type(screen.getByLabelText(TITLE), "Test event");
-    userEvent.type(screen.getByLabelText(LOCATION), "tes{enter}");
-    userEvent.click(
-      await screen.findByText("test city, test county, test country")
-    );
-    userEvent.type(screen.getByLabelText(EVENT_DETAILS), "sick social!");
-    userEvent.click(screen.getByRole("button", { name: CREATE }));
-
-    await waitFor(() => {
-      expect(createEventMock).toHaveBeenCalledTimes(1);
-    });
-
-    expect(createEventMock).toHaveBeenCalledWith({
-      isOnline: false,
-      lat: 2,
-      lng: 1,
-      address: "test city, test county, test country",
-      title: "Test event",
-      content: "sick social!",
-      photoKey: "",
-      startTime: expect.any(Date),
-      endTime: expect.any(Date),
-      parentCommunityId: 99,
-    });
-  });
-});

--- a/app/frontend/src/features/communities/events/CreateEventPage.test.tsx
+++ b/app/frontend/src/features/communities/events/CreateEventPage.test.tsx
@@ -116,8 +116,6 @@ describe("Create event page", () => {
   });
 
   it("creates on offline event with route state correctly", async () => {
-    jest.useFakeTimers("modern");
-    jest.setSystemTime(new Date("2021-08-01 00:00"));
     renderPageWithState({ communityId: 99 });
 
     userEvent.type(screen.getByLabelText(TITLE), "Test event");

--- a/app/frontend/src/features/communities/events/CreateEventPage.tsx
+++ b/app/frontend/src/features/communities/events/CreateEventPage.tsx
@@ -1,3 +1,6 @@
+import { Typography } from "@material-ui/core";
+import Button from "components/Button";
+import { CREATE } from "features/constants";
 import { Error as GrpcError } from "grpc-web";
 import { Event } from "proto/events_pb";
 import { communityEventsBaseKey } from "queryKeys";
@@ -9,12 +12,17 @@ import type { CreateEventInput } from "service/events";
 import dayjs, { TIME_FORMAT } from "utils/dayjs";
 import makeStyles from "utils/makeStyles";
 
-import { CREATE_EVENT } from "./constants";
-import EventForm, { CreateEventData } from "./EventForm";
+import { CREATE_EVENT, CREATE_EVENT_DISCLAIMER } from "./constants";
+import EventForm, { CreateEventData, useEventFormStyles } from "./EventForm";
 
-const useStyles = makeStyles((theme) => ({}));
+const useStyles = makeStyles((theme) => ({
+  disclaimer: {
+    color: theme.palette.grey[600],
+  },
+}));
 
 export default function CreateEventPage() {
+  const classes = { ...useEventFormStyles(), ...useStyles() };
   const history = useHistory<{ communityId?: number }>();
   const queryClient = useQueryClient();
   const {
@@ -97,6 +105,21 @@ export default function CreateEventPage() {
       isMutationLoading={isLoading}
       mutate={createEvent}
       title={CREATE_EVENT}
-    />
+    >
+      {({ isMutationLoading }) => (
+        <>
+          <Button
+            className={classes.submitButton}
+            loading={isMutationLoading}
+            type="submit"
+          >
+            {CREATE}
+          </Button>
+          <Typography className={classes.disclaimer} variant="body1">
+            {CREATE_EVENT_DISCLAIMER}
+          </Typography>
+        </>
+      )}
+    </EventForm>
   );
 }

--- a/app/frontend/src/features/communities/events/EditEventPage.test.tsx
+++ b/app/frontend/src/features/communities/events/EditEventPage.test.tsx
@@ -59,7 +59,7 @@ describe("Edit event page", () => {
 
     await waitForElementToBeRemoved(screen.getByRole("progressbar"));
 
-    // High level check that the form has existing data, more detailed ones done in form unit test
+    // Brief sanity check that the form has existing data
     const titleField = screen.getByLabelText(TITLE);
     expect(titleField).toHaveValue("Weekly Meetup");
 

--- a/app/frontend/src/features/communities/events/EditEventPage.test.tsx
+++ b/app/frontend/src/features/communities/events/EditEventPage.test.tsx
@@ -1,0 +1,94 @@
+import {
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TITLE, UPDATE } from "features/constants";
+import { Route, Switch } from "react-router-dom";
+import { editEventRoute, eventRoute, routeToEditEvent } from "routes";
+import { service } from "service";
+import events from "test/fixtures/events.json";
+import { getHookWrapperWithClient } from "test/hookWrapper";
+
+import { EVENT_DETAILS, EVENT_LINK, VIRTUAL_EVENT } from "./constants";
+import EditEventPage from "./EditEventPage";
+
+jest.mock("components/MarkdownInput");
+
+const getEventMock = service.events.getEvent as jest.MockedFunction<
+  typeof service.events.getEvent
+>;
+const updateEventMock = service.events.updateEvent as jest.MockedFunction<
+  typeof service.events.updateEvent
+>;
+
+function renderPage() {
+  const { wrapper } = getHookWrapperWithClient({
+    initialRouterEntries: [routeToEditEvent(1, "weekly-meetup")],
+  });
+
+  render(
+    <Switch>
+      <Route path={editEventRoute}>
+        <EditEventPage />
+      </Route>
+      <Route path={eventRoute}>
+        <h1 data-testid="event-page">Event page</h1>
+      </Route>
+    </Switch>,
+    { wrapper }
+  );
+}
+
+describe("Edit event page", () => {
+  beforeEach(() => {
+    getEventMock.mockResolvedValue(events[0]);
+    updateEventMock.mockResolvedValue(events[0]);
+    jest.useFakeTimers("modern");
+    jest.setSystemTime(new Date("2021-06-01 00:00"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("renders with the existing event and updates it successfully", async () => {
+    renderPage();
+
+    await waitForElementToBeRemoved(screen.getByRole("progressbar"));
+
+    // High level check that the form has existing data, more detailed ones done in form unit test
+    const titleField = screen.getByLabelText(TITLE);
+    expect(titleField).toHaveValue("Weekly Meetup");
+
+    userEvent.type(titleField, " in the dam");
+    userEvent.click(screen.getByLabelText(VIRTUAL_EVENT));
+    userEvent.type(
+      screen.getByLabelText(EVENT_LINK),
+      "https://couchers.org/amsterdam-social"
+    );
+    const eventDetails = screen.getByLabelText(EVENT_DETAILS);
+    userEvent.clear(eventDetails);
+    userEvent.type(eventDetails, "We are going virtual this week!");
+    userEvent.click(screen.getByRole("button", { name: UPDATE }));
+
+    await waitFor(() => {
+      expect(updateEventMock).toHaveBeenCalledTimes(1);
+    });
+    expect(updateEventMock).toHaveBeenCalledWith({
+      eventId: 1,
+      isOnline: true,
+      title: "Weekly Meetup in the dam",
+      content: "We are going virtual this week!",
+      photoKey: "",
+      startTime: new Date("2021-06-29 02:37"),
+      endTime: new Date("2021-06-29 03:37"),
+      link: "https://couchers.org/amsterdam-social",
+    });
+
+    // Verifies that success re-directs user
+    expect(screen.getByTestId("event-page")).toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/features/communities/events/EditEventPage.test.tsx
+++ b/app/frontend/src/features/communities/events/EditEventPage.test.tsx
@@ -11,6 +11,7 @@ import { editEventRoute, eventRoute, routeToEditEvent } from "routes";
 import { service } from "service";
 import events from "test/fixtures/events.json";
 import { getHookWrapperWithClient } from "test/hookWrapper";
+import { assertErrorAlert, mockConsoleError } from "test/utils";
 
 import { EVENT_DETAILS, EVENT_LINK, VIRTUAL_EVENT } from "./constants";
 import EditEventPage from "./EditEventPage";
@@ -90,5 +91,15 @@ describe("Edit event page", () => {
 
     // Verifies that success re-directs user
     expect(screen.getByTestId("event-page")).toBeInTheDocument();
+  });
+
+  it("shows an error message if the event to be edited cannot be found", async () => {
+    mockConsoleError();
+    const errorMessage = "Event not found.";
+    getEventMock.mockRejectedValue(new Error(errorMessage));
+    renderPage();
+
+    await assertErrorAlert(errorMessage);
+    expect(screen.queryByLabelText(TITLE)).not.toBeInTheDocument();
   });
 });

--- a/app/frontend/src/features/communities/events/EditEventPage.tsx
+++ b/app/frontend/src/features/communities/events/EditEventPage.tsx
@@ -1,3 +1,4 @@
+import { CircularProgress } from "@material-ui/core";
 import Button from "components/Button";
 import { UPDATE } from "features/constants";
 import NotFoundPage from "features/NotFoundPage";
@@ -18,7 +19,12 @@ export default function EditEventPage() {
   const classes = useEventFormStyles();
   const history = useHistory();
 
-  const { data: event, eventId, isValidEventId } = useEvent();
+  const {
+    data: event,
+    eventId,
+    isLoading: isEventLoading,
+    isValidEventId,
+  } = useEvent();
 
   const queryClient = useQueryClient();
   const {
@@ -99,23 +105,27 @@ export default function EditEventPage() {
   );
 
   return isValidEventId ? (
-    <EventForm
-      error={error}
-      event={event}
-      isMutationLoading={isLoading}
-      mutate={updateEvent}
-      title="Edit event"
-    >
-      {({ isMutationLoading }) => (
-        <Button
-          className={classes.submitButton}
-          loading={isMutationLoading}
-          type="submit"
-        >
-          {UPDATE}
-        </Button>
-      )}
-    </EventForm>
+    isEventLoading ? (
+      <CircularProgress />
+    ) : (
+      <EventForm
+        error={error}
+        event={event}
+        isMutationLoading={isLoading}
+        mutate={updateEvent}
+        title="Edit event"
+      >
+        {({ isMutationLoading }) => (
+          <Button
+            className={classes.submitButton}
+            loading={isMutationLoading}
+            type="submit"
+          >
+            {UPDATE}
+          </Button>
+        )}
+      </EventForm>
+    )
   ) : (
     <NotFoundPage />
   );

--- a/app/frontend/src/features/communities/events/EditEventPage.tsx
+++ b/app/frontend/src/features/communities/events/EditEventPage.tsx
@@ -1,25 +1,24 @@
+import Button from "components/Button";
+import { UPDATE } from "features/constants";
 import NotFoundPage from "features/NotFoundPage";
 import type { Error as GrpcError } from "grpc-web";
 import { Event } from "proto/events_pb";
 import { communityEventsBaseKey, eventKey } from "queryKeys";
 import { useMutation, useQueryClient } from "react-query";
-import { useParams } from "react-router";
 import { useHistory } from "react-router-dom";
 import { routeToEvent } from "routes";
 import { service } from "service";
 import type { UpdateEventInput } from "service/events";
 import dayjs, { TIME_FORMAT } from "utils/dayjs";
 
-import EventForm, { CreateEventData } from "./EventForm";
+import EventForm, { CreateEventData, useEventFormStyles } from "./EventForm";
+import { useEvent } from "./hooks";
 
 export default function EditEventPage() {
+  const classes = useEventFormStyles();
   const history = useHistory();
 
-  // TODO: refactor this into custom hook - copy/pasted from event page
-  const { eventId: rawEventId } =
-    useParams<{ eventId: string; eventSlug?: string }>();
-  const eventId = +rawEventId;
-  const isValidEventId = !isNaN(eventId) && eventId > 0;
+  const { data: event, eventId, isValidEventId } = useEvent();
 
   const queryClient = useQueryClient();
   const {
@@ -102,10 +101,21 @@ export default function EditEventPage() {
   return isValidEventId ? (
     <EventForm
       error={error}
+      event={event}
       isMutationLoading={isLoading}
       mutate={updateEvent}
       title="Edit event"
-    />
+    >
+      {({ isMutationLoading }) => (
+        <Button
+          className={classes.submitButton}
+          loading={isMutationLoading}
+          type="submit"
+        >
+          {UPDATE}
+        </Button>
+      )}
+    </EventForm>
   ) : (
     <NotFoundPage />
   );

--- a/app/frontend/src/features/communities/events/EditEventPage.tsx
+++ b/app/frontend/src/features/communities/events/EditEventPage.tsx
@@ -1,4 +1,5 @@
 import { CircularProgress } from "@material-ui/core";
+import Alert from "components/Alert";
 import Button from "components/Button";
 import { UPDATE } from "features/constants";
 import NotFoundPage from "features/NotFoundPage";
@@ -22,6 +23,7 @@ export default function EditEventPage() {
   const {
     data: event,
     eventId,
+    error: eventError,
     isLoading: isEventLoading,
     isValidEventId,
   } = useEvent();
@@ -105,7 +107,9 @@ export default function EditEventPage() {
   );
 
   return isValidEventId ? (
-    isEventLoading ? (
+    eventError ? (
+      <Alert severity="error">{eventError.message}</Alert>
+    ) : isEventLoading ? (
       <CircularProgress />
     ) : (
       <EventForm

--- a/app/frontend/src/features/communities/events/EditEventPage.tsx
+++ b/app/frontend/src/features/communities/events/EditEventPage.tsx
@@ -1,0 +1,112 @@
+import NotFoundPage from "features/NotFoundPage";
+import type { Error as GrpcError } from "grpc-web";
+import { Event } from "proto/events_pb";
+import { communityEventsBaseKey, eventKey } from "queryKeys";
+import { useMutation, useQueryClient } from "react-query";
+import { useParams } from "react-router";
+import { useHistory } from "react-router-dom";
+import { routeToEvent } from "routes";
+import { service } from "service";
+import type { UpdateEventInput } from "service/events";
+import dayjs, { TIME_FORMAT } from "utils/dayjs";
+
+import EventForm, { CreateEventData } from "./EventForm";
+
+export default function EditEventPage() {
+  const history = useHistory();
+
+  // TODO: refactor this into custom hook - copy/pasted from event page
+  const { eventId: rawEventId } =
+    useParams<{ eventId: string; eventSlug?: string }>();
+  const eventId = +rawEventId;
+  const isValidEventId = !isNaN(eventId) && eventId > 0;
+
+  const queryClient = useQueryClient();
+  const {
+    mutate: updateEvent,
+    error,
+    isLoading,
+  } = useMutation<
+    Event.AsObject,
+    GrpcError,
+    CreateEventData,
+    { parentCommunityId?: number }
+  >(
+    (data) => {
+      let updateEventInput: UpdateEventInput;
+      const startTime = dayjs(data.startTime, TIME_FORMAT);
+      const endTime = dayjs(data.endTime, TIME_FORMAT);
+      const finalStartDate = data.startDate
+        .startOf("day")
+        .add(startTime.get("hour"), "hour")
+        .add(startTime.get("minute"), "minute")
+        .toDate();
+      const finalEndDate = data.endDate
+        .startOf("day")
+        .add(endTime.get("hour"), "hour")
+        .add(endTime.get("minute"), "minute")
+        .toDate();
+
+      if (data.isOnline) {
+        updateEventInput = {
+          eventId,
+          isOnline: data.isOnline,
+          title: data.title,
+          content: data.content,
+          photoKey: data.eventImage,
+          startTime: finalStartDate,
+          endTime: finalEndDate,
+          link: data.link,
+        };
+      } else {
+        updateEventInput = {
+          eventId,
+          isOnline: data.isOnline,
+          title: data.title,
+          content: data.content,
+          photoKey: data.eventImage,
+          startTime: finalStartDate,
+          endTime: finalEndDate,
+          address: data.location.name,
+          lat: data.location.location.lat,
+          lng: data.location.location.lng,
+        };
+      }
+      return service.events.updateEvent(updateEventInput);
+    },
+    {
+      onMutate({ parentCommunityId }) {
+        return { parentCommunityId };
+      },
+      onSuccess(updatedEvent, _, context) {
+        queryClient.setQueryData<Event.AsObject>(
+          eventKey(eventId),
+          updatedEvent
+        );
+        queryClient.invalidateQueries(eventKey(eventId), {
+          refetchActive: false,
+        });
+        queryClient.invalidateQueries(
+          context?.parentCommunityId
+            ? [communityEventsBaseKey, context.parentCommunityId]
+            : communityEventsBaseKey
+        );
+        history.push(routeToEvent(updatedEvent.eventId, updatedEvent.slug));
+      },
+      onSettled() {
+        window.scroll({ top: 0, behavior: "smooth" });
+      },
+    }
+  );
+
+  return isValidEventId ? (
+    <EventForm
+      error={error}
+      isMutationLoading={isLoading}
+      mutate={updateEvent}
+      title="Edit event"
+    />
+  ) : (
+    <NotFoundPage />
+  );
+}

--- a/app/frontend/src/features/communities/events/EventForm.test.tsx
+++ b/app/frontend/src/features/communities/events/EventForm.test.tsx
@@ -38,7 +38,9 @@ function TestComponent() {
       mutate={mutate}
       isMutationLoading={isLoading}
       title={CREATE_EVENT}
-    />
+    >
+      {() => <button type="submit">{CREATE}</button>}
+    </EventForm>
   );
 }
 

--- a/app/frontend/src/features/communities/events/EventForm.test.tsx
+++ b/app/frontend/src/features/communities/events/EventForm.test.tsx
@@ -214,6 +214,9 @@ describe("Submitting an offine event", () => {
 
   afterAll(() => {
     server.close();
+  });
+
+  afterEach(() => {
     jest.useRealTimers();
   });
 

--- a/app/frontend/src/features/communities/events/EventForm.tsx
+++ b/app/frontend/src/features/communities/events/EventForm.tsx
@@ -158,7 +158,7 @@ export default function EventForm({
         alt={EVENT_IMAGE_INPUT_ALT}
         control={control}
         id="event-image-input"
-        initialPreviewSrc={event?.photoUrl}
+        initialPreviewSrc={event?.photoUrl || undefined}
         name="eventImage"
         type="rect"
       />

--- a/app/frontend/src/features/communities/events/EventForm.tsx
+++ b/app/frontend/src/features/communities/events/EventForm.tsx
@@ -1,14 +1,16 @@
 import { Checkbox, FormControlLabel, Typography } from "@material-ui/core";
 import classNames from "classnames";
 import Alert from "components/Alert";
-import Button from "components/Button";
 import ImageInput from "components/ImageInput";
 import MarkdownInput from "components/MarkdownInput";
 import PageTitle from "components/PageTitle";
 import TextField from "components/TextField";
-import { CREATE, TITLE } from "features/constants";
+import { TITLE } from "features/constants";
 import LocationAutocomplete from "features/search/LocationAutocomplete";
 import { Error as GrpcError } from "grpc-web";
+import { LngLat } from "maplibre-gl";
+import { Event } from "proto/events_pb";
+import { useRef } from "react";
 import { useForm } from "react-hook-form";
 import { UseMutateFunction } from "react-query";
 import { Dayjs } from "utils/dayjs";
@@ -65,8 +67,8 @@ export const useEventFormStyles = makeStyles((theme) => ({
     display: "grid",
     rowGap: theme.spacing(1),
   },
-  createEventButton: {
-    justifySelf: "end",
+  submitButton: {
+    justifySelf: "start",
   },
 }));
 
@@ -97,6 +99,8 @@ interface OnlineEventData extends BaseEventData {
 export type CreateEventData = OfflineEventData | OnlineEventData;
 
 interface EventFormProps {
+  children(data: { isMutationLoading: boolean }): React.ReactNode;
+  event?: Event.AsObject;
   error: GrpcError | null;
   mutate: UseMutateFunction<unknown, GrpcError, CreateEventData, unknown>;
   isMutationLoading: boolean;
@@ -104,6 +108,8 @@ interface EventFormProps {
 }
 
 export default function EventForm({
+  children,
+  event,
   error,
   mutate,
   isMutationLoading,
@@ -122,6 +128,18 @@ export default function EventForm({
   } = useForm<CreateEventData>();
 
   const isOnline = watch("isOnline", false);
+  const locationDefaultValue = useRef(
+    event?.offlineInformation
+      ? {
+          name: event.offlineInformation.address,
+          simplifiedName: event.offlineInformation.address,
+          location: new LngLat(
+            event.offlineInformation.lng,
+            event.offlineInformation.lat
+          ),
+        }
+      : undefined
+  ).current;
 
   const onSubmit = handleSubmit(
     (data) => {
@@ -140,6 +158,7 @@ export default function EventForm({
         alt={EVENT_IMAGE_INPUT_ALT}
         control={control}
         id="event-image-input"
+        initialPreviewSrc={event?.photoUrl}
         name="eventImage"
         type="rect"
       />
@@ -154,6 +173,7 @@ export default function EventForm({
       )}
       <form className={classes.form} onSubmit={onSubmit}>
         <TextField
+          defaultValue={event?.title}
           error={!!errors.title}
           fullWidth
           helperText={errors.title?.message || ""}
@@ -169,6 +189,7 @@ export default function EventForm({
         <EventTimeChanger
           control={control}
           errors={errors}
+          event={event}
           getValues={getValues}
           register={register}
           setValue={setValue}
@@ -181,6 +202,7 @@ export default function EventForm({
         >
           {isOnline ? (
             <TextField
+              defaultValue={event?.onlineInformation?.link}
               error={!!errors.link?.message}
               helperText={errors.link?.message || ""}
               fullWidth
@@ -193,6 +215,7 @@ export default function EventForm({
           ) : (
             <LocationAutocomplete
               control={control}
+              defaultValue={locationDefaultValue}
               // @ts-expect-error
               fieldError={errors.location?.message}
               fullWidth
@@ -203,7 +226,13 @@ export default function EventForm({
           )}
           <div className={classes.isOnlineCheckbox}>
             <FormControlLabel
-              control={<Checkbox name="isOnline" inputRef={register} />}
+              control={
+                <Checkbox
+                  defaultChecked={!!event?.onlineInformation}
+                  name="isOnline"
+                  inputRef={register}
+                />
+              }
               label={VIRTUAL_EVENT}
             />
             <Typography variant="body2">{VIRTUAL_EVENTS_SUBTEXT}</Typography>
@@ -215,6 +244,7 @@ export default function EventForm({
           </Typography>
           <MarkdownInput
             control={control}
+            defaultValue={event?.content}
             id="content"
             name="content"
             labelId="content-label"
@@ -226,13 +256,7 @@ export default function EventForm({
             </Typography>
           )}
         </div>
-        <Button
-          className={classes.createEventButton}
-          loading={isMutationLoading}
-          type="submit"
-        >
-          {CREATE}
-        </Button>
+        {children({ isMutationLoading })}
       </form>
     </div>
   );

--- a/app/frontend/src/features/communities/events/EventPage.test.tsx
+++ b/app/frontend/src/features/communities/events/EventPage.test.tsx
@@ -23,6 +23,7 @@ import { PREVIOUS_PAGE, WRITE_COMMENT_A11Y_LABEL } from "../constants";
 import {
   ATTENDEES,
   details,
+  EDIT_EVENT,
   EVENT_DISCUSSION,
   EVENT_LINK,
   JOIN_EVENT,
@@ -162,6 +163,33 @@ describe("Event page", () => {
     userEvent.click(screen.getByRole("button", { name: PREVIOUS_PAGE }));
 
     expect(screen.getByTestId("previous-page")).toBeInTheDocument();
+  });
+
+  it("shows the 'edit event' button if the user has edit permission", async () => {
+    getEventMock.mockResolvedValue({ ...firstEvent, canEdit: true });
+    renderEventPage();
+
+    expect(
+      await screen.findByRole("button", { name: EDIT_EVENT })
+    ).toBeVisible();
+  });
+
+  it("shows the 'edit event' button if the user has moderation permission", async () => {
+    getEventMock.mockResolvedValue({ ...firstEvent, canModerate: true });
+    renderEventPage();
+
+    expect(
+      await screen.findByRole("button", { name: EDIT_EVENT })
+    ).toBeVisible();
+  });
+
+  it("does not show the 'edit event' button if the user does not have edit permission", async () => {
+    renderEventPage();
+    await waitForElementToBeRemoved(screen.getByRole("progressbar"));
+
+    expect(
+      screen.queryByRole("button", { name: EDIT_EVENT })
+    ).not.toBeInTheDocument();
   });
 
   it("shows the not found page if the user tries to find an event with an invalid ID in the URL", async () => {

--- a/app/frontend/src/features/communities/events/EventPage.tsx
+++ b/app/frontend/src/features/communities/events/EventPage.tsx
@@ -17,8 +17,8 @@ import { Error as GrpcError } from "grpc-web";
 import { AttendanceState, Event } from "proto/events_pb";
 import { eventAttendeesBaseKey, eventKey } from "queryKeys";
 import { useEffect } from "react";
-import { useMutation, useQuery, useQueryClient } from "react-query";
-import { Link, useHistory, useParams } from "react-router-dom";
+import { useMutation, useQueryClient } from "react-query";
+import { Link, useHistory } from "react-router-dom";
 import { routeToEditEvent, routeToEvent } from "routes";
 import { service } from "service";
 import { timestamp2Date } from "utils/date";
@@ -39,6 +39,7 @@ import {
 import EventAttendees from "./EventAttendees";
 import eventImagePlaceholder from "./eventImagePlaceholder.svg";
 import EventOrganisers from "./EventOrganisers";
+import { useEvent } from "./hooks";
 
 export const useEventPageStyles = makeStyles<Theme, { eventImageSrc: string }>(
   (theme) => ({
@@ -142,21 +143,15 @@ function getEventTimeString(
 
 export default function EventPage() {
   const history = useHistory();
-  const { eventId: rawEventId, eventSlug } =
-    useParams<{ eventId: string; eventSlug?: string }>();
-
-  const eventId = +rawEventId;
-  const isValidEventId = !isNaN(eventId) && eventId > 0;
   const queryClient = useQueryClient();
   const {
     data: event,
     error: eventError,
+    eventId,
+    eventSlug,
     isLoading,
-  } = useQuery<Event.AsObject, GrpcError>({
-    queryKey: eventKey(eventId),
-    queryFn: () => service.events.getEvent(eventId),
-    enabled: isValidEventId,
-  });
+    isValidEventId,
+  } = useEvent();
 
   const {
     isLoading: isSetEventAttendanceLoading,

--- a/app/frontend/src/features/communities/events/EventPage.tsx
+++ b/app/frontend/src/features/communities/events/EventPage.tsx
@@ -1,7 +1,7 @@
 import {
   Card,
   CircularProgress,
-  Link,
+  Link as MuiLink,
   Theme,
   Typography,
 } from "@material-ui/core";
@@ -18,8 +18,8 @@ import { AttendanceState, Event } from "proto/events_pb";
 import { eventAttendeesBaseKey, eventKey } from "queryKeys";
 import { useEffect } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
-import { useHistory, useParams } from "react-router-dom";
-import { routeToEvent } from "routes";
+import { Link, useHistory, useParams } from "react-router-dom";
+import { routeToEditEvent, routeToEvent } from "routes";
 import { service } from "service";
 import { timestamp2Date } from "utils/date";
 import dayjs from "utils/dayjs";
@@ -29,6 +29,7 @@ import { PREVIOUS_PAGE } from "../constants";
 import CommentTree from "../discussions/CommentTree";
 import {
   details,
+  EDIT_EVENT,
   EVENT_DISCUSSION,
   EVENT_LINK,
   JOIN_EVENT,
@@ -58,7 +59,7 @@ export const useEventPageStyles = makeStyles<Theme, { eventImageSrc: string }>(
       gridTemplateAreas: `
       "backButton eventTitle eventTitle"
       "eventTime eventTime eventTime"
-      "attendanceButton attendanceButton ."
+      "actionButtons actionButtons ."
     `,
       gridAutoFlow: "column",
       gridTemplateColumns: "3.125rem 1fr auto",
@@ -66,7 +67,7 @@ export const useEventPageStyles = makeStyles<Theme, { eventImageSrc: string }>(
       marginBlockStart: theme.spacing(2),
       [theme.breakpoints.up("sm")]: {
         gridTemplateAreas: `
-      "backButton eventTitle attendanceButton"
+      "backButton eventTitle actionButtons"
       ". eventTime eventTime"
     `,
       },
@@ -85,8 +86,11 @@ export const useEventPageStyles = makeStyles<Theme, { eventImageSrc: string }>(
       gridAutoFlow: "column",
       gridTemplateColumns: "max-content max-content",
     },
-    attendanceButton: {
-      gridArea: "attendanceButton",
+    actionButtons: {
+      display: "grid",
+      gridAutoFlow: "column",
+      columnGap: theme.spacing(1),
+      gridArea: "actionButtons",
       justifySelf: "start",
     },
     eventTypeText: {
@@ -230,9 +234,9 @@ export default function EventPage() {
                     >
                       {VIRTUAL_EVENT}
                     </Typography>
-                    <Link href={event.onlineInformation.link}>
+                    <MuiLink href={event.onlineInformation.link}>
                       {EVENT_LINK}
-                    </Link>
+                    </MuiLink>
                   </div>
                 ) : (
                   <Typography className={classes.eventTypeText} variant="body1">
@@ -240,23 +244,31 @@ export default function EventPage() {
                   </Typography>
                 )}
               </div>
-
-              <Button
-                className={classes.attendanceButton}
-                loading={isSetEventAttendanceLoading}
-                onClick={() => setEventAttendance(event.attendanceState)}
-                variant={
-                  event.attendanceState ===
+              <div className={classes.actionButtons}>
+                {event.canEdit || event.canModerate ? (
+                  <Button
+                    component={Link}
+                    to={routeToEditEvent(event.eventId, event.slug)}
+                  >
+                    {EDIT_EVENT}
+                  </Button>
+                ) : null}
+                <Button
+                  loading={isSetEventAttendanceLoading}
+                  onClick={() => setEventAttendance(event.attendanceState)}
+                  variant={
+                    event.attendanceState ===
+                    AttendanceState.ATTENDANCE_STATE_GOING
+                      ? "outlined"
+                      : "contained"
+                  }
+                >
+                  {event.attendanceState ===
                   AttendanceState.ATTENDANCE_STATE_GOING
-                    ? "outlined"
-                    : "contained"
-                }
-              >
-                {event.attendanceState ===
-                AttendanceState.ATTENDANCE_STATE_GOING
-                  ? LEAVE_EVENT
-                  : JOIN_EVENT}
-              </Button>
+                    ? LEAVE_EVENT
+                    : JOIN_EVENT}
+                </Button>
+              </div>
 
               <div className={classes.eventTimeContainer}>
                 <CalendarIcon className={classes.calendarIcon} />

--- a/app/frontend/src/features/communities/events/constants.ts
+++ b/app/frontend/src/features/communities/events/constants.ts
@@ -3,6 +3,8 @@ export const details = ({ colon = false }: { colon?: boolean } = {}) =>
   `Details${colon ? ":" : ""}`;
 export const CREATE_AN_EVENT = "Create an event";
 export const CREATE_EVENT = "Create event";
+export const CREATE_EVENT_DISCLAIMER =
+  "By selecting this button, your event will be publicly displayed for the Couchers.org community to see.";
 export const DATE_REQUIRED = "Please enter a date.";
 export const EDIT_EVENT = "Edit event";
 export const END_DATE = "End date";

--- a/app/frontend/src/features/communities/events/constants.ts
+++ b/app/frontend/src/features/communities/events/constants.ts
@@ -4,6 +4,7 @@ export const details = ({ colon = false }: { colon?: boolean } = {}) =>
 export const CREATE_AN_EVENT = "Create an event";
 export const CREATE_EVENT = "Create event";
 export const DATE_REQUIRED = "Please enter a date.";
+export const EDIT_EVENT = "Edit event";
 export const END_DATE = "End date";
 export const END_TIME = "End time";
 export const END_TIME_ERROR =

--- a/app/frontend/src/features/communities/events/hooks.ts
+++ b/app/frontend/src/features/communities/events/hooks.ts
@@ -1,8 +1,18 @@
 import useUsers from "features/userQueries/useUsers";
 import { Error as GrpcError } from "grpc-web";
-import { ListEventAttendeesRes, ListEventOrganizersRes } from "proto/events_pb";
-import { eventAttendeesKey, eventOrganisersKey, QueryType } from "queryKeys";
-import { useInfiniteQuery } from "react-query";
+import {
+  Event,
+  ListEventAttendeesRes,
+  ListEventOrganizersRes,
+} from "proto/events_pb";
+import {
+  eventAttendeesKey,
+  eventKey,
+  eventOrganisersKey,
+  QueryType,
+} from "queryKeys";
+import { useInfiniteQuery, useQuery } from "react-query";
+import { useParams } from "react-router-dom";
 import { service } from "service";
 
 export interface UseEventUsersInput {
@@ -76,5 +86,26 @@ export function useEventAttendees({
     attendees,
     isAttendeesLoading,
     isAttendeesRefetching,
+  };
+}
+
+export function useEvent() {
+  const { eventId: rawEventId, eventSlug } =
+    useParams<{ eventId: string; eventSlug?: string }>();
+
+  const eventId = +rawEventId;
+  const isValidEventId = !isNaN(eventId) && eventId > 0;
+
+  const eventQuery = useQuery<Event.AsObject, GrpcError>({
+    queryKey: eventKey(eventId),
+    queryFn: () => service.events.getEvent(eventId),
+    enabled: isValidEventId,
+  });
+
+  return {
+    ...eventQuery,
+    eventId,
+    eventSlug,
+    isValidEventId,
   };
 }

--- a/app/frontend/src/routes.ts
+++ b/app/frontend/src/routes.ts
@@ -109,8 +109,11 @@ export const routeToDiscussion = (id: number, slug: string) =>
 export const eventBaseRoute = "/event";
 export const eventRoute = `${eventBaseRoute}/:eventId/:eventSlug?`;
 export const newEventRoute = `${eventBaseRoute}/new`;
+export const editEventRoute = `${eventRoute}/edit`;
 export const routeToEvent = (id: number, slug: string) =>
   `${eventBaseRoute}/${id}/${slug}`;
+export const routeToEditEvent = (id: number, slug: string) =>
+  `${routeToEvent(id, slug)}/edit`;
 
 const communityBaseRoute = "/community";
 export type CommunityTab = "overview" | "info" | "discussions" | "events";

--- a/app/frontend/src/test/utils.tsx
+++ b/app/frontend/src/test/utils.tsx
@@ -15,6 +15,11 @@ export async function assertErrorAlert(message: string) {
   expect(errorAlert).toHaveTextContent(message);
 }
 
+export function assertFieldVisibleWithValue(field: HTMLElement, value: string) {
+  expect(field).toBeVisible();
+  expect(field).toHaveValue(value);
+}
+
 export function mockConsoleError() {
   jest.spyOn(console, "error").mockReturnValue(undefined);
 }


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
This is probably the final piece for the MVP of #541. It looks more or less identical to the "create event page" since they share the same form UI. This has been intentional with how I put the form UI into its own component:

![Screenshot 2021-08-24 at 01 11 36](https://user-images.githubusercontent.com/13669362/130535359-2b89c129-1fc7-4c5c-b453-6f844320e9fe.png)


Also added a new "edit event" button that's only visible to users with edit or community moderation permissions:
![Screenshot 2021-08-24 at 01 11 04](https://user-images.githubusercontent.com/13669362/130535327-03ff7682-9a08-424a-8a20-46339855f4e4.png)
![Screenshot 2021-08-24 at 01 11 16](https://user-images.githubusercontent.com/13669362/130535334-1032dc13-4c49-4eb1-a859-61617705ff88.png)


<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on frontend)
If you need help with any of these, please ask :)
--->

**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
