### PR TITLE
Switch to new stripe account

### DIFF
--- a/app/backend/src/couchers/migrations/versions/a6c8b3a9a986_switch_to_new_stripe_account.py
+++ b/app/backend/src/couchers/migrations/versions/a6c8b3a9a986_switch_to_new_stripe_account.py
@@ -1,0 +1,25 @@
+"""Switch to new stripe account
+
+Revision ID: a6c8b3a9a986
+Revises: 6aa87f3539f9
+Create Date: 2022-01-14 14:33:58.465424
+
+"""
+import geoalchemy2
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a6c8b3a9a986"
+down_revision = "6aa87f3539f9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TABLE users RENAME COLUMN stripe_customer_id TO stripe_customer_id_au")
+    op.add_column("users", sa.Column("stripe_customer_id", sa.String(), nullable=True))
+
+
+def downgrade():
+    raise Exception("Can't downgrade")

--- a/app/backend/src/couchers/migrations/versions/a6c8b3a9a986_switch_to_new_stripe_account.py
+++ b/app/backend/src/couchers/migrations/versions/a6c8b3a9a986_switch_to_new_stripe_account.py
@@ -17,7 +17,7 @@ depends_on = None
 
 
 def upgrade():
-    op.execute("ALTER TABLE users RENAME COLUMN stripe_customer_id TO stripe_customer_id_au")
+    op.execute("ALTER TABLE users RENAME COLUMN stripe_customer_id TO stripe_customer_id_old")
     op.add_column("users", sa.Column("stripe_customer_id", sa.String(), nullable=True))
 
 

--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -240,7 +240,7 @@ class User(Base):
     # for new US entity
     stripe_customer_id = Column(String, nullable=True)
     # for old AU entity
-    stripe_customer_id_au = Column(String, nullable=True)
+    stripe_customer_id_old = Column(String, nullable=True)
 
     # Verified phone numbers should be unique
     Index(

--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -237,7 +237,10 @@ class User(Base):
 
     # the stripe customer identifier if the user has donated to Couchers
     # e.g. cus_JjoXHttuZopv0t
+    # for new US entity
     stripe_customer_id = Column(String, nullable=True)
+    # for old AU entity
+    stripe_customer_id_au = Column(String, nullable=True)
 
     # Verified phone numbers should be unique
     Index(


### PR DESCRIPTION
Switch donations to go to the US entity.

The backend change is a tad hacky and quick. We'll disable the webhooks for the AU entity and ask people to transfer their subscriptions to the new entity.

There will be some more stuff coming up for this, and this can be discussed on slack.

**Backend checklist**
- [ ] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history