### PR TITLE
Try to fix flakey ci

### DIFF
--- a/app/web/components/EditLocationMap.test.tsx
+++ b/app/web/components/EditLocationMap.test.tsx
@@ -130,7 +130,14 @@ describe("Edit location map", () => {
           t("global:components.edit_location_map.display_location_label")
         )
       ).toHaveValue("test city, test country");
-      await waitFor(() => expect(updateLocation).toHaveBeenCalledTimes(1));
+      await waitFor(() => {
+        expect(
+          screen
+            .getByRole("combobox")
+            .classList.contains("MuiAutocomplete-loading")
+        ).toBe(false);
+        expect(updateLocation).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -15,7 +15,7 @@
     "lint": "next lint",
     "serve": "next start",
     "storybook": "start-storybook -p 6006 -s public",
-    "test-ci": "tsc && cross-env CI=true TZ=UTC jest --runInBand --coverageReporters=\"text\" --coverageReporters=\"cobertura\" --coverageReporters=\"lcov\" --reporters=\"default\" --reporters=\"jest-junit\" --coverage",
+    "test-ci": "tsc && cross-env CI=true TZ=UTC jest --runInBand --coverageReporters=\"cobertura\" --coverageReporters=\"lcov\" --reporters=\"default\" --reporters=\"jest-junit\" --coverage",
     "test": "cross-env TZ=UTC jest --watch",
     "typecheck": "tsc"
   },

--- a/app/web/utils/hooks.ts
+++ b/app/web/utils/hooks.ts
@@ -70,58 +70,66 @@ export interface GeocodeResult {
 const NOMINATIM_URL = process.env.NEXT_PUBLIC_NOMINATIM_URL;
 
 const useGeocodeQuery = () => {
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | undefined>(undefined);
-  const [results, setResults] = useState<GeocodeResult[] | undefined>(
+  const isMounted = useIsMounted();
+  const [isLoading, setIsLoading] = useSafeState(isMounted, false);
+  const [error, setError] = useSafeState<string | undefined>(
+    isMounted,
+    undefined
+  );
+  const [results, setResults] = useSafeState<GeocodeResult[] | undefined>(
+    isMounted,
     undefined
   );
 
-  const query = useCallback(async (value: string) => {
-    if (!value) {
-      return;
-    }
-    setIsLoading(true);
-    setError(undefined);
-    setResults(undefined);
-    const url = `${NOMINATIM_URL!}search?format=jsonv2&q=${encodeURIComponent(
-      value
-    )}&addressdetails=1`;
-    const fetchOptions = {
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json;charset=UTF-8",
-      },
-      method: "GET",
-    };
-    try {
-      const response = await fetch(url, fetchOptions);
-      if (!response.ok) throw Error(await response.text());
-
-      const nominatimResults: NominatimPlace[] = await response.json();
-
-      if (nominatimResults.length === 0) {
-        setResults([]);
-      } else {
-        const filteredResults = filterDuplicatePlaces(nominatimResults);
-        const formattedResults = filteredResults.map((result) => ({
-          location: new LngLat(Number(result["lon"]), Number(result["lat"])),
-          name: result["display_name"],
-          simplifiedName: simplifyPlaceDisplayName(result),
-          isRegion: !nonRegionKeys.some((k) => k in result.address),
-        }));
-
-        setResults(formattedResults);
+  const query = useCallback(
+    async (value: string) => {
+      if (!value) {
+        return;
       }
-    } catch (e) {
-      Sentry.captureException(e, {
-        tags: {
-          hook: "useGeocodeQuery",
+      setIsLoading(true);
+      setError(undefined);
+      setResults(undefined);
+      const url = `${NOMINATIM_URL!}search?format=jsonv2&q=${encodeURIComponent(
+        value
+      )}&addressdetails=1`;
+      const fetchOptions = {
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json;charset=UTF-8",
         },
-      });
-      setError(e instanceof Error ? e.message : "");
-    }
-    setIsLoading(false);
-  }, []);
+        method: "GET",
+      };
+      try {
+        const response = await fetch(url, fetchOptions);
+        if (!response.ok) throw Error(await response.text());
+
+        const nominatimResults: NominatimPlace[] = await response.json();
+
+        if (nominatimResults.length === 0) {
+          setResults([]);
+        } else {
+          const filteredResults = filterDuplicatePlaces(nominatimResults);
+          const formattedResults = filteredResults.map((result) => ({
+            location: new LngLat(Number(result["lon"]), Number(result["lat"])),
+            name: result["display_name"],
+            simplifiedName: simplifyPlaceDisplayName(result),
+            isRegion: !nonRegionKeys.some((k) => k in result.address),
+          }));
+
+          setResults(formattedResults);
+        }
+      } catch (e) {
+        Sentry.captureException(e, {
+          tags: {
+            hook: "useGeocodeQuery",
+          },
+        });
+        setError(e instanceof Error ? e.message : "");
+      }
+      setIsLoading(false);
+    },
+    [setError, setIsLoading, setResults]
+  );
 
   return { isLoading, error, results, query };
 };


### PR DESCRIPTION
```
Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "Warning: An update to MapSearch inside a test was not wrapped in act(...).
    When testing, code that causes React state updates should be wrapped into act(...):
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
        at MapSearch (/app/components/MapSearch.tsx:[122](https://gitlab.com/couchers/couchers/-/jobs/2037102478#L122)5:3)
        at div
        at div
        at EditLocationMap (/app/components/EditLocationMap.tsx:3724:5)".
```

I currently suspect this is caused by the rest mocking somehow. Maybe the callback in `useGeocodeQuery`