### PR TITLE
fix: redirect to page with middleware using absolute URL

### DIFF
--- a/app/web/pages/_middleware.ts
+++ b/app/web/pages/_middleware.ts
@@ -2,7 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 
 export function middleware(req: NextRequest) {
   if (req.cookies["couchers-sesh"] && req.nextUrl.pathname === "/") {
-    return NextResponse.rewrite("/dashboard");
+    const url = req.nextUrl.clone();
+    url.pathname = "/dashboard";
+    return NextResponse.rewrite(url);
   }
   return NextResponse.next();
 }


### PR DESCRIPTION
Trying the fix as outlined in https://nextjs.org/docs/messages/middleware-relative-urls, apparently this has changed in Next 12.1 (we bumped up recently) and because the middleware stuff is still in beta, they're not following semver so things can break in minor version changes as in this case...

Closes #2625

<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->


<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
