### PR TITLE
Add link to donations page on the "support" word in the dashboard

### DIFF
--- a/app/web/features/dashboard/Dashboard.tsx
+++ b/app/web/features/dashboard/Dashboard.tsx
@@ -10,7 +10,7 @@ import PageTitle from "components/PageTitle";
 import DashboardBanners from "features/dashboard/DashboardBanners";
 import { Trans, useTranslation } from "i18n";
 import { DASHBOARD, GLOBAL } from "i18n/namespaces";
-import { blogRoute } from "routes";
+import { blogRoute, donationsRoute } from "routes";
 
 import CommunitiesSection from "./CommunitiesSection";
 import DashboardUserProfileSummary from "./DashboardUserProfileSummary";
@@ -47,7 +47,15 @@ export default function Dashboard() {
             <MuiLink href={blogRoute} target="_blank" rel="noreferrer noopener">
               features
             </MuiLink>
-            {` like events, local guides, moderation and hangouts. We appreciate your patience and support as we develop these.`}
+            {` like events, local guides, moderation and hangouts. We appreciate your patience and `}
+            <MuiLink
+              href={donationsRoute}
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              support
+            </MuiLink>
+            {` as we develop these.`}
           </Trans>
         </Typography>
 

--- a/app/web/features/dashboard/Dashboard.tsx
+++ b/app/web/features/dashboard/Dashboard.tsx
@@ -1,12 +1,8 @@
-import {
-  Grid,
-  Link as MuiLink,
-  makeStyles,
-  Typography,
-} from "@material-ui/core";
+import { Grid, makeStyles, Typography } from "@material-ui/core";
 import Divider from "components/Divider";
 import HtmlMeta from "components/HtmlMeta";
 import PageTitle from "components/PageTitle";
+import StyledLink from "components/StyledLink";
 import DashboardBanners from "features/dashboard/DashboardBanners";
 import { Trans, useTranslation } from "i18n";
 import { DASHBOARD, GLOBAL } from "i18n/namespaces";
@@ -44,17 +40,9 @@ export default function Dashboard() {
         <Typography variant="body1" paragraph>
           <Trans i18nKey="dashboard:landing_text">
             {`We are building new `}
-            <MuiLink href={blogRoute} target="_blank" rel="noreferrer noopener">
-              features
-            </MuiLink>
+            <StyledLink href={blogRoute}>features</StyledLink>
             {` like events, local guides, moderation and hangouts. We appreciate your patience and `}
-            <MuiLink
-              href={donationsRoute}
-              target="_blank"
-              rel="noreferrer noopener"
-            >
-              support
-            </MuiLink>
+            <StyledLink href={donationsRoute}>support</StyledLink>
             {` as we develop these.`}
           </Trans>
         </Typography>

--- a/app/web/features/dashboard/locales/en.json
+++ b/app/web/features/dashboard/locales/en.json
@@ -14,7 +14,7 @@
   "load_more": "Load more",
   "welcome": "Welcome to the Couchers.org Beta!",
   "new_pill": "New",
-  "landing_text": "We are building new <1>features</1> like events, local guides, moderation and hangouts. We appreciate your patience and support as we develop these.",
+  "landing_text": "We are building new <1>features</1> like events, local guides, moderation and hangouts. We appreciate your patience and <3>support</3> as we develop these.",
   "your_communities_helper_text": "You have been added to all communities based on your location. Feel free to <1>browse communities</1> in other locations as well.",
   "your_communities_helper_text2": "Don't see your community? <1>Get it started!</1>",
   "community_builder_form_text": "Start your own local community",


### PR DESCRIPTION
As requested via Slack: https://couchersorg.slack.com/archives/C01FAQY1H8X/p1652460973764429

I made the decision to make these 2 links open in new tabs, since they feel a bit outside the application. But I'm 2nd guessing myself. Any thoughts on just handling them as next/link components?

![Screen Shot 2022-05-14 at 12 53 51](https://user-images.githubusercontent.com/1557348/168422776-51ecb8f2-5f95-4f80-8c33-2380d100c55a.png)

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [x] Added any new components to storybook
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes
