### PR TITLE
Automatically convert links within user messages

### DIFF
--- a/app/web/src/components/Linkify.test.tsx
+++ b/app/web/src/components/Linkify.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import Linkify from "./Linkify";
+
+test("renders links as anchor tags with correct href attributes", () => {
+  const testMessages = [
+    {
+      text: "I really do all my shopping on amazon.es.",
+      searchTerm: /amazon\.es/,
+      href: "//amazon.es",
+    },
+    {
+      text: "www is uncool, I only use old.reddit.com",
+      searchTerm: /reddit\.com/,
+      href: "//old.reddit.com",
+    },
+    {
+      text: "www.google.com",
+      searchTerm: /www\.google\.com/,
+      href: "//www.google.com",
+    },
+    {
+      text: "this should answer your question: https://stackoverflow.com/questions/57827126/how-to-test-anchors-href-with-react-testing-library",
+      searchTerm: /how-to-test-anchors-href-with-react-testing-library/,
+      href: "https://stackoverflow.com/questions/57827126/how-to-test-anchors-href-with-react-testing-library",
+    },
+    {
+      text: "if you want to know your ip: https://duckduckgo.com/?q=what+is+my+ip&t=h_&ia=answer",
+      searchTerm: /ia=answer/,
+      href: "https://duckduckgo.com/?q=what+is+my+ip&t=h_&ia=answer",
+    },
+  ];
+  for (const message of testMessages) {
+    render(<Linkify text={message.text} />);
+    const linkElement = screen.getByText(message.searchTerm);
+    expect(linkElement).toBeInTheDocument();
+    expect(linkElement).toHaveAttribute("href", message.href);
+  }
+});

