### PR TITLE
Disable enter-to-send on host requests/replies

### DIFF
--- a/app/web/src/features/messages/groupchats/GroupChatSendField.tsx
+++ b/app/web/src/features/messages/groupchats/GroupChatSendField.tsx
@@ -34,7 +34,7 @@ export default function GroupChatSendField({
   });
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === "Enter" && !event.shiftKey) {
+    if (event.key === "Enter" && event.ctrlKey) {
       event.preventDefault();
       onSubmit();
     }

--- a/app/web/src/features/messages/groupchats/GroupChatView.test.tsx
+++ b/app/web/src/features/messages/groupchats/GroupChatView.test.tsx
@@ -308,7 +308,7 @@ describe("GroupChatView", () => {
     expect(getGroupChatMessagesMock).toHaveBeenCalledTimes(2);
   });
 
-  it("sends the message successfully via enter key", async () => {
+  it("sends the message successfully via ctrl+enter combination", async () => {
     sendMessageMock.mockResolvedValue(new Empty());
     getGroupChatMock
       .mockResolvedValueOnce(baseGroupChatMockResponse)
@@ -345,11 +345,11 @@ describe("GroupChatView", () => {
     await screen.findByRole("heading", { level: 1, name: "Test group chat" });
 
     userEvent.type(screen.getByLabelText("Message"), "Sounds good");
-    userEvent.keyboard("{shift>}{enter}{/shift}");
+    userEvent.keyboard("{enter}");
 
     expect(sendMessageMock).toHaveBeenCalledTimes(0);
 
-    userEvent.keyboard("{enter}");
+    userEvent.keyboard("{ctrl>}{enter}{/ctrl}");
 
     expect(await screen.findByText("Sounds good")).toBeVisible();
     expect(sendMessageMock).toHaveBeenCalledTimes(1);

--- a/app/web/src/features/messages/requests/HostRequestSendField.tsx
+++ b/app/web/src/features/messages/requests/HostRequestSendField.tsx
@@ -128,13 +128,6 @@ export default function HostRequestSendField({
       ({ hostRequestId }) => hostRequestId === hostRequest.hostRequestId
     );
 
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === "Enter" && !event.shiftKey) {
-      event.preventDefault();
-      onSubmit();
-    }
-  };
-
   return (
     <form onSubmit={onSubmit}>
       <div className={classes.buttonContainer}>
@@ -247,7 +240,6 @@ export default function HostRequestSendField({
           name="text"
           minRows={4}
           maxRows={6}
-          onKeyDown={handleKeyDown}
         />
         <FieldButton
           callback={onSubmit}

--- a/app/web/src/features/messages/requests/HostRequestSendField.tsx
+++ b/app/web/src/features/messages/requests/HostRequestSendField.tsx
@@ -128,6 +128,13 @@ export default function HostRequestSendField({
       ({ hostRequestId }) => hostRequestId === hostRequest.hostRequestId
     );
 
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "Enter" && event.ctrlKey) {
+      event.preventDefault();
+      onSubmit();
+    }
+  };
+
   return (
     <form onSubmit={onSubmit}>
       <div className={classes.buttonContainer}>
@@ -240,6 +247,7 @@ export default function HostRequestSendField({
           name="text"
           minRows={4}
           maxRows={6}
+          onKeyDown={handleKeyDown}
         />
         <FieldButton
           callback={onSubmit}


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

Intending to close https://github.com/Couchers-org/couchers/issues/2096

Partially reverting https://github.com/Couchers-org/couchers/pull/2048, now using Enter key only for the "Chat" feature, not for host messages/replies, which are intended to be longer and have paragraphs. 

May want to remove enter-to-send in Chat as well, for consistency or just because, though personally I think enter-to-send makes sense for chats.

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes
