### PR TITLE
Tweaks to auth flows

### DIFF
--- a/app/backend/src/couchers/migrations/versions/ffe7d9a87925_update_session_token_default_expiry.py
+++ b/app/backend/src/couchers/migrations/versions/ffe7d9a87925_update_session_token_default_expiry.py
@@ -1,0 +1,24 @@
+"""Update session token default expiry
+
+Revision ID: ffe7d9a87925
+Revises: 7f9f32e4b055
+Create Date: 2024-04-18 14:26:10.920560
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ffe7d9a87925"
+down_revision = "7f9f32e4b055"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("sessions", "expiry", server_default=sa.func.now() + sa.text("interval '730 days'"))
+
+
+def downgrade():
+    op.alter_column("sessions", "expiry", server_default=sa.func.now() + sa.text("interval '90 days'"))

--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -757,7 +757,7 @@ class UserSession(Base):
     created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
     # the expiry of the session: the session *cannot* be refreshed past this
-    expiry = Column(DateTime(timezone=True), nullable=False, server_default=func.now() + text("interval '90 days'"))
+    expiry = Column(DateTime(timezone=True), nullable=False, server_default=func.now() + text("interval '730 days'"))
 
     # the time at which the token was invalidated, allows users to delete sessions
     deleted = Column(DateTime(timezone=True), nullable=True, default=None)

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -101,7 +101,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
             if not user:
                 context.abort(grpc.StatusCode.NOT_FOUND, errors.USER_NOT_FOUND)
             token, expiry = create_session(
-                context, session, user, long_lived=True, is_api_key=True, duration=timedelta(days=365)
+                context, session, user, long_lived=True, is_api_key=True, duration=timedelta(days=365), set_cookie=False
             )
             send_api_key_email(session, user, token, expiry)
 

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -84,7 +84,7 @@ def create_session(context, session, user, long_lived, is_api_key=False, duratio
         token=token,
         user=user,
         long_lived=long_lived,
-        ip_address=headers.get("x-forwarded-for"),
+        ip_address=headers.get("x-couchers-real-ip"),
         user_agent=headers.get("user-agent"),
         is_api_key=is_api_key,
     )

--- a/app/backend/src/couchers/sql.py
+++ b/app/backend/src/couchers/sql.py
@@ -30,11 +30,11 @@ def couchers_select(*expr):
 class CouchersSelect(Select):
     inherit_cache = True
 
-    def where_username_or_email(self, field):
+    def where_username_or_email(self, field, model=User):
         if is_valid_username(field):
-            return self.where(User.username == field)
+            return self.where(model.username == field)
         elif is_valid_email(field):
-            return self.where(User.email == field)
+            return self.where(model.email == field)
         # no fields match, this will return no rows
         return self.where(False)
 

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -274,7 +274,7 @@ def generate_user(*, delete_user=False, **kwargs):
             def invocation_metadata(self):
                 return {}
 
-        token, _ = create_session(_DummyContext(), session, user, False)
+        token, _ = create_session(_DummyContext(), session, user, False, set_cookie=False)
 
         # deleted user aborts session creation, hence this follows and necessitates a second commit
         if delete_user:

--- a/app/nginx/sites-enabled/api.conf
+++ b/app/nginx/sites-enabled/api.conf
@@ -10,6 +10,8 @@ server {
     ssl_certificate_key /certs/live/{API_DOMAIN}/privkey.pem;
 
     location / {
+        proxy_set_header x-couchers-real-ip $remote_addr;
+
         proxy_http_version 1.1;
         proxy_pass http://envoy:8888;
     }
@@ -27,6 +29,8 @@ server {
     ssl_certificate_key /certs/live/{API_DOMAIN}/privkey.pem;
 
     location / {
+        grpc_set_header x-couchers-real-ip $remote_addr;
+
         grpc_pass envoy:8888;
     }
 }

--- a/app/proto/auth.proto
+++ b/app/proto/auth.proto
@@ -96,6 +96,14 @@ service Auth {
 
   rpc CompletePasswordReset(CompletePasswordResetReq) returns (google.protobuf.Empty) {
     // Triggered when the user goes to the link sent in the forgot password email
+    //
+    // Clears the user's password, which then causes them to have to set one through the jail mechanism right after
+  }
+
+  rpc CompletePasswordResetV2(CompletePasswordResetV2Req) returns (google.protobuf.Empty) {
+    // Triggered when the user goes to the link sent in the forgot password email
+    //
+    // Actually changes the user's password
   }
 
   rpc ConfirmChangeEmail(ConfirmChangeEmailReq) returns (ConfirmChangeEmailRes) {
@@ -220,6 +228,12 @@ message ResetPasswordReq {
 
 message CompletePasswordResetReq {
   string password_reset_token = 1 [ (sensitive) = true ];
+}
+
+message CompletePasswordResetV2Req {
+  string password_reset_token = 1 [ (sensitive) = true ];
+  // the frontend should ask for the password twice and whatnot
+  string new_password = 2 [ (sensitive) = true ];
 }
 
 message ConfirmChangeEmailReq {

--- a/app/proto/auth.proto
+++ b/app/proto/auth.proto
@@ -100,8 +100,8 @@ service Auth {
     // Clears the user's password, which then causes them to have to set one through the jail mechanism right after
   }
 
-  rpc CompletePasswordResetV2(CompletePasswordResetV2Req) returns (google.protobuf.Empty) {
-    // Triggered when the user goes to the link sent in the forgot password email
+  rpc CompletePasswordResetV2(CompletePasswordResetV2Req) returns (AuthRes) {
+    // Triggered when the user goes to the link sent in the forgot password email, and logs the user in
     //
     // Actually changes the user's password
   }


### PR DESCRIPTION
* Sends a user a reminder to finish signing up if they try to log in with a username/email that hasn't completed signup
* Adds a new password reset endpoint that actually resets password, instead of just clearing it and making the user do it on the next screen, closes #4058
* Extends session expiry, closes #4059 
* Passes the real IP address through nginx to the backend

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Backend checklist**
- [x] Formatted my code by running `autoflake --exclude src/proto -r -i --remove-all-unused-imports src && isort . && black .` in `app/backend`
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] All tests pass
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

<!---
Remember to request review from couchers-org/web, couchers-org/@backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
