### PR TITLE
Use column_property for faster tz lookup

### DIFF
--- a/app/backend/Dockerfile
+++ b/app/backend/Dockerfile
@@ -14,7 +14,7 @@ RUN wget http://eradman.com/entrproject/code/entr-4.6.tar.gz \
 
 RUN apt-get install -y zstd
 
-RUN wget https://github.com/Couchers-org/resources/raw/b4d9e32d4191b581dd59df8df9223aa45c9f6474/timezone_areas/timezone_areas.sql.zst \
+RUN wget https://github.com/Couchers-org/resources/raw/101e811dc9d1a51c2ccf39fe129497e917bb2ad7/timezone_areas/timezone_areas.sql.zst \
     && zstd -d timezone_areas.sql.zst
 
 FROM base

--- a/app/backend/Dockerfile
+++ b/app/backend/Dockerfile
@@ -14,7 +14,7 @@ RUN wget http://eradman.com/entrproject/code/entr-4.6.tar.gz \
 
 RUN apt-get install -y zstd
 
-RUN wget https://github.com/Couchers-org/resources/raw/8c68639a525e2dc85c37d0abb5a6e5a1e12968be/timezone_areas/timezone_areas.sql.zst \
+RUN wget https://github.com/Couchers-org/resources/raw/a664750dc60771ec5080ac4753d9a27e6ec544b9/timezone_areas/timezone_areas.sql.zst \
     && zstd -d timezone_areas.sql.zst
 
 FROM base

--- a/app/backend/Dockerfile
+++ b/app/backend/Dockerfile
@@ -14,7 +14,7 @@ RUN wget http://eradman.com/entrproject/code/entr-4.6.tar.gz \
 
 RUN apt-get install -y zstd
 
-RUN wget https://github.com/Couchers-org/resources/raw/101e811dc9d1a51c2ccf39fe129497e917bb2ad7/timezone_areas/timezone_areas.sql.zst \
+RUN wget https://github.com/Couchers-org/resources/raw/8c68639a525e2dc85c37d0abb5a6e5a1e12968be/timezone_areas/timezone_areas.sql.zst \
     && zstd -d timezone_areas.sql.zst
 
 FROM base

--- a/app/backend/src/couchers/migrations/versions/39295ed931f6_update_tz_table_and_add_index.py
+++ b/app/backend/src/couchers/migrations/versions/39295ed931f6_update_tz_table_and_add_index.py
@@ -6,6 +6,7 @@ Create Date: 2022-02-14 13:18:46.176547
 
 """
 from alembic import op
+from sqlalchemy.orm.session import Session
 
 from couchers.resources import copy_resources_to_database
 

--- a/app/backend/src/couchers/migrations/versions/39295ed931f6_update_tz_table_and_add_index.py
+++ b/app/backend/src/couchers/migrations/versions/39295ed931f6_update_tz_table_and_add_index.py
@@ -1,7 +1,7 @@
 """Update tz table and add index
 
 Revision ID: 39295ed931f6
-Revises: 13fe6ada1535
+Revises: 9261e9647b69
 Create Date: 2022-02-14 13:18:46.176547
 
 """
@@ -11,7 +11,7 @@ from couchers.resources import copy_resources_to_database
 
 # revision identifiers, used by Alembic.
 revision = "39295ed931f6"
-down_revision = "13fe6ada1535"
+down_revision = "9261e9647b69"
 branch_labels = None
 depends_on = None
 

--- a/app/backend/src/couchers/migrations/versions/39295ed931f6_update_tz_table_and_add_index.py
+++ b/app/backend/src/couchers/migrations/versions/39295ed931f6_update_tz_table_and_add_index.py
@@ -1,7 +1,7 @@
 """Update tz table and add index
 
 Revision ID: 39295ed931f6
-Revises: 9261e9647b69
+Revises: 82289f7fdeab
 Create Date: 2022-02-14 13:18:46.176547
 
 """
@@ -12,7 +12,7 @@ from couchers.resources import copy_resources_to_database
 
 # revision identifiers, used by Alembic.
 revision = "39295ed931f6"
-down_revision = "9261e9647b69"
+down_revision = "82289f7fdeab"
 branch_labels = None
 depends_on = None
 

--- a/app/backend/src/couchers/migrations/versions/39295ed931f6_update_tz_table_and_add_index.py
+++ b/app/backend/src/couchers/migrations/versions/39295ed931f6_update_tz_table_and_add_index.py
@@ -1,0 +1,30 @@
+"""Update tz table and add index
+
+Revision ID: 39295ed931f6
+Revises: 13fe6ada1535
+Create Date: 2022-02-14 13:18:46.176547
+
+"""
+from alembic import op
+
+from couchers.resources import copy_resources_to_database
+
+# revision identifiers, used by Alembic.
+revision = "39295ed931f6"
+down_revision = "13fe6ada1535"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    session = Session(bind=op.get_bind())
+    copy_resources_to_database(session)
+    session.commit()
+
+    op.create_index(
+        "ix_timezone_areas_geom_tzid", "timezone_areas", ["geom", "tzid"], unique=False, postgresql_using="gist"
+    )
+
+
+def downgrade():
+    op.drop_index("ix_timezone_areas_geom_tzid", table_name="timezone_areas", postgresql_using="gist")

--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -93,7 +93,6 @@ class TimezoneArea(Base):
     geom = Column(Geometry(geometry_type="MULTIPOLYGON", srid=4326), nullable=False)
 
     __table_args__ = (
-        # Verified phone numbers should be unique
         Index(
             "ix_timezone_areas_geom_tzid",
             geom,

--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -92,6 +92,16 @@ class TimezoneArea(Base):
     tzid = Column(String)
     geom = Column(Geometry(geometry_type="MULTIPOLYGON", srid=4326), nullable=False)
 
+    __table_args__ = (
+        # Verified phone numbers should be unique
+        Index(
+            "ix_timezone_areas_geom_tzid",
+            geom,
+            tzid,
+            postgresql_using="gist",
+        ),
+    )
+
 
 class User(Base):
     """


### PR DESCRIPTION
The underlying SQL turns from

```sql
SELECT timezone_areas.id AS timezone_areas_id, timezone_areas.tzid AS timezone_areas_tzid, ST_AsEWKB(timezone_areas.geom) AS timezone_areas_geom 
FROM timezone_areas 
WHERE ST_Contains(timezone_areas.geom, ST_GeomFromEWKT('0101000020E61000007C5B6C9B927D52C06066C2B869674440'));
```

(Note it returns the full geometry).

To this:

```sql
SELECT (SELECT timezone_areas.tzid
FROM timezone_areas 
WHERE ST_Contains(timezone_areas.geom, users.geom) 
 LIMIT 1) AS anon_1
FROM users
WHERE users.id = 1
```

~~Better yet would be to split the tz areas at say, squares of 10x10 degrees so the R-tree becomes much simpler and faster to use.~~

**Backend checklist**
- [ ] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history
