### PR TITLE
Make sentry happy

### DIFF
--- a/app/web/features/auth/notifications/PushNotificationSettings.tsx
+++ b/app/web/features/auth/notifications/PushNotificationSettings.tsx
@@ -37,6 +37,7 @@ export default function PushNotificationSettings({
 }) {
   const { t } = useTranslation(AUTH);
   const classes = useStyles();
+  const isNotificationSupported = typeof Notification !== "undefined";
 
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isPushEnabled, setIsPushEnabled] = useState<boolean>(false);
@@ -191,7 +192,9 @@ export default function PushNotificationSettings({
           {t("notification_settings.push_notifications.allow_push")}
         </Alert>
       )}
-      {Notification.permission === "denied" && <PushNotificationDenied />}
+      {isNotificationSupported && Notification.permission === "denied" && (
+        <PushNotificationDenied />
+      )}
       <Typography variant="body1" className={classes.status}>
         {isPushEnabled ? (
           <Trans i18nKey="auth:notification_settings.push_notifications.enabled_message">


### PR DESCRIPTION
Just fixing this. It's happening I think since Next.js is server-side and the `Notification` object isn't available server-side.

Works fine in the client browser though this is mostly to make Sentry happy.

<img width="833" alt="Screenshot 2024-09-17 at 10 00 54 AM" src="https://github.com/user-attachments/assets/c1b55916-1a0a-46bd-a2a3-34e53ad3b70b">


**Web frontend checklist**
- [ x ] Formatted my code with `yarn format`
- [ ] There are no warnings from `yarn lint --fix`
- [ x ] There are no console warnings when running the app
- [ N/A ] Added any new components to storybook
- [ N/A ] Added tests where relevant
- [ x ] All tests pass
- [ x ] Clicked around my changes running locally and it works
- [ x ] Checked Desktop, Mobile and Tablet screen sizes