### PR TITLE
Fix typo in the translation doc's section link

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -23,7 +23,7 @@ If you wish to help translate our app, please begin by creating an account on We
 
 Are you fluent in a language you want to help us but you can't find it? Send us a request to add the language to the project!
 
-1. Follow step 1 and 2 in the [Finding messages that require translations](#finding-messages-that-require-translation) section above.
+1. Follow step 1 and 2 in the [Finding messages that require translations](#finding-messages-that-require-translations) section above.
 
 2. Click the "Start new translation" button in the individual component's page.
 


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
As in title, otherwise the link didn't jump back up to the section when clicked...


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
