### PR TITLE
filter out incomplete profiles

### DIFF
--- a/app/backend/src/couchers/servicers/search.py
+++ b/app/backend/src/couchers/servicers/search.py
@@ -408,7 +408,7 @@ class Search(search_pb2_grpc.SearchServicer):
                     User.parking_details.in_([parkingdetails2sql[det] for det in request.parking_details_filter])
                 )
             if request.HasField("profile_completed"):
-                statement = statement.where(User.profile_completed == request.profile_completed.value)
+                statement = statement.where(User.has_completed_profile == request.profile_completed.value)
             if request.HasField("guests"):
                 statement = statement.where(User.max_guests >= request.guests.value)
             if request.HasField("last_minute"):

--- a/app/backend/src/couchers/servicers/search.py
+++ b/app/backend/src/couchers/servicers/search.py
@@ -1,6 +1,7 @@
 """
 See //docs/search.md for overview.
 """
+
 import grpc
 from sqlalchemy.sql import func, or_
 
@@ -293,9 +294,9 @@ def _search_clusters(
     return [
         search_pb2.Result(
             rank=rank,
-            community=community_to_pb(cluster.official_cluster_for_node, context)
-            if cluster.is_official_cluster
-            else None,
+            community=(
+                community_to_pb(cluster.official_cluster_for_node, context) if cluster.is_official_cluster else None
+            ),
             group=group_to_pb(cluster, context) if not cluster.is_official_cluster else None,
             snippet=snippet,
         )
@@ -461,7 +462,6 @@ class Search(search_pb2_grpc.SearchServicer):
             if request.only_with_references:
                 statement = statement.join(Reference, Reference.to_user_id == User.id)
 
-
             # TODO:
             # google.protobuf.StringValue language = 11;
             # bool friends_only = 13;
@@ -486,7 +486,7 @@ class Search(search_pb2_grpc.SearchServicer):
                     )
                     for user in users[:page_size]
                 ],
-                next_page_token=encrypt_page_token(str(users[-1].recommendation_score))
-                if len(users) > page_size
-                else None,
+                next_page_token=(
+                    encrypt_page_token(str(users[-1].recommendation_score)) if len(users) > page_size else None
+                ),
             )

--- a/app/backend/src/couchers/servicers/search.py
+++ b/app/backend/src/couchers/servicers/search.py
@@ -458,6 +458,8 @@ class Search(search_pb2_grpc.SearchServicer):
 
             if request.only_with_references:
                 statement = statement.join(Reference, Reference.to_user_id == User.id)
+            if request.profile_completed:
+                statement = statement.where(User.has_completed_profile == True)
 
             # TODO:
             # google.protobuf.StringValue language = 11;

--- a/app/backend/src/couchers/servicers/search.py
+++ b/app/backend/src/couchers/servicers/search.py
@@ -378,6 +378,8 @@ class Search(search_pb2_grpc.SearchServicer):
                             User.additional_information.ilike(f"%{request.query.value}%"),
                         )
                     )
+            if request.profile_completed:
+                statement = statement.where(User.has_completed_profile == True)
 
             if request.HasField("last_active"):
                 raw_dt = to_aware_datetime(request.last_active)
@@ -458,8 +460,7 @@ class Search(search_pb2_grpc.SearchServicer):
 
             if request.only_with_references:
                 statement = statement.join(Reference, Reference.to_user_id == User.id)
-            if request.profile_completed:
-                statement = statement.where(User.has_completed_profile == True)
+
 
             # TODO:
             # google.protobuf.StringValue language = 11;

--- a/app/backend/src/couchers/servicers/search.py
+++ b/app/backend/src/couchers/servicers/search.py
@@ -379,8 +379,8 @@ class Search(search_pb2_grpc.SearchServicer):
                             User.additional_information.ilike(f"%{request.query.value}%"),
                         )
                     )
-            if request.profile_completed:
-                statement = statement.where(User.has_completed_profile == True)
+            # if request.profile_completed:
+            #     statement = statement.where(User.has_completed_profile == True)
 
             if request.HasField("last_active"):
                 raw_dt = to_aware_datetime(request.last_active)
