### PR TITLE
return only users with a complete profile

### DIFF
--- a/app/backend/src/couchers/servicers/search.py
+++ b/app/backend/src/couchers/servicers/search.py
@@ -1,6 +1,7 @@
 """
 See //docs/search.md for overview.
 """
+
 import grpc
 from sqlalchemy.sql import func, or_
 
@@ -293,9 +294,9 @@ def _search_clusters(
     return [
         search_pb2.Result(
             rank=rank,
-            community=community_to_pb(cluster.official_cluster_for_node, context)
-            if cluster.is_official_cluster
-            else None,
+            community=(
+                community_to_pb(cluster.official_cluster_for_node, context) if cluster.is_official_cluster else None
+            ),
             group=group_to_pb(cluster, context) if not cluster.is_official_cluster else None,
             snippet=snippet,
         )
@@ -461,7 +462,6 @@ class Search(search_pb2_grpc.SearchServicer):
             if request.only_with_references:
                 statement = statement.join(Reference, Reference.to_user_id == User.id)
 
-
             # TODO:
             # google.protobuf.StringValue language = 11;
             # bool friends_only = 13;
@@ -486,7 +486,7 @@ class Search(search_pb2_grpc.SearchServicer):
                     )
                     for user in users[:page_size]
                 ],
-                next_page_token=encrypt_page_token(str(users[-1].recommendation_score))
-                if len(users) > page_size
-                else None,
+                next_page_token=(
+                    encrypt_page_token(str(users[-1].recommendation_score)) if len(users) > page_size else None
+                ),
             )

--- a/app/backend/src/couchers/servicers/search.py
+++ b/app/backend/src/couchers/servicers/search.py
@@ -458,6 +458,8 @@ class Search(search_pb2_grpc.SearchServicer):
 
             if request.only_with_references:
                 statement = statement.join(Reference, Reference.to_user_id == User.id)
+            if request.profile_completed:
+                statement = statement.where(User.has_completed_profile == True)
 
             # TODO:
             # google.protobuf.StringValue language = 11;

--- a/app/backend/src/couchers/servicers/search.py
+++ b/app/backend/src/couchers/servicers/search.py
@@ -378,6 +378,8 @@ class Search(search_pb2_grpc.SearchServicer):
                             User.additional_information.ilike(f"%{request.query.value}%"),
                         )
                     )
+            if request.profile_completed:
+                statement = statement.where(User.has_completed_profile == True)
 
             if request.HasField("last_active"):
                 raw_dt = to_aware_datetime(request.last_active)
@@ -458,8 +460,7 @@ class Search(search_pb2_grpc.SearchServicer):
 
             if request.only_with_references:
                 statement = statement.join(Reference, Reference.to_user_id == User.id)
