### PR TITLE
WIP: auth translation key tidy

### DIFF
--- a/app/web/.eslintrc.json
+++ b/app/web/.eslintrc.json
@@ -43,7 +43,9 @@
     //not using this right now
     "@next/next/no-img-element": "off",
     //this is ugly
-    "react/no-unescaped-entities": "off"
+    "react/no-unescaped-entities": "off",
+    // Prefer inferred types so that the code is as close to JS as possible
+    "@typescript-eslint/explicit-module-boundary-types": "off"
   },
   "overrides": [
     //allow any in stories

--- a/app/web/features/auth/AuthPage.tsx
+++ b/app/web/features/auth/AuthPage.tsx
@@ -157,7 +157,7 @@ export default function AuthPage() {
             rel="noopener noreferrer"
             href="https://vercel.com?utm_source=couchers-org&utm_campaign=oss"
           >
-            <img alt="Powered by Vercel" src={vercelLogo.src} />
+            <img alt={t("auth:vercel_logo_alt_text")} src={vercelLogo.src} />
           </a>
         )}
       </div>

--- a/app/web/features/auth/AuthPage.tsx
+++ b/app/web/features/auth/AuthPage.tsx
@@ -3,8 +3,9 @@ import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import DesktopAuthBg from "features/auth/resources/desktop-auth-bg.jpg";
 import MobileAuthBg from "features/auth/resources/mobile-auth-bg.jpg";
 import useAuthStyles from "features/auth/useAuthStyles";
+import { useTranslation } from "i18n";
+import { AUTH, GLOBAL } from "i18n/namespaces";
 import Link from "next/link";
-import { useTranslation } from "next-i18next";
 import CouchersLogo from "resources/CouchersLogo";
 import vercelLogo from "resources/vercel.svg";
 import { loginRoute, signupRoute } from "routes";
@@ -112,7 +113,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function AuthPage() {
-  const { t } = useTranslation(["auth", "global"]);
+  const { t } = useTranslation([AUTH, GLOBAL]);
   const classes = useStyles();
   const authClasses = useAuthStyles();
 

--- a/app/web/features/auth/AuthProvider.test.ts
+++ b/app/web/features/auth/AuthProvider.test.ts
@@ -5,13 +5,9 @@ import { service } from "service";
 
 import * as client from "../../service/client";
 import wrapper from "../../test/hookWrapper";
-import { addDefaultUser } from "../../test/utils";
+import { addDefaultUser, t } from "../../test/utils";
 import { useAuthContext } from "./AuthProvider";
-import {
-  JAILED_ERROR_MESSAGE,
-  LOGGED_OUT_ERROR_MESSAGE,
-  YOU_WERE_LOGGED_OUT,
-} from "./constants";
+import { JAILED_ERROR_MESSAGE, LOGGED_OUT_ERROR_MESSAGE } from "./constants";
 
 const logoutMock = service.user.logout as jest.Mock;
 const getIsJailedMock = service.jail.getIsJailed as jest.Mock;
@@ -40,7 +36,7 @@ describe("AuthProvider", () => {
       await handler({ message: LOGGED_OUT_ERROR_MESSAGE } as RpcError);
     });
     expect(result.current.authState.authenticated).toBe(false);
-    expect(result.current.authState.error).toBe(YOU_WERE_LOGGED_OUT);
+    expect(result.current.authState.error).toBe(t("auth:logged_out_message"));
   });
 
   it("sets an unauthenticatedErrorHandler function that redirects to jail if jailed correctly", async () => {

--- a/app/web/features/auth/AuthProvider.tsx
+++ b/app/web/features/auth/AuthProvider.tsx
@@ -1,10 +1,12 @@
 import { RpcError } from "grpc-web";
+import { useTranslation } from "i18n";
+import { AUTH } from "i18n/namespaces";
 import React, { Context, ReactNode, useContext, useEffect } from "react";
 import { jailRoute, loginRoute } from "routes";
 import { setUnauthenticatedErrorHandler } from "service/client";
 import useStablePush from "utils/useStablePush";
 
-import { JAILED_ERROR_MESSAGE, YOU_WERE_LOGGED_OUT } from "./constants";
+import { JAILED_ERROR_MESSAGE } from "./constants";
 import useAuthStore, { AuthStoreType } from "./useAuthStore";
 
 export const AuthContext = React.createContext<null | AuthStoreType>(null);
@@ -18,6 +20,7 @@ function useAppContext<T>(context: Context<T | null>) {
 }
 
 export default function AuthProvider({ children }: { children: ReactNode }) {
+  const { t } = useTranslation(AUTH);
   const store = useAuthStore();
 
   const push = useStablePush();
@@ -31,7 +34,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
       } else {
         // completely logged out
         await store.authActions.logout();
-        store.authActions.authError(YOU_WERE_LOGGED_OUT);
+        store.authActions.authError(t("logged_out_message"));
         push(loginRoute);
       }
     });
@@ -39,7 +42,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
     return () => {
       setUnauthenticatedErrorHandler(async () => {});
     };
-  }, [store.authActions, push]);
+  }, [store.authActions, push, t]);
 
   return <AuthContext.Provider value={store}>{children}</AuthContext.Provider>;
 }

--- a/app/web/features/auth/CommunityGuidelines.tsx
+++ b/app/web/features/auth/CommunityGuidelines.tsx
@@ -13,7 +13,8 @@ import Alert from "components/Alert";
 import Button from "components/Button";
 import { communityGuidelinesQueryKey } from "features/queryKeys";
 import { RpcError } from "grpc-web";
