### PR TITLE
redirect on reference form page when steps are missing

### DIFF
--- a/app/web/features/profile/view/leaveReference/LeaveReferencePage.test.tsx
+++ b/app/web/features/profile/view/leaveReference/LeaveReferencePage.test.tsx
@@ -25,14 +25,25 @@ const getUserMock = service.user.getUser as MockedService<
   typeof service.user.getUser
 >;
 
-function renderLeaveFriendReferencePage(referenceType: string, userId: number) {
+function renderLeaveFriendReferencePage(
+  referenceType: string,
+  userId: number,
+  step?: ReferenceStep
+) {
   mockRouter.setCurrentUrl(
-    `${leaveReferenceBaseRoute}/${referenceType}/${userId}`
+    `${leaveReferenceBaseRoute}/${referenceType}/${userId}/${step}`
   );
 
-  render(<LeaveReferencePage referenceType={referenceType} userId={userId} />, {
-    wrapper,
-  });
+  render(
+    <LeaveReferencePage
+      referenceType={referenceType}
+      userId={userId}
+      step={step}
+    />,
+    {
+      wrapper,
+    }
+  );
 }
 
 function renderLeaveRequestReferencePage(
@@ -42,7 +53,7 @@ function renderLeaveRequestReferencePage(
   step?: ReferenceStep
 ) {
   mockRouter.setCurrentUrl(
-    `${leaveReferenceBaseRoute}/${referenceType}/${userId}/${hostRequestId}`
+    `${leaveReferenceBaseRoute}/${referenceType}/${userId}/${hostRequestId}/${step}`
   );
 
   render(
@@ -185,12 +196,19 @@ describe("LeaveReferencePage", () => {
     });
   });
 
-  describe("When the user skips a step in the form", () => {
-    it("redirects to first step", async () => {
+  describe("When the user skips a step", () => {
+    it("redirects to first step of the hosting reference form", async () => {
       renderLeaveRequestReferencePage("hosted", 5, 1, "submit");
 
       await waitForElementToBeRemoved(screen.getByRole("progressbar"));
       expect(mockRouter.pathname).toBe(`${leaveReferenceBaseRoute}/hosted/5/1`);
+    });
+
+    it("redirects to first step of the friend reference form", async () => {
+      renderLeaveFriendReferencePage("friend", 5, "submit");
+
+      await waitForElementToBeRemoved(screen.getByRole("progressbar"));
+      expect(mockRouter.pathname).toBe(`${leaveReferenceBaseRoute}/friend/5`);
     });
   });
 });

--- a/app/web/features/profile/view/leaveReference/LeaveReferencePage.test.tsx
+++ b/app/web/features/profile/view/leaveReference/LeaveReferencePage.test.tsx
@@ -1,10 +1,15 @@
-import { render, screen, within } from "@testing-library/react";
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+  within,
+} from "@testing-library/react";
 import {
   INVALID_REFERENCE_TYPE,
   REFERENCE_TYPE_NOT_AVAILABLE,
 } from "features/profile/constants";
 import mockRouter from "next-router-mock";
-import { leaveReferenceBaseRoute } from "routes";
+import { leaveReferenceBaseRoute, ReferenceStep } from "routes";
 import { service } from "service";
 import wrapper from "test/hookWrapper";
 import { getAvailableReferences, getUser } from "test/serviceMockDefaults";
@@ -33,7 +38,8 @@ function renderLeaveFriendReferencePage(referenceType: string, userId: number) {
 function renderLeaveRequestReferencePage(
   referenceType: string,
   userId: number,
-  hostRequestId: number
+  hostRequestId: number,
+  step?: ReferenceStep
 ) {
   mockRouter.setCurrentUrl(
     `${leaveReferenceBaseRoute}/${referenceType}/${userId}/${hostRequestId}`
@@ -44,6 +50,7 @@ function renderLeaveRequestReferencePage(
       referenceType={referenceType}
       userId={userId}
       hostRequestId={hostRequestId}
+      step={step}
     />,
     { wrapper }
   );
@@ -175,6 +182,15 @@ describe("LeaveReferencePage", () => {
           })
         ).not.toBeInTheDocument();
       });
+    });
+  });
+
+  describe("When the user skips a step in the form", () => {
+    it("redirects to first step", async () => {
+      renderLeaveRequestReferencePage("hosted", 5, 1, "submit");
+
+      await waitForElementToBeRemoved(screen.getByRole("progressbar"));
+      expect(mockRouter.pathname).toBe(`${leaveReferenceBaseRoute}/hosted/5/1`);
     });
   });
 });

--- a/app/web/features/profile/view/leaveReference/ReferenceForm.tsx
+++ b/app/web/features/profile/view/leaveReference/ReferenceForm.tsx
@@ -88,11 +88,13 @@ export default function ReferenceForm({
 
   const isSkippedStep =
     referenceData.wasAppropriate === "" && step !== "appropriate";
+  const redirectTo =
+    referenceType === "friend"
+      ? `${leaveReferenceBaseRoute}/${referenceType}/${userId}`
+      : `${leaveReferenceBaseRoute}/${referenceType}/${userId}/${hostRequestId}`;
 
   return isSkippedStep ? (
-    <Redirect
-      to={`${leaveReferenceBaseRoute}/${referenceType}/${userId}/${hostRequestId}`}
-    />
+    <Redirect to={redirectTo} />
   ) : step === "appropriate" ? (
     <Appropriate
       referenceData={referenceData}

--- a/app/web/features/profile/view/leaveReference/ReferenceForm.tsx
+++ b/app/web/features/profile/view/leaveReference/ReferenceForm.tsx
@@ -1,11 +1,12 @@
 import { Alert } from "@material-ui/lab";
+import Redirect from "components/Redirect";
 import { INVALID_STEP } from "features/profile/constants";
 import Appropriate from "features/profile/view/leaveReference/formSteps/Appropriate";
 import Rating from "features/profile/view/leaveReference/formSteps/Rating";
 import SubmitReference from "features/profile/view/leaveReference/formSteps/submit/SubmitReference";
 import Text from "features/profile/view/leaveReference/formSteps/Text";
 import { useState } from "react";
-import { ReferenceStep } from "routes";
+import { leaveReferenceBaseRoute, ReferenceStep } from "routes";
 import makeStyles from "utils/makeStyles";
 
 export const useReferenceStyles = makeStyles((theme) => ({
@@ -85,7 +86,14 @@ export default function ReferenceForm({
     }));
   };
 
-  return step === "appropriate" ? (
+  const isSkippedStep =
+    referenceData.wasAppropriate === "" && step !== "appropriate";
+
+  return isSkippedStep ? (
+    <Redirect
+      to={`${leaveReferenceBaseRoute}/${referenceType}/${userId}/${hostRequestId}`}
+    />
+  ) : step === "appropriate" ? (
     <Appropriate
       referenceData={referenceData}
       setReferenceValues={setReferenceValues}


### PR DESCRIPTION
closes Couchers-org/web-frontend#28 

Just redirect to the first page in the reference form if any steps are missing (e.g. because the user refreshed the page).

We could still add an alert and/or persist the form data in session storage, but this change covers the case where all data is lost and user ends up on a page they shouldn't be at yet.

**Web frontend checklist**
- [x] Formatted my code with `yarn format && yarn lint --fix`
- [x] There are no warnings from `yarn lint`
- [x] There are no console warnings when running the app
- [x] Added any new components to storybook
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes
