### PR TITLE
Self host fonts instead of using Google Fonts

### DIFF
--- a/app/web/.storybook/preview.js
+++ b/app/web/.storybook/preview.js
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from "react-query";
 
 import { theme } from "../theme";
 import { AuthContext } from "../features/auth/AuthProvider";
-import "../app.css";
+import "../fonts";
 import "./i18n";
 import "./reset.css";
 import { Suspense } from "react";

--- a/app/web/app.css
+++ b/app/web/app.css
@@ -1,2 +1,0 @@
-@import url("https://fonts.googleapis.com/css2?family=Ubuntu:wght@400;700&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Mansalva&display=swap");

--- a/app/web/fonts.ts
+++ b/app/web/fonts.ts
@@ -1,0 +1,4 @@
+import "@fontsource/mansalva/400.css";
+import "@fontsource/ubuntu/400.css";
+import "@fontsource/ubuntu/400-italic.css";
+import "@fontsource/ubuntu/700.css";

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -21,6 +21,8 @@
   },
   "dependencies": {
     "@date-io/dayjs": "1.x",
+    "@fontsource/mansalva": "^4.5.2",
+    "@fontsource/ubuntu": "^4.5.2",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.60",

--- a/app/web/pages/_app.tsx
+++ b/app/web/pages/_app.tsx
@@ -1,5 +1,5 @@
 import "intersection-observer";
-import "app.css";
+import "fonts";
 
 import { CssBaseline, ThemeProvider } from "@material-ui/core";
 import * as Sentry from "@sentry/nextjs";

--- a/app/web/yarn.lock
+++ b/app/web/yarn.lock
@@ -1345,6 +1345,16 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fontsource/mansalva@^4.5.2":
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/@fontsource/mansalva/-/mansalva-4.5.2.tgz#4b076da36f2fff380e45b5d85a33d2f4b3046815"
+  integrity sha512-Q0/l382Dk7sB/kN8Uvs2j7ru9sGkweH5vcf7gPEEP+Th9iwsdEZtN9QXoOwYuV6Q6qlEGJRm5HOlInFqWtqK3Q==
+
+"@fontsource/ubuntu@^4.5.2":
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/@fontsource/ubuntu/-/ubuntu-4.5.2.tgz#b4f32056d4eef3dd9c2d2740d9922859c67cf3c4"
+  integrity sha512-81PR4lS/sbcq9sOV8pkH/X4FopQTVVugBxUzuDLJjcqThyjKYdTwjPcj9tCZEH07d6q8sJrt0u3PrTI/o2GhUg==
+
 "@gar/promisify@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"


### PR DESCRIPTION
This is faster (due to fewer domains connected to hence fewer DNS queries and TLS connections) and we avoid another Google dependency.

**Web frontend checklist**
- [ ] Formatted my code with `yarn format && yarn lint --fix`
- [ ] There are no warnings from `yarn lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [ ] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes
