### PR TITLE
Bug - Fix bbox value

### DIFF
--- a/app/web/Dockerfile.prod
+++ b/app/web/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM node:20-bullseye as builder
+FROM node:20-bullseye AS builder
 
 ARG environment=development
 WORKDIR /app
@@ -22,7 +22,7 @@ RUN cp .env.$environment env && \
 
 RUN yarn build
 
-FROM node:20-slim as runner
+FROM node:20-slim AS runner
 
 WORKDIR /app
 ENV NEXT_TELEMETRY_DISABLED 1

--- a/app/web/features/dashboard/Hero/HeroSearch.tsx
+++ b/app/web/features/dashboard/Hero/HeroSearch.tsx
@@ -45,13 +45,14 @@ export default function HeroSearch() {
         defaultValue={""}
         onChange={(value) => {
           if (value !== "") {
+            const newBbox: [number, number, number, number] = [value.bbox[2], value.bbox[3], value.bbox[0], value.bbox[1]];
             const searchRouteWithSearchQuery = routeToSearch({
               location: value.simplifiedName,
               hostingStatusOptions: [
                 HostingStatus.HOSTING_STATUS_CAN_HOST,
                 HostingStatus.HOSTING_STATUS_MAYBE,
               ],
-              bbox: value.bbox,
+              bbox: newBbox,
             });
             router.push(searchRouteWithSearchQuery);
           }

--- a/app/web/features/dashboard/Hero/HeroSearch.tsx
+++ b/app/web/features/dashboard/Hero/HeroSearch.tsx
@@ -45,7 +45,12 @@ export default function HeroSearch() {
         defaultValue={""}
         onChange={(value) => {
           if (value !== "") {
-            const newBbox: [number, number, number, number] = [value.bbox[2], value.bbox[3], value.bbox[0], value.bbox[1]];
+            const newBbox: [number, number, number, number] = [
+              value.bbox[2],
+              value.bbox[3],
+              value.bbox[0],
+              value.bbox[1],
+            ];
             const searchRouteWithSearchQuery = routeToSearch({
               location: value.simplifiedName,
               hostingStatusOptions: [

--- a/app/web/features/search/SearchBox.tsx
+++ b/app/web/features/search/SearchBox.tsx
@@ -62,7 +62,12 @@ export default function SearchBox({
 
   const handleOnChangeAutocomplete = (event: GeocodeResult) => {
     if (event) {
-      setLocationResult(event);
+      const { bbox } = event;
+      const newLocationResult: GeocodeResult = {
+        ...event,
+        bbox: [bbox[2], bbox[3], bbox[0], bbox[1]], //sw long, sw lat, ne long, ne lat
+      };
+      setLocationResult(newLocationResult);
     }
   };
 


### PR DESCRIPTION
I was working on another branch, clicking around to make sure I didn't break anything. I noticed when I searched a location on the map, it jumped to a random unrelated place.

I replicated this on prod, so seems it's a bug. Since I recently upgraded maplibre in #5119 , I thought maybe I broke something.

But in the end seems like we were putting the bbox values in the wrong order on search?! So either this has been a longstanding issue we didn't notice or ???.

I guess the NominatumPlace could have also changed via that api call, but that also does not make sense tbh.

But hey...it works?!

**Definitely test this one though in case I'm going crazy!**. I tested a lot myself but I still don't understand why we had this bug to begin with.


**Web frontend checklist**
- [ x ] Formatted my code with `yarn format`
- [ x ] There are no warnings from `yarn lint --fix`
- [ x ] There are no console warnings when running the app
- [ x ] All tests pass
- [ x ] Clicked around my changes running locally and it works
- [ x ] Checked Desktop, Mobile and Tablet screen sizes

