### PR TITLE
fix: create/edit event form from overflowing on mobile screens

### DIFF
--- a/app/web/src/features/communities/events/EventForm.tsx
+++ b/app/web/src/features/communities/events/EventForm.tsx
@@ -41,6 +41,7 @@ export const useEventFormStyles = makeStyles((theme) => ({
   },
   form: {
     display: "grid",
+    gridTemplateColumns: "minmax(0, 1fr)",
     rowGap: theme.spacing(3),
     marginBlockEnd: theme.spacing(3),
   },
@@ -65,6 +66,7 @@ export const useEventFormStyles = makeStyles((theme) => ({
   },
   eventDetailsContainer: {
     display: "grid",
+    gridTemplateColumns: "minmax(0, 1fr)",
     rowGap: theme.spacing(1),
   },
   submitButton: {


### PR DESCRIPTION
The problem seems to be a grid "gotcha", where "1fr" really means
minmax(auto, 1fr), which means it's possible that the element in the
grid's min-width is larger than the width of the grid itself. I.e. auto
is greater than 1fr. This means the grid column can't shrink below that
size.

Setting min-width to 0 with minmax(0, 1fr) at the grid level allows the
grid column to shrink to fit to the width of the container, as 1fr is
guaranteed to be the max value of the two.
https://css-tricks.com/preventing-a-grid-blowout/

<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->


<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [ ] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
