### PR TITLE
add button to add event to a community

### DIFF
--- a/app/web/features/communities/events/EventPage.tsx
+++ b/app/web/features/communities/events/EventPage.tsx
@@ -6,6 +6,7 @@ import {
   Link as MuiLink,
   Theme,
   Typography,
+  Snackbar,
 } from "@material-ui/core";
 import { eventImagePlaceholderUrl } from "appConstants";
 import Alert from "components/Alert";
@@ -75,6 +76,9 @@ export const useEventPageStyles = makeStyles<Theme, { eventImageSrc: string }>(
       gridArea: "backButton",
       width: "3.125rem",
       height: "3.125rem",
+    },
+    snackBar: {
+      fontSize: "0.9rem !important",
     },
     eventTitle: {
       gridArea: "eventTitle",
@@ -194,6 +198,8 @@ export default function EventPage({
   );
 
   const [cancelDialogIsOpen, setCancelDialogIsOpen] = useState(false);
+  const [showInviteCommunitySuccess, setShowInviteCommunitySuccess] =
+    useState(false);
   const [inviteCommunityDialogIsOpen, setInviteCommunityDialogIsOpen] =
     useState(false);
 
@@ -211,9 +217,11 @@ export default function EventPage({
     eventImageSrc: event?.photoUrl || eventImagePlaceholderUrl,
   });
 
-  return !isValidEventId ? (
-    <NotFoundPage />
-  ) : (
+  if (!isValidEventId) {
+    return <NotFoundPage />;
+  }
+
+  return (
     <>
       <HtmlMeta title={event?.title} />
       {(eventError || setEventAttendanceError) && (
@@ -221,6 +229,20 @@ export default function EventPage({
           {eventError?.message || setEventAttendanceError?.message || ""}
         </Alert>
       )}
+
+      <Snackbar
+        className={classes.snackBar}
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+        open={showInviteCommunitySuccess}
+        autoHideDuration={5000}
+        onClose={() => setShowInviteCommunitySuccess(false)}
+        children={
+          <Alert className={classes.snackBar} severity="success">
+            {t("communities:invite_community_dialog.toast_success")}
+          </Alert>
+        }
+      />
+
       {isLoading ? (
         <CircularProgress />
       ) : (
@@ -303,12 +325,15 @@ export default function EventPage({
                       color="secondary"
                       disabled={event.isCancelled || isPastEvent}
                     >
-                      {t("communities:invite_community_button")}
+                      {t("communities:invite_community_dialog_buttons.open")}
                     </Button>
                     <InviteCommunityDialog
                       open={inviteCommunityDialogIsOpen}
                       onClose={() => setInviteCommunityDialogIsOpen(false)}
                       eventId={eventId}
+                      afterSuccess={() => {
+                        setShowInviteCommunitySuccess(true);
+                      }}
                     />
                   </>
                 ) : null}

--- a/app/web/features/communities/events/EventPage.tsx
+++ b/app/web/features/communities/events/EventPage.tsx
@@ -6,8 +6,8 @@ import {
   Link as MuiLink,
   Theme,
   Typography,
-  Snackbar,
 } from "@material-ui/core";
+import Snackbar from "components/Snackbar";
 import { eventImagePlaceholderUrl } from "appConstants";
 import Alert from "components/Alert";
 import Button from "components/Button";
@@ -230,18 +230,12 @@ export default function EventPage({
         </Alert>
       )}
 
-      <Snackbar
-        className={classes.snackBar}
-        anchorOrigin={{ vertical: "top", horizontal: "center" }}
-        open={showInviteCommunitySuccess}
-        autoHideDuration={5000}
-        onClose={() => setShowInviteCommunitySuccess(false)}
-        children={
-          <Alert className={classes.snackBar} severity="success">
-            {t("communities:invite_community_dialog.toast_success")}
-          </Alert>
-        }
-      />
+      {showInviteCommunitySuccess && (
+        <Snackbar
+          severity="success"
+          children={t("communities:invite_community_dialog.toast_success")}
+        />
+      )}
 
       {isLoading ? (
         <CircularProgress />
@@ -328,12 +322,10 @@ export default function EventPage({
                       {t("communities:invite_community_dialog_buttons.open")}
                     </Button>
                     <InviteCommunityDialog
+                      afterSuccess={() => setShowInviteCommunitySuccess(true)}
                       open={inviteCommunityDialogIsOpen}
                       onClose={() => setInviteCommunityDialogIsOpen(false)}
                       eventId={eventId}
-                      afterSuccess={() => {
-                        setShowInviteCommunitySuccess(true);
-                      }}
                     />
                   </>
                 ) : null}

--- a/app/web/features/communities/events/EventPage.tsx
+++ b/app/web/features/communities/events/EventPage.tsx
@@ -77,9 +77,6 @@ export const useEventPageStyles = makeStyles<Theme, { eventImageSrc: string }>(
       width: "3.125rem",
       height: "3.125rem",
     },
-    snackBar: {
-      fontSize: "0.9rem !important",
-    },
     eventTitle: {
       gridArea: "eventTitle",
     },
@@ -231,9 +228,7 @@ export default function EventPage({
       )}
 
       {showInviteCommunitySuccess && (
-        <Snackbar
-          severity="success"
-        >
+        <Snackbar severity="success">
           {t("communities:invite_community_dialog.toast_success")}
         </Snackbar>
       )}

--- a/app/web/features/communities/events/EventPage.tsx
+++ b/app/web/features/communities/events/EventPage.tsx
@@ -37,6 +37,7 @@ import CancelEventDialog from "./CancelEventDialog";
 import EventAttendees from "./EventAttendees";
 import EventOrganizers from "./EventOrganizers";
 import { useEvent } from "./hooks";
+import InviteCommunityDialog from "./InviteCommunityDialog";
 
 export const useEventPageStyles = makeStyles<Theme, { eventImageSrc: string }>(
   (theme) => ({
@@ -193,6 +194,7 @@ export default function EventPage({
   );
 
   const [cancelDialogIsOpen, setCancelDialogIsOpen] = useState(false);
+  const [inviteCommunityDialogIsOpen, setInviteCommunityDialogIsOpen] = useState(false);
 
   const isPastEvent = event?.endTime
     ? dayjs().isAfter(timestamp2Date(event.endTime))
@@ -292,6 +294,19 @@ export default function EventPage({
                     <CancelEventDialog
                       open={cancelDialogIsOpen}
                       onClose={() => setCancelDialogIsOpen(false)}
+                      eventId={eventId}
+                    />
+                    <Button
+                      onClick={() => setInviteCommunityDialogIsOpen(true)}
+                      variant="contained"
+                      color="secondary"
+                      disabled={event.isCancelled || isPastEvent}
+                    >
+                      {'invite communities'}
+                    </Button>
+                    <InviteCommunityDialog
+                      open={inviteCommunityDialogIsOpen}
+                      onClose={() => setInviteCommunityDialogIsOpen(false)}
                       eventId={eventId}
                     />
                   </>

--- a/app/web/features/communities/events/EventPage.tsx
+++ b/app/web/features/communities/events/EventPage.tsx
@@ -194,7 +194,8 @@ export default function EventPage({
   );
 
   const [cancelDialogIsOpen, setCancelDialogIsOpen] = useState(false);
-  const [inviteCommunityDialogIsOpen, setInviteCommunityDialogIsOpen] = useState(false);
+  const [inviteCommunityDialogIsOpen, setInviteCommunityDialogIsOpen] =
+    useState(false);
 
   const isPastEvent = event?.endTime
     ? dayjs().isAfter(timestamp2Date(event.endTime))
@@ -302,7 +303,7 @@ export default function EventPage({
                       color="secondary"
                       disabled={event.isCancelled || isPastEvent}
                     >
-                      {t('communities:invite_community_button')}
+                      {t("communities:invite_community_button")}
                     </Button>
                     <InviteCommunityDialog
                       open={inviteCommunityDialogIsOpen}

--- a/app/web/features/communities/events/EventPage.tsx
+++ b/app/web/features/communities/events/EventPage.tsx
@@ -302,7 +302,7 @@ export default function EventPage({
                       color="secondary"
                       disabled={event.isCancelled || isPastEvent}
                     >
-                      {'invite communities'}
+                      {t('communities:invite_community_button')}
                     </Button>
                     <InviteCommunityDialog
                       open={inviteCommunityDialogIsOpen}

--- a/app/web/features/communities/events/EventPage.tsx
+++ b/app/web/features/communities/events/EventPage.tsx
@@ -233,8 +233,9 @@ export default function EventPage({
       {showInviteCommunitySuccess && (
         <Snackbar
           severity="success"
-          children={t("communities:invite_community_dialog.toast_success")}
-        />
+        >
+          {t("communities:invite_community_dialog.toast_success")}
+        </Snackbar>
       )}
 
       {isLoading ? (

--- a/app/web/features/communities/events/InviteCommunityDialog.tsx
+++ b/app/web/features/communities/events/InviteCommunityDialog.tsx
@@ -8,7 +8,7 @@ import {
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { useMutation, useQueryClient } from "react-query";
 import { COMMUNITIES, GLOBAL } from "i18n/namespaces";
-import { DialogProps } from "@material-ui/core";
+import { DialogProps, Link as MuiLink } from "@material-ui/core";
 import { eventKey } from "features/queryKeys";
 import Button from "components/Button";
 import { useTranslation } from "i18n";
@@ -19,14 +19,16 @@ import React from "react";
 
 export default function InviteCommunityDialog({
   eventId,
+  afterSuccess,
   ...props
-}: DialogProps & { eventId: number }) {
+}: DialogProps & { eventId: number; afterSuccess: () => void }) {
   const { t } = useTranslation([GLOBAL, COMMUNITIES]);
   const queryClient = useQueryClient();
   const inviteCommunityMutation = useMutation<Empty, RpcError, void>(
     () => service.events.RequestCommunityInvite(eventId),
     {
       onSuccess: () => {
+        afterSuccess();
         queryClient.invalidateQueries(eventKey(eventId));
         if (props.onClose) props.onClose({}, "escapeKeyDown");
       },
@@ -48,6 +50,18 @@ export default function InviteCommunityDialog({
         )}
         <DialogContentText>
           {t("communities:invite_community_dialog.message")}
+          <br />
+          <br />
+          <MuiLink
+            key={"link_invite_community"}
+            target="_blank"
+            rel="noreferrer"
+            href={
+              "https://help.couchers.org/hc/couchersorg-help-center/articles/1720304409-how-does-the-invite-the-community-feature-work"
+            }
+          >
+            {t("communities:invite_community_dialog.link")}
+          </MuiLink>
         </DialogContentText>
       </DialogContent>
       <DialogActions>
@@ -55,7 +69,7 @@ export default function InviteCommunityDialog({
           onClick={inviteCommunity}
           loading={inviteCommunityMutation.isLoading}
         >
-          {t("global:yes")}
+          {t("communities:invite_community_dialog_buttons.confirm")}
         </Button>
         <Button
           onClick={() =>
@@ -63,7 +77,7 @@ export default function InviteCommunityDialog({
           }
           loading={inviteCommunityMutation.isLoading}
         >
-          {t("global:no")}
+          {t("communities:invite_community_dialog_buttons.close")}
         </Button>
       </DialogActions>
     </Dialog>

--- a/app/web/features/communities/events/InviteCommunityDialog.tsx
+++ b/app/web/features/communities/events/InviteCommunityDialog.tsx
@@ -1,0 +1,69 @@
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from "components/Dialog";
+import { Empty } from "google-protobuf/google/protobuf/empty_pb";
+import { useMutation, useQueryClient } from "react-query";
+import { COMMUNITIES, GLOBAL } from "i18n/namespaces";
+import { DialogProps } from "@material-ui/core";
+import { eventKey } from "features/queryKeys";
+import Button from "components/Button";
+import { useTranslation } from "i18n";
+import Alert from "components/Alert";
+import { RpcError } from "grpc-web";
+import { service } from "service";
+import React from "react";
+
+export default function InviteCommunityDialog({
+  eventId,
+  ...props
+}: DialogProps & { eventId: number }) {
+  const { t } = useTranslation([GLOBAL, COMMUNITIES]);
+  const queryClient = useQueryClient();
+  const inviteCommunityMutation = useMutation<Empty, RpcError, void>(
+    () => service.events.RequestCommunityInvite(eventId),
+    {
+      onSuccess: (e) => {
+        queryClient.invalidateQueries(eventKey(eventId));
+        if (props.onClose) props.onClose({}, "escapeKeyDown");
+      },
+    }
+  );
+
+  const inviteCommunity = () => inviteCommunityMutation.mutate();
+
+  return (
+    <Dialog {...props} aria-labelledby="invite-community-dialog-title">
+      <DialogTitle id="invite-community-dialog-title">
+        {t("communities:invite_community_dialog.title")}
+      </DialogTitle>
+      <DialogContent>
+        {inviteCommunityMutation.error && (
+          <Alert severity="error">{inviteCommunityMutation.error?.message}</Alert>
+        )}
+        <DialogContentText>
+          {t("communities:invite_community_dialog.message")}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          onClick={inviteCommunity}
+          loading={inviteCommunityMutation.isLoading}
+        >
+          {t("global:yes")}
+        </Button>
+        <Button
+          onClick={() =>
+            props.onClose ? props.onClose({}, "escapeKeyDown") : null
+          }
+          loading={inviteCommunityMutation.isLoading}
+        >
+          {t("global:no")}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/app/web/features/communities/events/InviteCommunityDialog.tsx
+++ b/app/web/features/communities/events/InviteCommunityDialog.tsx
@@ -26,7 +26,7 @@ export default function InviteCommunityDialog({
   const inviteCommunityMutation = useMutation<Empty, RpcError, void>(
     () => service.events.RequestCommunityInvite(eventId),
     {
-      onSuccess: (e) => {
+      onSuccess: () => {
         queryClient.invalidateQueries(eventKey(eventId));
         if (props.onClose) props.onClose({}, "escapeKeyDown");
       },

--- a/app/web/features/communities/events/InviteCommunityDialog.tsx
+++ b/app/web/features/communities/events/InviteCommunityDialog.tsx
@@ -42,7 +42,9 @@ export default function InviteCommunityDialog({
       </DialogTitle>
       <DialogContent>
         {inviteCommunityMutation.error && (
-          <Alert severity="error">{inviteCommunityMutation.error?.message}</Alert>
+          <Alert severity="error">
+            {inviteCommunityMutation.error?.message}
+          </Alert>
         )}
         <DialogContentText>
           {t("communities:invite_community_dialog.message")}

--- a/app/web/features/communities/locales/en.json
+++ b/app/web/features/communities/locales/en.json
@@ -10,6 +10,10 @@
         "title": "Cancel event?",
         "message": "Are you sure you want to cancel this event?"
     },
+    "invite_community_dialog": {
+        "title": "Add this event to its community",
+        "message": "link which describes what it does"
+    },
     "comment": "Comment",
     "comments": "Comments",
     "comments_count": "Comments | {{count}}",

--- a/app/web/features/communities/locales/en.json
+++ b/app/web/features/communities/locales/en.json
@@ -11,8 +11,15 @@
         "message": "Are you sure you want to cancel this event?"
     },
     "invite_community_dialog": {
-        "title": "Add this event to its community",
-        "message": "link which describes what it does"
+        "title": "Request a community invite for this event",
+        "message": "Use this form to request that the moderators send a notification about this event to all nearby users.",
+        "toast_success": "Thanks, the request has been submitted",
+        "link": "more info"
+    },
+    "invite_community_dialog_buttons": {
+        "open": "Invite the community",
+        "confirm": "Confirm",
+        "close": "Cancel"
     },
     "invite_community_button": "Invite community",
     "comment": "Comment",

--- a/app/web/features/communities/locales/en.json
+++ b/app/web/features/communities/locales/en.json
@@ -14,14 +14,13 @@
         "title": "Request a community invite for this event",
         "message": "Use this form to request that the moderators send a notification about this event to all nearby users.",
         "toast_success": "Thanks, the request has been submitted",
-        "link": "more info"
+        "link": "More information on this feature"
     },
     "invite_community_dialog_buttons": {
         "open": "Invite the community",
         "confirm": "Confirm",
         "close": "Cancel"
     },
-    "invite_community_button": "Invite community",
     "comment": "Comment",
     "comments": "Comments",
     "comments_count": "Comments | {{count}}",

--- a/app/web/features/communities/locales/en.json
+++ b/app/web/features/communities/locales/en.json
@@ -14,6 +14,7 @@
         "title": "Add this event to its community",
         "message": "link which describes what it does"
     },
+    "invite_community_button": "Invite community",
     "comment": "Comment",
     "comments": "Comments",
     "comments_count": "Comments | {{count}}",

--- a/app/web/service/events.ts
+++ b/app/web/service/events.ts
@@ -14,6 +14,7 @@ import {
   OnlineEventInformation,
   SetEventAttendanceReq,
   UpdateEventReq,
+  RequestCommunityInviteReq,
 } from "proto/events_pb";
 import client from "service/client";
 
@@ -46,6 +47,12 @@ export function cancelEvent(eventId: number) {
   const req = new CancelEventReq();
   req.setEventId(eventId);
   return client.events.cancelEvent(req);
+}
+
+export function RequestCommunityInvite(eventId: number) {
+  const req = new RequestCommunityInviteReq();
+  req.setEventId(eventId);
+  return client.events.requestCommunityInvite(req);
 }
 
 interface ListEventUsersInput {


### PR DESCRIPTION
Closes #4449 

Quick ticket to implement a button in the frontend which will call the `RequestCommunityInvite` when pressed

**Backend checklist**
- [ ] Formatted my code by running `ruff check --select I --fix . && ruff check . && ruff format .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [ ] Formatted my code with `make format`
- [ ] There are no warnings from `make lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [ ] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
