### PR TITLE
Native link

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -4,3 +4,5 @@
 
 # protobuf descriptor sets
 descriptors.pb
+
+/native/

--- a/app/generate_protos.sh
+++ b/app/generate_protos.sh
@@ -8,6 +8,7 @@ mkdir -p proto/gen/ts/proto
 mkdir -p backend/src/proto/
 mkdir -p media/src/proto/
 mkdir -p web/proto/
+mkdir -p native/proto/
 mkdir -p client/src/couchers/proto/google/api
 touch client/src/couchers/proto/__init__.py
 touch client/src/couchers/proto/google/__init__.py
@@ -37,6 +38,9 @@ find proto -name '*.proto' | protoc -I proto \
   \
   --js_out="import_style=commonjs,binary:web/proto" \
   --grpc-web_out="import_style=commonjs+dts,mode=grpcweb:web/proto" \
+  \
+  --js_out="import_style=commonjs,binary:native/proto" \
+  --grpc-web_out="import_style=commonjs+dts,mode=grpcweb:native/proto" \
   \
   $(xargs)
 

--- a/app/web/components/AppRoute.tsx
+++ b/app/web/components/AppRoute.tsx
@@ -6,6 +6,7 @@ import ErrorBoundary from "components/ErrorBoundary";
 import Footer from "components/Footer";
 import { useAuthContext } from "features/auth/AuthProvider";
 import { useRouter } from "next/router";
+import { useIsNativeEmbed } from "platform/nativeLink";
 import { ReactNode, useEffect, useState } from "react";
 import { jailRoute, loginRoute } from "routes";
 import makeStyles from "utils/makeStyles";
