### PR TITLE
fix: don't autofocus markdown fields

### DIFF
--- a/app/web/src/components/MarkdownInput/MarkdownInput.tsx
+++ b/app/web/src/components/MarkdownInput/MarkdownInput.tsx
@@ -63,6 +63,7 @@ export interface MarkdownInputProps {
   name: string;
   imageUpload?: boolean;
   required?: string;
+  autofocus?: boolean;
 }
 
 export default function MarkdownInput({
@@ -73,6 +74,7 @@ export default function MarkdownInput({
   labelId,
   name,
   imageUpload = false,
+  autofocus = false,
   required,
 }: MarkdownInputProps) {
   const classes = useStyles();
@@ -138,6 +140,7 @@ export default function MarkdownInput({
       initialValue: initialDefaultValue.current ?? "",
       usageStatistics: false,
       toolbarItems,
+      autofocus,
     });
 
     if (resetInputRef) {
@@ -162,7 +165,7 @@ export default function MarkdownInput({
       if (imageUpload) uploadButton!.removeEventListener("click", openDialog);
       (fieldRef.current as ToastUIEditor).destroy();
     };
-  }, [fieldRef, resetInputRef, id, labelId, imageUpload]);
+  }, [autofocus, fieldRef, resetInputRef, id, labelId, imageUpload]);
 
   return (
     <>


### PR DESCRIPTION
Don't autofocus markdown editors by default and allow to add the `autofocus` prop to the `MarkdownInput` component if autofocus would be required.

Fixes #1887, #1940

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint` 
   => There are warnings but aren't mine
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
  =>  Tried to add a test to the edit event page to test if the first text field (title) had focus but couldn't find out how to do it
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes
