### PR TITLE
Add linting to web gitlab checks

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -352,6 +352,25 @@ test:web-prettier:
       changes:
       - app/web/**/*
 
+test:web-linting:
+  needs: ["build:web-dev"]
+  stage: test
+  image: $WEB_DEV_TAG
+  inherit:
+    # no docker login
+    default: false
+  script:
+    - cd /app
+    - yarn lint
+  rules:
+    - if: ($BUILD_WEB == "true") && ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
+      changes:
+        - app/**/*
+    - if: ($BUILD_WEB == "true") && ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
+      changes:
+        - app/web/**/*
+
+
 test:storybook:
   needs: ["build:web-dev"]
   stage: test


### PR DESCRIPTION
We have prettier as a gitlab check on the branch for frontend but not linting, means it's possible to merge a branch with linting errors.

Here's my attempt to add it, feel free to yell at me if there's a reason I was unaware of that it's not there.
