### PR TITLE
fix: event card title overlapping with location

### DIFF
--- a/app/frontend/src/features/communities/events/EventCard.tsx
+++ b/app/frontend/src/features/communities/events/EventCard.tsx
@@ -6,19 +6,19 @@ import {
   Theme,
   Typography,
 } from "@material-ui/core";
+import type { TypographyStyleOptions } from "@material-ui/core/styles/createTypography";
 import classNames from "classnames";
 import { AttendeesIcon, CalendarIcon } from "components/Icons";
 import { Event } from "proto/events_pb";
 import { useMemo } from "react";
-import LinesEllipsis from "react-lines-ellipsis";
 import { Link } from "react-router-dom";
 import { routeToEvent } from "routes";
 import { timestamp2Date } from "utils/date";
 import dayjs from "utils/dayjs";
 import makeStyles from "utils/makeStyles";
+import stripMarkdown from "utils/stripMarkdown";
 
 import { getAttendeesCount, ONLINE } from "../constants";
-import getContentSummary from "../getContentSummary";
 import { details, VIEW_DETAILS_FOR_LINK } from "./constants";
 import eventImagePlaceholder from "./eventImagePlaceholder.svg";
 
@@ -48,14 +48,33 @@ const useStyles = makeStyles<Theme, { eventImageSrc: string }>((theme) => ({
   },
   title: {
     ...theme.typography.h2,
+    display: "-webkit-box",
+    boxOrient: "vertical",
+    lineClamp: 2,
+    overflow: "hidden",
     height: `calc(2 * calc(${theme.typography.h2.lineHeight} * ${theme.typography.h2.fontSize}))`,
     marginBottom: 0,
     marginTop: 0,
+    [theme.breakpoints.up("md")]: {
+      height: `calc(2 * calc(${theme.typography.h2.lineHeight} * ${
+        (
+          theme.typography.h2[
+            theme.breakpoints.up("md")
+          ] as TypographyStyleOptions
+        ).fontSize
+      }))`,
+      fontSize: (
+        theme.typography.h2[
+          theme.breakpoints.up("md")
+        ] as TypographyStyleOptions
+      ).fontSize,
+    },
   },
   subtitle: {
     marginBottom: theme.spacing(2),
     color: theme.palette.grey[600],
     fontWeight: "bold",
+    height: `calc(${theme.typography.body2.lineHeight} * ${theme.typography.body2.fontSize})`,
   },
   icon: {
     display: "block",
@@ -81,6 +100,12 @@ const useStyles = makeStyles<Theme, { eventImageSrc: string }>((theme) => ({
   otherInfoSection: {
     marginTop: theme.spacing(1),
   },
+  content: {
+    display: "-webkit-box",
+    boxOrient: "vertical",
+    lineClamp: 5,
+    overflow: "hidden",
+  },
 }));
 
 export const EVENT_CARD_TEST_ID = "event-card";
@@ -97,8 +122,8 @@ export default function EventCard({ event, className }: EventCardProps) {
   const startTime = dayjs(timestamp2Date(event.startTime!));
   const endTime = dayjs(timestamp2Date(event.endTime!));
 
-  const truncatedContent = useMemo(
-    () => getContentSummary({ originalContent: event.content, maxLength: 200 }),
+  const strippedContent = useMemo(
+    () => stripMarkdown(event.content),
     [event.content]
   );
 
@@ -117,13 +142,10 @@ export default function EventCard({ event, className }: EventCardProps) {
           )}
         </CardMedia>
         <CardContent>
-          <LinesEllipsis
-            maxLine={2}
-            text={event.title}
-            component="h3"
-            className={classes.title}
-          />
-          <Typography className={classes.subtitle} variant="body2">
+          <Typography component="h3" className={classes.title}>
+            {event.title}
+          </Typography>
+          <Typography className={classes.subtitle} noWrap variant="body2">
             {event.offlineInformation
               ? event.offlineInformation.address
               : VIEW_DETAILS_FOR_LINK}
@@ -146,7 +168,9 @@ export default function EventCard({ event, className }: EventCardProps) {
           </ul>
           <div className={classes.otherInfoSection}>
             <Typography variant="h4">{details({ colon: true })}</Typography>
-            <Typography variant="body1">{truncatedContent}</Typography>
+            <Typography className={classes.content} variant="body1">
+              {strippedContent}
+            </Typography>
           </div>
         </CardContent>
       </Link>

--- a/app/frontend/src/test/fixtures/events.json
+++ b/app/frontend/src/test/fixtures/events.json
@@ -99,7 +99,7 @@
     "endTime": { "nanos": 0, "seconds": 1625018400 },
     "startTimeDisplay": "",
     "endTimeDisplay": "",
-    "title": "Cherry Blossom Bike Ride",
+    "title": "Cherry Blossom Bike Ride around the entire Amsterdam because I like to write long event titles",
     "timezone": "Europe/Amsterdam"
   }
 ]

--- a/app/frontend/src/test/hookWrapper.tsx
+++ b/app/frontend/src/test/hookWrapper.tsx
@@ -1,7 +1,9 @@
+import { ThemeProvider } from "@material-ui/core";
 import { LocationDescriptor } from "history";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import { theme } from "theme";
 
 import AuthProvider from "../features/auth/AuthProvider";
 
@@ -18,11 +20,13 @@ export default function hookWrapper({
     },
   });
   return (
-    <MemoryRouter>
-      <QueryClientProvider client={client}>
-        <AuthProvider>{children}</AuthProvider>
-      </QueryClientProvider>
-    </MemoryRouter>
+    <ThemeProvider theme={theme}>
+      <MemoryRouter>
+        <QueryClientProvider client={client}>
+          <AuthProvider>{children}</AuthProvider>
+        </QueryClientProvider>
+      </MemoryRouter>
+    </ThemeProvider>
   );
 }
 
@@ -47,14 +51,16 @@ export function getHookWrapperWithClient({
     },
   });
   const wrapper = ({ children }: { children?: React.ReactNode }) => (
-    <MemoryRouter
-      initialIndex={initialIndex}
-      initialEntries={initialRouterEntries}
-    >
-      <QueryClientProvider client={client}>
-        <AuthProvider>{children}</AuthProvider>
-      </QueryClientProvider>
-    </MemoryRouter>
+    <ThemeProvider theme={theme}>
+      <MemoryRouter
+        initialIndex={initialIndex}
+        initialEntries={initialRouterEntries}
+      >
+        <QueryClientProvider client={client}>
+          <AuthProvider>{children}</AuthProvider>
+        </QueryClientProvider>
+      </MemoryRouter>
+    </ThemeProvider>
   );
 
   return {


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
Fixes #1877 

|| Before      | After |
|----------- | ----------- | ----------- |
| Web | ![Screenshot 2021-08-26 at 03 24 31](https://user-images.githubusercontent.com/13669362/130890119-298c4866-6b87-4428-a87d-0f326665013b.png)      | ![Screenshot 2021-08-26 at 03 21 02](https://user-images.githubusercontent.com/13669362/130889818-ca8cfec7-177e-4e61-b398-036c5201f1ac.png) |
| Mobile | ![Screenshot 2021-08-26 at 03 24 54](https://user-images.githubusercontent.com/13669362/130890121-7ba00cf9-0dc5-4bf3-a548-1a572c6c4d82.png)   | ![Screenshot 2021-08-26 at 03 21 29](https://user-images.githubusercontent.com/13669362/130889826-0fcaa5eb-a818-4261-ba6f-4cc48a9ef6da.png) |



For some weird reasons, on small mobile screens sometimes the event title goes onto 3 lines. I think the `LineEllipsis` thing is kinda flaky and doesn't really work when the width of the viewport changes (e.g. when device rotates). But I think this will do for now as a quick fix.

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on frontend)
If you need help with any of these, please ask :)
--->

**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
