### PR TITLE
Add path to download descriptors.pb from envoy proxy

### DIFF
--- a/app/proxy/Dockerfile
+++ b/app/proxy/Dockerfile
@@ -1,7 +1,7 @@
 FROM envoyproxy/envoy:v1.24.0
 
 COPY ./envoy.yaml /etc/envoy/envoy.yaml
-COPY ./descriptors.pb /tmp/envoy/descriptors.pb
+COPY ./descriptors.pb /etc/envoy/descriptors.pb
 
 EXPOSE 8888
 EXPOSE 9901

--- a/app/proxy/envoy.yaml
+++ b/app/proxy/envoy.yaml
@@ -18,6 +18,7 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
           route_config:
             name: local_route
+            max_direct_response_body_size_bytes: 10485760
             virtual_hosts:
             - name: local_service
               domains: ["*"]
@@ -31,6 +32,16 @@ static_resources:
                       in building the next-generation couch surfing platform with us, or if you're
                       just interested in API access, please contact us through https://couchers.org
                       or come help out on GitHub at https://github.com/Couchers-org.
+              - match: { path: "/descriptors.pb" }
+                direct_response:
+                  status: 200
+                  body:
+                    filename: "/etc/envoy/descriptors.pb"
+                response_headers_to_add:
+                  - header:
+                      key: content-type
+                      value: application/octet-stream
+                    append: false
               - match: { prefix: "/" }
                 route:
                   cluster: couchers_service
@@ -90,7 +101,7 @@ static_resources:
           - name: envoy.filters.http.grpc_json_transcoder
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder
-              proto_descriptor: "/tmp/envoy/descriptors.pb"
+              proto_descriptor: "/etc/envoy/descriptors.pb"
               services:
                 - org.couchers.auth.Auth
                 - org.couchers.json.GIS


### PR DESCRIPTION
This allows one to go download the protos in use by envoy by going to https://api.couchers.org/descriptors.pb, which allows me to build a tool that will get the latest protos from the API it's hitting.


<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Backend checklist**
- [ ] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