--- a/app/web/src/components/Linkify.tsx
+++ b/app/web/src/components/Linkify.tsx
@@ -11,9 +11,6 @@ const useStyles = makeStyles((theme) => {
 });
 
 const urlRegex = () => {
-  /*
-
-  */
   const protocol = `(?:https?://)?`;
   const auth = "(?:\\S+(?::\\S*)?@)?";
   const host = "(?:(?:[a-z\\u00a1-\\uffff0-9][-_]*)*[a-z\\u00a1-\\uffff0-9]+)";

--- a/app/web/src/components/Linkify.tsx
+++ b/app/web/src/components/Linkify.tsx
@@ -1,0 +1,67 @@
+import classNames from "classnames";
+import React from "react";
+import makeStyles from "utils/makeStyles";
+
+const useStyles = makeStyles((theme) => {
+  return {
+    a: {
+      color: theme.palette.primary.main,
+    },
+  };
+});
+
+const urlRegex = () => {
+  /*
+
+  */
+  const protocol = `(?:https?://)?`;
+  const auth = "(?:\\S+(?::\\S*)?@)?";
+  const host = "(?:(?:[a-z\\u00a1-\\uffff0-9][-_]*)*[a-z\\u00a1-\\uffff0-9]+)";
+  const domain =
+    "(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*";
+  const tld = `(?:\\.)[a-z]{2,}`;
+  const path = '(?:[/?#][^\\s"]*)?';
+  const regex = `(?:${protocol}${auth}(?:${host}${domain}${tld})${path})`;
+  const result = new RegExp(`(${regex})`, "ig");
+  return result;
+};
+
+interface LinkifyProps {
+  text: string;
+}
+
+function Linkify(props: LinkifyProps) {
+  const classes = useStyles();
+  const nonCapturingRegex = urlRegex();
+  const parts = props.text.split(nonCapturingRegex);
+
+  const result = parts.map((part, i) => {
+    if (!part || !part.match) {
+      return undefined;
+    }
+    if (part.match(nonCapturingRegex)) {
+      // Exclude email addresses
+      if (part.includes("@") && !part.includes("/")) {
+        return <React.Fragment key={i}>{part}</React.Fragment>;
+      }
+      const href = part.endsWith(".") ? part.slice(0, -1) : part;
+      const protocolPrefix = part.match(/https?:?\/\//) ? "" : "//";
+      return (
+        <a
+          key={i}
+          className={classNames(classes.a)}
+          target="_blank"
+          rel="noreferrer"
+          href={`${protocolPrefix}${href}`}
+        >
+          {part}
+        </a>
+      );
+    }
+    return <React.Fragment key={i}>{part}</React.Fragment>;
+  });
+
+  return <>{result}</>;
+}
+
+export default Linkify;

--- a/app/web/src/components/Linkify.tsx
+++ b/app/web/src/components/Linkify.tsx
@@ -27,14 +27,14 @@ interface LinkifyProps {
   text: string;
 }
 
-function Linkify(props: LinkifyProps) {
+function Linkify({ text }: LinkifyProps) {
   const classes = useStyles();
   const nonCapturingRegex = urlRegex();
-  const parts = props.text.split(nonCapturingRegex);
+  const parts = text.split(nonCapturingRegex);
 
   const result = parts.map((part, i) => {
     if (!part || !part.match) {
-      return undefined;
+      return null;
     }
     if (part.match(nonCapturingRegex)) {
       // Exclude email addresses

--- a/app/web/src/components/Linkify.tsx
+++ b/app/web/src/components/Linkify.tsx
@@ -1,14 +1,5 @@
-import classNames from "classnames";
+import { Link as MuiLink } from "@material-ui/core";
 import React from "react";
-import makeStyles from "utils/makeStyles";
-
-const useStyles = makeStyles((theme) => {
-  return {
-    a: {
-      color: theme.palette.primary.main,
-    },
-  };
-});
 
 const urlRegex = () => {
   const protocol = `(?:https?://)?`;
@@ -28,7 +19,6 @@ interface LinkifyProps {
 }
 
 function Linkify({ text }: LinkifyProps) {
-  const classes = useStyles();
   const nonCapturingRegex = urlRegex();
   const parts = text.split(nonCapturingRegex);
 
@@ -44,15 +34,14 @@ function Linkify({ text }: LinkifyProps) {
       const href = part.endsWith(".") ? part.slice(0, -1) : part;
       const protocolPrefix = part.match(/https?:?\/\//) ? "" : "//";
       return (
-        <a
+        <MuiLink
           key={i}
-          className={classNames(classes.a)}
           target="_blank"
           rel="noreferrer"
           href={`${protocolPrefix}${href}`}
         >
           {part}
-        </a>
+        </MuiLink>
       );
     }
     return <React.Fragment key={i}>{part}</React.Fragment>;

--- a/app/web/src/components/Markdown.tsx
+++ b/app/web/src/components/Markdown.tsx
@@ -75,6 +75,7 @@ export default function Markdown({
     viewer.current = new ToastUIEditorViewer({
       el: rootEl.current!,
       initialValue: sanitizedSource,
+      extendedAutolinks: true,
     });
     return () => viewer.current?.destroy();
   }, [source, topHeaderLevel, allowImages]);

--- a/app/web/src/components/MarkdownInput/MarkdownInput.tsx
+++ b/app/web/src/components/MarkdownInput/MarkdownInput.tsx
@@ -137,6 +137,7 @@ export default function MarkdownInput({
       usageStatistics: false,
       toolbarItems,
       autofocus,
+      extendedAutolinks: true,
     });
 
     if (resetInputRef) {

--- a/app/web/src/features/messages/messagelist/MessageView.tsx
+++ b/app/web/src/features/messages/messagelist/MessageView.tsx
@@ -3,6 +3,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import { Skeleton } from "@material-ui/lab";
 import classNames from "classnames";
 import Avatar from "components/Avatar";
+import Linkify from "components/Linkify";
 import TextBody from "components/TextBody";
 import FlagButton from "features/FlagButton";
 import TimeInterval from "features/messages/messagelist/TimeInterval";
@@ -141,7 +142,9 @@ export default function MessageView({
         </div>
 
         <CardContent className={classes.messageBody}>
-          <TextBody>{message.text?.text || ""}</TextBody>
+          <TextBody>
+            <Linkify text={message.text?.text || ""} />
+          </TextBody>
         </CardContent>
 
         {isCurrentUser && (


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
Adding a component to render user messages containing links with `<a>` tags instead of plaintext.

This actually turns out to be surprisingly complicated, and would be even harder if you really wanted to be sure to cover all possible URLs while avoiding any false positives. So I decided to try for something "good enough" instead.

URL regex modified from: https://github.com/kevva/url-regex

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes
