### PR TITLE
Feat/frontend/community photo

### DIFF
--- a/app/web/src/features/communities/EditCommunityInfoPage.test.tsx
+++ b/app/web/src/features/communities/EditCommunityInfoPage.test.tsx
@@ -99,6 +99,7 @@ describe("Edit community page", () => {
     expect(updatePageMock).toHaveBeenCalledWith({
       content: newContent,
       pageId: 3,
+      photoKey: "",
     });
   });
 

--- a/app/web/src/features/communities/EditCommunityInfoPage.tsx
+++ b/app/web/src/features/communities/EditCommunityInfoPage.tsx
@@ -23,6 +23,7 @@ import {
   COMMUNITY_PAGE_UPDATED,
   EDIT_LOCAL_INFO,
   PAGE_CONTENT_FIELD_LABEL,
+  PAGE_CONTENT_REQUIRED,
   UPLOAD_HELPER_TEXT,
   UPLOAD_HELPER_TEXT_REPLACE,
 } from "./constants";
@@ -141,7 +142,13 @@ export default function EditCommunityPage() {
                 id="content"
                 name="content"
                 imageUpload
+                required={PAGE_CONTENT_REQUIRED}
               />
+              {errors.content && (
+                <Typography color="error" variant="body2">
+                  {errors.content.message}
+                </Typography>
+              )}
               <input
                 id="pageId"
                 name="pageId"

--- a/app/web/src/features/communities/EditCommunityInfoPage.tsx
+++ b/app/web/src/features/communities/EditCommunityInfoPage.tsx
@@ -1,5 +1,7 @@
 import { Typography } from "@material-ui/core";
+import Alert from "components/Alert";
 import Button from "components/Button";
+import ImageInput from "components/ImageInput";
 import MarkdownInput from "components/MarkdownInput";
 import PageTitle from "components/PageTitle";
 import Snackbar from "components/Snackbar";
@@ -17,15 +19,21 @@ import makeStyles from "utils/makeStyles";
 
 import CommunityBase from "./CommunityBase";
 import {
+  COMMUNITY_IMAGE_INPUT_ALT,
   COMMUNITY_PAGE_UPDATED,
   EDIT_LOCAL_INFO,
   PAGE_CONTENT_FIELD_LABEL,
+  UPLOAD_HELPER_TEXT,
+  UPLOAD_HELPER_TEXT_REPLACE,
 } from "./constants";
 
 const useStyles = makeStyles((theme) => ({
   root: {
     display: "flex",
     justifyContent: "space-between",
+  },
+  imageUploadhelperText: {
+    textAlign: "center",
   },
   form: {
     display: "grid",
@@ -45,12 +53,13 @@ interface UpdatePageData {
   communityId: string;
   content: string;
   pageId: string;
+  communityPhotoKey?: string;
 }
 
 export default function EditCommunityPage() {
   const classes = useStyles();
   const queryClient = useQueryClient();
-  const { control, handleSubmit, register } = useForm<UpdatePageData>();
+  const { control, handleSubmit, register, errors } = useForm<UpdatePageData>();
 
   const {
     error,
@@ -58,8 +67,14 @@ export default function EditCommunityPage() {
     isSuccess,
     mutate: updatePage,
   } = useMutation<Page.AsObject, GrpcError, UpdatePageData>(
-    ({ content, pageId }) =>
-      service.pages.updatePage({ content, pageId: +pageId }),
+    (data) => {
+      const { communityPhotoKey, content, pageId } = data;
+      return service.pages.updatePage({
+        content,
+        pageId: +pageId,
+        photoKey: communityPhotoKey,
+      });
+    },
     {
       onSuccess(newPageData, { communityId }) {
         queryClient.setQueryData<Community.AsObject | undefined>(
@@ -77,9 +92,16 @@ export default function EditCommunityPage() {
     }
   );
 
-  const onSubmit = handleSubmit((data) => {
-    updatePage(data);
-  });
+  const onSubmit = handleSubmit(
+    (data) => {
+      updatePage(data);
+    },
+    (errors) => {
+      if (errors.communityPhotoKey) {
+        window.scroll({ top: 0, behavior: "smooth" });
+      }
+    }
+  );
 
   return (
     <CommunityBase>
@@ -87,7 +109,28 @@ export default function EditCommunityPage() {
         return community.mainPage?.canEdit ? (
           <>
             <PageTitle>{EDIT_LOCAL_INFO}</PageTitle>
+            {(error || errors.communityPhotoKey) && (
+              <Alert severity="error">
+                {error?.message || errors.communityPhotoKey?.message || ""}
+              </Alert>
+            )}
             <form className={classes.form} onSubmit={onSubmit}>
+              <ImageInput
+                alt={COMMUNITY_IMAGE_INPUT_ALT}
+                control={control}
+                id="community-image-input"
+                initialPreviewSrc={community.mainPage?.photoUrl || undefined}
+                name="communityPhotoKey"
+                type="rect"
+              />
+              <Typography
+                className={classes.imageUploadhelperText}
+                variant="body1"
+              >
+                {community.mainPage?.photoUrl
+                  ? UPLOAD_HELPER_TEXT_REPLACE
+                  : UPLOAD_HELPER_TEXT}
+              </Typography>
               <Typography id="content-label" variant="h2">
                 {PAGE_CONTENT_FIELD_LABEL}
               </Typography>
@@ -121,7 +164,6 @@ export default function EditCommunityPage() {
                 {UPDATE}
               </Button>
             </form>
-            {error && <Snackbar severity="error">{error.message}</Snackbar>}
             {isSuccess && (
               <Snackbar severity="success">{COMMUNITY_PAGE_UPDATED}</Snackbar>
             )}

--- a/app/web/src/features/communities/EditCommunityInfoPage.tsx
+++ b/app/web/src/features/communities/EditCommunityInfoPage.tsx
@@ -68,8 +68,7 @@ export default function EditCommunityPage() {
     isSuccess,
     mutate: updatePage,
   } = useMutation<Page.AsObject, GrpcError, UpdatePageData>(
-    (data) => {
-      const { communityPhotoKey, content, pageId } = data;
+    ({ communityPhotoKey, content, pageId }) => {
       return service.pages.updatePage({
         content,
         pageId: +pageId,

--- a/app/web/src/features/communities/constants.ts
+++ b/app/web/src/features/communities/constants.ts
@@ -14,6 +14,9 @@ export const CLOSE = "Close";
 export const COMMENT = "Comment";
 export const COMMENTS = "Comments";
 export const COMMUNITY_HEADING = (name: string) => `Welcome to ${name}!`;
+export const COMMUNITY_IMAGE_INPUT_ALT = "Community image input";
+export const UPLOAD_HELPER_TEXT = "Click to upload photo";
+export const UPLOAD_HELPER_TEXT_REPLACE = "Click to change photo";
 export const COMMUNITY_MODERATORS = "Community Builders";
 export const COMMUNITY_PAGE_UPDATED =
   "The community page has been successfully updated.";

--- a/app/web/src/features/communities/constants.ts
+++ b/app/web/src/features/communities/constants.ts
@@ -56,6 +56,7 @@ export const NO_MODERATORS =
 export const ONLINE = "Online";
 export const OVERVIEW_LABEL = "Overview";
 export const PAGE_CONTENT_FIELD_LABEL = "Page content";
+export const PAGE_CONTENT_REQUIRED = "Please fill the page content";
 export const PLACES_EMPTY_STATE = "No places to show yet.";
 export const PLACES_TITLE = "Places";
 export const POST = "Post";

--- a/app/web/src/service/pages.ts
+++ b/app/web/src/service/pages.ts
@@ -66,9 +66,20 @@ interface UpdatePageInput {
   content?: string;
   pageId: number;
   title?: string;
+  photoKey?: string;
 }
-export async function updatePage({ content, pageId, title }: UpdatePageInput) {
+export async function updatePage({
+  content,
+  pageId,
+  title,
+  photoKey,
+}: UpdatePageInput) {
   const req = new UpdatePageReq();
+
+  if (photoKey) {
+    req.setPhotoKey(new StringValue().setValue(photoKey));
+  }
+
   req.setPageId(pageId);
   if (content) {
     req.setContent(new StringValue().setValue(content));


### PR DESCRIPTION
This adds an image input component to the edit community page. Not sure if that's what was originally intended with this issue. Some refactoring might be needed to reuse the page form for other pages as well.  (like how the EditEventForm component is now reused)

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes
  -> styling is not ideal now but that is better done in separate issue