@@ -30,6 +31,10 @@ export const useAppRouteStyles = makeStyles((theme) => ({
     margin: "0 auto",
     paddingLeft: 0,
     paddingRight: 0,
+  },
+  nativeEmbedContainer: {
+    margin: "0 auto",
+    padding: 0,
   },
   loader: {
     //minimal-effort reduction of layout shifting
@@ -79,6 +84,8 @@ export default function AppRoute({
   const isAuthenticated = authState.authenticated;
   const isJailed = authState.jailed;
 
+  const isNativeEmbed = useIsNativeEmbed();
+
   //there must be the same loading state on auth'd pages on server and client
   //for hydration matching, so we will display a loader until mounted.
   const [isMounted, setIsMounted] = useState(false);
@@ -102,12 +109,13 @@ export default function AppRoute({
         </div>
       ) : (
         <>
-          <Navigation />
+          {!isNativeEmbed && <Navigation />}
           {/* Temporary container injected for marketing to test dynamic "announcements".
            * Find a better spot to componentise this code once plan is more finalised with this */}
           <div id="announcements"></div>
           <Container
             className={classNames({
+              [classes.nativeEmbedContainer]: isNativeEmbed,
               [classes.nonFullScreenStyles]: variant !== "full-screen",
               [classes.fullWidthContainer]: variant === "full-width",
               [classes.fullscreenContainer]: variant === "full-screen",
@@ -122,10 +130,10 @@ export default function AppRoute({
             {/* Have to wrap this in a fragment because of https://github.com/mui-org/material-ui/issues/21711 */}
             <>{children}</>
           </Container>
-          {!noFooter && <Footer />}
+          {!noFooter && !isNativeEmbed && <Footer />}
         </>
       )}
-      {!isPrivate && <CookieBanner />}
+      {!isPrivate && !isNativeEmbed && <CookieBanner />}
     </ErrorBoundary>
   );
 }

--- a/app/web/features/auth/signup/Signup.tsx
+++ b/app/web/features/auth/signup/Signup.tsx
@@ -10,6 +10,7 @@ import CommunityGuidelinesForm from "features/auth/signup/CommunityGuidelinesFor
 import { Trans, useTranslation } from "i18n";
 import { AUTH, GLOBAL } from "i18n/namespaces";
 import { useRouter } from "next/router";
+import { useIsNativeEmbed } from "platform/nativeLink";
 import Sentry from "platform/sentry";
 import { useEffect, useState } from "react";
 import vercelLogo from "resources/vercel.svg";
@@ -68,6 +69,9 @@ const useStyles = makeStyles((theme) => ({
     [theme.breakpoints.down("sm")]: {
       width: "100%",
     },
+  },
+  mobileEmbed: {
+    margin: theme.spacing(3),
   },
 }));
 
@@ -168,6 +172,8 @@ export default function Signup() {
   const router = useRouter();
   const urlToken = stringOrFirstString(router.query.token);
 
+  const isNativeEmbed = useIsNativeEmbed();
+
   useEffect(() => {
     authActions.clearError();
   }, [authActions]);
@@ -202,6 +208,19 @@ export default function Signup() {
     // next-router-mock router isn't memoized, so putting router in the dependencies
     // causes infinite looping in tests
   }, [urlToken, authActions, t]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (isNativeEmbed) {
+    return (
+      <div className={classes.mobileEmbed}>
+        {error && (
+          <Alert className={authClasses.errorMessage} severity="error">
+            {error}
+          </Alert>
+        )}
+        {loading ? <CircularProgress /> : <CurrentForm />}
+      </div>
+    );
+  }
 
   return (
     <>

--- a/app/web/global.d.ts
+++ b/app/web/global.d.ts
@@ -1,0 +1,6 @@
+interface Window {
+  ReactNativeWebView?: {
+    injectedObjectJson: () => any;
+    postMessage: (message: string) => void;
+  };
+}

--- a/app/web/global.d.ts
+++ b/app/web/global.d.ts
@@ -1,6 +1,6 @@
 interface Window {
   ReactNativeWebView?: {
-    injectedObjectJson: () => any;
+    injectedObjectJson: () => string;
     postMessage: (message: string) => void;
   };
 }

--- a/app/web/platform/nativeLink.ts
+++ b/app/web/platform/nativeLink.ts
@@ -1,23 +1,19 @@
 import { useEffect, useState } from "react";
 
 export function getReactNativeWebView(): typeof window.ReactNativeWebView {
-  if (
-    typeof window !== "undefined" &&
-    window.ReactNativeWebView !== undefined
-  ) {
+  if (window && window.ReactNativeWebView) {
     return window.ReactNativeWebView;
   }
 }
 
 export function isNativeEmbed(): boolean {
-  return getReactNativeWebView() !== undefined;
+  return !!getReactNativeWebView();
 }
 
 export function getNativeData() {
-  const wv = getReactNativeWebView();
-  if (!wv) return;
-  if (wv.injectedObjectJson()) {
-    return JSON.parse(wv.injectedObjectJson());
+  const webview = getReactNativeWebView();
+  if (webview && webview.injectedObjectJson()) {
+    return JSON.parse(webview.injectedObjectJson());
   }
 }
 
@@ -25,9 +21,7 @@ export function useIsNativeEmbed(): boolean {
   const [isNative, setIsNative] = useState(false);
 
   useEffect(() => {
-    setIsNative(
-      typeof window !== "undefined" && window.ReactNativeWebView !== undefined
-    );
+    setIsNative(isNativeEmbed());
   }, []);
 
   return isNative;
@@ -40,12 +34,6 @@ export function sendToNative(type: MessageType, data: any) {
   getReactNativeWebView()!.postMessage(
     JSON.stringify({ type: type, data: data })
   );
-}
-
-export function getState<T>(key: string) {
-  if (!isNativeEmbed()) return undefined;
-  const data = getNativeData();
-  // if ()
 }
 
 export function sendState<T>(key: string, value: T) {

--- a/app/web/platform/nativeLink.ts
+++ b/app/web/platform/nativeLink.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+
+export function getReactNativeWebView(): typeof window.ReactNativeWebView {
+  if (
+    typeof window !== "undefined" &&
+    window.ReactNativeWebView !== undefined
+  ) {
+    return window.ReactNativeWebView;
+  }
+}
+
+export function isNativeEmbed(): boolean {
+  return getReactNativeWebView() !== undefined;
+}
+
+export function getNativeData() {
+  const wv = getReactNativeWebView();
+  if (!wv) return;
+  if (wv.injectedObjectJson()) {
+    return JSON.parse(wv.injectedObjectJson());
+  }
+}
+
+export function useIsNativeEmbed(): boolean {
+  const [isNative, setIsNative] = useState(false);
+
+  useEffect(() => {
+    setIsNative(
+      typeof window !== "undefined" && window.ReactNativeWebView !== undefined
+    );
+  }, []);
+
+  return isNative;
+}
+
+type MessageType = "sendState" | "clearState";
+
+export function sendToNative(type: MessageType, data: any) {
+  if (!isNativeEmbed()) return;
+  getReactNativeWebView()!.postMessage(
+    JSON.stringify({ type: type, data: data })
+  );
+}
+
+export function getState<T>(key: string) {
+  if (!isNativeEmbed()) return undefined;
+  const data = getNativeData();
+  // if ()
+}
+
+export function sendState<T>(key: string, value: T) {
+  sendToNative("sendState", { key: key, value: value });
+}
+
+export function clearState(key: string) {
+  sendToNative("clearState", { key: key });
+}

--- a/app/web/platform/usePersistedState.ts
+++ b/app/web/platform/usePersistedState.ts
@@ -1,4 +1,8 @@
 import { useCallback, useState } from "react";
+import {
+  sendState,
+  clearState as nativeLinkClearState,
+} from "platform/nativeLink";
 
 type StorageType = "localStorage" | "sessionStorage";
 
@@ -20,12 +24,14 @@ export function usePersistedState<T>(
       }
       const v = value === undefined ? null : value;
       window[storage].setItem(key, JSON.stringify(v));
+      sendState(key, v);
       _setState(value);
     },
     [key, storage]
   );
   const clearState = useCallback(() => {
     window[storage].removeItem(key);
+    nativeLinkClearState(key);
     _setState(undefined);
   }, [key, storage]);
   return [_state, setState, clearState];


### PR DESCRIPTION
For now we are building the native app by largely embedding WebViews that load from the frontend web server.

This PR introduces `nativeLink`, which tells us if we're in a webview and allows us to accommodate the embedding in the frontend. For example this hides navigation menus (will be implemented natively) and some pretty stuff during the signup flow.


**Web frontend checklist**
- [x] Formatted my code with `make format`
- [x] There are no warnings from `make lint`
- [x] There are no console warnings when running the app
- [x] Added any new components to storybook
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
