### PR TITLE
To fix the automated tests in test_search.py

### DIFF
--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -66,6 +66,13 @@ def _get_base_engine():
     )
 
 
+def clear_base_engine_cache():
+    """
+    This needs to be done when the public schema is dropped.
+    """
+    _get_base_engine.cache_clear()
+
+
 def get_engine(isolation_level=None):
     """
     Creates an engine with the given isolation level.

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -12,7 +12,7 @@ from sqlalchemy.sql import or_, text
 from couchers.config import config
 from couchers.constants import GUIDELINES_VERSION, TOS_VERSION
 from couchers.crypto import random_hex
-from couchers.db import get_engine, session_scope, clear_base_engine_cache
+from couchers.db import clear_base_engine_cache, get_engine, session_scope
 from couchers.interceptors import AuthValidatorInterceptor, _try_get_and_update_user_details
 from couchers.models import (
     Base,

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -187,7 +187,7 @@ def recreate_database():
 
     # drop everything currently in the database
     drop_all()
-    clear_base_engine_cache() # to address errors like sqlalchemy.exc.InternalError: (psycopg2.errors.InternalError_) no spatial operator found for 'st_dwithin'
+    clear_base_engine_cache()  # to address errors like sqlalchemy.exc.InternalError: (psycopg2.errors.InternalError_) no spatial operator found for 'st_dwithin'
 
     # create everything from the current models, not incrementally through migrations
     create_schema_from_models()

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -12,7 +12,7 @@ from sqlalchemy.sql import or_, text
 from couchers.config import config
 from couchers.constants import GUIDELINES_VERSION, TOS_VERSION
 from couchers.crypto import random_hex
-from couchers.db import get_engine, session_scope
+from couchers.db import get_engine, session_scope, clear_base_engine_cache
 from couchers.interceptors import AuthValidatorInterceptor, _try_get_and_update_user_details
 from couchers.models import (
     Base,
@@ -187,6 +187,7 @@ def recreate_database():
 
     # drop everything currently in the database
     drop_all()
+    clear_base_engine_cache() # to address errors like sqlalchemy.exc.InternalError: (psycopg2.errors.InternalError_) no spatial operator found for 'st_dwithin'
 
     # create everything from the current models, not incrementally through migrations
     create_schema_from_models()


### PR DESCRIPTION
FAILED tests/test_search.py::test_regression_search_in_area - sqlalchemy.exc.InternalError: (psycopg2.errors.InternalError_) no spatial operator found for 'st_dwithin': opfamil...
ERROR tests/test_search.py::test_UserSearch - sqlalchemy.exc.InternalError: (psycopg2.errors.InternalError_) no spatial operator found for 'st_contains': opfami...

The failure did not happen when tests were run individually, suggesting it was due to test interaction.

<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->


<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Backend checklist**
- [x] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] All tests pass
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