-import { useTranslation } from "next-i18next";
+import { useTranslation } from "i18n";
+import { AUTH, GLOBAL } from "i18n/namespaces";
 import { GetCommunityGuidelinesRes } from "proto/resources_pb";
 import React, { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
@@ -53,7 +54,7 @@ export default function CommunityGuidelines({
   className,
   title,
 }: CommunityGuidelinesProps) {
-  const { t } = useTranslation(["auth", "global"]);
+  const { t } = useTranslation([AUTH, GLOBAL]);
   const classes = useStyles();
   const isMounted = useIsMounted();
   const [completed, setCompleted] = useSafeState(isMounted, false);

--- a/app/web/features/auth/FeaturePreview.tsx
+++ b/app/web/features/auth/FeaturePreview.tsx
@@ -3,7 +3,8 @@ import { Alert as MuiAlert } from "@material-ui/lab/";
 import HtmlMeta from "components/HtmlMeta";
 import PageTitle from "components/PageTitle";
 import NotificationSettings from "features/auth/notifications/NotificationSettings";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "i18n";
+import { AUTH } from "i18n/namespaces";
 import makeStyles from "utils/makeStyles";
 
 const useStyles = makeStyles((theme) => ({
@@ -15,7 +16,7 @@ const useStyles = makeStyles((theme) => ({
 export default function FeaturePreview() {
   const classes = useStyles();
 
-  const { t } = useTranslation("auth");
+  const { t } = useTranslation(AUTH);
 
   return (
     <>

--- a/app/web/features/auth/NoFeaturePreviews.tsx
+++ b/app/web/features/auth/NoFeaturePreviews.tsx
@@ -1,4 +1,5 @@
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "i18n";
+import { AUTH } from "i18n/namespaces";
 import makeStyles from "utils/makeStyles";
 
 import Section from "./section/Section";
@@ -11,7 +12,7 @@ const useStyles = makeStyles((theme) => ({
 
 export function NoFeaturePreviews() {
   const classes = useStyles();
-  const { t } = useTranslation("auth");
+  const { t } = useTranslation(AUTH);
 
   return (
     <Section

--- a/app/web/features/auth/Settings.tsx
+++ b/app/web/features/auth/Settings.tsx
@@ -7,16 +7,9 @@ import { ChangePassword } from "features/auth/password";
 import Section from "features/auth/section/Section";
 import Timezone from "features/auth/timezone/Timezone";
 import Username from "features/auth/username/Username";
-import { GetAccountInfoRes } from "proto/account_pb";
+import { useTranslation } from "i18n";
 import makeStyles from "utils/makeStyles";
 
-import {
-  ACCOUNT_SETTINGS,
-  CHANGE_BIRTHDATE,
-  CHANGE_BIRTHDATE_CONTACT,
-  CHANGE_GENDER,
-  CHANGE_GENDER_CONTACT,
-} from "./constants";
 import useAccountInfo from "./useAccountInfo";
 
 const useStyles = makeStyles((theme) => ({
@@ -29,6 +22,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function Settings() {
+  const { t } = useTranslation("auth");
   const {
     data: accountInfo,
     error: accountInfoError,
@@ -39,17 +33,17 @@ export default function Settings() {
 
   return (
     <>
-      <HtmlMeta title={ACCOUNT_SETTINGS} />
-      <PageTitle>{ACCOUNT_SETTINGS}</PageTitle>
+      <HtmlMeta title={t("account_settings_page.title")} />
+      <PageTitle>{t("account_settings_page.title")}</PageTitle>
       <Section
         className={classes.section}
-        title={CHANGE_GENDER}
-        content={CHANGE_GENDER_CONTACT}
+        title={t("account_settings_page.gender_section.title")}
+        content={t("account_settings_page.gender_section.explanation")}
       />
       <Section
         className={classes.section}
-        title={CHANGE_BIRTHDATE}
-        content={CHANGE_BIRTHDATE_CONTACT}
+        title={t("account_settings_page.birth_date_section.title")}
+        content={t("account_settings_page.birth_date_section.explanation")}
       />
       {isAccountInfoLoading ? (
         <CircularProgress />
@@ -59,7 +53,7 @@ export default function Settings() {
         <>
           <Username
             className={classes.section}
-            {...(accountInfo as GetAccountInfoRes.AsObject)}
+            username={accountInfo.username}
           />
           <Timezone
             className={classes.section}
@@ -67,11 +61,12 @@ export default function Settings() {
           />
           <ChangeEmail
             className={classes.section}
-            {...(accountInfo as GetAccountInfoRes.AsObject)}
+            email={accountInfo.email}
+            hasPassword={accountInfo.hasPassword}
           />
           <ChangePassword
             className={classes.section}
-            {...(accountInfo as GetAccountInfoRes.AsObject)}
+            hasPassword={accountInfo.hasPassword}
           />
         </>
       ) : null}

--- a/app/web/features/auth/Settings.tsx
+++ b/app/web/features/auth/Settings.tsx
@@ -8,6 +8,7 @@ import Section from "features/auth/section/Section";
 import Timezone from "features/auth/timezone/Timezone";
 import Username from "features/auth/username/Username";
 import { useTranslation } from "i18n";
+import { AUTH } from "i18n/namespaces";
 import makeStyles from "utils/makeStyles";
 
 import useAccountInfo from "./useAccountInfo";
@@ -22,7 +23,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function Settings() {
-  const { t } = useTranslation("auth");
+  const { t } = useTranslation(AUTH);
   const {
     data: accountInfo,
     error: accountInfoError,

--- a/app/web/features/auth/Settings.tsx
+++ b/app/web/features/auth/Settings.tsx
@@ -55,7 +55,7 @@ export default function Settings() {
         <CircularProgress />
       ) : accountInfoError ? (
         <Alert severity="error">{accountInfoError.message}</Alert>
-      ) : (
+      ) : accountInfo ? (
         <>
           <Username
             className={classes.section}
@@ -63,7 +63,7 @@ export default function Settings() {
           />
           <Timezone
             className={classes.section}
-            {...(accountInfo as GetAccountInfoRes.AsObject)}
+            timezone={accountInfo.timezone}
           />
           <ChangeEmail
             className={classes.section}
@@ -74,7 +74,7 @@ export default function Settings() {
             {...(accountInfo as GetAccountInfoRes.AsObject)}
           />
         </>
-      )}
+      ) : null}
     </>
   );
 }

--- a/app/web/features/auth/constants.tsx
+++ b/app/web/features/auth/constants.tsx
@@ -17,10 +17,7 @@ export const CHANGE_GENDER_CONTACT =
   "Admins will be happy to change your gender label. Please contact support@couchers.org!";
 export const CHANGE_BIRTHDATE_CONTACT =
   "Admins will be happy to change your birthdate. Please contact support@couchers.org!";
-export const FULL_NAME = "Full name";
 export const LOGIN_PAGE = "Log in page";
-export const NO_SIGNUP =
-  "There is no signup in progress. Try starting from scratch.";
 export const REQUIRED = "Required";
 export const TERMS = "Terms";
 
@@ -31,9 +28,3 @@ export const YOU_WERE_LOGGED_OUT = "You were logged out.";
 export const JAILED_ERROR_MESSAGE = "Permission denied";
 // error message when not jailed (invalid token, logged out, etc)
 export const LOGGED_OUT_ERROR_MESSAGE = "Unauthorized";
-
-//Randomize Location Warning
-export const LOCATION_CONFIRM_TITLE = "Double check your map before continuing";
-export const LOCATION_CONFIRM_WARN =
-  "Make sure your home is not at the center of the circle, so people will not know the exact location. Click and drag the circle on the map to show people the approximate location of your home.";
-export const OKAY = "Okay";

--- a/app/web/features/auth/constants.tsx
+++ b/app/web/features/auth/constants.tsx
@@ -1,10 +1,3 @@
-export const TIMEZONE = "Timezone and localisation";
-export const YOUR_TIMEZONE = "Your timezone is";
-export const YOUR_LOCAL_TIME_IS =
-  ", based on this, your local time is approximately";
-export const TIMEZONE_HELPER =
-  "This time and timezone is determined based on your home location. Please report a bug if it is incorrect.";
-
 export const USERNAME_HELPER =
   "Your username is set when you create your account.";
 export const YOUR_USERNAME_IS = "Your username is";

--- a/app/web/features/auth/constants.tsx
+++ b/app/web/features/auth/constants.tsx
@@ -1,20 +1,4 @@
-export const USERNAME_HELPER =
-  "Your username is set when you create your account.";
-export const YOUR_USERNAME_IS = "Your username is";
-
-export const ACCOUNT_SETTINGS = "Account Settings";
-export const CHANGE_GENDER = "Change Gender";
-export const CHANGE_BIRTHDATE = "Change Birthdate";
-
-export const CHANGE_GENDER_CONTACT =
-  "Admins will be happy to change your gender label. Please contact support@couchers.org!";
-export const CHANGE_BIRTHDATE_CONTACT =
-  "Admins will be happy to change your birthdate. Please contact support@couchers.org!";
-export const LOGIN_PAGE = "Log in page";
-export const REQUIRED = "Required";
 export const TERMS = "Terms";
-
-export const YOU_WERE_LOGGED_OUT = "You were logged out.";
 
 // don't change these, these are set in the backend
 // error message when jailed

--- a/app/web/features/auth/email/ChangeEmail.tsx
+++ b/app/web/features/auth/email/ChangeEmail.tsx
@@ -4,7 +4,8 @@ import Button from "components/Button";
 import TextField from "components/TextField";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { RpcError } from "grpc-web";
-import { Trans, useTranslation } from "next-i18next";
+import { Trans, useTranslation } from "i18n";
+import { AUTH, GLOBAL } from "i18n/namespaces";
 import { GetAccountInfoRes } from "proto/account_pb";
 import { useForm } from "react-hook-form";
 import { useMutation } from "react-query";
@@ -23,7 +24,7 @@ type ChangeEmailProps = GetAccountInfoRes.AsObject & {
 };
 
 export default function ChangeEmail(props: ChangeEmailProps) {
-  const { t } = useTranslation(["auth", "global"]);
+  const { t } = useTranslation([AUTH, GLOBAL]);
   const { className } = props;
   const formClasses = useChangeDetailsFormStyles();
   const theme = useTheme();

--- a/app/web/features/auth/email/ChangeEmail.tsx
+++ b/app/web/features/auth/email/ChangeEmail.tsx
@@ -6,7 +6,6 @@ import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { RpcError } from "grpc-web";
 import { Trans, useTranslation } from "i18n";
 import { AUTH, GLOBAL } from "i18n/namespaces";
-import { GetAccountInfoRes } from "proto/account_pb";
 import { useForm } from "react-hook-form";
 import { useMutation } from "react-query";
 import { service } from "service";
@@ -19,13 +18,18 @@ interface ChangeEmailFormData {
   currentPassword?: string;
 }
 
-type ChangeEmailProps = GetAccountInfoRes.AsObject & {
+interface ChangeEmailProps {
+  email: string;
+  hasPassword: boolean;
   className?: string;
-};
+}
 
-export default function ChangeEmail(props: ChangeEmailProps) {
+export default function ChangeEmail({
+  className,
+  email,
+  hasPassword,
+}: ChangeEmailProps) {
   const { t } = useTranslation([AUTH, GLOBAL]);
-  const { className } = props;
   const formClasses = useChangeDetailsFormStyles();
   const theme = useTheme();
   const isMdOrWider = useMediaQuery(theme.breakpoints.up("md"));
@@ -60,7 +64,7 @@ export default function ChangeEmail(props: ChangeEmailProps) {
       <>
         <Typography variant="body1">
           <Trans t={t} i18nKey="auth:change_email_form.current_email_message">
-            Your email address is currently <b>{{ email: props.email }}</b>.
+            Your email address is currently <strong>{{ email }}</strong>.
           </Trans>
         </Typography>
         {changeEmailError && (
@@ -72,7 +76,7 @@ export default function ChangeEmail(props: ChangeEmailProps) {
           </Alert>
         )}
         <form className={formClasses.form} onSubmit={onSubmit}>
-          {props.hasPassword && (
+          {hasPassword && (
             <TextField
               id="currentPassword"
               inputRef={register({ required: true })}

--- a/app/web/features/auth/email/ConfirmChangeEmail.tsx
+++ b/app/web/features/auth/email/ConfirmChangeEmail.tsx
@@ -2,8 +2,9 @@ import { Typography } from "@material-ui/core";
 import Alert from "components/Alert";
 import StyledLink from "components/StyledLink";
 import { RpcError } from "grpc-web";
+import { useTranslation } from "i18n";
+import { AUTH } from "i18n/namespaces";
 import { useRouter } from "next/router";
-import { useTranslation } from "next-i18next";
 import { ConfirmChangeEmailRes, EmailConfirmationState } from "proto/auth_pb";
 import { useEffect } from "react";
 import { useMutation } from "react-query";
@@ -12,7 +13,7 @@ import { service } from "service";
 import stringOrFirstString from "utils/stringOrFirstString";
 
 export default function ConfirmChangeEmail() {
-  const { t } = useTranslation("auth");
+  const { t } = useTranslation(AUTH);
 
   const router = useRouter();
   const changeToken = stringOrFirstString(router.query.token);

--- a/app/web/features/auth/jail/Jail.tsx
+++ b/app/web/features/auth/jail/Jail.tsx
@@ -9,13 +9,13 @@ import { useAuthContext } from "features/auth/AuthProvider";
 import CommunityGuidelinesSection from "features/auth/jail/CommunityGuidelinesSection";
 import LocationSection from "features/auth/jail/LocationSection";
 import TOSSection from "features/auth/jail/TOSSection";
+import { useTranslation } from "i18n";
 import { JailInfoRes } from "proto/jail_pb";
 import React, { useEffect, useState } from "react";
 import { loginRoute } from "routes";
 import { service } from "service";
 import makeStyles from "utils/makeStyles";
 
-import { MORE_INFO_REQUIRED, PLEASE_CHECK_JAIL } from "./constants";
 import PasswordSection from "./PasswordSection";
 
 const useStyles = makeStyles((theme) => ({
@@ -24,6 +24,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function Jail() {
+  const { t } = useTranslation("auth");
   const classes = useStyles(makeStyles);
 
   const { authState, authActions } = useAuthContext();
@@ -54,10 +55,12 @@ export default function Jail() {
   return (
     <>
       {!isJailed && <Redirect to="/" />}
-      <HtmlMeta title={MORE_INFO_REQUIRED} />
-      <PageTitle>{MORE_INFO_REQUIRED}</PageTitle>
+      <HtmlMeta title={t("jail.title")} />
+      <PageTitle>{t("jail.title")}</PageTitle>
       {authError && <Alert severity="error">{authError}</Alert>}
-      <TextBody className={classes.bottomMargin}>{PLEASE_CHECK_JAIL}</TextBody>
+      <TextBody className={classes.bottomMargin}>
+        {t("jail.description")}
+      </TextBody>
       <Backdrop open={loading || authLoading}>
         <CircularProgress />
       </Backdrop>

--- a/app/web/features/auth/jail/Jail.tsx
+++ b/app/web/features/auth/jail/Jail.tsx
@@ -10,6 +10,7 @@ import CommunityGuidelinesSection from "features/auth/jail/CommunityGuidelinesSe
 import LocationSection from "features/auth/jail/LocationSection";
 import TOSSection from "features/auth/jail/TOSSection";
 import { useTranslation } from "i18n";
+import { AUTH } from "i18n/namespaces";
 import { JailInfoRes } from "proto/jail_pb";
 import React, { useEffect, useState } from "react";
 import { loginRoute } from "routes";
@@ -24,7 +25,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function Jail() {
-  const { t } = useTranslation("auth");
+  const { t } = useTranslation(AUTH);
   const classes = useStyles(makeStyles);
 
   const { authState, authActions } = useAuthContext();

--- a/app/web/features/auth/jail/LocationSection.tsx
+++ b/app/web/features/auth/jail/LocationSection.tsx
@@ -6,7 +6,8 @@ import EditLocationMap, {
   ApproximateLocation,
 } from "components/EditLocationMap";
 import TextBody from "components/TextBody";
-import { useTranslation } from "next-i18next";
+import { useTranslation } from "i18n";
+import { AUTH, GLOBAL } from "i18n/namespaces";
 import React, { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { service } from "service";
@@ -25,7 +26,7 @@ export default function LocationSection({
   updateJailed,
   className,
 }: LocationSectionProps) {
-  const { t } = useTranslation(["auth", "global"]);
+  const { t } = useTranslation([AUTH, GLOBAL]);
   const [completed, setCompleted] = useState(false);
   const [error, setError] = useState("");
 

--- a/app/web/features/auth/jail/LocationSection.tsx
+++ b/app/web/features/auth/jail/LocationSection.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from "@material-ui/core";
+import { Typography } from "@material-ui/core";
 import * as Sentry from "@sentry/react";
 import Alert from "components/Alert";
 import Button from "components/Button";
@@ -11,8 +11,6 @@ import React, { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { service } from "service";
 import isGrpcError from "utils/isGrpcError";
-
-import { LOCATION_SECTION_HEADING } from "./constants";
 
 interface LocationInfo {
   location: ApproximateLocation;
@@ -61,8 +59,10 @@ export default function LocationSection({
 
   return (
     <>
-      <Typography variant="h2">{LOCATION_SECTION_HEADING}</Typography>
-      <Box className={className}>
+      <Typography variant="h2">
+        {t("auth:jail.location_section.title")}
+      </Typography>
+      <div className={className}>
         {error && <Alert severity="error">{error}</Alert>}
         <Controller
           name="location"
@@ -89,15 +89,17 @@ export default function LocationSection({
 
         <TextBody>
           <Button onClick={save} disabled={completed}>
-            {completed ? "Thanks!" : "Save"}
+            {!completed
+              ? t("auth:jail.location_section.submit_button.active_text")
+              : t("auth:jail.location_section.submit_button.inactive_text")}
           </Button>
           {completed && (
             <Button component="a" onClick={save}>
-              Re-submit
+              {t("auth:jail.location_section.resubmit_button_text")}
             </Button>
           )}
         </TextBody>
-      </Box>
+      </div>
     </>
   );
 }

--- a/app/web/features/auth/jail/PasswordSection.tsx
+++ b/app/web/features/auth/jail/PasswordSection.tsx
@@ -4,7 +4,8 @@ import Button from "components/Button";
 import TextField from "components/TextField";
 import useChangeDetailsFormStyles from "features/auth/useChangeDetailsFormStyles";
 import { RpcError } from "grpc-web";
-import { useTranslation } from "next-i18next";
+import { useTranslation } from "i18n";
+import { AUTH, GLOBAL } from "i18n/namespaces";
 import { useForm } from "react-hook-form";
 import { useMutation } from "react-query";
 import { service } from "service";
@@ -28,7 +29,7 @@ export default function PasswordSection({
   className,
 }: PasswordSectionProps) {
   const classes = useChangeDetailsFormStyles();
-  const { t } = useTranslation(["auth", "global"]);
+  const { t } = useTranslation([AUTH, GLOBAL]);
 
   const isMdOrWider = useMediaQuery(theme.breakpoints.up("md"));
 

--- a/app/web/features/auth/jail/TOSSection.tsx
+++ b/app/web/features/auth/jail/TOSSection.tsx
@@ -1,11 +1,9 @@
 import { Typography } from "@material-ui/core";
 import Button from "components/Button";
 import TOSLink from "components/TOSLink";
-import { useTranslation } from "next-i18next";
+import { Trans, useTranslation } from "i18n";
 import { useState } from "react";
 import { service } from "service";
-
-import { JAIL_TOS_TEXT } from "./constants";
 
 interface TOSSectionProps {
   updateJailed: () => void;
@@ -16,7 +14,7 @@ export default function TOSSection({
   updateJailed,
   className,
 }: TOSSectionProps) {
-  const { t } = useTranslation("global");
+  const { t } = useTranslation(["auth", "global"]);
   const [completed, setCompleted] = useState(false);
   const [loading, setLoading] = useState(false);
 
@@ -35,11 +33,13 @@ export default function TOSSection({
   return (
     <div className={className}>
       <Typography variant="body1">
-        {JAIL_TOS_TEXT}
-        <TOSLink />.
+        <Trans t={t} i18nKey="auth:jail.terms_of_service_section.description">
+          We've update our Terms of Service. To continue, please read and accept
+          the new <TOSLink />
+        </Trans>
       </Typography>
       <Button loading={loading} onClick={accept} disabled={completed}>
-        {completed ? t("thanks") : t("accept")}
+        {completed ? t("global:thanks") : t("global:accept")}
       </Button>
     </div>
   );

--- a/app/web/features/auth/jail/TOSSection.tsx
+++ b/app/web/features/auth/jail/TOSSection.tsx
@@ -2,6 +2,7 @@ import { Typography } from "@material-ui/core";
 import Button from "components/Button";
 import TOSLink from "components/TOSLink";
 import { Trans, useTranslation } from "i18n";
+import { AUTH, GLOBAL } from "i18n/namespaces";
 import { useState } from "react";
 import { service } from "service";
 
@@ -14,7 +15,7 @@ export default function TOSSection({
   updateJailed,
   className,
 }: TOSSectionProps) {
-  const { t } = useTranslation(["auth", "global"]);
+  const { t } = useTranslation([AUTH, GLOBAL]);
   const [completed, setCompleted] = useState(false);
   const [loading, setLoading] = useState(false);
 

--- a/app/web/features/auth/jail/constants.ts
+++ b/app/web/features/auth/jail/constants.ts
@@ -1,6 +1,0 @@
-export const JAIL_TOS_TEXT =
-  "We've update our Terms of Service. To continue, please read and accept the new ";
-export const LOCATION_SECTION_HEADING = "Please add your location";
-export const PLEASE_CHECK_JAIL =
-  "Please check the following in order to continue.";
-export const MORE_INFO_REQUIRED = "More information required";

--- a/app/web/features/auth/locales/en.json
+++ b/app/web/features/auth/locales/en.json
@@ -1,160 +1,172 @@
 {
-    "change_email_form": {
-        "title": "Change Email",
-        "current_email_message": "Your email address is currently <1>{{email}}</1>.",
-        "success_message": "Your email change has been received. Check your new email to complete the change.",
-        "current_password": "Current password",
-        "new_email": "New email"
-    },
-    "change_email_confirmation": {
-        "change_in_progress": "Email change in progress...",
-        "success_message": "Your email has been changed successfully!",
-        "requires_confirmation_from_new_email": "Thank you for confirming your old email address. To complete the change, you still need to confirm your new email address.",
-        "requires_confirmation_from_old_email": "Thank you for confirming your new email address. To complete the change, you still need to confirm your old email address.",
-        "invalid_confirmation_state": "Invalid email confirmation state",
-        "error_message": "Error changing email: {{message}}"
-    },
-    "change_password_form": {
-        "title": "Change password",
-        "confirm_password": "Confirm password",
-        "password_changed_success": "Your new password has been set and a notification was sent to your email.",
-        "old_password": "Old password",
-        "new_password": "New password",
-        "password_mismatch_error": "This does not match the new password you typed above."
-    },
-    "jail_set_password_form": {
-        "title": "Set a password",
-        "explanation": "You have not previously set a password for your account. Please create one now to continue."
-    },
-    "reset_password_form": {
-        "enter_email": "Enter your username/email",
-        "success_message": "Check your email for a reset password link!"
-    },
-    "login_page": {
-        "title": "Log in",
-        "header": "Welcome back!",
-        "no_account_prompt": "No account yet? <2>$t(global:sign_up)</2>"
-    },
-    "basic_sign_up_form": {
-        "header": "Let's get started!",
-        "existing_user_prompt": "Already have an account? <2>$t(global:login)</2>",
-        "sign_up_agreement_explainer": "By continuing, you agree to our <2>Terms of Service</2>, including our cookie, email, and data handling policies."
-    },
-    "account_form": {
-        "header": "Your account details",
-        "username": {
-            "field_label": "Username",
-            "required_error": "Enter your username",
-            "username_taken_error": "This username is taken.",
-            "validation_error": "Username can only have numbers or _, starting with a letter."
-        },
-        "password": {
-            "field_label": "Password",
-            "required_error": "Enter a password",
-            "validation_error": "Password must be between 8 and 256 characters and not be extremely common."
-        },
-        "birthday": {
-            "field_label": "Birthday",
-            "required_error": "Enter your birthdate",
-            "validation_error": "Must be a valid date in the past."
-        },
-        "hosting_status": {
-            "field_label": "Hosting status",
-            "can_host": "Can host",
-            "maybe": "May host",
-            "cant_host": "Can't host"
-        },
-        "gender": {
-            "field_label": "I identify as ...",
-            "required_error": "Please select your gender identity",
-            "man": "Man",
-            "non_binary": "Non-binary",
-            "woman": "Woman"
-        },
-        "tos_prompt": "To continue, please read and accept the <1></1>.",
-        "tos_accept_label": "I Accept the $t(global:terms_of_service)."
-    },
-    "basic_form": {
-        "name": {
-            "field_label": "Your name",
-            "empty_error": "Please enter your name",
-            "required_error": "Name can't be just white space."
-        },
-        "email": {
-            "field_label": "Email",
-            "empty_error": "Please enter a valid email address",
-            "required_error": "Email can't be empty."
-        }
-    },
-    "location": {
-        "field_label": "Your location",
-        "validation_error": "Please select a valid location."
-    },
-    "community_guidelines_form": {
-        "header": "Community Guidelines",
-        "guideline": {
-            "checkbox_label": "Okay, got it",
-            "required_error": "All checkboxes are required"
-        }
-    },
-    "feedback_form": {
-        "header": "Have your say"
-    },
-    "sign_up_completed_title": "Thank you for signing up!",
-    "sign_up_completed_prompt": "We have sent an email with a verification link to your email address. Please click the link to activate your account.",
-    "sign_up_confirmed_prompt": "You're all done! If you are not redirected, try logging in.",
-    "unhandled_sign_up_state": "Unhandled signup flow state.",
-    "reset_password_success": "Your password has been reset successfully! You will now be emailed a magic link when you log in with your username or email.",
-    "login_prompt": "Click here to log in",
-    "about_us": "About us",
-    "accept": "Accept",
-    "timezone": "Timezone and localisation",
-    "your_timezone": "Your timezone is",
-    "your_local_time_is": ", based on this, your local time is approximately",
-    "timezone_helper": "This time and timezone is determined based on your home location. Please report a bug if it is incorrect.",
-    "username_helper": "Your username is set when you create your account.",
-    "your_username_is": "Your username is",
-    "account_settings": "Account Settings",
-    "change_gender": "Change Gender",
-    "change_birthdate": "Change Birthdate",
-    "change_gender_contact": "Admins will be happy to change your gender label. Please contact support@couchers.org!",
-    "change_birthdate_contact": "Admins will be happy to change your birthdate. Please contact support@couchers.org!",
-    "full_name": "Full name",
-    "introduction_subtitle": "Free forever. Community-led. Non-profit. Modern.",
-    "introduction_title": "Join and help grow the new alternative to Couchsurfing™",
-    "no_signup": "There is no signup in progress. Try starting from scratch.",
-    "reset_password": "Reset password",
-    "reset_password_error": "Error resetting password: {{message}}",
-    "submit": "Submit",
-    "terms": "Terms",
-    "thanks": "Thanks!",
-    "you_were_logged_out": "You were logged out.",
-    "jailed_error_message": "Permission denied",
-    "logged_out_error_message": "Unauthorized",
-    "location_confirm_title": "Double check your map before continuing",
-    "location_confirm_warn": "Make sure your home is not at the center of the circle, so people will not know the exact location. Click and drag the circle on the map to show people the approximate location of your home.",
-    "okay": "Okay",
-    "jail": {
-        "jail_tos_text": "We've update our Terms of Service. To continue, please read and accept the new ",
-        "location_section_heading": "Please add your location",
-        "please_check_jail": "Please check the following in order to continue.",
-        "more_info_required": "More information required"
-    },
-    "check_email_for_link": "Check your email for a link to log in! :)",
-    "email_username": "Email/Username",
-    "password": "Password",
-    "remember_me": "Remember me",
-    "forgot_password": "Forgot password?",
-    "feature_preview": {
-        "title": "Feature Preview",
-        "explanation": "This page allows you to try out features that are still in development before they are quite ready for use by everyone.",
-        "disclaimer": "Please keep in mind that these features are experimental. They may not work as intended, and they may change rapidly as we develop them, feel free to give feedback on our forum. Please report any bugs!",
-        "no_previews": {
-            "title": "No features currently in preview",
-            "explanation": "There are currently no active features in preview, please check back later!"
-        }
-    },
-    "notification_settings": {
-        "title": "Notification settings"
+  "change_email_form": {
+    "title": "Change Email",
+    "current_email_message": "Your email address is currently <1>{{email}}</1>.",
+    "success_message": "Your email change has been received. Check your new email to complete the change.",
+    "current_password": "Current password",
+    "new_email": "New email"
+  },
+  "change_email_confirmation": {
+    "change_in_progress": "Email change in progress...",
+    "success_message": "Your email has been changed successfully!",
+    "requires_confirmation_from_new_email": "Thank you for confirming your old email address. To complete the change, you still need to confirm your new email address.",
+    "requires_confirmation_from_old_email": "Thank you for confirming your new email address. To complete the change, you still need to confirm your old email address.",
+    "invalid_confirmation_state": "Invalid email confirmation state",
+    "error_message": "Error changing email: {{message}}"
+  },
+  "change_password_form": {
+    "title": "Change password",
+    "confirm_password": "Confirm password",
+    "password_changed_success": "Your new password has been set and a notification was sent to your email.",
+    "old_password": "Old password",
+    "new_password": "New password",
+    "password_mismatch_error": "This does not match the new password you typed above."
+  },
+  "jail_set_password_form": {
+    "title": "Set a password",
+    "explanation": "You have not previously set a password for your account. Please create one now to continue."
+  },
+  "reset_password_form": {
+    "enter_email": "Enter your username/email",
+    "success_message": "Check your email for a reset password link!"
+  },
+  "login_page": {
+    "title": "Log in",
+    "header": "Welcome back!",
+    "no_account_prompt": "No account yet? <2>$t(global:sign_up)</2>",
+    "form": {
+      "username_field_label": "Email/Username",
+      "password_field_label": "Password",
+      "no_password_login_prompt": "Check your email for a link to log in! :)",
+      "you_were_logged_out": "You were logged out.",
+      "remember_me": "Remember me",
+      "forgot_password": "Forgot password?"
     }
+  },
+  "basic_sign_up_form": {
+    "header": "Let's get started!",
+    "existing_user_prompt": "Already have an account? <2>$t(global:login)</2>",
+    "sign_up_agreement_explainer": "By continuing, you agree to our <2>Terms of Service</2>, including our cookie, email, and data handling policies."
+  },
+  "account_form": {
+    "header": "Your account details",
+    "username": {
+      "field_label": "Username",
+      "required_error": "Enter your username",
+      "username_taken_error": "This username is taken.",
+      "validation_error": "Username can only have numbers or _, starting with a letter."
+    },
+    "password": {
+      "field_label": "Password",
+      "required_error": "Enter a password",
+      "validation_error": "Password must be between 8 and 256 characters and not be extremely common."
+    },
+    "birthday": {
+      "field_label": "Birthday",
+      "required_error": "Enter your birthdate",
+      "validation_error": "Must be a valid date in the past."
+    },
+    "hosting_status": {
+      "field_label": "Hosting status",
+      "can_host": "Can host",
+      "maybe": "May host",
+      "cant_host": "Can't host"
+    },
+    "gender": {
+      "field_label": "I identify as ...",
+      "required_error": "Please select your gender identity",
+      "man": "Man",
+      "non_binary": "Non-binary",
+      "woman": "Woman"
+    },
+    "tos_prompt": "To continue, please read and accept the <1></1>.",
+    "tos_accept_label": "I Accept the $t(global:terms_of_service)."
+  },
+  "basic_form": {
+    "name": {
+      "field_label": "Your name",
+      "empty_error": "Please enter your name",
+      "required_error": "Name can't be just white space."
+    },
+    "email": {
+      "field_label": "Email",
+      "empty_error": "Please enter a valid email address",
+      "required_error": "Email can't be empty."
+    }
+  },
+  "location": {
+    "field_label": "Your location",
+    "validation_error": "Please select a valid location."
+  },
+  "community_guidelines_form": {
+    "header": "Community Guidelines",
+    "guideline": {
+      "checkbox_label": "Okay, got it",
+      "required_error": "All checkboxes are required"
+    }
+  },
+  "feedback_form": {
+    "header": "Have your say"
+  },
+  "jail": {
+    "title": "More information required",
+    "description": "Please check the following in order to continue.",
+    "terms_of_service_section": {
+      "description": "We've update our Terms of Service. To continue, please read and accept the new <1></1>."
+    },
+    "location_section": {
+      "title": "Please add your location",
+      "submit_button": {
+        "active_text": "Save",
+        "inactive_text": "Thanks!"
+      },
+      "resubmit_button_text": "Re-submit"
+    }
+  },
+  "sign_up_completed_title": "Thank you for signing up!",
+  "sign_up_completed_prompt": "We have sent an email with a verification link to your email address. Please click the link to activate your account.",
+  "sign_up_confirmed_prompt": "You're all done! If you are not redirected, try logging in.",
+  "unhandled_sign_up_state": "Unhandled signup flow state.",
+  "reset_password_success": "Your password has been reset successfully! You will now be emailed a magic link when you log in with your username or email.",
+  "login_prompt": "Click here to log in",
+  "about_us": "About us",
+  "introduction_subtitle": "Free forever. Community-led. Non-profit. Modern.",
+  "introduction_title": "Join and help grow the new alternative to Couchsurfing™",
+  "reset_password": "Reset password",
+  "reset_password_error": "Error resetting password: {{message}}",
+  "timezone_section": {
+    "title": "Timezone and localisation",
+    "description": "Your timezone is <1>{{timezone}}</1>. Based on this, your local time is approximately <4>{{time}}</4>.",
+    "timezone_explanation": "This time and timezone is determined based on your home location. Please report a bug if it is incorrect."
+  },
+
+  "username_helper": "Your username is set when you create your account.",
+  "your_username_is": "Your username is",
+  "account_settings": "Account Settings",
+  "change_gender": "Change Gender",
+  "change_birthdate": "Change Birthdate",
+  "change_gender_contact": "Admins will be happy to change your gender label. Please contact support@couchers.org!",
+  "change_birthdate_contact": "Admins will be happy to change your birthdate. Please contact support@couchers.org!",
+  "vercel_logo_alt_text": "Powered by Vercel",
+
+  "feature_preview": {
+    "title": "Feature Preview",
+    "explanation": "This page allows you to try out features that are still in development before they are quite ready for use by everyone.",
+    "disclaimer": "Please keep in mind that these features are experimental. They may not work as intended, and they may change rapidly as we develop them, feel free to give feedback on our forum. Please report any bugs!",
+    "no_previews": {
+      "title": "No features currently in preview",
+      "explanation": "There are currently no active features in preview, please check back later!"
+    }
+  },
+  "notification_settings": {
+    "title": "Notification settings",
+    "status": {
+      "enabled_message": "The new notification system is currently <2>enabled</2> for your account.",
+      "disabled_message": "The new notification system is currently <2>disabled</2> for your account."
+    },
+    "action_button": {
+      "enable_text": "Enable new notifications system",
+      "disable_text": "Disable new notifications system"
+    }
+  }
 }

--- a/app/web/features/auth/locales/en.json
+++ b/app/web/features/auth/locales/en.json
@@ -134,16 +134,6 @@
   "introduction_title": "Join and help grow the new alternative to Couchsurfing™",
   "reset_password": "Reset password",
   "reset_password_error": "Error resetting password: {{message}}",
-  "timezone_section": {
-    "title": "Timezone and localisation",
-    "description": "Your timezone is <1>{{timezone}}</1>. Based on this, your local time is approximately <4>{{time}}</4>.",
-    "explanation": "This time and timezone is determined based on your home location. Please report a bug if it is incorrect."
-  },
-  "username_section": {
-    "title": "Username",
-    "description": "Your username is <1>{{username}}</1>.",
-    "explanation": "Your username is set when you create your account."
-  },
   "account_settings_page": {
     "title": "Account settings",
     "gender_section": {
@@ -153,6 +143,16 @@
     "birth_date_section": {
       "title": "Change birthdate",
       "explanation": "Admins will be happy to change your birthdate. Please contact support@couchers.org!"
+    },
+    "timezone_section": {
+      "title": "Timezone and localisation",
+      "description": "Your timezone is <1>{{timezone}}</1>. Based on this, your local time is approximately <4>{{time}}</4>.",
+      "explanation": "This time and timezone is determined based on your home location. Please report a bug if it is incorrect."
+    },
+    "username_section": {
+      "title": "Username",
+      "description": "Your username is <1>{{username}}</1>.",
+      "explanation": "Your username is set when you create your account."
     }
   },
 

--- a/app/web/features/auth/locales/en.json
+++ b/app/web/features/auth/locales/en.json
@@ -33,7 +33,7 @@
   "login_page": {
     "title": "Log in",
     "header": "Welcome back!",
-    "no_account_prompt": "No account yet? <2>$t(global:sign_up)</2>",
+    "no_account_prompt": "No account yet? <2>Sign up</2>",
     "form": {
       "username_field_label": "Email/Username",
       "password_field_label": "Password",
@@ -44,7 +44,7 @@
   },
   "basic_sign_up_form": {
     "header": "Let's get started!",
-    "existing_user_prompt": "Already have an account? <2>$t(global:login)</2>",
+    "existing_user_prompt": "Already have an account? <2>Log in</2>",
     "sign_up_agreement_explainer": "By continuing, you agree to our <2>Terms of Service</2>, including our cookie, email, and data handling policies."
   },
   "account_form": {
@@ -79,7 +79,7 @@
       "woman": "Woman"
     },
     "tos_prompt": "To continue, please read and accept the <1></1>.",
-    "tos_accept_label": "I Accept the $t(global:terms_of_service)."
+    "tos_accept_label": "I Accept the Terms of Service."
   },
   "basic_form": {
     "name": {

--- a/app/web/features/auth/locales/en.json
+++ b/app/web/features/auth/locales/en.json
@@ -38,7 +38,6 @@
       "username_field_label": "Email/Username",
       "password_field_label": "Password",
       "no_password_login_prompt": "Check your email for a link to log in! :)",
-      "you_were_logged_out": "You were logged out.",
       "remember_me": "Remember me",
       "forgot_password": "Forgot password?"
     }
@@ -123,6 +122,7 @@
       "resubmit_button_text": "Re-submit"
     }
   },
+  "logged_out_message": "You were logged out.",
   "sign_up_completed_title": "Thank you for signing up!",
   "sign_up_completed_prompt": "We have sent an email with a verification link to your email address. Please click the link to activate your account.",
   "sign_up_confirmed_prompt": "You're all done! If you are not redirected, try logging in.",
@@ -137,16 +137,25 @@
   "timezone_section": {
     "title": "Timezone and localisation",
     "description": "Your timezone is <1>{{timezone}}</1>. Based on this, your local time is approximately <4>{{time}}</4>.",
-    "timezone_explanation": "This time and timezone is determined based on your home location. Please report a bug if it is incorrect."
+    "explanation": "This time and timezone is determined based on your home location. Please report a bug if it is incorrect."
+  },
+  "username_section": {
+    "title": "Username",
+    "description": "Your username is <1>{{username}}</1>.",
+    "explanation": "Your username is set when you create your account."
+  },
+  "account_settings_page": {
+    "title": "Account settings",
+    "gender_section": {
+      "title": "Change gender",
+      "explanation": "Admins will be happy to change your gender label. Please contact support@couchers.org!"
+    },
+    "birth_date_section": {
+      "title": "Change birthdate",
+      "explanation": "Admins will be happy to change your birthdate. Please contact support@couchers.org!"
+    }
   },
 
-  "username_helper": "Your username is set when you create your account.",
-  "your_username_is": "Your username is",
-  "account_settings": "Account Settings",
-  "change_gender": "Change Gender",
-  "change_birthdate": "Change Birthdate",
-  "change_gender_contact": "Admins will be happy to change your gender label. Please contact support@couchers.org!",
-  "change_birthdate_contact": "Admins will be happy to change your birthdate. Please contact support@couchers.org!",
   "vercel_logo_alt_text": "Powered by Vercel",
 
   "feature_preview": {

--- a/app/web/features/auth/login/Login.test.tsx
+++ b/app/web/features/auth/login/Login.test.tsx
@@ -4,7 +4,6 @@ import { service } from "service";
 import wrapper from "test/hookWrapper";
 import { assertErrorAlert, t } from "test/utils";
 
-import { EMAIL_USERNAME } from "./constants";
 import Login from "./Login";
 
 const checkUsernameMock = service.auth.checkUsername as jest.MockedFunction<
@@ -19,7 +18,12 @@ it("shows the known gRPC error from the API", async () => {
   });
   render(<Login />, { wrapper });
 
-  userEvent.type(await screen.findByLabelText(EMAIL_USERNAME), "invalid");
+  userEvent.type(
+    await screen.findByLabelText(
+      t("auth:login_page.form.username_field_label")
+    ),
+    "invalid"
+  );
   userEvent.click(screen.getByRole("button", { name: t("global:continue") }));
 
   await assertErrorAlert(errorMessage);
@@ -31,7 +35,12 @@ it("shows the fatal error message for unknown errors", async () => {
   });
   render(<Login />, { wrapper });
 
-  userEvent.type(await screen.findByLabelText(EMAIL_USERNAME), "invalid");
+  userEvent.type(
+    await screen.findByLabelText(
+      t("auth:login_page.form.username_field_label")
+    ),
+    "invalid"
+  );
   userEvent.click(screen.getByRole("button", { name: t("global:continue") }));
 
   await assertErrorAlert(t("global:fatal_error_message"));

--- a/app/web/features/auth/login/Login.tsx
+++ b/app/web/features/auth/login/Login.tsx
@@ -95,7 +95,7 @@ export default function Login() {
             rel="noopener noreferrer"
             href="https://vercel.com?utm_source=couchers-org&utm_campaign=oss"
           >
-            <img alt="Powered by Vercel" src={vercelLogo.src} />
+            <img alt={t("auth:vercel_logo_alt_text")} src={vercelLogo.src} />
           </a>
         )}
       </div>

--- a/app/web/features/auth/login/Login.tsx
+++ b/app/web/features/auth/login/Login.tsx
@@ -3,15 +3,16 @@ import classNames from "classnames";
 import Alert from "components/Alert";
 import HtmlMeta from "components/HtmlMeta";
 import StyledLink from "components/StyledLink";
+import { Trans, useTranslation } from "i18n";
+import { AUTH, GLOBAL } from "i18n/namespaces";
 import { useRouter } from "next/router";
-import { Trans, useTranslation } from "next-i18next";
 import { useEffect } from "react";
 import CouchersLogo from "resources/CouchersLogo";
 import vercelLogo from "resources/vercel.svg";
+import { signupRoute } from "routes";
 import makeStyles from "utils/makeStyles";
 import stringOrFirstString from "utils/stringOrFirstString";
 
-import { signupRoute } from "../../../routes";
 import { useAuthContext } from "../AuthProvider";
 import useAuthStyles from "../useAuthStyles";
 import LoginForm from "./LoginForm";
@@ -19,7 +20,7 @@ import LoginForm from "./LoginForm";
 const useStyles = makeStyles((theme) => ({}));
 
 export default function Login() {
-  const { t } = useTranslation(["auth", "global"]);
+  const { t } = useTranslation([AUTH, GLOBAL]);
   const { authState, authActions } = useAuthContext();
   const authenticated = authState.authenticated;
   const error = authState.error;

--- a/app/web/features/auth/login/LoginForm.tsx
+++ b/app/web/features/auth/login/LoginForm.tsx
@@ -16,15 +16,6 @@ import isGrpcError from "utils/isGrpcError";
 import makeStyles from "utils/makeStyles";
 import { lowercaseAndTrimField } from "utils/validation";
 
-import {
-  CHECK_EMAIL,
-  CONTINUE,
-  EMAIL_USERNAME,
-  FORGOT_PASSWORD,
-  PASSWORD,
-  REMEMBER_ME,
-} from "./constants";
-
 const useStyles = makeStyles((theme) => ({
   rememberSwitch: {
     display: "block",
@@ -97,12 +88,12 @@ export default function LoginForm() {
     <>
       {sent && (
         <TextBody className={authClasses.feedbackMessage}>
-          {CHECK_EMAIL}
+          {t("auth:login_page.form.no_password_login_prompt")}
         </TextBody>
       )}
       <form className={authClasses.form} onSubmit={onSubmit}>
         <InputLabel className={authClasses.formLabel} htmlFor="username">
-          {EMAIL_USERNAME}
+          {t("auth:login_page.form.username_field_label")}
         </InputLabel>
         <TextField
           className={authClasses.formField}
@@ -116,7 +107,7 @@ export default function LoginForm() {
         {!loginWithLink && (
           <>
             <InputLabel className={authClasses.formLabel} htmlFor="password">
-              {PASSWORD}
+              {t("auth:login_page.form.password_field_label")}
             </InputLabel>
             <TextField
               className={authClasses.formField}
@@ -138,10 +129,12 @@ export default function LoginForm() {
           <FormControlLabel
             className={classes.rememberSwitch}
             control={<Switch size="small" />}
-            label={REMEMBER_ME}
+            label={t("auth:login_page.form.remember_me")}
           />
           {!loginWithLink && (
-            <StyledLink href={resetPasswordRoute}>{FORGOT_PASSWORD}</StyledLink>
+            <StyledLink href={resetPasswordRoute}>
+              {t("auth:login_page.form.forgot_password")}
+            </StyledLink>
           )}
         </div>
         <Button
@@ -155,7 +148,7 @@ export default function LoginForm() {
           type="submit"
           variant="contained"
         >
-          {CONTINUE}
+          {t("global:continue")}
         </Button>
       </form>
     </>

--- a/app/web/features/auth/login/LoginForm.tsx
+++ b/app/web/features/auth/login/LoginForm.tsx
@@ -6,7 +6,8 @@ import TextBody from "components/TextBody";
 import TextField from "components/TextField";
 import { useAuthContext } from "features/auth/AuthProvider";
 import useAuthStyles from "features/auth/useAuthStyles";
-import { useTranslation } from "next-i18next";
+import { useTranslation } from "i18n";
+import { AUTH, GLOBAL } from "i18n/namespaces";
 import { LoginRes } from "proto/auth_pb";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
@@ -36,7 +37,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function LoginForm() {
-  const { t } = useTranslation(["auth", "global"]);
+  const { t } = useTranslation([AUTH, GLOBAL]);
   const classes = useStyles();
   const authClasses = useAuthStyles();
   const { authState, authActions } = useAuthContext();

--- a/app/web/features/auth/login/constants.ts
+++ b/app/web/features/auth/login/constants.ts
@@ -1,6 +1,0 @@
-export const CHECK_EMAIL = "Check your email for a link to log in! :)";
-export const EMAIL_USERNAME = "Email/Username";
-export const PASSWORD = "Password";
-export const REMEMBER_ME = "Remember me";
-export const FORGOT_PASSWORD = "Forgot password?";
-export const CONTINUE = "Continue";

--- a/app/web/features/auth/notifications/NotificationSettings.tsx
+++ b/app/web/features/auth/notifications/NotificationSettings.tsx
@@ -5,6 +5,7 @@ import CircularProgress from "components/CircularProgress";
 import { notificationSettingsQueryKey } from "features/queryKeys";
 import { RpcError } from "grpc-web";
 import { Trans, useTranslation } from "i18n";
+import { AUTH } from "i18n/namespaces";
 import {
   GetNotificationSettingsRes,
   SetNotificationSettingsRes,
@@ -21,7 +22,7 @@ export default function NotificationSettings({
 }: {
   className: string;
 }) {
-  const { t } = useTranslation("auth");
+  const { t } = useTranslation(AUTH);
 
   const queryClient = useQueryClient();
 

--- a/app/web/features/auth/notifications/NotificationSettings.tsx
+++ b/app/web/features/auth/notifications/NotificationSettings.tsx
@@ -4,11 +4,11 @@ import Button from "components/Button";
 import CircularProgress from "components/CircularProgress";
 import { notificationSettingsQueryKey } from "features/queryKeys";
 import { RpcError } from "grpc-web";
+import { Trans, useTranslation } from "i18n";
 import {
   GetNotificationSettingsRes,
   SetNotificationSettingsRes,
 } from "proto/notifications_pb";
-import { useTranslation } from "react-i18next";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { service } from "service";
 
@@ -66,17 +66,26 @@ export default function NotificationSettings({
       ) : (
         <>
           <Typography variant="body1">
-            The new notification system is currently{" "}
-            <b>{data.newNotificationsEnabled ? "enabled" : "disabled"}</b> for
-            your account.
+            <Trans
+              t={t}
+              i18nKey={
+                data.newNotificationsEnabled
+                  ? "notification_settings.status.enabled_message"
+                  : "notification_settings.status.disabled_message"
+              }
+            >
+              The new notification system is currently{" "}
+              <strong>enabled/disabled</strong> for your account.
+            </Trans>
           </Typography>
           <Typography variant="body1">
             <Button
               onClick={() => toggleNewNotifications()}
               loading={mutation.isLoading}
             >
-              {data.newNotificationsEnabled ? "Disable" : "Enable"} new
-              notification system.
+              {data.newNotificationsEnabled
+                ? t("notification_settings.action_button.disable_text")
+                : t("notification_settings.action_button.enable_text")}
             </Button>
           </Typography>
         </>

--- a/app/web/features/auth/password/ChangePassword.tsx
+++ b/app/web/features/auth/password/ChangePassword.tsx
@@ -8,7 +8,6 @@ import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { RpcError } from "grpc-web";
 import { useTranslation } from "i18n";
 import { AUTH, GLOBAL } from "i18n/namespaces";
-import { GetAccountInfoRes } from "proto/account_pb";
 import { useForm } from "react-hook-form";
 import { useMutation, useQueryClient } from "react-query";
 import { service } from "service";
@@ -22,13 +21,14 @@ interface ChangePasswordFormData extends ChangePasswordVariables {
   passwordConfirmation?: string;
 }
 
-type ChangePasswordProps = GetAccountInfoRes.AsObject & {
+interface ChangePasswordProps {
+  hasPassword: boolean;
   className?: string;
-};
+}
 
 export default function ChangePassword({
   className,
-  ...accountInfo
+  hasPassword,
 }: ChangePasswordProps) {
   const { t } = useTranslation([AUTH, GLOBAL]);
   const classes = useChangeDetailsFormStyles();
@@ -82,7 +82,7 @@ export default function ChangePassword({
         </Alert>
       )}
       <form className={classes.form} onSubmit={onSubmit}>
-        {accountInfo && accountInfo.hasPassword && (
+        {hasPassword && (
           <TextField
             id="oldPassword"
             inputRef={register({ required: true })}
@@ -94,7 +94,7 @@ export default function ChangePassword({
         )}
         <TextField
           id="newPassword"
-          inputRef={register({ required: !accountInfo?.hasPassword })}
+          inputRef={register({ required: !hasPassword })}
           label={t("auth:change_password_form.new_password")}
           name="newPassword"
           type="password"

--- a/app/web/features/auth/password/ChangePassword.tsx
+++ b/app/web/features/auth/password/ChangePassword.tsx
@@ -6,7 +6,8 @@ import useChangeDetailsFormStyles from "features/auth/useChangeDetailsFormStyles
 import { accountInfoQueryKey } from "features/queryKeys";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { RpcError } from "grpc-web";
-import { useTranslation } from "next-i18next";
+import { useTranslation } from "i18n";
+import { AUTH, GLOBAL } from "i18n/namespaces";
 import { GetAccountInfoRes } from "proto/account_pb";
 import { useForm } from "react-hook-form";
 import { useMutation, useQueryClient } from "react-query";
@@ -29,7 +30,7 @@ export default function ChangePassword({
   className,
   ...accountInfo
 }: ChangePasswordProps) {
-  const { t } = useTranslation(["auth", "global"]);
+  const { t } = useTranslation([AUTH, GLOBAL]);
   const classes = useChangeDetailsFormStyles();
   const theme = useTheme();
   const isMdOrWider = useMediaQuery(theme.breakpoints.up("md"));

--- a/app/web/features/auth/password/CompleteResetPassword.tsx
+++ b/app/web/features/auth/password/CompleteResetPassword.tsx
@@ -5,8 +5,9 @@ import HtmlMeta from "components/HtmlMeta";
 import StyledLink from "components/StyledLink";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { RpcError } from "grpc-web";
+import { useTranslation } from "i18n";
+import { AUTH } from "i18n/namespaces";
 import { useRouter } from "next/router";
-import { useTranslation } from "next-i18next";
 import { useEffect } from "react";
 import { useMutation } from "react-query";
 import { loginRoute } from "routes";
@@ -14,7 +15,7 @@ import { service } from "service";
 import stringOrFirstString from "utils/stringOrFirstString";
 
 export default function CompleteResetPassword() {
-  const { t } = useTranslation("auth");
+  const { t } = useTranslation(AUTH);
   const classes = useAppRouteStyles();
 
   const router = useRouter();

--- a/app/web/features/auth/password/ResetPassword.tsx
+++ b/app/web/features/auth/password/ResetPassword.tsx
@@ -6,7 +6,8 @@ import PageTitle from "components/PageTitle";
 import TextField from "components/TextField";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { RpcError } from "grpc-web";
-import { useTranslation } from "next-i18next";
+import { useTranslation } from "i18n";
+import { AUTH, GLOBAL } from "i18n/namespaces";
 import { useForm } from "react-hook-form";
 import { useMutation } from "react-query";
 import { service } from "service";
@@ -27,7 +28,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function ResetPassword() {
-  const { t } = useTranslation(["auth", "global"]);
+  const { t } = useTranslation([AUTH, GLOBAL]);
   const classes = useStyles();
   const { handleSubmit, register } = useForm<{ userId: string }>();
 

--- a/app/web/features/auth/signup/AccountForm.tsx
+++ b/app/web/features/auth/signup/AccountForm.tsx
@@ -22,7 +22,8 @@ import { Dayjs } from "dayjs";
 import { useAuthContext } from "features/auth/AuthProvider";
 import useAuthStyles from "features/auth/useAuthStyles";
 import { RpcError } from "grpc-web";
-import { Trans, useTranslation } from "next-i18next";
+import { Trans, useTranslation } from "i18n";
+import { AUTH, GLOBAL } from "i18n/namespaces";
 import { HostingStatus } from "proto/api_pb";
 import { useRef } from "react";
 import { Controller, useForm } from "react-hook-form";
@@ -61,7 +62,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function AccountForm() {
-  const { t } = useTranslation(["auth", "global"]);
+  const { t } = useTranslation([AUTH, GLOBAL]);
   const { authState, authActions } = useAuthContext();
   const authLoading = authState.loading;
 

--- a/app/web/features/auth/signup/BasicForm.tsx
+++ b/app/web/features/auth/signup/BasicForm.tsx
@@ -5,7 +5,8 @@ import TextField from "components/TextField";
 import { useAuthContext } from "features/auth/AuthProvider";
 import useAuthStyles from "features/auth/useAuthStyles";
 import { RpcError } from "grpc-web";
-import { useTranslation } from "next-i18next";
+import { useTranslation } from "i18n";
+import { AUTH, GLOBAL } from "i18n/namespaces";
 import { useRef } from "react";
 import { useForm } from "react-hook-form";
 import { useMutation } from "react-query";
@@ -22,7 +23,7 @@ type SignupBasicInputs = {
 };
 
 export default function BasicForm() {
-  const { t } = useTranslation(["auth", "global"]);
+  const { t } = useTranslation([AUTH, GLOBAL]);
   const { authActions } = useAuthContext();
   const authClasses = useAuthStyles();
 

--- a/app/web/features/auth/signup/FeedbackForm.tsx
+++ b/app/web/features/auth/signup/FeedbackForm.tsx
@@ -1,13 +1,14 @@
 import * as Sentry from "@sentry/react";
 import ContributorForm from "components/ContributorForm";
 import { useAuthContext } from "features/auth/AuthProvider";
-import { useTranslation } from "next-i18next";
+import { useTranslation } from "i18n";
+import { GLOBAL } from "i18n/namespaces";
 import { ContributorForm as ContributorFormPb } from "proto/auth_pb";
 import { service } from "service";
 import isGrpcError from "utils/isGrpcError";
 
 export default function FeedbackForm() {
-  const { t } = useTranslation("global");
+  const { t } = useTranslation(GLOBAL);
   const { authActions, authState } = useAuthContext();
 
   const handleSubmit = async (form: ContributorFormPb.AsObject) => {

--- a/app/web/features/auth/signup/Signup.tsx
+++ b/app/web/features/auth/signup/Signup.tsx
@@ -250,7 +250,7 @@ export default function Signup() {
             rel="noopener noreferrer"
             href="https://vercel.com?utm_source=couchers-org&utm_campaign=oss"
           >
-            <img alt="Powered by Vercel" src={vercelLogo.src} />
+            <img alt={t("auth:vercel_logo_alt_text")} src={vercelLogo.src} />
           </a>
         )}
       </div>

--- a/app/web/features/auth/signup/Signup.tsx
+++ b/app/web/features/auth/signup/Signup.tsx
@@ -8,8 +8,9 @@ import Redirect from "components/Redirect";
 import StyledLink from "components/StyledLink";
 import MobileAuthBg from "features/auth/resources/mobile-auth-bg.jpg";
 import CommunityGuidelinesForm from "features/auth/signup/CommunityGuidelinesForm";
+import { Trans, useTranslation } from "i18n";
+import { AUTH, GLOBAL } from "i18n/namespaces";
 import { useRouter } from "next/router";
-import { Trans, useTranslation } from "next-i18next";
 import { useEffect, useState } from "react";
 import CouchersLogo from "resources/CouchersLogo";
 import vercelLogo from "resources/vercel.svg";
@@ -59,7 +60,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 function CurrentForm() {
-  const { t } = useTranslation(["auth", "global"]);
+  const { t } = useTranslation([AUTH, GLOBAL]);
   const classes = useStyles();
   const { authState } = useAuthContext();
   const state = authState.flowState;
@@ -144,7 +145,7 @@ function CurrentForm() {
 }
 
 export default function Signup() {
-  const { t } = useTranslation(["auth", "global"]);
+  const { t } = useTranslation([AUTH, GLOBAL]);
   const { authState, authActions } = useAuthContext();
   const authenticated = authState.authenticated;
   const error = authState.error;

--- a/app/web/features/auth/timezone/Timezone.tsx
+++ b/app/web/features/auth/timezone/Timezone.tsx
@@ -13,16 +13,21 @@ export default function Timezone({ className, timezone }: TimezoneProps) {
 
   return (
     <div className={className}>
-      <Typography variant="h2">{t("timezone_section.title")}</Typography>
+      <Typography variant="h2">
+        {t("account_settings_page.birth_date_section.title")}
+      </Typography>
       <Typography variant="body1">
-        <Trans t={t} i18nKey="timezone_section.description">
+        <Trans
+          t={t}
+          i18nKey="account_settings_page.timezone_section.description"
+        >
           Your timezone is <strong>{{ timezone: timezone }}</strong>, based on
           this, your local time is approximately{" "}
           <strong>{{ time: dayjs().tz(timezone).format("LT") }}</strong>.
         </Trans>
       </Typography>
       <Typography variant="body1">
-        {t("timezone_section.explanation")}
+        {t("account_settings_page.timezone_section.explanation")}
       </Typography>
     </div>
   );

--- a/app/web/features/auth/timezone/Timezone.tsx
+++ b/app/web/features/auth/timezone/Timezone.tsx
@@ -22,7 +22,7 @@ export default function Timezone({ className, timezone }: TimezoneProps) {
         </Trans>
       </Typography>
       <Typography variant="body1">
-        {t("timezone_section.timezone_explanation")}
+        {t("timezone_section.explanation")}
       </Typography>
     </div>
   );

--- a/app/web/features/auth/timezone/Timezone.tsx
+++ b/app/web/features/auth/timezone/Timezone.tsx
@@ -1,5 +1,6 @@
 import { Typography } from "@material-ui/core";
 import { Trans, useTranslation } from "i18n";
+import { AUTH } from "i18n/namespaces";
 import dayjs from "utils/dayjs";
 
 interface TimezoneProps {
@@ -8,7 +9,7 @@ interface TimezoneProps {
 }
 
 export default function Timezone({ className, timezone }: TimezoneProps) {
-  const { t } = useTranslation("auth");
+  const { t } = useTranslation(AUTH);
 
   return (
     <div className={className}>

--- a/app/web/features/auth/timezone/Timezone.tsx
+++ b/app/web/features/auth/timezone/Timezone.tsx
@@ -1,28 +1,28 @@
 import { Typography } from "@material-ui/core";
-import { GetAccountInfoRes } from "proto/account_pb";
+import { Trans, useTranslation } from "i18n";
 import dayjs from "utils/dayjs";
 
-import {
-  TIMEZONE,
-  TIMEZONE_HELPER,
-  YOUR_LOCAL_TIME_IS,
-  YOUR_TIMEZONE,
-} from "../constants";
-
-type TimezoneProps = GetAccountInfoRes.AsObject & {
+interface TimezoneProps {
   className?: string;
-};
+  timezone: string;
+}
 
-export default function Timezone(props: TimezoneProps) {
-  const { className } = props;
+export default function Timezone({ className, timezone }: TimezoneProps) {
+  const { t } = useTranslation("auth");
+
   return (
     <div className={className}>
-      <Typography variant="h2">{TIMEZONE}</Typography>
+      <Typography variant="h2">{t("timezone_section.title")}</Typography>
       <Typography variant="body1">
-        {YOUR_TIMEZONE} <b>{props.timezone}</b>
-        {YOUR_LOCAL_TIME_IS} <b>{dayjs().tz(props.timezone).format("LT")}</b>.
+        <Trans t={t} i18nKey="timezone_section.description">
+          Your timezone is <strong>{{ timezone: timezone }}</strong>, based on
+          this, your local time is approximately{" "}
+          <strong>{{ time: dayjs().tz(timezone).format("LT") }}</strong>.
+        </Trans>
       </Typography>
-      <Typography variant="body1">{TIMEZONE_HELPER}</Typography>
+      <Typography variant="body1">
+        {t("timezone_section.timezone_explanation")}
+      </Typography>
     </div>
   );
 }

--- a/app/web/features/auth/useAuthStore.ts
+++ b/app/web/features/auth/useAuthStore.ts
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 import { userKey } from "features/queryKeys";
-import { useTranslation } from "next-i18next";
+import { useTranslation } from "i18n";
+import { GLOBAL } from "i18n/namespaces";
 import { AuthRes, SignupFlowRes } from "proto/auth_pb";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "react-query";
@@ -50,7 +51,7 @@ export default function useAuthStore() {
   //may as well not waste the api call since it is needed for userId
   const queryClient = useQueryClient();
 
-  const { t } = useTranslation("global");
+  const { t } = useTranslation(GLOBAL);
   const fatalErrorMessage = useRef(t("fatal_error_message"));
   const authActions = useMemo(
     () => ({

--- a/app/web/features/auth/username/Username.tsx
+++ b/app/web/features/auth/username/Username.tsx
@@ -1,5 +1,6 @@
 import { Typography } from "@material-ui/core";
-import { useTranslation } from "next-i18next";
+import { useTranslation } from "i18n";
+import { AUTH } from "i18n/namespaces";
 import { GetAccountInfoRes } from "proto/account_pb";
 
 import { USERNAME_HELPER, YOUR_USERNAME_IS } from "../constants";
@@ -9,7 +10,7 @@ type UsernameProps = GetAccountInfoRes.AsObject & {
 };
 
 export default function Username(props: UsernameProps) {
-  const { t } = useTranslation("auth");
+  const { t } = useTranslation(AUTH);
   const { className } = props;
 
   return (

--- a/app/web/features/auth/username/Username.tsx
+++ b/app/web/features/auth/username/Username.tsx
@@ -1,17 +1,14 @@
 import { Typography } from "@material-ui/core";
-import { useTranslation } from "i18n";
+import { Trans, useTranslation } from "i18n";
 import { AUTH } from "i18n/namespaces";
-import { GetAccountInfoRes } from "proto/account_pb";
 
-import { USERNAME_HELPER, YOUR_USERNAME_IS } from "../constants";
-
-type UsernameProps = GetAccountInfoRes.AsObject & {
+interface UsernameProps {
+  username: string;
   className?: string;
-};
+}
 
-export default function Username(props: UsernameProps) {
+export default function Username({ className, username }: UsernameProps) {
   const { t } = useTranslation(AUTH);
-  const { className } = props;
 
   return (
     <div className={className}>
@@ -19,9 +16,13 @@ export default function Username(props: UsernameProps) {
         {t("account_form.username.field_label")}
       </Typography>
       <Typography variant="body1">
-        {YOUR_USERNAME_IS} <b>{props.username}</b>.
+        <Trans t={t} i18nKey="username_section.description">
+          Your username is <strong>{{ username }}</strong>.
+        </Trans>
       </Typography>
-      <Typography variant="body1">{USERNAME_HELPER}</Typography>
+      <Typography variant="body1">
+        {t("username_section.explanation")}
+      </Typography>
     </div>
   );
 }

--- a/app/web/features/auth/username/Username.tsx
+++ b/app/web/features/auth/username/Username.tsx
@@ -13,15 +13,18 @@ export default function Username({ className, username }: UsernameProps) {
   return (
     <div className={className}>
       <Typography variant="h2">
-        {t("account_form.username.field_label")}
+        {t("account_settings_page.username_section.title")}
       </Typography>
       <Typography variant="body1">
-        <Trans t={t} i18nKey="username_section.description">
+        <Trans
+          t={t}
+          i18nKey="account_settings_page.username_section.description"
+        >
           Your username is <strong>{{ username }}</strong>.
         </Trans>
       </Typography>
       <Typography variant="body1">
-        {t("username_section.explanation")}
+        {t("account_settings_page.username_section.explanation")}
       </Typography>
     </div>
   );

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -13,7 +13,8 @@
     "serve": "next start",
     "storybook": "start-storybook -p 6006 -s public",
     "test-ci": "tsc && cross-env CI=true TZ=UTC jest --runInBand --coverageReporters=\"text\" --coverageReporters=\"cobertura\" --coverageReporters=\"lcov\" --reporters=\"default\" --reporters=\"jest-junit\" --coverage",
-    "test": "cross-env TZ=UTC jest --watch"
+    "test": "cross-env TZ=UTC jest --watch",
+    "typecheck": "tsc"
   },
   "dependencies": {
     "@date-io/dayjs": "1.x",


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes Couchers-org/couchers#1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of Couchers-org/couchers#1234"
--->
Relates to Couchers-org/couchers#4152 for the "auth" feature area. This PR does another sweep to refactor things based on things we recently agreed on (e.g. only importing from `i18n` rather than the module directly), as well as aiming to move some straggler components over to using the JSON file that were missed the first time (looks like there were still quite a few 😢 )

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
