### PR TITLE
fix: block private pages with loader to prevent flash

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,7 +11,7 @@ tasks:
     init: |
       yarn install
       gp await-port 8888
-    command: REACT_APP_API_BASE_URL=$(gp url 8888) yarn start
+    command: NEXT_PUBLIC_API_BASE_URL=$(gp url 8888) yarn start
 
   - name: Instructions
     before: cd app/

--- a/app/web/components/AppRoute.tsx
+++ b/app/web/components/AppRoute.tsx
@@ -75,32 +75,35 @@ export default function AppRoute({
   });
 
   return (
-    <>
-      {variant !== "full-screen" && <Navigation />}
-      <Container
-        className={classNames({
-          [classes.nonFullScreenStyles]: variant !== "full-screen",
-          [classes.fullWidthContainer]: variant === "full-width",
-          [classes.fullscreenContainer]: variant === "full-screen",
-          [classes.standardContainer]: variant === "standard",
-        })}
-        maxWidth={
-          variant === "full-screen" || variant === "full-width" ? false : "lg"
-        }
-      >
-        <ErrorBoundary>
-          {!isMounted && isPrivate ? (
-            <div className={classes.loader}>
-              <CircularProgress />
-            </div>
-          ) : (
-            children
-          )}
-          {!isPrivate && <CookieBanner />}
-        </ErrorBoundary>
-      </Container>
-      {!noFooter && <Footer />}
-    </>
+    <ErrorBoundary>
+      {!isMounted || (isPrivate && !isAuthenticated) ? (
+        <div className={classes.loader}>
+          <CircularProgress />
+        </div>
+      ) : (
+        <>
+          {variant !== "full-screen" && <Navigation />}
+          <Container
+            className={classNames({
+              [classes.nonFullScreenStyles]: variant !== "full-screen",
+              [classes.fullWidthContainer]: variant === "full-width",
+              [classes.fullscreenContainer]: variant === "full-screen",
+              [classes.standardContainer]: variant === "standard",
+            })}
+            maxWidth={
+              variant === "full-screen" || variant === "full-width"
+                ? false
+                : "lg"
+            }
+          >
+            {/* Have to wrap this in a fragment because of https://github.com/mui-org/material-ui/issues/21711 */}
+            <>{children}</>
+          </Container>
+          {!noFooter && <Footer />}
+        </>
+      )}
+      {!isPrivate && <CookieBanner />}
+    </ErrorBoundary>
   );
 }
 


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
Before this, the user will see a brief flash of the private page with a bunch of errors (as the app would have been trying to access the private API without being authenticated) before being redirected to the login page.

**Before**

https://user-images.githubusercontent.com/13669362/148663809-3a306851-33cc-4bf6-9f18-a2092a385ee6.mp4



**After**

https://user-images.githubusercontent.com/13669362/148663904-23a2de5f-77f9-43b2-b6e4-8220f5ea519d.mp4



<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
