### PR TITLE
Change reference reminders

### DIFF
--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -242,11 +242,11 @@ def process_send_reference_reminders(payload):
     reference_reminder_schedule = [
         # (number, days before you end of write reference period, text for how long they have left to write the ref)
         # 8 pm ish on the last day of the stay
-        (1, timedelta(days=14) - timedelta(hours=20), "14 days"),
+        (1, timedelta(days=15) - timedelta(hours=20), "14 days"),
         # 2 pm ish a week after stay
-        (2, timedelta(days=7) - timedelta(hours=14), "7 days"),
+        (2, timedelta(days=8) - timedelta(hours=14), "7 days"),
         # 10 am ish 3 days before end of time to write ref
-        (3, timedelta(days=3) - timedelta(hours=10), "3 days"),
+        (3, timedelta(days=4) - timedelta(hours=10), "3 days"),
     ]
 
     with session_scope() as session:

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -241,8 +241,8 @@ def process_send_reference_reminders(payload):
     # Keep this in chronological order!
     reference_reminder_schedule = [
         # (number, days after stay, text for how long they have left to write the ref)
-        # 6 pm ish a day after stay
-        (1, timedelta(days=1) - timedelta(hours=6), "13 days"),
+        # 8 pm ish on the last day of the stay
+        (1, -timedelta(hours=4), "14 days"),
         # 2 pm ish a week after stay
         (2, timedelta(days=7) - timedelta(hours=10), "7 days"),
         # 10 am ish 3 days before end of time to write ref

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -240,13 +240,13 @@ def process_send_reference_reminders(payload):
 
     # Keep this in chronological order!
     reference_reminder_schedule = [
-        # (number, days after stay, text for how long they have left to write the ref)
+        # (number, days before you end of write reference period, text for how long they have left to write the ref)
         # 8 pm ish on the last day of the stay
-        (1, -timedelta(hours=4), "14 days"),
+        (1, timedelta(days=14) - timedelta(hours=20), "14 days"),
         # 2 pm ish a week after stay
-        (2, timedelta(days=7) - timedelta(hours=10), "7 days"),
+        (2, timedelta(days=7) - timedelta(hours=14), "7 days"),
         # 10 am ish 3 days before end of time to write ref
-        (3, timedelta(days=11) - timedelta(hours=14), "3 days"),
+        (3, timedelta(days=3) - timedelta(hours=10), "3 days"),
     ]
 
     with session_scope() as session:
@@ -272,7 +272,7 @@ def process_send_reference_reminders(payload):
                 .where(Reference.id == None)
                 .where(HostRequest.can_write_reference)
                 .where(HostRequest.surfer_sent_reference_reminders < reminder_no)
-                .where(HostRequest.end_time + reminder_time < now())
+                .where(HostRequest.end_time_to_write_reference - reminder_time < now())
             )
 
             # hosts needing to write a ref
@@ -293,7 +293,7 @@ def process_send_reference_reminders(payload):
                 .where(Reference.id == None)
                 .where(HostRequest.can_write_reference)
                 .where(HostRequest.host_sent_reference_reminders < reminder_no)
