### PR TITLE
Fix gitlab failing if protos doesn't need to run

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -516,6 +516,8 @@ preview:web-next:
 
 preview:protos:
   needs: ["protos"]
+    - job: "protos"
+      artifacts: true # Only run if artifacts exist
   stage: preview
   image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest
   inherit:

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -515,9 +515,7 @@ preview:web-next:
         - app/web/**/*
 
 preview:protos:
-  needs:
-    - job: "protos"
-      artifacts: true # Only run if artifacts exist
+  needs: ["protos"]
   stage: preview
   image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest
   inherit:

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -141,7 +141,7 @@ build:web-dev:
   rules:
     - if: ($BUILD_WEB == "true") && ($DO_CHECKS == "true") &&($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
       changes:
-      - app/**/*
+        - app/**/*
     - if: ($BUILD_WEB == "true") && ($DO_CHECKS == "true") &&($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
       changes:
         - app/proto/**/*
@@ -150,7 +150,7 @@ build:web-dev:
     paths:
       - artifacts/web-dev/
   tags:
-      - saas-linux-large-amd64
+    - saas-linux-large-amd64
 
 build:web:
   needs: ["protos"]
@@ -263,7 +263,7 @@ test:backend:
         - app/proto/**/*
         - app/backend/**/*
   tags:
-      - saas-linux-medium-amd64
+    - saas-linux-medium-amd64
 
 test:backend-format:
   needs: ["build:backend"]
@@ -486,10 +486,10 @@ preview:web:
   rules:
     - if: ($BUILD_WEB == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
       changes:
-      - app/**/*
+        - app/**/*
     - if: ($BUILD_WEB == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
       changes:
-      - app/web/**/*
+        - app/web/**/*
 
 preview:web-next:
   needs: ["build:web-next"]
@@ -509,13 +509,15 @@ preview:web-next:
   rules:
     - if: ($BUILD_WEB == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
       changes:
-      - app/**/*
+        - app/**/*
     - if: ($BUILD_WEB == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
       changes:
-      - app/web/**/*
+        - app/web/**/*
 
 preview:protos:
-  needs: ["protos"]
+  needs:
+    - job: "protos"
+      artifacts: true # Only run if artifacts exist
   stage: preview
   image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest
   inherit:

--- a/docs/testing123.md
+++ b/docs/testing123.md
@@ -1,1 +1,0 @@
-Just testing gitlab - delete later

--- a/docs/testing123.md
+++ b/docs/testing123.md
@@ -1,0 +1,1 @@
+Just testing gitlab - delete later


### PR DESCRIPTION
Right now GitLab will fail if we didn't update anything that makes the protos job run, for example adding meeting notes or adjusting settings.json.

This is because the `preview:protos` job needs the `protos` job. To make the `preview:protos` job conditional on whether the `protos` job ran, we should use a when condition in the GitLab CI/CD configuration. This setting can prevent the `preview:protos` job from failing if the `protos` job did not produce new artifacts, such as when the only changes are in files like .eslint or settings.json.
