### PR TITLE
Add user ids to report emails

### DIFF
--- a/app/backend/templates/content_report.md
+++ b/app/backend/templates/content_report.md
@@ -23,6 +23,7 @@ Content Report #{{ report.id|couchers_escape }}.
 Name: {{ report.reporting_user.name|couchers_escape }}{{ newline(html)|couchers_safe }}
 Email: {{ report.reporting_user.email|couchers_escape }}{{ newline(html)|couchers_safe }}
 Username: {{ report.reporting_user.username|couchers_escape }}{{ newline(html)|couchers_safe }}
+User ID: {{ report.reporting_user.id|couchers_escape }}{{ newline(html)|couchers_safe }}
 Profile: {{ link(reporting_user_user_link, html)|couchers_safe }}
 
 
@@ -30,6 +31,7 @@ Profile: {{ link(reporting_user_user_link, html)|couchers_safe }}
 Name: {{ report.author_user.name|couchers_escape }}{{ newline(html)|couchers_safe }}
 Email: {{ report.author_user.email|couchers_escape }}{{ newline(html)|couchers_safe }}
 Username: {{ report.author_user.username|couchers_escape }}{{ newline(html)|couchers_safe }}
+User ID: {{ report.author_user.id|couchers_escape }}{{ newline(html)|couchers_safe }}
 Profile: {{ link(author_user_user_link, html)|couchers_safe }}
 
 

--- a/app/backend/templates/reference_report.md
+++ b/app/backend/templates/reference_report.md
@@ -27,6 +27,7 @@ Someone wrote a bad reference.
 Name: {{ reference.from_user.name|couchers_escape }}{{ newline(html)|couchers_safe }}
 Email: {{ reference.from_user.email|couchers_escape }}{{ newline(html)|couchers_safe }}
 Username: {{ reference.from_user.username|couchers_escape }}{{ newline(html)|couchers_safe }}
+User ID: {{ reference.from_user.id|couchers_escape }}{{ newline(html)|couchers_safe }}
 Profile: {{ link(from_user_user_link, html)|couchers_safe }}
 
 
@@ -34,6 +35,7 @@ Profile: {{ link(from_user_user_link, html)|couchers_safe }}
 Name: {{ reference.to_user.name|couchers_escape }}{{ newline(html)|couchers_safe }}
 Email: {{ reference.to_user.email|couchers_escape }}{{ newline(html)|couchers_safe }}
 Username: {{ reference.to_user.username|couchers_escape }}{{ newline(html)|couchers_safe }}
+User ID: {{ reference.to_user.id|couchers_escape }}{{ newline(html)|couchers_safe }}
 Profile: {{ link(to_user_user_link, html)|couchers_safe }}
 
 


### PR DESCRIPTION
This is in the tests, and it's good for the support team to be able to see the IDs without an admin call.

**Backend checklist**
- [ ] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history
