### PR TITLE
fix: event translation keys in pages

### DIFF
--- a/app/web/pages/community/[id]/[slug]/[...params].tsx
+++ b/app/web/pages/community/[id]/[slug]/[...params].tsx
@@ -1,6 +1,7 @@
 import { appGetLayout } from "components/AppRoute";
 import CommunityPageComponent from "features/communities/CommunityPage";
 import NotFoundPage from "features/NotFoundPage";
+import { COMMUNITIES, GLOBAL } from "i18n/namespaces";
 import { GetStaticPaths, GetStaticProps } from "next";
 import { useRouter } from "next/router";
 import nextI18nextConfig from "next-i18next.config";
@@ -17,7 +18,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(
       locale ?? "en",
-      ["global", "communities"],
+      [GLOBAL, COMMUNITIES],
       nextI18nextConfig
     )),
   },

--- a/app/web/pages/community/[id]/[slug]/index.tsx
+++ b/app/web/pages/community/[id]/[slug]/index.tsx
@@ -1,6 +1,7 @@
 import { appGetLayout } from "components/AppRoute";
 import CommunityPageComponent from "features/communities/CommunityPage";
 import NotFoundPage from "features/NotFoundPage";
+import { COMMUNITIES, GLOBAL } from "i18n/namespaces";
 import { GetStaticPaths, GetStaticProps } from "next";
 import { useRouter } from "next/router";
 import nextI18nextConfig from "next-i18next.config";
@@ -16,7 +17,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(
       locale ?? "en",
-      ["global", "communities"],
+      [GLOBAL, COMMUNITIES],
       nextI18nextConfig
     )),
   },

--- a/app/web/pages/dashboard.tsx
+++ b/app/web/pages/dashboard.tsx
@@ -1,6 +1,6 @@
 import { appGetLayout } from "components/AppRoute";
 import Dashboard from "features/dashboard/Dashboard";
-import { AUTH, DASHBOARD, GLOBAL } from "i18n/namespaces";
+import { AUTH, COMMUNITIES, DASHBOARD, GLOBAL } from "i18n/namespaces";
 import { GetStaticProps } from "next";
 import nextI18nextConfig from "next-i18next.config";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -9,7 +9,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(
       locale ?? "en",
-      [GLOBAL, DASHBOARD, AUTH],
+      [GLOBAL, DASHBOARD, AUTH, COMMUNITIES],
       nextI18nextConfig
     )),
   },

--- a/app/web/pages/event/[id]/[slug]/edit.tsx
+++ b/app/web/pages/event/[id]/[slug]/edit.tsx
@@ -1,6 +1,7 @@
 import { appGetLayout } from "components/AppRoute";
 import EditEventPageComponent from "features/communities/events/EditEventPage";
 import NotFoundPage from "features/NotFoundPage";
+import { COMMUNITIES, GLOBAL } from "i18n/namespaces";
 import { GetStaticPaths, GetStaticProps } from "next";
 import { useRouter } from "next/router";
 import nextI18nextConfig from "next-i18next.config";
@@ -16,7 +17,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(
       locale ?? "en",
-      ["global", "communities"],
+      [GLOBAL, COMMUNITIES],
       nextI18nextConfig
     )),
   },

--- a/app/web/pages/event/[id]/[slug]/index.tsx
+++ b/app/web/pages/event/[id]/[slug]/index.tsx
@@ -1,6 +1,7 @@
 import { appGetLayout } from "components/AppRoute";
 import EventPageComponent from "features/communities/events/EventPage";
 import NotFoundPage from "features/NotFoundPage";
+import { COMMUNITIES, GLOBAL } from "i18n/namespaces";
 import { GetStaticPaths, GetStaticProps } from "next";
 import { useRouter } from "next/router";
 import nextI18nextConfig from "next-i18next.config";
@@ -16,7 +17,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(
       locale ?? "en",
-      ["global", "communities"],
+      [GLOBAL, COMMUNITIES],
       nextI18nextConfig
     )),
   },

--- a/app/web/pages/event/new.tsx
+++ b/app/web/pages/event/new.tsx
@@ -1,5 +1,6 @@
 import { appGetLayout } from "components/AppRoute";
 import CreateEventPage from "features/communities/events/CreateEventPage";
+import { COMMUNITIES, GLOBAL } from "i18n/namespaces";
 import { GetStaticProps } from "next";
 import nextI18nextConfig from "next-i18next.config";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -8,7 +9,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(
       locale ?? "en",
-      ["global", "events"],
+      [GLOBAL, COMMUNITIES],
       nextI18nextConfig
     )),
   },

--- a/app/web/pages/events.tsx
+++ b/app/web/pages/events.tsx
@@ -1,5 +1,6 @@
 import { appGetLayout } from "components/AppRoute";
 import EventsPageComponent from "features/communities/events/EventsPage";
+import { COMMUNITIES, GLOBAL } from "i18n/namespaces";
 import { GetStaticProps } from "next";
 import nextI18nextConfig from "next-i18next.config";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -8,7 +9,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(
       locale ?? "en",
-      ["global", "communities"],
+      [GLOBAL, COMMUNITIES],
       nextI18nextConfig
     )),
   },


### PR DESCRIPTION
Fix: #2556 #2555 #2553
Some translation keys for events were displayed instead of the actual translation text.

The reason for that is that some app/web/pages/ next.js definitions did not include the COMMUNITIES namespace.
![fix1](https://user-images.githubusercontent.com/1676528/153772389-5fc577e0-417a-4069-b464-269b401faa03.png)
![fix2](https://user-images.githubusercontent.com/1676528/153772402-5c25dab3-4e70-4c08-8e8d-d09858813972.png)

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes