### PR TITLE
Change dependabot to monthly for python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/app/backend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "1.topic backend"
       - "dependencies"
@@ -14,7 +14,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/app/media"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "1.topic backend"
       - "dependencies"


### PR DESCRIPTION
Our deps don't move that quickly for backend.