### PR TITLE
floating save button

### DIFF
--- a/app/web/src/features/profile/edit/EditHostingPreference.tsx
+++ b/app/web/src/features/profile/edit/EditHostingPreference.tsx
@@ -55,9 +55,9 @@ import {
 import { useState } from "react";
 import { Controller, useForm, UseFormMethods } from "react-hook-form";
 import { HostingPreferenceData } from "service";
-import makeStyles from "utils/makeStyles";
 
 import { DEFAULT_ABOUT_HOME_HEADINGS } from "./constants";
+import useStyles from "./styles";
 
 interface HostingPreferenceCheckboxProps {
   className: string;
@@ -85,42 +85,6 @@ function HostingPreferenceCheckbox({
     </FormControl>
   );
 }
-
-const useStyles = makeStyles((theme) => ({
-  alert: {
-    marginBottom: theme.spacing(3),
-  },
-  buttonContainer: {
-    display: "flex",
-    justifyContent: "center",
-    paddingTop: theme.spacing(1),
-  },
-  field: {
-    [theme.breakpoints.up("md")]: {
-      "& > .MuiInputBase-root": {
-        width: 400,
-      },
-    },
-    "& > .MuiInputBase-root": {
-      width: "100%",
-    },
-  },
-  form: {
-    marginTop: theme.spacing(1),
-    marginBottom: theme.spacing(2),
-  },
-  formControl: {
-    display: "block",
-  },
-  preferenceSection: {
-    paddingTop: theme.spacing(3),
-  },
-  checkboxContainer: {
-    display: "grid",
-    gridTemplateColumns: "repeat(auto-fit, minmax(180px, auto))",
-    columnGap: theme.spacing(2),
-  },
-}));
 
 export default function HostingPreferenceForm() {
   const classes = useStyles();

--- a/app/web/src/features/profile/edit/EditProfile.tsx
+++ b/app/web/src/features/profile/edit/EditProfile.tsx
@@ -80,6 +80,7 @@ const useStyles = makeStyles((theme) => ({
     left: 0,
     width: "100%",
     display: "flex",
+    zIndex: 105,
     backgroundColor: theme.palette.background.paper,
     borderTop: `1px solid ${theme.palette.divider}`,
     justifyContent: "center",
@@ -94,7 +95,7 @@ const useStyles = makeStyles((theme) => ({
     [theme.breakpoints.up("md")]: {
       margin: theme.spacing(0, 10),
     },
-    paddingBottom: theme.spacing(50)
+    paddingBottom: theme.spacing(50),
   },
   // .field is the free text fields
   field: {

--- a/app/web/src/features/profile/edit/EditProfile.tsx
+++ b/app/web/src/features/profile/edit/EditProfile.tsx
@@ -75,7 +75,13 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   buttonContainer: {
+    position: "fixed",
+    bottom: 0,
+    left: 0,
+    width: "100%",
     display: "flex",
+    backgroundColor: theme.palette.background.paper,
+    borderTop: `1px solid ${theme.palette.divider}`,
     justifyContent: "center",
     paddingBottom: theme.spacing(1),
     paddingTop: theme.spacing(1),
@@ -88,6 +94,7 @@ const useStyles = makeStyles((theme) => ({
     [theme.breakpoints.up("md")]: {
       margin: theme.spacing(0, 10),
     },
+    paddingBottom: theme.spacing(50)
   },
   // .field is the free text fields
   field: {

--- a/app/web/src/features/profile/edit/EditProfile.tsx
+++ b/app/web/src/features/profile/edit/EditProfile.tsx
@@ -50,68 +50,12 @@ import { Controller, useForm } from "react-hook-form";
 import { useQueryClient } from "react-query";
 import { service, UpdateUserProfileData } from "service/index";
 import { useIsMounted, useSafeState } from "utils/hooks";
-import makeStyles from "utils/makeStyles";
 
 import {
   DEFAULT_ABOUT_ME_HEADINGS,
   DEFAULT_HOBBIES_HEADINGS,
 } from "./constants";
-
-const useStyles = makeStyles((theme) => ({
-  avatar: {
-    width: 120,
-    height: 120,
-  },
-  topFormContainer: {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    [theme.breakpoints.up("md")]: {
-      flexDirection: "row",
-      margin: theme.spacing(1, 10),
-    },
-    "& .MuiTextField-root": {
-      width: "100%",
-    },
-  },
-  buttonContainer: {
-    position: "fixed",
-    bottom: 0,
-    left: 0,
-    width: "100%",
-    display: "flex",
-    zIndex: 105,
-    backgroundColor: theme.palette.background.paper,
-    borderTop: `1px solid ${theme.palette.divider}`,
-    justifyContent: "center",
-    paddingBottom: theme.spacing(1),
-    paddingTop: theme.spacing(1),
-  },
-  // Everything under the mapbox
-  bottomFormContainer: {
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "center",
-    [theme.breakpoints.up("md")]: {
-      margin: theme.spacing(0, 10),
-    },
-    paddingBottom: theme.spacing(50),
-  },
-  // .field is the free text fields
-  field: {
-    "& > .MuiInputBase-root": {
-      width: "100%",
-    },
-  },
-  radioButtons: {
-    display: "flex",
-    flexDirection: "column",
-    [theme.breakpoints.up("sm")]: {
-      display: "grid",
-      gridTemplateColumns: "repeat(3, 1fr)",
-    },
-  },
-}));
+import useStyles from "./styles";
 
 type FormValues = Omit<UpdateUserProfileData, "languageAbilities"> & {
   fluentLanguages: string[];

--- a/app/web/src/features/profile/edit/styles.ts
+++ b/app/web/src/features/profile/edit/styles.ts
@@ -1,0 +1,81 @@
+import makeStyles from "utils/makeStyles";
+
+const useStyles = makeStyles((theme) => ({
+  avatar: {
+    width: 120,
+    height: 120,
+  },
+  topFormContainer: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    [theme.breakpoints.up("md")]: {
+      flexDirection: "row",
+      margin: theme.spacing(1, 10),
+    },
+    "& .MuiTextField-root": {
+      width: "100%",
+    },
+  },
+  buttonContainer: {
+    position: "fixed",
+    bottom: 0,
+    left: 0,
+    width: "100%",
+    display: "flex",
+    zIndex: 105,
+    backgroundColor: theme.palette.background.paper,
+    borderTop: `1px solid ${theme.palette.divider}`,
+    justifyContent: "center",
+    paddingBottom: theme.spacing(1),
+    paddingTop: theme.spacing(1),
+  },
+  // Everything under the mapbox
+  bottomFormContainer: {
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    [theme.breakpoints.up("md")]: {
+      margin: theme.spacing(0, 10),
+    },
+    paddingBottom: theme.spacing(5),
+  },
+  radioButtons: {
+    display: "flex",
+    flexDirection: "column",
+    [theme.breakpoints.up("sm")]: {
+      display: "grid",
+      gridTemplateColumns: "repeat(3, 1fr)",
+    },
+  },
+  alert: {
+    marginBottom: theme.spacing(3),
+  },
+  field: {
+    [theme.breakpoints.up("md")]: {
+      "& > .MuiInputBase-root": {
+        width: 400,
+      },
+    },
+    "& > .MuiInputBase-root": {
+      width: "100%",
+    },
+  },
+  form: {
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(2),
+  },
+  formControl: {
+    display: "block",
+  },
+  preferenceSection: {
+    paddingTop: theme.spacing(3),
+  },
+  checkboxContainer: {
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fit, minmax(180px, auto))",
+    columnGap: theme.spacing(2),
+  },
+}));
+
+export default useStyles;

--- a/app/web/src/features/profile/edit/styles.ts
+++ b/app/web/src/features/profile/edit/styles.ts
@@ -38,7 +38,8 @@ const useStyles = makeStyles((theme) => ({
     [theme.breakpoints.up("md")]: {
       margin: theme.spacing(0, 10),
     },
-    paddingBottom: theme.spacing(5),
+    // to make space for floating save button
+    paddingBottom: theme.spacing(5), 
   },
   radioButtons: {
     display: "flex",
@@ -64,6 +65,8 @@ const useStyles = makeStyles((theme) => ({
   form: {
     marginTop: theme.spacing(1),
     marginBottom: theme.spacing(2),
+    // to make space for floating save button
+    paddingBottom: theme.spacing(5),
   },
   formControl: {
     display: "block",

--- a/app/web/src/features/profile/edit/styles.ts
+++ b/app/web/src/features/profile/edit/styles.ts
@@ -39,7 +39,7 @@ const useStyles = makeStyles((theme) => ({
       margin: theme.spacing(0, 10),
     },
     // to make space for floating save button
-    paddingBottom: theme.spacing(5), 
+    paddingBottom: theme.spacing(5),
   },
   radioButtons: {
     display: "flex",


### PR DESCRIPTION
part of #1611 

Save button on edit profile page sticks at the bottom of screen. It should be good enough until the edit page form will be reworked.

Desktop
<img width="1314" alt="image" src="https://user-images.githubusercontent.com/1890782/134665924-28e44152-12df-4886-87ba-c3b94d02198b.png">

Tablet
<img width="1026" alt="image" src="https://user-images.githubusercontent.com/1890782/134666171-dcde2c7c-cccd-4448-8a70-ee78406cc880.png">

Phone
<img width="319" alt="image" src="https://user-images.githubusercontent.com/1890782/134665990-9129629c-f22b-49bc-a3e7-d822217ca0a3.png">



**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes