### PR TITLE
Comma-separated countries lists in About

### DIFF
--- a/app/web/src/features/constants.ts
+++ b/app/web/src/features/constants.ts
@@ -1,6 +1,7 @@
 // General strings
 export const CLOSE = "Close";
 export const CREATE = "Create";
+export const NONE = "None";
 export const TITLE = "Title";
 export const TO = "to";
 export const UPDATE = "Update";
@@ -30,15 +31,14 @@ export const HOMETOWN = "Grew up in";
 export const JOINED = "Coucher since";
 export const LANGUAGES_CONVERSATIONAL = "Conversational in";
 export const LANGUAGES_FLUENT = "Fluent languages";
-export const LIVED_IN = "Lived in";
+export const LIVED_IN = "Countries I've lived in";
 export const MEDIA = "Art, Books, Movies, and Music I like";
 export const MISSION = "Current mission";
 export const OCCUPATION = "Occupation";
 export const OVERVIEW = "Overview";
 export const PHOTOS = "Photos";
 export const STORY = "My favorite hosting or travel story";
-export const TRAVELED_TO = "Traveled to";
-export const TRAVELS = "My travels";
+export const TRAVELED_TO = "Countries I've traveled to";
 export const WHO = "Who I am";
 export const WHY = "Why I use Couchers";
 

--- a/app/web/src/features/profile/view/About.test.tsx
+++ b/app/web/src/features/profile/view/About.test.tsx
@@ -27,10 +27,12 @@ describe("About (user)", () => {
     renderAbout();
 
     // Australia is displayed both for lived and visited regions
-    expect((await screen.findAllByText("Australia")).length).toBe(2);
-
-    expect(screen.getByText("Sweden")).toBeInTheDocument();
-    expect(screen.getByText("Finland")).toBeInTheDocument();
-    expect(screen.getByText("United States")).toBeInTheDocument();
+    expect(
+      (await screen.findAllByText("Australia", { exact: false })).length
+    ).toBe(2);
+    // Sweden is only displayed for lived regions
+    expect(
+      (await screen.findAllByText("Sweden", { exact: false })).length
+    ).toBe(1);
   });
 });

--- a/app/web/src/features/profile/view/About.test.tsx
+++ b/app/web/src/features/profile/view/About.test.tsx
@@ -35,4 +35,13 @@ describe("About (user)", () => {
       (await screen.findAllByText("Sweden", { exact: false })).length
     ).toBe(1);
   });
+
+  it("displays None when there are no regions", async () => {
+    renderAbout({
+      ...defaultUser,
+      regionsVisitedList: [],
+      regionsLivedList: [],
+    });
+    expect((await screen.findAllByText("None")).length).toBe(2);
+  });
 });

--- a/app/web/src/features/profile/view/About.tsx
+++ b/app/web/src/features/profile/view/About.tsx
@@ -5,9 +5,9 @@ import {
   ADDITIONAL,
   HOBBIES,
   LIVED_IN,
+  NONE,
   OVERVIEW,
   TRAVELED_TO,
-  TRAVELS,
   WHO,
 } from "features/constants";
 import { User } from "proto/api_pb";
@@ -26,41 +26,6 @@ const useStyles = makeStyles((theme) => ({
   root: {
     marginTop: theme.spacing(1),
   },
-  countriesContainer: {
-    display: "flex",
-    marginTop: theme.spacing(1),
-    "& > div": {
-      display: "flex",
-      flexDirection: "column",
-    },
-  },
-  countriesList: {
-    margin: theme.spacing(0, 1),
-  },
-  countryLabel: {
-    display: "flex",
-    alignItems: "center",
-  },
-  traveledToColor: {
-    width: "100%",
-    display: "block",
-    height: theme.spacing(0.5),
-    backgroundColor: theme.palette.primary.main,
-  },
-  livedInColor: {
-    width: "100%",
-    display: "block",
-    height: theme.spacing(0.5),
-    backgroundColor: theme.palette.secondary.main,
-  },
-  labelMarker: {
-    fontWeight: "bold",
-    display: "inline-block",
-    width: theme.spacing(1),
-    height: theme.spacing(1),
-    marginRight: theme.spacing(2),
-  },
-
   marginTop3: {
     marginTop: theme.spacing(3),
   },
@@ -96,43 +61,21 @@ export default function About({ user }: AboutProps) {
           <Divider className={classes.marginTop3} />
         </>
       )}
-      <Typography variant="h1">{TRAVELS}</Typography>
-      <div className={classes.countriesContainer}>
-        <div>
-          <div className={classes.countryLabel}>
-            <span
-              className={`${classes.traveledToColor} ${classes.labelMarker}`}
-            ></span>
-            <Typography variant="body1">{TRAVELED_TO}</Typography>
-          </div>
-          <div className={classes.countryLabel}>
-            <span
-              className={`${classes.livedInColor} ${classes.labelMarker}`}
-            ></span>
-            <Typography variant="body1">{LIVED_IN}</Typography>
-          </div>
-        </div>
-        {regions ? (
-          <>
-            <ul className={classes.countriesList}>
-              <span className={classes.traveledToColor}></span>
-              {user.regionsVisitedList.map((country) => (
-                <li key={`Visited ${country}`}>
-                  <Typography variant="body1">{regions[country]}</Typography>
-                </li>
-              ))}
-            </ul>
-            <ul className={classes.countriesList}>
-              <span className={classes.livedInColor}></span>
-              {user.regionsLivedList.map((country) => (
-                <li key={`Lived in ${country}`}>
-                  <Typography variant="body1">{regions[country]}</Typography>
-                </li>
-              ))}
-            </ul>
-          </>
-        ) : null}
-      </div>
+      <Typography variant="h1">{TRAVELED_TO}</Typography>
+      <Typography variant="body1">
+        {regions
+          ? user.regionsVisitedList
+              .map((country) => regions[country])
+              .join(`, `)
+          : NONE}
+      </Typography>
+      <Divider className={classes.marginTop3} />
+      <Typography variant="h1">{LIVED_IN}</Typography>
+      <Typography variant="body1">
+        {regions
+          ? user.regionsLivedList.map((country) => regions[country]).join(`, `)
+          : NONE}
+      </Typography>
     </div>
   );
 }

--- a/app/web/src/features/profile/view/About.tsx
+++ b/app/web/src/features/profile/view/About.tsx
@@ -63,7 +63,7 @@ export default function About({ user }: AboutProps) {
       )}
       <Typography variant="h1">{TRAVELED_TO}</Typography>
       <Typography variant="body1">
-        {regions
+        {regions && user.regionsVisitedList.length > 0
           ? user.regionsVisitedList
               .map((country) => regions[country])
               .join(`, `)
@@ -72,7 +72,7 @@ export default function About({ user }: AboutProps) {
       <Divider className={classes.marginTop3} />
       <Typography variant="h1">{LIVED_IN}</Typography>
       <Typography variant="body1">
-        {regions
+        {regions && user.regionsLivedList.length > 0
           ? user.regionsLivedList.map((country) => regions[country]).join(`, `)
           : NONE}
       </Typography>


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

Closes #1997 by changing the vertical unordered lists of regions visited/lived to comma-separated lists.

A bite-sized first PR 🎉 
I did pore through the contributing guide but lmk if there's anything I can do to improve my contributing workflow!

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [x] Added any new components to storybook
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
