### PR TITLE
Add release frontend source map step on CI

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -512,6 +512,24 @@ release:frontend:
       changes:
       - app/**/*
 
+release:frontend-sourcemaps:
+  needs: ["build:frontend"]
+  stage: release
+  image: $FRONTEND_NEXT_TAG
+  inherit:
+    # no docker login
+    default: false
+  script:
+    - cd /app && SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN yarn upload-sourcemap
+  rules:
+    - if: ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
+      changes:
+      - app/**/*
+    - if: ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
+      changes:
+      - app/proto/**/*
+      - app/frontend/**/*
+
 release:nginx-next:
   stage: release
   script:

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -525,10 +525,6 @@ release:frontend-sourcemaps:
     - if: ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
       changes:
       - app/**/*
-    - if: ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
-      changes:
-      - app/proto/**/*
-      - app/frontend/**/*
 
 release:nginx-next:
   stage: release

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -515,14 +515,14 @@ release:frontend:
 release:frontend-sourcemaps:
   needs: ["build:frontend"]
   stage: release
-  image: $FRONTEND_NEXT_TAG
+  image: $FRONTEND_TAG
   inherit:
     # no docker login
     default: false
   script:
     - cd /app && SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN yarn upload-sourcemap
   rules:
-    - if: ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
+    - if: $CI_COMMIT_BRANCH == $RELEASE_BRANCH
       changes:
       - app/**/*
 

--- a/app/frontend/.sentryclirc
+++ b/app/frontend/.sentryclirc
@@ -1,0 +1,3 @@
+[defaults]
+project=frontend
+org=couchers

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -42,6 +42,7 @@
     "jest": "jest --modulePaths=src",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "NODE_PATH=. build-storybook -s public",
+    "upload-sourcemap": "node sentry.js",
     "typecheck": "tsc"
   },
   "eslintConfig": {
@@ -95,6 +96,7 @@
     ]
   },
   "devDependencies": {
+    "@sentry/cli": "^1.68.0",
     "@sentry/integrations": "^6.11.0",
     "@storybook/addon-actions": "^6.1.15",
     "@storybook/addon-essentials": "^6.1.15",

--- a/app/frontend/sentry.js
+++ b/app/frontend/sentry.js
@@ -1,0 +1,30 @@
+const SentryCli = require("@sentry/cli");
+
+async function createReleaseAndUpload() {
+  const release = process.env.REACT_APP_VERSION;
+  if (!release) {
+    console.warn("REACT_APP_VERSION is not set");
+    return;
+  }
+
+  /**
+   * @type import("@sentry/cli").default
+   */
+  const cli = new SentryCli();
+
+  try {
+    console.log(`Creating sentry release ${release}`);
+    await cli.releases.new(release);
+    console.log("Uploading source maps");
+    await cli.releases.uploadSourceMaps(release, {
+      include: ["build/static/js"],
+      urlPrefix: "~/static/js",
+      rewrite: false,
+    });
+    console.log("Finalizing release");
+    await cli.releases.finalize(release);
+  } catch (e) {
+    console.error("Source maps uploading failed:", e);
+  }
+}
+createReleaseAndUpload();

--- a/app/frontend/yarn.lock
+++ b/app/frontend/yarn.lock
@@ -2047,6 +2047,18 @@
     "@sentry/utils" "6.11.0"
     tslib "^1.9.3"
 
+"@sentry/cli@^1.68.0":
+  version "1.68.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.68.0.tgz#2ced8fac67ee01e746a45e8ee45a518d4526937e"
+  integrity sha512-zc7+cxKDqpHLREGJKRH6KwE8fZW8bnczg3OLibJ0czleXoWPdAuOK1Xm1BTMcOnaXfg3VKAh0rI7S1PTdj+SrQ==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    mkdirp "^0.5.5"
+    node-fetch "^2.6.0"
+    npmlog "^4.1.2"
+    progress "^2.0.3"
+    proxy-from-env "^1.1.0"
+
 "@sentry/core@6.11.0":
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.11.0.tgz#40e94043afcf6407a109be26655c77832c64e740"
@@ -3640,6 +3652,13 @@ adjust-sourcemap-loader@3.0.0:
   dependencies:
     loader-utils "^2.0.0"
     regex-parser "^2.2.11"
+
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -6036,6 +6055,13 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
+debug@4, debug@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
+
 debug@^3.0.0, debug@^3.1.1, debug@^3.2.6:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
@@ -6047,13 +6073,6 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
-  dependencies:
-    ms "2.1.2"
-
-debug@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
   dependencies:
     ms "2.1.2"
 
@@ -8338,6 +8357,14 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
+
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 human-signals@^1.1.1:
   version "1.1.1"
@@ -12308,7 +12335,7 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
-progress@^2.0.0:
+progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -12447,6 +12474,11 @@ proxy-addr@~2.0.5:
   dependencies:
     forwarded "~0.1.2"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
Adds an additional step to CI to upload source maps for the frontend on merge to develop, so that it works more reliably with Sentry error reporting for the frontend. Closes #1784 

The mapping thing actually seems to work before already without this, probably because the [source maps can be accessed publicly](https://docs.sentry.io/platforms/javascript/guides/react/sourcemaps/uploading/hosting-publicly/), but from the Sentry docs:

> While making source maps available to Sentry from your servers is the most natural integration, it is not always advisable:
>
> * Sentry may not always be able to reach your servers.
> * If you do not specify versions in your asset URLs, there may be a version mismatch
> * The additional latency may mean that source mappings are not available for all errors.
>
> For these reasons, it is best practice to upload source maps to Sentry beforehand (see below).

It seems like it doesn't hurt to explicitly upload them, especially as this is only configured to do so on `develop` only.

https://gitlab.com/couchers/couchers/-/jobs/1554637146 shows that it works :D

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on frontend)
If you need help with any of these, please ask :)
--->

**Frontend checklist**
N/A, no frontend code has changed 😎 


<!---
Remember to request review from couchers-org/frontend, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
