### PR TITLE
fix: default start/end date & time not adjusting correctly on the hour of 11pm in create event form

### DIFF
--- a/app/frontend/src/features/communities/events/EventTimeChanger.test.tsx
+++ b/app/frontend/src/features/communities/events/EventTimeChanger.test.tsx
@@ -47,6 +47,26 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
+it("should load with the start/end date adjusted to the next hour by default", async () => {
+  render(<TestForm />, { wrapper });
+
+  expect(await screen.findByLabelText(START_DATE)).toHaveValue("08/01/2021");
+  expect(screen.getByLabelText(START_TIME)).toHaveValue("01:00");
+  expect(await screen.findByLabelText(END_DATE)).toHaveValue("08/01/2021");
+  expect(screen.getByLabelText(END_TIME)).toHaveValue("02:00");
+});
+
+// Regression test
+it("should load with the start/end date adjusted correctly to the next hour at 11pm by default", async () => {
+  jest.setSystemTime(new Date("2021-08-01 23:00"));
+  render(<TestForm />, { wrapper });
+
+  expect(await screen.findByLabelText(START_DATE)).toHaveValue("08/02/2021");
+  expect(screen.getByLabelText(START_TIME)).toHaveValue("00:00");
+  expect(await screen.findByLabelText(END_DATE)).toHaveValue("08/02/2021");
+  expect(screen.getByLabelText(END_TIME)).toHaveValue("01:00");
+});
+
 it("should not submit if the start date/time is in the past", async () => {
   render(<TestForm />, { wrapper });
 

--- a/app/frontend/src/features/communities/events/EventTimeChanger.tsx
+++ b/app/frontend/src/features/communities/events/EventTimeChanger.tsx
@@ -58,11 +58,14 @@ export default function EventTimeChanger({
   const { date: eventEndDate, time: eventEndTime } =
     splitTimestampToDateAndTime(event?.endTime);
 
+  const now = dayjs();
+  const defaultDate = now.get("hour") === 23 ? now.add(1, "day") : now;
+
   const dateDelta = useRef(0);
   const endDate = useWatch({
     control,
     name: "endDate",
-    defaultValue: eventEndDate || dayjs(),
+    defaultValue: eventEndDate || defaultDate,
   });
   useEffect(() => {
     const startDate = getValues("startDate");
@@ -104,7 +107,7 @@ export default function EventTimeChanger({
       <div className={classes.duoContainer}>
         <Datepicker
           control={control}
-          defaultValue={eventStartDate}
+          defaultValue={eventStartDate ?? defaultDate}
           // @ts-expect-error - react-hook-form incorrect types the message property for input fields with object values
           error={!!errors.startDate?.message}
           // @ts-expect-error
@@ -165,7 +168,7 @@ export default function EventTimeChanger({
       <div className={classes.duoContainer}>
         <Datepicker
           control={control}
-          defaultValue={eventEndDate}
+          defaultValue={eventEndDate ?? defaultDate}
           // @ts-expect-error
           error={!!errors.endDate?.message}
           // @ts-expect-error


### PR DESCRIPTION
Spotted this because the current tests are failing on develop.

Between 11-11:59pm on any given day, the existing code for making sure
the default start date is at the next hour is by adding an hour to it,
but that wraps back around to 12am and since the date part was not
adjusted, the default date and time goes back to 12am of the given day.
The end date/time suffers a similar problem (1am of the given day) since
it's relative to the start date/time.

This fixes it by checking that if we are at 11pm, the default start/end
date also gets adjusted to tomorrow.

**This should also fix the broken test on develop.**

Lol date/time is hard goddamnit :(

<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->


<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on frontend)
If you need help with any of these, please ask :)
--->

**Frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
