### PR TITLE
feature: use enter key to send chat

### DIFF
--- a/app/web/src/features/messages/groupchats/GroupChatSendField.tsx
+++ b/app/web/src/features/messages/groupchats/GroupChatSendField.tsx
@@ -29,9 +29,16 @@ export default function GroupChatSendField({
 
   const { register, handleSubmit, reset } = useForm<MessageFormData>();
   const onSubmit = handleSubmit(async (data: MessageFormData) => {
-    handleSend(data.text);
+    handleSend(data.text.trimRight());
     reset();
   });
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      onSubmit();
+    }
+  };
 
   return (
     <form onSubmit={onSubmit} className={classes.container}>
@@ -45,6 +52,7 @@ export default function GroupChatSendField({
         maxRows={4}
         multiline
         fullWidth
+        onKeyDown={handleKeyDown}
       />
 
       <Button

--- a/app/web/src/features/messages/groupchats/GroupChatView.test.tsx
+++ b/app/web/src/features/messages/groupchats/GroupChatView.test.tsx
@@ -307,4 +307,54 @@ describe("GroupChatView", () => {
     expect(getGroupChatMock).toHaveBeenCalledTimes(2);
     expect(getGroupChatMessagesMock).toHaveBeenCalledTimes(2);
   });
+
+  it("sends the message successfully via enter key", async () => {
+    sendMessageMock.mockResolvedValue(new Empty());
+    getGroupChatMock
+      .mockResolvedValueOnce(baseGroupChatMockResponse)
+      .mockResolvedValue({
+        ...baseGroupChatMockResponse,
+        latestMessage: {
+          authorUserId: 1,
+          messageId: 6,
+          text: {
+            text: "Sounds good",
+          },
+          time: {
+            nanos: 0,
+            seconds: 1577962000,
+          },
+        },
+      });
+    getGroupChatMessagesMock
+      .mockImplementationOnce(getGroupChatMessages)
+      .mockResolvedValue({
+        lastMessageId: 6,
+        messagesList: [
+          {
+            messageId: 6,
+            authorUserId: 1,
+            text: { text: "Sounds good" },
+            time: { seconds: 1577962000, nanos: 0 },
+          },
+          ...messageData,
+        ],
+        noMore: true,
+      });
+    renderGroupChatView();
+    await screen.findByRole("heading", { level: 1, name: "Test group chat" });
+
+    userEvent.type(screen.getByLabelText("Message"), "Sounds good");
+    userEvent.keyboard("{shift>}{enter}{/shift}");
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(0);
+
+    userEvent.keyboard("{enter}");
+
+    expect(await screen.findByText("Sounds good")).toBeVisible();
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageMock).toHaveBeenCalledWith(1, "Sounds good");
+    expect(getGroupChatMock).toHaveBeenCalledTimes(2);
+    expect(getGroupChatMessagesMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/app/web/src/features/messages/requests/HostRequestSendField.tsx
+++ b/app/web/src/features/messages/requests/HostRequestSendField.tsx
@@ -128,6 +128,13 @@ export default function HostRequestSendField({
       ({ hostRequestId }) => hostRequestId === hostRequest.hostRequestId
     );
 
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      onSubmit();
+    }
+  };
+
   return (
     <form onSubmit={onSubmit}>
       <div className={classes.buttonContainer}>
@@ -240,6 +247,7 @@ export default function HostRequestSendField({
           name="text"
           minRows={4}
           maxRows={6}
+          onKeyDown={handleKeyDown}
         />
         <FieldButton
           callback={onSubmit}


### PR DESCRIPTION
I hadn't opened an issue for this before creating the PR, which would have given more opportunity for discussion. Take this as a suggestion and feel free to discuss/reject.

In online chats, users will generally expect to be able to use the `enter` key to send messages (e.g. WhatsApp, Facebook Messenger). The chat function on couchers should allow this behavior.

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes
