### PR TITLE
Hotfix: Treat empty string as missing for translations + fix donation amount formatting

### DIFF
--- a/app/web/src/features/donations/DonationsBox.tsx
+++ b/app/web/src/features/donations/DonationsBox.tsx
@@ -265,6 +265,14 @@ export default function DonationsBox() {
       setisPredefinedAmount(true);
     };
 
+  const formatDonationValue = (val: number) =>
+    t("donations_value", {
+      val,
+      formatParams: {
+        val: { currency: "USD", minimumFractionDigits: 0, locale: "en-US" },
+      },
+    });
+
   return (
     <>
       <form onSubmit={onSubmit} className={classes.donationsBox}>
@@ -342,12 +350,7 @@ export default function DonationsBox() {
                       value === DONATIONSBOX_VALUES[0] && isPredefinedAmount,
                   })}
                 >
-                  {t("donations_value", {
-                    val: DONATIONSBOX_VALUES[0],
-                    formatParams: {
-                      val: { currency: "USD", minimumFractionDigits: 0 },
-                    },
-                  })}
+                  {formatDonationValue(DONATIONSBOX_VALUES[0])}
                 </button>
                 <button
                   type="button"
@@ -360,12 +363,7 @@ export default function DonationsBox() {
                       value === DONATIONSBOX_VALUES[1] && isPredefinedAmount,
                   })}
                 >
-                  {t("donations_value", {
-                    val: DONATIONSBOX_VALUES[1],
-                    formatParams: {
-                      val: { currency: "USD", minimumFractionDigits: 0 },
-                    },
-                  })}
+                  {formatDonationValue(DONATIONSBOX_VALUES[1])}
                 </button>
               </div>
 
@@ -381,12 +379,7 @@ export default function DonationsBox() {
                       value === DONATIONSBOX_VALUES[2] && isPredefinedAmount,
                   })}
                 >
-                  {t("donations_value", {
-                    val: DONATIONSBOX_VALUES[2],
-                    formatParams: {
-                      val: { currency: "USD", minimumFractionDigits: 0 },
-                    },
-                  })}
+                  {formatDonationValue(DONATIONSBOX_VALUES[2])}
                 </button>
                 <button
                   type="button"
@@ -399,12 +392,7 @@ export default function DonationsBox() {
                       value === DONATIONSBOX_VALUES[3] && isPredefinedAmount,
                   })}
                 >
-                  {t("donations_value", {
-                    val: DONATIONSBOX_VALUES[3],
-                    formatParams: {
-                      val: { currency: "USD", minimumFractionDigits: 0 },
-                    },
-                  })}
+                  {formatDonationValue(DONATIONSBOX_VALUES[3])}
                 </button>
               </div>
 
@@ -420,12 +408,7 @@ export default function DonationsBox() {
                       value === DONATIONSBOX_VALUES[4] && isPredefinedAmount,
                   })}
                 >
-                  {t("donations_value", {
-                    val: DONATIONSBOX_VALUES[4],
-                    formatParams: {
-                      val: { currency: "USD", minimumFractionDigits: 0 },
-                    },
-                  })}
+                  {formatDonationValue(DONATIONSBOX_VALUES[4])}
                 </button>
                 <button
                   type="button"
@@ -438,12 +421,7 @@ export default function DonationsBox() {
                       value === DONATIONSBOX_VALUES[5] && isPredefinedAmount,
                   })}
                 >
-                  {t("donations_value", {
-                    val: DONATIONSBOX_VALUES[5],
-                    formatParams: {
-                      val: { currency: "USD", minimumFractionDigits: 0 },
-                    },
-                  })}
+                  {formatDonationValue(DONATIONSBOX_VALUES[5])}
                 </button>
               </div>
 
@@ -460,12 +438,7 @@ export default function DonationsBox() {
                         value === DONATIONSBOX_VALUES[6] && isPredefinedAmount,
                     })}
                   >
-                    {t("donations_value", {
-                      val: DONATIONSBOX_VALUES[6],
-                      formatParams: {
-                        val: { currency: "USD", minimumFractionDigits: 0 },
-                      },
-                    })}
+                    {formatDonationValue(DONATIONSBOX_VALUES[6])}
                   </button>
                   <div className={classes.inputWrapper}>
                     <input

--- a/app/web/src/i18n/index.ts
+++ b/app/web/src/i18n/index.ts
@@ -37,6 +37,7 @@ i18n
       escapeValue: false,
     },
     ns: ["global"],
+    returnEmptyString: false,
   });
 
 export default i18n;


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
As in title.

This might be controllable from Weblate... but I have no idea why sometimes it outputs untranslated keys with an empty strings (but not always), so the first fix deals with that and makes i18next fallback to English instead of displaying the empty string, which would lead to a broken UI for users.

Second fix: I noticed that since I added the language detector (currently based on the user's browser preferred language), the USD is formatted differently and does so for every language. Since in our free field (where we allow the user to type in an amount they want to donate), we still hardcode "$" there... I thought it's best the rest will remain consistently formatted with $3, $5 etc. To achieve this, had to hardcode the currency formatter to use the `en-US` locale for that.

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [ ] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
