### PR TITLE
Make sure message list is always visible even on small screens

### DIFF
--- a/app/web/features/messages/groupchats/GroupChatView.tsx
+++ b/app/web/features/messages/groupchats/GroupChatView.tsx
@@ -69,7 +69,7 @@ export const useGroupChatViewStyles = makeStyles((theme) => ({
     display: "flex",
     flexDirection: "column",
     // 56px = address bar height on mobile - https://dev.to/peiche/100vh-behavior-on-chrome-2hm8
-    height: `calc(100vh - ${theme.shape.navPaddingXs} - 56px)`,
+    height: `calc(100vh - ${theme.shape.navPaddingXs} - 56px - 80px)`,
   },
   title: {
     flexGrow: 1,

--- a/app/web/features/messages/messagelist/InfiniteMessageLoader.tsx
+++ b/app/web/features/messages/messagelist/InfiniteMessageLoader.tsx
@@ -28,6 +28,7 @@ const useStyles = makeStyles((theme) => ({
   scroll: {
     ...theme.shape.scrollBar,
     position: "relative",
+    minHeight: "80px",
   },
 }));
 


### PR DESCRIPTION
Had a bug report about this in person, here it is, now in digital form: closes #4775

Closes #4112

Makes sure the message scroll page is always at least 80 px, otherwise on small screens sometimes that gets squeezed due to flex box stuff!

**Web frontend checklist**
- [ ] Formatted my code with `yarn format`
- [ ] There are no warnings from `yarn lint --fix`
- [ ] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [ ] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
