### PR TITLE
error message on DonationsBox

### DIFF
--- a/app/web/features/donations/DonationsBox.tsx
+++ b/app/web/features/donations/DonationsBox.tsx
@@ -219,11 +219,11 @@ export default function DonationsBox() {
   } = useForm<DonationFormData>();
 
   const customAmountInput = useRef<HTMLInputElement>(null);
-  
+
   const checkForValidAmount: boolean = (amount: number) => {
-      if (!Number.isInteger(amount)) return false;
-      if (amount < 1) return false;
-      return true;
+    if (!Number.isInteger(amount)) return false;
+    if (amount < 1) return false;
+    return true;
   };
 
   const {
@@ -232,9 +232,9 @@ export default function DonationsBox() {
     mutate: initiateDonation,
   } = useMutation<void, RpcError, DonationFormData>(
     async ({ amount, recurring }) => {
-        if  (!checkForValidAmount(amount)) {
-          throw Error(t("donations_box.amount_validation_error"));
-      };
+      if (!checkForValidAmount(amount)) {
+        throw Error(t("donations_box.amount_validation_error"));
+      }
       const stripe = (await stripePromise)!;
       const session_id = await service.donations.initiateDonation(
         amount,

--- a/app/web/features/donations/DonationsBox.tsx
+++ b/app/web/features/donations/DonationsBox.tsx
@@ -219,6 +219,12 @@ export default function DonationsBox() {
   } = useForm<DonationFormData>();
 
   const customAmountInput = useRef<HTMLInputElement>(null);
+  
+  const checkForValidAmount: boolean = (amount: number) => {
+      if (!Number.isInteger(amount)) return false;
+      if (amount < 1) return false;
+      return true;
+  };
 
   const {
     error,
@@ -226,6 +232,9 @@ export default function DonationsBox() {
     mutate: initiateDonation,
   } = useMutation<void, RpcError, DonationFormData>(
     async ({ amount, recurring }) => {
+        if  (!checkForValidAmount(amount)) {
+          throw Error(t("donations_box.amount_validation_error"));
+      };
       const stripe = (await stripePromise)!;
       const session_id = await service.donations.initiateDonation(
         amount,
@@ -275,7 +284,7 @@ export default function DonationsBox() {
   return (
     <>
       <form onSubmit={onSubmit} className={classes.donationsBox}>
-        {error && <Alert severity="error">{error.message !== "Assertion failed" ? error.message : "Whole numbers only, please!"}</Alert>}
+        {error && <Alert severity="error">{error.message}</Alert>}
         {success && (
           <Alert severity="success">
             {t("donations_box.alert.success_message")}

--- a/app/web/features/donations/DonationsBox.tsx
+++ b/app/web/features/donations/DonationsBox.tsx
@@ -275,7 +275,7 @@ export default function DonationsBox() {
   return (
     <>
       <form onSubmit={onSubmit} className={classes.donationsBox}>
-        {error && <Alert severity="error">{error.message}</Alert>}
+        {error && <Alert severity="error">{error.message !== "Assertion failed" ? error.message : "Whole numbers only, please!"}</Alert>}
         {success && (
           <Alert severity="success">
             {t("donations_box.alert.success_message")}
@@ -443,6 +443,7 @@ export default function DonationsBox() {
                     <input
                       ref={customAmountInput}
                       type="number"
+                      min="1"
                       onChange={(e) => {
                         onChange(
                           typeof e.target.valueAsNumber === "number"

--- a/app/web/features/donations/DonationsBox.tsx
+++ b/app/web/features/donations/DonationsBox.tsx
@@ -220,7 +220,7 @@ export default function DonationsBox() {
 
   const customAmountInput = useRef<HTMLInputElement>(null);
 
-  const checkForValidAmount: boolean = (amount: number) => {
+  const checkForValidAmount = (amount: number) => {
     if (!Number.isInteger(amount)) return false;
     if (amount < 1) return false;
     return true;

--- a/app/web/features/donations/locales/en.json
+++ b/app/web/features/donations/locales/en.json
@@ -11,6 +11,7 @@
         "action_button_label": "Next",
         "recurrence_aria_label": "recurring",
         "title": "Donation Amount",
+        "amount_validation_error": "Whole numbers only, please.",
         "alert": {
             "success_message": "Thank you for donating to Couchers.org, we appreciate your support! You will receive an email shortly.",
             "warning_message": "The payment was cancelled."

--- a/app/web/features/donations/locales/fr.json
+++ b/app/web/features/donations/locales/fr.json
@@ -4,6 +4,7 @@
         "action_button_label": "Suivant",
         "monthly_button_label": "Mensuel",
         "one_time_button_label": "Unique",
+        "amount_validation_error": "Nombres entiers uniquement, merci.",
         "alert": {
             "warning_message": "Le paiement a été annulé.",
             "success_message": "Merci d'avoir fait un don à Couchers.org, nous apprécions votre soutien ! Vous recevrez bientôt un courriel."


### PR DESCRIPTION
better error message when donating decimals or negative numbers

<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

closes #2432 
when entering a negative number or a decimal number on the donation page, and submitting the form, the "Assertion error" message is replaced by "Whole numbers only, please!".

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->

**Web frontend checklist**
- [X] Formatted my code with `yarn format && yarn lint --fix`
- [X] There are no warnings from `yarn lint`
- [X] There are no console warnings when running the app
- [X] All tests pass
- [X] Clicked around my changes running locally and it works
- [X] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->