### PR TITLE
[#1915] Frontend - Trim name on login page

### DIFF
--- a/app/web/src/features/auth/constants.tsx
+++ b/app/web/src/features/auth/constants.tsx
@@ -102,7 +102,6 @@ export const USERNAME_TAKEN = "This username is taken.";
 export const NAME_LABEL = "Your name";
 export const NAME_EMPTY = "Please enter your name";
 export const NAME_REQUIRED = "Name can't be just white space.";
-export const NAME_NOT_TRIMMED = "Name can't start with white space.";
 
 export const EMAIL_LABEL = "Email";
 export const EMAIL_EMPTY = "Please enter a valid email address";

--- a/app/web/src/features/auth/constants.tsx
+++ b/app/web/src/features/auth/constants.tsx
@@ -102,6 +102,7 @@ export const USERNAME_TAKEN = "This username is taken.";
 export const NAME_LABEL = "Your name";
 export const NAME_EMPTY = "Please enter your name";
 export const NAME_REQUIRED = "Name can't be just white space.";
+export const NAME_NOT_TRIMMED = "Name can't start with white space.";
 
 export const EMAIL_LABEL = "Email";
 export const EMAIL_EMPTY = "Please enter a valid email address";

--- a/app/web/src/features/auth/signup/BasicForm.tsx
+++ b/app/web/src/features/auth/signup/BasicForm.tsx
@@ -23,6 +23,7 @@ import {
   NAME_EMPTY,
   NAME_LABEL,
   NAME_REQUIRED,
+  NAME_NOT_TRIMMED,
 } from "../constants";
 
 type SignupBasicInputs = {
@@ -42,9 +43,9 @@ export default function BasicForm() {
   const mutation = useMutation<void, GrpcError, SignupBasicInputs>(
     async (data) => {
       const sanitizedEmail = lowercaseAndTrimField(data.email);
-      const saniitzedName = data.name.trim();
+      const sanitizedName = data.name.trim();
       const state = await service.auth.startSignup(
-        saniitzedName,
+        sanitizedName,
         sanitizedEmail
       );
       return authActions.updateSignupState(state);
@@ -86,6 +87,11 @@ export default function BasicForm() {
                 value: nameValidationPattern,
               },
               required: NAME_REQUIRED,
+              validate: {
+                startsWithWhiteSpace: (value) => {
+                  return !value.startsWith(" ") || NAME_NOT_TRIMMED;
+                },
+              },
             });
           }}
           helperText={errors?.name?.message ?? " "}

--- a/app/web/src/features/auth/signup/BasicForm.tsx
+++ b/app/web/src/features/auth/signup/BasicForm.tsx
@@ -22,8 +22,8 @@ import {
   EMAIL_REQUIRED,
   NAME_EMPTY,
   NAME_LABEL,
-  NAME_REQUIRED,
   NAME_NOT_TRIMMED,
+  NAME_REQUIRED,
 } from "../constants";
 
 type SignupBasicInputs = {

--- a/app/web/src/features/auth/signup/BasicForm.tsx
+++ b/app/web/src/features/auth/signup/BasicForm.tsx
@@ -42,7 +42,11 @@ export default function BasicForm() {
   const mutation = useMutation<void, GrpcError, SignupBasicInputs>(
     async (data) => {
       const sanitizedEmail = lowercaseAndTrimField(data.email);
-      const state = await service.auth.startSignup(data.name, sanitizedEmail);
+      const saniitzedName = data.name.trim();
+      const state = await service.auth.startSignup(
+        saniitzedName,
+        sanitizedEmail
+      );
       return authActions.updateSignupState(state);
     },
     {

--- a/app/web/src/features/auth/signup/BasicForm.tsx
+++ b/app/web/src/features/auth/signup/BasicForm.tsx
@@ -22,7 +22,6 @@ import {
   EMAIL_REQUIRED,
   NAME_EMPTY,
   NAME_LABEL,
-  NAME_NOT_TRIMMED,
   NAME_REQUIRED,
 } from "../constants";
 
@@ -87,11 +86,6 @@ export default function BasicForm() {
                 value: nameValidationPattern,
               },
               required: NAME_REQUIRED,
-              validate: {
-                startsWithWhiteSpace: (value) => {
-                  return !value.startsWith(" ") || NAME_NOT_TRIMMED;
-                },
-              },
             });
           }}
           helperText={errors?.name?.message ?? " "}

--- a/app/web/src/features/profile/view/UserPage.test.tsx
+++ b/app/web/src/features/profile/view/UserPage.test.tsx
@@ -26,14 +26,7 @@ import { getHookWrapperWithClient } from "test/hookWrapper";
 import { getLanguages, getRegions, getUser } from "test/serviceMockDefaults";
 import { addDefaultUser, MockedService } from "test/utils";
 
-import {
-  CANCEL,
-  MORE_PROFILE_ACTIONS_A11Y_TEXT,
-  REPORT_DETAILS,
-  REPORT_REASON,
-  REPORT_USER,
-  SEND,
-} from "../constants";
+import { CANCEL, MORE_PROFILE_ACTIONS_A11Y_TEXT } from "../constants";
 import UserPage from "./UserPage";
 
 jest.mock("features/userQueries/useCurrentUser");


### PR DESCRIPTION
Closes #1915

I'm just not sure if it's a good behavior to trim name without user's knowledge, but I don't have any other idea, since it's uncontrolled component

**Web frontend checklist**
- [ :heavy_check_mark: ] Formatted my code with `yarn format && yarn lint --fix`
- [ :heavy_check_mark: ] There are no warnings from `yarn lint`
- [:heavy_check_mark: ] There are no console warnings when running the app
- [ :white_circle: ] Added any new components to storybook - no component added
- [ :white_circle:  ] Added tests where relevant - no tests added
- [ :grey_exclamation: ] All tests pass - still don't know how to run tests on widnows :see_no_evil:
- [:heavy_check_mark:  ] Clicked around my changes running locally and it works
- [ :heavy_check_mark: ] Checked Desktop, Mobile and Tablet screen sizes
