### PR TITLE
Don't check for overlap on all events when updating/scheduling

### DIFF
--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -325,7 +325,11 @@ class Events(events_pb2_grpc.EventsServicer):
 
             # && is the overlap operator for ranges
             if (
-                session.execute(select(EventOccurrence.id).where(EventOccurrence.during.op("&&")(during)))
+                session.execute(
+                    select(EventOccurrence.id)
+                    .where(EventOccurrence.event_id == event.id)
+                    .where(EventOccurrence.during.op("&&")(during))
+                )
                 .scalars()
                 .first()
                 is not None
@@ -421,6 +425,7 @@ class Events(events_pb2_grpc.EventsServicer):
                 if (
                     session.execute(
                         select(EventOccurrence.id)
+                        .where(EventOccurrence.event_id == event.id)
                         .where(EventOccurrence.id != occurrence.id)
                         .where(EventOccurrence.during.op("&&")(during))
                     )

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -1812,7 +1812,7 @@ def test_ListEventAttendees_regression(db):
     # `ListEventAttendees` should return the current user's ID
     #
     # **Actual/current behaviour**
-    # `ListEventAttendees` returns another user's ID. This ID seems to be determined from the row's auto increment ID in `event_occurence_attendees` in the database
+    # `ListEventAttendees` returns another user's ID. This ID seems to be determined from the row's auto increment ID in `event_occurrence_attendees` in the database
 
     user1, token1 = generate_user()
     user2, token2 = generate_user()
@@ -1907,8 +1907,8 @@ def test_event_threads(db):
         assert ret.replies[0].num_replies == 0
 
 
-def test_can_overlap_other_events_schedule(db):
-    # we had a bug where we were checking overlapping for *all* occurences of *all* events, not just the ones for this event
+def test_can_overlap_other_events_schedule_regression(db):
+    # we had a bug where we were checking overlapping for *all* occurrences of *all* events, not just the ones for this event
     user, token = generate_user()
 
     with session_scope() as session:
@@ -1947,7 +1947,7 @@ def test_can_overlap_other_events_schedule(db):
             )
         )
 
-        # this doesn't overlap with the just created event, but does overlap with the occurence from earlier; which should be no problem
+        # this doesn't overlap with the just created event, but does overlap with the occurrence from earlier; which should be no problem
         api.ScheduleEvent(
             events_pb2.ScheduleEventReq(
                 event_id=res.event_id,
@@ -1964,7 +1964,7 @@ def test_can_overlap_other_events_schedule(db):
         )
 
 
-def test_cannot_overlap_occurrences_update(db):
+def test_can_overlap_other_events_update_regression(db):
     user, token = generate_user()
 
     with session_scope() as session:


### PR DESCRIPTION
Closes #1924.

The code currently does not allow you to schedule/update if there are any overlapping occurrences in any events.

**Backend checklist**
- [ ] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history
