### PR TITLE
set node version for web to >=14

### DIFF
--- a/app/web/package.json
+++ b/app/web/package.json
@@ -2,6 +2,9 @@
   "name": "web",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=14"
+  },
   "scripts": {
     "build-storybook": "build-storybook",
     "build": "next build",


### PR DESCRIPTION
closes #2531 

This change is to make it more obvious for new devs that node 14 is required for the project to run without errors. This is the output you will get now:

```
$ yarn install
yarn install v1.12.3
[1/5] 🔍  Validating package.json...
error web@0.1.0: The engine "node" is incompatible with this module. Expected version ">=14". Got "12.22.3"
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [x] Added any new components to storybook
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
