### PR TITLE
Enable Gitpod prebuilds in all branches

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -25,3 +25,9 @@ ports:
     onOpen: open-preview
   - port: 8888
     visibility: public
+
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
I saw this in the Gitpod docs and it seems like turning this on means it will build the workspace whenever there's a new change pushed to a branch, as controlled by this update in the `.gitpod.yml` config. This means less waiting around for things to build as the workspace should hopefully be ready by the time someone opens it.

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
