### PR TITLE
Fix some event design issues

### DIFF
--- a/app/web/features/communities/events/DiscoverEventsList.tsx
+++ b/app/web/features/communities/events/DiscoverEventsList.tsx
@@ -64,7 +64,6 @@ const useStyles = makeStyles((theme) => ({
   row: {
     display: "flex",
     justifyContent: "space-between",
-    alignItems: "center",
     width: "100%",
     [theme.breakpoints.down("sm")]: {
       flexDirection: "column",

--- a/app/web/features/communities/events/EventsList.tsx
+++ b/app/web/features/communities/events/EventsList.tsx
@@ -23,6 +23,8 @@ const useStyles = makeStyles((theme) => ({
           [theme.breakpoints.down("xs")]: {
             gridTemplateColumns: "1fr",
             gridGap: theme.spacing(2),
+            padding: theme.spacing(2),
+
             //break out of page padding
             left: "50%",
             marginLeft: "-50vw",

--- a/app/web/features/communities/events/LongEventCard.tsx
+++ b/app/web/features/communities/events/LongEventCard.tsx
@@ -26,6 +26,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     border: `1px solid ${theme.palette.grey[300]}`,
     borderRadius: theme.spacing(1),
+    
+    "&:hover": {
+      backgroundColor: theme.palette.grey[50],
+    },
   },
   attendees: {
     display: "flex",

--- a/app/web/features/communities/events/LongEventCard.tsx
+++ b/app/web/features/communities/events/LongEventCard.tsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     border: `1px solid ${theme.palette.grey[300]}`,
     borderRadius: theme.spacing(1),
-    
+
     "&:hover": {
       backgroundColor: theme.palette.grey[50],
     },


### PR DESCRIPTION
I was scrolling the events on my phone and noticed some design inconsistencies. Fixing these ones here:

* Discover event items had no padding on mobile and were touching the edges of the screen. Add padding.
* Long event cards had no gray color on hover, but discover event cards did. Make them consistent and add hover.
* On mobile, the pills for "My Events" were to the left but for "Discover Events" were in the center. Make them both to the left.

![IMG_1412](https://github.com/user-attachments/assets/34c1df41-026a-4df1-87c6-1e0bcc2b0d35)


**Web frontend checklist**
- [ x ] Formatted my code with `yarn format`
- [ x ] There are no warnings from `yarn lint --fix`
- [ ] There are no console warnings when running the app (no new ones)
- [ N/A ] Added any new components to storybook
- [ N/A ] Added tests where relevant
- [ x ] All tests pass
- [ x ] Clicked around my changes running locally and it works
- [ x ] Checked Desktop, Mobile and Tablet screen sizes
