### PR TITLE
Add links to guides in various places

### DIFF
--- a/app/web/components/ProfileIncompleteDialog/ProfileIncompleteDialog.tsx
+++ b/app/web/components/ProfileIncompleteDialog/ProfileIncompleteDialog.tsx
@@ -11,7 +11,7 @@ import { Trans, useTranslation } from "i18n";
 import { DASHBOARD } from "i18n/namespaces";
 import Link from "next/link";
 import React from "react";
-import { routeToEditProfile } from "routes";
+import { howToCompleteProfileUrl, routeToEditProfile } from "routes";
 
 export interface ProfileIncompleteDialogProps {
   open: boolean;
@@ -51,7 +51,7 @@ export default function ProfileIncompleteDialog({
           <Trans i18nKey="dashboard:complete_profile_dialog.description_2">
             This helps build a trusted community and reduce spam. For more
             information,{" "}
-            <StyledLink href="https://help.couchers.org/hc/couchersorg-help-center/articles/1725919152-why-do-i-need-to-complete-my-profile-to-use-some-features">
+            <StyledLink href={howToCompleteProfileUrl}>
               please refer to this help page
             </StyledLink>
             . Thank you for your help!

--- a/app/web/features/auth/phone/ChangePhone.tsx
+++ b/app/web/features/auth/phone/ChangePhone.tsx
@@ -18,6 +18,7 @@ import PhoneInput, {
   isValidPhoneNumber,
 } from "react-phone-number-input";
 import { useMutation, useQueryClient } from "react-query";
+import { howToDonateUrl } from "routes";
 import { service } from "service";
 
 import useChangeDetailsFormStyles from "../useChangeDetailsFormStyles";
@@ -142,10 +143,7 @@ export default function ChangePhone({
         !accountInfo.hasDonated ? (
           <Typography variant="body1">
             <Trans i18nKey="auth:change_phone.need_to_donate">
-              You need to{" "}
-              <StyledLink href="https://help.couchers.org/hc/couchersorg-help-center/articles/1715658357-how-to-write-a-request-that-gets-accepted">
-                donate
-              </StyledLink>
+              You need to <StyledLink href={howToDonateUrl}>donate</StyledLink>
               before you can complete phone verification.
             </Trans>
           </Typography>

--- a/app/web/features/communities/events/InviteCommunityDialog.tsx
+++ b/app/web/features/communities/events/InviteCommunityDialog.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "i18n";
 import { COMMUNITIES, GLOBAL } from "i18n/namespaces";
 import React from "react";
 import { useMutation, useQueryClient } from "react-query";
+import { howToInviteCommunityUrl } from "routes";
 import { service } from "service";
 
 export default function InviteCommunityDialog({
@@ -56,9 +57,7 @@ export default function InviteCommunityDialog({
             key={"link_invite_community"}
             target="_blank"
             rel="noreferrer"
-            href={
-              "https://help.couchers.org/hc/couchersorg-help-center/articles/1720304409-how-does-the-invite-the-community-feature-work"
-            }
+            href={howToInviteCommunityUrl}
             underline="hover"
           >
             {t("communities:invite_community_dialog.link")}

--- a/app/web/features/messages/locales/en.json
+++ b/app/web/features/messages/locales/en.json
@@ -7,7 +7,8 @@
   "close_request_dialog_surfer": "Please make sure you are done chatting before you cancel your request.",
   "close_request_button_text": "Decline",
   "confirm_request_button_text": "Confirm",
-  "pending_request_help_text": "Not sure how to respond? Read some tips on <2>how to respond to a request</2>.",
+  "host_pending_request_help_text": "Not sure how to respond? Read some tips on <2>how to respond to a request</2>.",
+  "surfer_declined_request_help_text": "Having trouble getting your requests accepted? Read our <2>guide on how to write a great request</2> for some tips!",
   "messages_page": {
     "title": "Messages",
     "tabs": {

--- a/app/web/features/messages/locales/en.json
+++ b/app/web/features/messages/locales/en.json
@@ -7,8 +7,8 @@
   "close_request_dialog_surfer": "Please make sure you are done chatting before you cancel your request.",
   "close_request_button_text": "Decline",
   "confirm_request_button_text": "Confirm",
-  "host_pending_request_help_text": "Not sure how to respond? Read some tips on <2>how to respond to a request</2>.",
-  "surfer_declined_request_help_text": "Having trouble getting your requests accepted? Read our <2>guide on how to write a great request</2> for some tips!",
+  "host_pending_request_help_text": "<0>Things to consider</0> before responding.",
+  "surfer_declined_request_help_text": "<0>Read our guide</0> on how to write a request that will get accepted.",
   "messages_page": {
     "title": "Messages",
     "tabs": {

--- a/app/web/features/messages/locales/en.json
+++ b/app/web/features/messages/locales/en.json
@@ -7,6 +7,7 @@
   "close_request_dialog_surfer": "Please make sure you are done chatting before you cancel your request.",
   "close_request_button_text": "Decline",
   "confirm_request_button_text": "Confirm",
+  "pending_request_help_text": "Not sure how to respond? Read some tips on <2>how to respond to a request</2>.",
   "messages_page": {
     "title": "Messages",
     "tabs": {

--- a/app/web/features/messages/requests/HostRequestSendField.tsx
+++ b/app/web/features/messages/requests/HostRequestSendField.tsx
@@ -1,12 +1,14 @@
+import { Typography } from "@material-ui/core";
 import Button from "components/Button";
 import ConfirmationDialogWrapper from "components/ConfirmationDialogWrapper";
+import StyledLink from "components/StyledLink";
 import TextField from "components/TextField";
 import { useAuthContext } from "features/auth/AuthProvider";
 import useSendFieldStyles from "features/messages/useSendFieldStyles";
 import { useListAvailableReferences } from "features/profile/hooks/referencesHooks";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { RpcError } from "grpc-web";
-import { useTranslation } from "i18n";
+import { Trans, useTranslation } from "i18n";
 import { GLOBAL, MESSAGES } from "i18n/namespaces";
 import Link from "next/link";
 import { HostRequestStatus } from "proto/conversations_pb";
@@ -131,6 +133,22 @@ export default function HostRequestSendField({
 
   return (
     <form onSubmit={onSubmit}>
+      {hostRequest.status === HostRequestStatus.HOST_REQUEST_STATUS_PENDING && (
+        <div className={classes.helpTextContainer}>
+          <Typography variant="body1">
+            <Trans i18nKey="profile:request_form.guide_link_help_text">
+              Not sure how to respond? Read some tips on{" "}
+              <StyledLink
+                variant="body1"
+                href="https://help.couchers.org/hc/couchersorg-help-center/articles/1715658357-how-to-write-a-request-that-gets-accepted"
+              >
+                how to respond to a request
+              </StyledLink>
+              .
+            </Trans>
+          </Typography>
+        </div>
+      )}
       <div className={classes.buttonContainer}>
         {isHost ? (
           <>

--- a/app/web/features/messages/requests/HostRequestSendField.tsx
+++ b/app/web/features/messages/requests/HostRequestSendField.tsx
@@ -17,7 +17,12 @@ import { HostRequest, RespondHostRequestReq } from "proto/requests_pb";
 import React from "react";
 import { useForm } from "react-hook-form";
 import { UseMutationResult } from "react-query";
-import { leaveReferenceBaseRoute, referenceTypeRoute } from "routes";
+import {
+  howToRespondRequestGuideUrl,
+  howToWriteRequestGuideUrl,
+  leaveReferenceBaseRoute,
+  referenceTypeRoute,
+} from "routes";
 
 interface MessageFormData {
   text: string;
@@ -145,14 +150,10 @@ export default function HostRequestSendField({
         <div className={classes.helpTextContainer}>
           <Typography variant="body1">
             <Trans i18nKey="messages:host_pending_request_help_text">
-              Not sure how to respond? Read some tips on{" "}
-              <StyledLink
-                variant="body1"
-                href="https://help.couchers.org/hc/couchersorg-help-center/articles/1715658357-how-to-write-a-request-that-gets-accepted"
-              >
-                how to respond to a request
-              </StyledLink>
-              .
+              <StyledLink variant="body1" href={howToRespondRequestGuideUrl}>
+                Things to consider
+              </StyledLink>{" "}
+              before responding.
             </Trans>
           </Typography>
         </div>
@@ -161,14 +162,10 @@ export default function HostRequestSendField({
         <div className={classes.helpTextContainer}>
           <Typography variant="body1">
             <Trans i18nKey="messages:surfer_declined_request_help_text">
-              Having trouble getting your requests accepted? Read our{" "}
-              <StyledLink
-                variant="body1"
-                href="https://help.couchers.org/hc/couchersorg-help-center/articles/1715658357-how-to-write-a-request-that-gets-accepted"
-              >
-                guide on how to write a request that gets accepted
+              <StyledLink variant="body1" href={howToWriteRequestGuideUrl}>
+                Read our guide
               </StyledLink>{" "}
-              for some tips!
+              on how to write a request that will get accepted.
             </Trans>
           </Typography>
         </div>

--- a/app/web/features/messages/requests/HostRequestSendField.tsx
+++ b/app/web/features/messages/requests/HostRequestSendField.tsx
@@ -1,4 +1,4 @@
-import { Typography } from "@material-ui/core";
+import { Typography } from "@mui/material";
 import Button from "components/Button";
 import ConfirmationDialogWrapper from "components/ConfirmationDialogWrapper";
 import StyledLink from "components/StyledLink";

--- a/app/web/features/messages/requests/HostRequestSendField.tsx
+++ b/app/web/features/messages/requests/HostRequestSendField.tsx
@@ -133,22 +133,42 @@ export default function HostRequestSendField({
 
   return (
     <form onSubmit={onSubmit}>
-      {hostRequest.status === HostRequestStatus.HOST_REQUEST_STATUS_PENDING && (
-        <div className={classes.helpTextContainer}>
-          <Typography variant="body1">
-            <Trans i18nKey="profile:request_form.guide_link_help_text">
-              Not sure how to respond? Read some tips on{" "}
-              <StyledLink
-                variant="body1"
-                href="https://help.couchers.org/hc/couchersorg-help-center/articles/1715658357-how-to-write-a-request-that-gets-accepted"
-              >
-                how to respond to a request
-              </StyledLink>
-              .
-            </Trans>
-          </Typography>
-        </div>
-      )}
+      {isHost &&
+        hostRequest.status ===
+          HostRequestStatus.HOST_REQUEST_STATUS_PENDING && (
+          <div className={classes.helpTextContainer}>
+            <Typography variant="body1">
+              <Trans i18nKey="messages:host_pending_request_help_text">
+                Not sure how to respond? Read some tips on{" "}
+                <StyledLink
+                  variant="body1"
+                  href="https://help.couchers.org/hc/couchersorg-help-center/articles/1715658357-how-to-write-a-request-that-gets-accepted"
+                >
+                  how to respond to a request
+                </StyledLink>
+                .
+              </Trans>
+            </Typography>
+          </div>
+        )}
+      {!isHost &&
+        hostRequest.status ===
+          HostRequestStatus.HOST_REQUEST_STATUS_REJECTED && (
+          <div className={classes.helpTextContainer}>
+            <Typography variant="body1">
+              <Trans i18nKey="messages:surfer_declined_request_help_text">
+                Having trouble getting your requests accepted? Read our{" "}
+                <StyledLink
+                  variant="body1"
+                  href="https://help.couchers.org/hc/couchersorg-help-center/articles/1715658357-how-to-write-a-request-that-gets-accepted"
+                >
+                  guide on how to write a request that gets accepted
+                </StyledLink>{" "}
+                for some tips!
+              </Trans>
+            </Typography>
+          </div>
+        )}
       <div className={classes.buttonContainer}>
         {isHost ? (
           <>

--- a/app/web/features/messages/requests/HostRequestSendField.tsx
+++ b/app/web/features/messages/requests/HostRequestSendField.tsx
@@ -131,44 +131,48 @@ export default function HostRequestSendField({
     }
   };
 
+  const isHostPending =
+    isHost &&
+    hostRequest.status === HostRequestStatus.HOST_REQUEST_STATUS_PENDING;
+
+  const isSurferRejected =
+    !isHost &&
+    hostRequest.status === HostRequestStatus.HOST_REQUEST_STATUS_REJECTED;
+
   return (
     <form onSubmit={onSubmit}>
-      {isHost &&
-        hostRequest.status ===
-          HostRequestStatus.HOST_REQUEST_STATUS_PENDING && (
-          <div className={classes.helpTextContainer}>
-            <Typography variant="body1">
-              <Trans i18nKey="messages:host_pending_request_help_text">
-                Not sure how to respond? Read some tips on{" "}
-                <StyledLink
-                  variant="body1"
-                  href="https://help.couchers.org/hc/couchersorg-help-center/articles/1715658357-how-to-write-a-request-that-gets-accepted"
-                >
-                  how to respond to a request
-                </StyledLink>
-                .
-              </Trans>
-            </Typography>
-          </div>
-        )}
-      {!isHost &&
-        hostRequest.status ===
-          HostRequestStatus.HOST_REQUEST_STATUS_REJECTED && (
-          <div className={classes.helpTextContainer}>
-            <Typography variant="body1">
-              <Trans i18nKey="messages:surfer_declined_request_help_text">
-                Having trouble getting your requests accepted? Read our{" "}
-                <StyledLink
-                  variant="body1"
-                  href="https://help.couchers.org/hc/couchersorg-help-center/articles/1715658357-how-to-write-a-request-that-gets-accepted"
-                >
-                  guide on how to write a request that gets accepted
-                </StyledLink>{" "}
-                for some tips!
-              </Trans>
-            </Typography>
-          </div>
-        )}
+      {isHostPending && (
+        <div className={classes.helpTextContainer}>
+          <Typography variant="body1">
+            <Trans i18nKey="messages:host_pending_request_help_text">
+              Not sure how to respond? Read some tips on{" "}
+              <StyledLink
+                variant="body1"
+                href="https://help.couchers.org/hc/couchersorg-help-center/articles/1715658357-how-to-write-a-request-that-gets-accepted"
+              >
+                how to respond to a request
+              </StyledLink>
+              .
+            </Trans>
+          </Typography>
+        </div>
+      )}
+      {isSurferRejected && (
+        <div className={classes.helpTextContainer}>
+          <Typography variant="body1">
+            <Trans i18nKey="messages:surfer_declined_request_help_text">
+              Having trouble getting your requests accepted? Read our{" "}
+              <StyledLink
+                variant="body1"
+                href="https://help.couchers.org/hc/couchersorg-help-center/articles/1715658357-how-to-write-a-request-that-gets-accepted"
+              >
+                guide on how to write a request that gets accepted
+              </StyledLink>{" "}
+              for some tips!
+            </Trans>
+          </Typography>
+        </div>
+      )}
       <div className={classes.buttonContainer}>
         {isHost ? (
           <>

--- a/app/web/features/messages/useSendFieldStyles.ts
+++ b/app/web/features/messages/useSendFieldStyles.ts
@@ -9,6 +9,12 @@ const useSendFieldStyles = makeStyles((theme) => ({
     marginBottom: 0,
     marginTop: "auto",
   },
+  helpTextContainer: {
+    display: "flex",
+    flexWrap: "wrap",
+    justifyContent: "center",
+    marginBottom: theme.spacing(2),
+  },
   buttonContainer: {
     "& > button": {
       marginInline: theme.spacing(2),

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -25,6 +25,7 @@ import { HostingStatus, LanguageAbility, MeetupStatus } from "proto/api_pb";
 import React, { useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useQueryClient } from "react-query";
+import { howToMakeGreatProfileUrl } from "routes";
 import { service, UpdateUserProfileData } from "service/index";
 import {
   useIsMounted,
@@ -160,10 +161,7 @@ export default function EditProfileForm() {
             <Typography variant="body1">
               <Trans i18nKey="profile:edit_profile_helper_text">
                 Looking for some inspiration on where to start?{" "}
-                <StyledLink
-                  variant="body1"
-                  href="https://help.couchers.org/hc/couchersorg-help-center/articles/1715658357-how-to-write-a-request-that-gets-accepted"
-                >
+                <StyledLink variant="body1" href={howToMakeGreatProfileUrl}>
                   Check out our guide on creating an awesome profile
                 </StyledLink>
                 .

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -10,6 +10,7 @@ import Button from "components/Button";
 import CircularProgress from "components/CircularProgress";
 import EditLocationMap from "components/EditLocationMap";
 import ImageInput from "components/ImageInput";
+import StyledLink from "components/StyledLink";
 import { useLanguages } from "features/profile/hooks/useLanguages";
 import { useRegions } from "features/profile/hooks/useRegions";
 import useUpdateUserProfile from "features/profile/hooks/useUpdateUserProfile";
@@ -18,7 +19,7 @@ import ProfileTagInput from "features/profile/ProfileTagInput";
 import ProfileTextInput from "features/profile/ProfileTextInput";
 import { userKey } from "features/queryKeys";
 import useCurrentUser from "features/userQueries/useCurrentUser";
-import { useTranslation } from "i18n";
+import { Trans, useTranslation } from "i18n";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
 import { HostingStatus, LanguageAbility, MeetupStatus } from "proto/api_pb";
 import React, { useEffect } from "react";
@@ -155,6 +156,20 @@ export default function EditProfileForm() {
       )}
       {user ? (
         <>
+          <div className={classes.helpTextContainer}>
+            <Typography variant="body1">
+              <Trans i18nKey="profile:edit_profile_helper_text">
+                Looking for some inspiration on where to start?{" "}
+                <StyledLink
+                  variant="body1"
+                  href="https://help.couchers.org/hc/couchersorg-help-center/articles/1715658357-how-to-write-a-request-that-gets-accepted"
+                >
+                  Check out our guide on creating an awesome profile
+                </StyledLink>
+                .
+              </Trans>
+            </Typography>
+          </div>
           <form onSubmit={onSubmit} className={classes.topFormContainer}>
             <ImageInput
               className={classes.avatar}

--- a/app/web/features/profile/edit/styles.ts
+++ b/app/web/features/profile/edit/styles.ts
@@ -17,6 +17,10 @@ const useStyles = makeStyles((theme) => ({
       width: "100%",
     },
   },
+  helpTextContainer: {
+    textAlign: "center",
+    margin: theme.spacing(2),
+  },
   buttonContainer: {
     position: "fixed",
     bottom: 0,

--- a/app/web/features/profile/locales/en.json
+++ b/app/web/features/profile/locales/en.json
@@ -150,7 +150,7 @@
     },
     "request_form": {
         "send_request": "Send {{name}} a request",
-        "guide_link_help_text": "Not quite sure how to send a great request? Read our <2>quick reference on requests</2> or our <6>full guide on sending a request that gets accepted (with examples)</6>.",
+        "guide_link_help_text": "<0>Read our guide</0> on how to write a request that will get accepted.",
         "arrival_date": "Arrival Date",
         "arrival_date_empty": "Please specify an arrival Date",
         "departure_date": "Departure Date",

--- a/app/web/features/profile/locales/en.json
+++ b/app/web/features/profile/locales/en.json
@@ -62,6 +62,7 @@
         "wheelchair": "Wheelchair accessible",
         "other_info": "Additional information"
     },
+    "edit_profile_helper_text": "Looking for some inspiration on where to start? <2>Check out our guide on creating an awesome profile</2>.",
     "edit_profile_headings": {
         "regions_visited": "Regions I've Visited",
         "regions_lived": "Regions I've Lived In",

--- a/app/web/features/profile/locales/en.json
+++ b/app/web/features/profile/locales/en.json
@@ -149,6 +149,7 @@
     },
     "request_form": {
         "send_request": "Send {{name}} a request",
+        "guide_link_help_text": "Not quite sure how to send a great request? Read our <2>quick reference on requests</2> or our <6>full guide on sending a request that gets accepted (with examples)</6>.",
         "arrival_date": "Arrival Date",
         "arrival_date_empty": "Please specify an arrival Date",
         "departure_date": "Departure Date",

--- a/app/web/features/profile/view/NewHostRequest.tsx
+++ b/app/web/features/profile/view/NewHostRequest.tsx
@@ -24,6 +24,7 @@ import { GLOBAL, PROFILE } from "i18n/namespaces";
 import React, { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useMutation } from "react-query";
+import { howToWriteRequestGuideUrl } from "routes";
 import { service } from "service";
 import { CreateHostRequestWrapper } from "service/requests";
 import { isSameOrFutureDate } from "utils/date";
@@ -44,7 +45,7 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: theme.spacing(1),
   },
   helpText: {
-    marginTop: theme.spacing(1),
+    marginTop: theme.spacing(2),
     marginBottom: theme.spacing(2),
   },
   request: {
@@ -151,25 +152,6 @@ export default function NewHostRequest({
           t("profile:request_form.send_request", { name: user.name })
         )}
       </Typography>
-      <Typography variant="body1" className={classes.helpText}>
-        <Trans i18nKey="profile:request_form.guide_link_help_text">
-          Not quite sure how to send a great request? Read our{" "}
-          <StyledLink
-            variant="body1"
-            href="https://help.couchers.org/hc/couchersorg-help-center/articles/1715658357-how-to-write-a-request-that-gets-accepted"
-          >
-            quick reference on writing good requests
-          </StyledLink>{" "}
-          or our{" "}
-          <StyledLink
-            variant="body1"
-            href="https://help.couchers.org/hc/couchersorg-help-center/articles/1715658357-how-to-write-a-request-that-gets-accepted"
-          >
-            full guide on sending a request that gets accepted
-          </StyledLink>
-          .
-        </Trans>
-      </Typography>
       {error && <Alert severity="error">{error.message}</Alert>}
       {hostError ? (
         <Alert severity={"error"}>{hostError?.message}</Alert>
@@ -257,6 +239,14 @@ export default function NewHostRequest({
               )}
             </div>
           </div>
+          <Typography variant="body1" className={classes.helpText}>
+            <Trans i18nKey="profile:request_form.guide_link_help_text">
+              <StyledLink variant="body1" href={howToWriteRequestGuideUrl}>
+                Read our guide
+              </StyledLink>{" "}
+              on how to write a request that will get accepted.
+            </Trans>
+          </Typography>
           <TextField
             id="text"
             className={classes.requestField}

--- a/app/web/features/profile/view/NewHostRequest.tsx
+++ b/app/web/features/profile/view/NewHostRequest.tsx
@@ -268,6 +268,7 @@ export default function NewHostRequest({
             placeholder={t("profile:request_form.request_description")}
             error={!!errors.text}
             helperText={errors.text?.message || ""}
+            InputLabelProps={{ shrink: true }}
             inputRef={register({
               required: t("profile:request_form.request_description_empty"),
             })}

--- a/app/web/features/profile/view/NewHostRequest.tsx
+++ b/app/web/features/profile/view/NewHostRequest.tsx
@@ -13,12 +13,13 @@ import makeStyles from "@mui/styles/makeStyles";
 import Alert from "components/Alert";
 import Button from "components/Button";
 import Datepicker from "components/Datepicker";
+import StyledLink from "components/StyledLink";
 import TextField from "components/TextField";
 import dayjs from "dayjs";
 import { useProfileUser } from "features/profile/hooks/useProfileUser";
 import { useLiteUser } from "features/userQueries/useLiteUsers";
 import { RpcError } from "grpc-web";
-import { useTranslation } from "i18n";
+import { Trans, useTranslation } from "i18n";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
 import React, { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
@@ -41,6 +42,10 @@ const useStyles = makeStyles((theme) => ({
   title: {
     marginTop: theme.spacing(1),
     marginBottom: theme.spacing(1),
+  },
+  helpText: {
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(2),
   },
   request: {
     display: "flex",
@@ -145,6 +150,25 @@ export default function NewHostRequest({
         ) : (
           t("profile:request_form.send_request", { name: user.name })
         )}
+      </Typography>
+      <Typography variant="body1" className={classes.helpText}>
+        <Trans i18nKey="profile:request_form.guide_link_help_text">
+          Not quite sure how to send a great request? Read our{" "}
+          <StyledLink
+            variant="body1"
+            href="https://help.couchers.org/hc/couchersorg-help-center/articles/1715658357-how-to-write-a-request-that-gets-accepted"
+          >
+            quick reference on writing good requests
+          </StyledLink>{" "}
+          or our{" "}
+          <StyledLink
+            variant="body1"
+            href="https://help.couchers.org/hc/couchersorg-help-center/articles/1715658357-how-to-write-a-request-that-gets-accepted"
+          >
+            full guide on sending a request that gets accepted
+          </StyledLink>
+          .
+        </Trans>
       </Typography>
       {error && <Alert severity="error">{error.message}</Alert>}
       {hostError ? (

--- a/app/web/routes.ts
+++ b/app/web/routes.ts
@@ -173,3 +173,11 @@ export const howToRespondRequestGuideUrl =
   "https://help.couchers.org/hc/couchersorg-help-center/articles/1715125658-what-are-some-things-i-should-think-about-before-responding-to-a-request";
 export const howToWriteRequestGuideUrl =
   "https://help.couchers.org/hc/couchersorg-help-center/articles/1725943310-quick-reference-writing-great-requests";
+export const howToDonateUrl =
+  "https://help.couchers.org/hc/couchersorg-help-center/articles/1715125658-how-do-i-donate-money-to-couchers-org";
+export const howToCompleteProfileUrl =
+  "https://help.couchers.org/hc/couchersorg-help-center/articles/1725919152-why-do-i-need-to-complete-my-profile-to-use-some-features";
+export const howToInviteCommunityUrl =
+  "https://help.couchers.org/hc/couchersorg-help-center/articles/1720304409-how-does-the-invite-the-community-feature-work";
+export const howToMakeGreatProfileUrl =
+  "https://help.couchers.org/hc/couchersorg-help-center/articles/1725919197-how-do-i-create-a-great-profile";

--- a/app/web/routes.ts
+++ b/app/web/routes.ts
@@ -168,3 +168,8 @@ export const strongVerificationURL = `${process.env.NEXT_PUBLIC_CONSOLE_BASE_URL
 export function adminPanelUserLink(username: string) {
   return `${process.env.NEXT_PUBLIC_CONSOLE_BASE_URL}/admin/user/${username}`;
 }
+
+export const howToRespondRequestGuideUrl =
+  "https://help.couchers.org/hc/couchersorg-help-center/articles/1715125658-what-are-some-things-i-should-think-about-before-responding-to-a-request";
+export const howToWriteRequestGuideUrl =
+  "https://help.couchers.org/hc/couchersorg-help-center/articles/1725943310-quick-reference-writing-great-requests";


### PR DESCRIPTION
This is ready for frontend review: @jesseallhands and I are still working to finish off the guides and tweak the exact wording!

Closes #4392, closes #4393.

WIP guides:
- [Quick reference: writing great requests](https://chatwoot.couchershq.org/app/accounts/2/portals/couchersorg-help-center/en/articles/57)
- [How to send a host a request that gets accepted (with examples)](https://chatwoot.couchershq.org/app/accounts/2/portals/couchersorg-help-center/en/articles/41)
- [How should I respond to a request?](https://chatwoot.couchershq.org/app/accounts/2/portals/couchersorg-help-center/en/articles/56)
- [How do I create a great profile?](https://chatwoot.couchershq.org/app/accounts/2/portals/couchersorg-help-center/en/articles/55)

**Web frontend checklist**
- [ ] Formatted my code with `yarn format`
- [ ] There are no warnings from `yarn lint --fix`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [ ] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
![Screenshot from 2024-09-09 18-34-31](https://github.com/user-attachments/assets/288a05f4-1b47-475b-a15f-01fc01ae898d)
![Screenshot from 2024-09-09 18-31-01](https://github.com/user-attachments/assets/cc6dab45-9815-449a-8919-adc578744a2f)
![Screenshot from 2024-09-09 18-47-28](https://github.com/user-attachments/assets/a9937a5f-28eb-47ad-a0f8-243e83afcb6e)
![Screenshot from 2024-09-09 19-00-11](https://github.com/user-attachments/assets/96143419-98fa-4fb7-9e6a-aaaed77b18fc)
![Screenshot from 2024-09-10 00-56-51](https://github.com/user-attachments/assets/4af2684e-6864-4a88-a2cf-e3c868681035)

