### PR TITLE
Auth check

### DIFF
--- a/app/web/features/auth/useAuthStore.ts
+++ b/app/web/features/auth/useAuthStore.ts
@@ -4,7 +4,7 @@ import { GLOBAL } from "i18n/namespaces";
 import Sentry from "platform/sentry";
 import { clearStorage, usePersistedState } from "platform/usePersistedState";
 import { AuthRes, SignupFlowRes } from "proto/auth_pb";
-import { useMemo, useRef, useState } from "react";
+import { useEffect,useMemo, useRef, useState } from "react";
 import { useQueryClient } from "react-query";
 import { service } from "service";
 import isGrpcError from "service/utils/isGrpcError";
@@ -15,6 +15,10 @@ export default function useAuthStore() {
     false
   );
   const [jailed, setJailed] = usePersistedState("auth.jailed", false);
+  const [checkedAuthStatus, setCheckedAuthStatus] = usePersistedState(
+    "auth.checkedAuthStatus",
+    false
+  );
   const [userId, setUserId] = usePersistedState<number | null>(
     "auth.userId",
     null
@@ -131,11 +135,52 @@ export default function useAuthStore() {
         }
         setLoading(false);
       },
+      async checkAuthStatus() {
+        try {
+          const res = await service.user.getAuthState();
+          if (res.loggedIn) {
+            console.log(
+              "We thought we were not logged in but an API call shows we were."
+            );
+            const auth = res.authRes!;
+            setUserId(auth.userId);
+            Sentry.setUser({ id: auth.userId.toString() });
+
+            //this must come after setting the userId, because calling setQueryData
+            //will also cause that query to be background fetched, and it needs
+            //userId to be set.
+            setJailed(auth.jailed);
+            setAuthenticated(true);
+          }
+        } catch (e) {
+          Sentry.captureException(e, {
+            tags: {
+              component: "auth/useAuthStore",
+              action: "checkAuthStatus",
+            },
+          });
+          setError(isGrpcError(e) ? e.message : fatalErrorMessage.current);
+        }
+      },
     }),
     //note: there should be no dependenices on the state or t, or
     //some useEffects will break. Eg. the token login in Login.tsx
     [setAuthenticated, setJailed, setUserId, setFlowState, queryClient]
   );
+
+  useEffect(() => {
+    // if we aren't logged in and are otherwise idle, but auth state changed, check if the cookie is set in the bg
+    if (
+      typeof window !== "undefined" &&
+      !authenticated &&
+      !loading &&
+      !error &&
+      !checkedAuthStatus
+    ) {
+      setCheckedAuthStatus(true);
+      authActions.checkAuthStatus();
+    }
+  }, [authenticated, checkedAuthStatus, setCheckedAuthStatus, authActions]);
 
   return {
     authActions,


### PR DESCRIPTION
It is currently possible for the react frontend to lose the "persistent" state it keeps in local storage: it seems sometimes when we upgrade the app this happens, and it otherwise too seems flaky.

The website cookies on the other hand are relatively solid. This means that occasionally the frontend thinks it's logged out when in reality the cookie is still there for a valid session. This means that users sometimes need to log in unnecessarily: this (according to metrics) seems to represent about 15-20% of logins. Logging in is a pain and so this metric does not capture the number of people who gave up because they were logged out.

This PR introduces an auth check that will ping the backend (using a new API call called `AuthCheck`) which will return back information about the current auth state, and will re-login the user if their state is out of sync. (In case the frontend thinks it's logged in but the cookie/session is expired, we catch that and log the user out in the frontend.)

[The cookie is not accessible to JS for security reasons, it's only available on the transport layer, so the frontend needs to query the backend about cookie status.]

This continues from https://github.com/Couchers-org/couchers/pull/4560.

**Web frontend checklist**
- [ ] Formatted my code with `make format`
- [ ] There are no warnings from `make lint`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [ ] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
