### PR TITLE
fix: highlight invalid location as error before creation

### DIFF
--- a/app/web/features/search/LocationAutocomplete/LocationAutocomplete.tsx
+++ b/app/web/features/search/LocationAutocomplete/LocationAutocomplete.tsx
@@ -99,9 +99,7 @@ export default function LocationAutocomplete({
       id="location-autocomplete"
       innerRef={controller.field.ref}
       label={label}
-      error={
-        fieldError !== SELECT_LOCATION ? fieldError || geocodeError : undefined
-      }
+      error={fieldError || geocodeError}
       fullWidth={fullWidth}
       helperText={
         fieldError === SELECT_LOCATION ? SELECT_LOCATION : SEARCH_LOCATION_HINT

--- a/app/web/features/search/constants.ts
+++ b/app/web/features/search/constants.ts
@@ -25,7 +25,8 @@ export const SEARCH_BY_KEYWORD = "By keyword";
 export const SEARCH_LOCATION_HINT =
   "Press enter or click the icon to choose a location";
 export const SEARCH_LOCATION_BUTTON = "Search location";
-export const SELECT_LOCATION = "Select a location from the list";
+export const SELECT_LOCATION =
+  "Press enter or click the icon, then select a location from the list";
 export const SHOWING_ALL = "Showing all users";
 
 export const lastActiveOptions = [


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
Potentially closes #2479

This is probably the simplest "fix" I can think of without needing to re-work the location auto complete component too much - it basically highlights the "select a location" as an error rather than as a neutral prompt before.

It might be "too aggressive", but honestly I think until we re-work the UX, enough people seem to get confused by the need to press enter/search icon, that making it red/an error makes sense to me to force them to read the prompt, even if it has been there all along.

After the fix:
![Screenshot 2022-02-07 020240](https://user-images.githubusercontent.com/13669362/152713722-4bad1106-c1b6-42c3-9ef8-e30aef32c045.png)


<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
