### PR TITLE
fix: fallback to English if empty string for translation key found

### DIFF
--- a/app/web/next-i18next.config.js
+++ b/app/web/next-i18next.config.js
@@ -18,6 +18,7 @@ module.exports = {
     "profile",
     "search",
   ],
+  returnEmptyString: false,
   serializeConfig: false,
   localePath: (locale, namespace) => {
     if (namespace === "global") {


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
Add the `returnEmptyString: false` setting back that was in the old config, so that translation keys with an empty string will be treated as missing and falls back to English accordingly. I found this whilst I was poking around locally and enabled another language when I was reviewing #2326 

Technically not an issue yet as we haven't enabled translations other than English at the moment, but best to fix it before it comes up as a surprise.


<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->

**Web frontend checklist**
N/A as it's only an i18next config change


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
