### PR TITLE
Make all functions in urls.py accept only keyword arguments

### DIFF
--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -707,7 +707,7 @@ class API(api_pb2_grpc.APIServicer):
         path = "upload?" + urlencode({"data": data, "sig": sig})
 
         return api_pb2.InitiateMediaUploadRes(
-            upload_url=urls.media_upload_url(path),
+            upload_url=urls.media_upload_url(path=path),
             expiry=Timestamp_from_datetime(expiry),
         )
 

--- a/app/backend/src/couchers/tasks.py
+++ b/app/backend/src/couchers/tasks.py
@@ -175,7 +175,7 @@ def send_friend_request_accepted_email(friend_relationship):
         "friend_request_accepted",
         template_args={
             "friend_relationship": friend_relationship,
-            "to_user_user_link": urls.user_link(friend_relationship.to_user.username),
+            "to_user_user_link": urls.user_link(username=friend_relationship.to_user.username),
         },
     )
 
@@ -196,7 +196,9 @@ def send_host_reference_email(reference, both_written):
         template_args={
             "reference": reference,
             "leave_reference_link": urls.leave_reference_link(
-                "surfed" if surfed else "hosted", reference.from_user_id, reference.host_request.conversation_id
+                reference_type="surfed" if surfed else "hosted",
+                to_user_id=reference.from_user_id,
+                host_request_id=reference.host_request.conversation_id,
             ),
             # if this reference was written by the surfer, then the recipient hosted
             "surfed": surfed,
@@ -230,7 +232,9 @@ def send_reference_reminder_email(user, other_user, host_request, surfed, time_l
             "other_user": other_user,
             "host_request": host_request,
             "leave_reference_link": urls.leave_reference_link(
-                "surfed" if surfed else "hosted", other_user.id, host_request.conversation_id
+                reference_type="surfed" if surfed else "hosted",
+                to_user_id=other_user.id,
+                host_request_id=host_request.conversation_id,
             ),
             "surfed": surfed,
             "time_left_text": time_left_text,
@@ -318,8 +322,8 @@ def send_content_report_email(content_report):
         "content_report",
         template_args={
             "report": content_report,
-            "author_user_user_link": urls.user_link(content_report.author_user.username),
-            "reporting_user_user_link": urls.user_link(content_report.reporting_user.username),
+            "author_user_user_link": urls.user_link(username=content_report.author_user.username),
+            "reporting_user_user_link": urls.user_link(username=content_report.reporting_user.username),
         },
     )
 
@@ -334,8 +338,8 @@ def maybe_send_reference_report_email(reference):
             "reference_report",
             template_args={
                 "reference": reference,
-                "from_user_user_link": urls.user_link(reference.from_user.username),
-                "to_user_user_link": urls.user_link(reference.to_user.username),
+                "from_user_user_link": urls.user_link(username=reference.from_user.username),
+                "to_user_user_link": urls.user_link(username=reference.to_user.username),
             },
         )
 
@@ -347,7 +351,7 @@ def maybe_send_contributor_form_email(form):
         email.enqueue_email_from_template(
             target_email,
             "contributor_form",
-            template_args={"form": form, "user_link": urls.user_link(form.user.username)},
+            template_args={"form": form, "user_link": urls.user_link(username=form.user.username)},
         )
 
 

--- a/app/backend/src/couchers/urls.py
+++ b/app/backend/src/couchers/urls.py
@@ -14,7 +14,7 @@ def profile_link():
     return f"{config['BASE_URL']}/profile"
 
 
-def user_link(username):
+def user_link(*, username):
     return f"{config['BASE_URL']}/user/{username}"
 
 
@@ -22,15 +22,15 @@ def edit_profile_link():
     return f"{config['BASE_URL']}/profile/edit"
 
 
-def signup_link(token):
+def signup_link(*, token):
     return f"{config['BASE_URL']}/signup?token={token}"
 
 
-def login_link(login_token):
+def login_link(*, login_token):
     return f"{config['BASE_URL']}/login?token={login_token}"
 
 
-def password_reset_link(password_reset_token):
+def password_reset_link(*, password_reset_token):
     return f"{config['BASE_URL']}/complete-password-reset?token={password_reset_token}"
 
 
@@ -46,7 +46,7 @@ def messages_link():
     return f"{config['BASE_URL']}/messages/"
 
 
-def leave_reference_link(reference_type, to_user_id, host_request_id=None):
+def leave_reference_link(*, reference_type, to_user_id, host_request_id=None):
     assert reference_type in ["friend", "surfed", "hosted"]
     if host_request_id:
         return f"{config['BASE_URL']}/leave-reference/{reference_type}/{to_user_id}/{host_request_id}"
@@ -58,11 +58,11 @@ def friend_requests_link():
     return f"{config['BASE_URL']}/connections/friends/"
 
 
-def media_upload_url(path):
+def media_upload_url(*, path):
     return f"{config['MEDIA_SERVER_BASE_URL']}/{path}"
 
 
-def change_email_link(confirmation_token):
+def change_email_link(*, confirmation_token):
     return f"{config['BASE_URL']}/confirm-email?token={confirmation_token}"
 
 


### PR DESCRIPTION
This helps a little bit avoid bugs like #2343 by making it clearer what's going on at the call site.

Follow up from #2345.

**Backend checklist**
- [ ] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history
