### PR TITLE
Backend cached clustered users map layer

### DIFF
--- a/app/backend/src/couchers/migrations/versions/d3f2cb24b948_add_clustered_users_materialized_view.py
+++ b/app/backend/src/couchers/migrations/versions/d3f2cb24b948_add_clustered_users_materialized_view.py
@@ -1,0 +1,48 @@
+"""Add clustered users materialized view
+
+Revision ID: d3f2cb24b948
+Revises: 64d94faabb20
+Create Date: 2024-10-25 16:11:06.270916
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d3f2cb24b948"
+down_revision = "64d94faabb20"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        CREATE MATERIALIZED VIEW clustered_users AS
+        WITH clustered AS (
+            SELECT
+                users.id AS id,
+                users.geom AS geom,
+                ST_ClusterDBSCAN(users.geom, 0.15, 5) OVER (ORDER BY users.id) AS cluster_id
+            FROM users
+            WHERE users.geom IS NOT NULL
+        )
+        SELECT
+            ST_Centroid(ST_Collect(clustered.geom)) AS geom,
+            count(*) AS count
+        FROM clustered
+        WHERE clustered.cluster_id IS NOT NULL
+        GROUP BY clustered.cluster_id
+        UNION ALL
+        SELECT
+            clustered.geom AS geom,
+            1 AS count
+        FROM clustered
+        WHERE clustered.cluster_id IS NULL;
+        CREATE INDEX idx_clustered_users_geom ON clustered_users USING gist (geom);
+    """
+    )
+
+
+def downgrade():
+    op.execute("DROP MATERIALIZED VIEW clustered_users")

--- a/app/backend/src/couchers/servicers/gis.py
+++ b/app/backend/src/couchers/servicers/gis.py
@@ -4,7 +4,7 @@ import logging
 from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy.sql import func
 
-from couchers.materialized_views import lite_users
+from couchers.materialized_views import clustered_users, lite_users
 from couchers.models import Node, Page, PageType, PageVersion
 from couchers.sql import couchers_select as select
 from proto import gis_pb2_grpc
@@ -43,6 +43,9 @@ class GIS(gis_pb2_grpc.GISServicer):
             .where(lite_users.c.geom != None)
         )
         return _statement_to_geojson_response(session, statement)
+
+    def GetClusteredUsers(self, request, context, session):
+        return _statement_to_geojson_response(session, select(clustered_users.c.geom, clustered_users.c.count))
 
     def GetCommunities(self, request, context, session):
         return _statement_to_geojson_response(session, select(Node).where(Node.geom != None))

--- a/app/backend/src/tests/test_gis.py
+++ b/app/backend/src/tests/test_gis.py
@@ -3,9 +3,9 @@ import json
 import pytest
 from google.protobuf import empty_pb2
 
-from couchers.materialized_views import refresh_materialized_views_rapid
+from couchers.materialized_views import refresh_materialized_views, refresh_materialized_views_rapid
 from tests.test_communities import testing_communities  # noqa
-from tests.test_fixtures import db, generate_user, gis_session, testconfig  # noqa
+from tests.test_fixtures import generate_user, gis_session, testconfig  # noqa
 
 
 @pytest.fixture(autouse=True)
@@ -32,7 +32,7 @@ class TestGIS:
     def test_GetClusteredUsers(testing_communities):
         _, token = generate_user()
 
-        refresh_materialized_views_rapid(None)
+        refresh_materialized_views(None)
 
         with gis_session(token) as gis:
             http_body = gis.GetClusteredUsers(empty_pb2.Empty())

--- a/app/backend/src/tests/test_gis.py
+++ b/app/backend/src/tests/test_gis.py
@@ -13,15 +13,31 @@ def _(testconfig):
     pass
 
 
-def test_GetUsers(testing_communities):
-    _, token = generate_user()
+class TestGIS:
+    @staticmethod
+    def test_GetUsers(testing_communities):
+        _, token = generate_user()
 
-    refresh_materialized_views_rapid(None)
+        refresh_materialized_views_rapid(None)
 
-    with gis_session(token) as gis:
-        http_body = gis.GetUsers(empty_pb2.Empty())
-        assert http_body.content_type == "application/json"
-        data = json.loads(http_body.data)
-        print(data)
-        assert data["type"] == "FeatureCollection"
-        assert len(data["features"]) > 1
+        with gis_session(token) as gis:
+            http_body = gis.GetUsers(empty_pb2.Empty())
+            assert http_body.content_type == "application/json"
+            data = json.loads(http_body.data)
+            print(data)
+            assert data["type"] == "FeatureCollection"
+            assert len(data["features"]) > 1
+
+    @staticmethod
+    def test_GetClusteredUsers(testing_communities):
+        _, token = generate_user()
+
+        refresh_materialized_views_rapid(None)
+
+        with gis_session(token) as gis:
+            http_body = gis.GetClusteredUsers(empty_pb2.Empty())
+            assert http_body.content_type == "application/json"
+            data = json.loads(http_body.data)
+            print(data)
+            assert data["type"] == "FeatureCollection"
+            assert len(data["features"]) > 1

--- a/app/proto/gis.proto
+++ b/app/proto/gis.proto
@@ -17,6 +17,12 @@ service GIS {
     };
   }
 
+  rpc GetClusteredUsers(google.protobuf.Empty) returns (google.api.HttpBody) {
+    option (google.api.http) = {
+      get : "/geojson/clustered-users"
+    };
+  }
+
   rpc GetCommunities(google.protobuf.Empty) returns (google.api.HttpBody) {
     option (google.api.http) = {
       get : "/geojson/communities"


### PR DESCRIPTION
Implement server-side clustered users layer based on a slowly refreshed materialized view.

**Backend checklist**
- [ ] Formatted my code by running `ruff check --select I --fix . && ruff check . && ruff format .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history
