### PR TITLE
feat: Html Meta for markdown pages

### DIFF
--- a/app/web/components/HtmlMeta.tsx
+++ b/app/web/components/HtmlMeta.tsx
@@ -1,5 +1,6 @@
 import {
   HTML_META_DEFAULT_DESCRIPTION,
+  HTML_META_DEFAULT_SHARE_IMAGE,
   HTML_META_DEFAULT_TITLE,
   HTML_META_TITLE_SUFFIX,
 } from "features/constants";
@@ -9,6 +10,7 @@ interface HtmlMetaProps {
   title?: string;
   sharingTitle?: string;
   description?: string;
+  shareImage?: string;
   noSuffix?: boolean;
 }
 
@@ -16,6 +18,7 @@ export default function HtmlMeta({
   title = HTML_META_DEFAULT_TITLE,
   sharingTitle = title,
   description = HTML_META_DEFAULT_DESCRIPTION,
+  shareImage = HTML_META_DEFAULT_SHARE_IMAGE,
   noSuffix,
 }: HtmlMetaProps) {
   return (
@@ -54,6 +57,8 @@ export default function HtmlMeta({
       <meta name="description" content={description} />
       <meta property="og:description" content={description} />
       <meta name="twitter:description" content={description} />
+      <meta property="og:image" content={shareImage} />
+      <meta property="twitter:image" content={shareImage} />
     </Head>
   );
 }

--- a/app/web/features/constants.ts
+++ b/app/web/features/constants.ts
@@ -175,5 +175,7 @@ export const CHANGE_TIME = "Change time";
 // Default HtmlMeta
 export const HTML_META_TITLE_SUFFIX = " | Couchers.org Beta";
 export const HTML_META_DEFAULT_TITLE = "Couchers.org Beta";
+export const HTML_META_DEFAULT_SHARE_IMAGE =
+  "https://couchers.org/img/share.jpg";
 export const HTML_META_DEFAULT_DESCRIPTION =
   "The new alternative to Couchsurfing™. Free forever. Community-led. Non-profit. Modern.";

--- a/app/web/features/markdown/MarkdownPage.tsx
+++ b/app/web/features/markdown/MarkdownPage.tsx
@@ -142,7 +142,11 @@ export default function MarkdownPage({
 
   return (
     <>
-      <HtmlMeta title={frontmatter.title} />
+      <HtmlMeta
+        title={frontmatter.title}
+        description={frontmatter.description}
+        shareImage={frontmatter.share_image}
+      />
       <div className={classes.root}>
         <Typography gutterBottom>
           <Breadcrumbs aria-label="breadcrumb" className={classes.crumbs}>


### PR DESCRIPTION
- Description and share image set in html meta tags
- Set default share image

[x] Formatted my code with `yarn format && yarn lint --fix`
[x] There are no warnings from `yarn lint`
[x] There are no console warnings when running the app
[ ] Added any new components to storybook
[ ] Added tests where relevant
[x] All tests pass
[x] Clicked around my changes running locally and it works
[ ] Checked Desktop, Mobile and Tablet screen sizes