-            if request.profile_completed:
-                statement = statement.where(User.has_completed_profile == True)
+
 
             # TODO:
             # google.protobuf.StringValue language = 11;

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -220,7 +220,7 @@ def generate_user(*, delete_user=False, **kwargs):
         user_opts = {
             "username": username,
             "email": f"{username}@dev.couchers.org",
-            "avatar_key": "test",
+            "avatar": "test",
             # password is just 'password'
             # this is hardcoded because the password is slow to hash (so would slow down tests otherwise)
             "hashed_password": b"$argon2id$v=19$m=65536,t=2,p=1$4cjGg1bRaZ10k+7XbIDmFg$tZG7JaLrkfyfO7cS233ocq7P8rf3znXR7SAfUt34kJg",

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -220,6 +220,7 @@ def generate_user(*, delete_user=False, **kwargs):
         user_opts = {
             "username": username,
             "email": f"{username}@dev.couchers.org",
+            "avatar_key": "test",
             # password is just 'password'
             # this is hardcoded because the password is slow to hash (so would slow down tests otherwise)
             "hashed_password": b"$argon2id$v=19$m=65536,t=2,p=1$4cjGg1bRaZ10k+7XbIDmFg$tZG7JaLrkfyfO7cS233ocq7P8rf3znXR7SAfUt34kJg",

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -85,17 +85,9 @@ def test_user_filter_complete_profile(db):
     user_incomplete_profile, token7 = generate_user(about_me=None, avatar_key="test_avatar_key_2")
 
     with search_session(token7) as api:
-        res = api.UserSearch(
-            search_pb2.UserSearchReq(
-                profile_completed=True
-            )
-        )
+        res = api.UserSearch(search_pb2.UserSearchReq(profile_completed=True))
     assert [result.user.user_id for result in res.results] == [user_complete_profile]
 
     with search_session(token7) as api:
-        res = api.UserSearch(
-            search_pb2.UserSearchReq(
-                profile_completed=False
-            )
-        )
+        res = api.UserSearch(search_pb2.UserSearchReq(profile_completed=False))
     assert [result.user.user_id for result in res.results] == [user_incomplete_profile]

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -80,9 +80,9 @@ def test_user_filter_complete_profile(db):
     Make sure the completed profile flag returns only completed user profile
     """
 
-    user_complete_profile, token6 = generate_user(about_me="this about me is not empty", avatar_key="test_avatar_key_1")
+    user_complete_profile, token6 = generate_user(about_me="this about me is not empty", avatar="test_avatar_1")
 
-    user_incomplete_profile, token7 = generate_user(about_me=None, avatar_key="test_avatar_key_2")
+    user_incomplete_profile, token7 = generate_user(about_me=None, avatar="test_avatar_2")
 
     with search_session(token7) as api:
         res = api.UserSearch(search_pb2.UserSearchReq(profile_completed=True))

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -73,3 +73,29 @@ def test_regression_search_in_area(db):
             )
         )
         assert [result.user.user_id for result in res.results] == [user3.id, user4.id]
+
+
+def test_user_filter_complete_profile(db):
+    """
+    Make sure the completed profile flag returns only completed user profile
+    """
+
+    user_complete_profile, token6 = generate_user(about_me="this about me is not empty", avatar_key="test_avatar_key_1")
+
+    user_incomplete_profile, token7 = generate_user(about_me=None, avatar_key="test_avatar_key_2")
+
+    with search_session(token7) as api:
+        res = api.UserSearch(
+            search_pb2.UserSearchReq(
+                profile_completed=True
+            )
+        )
+    assert [result.user.user_id for result in res.results] == [user_complete_profile]
+
+    with search_session(token7) as api:
+        res = api.UserSearch(
+            search_pb2.UserSearchReq(
+                profile_completed=False
+            )
+        )
+    assert [result.user.user_id for result in res.results] == [user_incomplete_profile]

--- a/app/proto/search.proto
+++ b/app/proto/search.proto
@@ -133,6 +133,7 @@ message UserSearchReq {
   google.protobuf.BoolValue drinks_at_home = 25;
   google.protobuf.BoolValue parking = 26;
   google.protobuf.BoolValue camping_ok = 27;
+  google.protobuf.BoolValue profile_completed = 31;
 
   uint32 page_size = 1;
   string page_token = 2;

--- a/app/proto/search.proto
+++ b/app/proto/search.proto
@@ -94,6 +94,7 @@ message UserSearchReq {
   google.protobuf.StringValue query = 3;
   // whether the query (if any) should only search through username and display name
   bool query_name_only = 30;
+  bool profile_completed = 31;
 
   // coarsened
   google.protobuf.Timestamp last_active = 4;
@@ -133,7 +134,6 @@ message UserSearchReq {
   google.protobuf.BoolValue drinks_at_home = 25;
   google.protobuf.BoolValue parking = 26;
   google.protobuf.BoolValue camping_ok = 27;
-  google.protobuf.BoolValue profile_completed = 31;
 
   uint32 page_size = 1;
   string page_token = 2;


### PR DESCRIPTION
closes #3978 - create a filter to return only users with a complete profile

**Backend checklist**
- [x] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] All tests pass
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history