-                .where(HostRequest.end_time + reminder_time < now())
+                .where(HostRequest.end_time_to_write_reference - reminder_time < now())
             )
 
             union = union_all(q1, q2).subquery()

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -241,8 +241,8 @@ def process_send_reference_reminders(payload):
     # Keep this in chronological order!
     reference_reminder_schedule = [
         # (number, days after stay, text for how long they have left to write the ref)
-        # 6 pm ish two days after stay
-        (1, timedelta(days=2) - timedelta(hours=6), "12 days"),
+        # 6 pm ish a day after stay
+        (1, timedelta(days=1) - timedelta(hours=6), "13 days"),
         # 2 pm ish a week after stay
         (2, timedelta(days=7) - timedelta(hours=10), "7 days"),
         # 10 am ish 3 days before end of time to write ref

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -240,7 +240,8 @@ def process_send_reference_reminders(payload):
 
     # Keep this in chronological order!
     reference_reminder_schedule = [
-        # (number, days before you end of write reference period, text for how long they have left to write the ref)
+        # (number, timedelta before we stop being able to write a ref, text for how long they have left to write the ref)
+        # the end time to write a reference is supposed to be midnight in the host's timezone
         # 8 pm ish on the last day of the stay
         (1, timedelta(days=15) - timedelta(hours=20), "14 days"),
         # 2 pm ish a week after stay

--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -937,7 +937,7 @@ class HostRequest(Base):
 
     # timezone aware start and end times of the request, can be compared to now()
     start_time = column_property(date_in_timezone(from_date, timezone))
-    end_time = column_property(date_in_timezone(to_date, timezone) + text("interval '15 days'"))
+    end_time = column_property(date_in_timezone(to_date, timezone) + text("interval '1 days'"))
     start_time_to_write_reference = column_property(date_in_timezone(to_date, timezone))
     # notice 1 day for midnight at the *end of the day*, then 14 days to write a ref
     end_time_to_write_reference = column_property(date_in_timezone(to_date, timezone) + text("interval '15 days'"))

--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -937,7 +937,8 @@ class HostRequest(Base):
 
     # timezone aware start and end times of the request, can be compared to now()
     start_time = column_property(date_in_timezone(from_date, timezone))
-    end_time = column_property(date_in_timezone(to_date, timezone) + text("interval '1 days'"))
+    end_time = column_property(date_in_timezone(to_date, timezone) + text("interval '15 days'"))
+    start_time_to_write_reference = column_property(date_in_timezone(to_date, timezone))
     # notice 1 day for midnight at the *end of the day*, then 14 days to write a ref
     end_time_to_write_reference = column_property(date_in_timezone(to_date, timezone) + text("interval '15 days'"))
 
@@ -958,7 +959,7 @@ class HostRequest(Base):
     def can_write_reference(self):
         return (
             (self.status == HostRequestStatus.confirmed)
-            & (now() >= self.end_time)
+            & (now() >= self.start_time_to_write_reference)
             & (now() <= self.end_time_to_write_reference)
         )
 
@@ -966,7 +967,7 @@ class HostRequest(Base):
     def can_write_reference(cls):
         return (
             (cls.status == HostRequestStatus.confirmed)
-            & (func.now() >= cls.end_time)
+            & (func.now() >= cls.start_time_to_write_reference)
             & (func.now() <= cls.end_time_to_write_reference)
         )
 

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -713,8 +713,8 @@ def test_process_send_reference_reminders(db):
     expected_emails = [
         ("user4@couchers.org.invalid", "You have 3 days to write a reference for User 3!"),
         ("user5@couchers.org.invalid", "You have 7 days to write a reference for User 6!"),
-        ("user7@couchers.org.invalid", "You have 12 days to write a reference for User 8!"),
-        ("user8@couchers.org.invalid", "You have 12 days to write a reference for User 7!"),
+        ("user7@couchers.org.invalid", "You have 13 days to write a reference for User 8!"),
+        ("user8@couchers.org.invalid", "You have 13 days to write a reference for User 7!"),
     ]
 
     process_send_reference_reminders(empty_pb2.Empty())

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -713,8 +713,8 @@ def test_process_send_reference_reminders(db):
     expected_emails = [
         ("user4@couchers.org.invalid", "You have 3 days to write a reference for User 3!"),
         ("user5@couchers.org.invalid", "You have 7 days to write a reference for User 6!"),
-        ("user7@couchers.org.invalid", "You have 13 days to write a reference for User 8!"),
-        ("user8@couchers.org.invalid", "You have 13 days to write a reference for User 7!"),
+        ("user7@couchers.org.invalid", "You have 14 days to write a reference for User 8!"),
+        ("user8@couchers.org.invalid", "You have 14 days to write a reference for User 7!"),
     ]
 
     process_send_reference_reminders(empty_pb2.Empty())


### PR DESCRIPTION
New schedule:

1. A reminder on the day they leave, at around 8 pm
2. A reminder about a week after, at 2 pm
3. A reminder 3 days and 14 hours before end time to write ref

**Backend checklist**
- [x] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] All tests pass
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history