### PR TITLE
Closes #2616 - Line break display in user-generated text of the profile page rendered with MarkdownNoSSR

### DIFF
--- a/app/web/components/MarkdownNoSSR.tsx
+++ b/app/web/components/MarkdownNoSSR.tsx
@@ -24,7 +24,6 @@ const useStyles = makeStyles((theme) => ({
       marginBottom: 0,
       marginTop: theme.spacing(2),
       overflowWrap: "break-word",
-      whiteSpace: "pre-wrap",
     },
     "& h1": theme.typography.h1,
     "& h2": theme.typography.h2,


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

Hi all! Creating a PR for my first issue from a forked repository, since I don't have write access yet.

This PR proposes a solution to address the issue #2616. The problem is that line breaks are double on the user profile user-generated texts, like the "Who am I" section.

### Edit mode screenshot

![Screen Shot 2022-03-10 at 11 25 14](https://user-images.githubusercontent.com/1557348/157642567-6e5894bb-767a-41a8-8369-ebbc40c6aee2.png)

### User profile before ❌

Line breaks are both `<br>` tags and actual line breaks on the markdown combined with `white-space: pre-wrap`.

![Screen Shot 2022-03-10 at 11 25 39](https://user-images.githubusercontent.com/1557348/157642616-0a785847-7461-4797-bd23-c7fe3b593639.png)

### User profile after ✅

Line breaks are only `<br>` tags.

![Screen Shot 2022-03-10 at 11 25 30](https://user-images.githubusercontent.com/1557348/157642593-fad8cf4f-9a1a-411d-a391-98074182e083.png)

### Reasoning for this fix

The rich text editor used is [Toast UI Editor](https://ui.toast.com/tui-editor). It provides a component for editing, `ToastUIEditor`, and a component for displaying `ToastUIEditorViewer`. The editor and viewer display line breaks consistently, although the actual HTML/CSS under the hood can be different. We can rely on `ToastUIEditorViewer` to display line breaks reliably, without adding new CSS rules, like `white-space`, to render line breaks differently that conflict with it.

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [ ] All tests pass
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
