### PR TITLE
fix: message input not visible in mobile screens

### DIFF
--- a/app/web/features/messages/groupchats/GroupChatView.tsx
+++ b/app/web/features/messages/groupchats/GroupChatView.tsx
@@ -69,7 +69,8 @@ export const useGroupChatViewStyles = makeStyles((theme) => ({
     alignItems: "stretch",
     display: "flex",
     flexDirection: "column",
-    height: `calc(100vh - ${theme.shape.navPaddingXs})`,
+    // 56px = address bar height on mobile - https://dev.to/peiche/100vh-behavior-on-chrome-2hm8
+    height: `calc(100vh - ${theme.shape.navPaddingXs} - 56px)`,
   },
   title: {
     flexGrow: 1,
@@ -219,7 +220,7 @@ export default function GroupChatView({ chatId }: { chatId: number }) {
     : undefined;
 
   return (
-    <div>
+    <>
       <HtmlMeta title={title} />
       {!chatId ? (
         <Alert severity="error">Invalid chat id.</Alert>
@@ -404,6 +405,6 @@ export default function GroupChatView({ chatId }: { chatId: number }) {
           )}
         </div>
       )}
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
On mobile screens, the chat input is not visible until you scroll so this PR aims to fix it.

The fix itself is a bit hacky, since the height of the address bar could be subject to change between OS versions. But honestly, I can't think of a more simpler way without either:
- Slapping the 100% height back everywhere again (since the use of `100vh` is the thing that caused issues - on mobile, `vh` doesn't seem to take into account the address bar as taking up space...), so that we can use `100%` in place of `100vh`
- Read the real view height in JS and set the height of the container accordingly (seems a bit overkill to me)

| Before     | After |
| ----------- | ----------- |
| ![Screenshot_20220308-025307](https://user-images.githubusercontent.com/13669362/157158247-4b17c5c0-475f-4fef-b7ad-62f6ed03b581.jpg)      | ![Screenshot_20220308-030628](https://user-images.githubusercontent.com/13669362/157158505-5f5c0851-1224-4b61-947d-bea1877fc9d1.jpg)       |





<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works (although admittedly, this is one where the simulated tool fails since it doesn't have the address bar covering up some pixels)
- [x] Checked Desktop, Mobile and Tablet screen sizes


<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
