### PR TITLE
Add Dummy Superuser API Key

### DIFF
--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -126,6 +126,8 @@ def check_config():
             raise Exception("Production site must have SMS enabled")
         if config["IN_TEST"]:
             raise Exception("IN_TEST while not DEV")
+        if config["ADD_DUMMY_DATA"]:
+            raise Exception("ADD_DUMMY_DATA while not DEV")
 
     if config["ENABLE_DONATIONS"]:
         if (

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -98,23 +98,6 @@ def create_session(context, session, user, long_lived, is_api_key=False, duratio
     return token, user_session.expiry
 
 
-def create_api_key(context, session, user):
-    token, expiry = create_session(
-        context, session, user, long_lived=True, is_api_key=True, duration=timedelta(days=365)
-    )
-    send_api_key_email(session, user, token, expiry)
-
-    notify(
-        user_id=user.id,
-        topic="api_key",
-        key="",
-        action="create",
-        icon="wrench",
-        title=f"An admin created an API key for you, please check your email",
-        link=urls.account_settings_link(),
-    )
-
-
 def delete_session(token):
     """
     Deletes the given session (practically logging the user out)

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -28,11 +28,11 @@ from couchers.tasks import (
     maybe_send_contributor_form_email,
     send_account_deletion_successful_email,
     send_account_recovered_email,
+    send_api_key_email,
     send_login_email,
     send_onboarding_email,
     send_password_reset_email,
     send_signup_email,
-    send_api_key_email,
 )
 from couchers.utils import (
     create_coordinate,
@@ -97,6 +97,7 @@ def create_session(context, session, user, long_lived, is_api_key=False, duratio
     logger.debug(f"Handing out {token=} to {user=}")
     return token, user_session.expiry
 
+
 def create_api_key(context, session, user):
     token, expiry = create_session(
         context, session, user, long_lived=True, is_api_key=True, duration=timedelta(days=365)
@@ -112,6 +113,7 @@ def create_api_key(context, session, user):
         title=f"An admin created an API key for you, please check your email",
         link=urls.account_settings_link(),
     )
+
 
 def delete_session(token):
     """

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -32,6 +32,7 @@ from couchers.tasks import (
     send_onboarding_email,
     send_password_reset_email,
     send_signup_email,
+    send_api_key_email,
 )
 from couchers.utils import (
     create_coordinate,
@@ -96,6 +97,21 @@ def create_session(context, session, user, long_lived, is_api_key=False, duratio
     logger.debug(f"Handing out {token=} to {user=}")
     return token, user_session.expiry
 
+def create_api_key(context, session, user):
+    token, expiry = create_session(
+        context, session, user, long_lived=True, is_api_key=True, duration=timedelta(days=365)
+    )
+    send_api_key_email(session, user, token, expiry)
+
+    notify(
+        user_id=user.id,
+        topic="api_key",
+        key="",
+        action="create",
+        icon="wrench",
+        title=f"An admin created an API key for you, please check your email",
+        link=urls.account_settings_link(),
+    )
 
 def delete_session(token):
     """

--- a/app/backend/src/data/dummy_users.json
+++ b/app/backend/src/data/dummy_users.json
@@ -31,7 +31,8 @@
         "SWE",
         "USA"
       ],
-      "hosting_status": "HOSTING_STATUS_CAN_HOST"
+      "hosting_status": "HOSTING_STATUS_CAN_HOST",
+      "is_superuser": true
     },
     {
       "username": "itsi",

--- a/app/backend/src/dummy_data.py
+++ b/app/backend/src/dummy_data.py
@@ -36,7 +36,7 @@ from couchers.models import (
     UserSession,
 )
 from couchers.servicers.api import hostingstatus2sql
-from couchers.servicers.auth import create_api_key
+from couchers.servicers.admin import create_api_key
 from couchers.sql import couchers_select as select
 from couchers.utils import create_coordinate, create_polygon_lng_lat, geojson_to_geom, to_multi
 from proto.api_pb2 import HostingStatus

--- a/app/backend/src/dummy_data.py
+++ b/app/backend/src/dummy_data.py
@@ -77,6 +77,7 @@ def add_dummy_users():
                         user["hosting_status"] if "hosting_status" in user else "HOSTING_STATUS_CANT_HOST"
                     )
                 ],
+                is_superuser=user.get("is_superuser", False),
                 new_notifications_enabled=True,
                 accepted_tos=TOS_VERSION,
                 accepted_community_guidelines=GUIDELINES_VERSION,

--- a/app/backend/src/dummy_data.py
+++ b/app/backend/src/dummy_data.py
@@ -37,10 +37,10 @@ from couchers.models import (
 )
 from couchers.servicers.api import hostingstatus2sql
 from couchers.servicers.auth import create_api_key
-from tests.test_fixtures import DummyContext
 from couchers.sql import couchers_select as select
 from couchers.utils import create_coordinate, create_polygon_lng_lat, geojson_to_geom, to_multi
 from proto.api_pb2 import HostingStatus
+from tests.test_fixtures import DummyContext
 
 logger = logging.getLogger(__name__)
 
@@ -368,6 +368,7 @@ def add_dummy_communities():
 
             session.add(page_version)
 
+
 def add_dummy_api_key():
     """
     add_dummy_api_key creates a dummy api key for the user with the id of 1.
@@ -377,17 +378,24 @@ def add_dummy_api_key():
     As an api key of a superuser, the key has access to all api endpoints
     """
     with session_scope() as session:
-        if session.execute(select(func.count())
-            .select_from(UserSession)
-            .where(UserSession.is_api_key)
-            .where(UserSession.is_valid)
-            .where(UserSession.user_id == 1)).scalar_one() > 0:
+        if (
+            session.execute(
+                select(func.count())
+                .select_from(UserSession)
+                .where(UserSession.is_api_key)
+                .where(UserSession.is_valid)
+                .where(UserSession.user_id == 1)
+            ).scalar_one()
+            > 0
+        ):
             logger.info("API Keys not empty, not adding dummy API key.")
-            token = session.execute(select(UserSession.token)
+            token = session.execute(
+                select(UserSession.token)
                 .select_from(UserSession)
                 .where(UserSession.is_valid)
                 .where(UserSession.is_api_key)
-                .where(UserSession.user_id == 1)).first()
+                .where(UserSession.user_id == 1)
+            ).first()
             logger.info(f"API Key: {token}")
             return
 

--- a/app/backend/src/tests/test_dummy_data.py
+++ b/app/backend/src/tests/test_dummy_data.py
@@ -1,7 +1,12 @@
+import pytest
 from couchers.db import session_scope
 from couchers.resources import copy_resources_to_database
 from dummy_data import add_dummy_data
 from tests.test_fixtures import db  # noqa
+
+@pytest.fixture(autouse=True)
+def _(testconfig):
+    pass
 
 
 def test_add_dummy_data(db, caplog):

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -269,11 +269,7 @@ def generate_user(*, delete_user=False, **kwargs):
         # this expires the user, so now it's "dirty"
         session.commit()
 
-        class _DummyContext:
-            def invocation_metadata(self):
-                return {}
-
-        token, _ = create_session(_DummyContext(), session, user, False)
+        token, _ = create_session(DummyContext(), session, user, False)
 
         # deleted user aborts session creation, hence this follows and necessitates a second commit
         if delete_user:
@@ -361,6 +357,9 @@ class FakeRpcError(grpc.RpcError):
     def details(self):
         return self._details
 
+class DummyContext:
+    def invocation_metadata(self):
+        return {}
 
 class FakeChannel:
     def __init__(self, user_id=None):

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -357,9 +357,11 @@ class FakeRpcError(grpc.RpcError):
     def details(self):
         return self._details
 
+
 class DummyContext:
     def invocation_metadata(self):
         return {}
+
 
 class FakeChannel:
     def __init__(self, user_id=None):


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

This PR introduces a dummy data API key for the dummy default Aapeli Admin user. The API key will be printed in the `backend` container logs as an email. On every restart of the server, an API key is checked for, and if one is found, it will be printed into the logs. 

In order to use the API Key, the dummy default Aapeli admin user was elevated to SuperUser. 

No tests were added as this is just operating on the dummy data. 

The PR can be tested via:
 * Start up the backend
 * Find the API key email (`You recently requested an API key for Couchers.org. We've issued you with the following API key:`)
 * Leveraging [grpcurl](https://github.com/fullstorydev/grpcurl), give it a try:
 ```bash
 grpcurl -H "Authorization: Bearer $BEARER_TOKEN" -plaintext -import-path /home/grellyd/projects/couchers/app/proto -proto /home/grellyd/projects/couchers/app/proto/api.proto -d '{"user": "1"}' localhost:1751 org.couchers.api.core.API/GetUser 
 ```
 * You should get a user object as a result, not an authentication error
 
 
 Resolves #1731 


**Backend checklist**
- [x] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history
