### PR TITLE
Implement Status and GetDescriptors methods

### DIFF
--- a/app/backend/src/couchers/descriptor_pool.py
+++ b/app/backend/src/couchers/descriptor_pool.py
@@ -5,6 +5,12 @@ from google.protobuf import descriptor_pb2, descriptor_pool
 
 
 @functools.lru_cache
+def get_descriptors_pb():
+    with open(Path(__file__).parent / ".." / "proto" / "descriptors.pb", "rb") as descriptor_set_f:
+        return descriptor_set_f.read()
+
+
+@functools.lru_cache
 def get_descriptor_pool():
     """
     Generates a protocol buffer object descriptor pool which allows looking up info about our proto API, such as options
@@ -14,8 +20,7 @@ def get_descriptor_pool():
     from proto import annotations_pb2  # noqa
 
     pool = descriptor_pool.DescriptorPool()
-    with open(Path(__file__).parent / ".." / "proto" / "descriptors.pb", "rb") as descriptor_set_f:
-        desc = descriptor_pb2.FileDescriptorSet.FromString(descriptor_set_f.read())
+    desc = descriptor_pb2.FileDescriptorSet.FromString(get_descriptors_pb())
     for file_descriptor in desc.file:
         pool.Add(file_descriptor)
     return pool

--- a/app/proto/bugs.proto
+++ b/app/proto/bugs.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package org.couchers.bugs;
 
 import "google/api/annotations.proto";
+import "google/api/httpbody.proto";
 import "google/protobuf/empty.proto";
 
 import "annotations.proto";
@@ -19,6 +20,20 @@ service Bugs {
 
   rpc ReportBug(ReportBugReq) returns (ReportBugRes) {
     // Report a bug
+  }
+
+  rpc Status(StatusReq) returns (StatusRes) {
+    // Hits database, can be used to check the backend is up and working
+    option (google.api.http) = {
+      get : "/status"
+    };
+  }
+
+  rpc GetDescriptors(google.protobuf.Empty) returns (google.api.HttpBody) {
+    // Returns the proto descriptors the backend is using
+    option (google.api.http) = {
+      get : "/descriptors.pb"
+    };
   }
 }
 
@@ -39,4 +54,14 @@ message ReportBugReq {
 message ReportBugRes {
   string bug_id = 2;
   string bug_url = 3;
+}
+
+message StatusReq {
+  string nonce = 1;
+}
+
+message StatusRes {
+  string nonce = 1;
+  string version = 2;
+  uint64 coucher_count = 3;
 }


### PR DESCRIPTION
This implements a status endpoint that checks that the database is working. I'll use it to set up status monitoring given the recent issues.

Also added the descriptors.pb thing from #4050 (this time in the backend). This allows one to go download the protos in use by envoy by going to https://api.couchers.org/descriptors.pb, which allows me to build a tool that will get the latest protos from the API it's hitting.

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Backend checklist**
- [ ] Formatted my code by running `autoflake -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
