### PR TITLE
Remove 'needs' from sourcemap upload job

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -513,7 +513,6 @@ release:frontend:
       - app/**/*
 
 release:frontend-sourcemaps:
-  needs: ["build:frontend"]
   stage: release
   image: $FRONTEND_TAG
   inherit:


### PR DESCRIPTION
This makes CI wait for all checks to complete before uploading the sourcemaps to sentry, so if some tests fail and the release isn't uploaded to the docker registry, the sourcemaps are also not uploaded
