### PR TITLE
fix message input overflow on android

### DIFF
--- a/app/web/features/messages/groupchats/GroupChatSendField.tsx
+++ b/app/web/features/messages/groupchats/GroupChatSendField.tsx
@@ -66,6 +66,7 @@ export default function GroupChatSendField({
         onChange={(event) => setPersistedMessage(event.target.value)}
         maxRows={4}
         size="small"
+        className={classes.textField}
       />
 
       <Button

--- a/app/web/features/messages/requests/HostRequestSendField.tsx
+++ b/app/web/features/messages/requests/HostRequestSendField.tsx
@@ -254,6 +254,7 @@ export default function HostRequestSendField({
           onKeyDown={handleKeyDown}
           maxRows={6}
           size="small"
+          className={classes.textField}
         />
         <FieldButton
           callback={onSubmit}

--- a/app/web/features/messages/useSendFieldStyles.ts
+++ b/app/web/features/messages/useSendFieldStyles.ts
@@ -25,6 +25,9 @@ const useSendFieldStyles = makeStyles((theme) => ({
   requestClosedLabel: {
     transform: "none",
   },
+  textField: {
+    background: theme.palette.common.white,
+  },
 }));
 
 export default useSendFieldStyles;

--- a/app/web/features/messages/useSendFieldStyles.ts
+++ b/app/web/features/messages/useSendFieldStyles.ts
@@ -26,6 +26,8 @@ const useSendFieldStyles = makeStyles((theme) => ({
     transform: "none",
   },
   textField: {
+    // so you can still see what you are typing when soft keyboard is up on
+    // devices with not much vertical space, which causes overlap with footer
     background: theme.palette.common.white,
   },
 }));


### PR DESCRIPTION
This has been bugging me on mobile. Hopefully this change makes it a little bit better.

| before | after |
|---|---|
|![165563982-ff304dbc-534c-4b46-9163-47a4e672aad1-1](https://user-images.githubusercontent.com/12486723/165792424-6d2069fb-4067-4b34-921e-d52003ebe97c.png)| ![IMAGE 2022-04-28 11:45:49](https://user-images.githubusercontent.com/12486723/165792157-68640f69-c0bc-45c3-bedd-d8de6b0ce981.jpg)|

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [x] Added any new components to storybook
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