@@ -407,7 +407,8 @@ class Search(search_pb2_grpc.SearchServicer):
                 statement = statement.where(
                     User.parking_details.in_([parkingdetails2sql[det] for det in request.parking_details_filter])
                 )
-
+            if request.HasField("profile_completed"):
+                statement = statement.where(User.profile_completed == request.profile_completed.value)
             if request.HasField("guests"):
                 statement = statement.where(User.max_guests >= request.guests.value)
             if request.HasField("last_minute"):

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -220,7 +220,7 @@ def generate_user(*, delete_user=False, **kwargs):
         user_opts = {
             "username": username,
             "email": f"{username}@dev.couchers.org",
-            "avatar_key": "test",
+            "avatar": "test",
             # password is just 'password'
             # this is hardcoded because the password is slow to hash (so would slow down tests otherwise)
             "hashed_password": b"$argon2id$v=19$m=65536,t=2,p=1$4cjGg1bRaZ10k+7XbIDmFg$tZG7JaLrkfyfO7cS233ocq7P8rf3znXR7SAfUt34kJg",

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -246,7 +246,6 @@ def generate_user(*, delete_user=False, **kwargs):
             "onboarding_emails_sent": 1,
             "last_onboarding_email_sent": now(),
             "new_notifications_enabled": True,
-            "profile_completed": True,
         }
 
         for key, value in kwargs.items():

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -220,7 +220,6 @@ def generate_user(*, delete_user=False, **kwargs):
         user_opts = {
             "username": username,
             "email": f"{username}@dev.couchers.org",
-            "avatar": "test",
             # password is just 'password'
             # this is hardcoded because the password is slow to hash (so would slow down tests otherwise)
             "hashed_password": b"$argon2id$v=19$m=65536,t=2,p=1$4cjGg1bRaZ10k+7XbIDmFg$tZG7JaLrkfyfO7cS233ocq7P8rf3znXR7SAfUt34kJg",

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -220,6 +220,7 @@ def generate_user(*, delete_user=False, **kwargs):
         user_opts = {
             "username": username,
             "email": f"{username}@dev.couchers.org",
+            "avatar_key": "test",
             # password is just 'password'
             # this is hardcoded because the password is slow to hash (so would slow down tests otherwise)
             "hashed_password": b"$argon2id$v=19$m=65536,t=2,p=1$4cjGg1bRaZ10k+7XbIDmFg$tZG7JaLrkfyfO7cS233ocq7P8rf3znXR7SAfUt34kJg",

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -246,6 +246,7 @@ def generate_user(*, delete_user=False, **kwargs):
             "onboarding_emails_sent": 1,
             "last_onboarding_email_sent": now(),
             "new_notifications_enabled": True,
+            "profile_completed": True,
         }
 
         for key, value in kwargs.items():

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -1,12 +1,11 @@
 import pytest
-
-from couchers.utils import create_coordinate
-from couchers.db import session_scope
-from couchers.crypto import random_hex
-from proto import search_pb2
-from couchers.models import Upload, User
 from google.protobuf import wrappers_pb2
 
+from couchers.crypto import random_hex
+from couchers.db import session_scope
+from couchers.models import Upload
+from couchers.utils import create_coordinate
+from proto import search_pb2
 from tests.test_communities import testing_communities  # noqa
 from tests.test_fixtures import db, generate_user, search_session, testconfig  # noqa
 

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -86,8 +86,8 @@ def test_user_filter_complete_profile(db):
 
     with search_session(token7) as api:
         res = api.UserSearch(search_pb2.UserSearchReq(profile_completed=True))
-    assert [result.user.user_id for result in res.results] == [user_complete_profile]
+        assert [result.user.user_id for result in res.results] == [user_complete_profile]
 
     with search_session(token7) as api:
         res = api.UserSearch(search_pb2.UserSearchReq(profile_completed=False))
-    assert [result.user.user_id for result in res.results] == [user_incomplete_profile]
+        assert [result.user.user_id for result in res.results] == [user_incomplete_profile]

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -82,7 +82,7 @@ def test_user_filter_complete_profile(db):
 
     user_complete_profile, token6 = generate_user(about_me="this about me is not empty")
 
-    user_incomplete_profile, token7 = generate_user(about_me=None)
+    user_incomplete_profile, token7 = generate_user(about_me="")
 
     with search_session(token7) as api:
         res = api.UserSearch(search_pb2.UserSearchReq(profile_completed=True))

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -80,11 +80,11 @@ def test_user_filter_complete_profile(db):
     Make sure the completed profile flag returns only completed user profile
     """
 
-    user_complete_profile, token6 = generate_user(about_me="this about me is not empty")
+    user_complete_profile, token6 = generate_user(profile_completed=True)
 
-    user_incomplete_profile, token7 = generate_user(about_me="")
+    user_incomplete_profile, token7 = generate_user(profile_completed=False)
 
-    with search_session(token7) as api:
+    with search_session(token6) as api:
         res = api.UserSearch(search_pb2.UserSearchReq(profile_completed=True))
         assert [result.user.user_id for result in res.results] == [user_complete_profile]
 

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -80,22 +80,14 @@ def test_user_filter_complete_profile(db):
     Make sure the completed profile flag returns only completed user profile
     """
 
-    user_complete_profile, token6 = generate_user(about_me="this about me is not empty", avatar_key="test_avatar_key_1")
+    user_complete_profile, token6 = generate_user(about_me="this about me is not empty", avatar="test_avatar_1")
 
-    user_incomplete_profile, token7 = generate_user(about_me=None, avatar_key="test_avatar_key_2")
+    user_incomplete_profile, token7 = generate_user(about_me=None, avatar="test_avatar_2")
 
     with search_session(token7) as api:
-        res = api.UserSearch(
-            search_pb2.UserSearchReq(
-                profile_completed=True
-            )
-        )
+        res = api.UserSearch(search_pb2.UserSearchReq(profile_completed=True))
     assert [result.user.user_id for result in res.results] == [user_complete_profile]
 
     with search_session(token7) as api:
-        res = api.UserSearch(
-            search_pb2.UserSearchReq(
-                profile_completed=False
-            )
-        )
+        res = api.UserSearch(search_pb2.UserSearchReq(profile_completed=False))
     assert [result.user.user_id for result in res.results] == [user_incomplete_profile]

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -80,9 +80,9 @@ def test_user_filter_complete_profile(db):
     Make sure the completed profile flag returns only completed user profile
     """
 
-    user_complete_profile, token6 = generate_user(about_me="this about me is not empty", avatar="test_avatar_1")
+    user_complete_profile, token6 = generate_user(about_me="this about me is not empty")
 
-    user_incomplete_profile, token7 = generate_user(about_me=None, avatar="test_avatar_2")
+    user_incomplete_profile, token7 = generate_user(about_me=None)
 
     with search_session(token7) as api:
         res = api.UserSearch(search_pb2.UserSearchReq(profile_completed=True))

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -5,6 +5,8 @@ from couchers.db import session_scope
 from couchers.crypto import random_hex
 from proto import search_pb2
 from couchers.models import Upload, User
+from google.protobuf import wrappers_pb2
+
 
 from tests.test_communities import testing_communities  # noqa
 from tests.test_fixtures import db, generate_user, search_session, testconfig  # noqa
@@ -114,11 +116,11 @@ def test_user_filter_complete_profile(db):
 
     with search_session(token6) as api:
         req = search_pb2.UserSearchReq()
-        req.profile_completed = True
+        req.profile_completed = wrappers_pb2.BoolValue(value=True)
         res = api.UserSearch(req)
         assert [result.user.user_id for result in res.results] == [user_complete_profile]
 
     with search_session(token7) as api:
         req = search_pb2.UserSearchReq()
-        req.profile_completed = False
+        req.profile_completed = wrappers_pb2.BoolValue(value=False)
         assert [result.user.user_id for result in res.results] == [user_incomplete_profile]

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -118,9 +118,9 @@ def test_user_filter_complete_profile(db):
         req = search_pb2.UserSearchReq()
         req.profile_completed.CopyFrom(wrappers_pb2.BoolValue(value=True))
         res = api.UserSearch(req)
-        assert [result.user.user_id for result in res.results] == [user_complete_profile]
+        assert [result.user.user_id for result in res.results] == [user_complete_profile.id]
 
     with search_session(token7) as api:
         req = search_pb2.UserSearchReq()
         req.profile_completed.CopyFrom(wrappers_pb2.BoolValue(value=False))
-        assert [result.user.user_id for result in res.results] == [user_incomplete_profile]
+        assert [result.user.user_id for result in res.results] == [user_incomplete_profile.id]

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -113,9 +113,12 @@ def test_user_filter_complete_profile(db):
     user_incomplete_profile, token7 = generate_user(about_me="", avatar_key=key2)
 
     with search_session(token6) as api:
-        res = api.UserSearch(search_pb2.UserSearchReq(profile_completed=True))
+        req = search_pb2.UserSearchReq()
+        req.profile_completed = True
+        res = api.UserSearch(req)
         assert [result.user.user_id for result in res.results] == [user_complete_profile]
 
     with search_session(token7) as api:
-        res = api.UserSearch(search_pb2.UserSearchReq(profile_completed=False))
+        req = search_pb2.UserSearchReq()
+        req.profile_completed = False
         assert [result.user.user_id for result in res.results] == [user_incomplete_profile]

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -85,6 +85,7 @@ def test_user_filter_complete_profile(db):
     Make sure the completed profile flag returns only completed user profile
     """
     uploader_user, _ = generate_user()
+    print(uploader_user)
     with session_scope() as session:
         key = random_hex(32)
         filename = random_hex(32) + ".jpg"
@@ -112,14 +113,12 @@ def test_user_filter_complete_profile(db):
     user_complete_profile, token6 = generate_user(about_me="this profile is complete", avatar_key=key)
 
     user_incomplete_profile, token7 = generate_user(about_me="", avatar_key=key2)
-    print(user_complete_profile)
-    print(user_incomplete_profile)
 
     with search_session(token7) as api:
         req = search_pb2.UserSearchReq()
         req.profile_completed.CopyFrom(wrappers_pb2.BoolValue(value=False))
         res = api.UserSearch(req)
-        assert [result.user.user_id for result in res.results] == [user_incomplete_profile.id]
+        assert user_incomplete_profile.id in [result.user.user_id for result in res.results]
 
     with search_session(token6) as api:
         req = search_pb2.UserSearchReq()

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -55,11 +55,11 @@ def test_regression_search_in_area(db):
     At the equator/prime meridian intersection (0,0), one degree is roughly 111 km.
     """
 
-    # # outside
-    # user1, token1 = generate_user(geom=create_coordinate(1, 0), geom_radius=100)
-    # # outside
-    # user2, token2 = generate_user(geom=create_coordinate(0, 1), geom_radius=100)
-    # # inside
+    # outside
+    user1, token1 = generate_user(geom=create_coordinate(1, 0), geom_radius=100)
+    # outside
+    user2, token2 = generate_user(geom=create_coordinate(0, 1), geom_radius=100)
+    # inside
     user3, token3 = generate_user(geom=create_coordinate(0.1, 0), geom_radius=100)
     # inside
     user4, token4 = generate_user(geom=create_coordinate(0, 0.1), geom_radius=100)
@@ -95,7 +95,6 @@ def test_user_filter_complete_profile(db):
                 creator_user_id=uploader_user.id,
             )
         )
-        session.commit()
 
     with session_scope() as session:
         key2 = random_hex(32)
@@ -107,7 +106,6 @@ def test_user_filter_complete_profile(db):
                 creator_user_id=uploader_user.id,
             )
         )
-        session.commit()
 
     user_complete_profile, token6 = generate_user(about_me="this profile is complete", avatar_key=key)
 

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -73,3 +73,29 @@ def test_regression_search_in_area(db):
             )
         )
         assert [result.user.user_id for result in res.results] == [user3.id, user4.id]
+
+
+def test_user_filter_complete_profile(db):
+    """
+    Make sure the completed profile flag returns only completed user profile
+    """
+
+    user_complete_profile, token6 = generate_user(about_me="this about me is not empty", avatar_key="test_avatar_key_1")
+
+    user_incomplete_profile, token7 = generate_user(about_me=None, avatar_key="test_avatar_key_2")
+
+    with search_session(token7) as api:
+        res = api.UserSearch(
+            search_pb2.UserSearchReq(
+                profile_completed=True
+            )
+        )
+    assert [result.user.user_id for result in res.results] == [user_complete_profile]
+
+    with search_session(token7) as api:
+        res = api.UserSearch(
+            search_pb2.UserSearchReq(
+                profile_completed=False
+            )
+        )
+    assert [result.user.user_id for result in res.results] == [user_incomplete_profile]

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -116,11 +116,11 @@ def test_user_filter_complete_profile(db):
 
     with search_session(token6) as api:
         req = search_pb2.UserSearchReq()
-        req.profile_completed = wrappers_pb2.BoolValue(value=True)
+        req.profile_completed.CopyFrom(wrappers_pb2.BoolValue(value=True))
         res = api.UserSearch(req)
         assert [result.user.user_id for result in res.results] == [user_complete_profile]
 
     with search_session(token7) as api:
         req = search_pb2.UserSearchReq()
-        req.profile_completed = wrappers_pb2.BoolValue(value=False)
+        req.profile_completed.CopyFrom(wrappers_pb2.BoolValue(value=False))
         assert [result.user.user_id for result in res.results] == [user_incomplete_profile]

--- a/app/proto/search.proto
+++ b/app/proto/search.proto
@@ -133,6 +133,7 @@ message UserSearchReq {
   google.protobuf.BoolValue drinks_at_home = 25;
   google.protobuf.BoolValue parking = 26;
   google.protobuf.BoolValue camping_ok = 27;
+  google.protobuf.BoolValue profile_completed = 31;
 
   uint32 page_size = 1;
   string page_token = 2;

--- a/app/proto/search.proto
+++ b/app/proto/search.proto
@@ -94,6 +94,7 @@ message UserSearchReq {
   google.protobuf.StringValue query = 3;
   // whether the query (if any) should only search through username and display name
   bool query_name_only = 30;
+  bool profile_completed = 31;
 
   // coarsened
   google.protobuf.Timestamp last_active = 4;
@@ -133,7 +134,6 @@ message UserSearchReq {
   google.protobuf.BoolValue drinks_at_home = 25;
   google.protobuf.BoolValue parking = 26;
   google.protobuf.BoolValue camping_ok = 27;
-  google.protobuf.BoolValue profile_completed = 31;
 
   uint32 page_size = 1;
   string page_token = 2;

--- a/app/proto/search.proto
+++ b/app/proto/search.proto
@@ -94,7 +94,6 @@ message UserSearchReq {
   google.protobuf.StringValue query = 3;
   // whether the query (if any) should only search through username and display name
   bool query_name_only = 30;
-  bool profile_completed = 31;
 
   // coarsened
   google.protobuf.Timestamp last_active = 4;
@@ -134,6 +133,8 @@ message UserSearchReq {
   google.protobuf.BoolValue drinks_at_home = 25;
   google.protobuf.BoolValue parking = 26;
   google.protobuf.BoolValue camping_ok = 27;
+  google.protobuf.BoolValue profile_completed = 31;
+
 
   uint32 page_size = 1;
   string page_token = 2;


### PR DESCRIPTION
closes #3978 - create a filter to return only users with a complete profile


- [x] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] All tests pass
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history
