### PR TITLE
Add instructions to run frontend local dev on your phone

### DIFF
--- a/app/web/readme.md
+++ b/app/web/readme.md
@@ -178,5 +178,3 @@ Runs storybook, good for testing and developing components in isolation.
 [Follow the main instructions](https://github.com/Couchers-org/couchers/blob/develop/app/readme.md) to start the docker containers and generate the protocol buffer code.
 
 _hint_: You can find a set of users for logging in at the [dummy data loaded in the docker container](https://github.com/Couchers-org/couchers/blob/develop/app/backend/src/data/dummy_users.json)
-
-

--- a/app/web/readme.md
+++ b/app/web/readme.md
@@ -179,21 +179,4 @@ Runs storybook, good for testing and developing components in isolation.
 
 _hint_: You can find a set of users for logging in at the [dummy data loaded in the docker container](https://github.com/Couchers-org/couchers/blob/develop/app/backend/src/data/dummy_users.json)
 
-## Running your local dev environment on your phone
-
-It's possible to run your local dev environment on your phone, for example if you need to replicate a bug only on the phone. Follow these steps:
-
-1. Find your local IP address:
-    - Mac: Click Apple icon menu => System Settings => Network => Wi-Fi => Details button => IP Address
-    - Linux: In the terminal type command `hostname -I` and hit Enter.
-    - Windows: Click Start Menu => Settings => Network and internet => Properties => IPv4 address
-2. In `envoy.yaml`, under the line `envoy.filters.http.cors` add a line after localhost:3000
-    - `- exact: http://{YOUR_IP_ADDRESS}:3000`
-3. In `backend.dev.env` change the value of `COOKIE_DOMAIN` to `COOKIE_DOMAIN={YOUR_IP_ADDRESS}`. No http or slashes here.
-4. In both `.env.localdev` and in `env.development` (or `.env.development.local` depending what you're using), change this value:
-    - `NEXT_PUBLIC_API_BASE_URL=http://{YOUR_IP_ADDRESS}:8888`
-5. You'll need to run the backend locally. Spin your docker containers down, then run:
-    - `docker-compose up --build`
-6. Restart your frontend `yarn start`.
-7. Now you should be able to access `http://{YOUR_IP_ADDRESS}:3000/` on your phone and log in to actively see how you local changes effect mobile.
 

--- a/app/web/readme.md
+++ b/app/web/readme.md
@@ -178,3 +178,22 @@ Runs storybook, good for testing and developing components in isolation.
 [Follow the main instructions](https://github.com/Couchers-org/couchers/blob/develop/app/readme.md) to start the docker containers and generate the protocol buffer code.
 
 _hint_: You can find a set of users for logging in at the [dummy data loaded in the docker container](https://github.com/Couchers-org/couchers/blob/develop/app/backend/src/data/dummy_users.json)
+
+## Running your local dev environment on your phone
+
+It's possible to run your local dev environment on your phone, for example if you need to replicate a bug only on the phone. Follow these steps:
+
+1. Find your local IP address:
+    - Mac: Click Apple icon menu => System Settings => Network => Wi-Fi => Details button => IP Address
+    - Linus: In the terminal type command `hostname -I` and hit Enter.
+    - Windows: Click Start Menu => Settings => Network and internet => Properties => IPv4 address
+2. In `envoy.yaml`, under the line `envoy.filters.http.cors` add a line after localhost:3000
+    - `- exact: http://{YOUR_IP_ADDRESS}:3000`
+3. In `backend.dev.env` change the value of `COOKIE_DOMAIN` to `COOKIE_DOMAIN={YOUR_IP_ADDRESS}`. No http or slashes here.
+4. In both `.env.localdev` and in `env.development` (or `.env.development.local` depending what you're using), change this value:
+    - `NEXT_PUBLIC_API_BASE_URL=http://{YOUR_IP_ADDRESS}:8888`
+5. You'll need to run the backend locally. Spin your docker containers down, then run:
+    - `docker-compose up --build`
+6. Restart your frontend `yarn start`.
+7. Now you should be able to access `http://{YOUR_IP_ADDRESS}:3000/` on your phone and log in to actively see how you local changes effect mobile.
+

--- a/app/web/readme.md
+++ b/app/web/readme.md
@@ -185,7 +185,7 @@ It's possible to run your local dev environment on your phone, for example if yo
 
 1. Find your local IP address:
     - Mac: Click Apple icon menu => System Settings => Network => Wi-Fi => Details button => IP Address
-    - Linus: In the terminal type command `hostname -I` and hit Enter.
+    - Linux: In the terminal type command `hostname -I` and hit Enter.
     - Windows: Click Start Menu => Settings => Network and internet => Properties => IPv4 address
 2. In `envoy.yaml`, under the line `envoy.filters.http.cors` add a line after localhost:3000
     - `- exact: http://{YOUR_IP_ADDRESS}:3000`

--- a/docs/run-local-app-on-mobile.md
+++ b/docs/run-local-app-on-mobile.md
@@ -1,0 +1,17 @@
+# How to run then local dev environment on your phone
+
+It's possible to run your local dev environment on your phone, for example if you need to replicate a bug only on affecting mobile. Follow these steps:
+
+1. Find your local IP address:
+   - Mac: Click Apple icon menu => System Settings => Network => Wi-Fi => Details button => IP Address
+   - Linux: In the terminal type command `hostname -I` and hit Enter.
+   - Windows: Click Start Menu => Settings => Network and internet => Properties => IPv4 address
+2. In `envoy.yaml`, under the line `envoy.filters.http.cors` add a line after localhost:3000
+   - `- exact: http://{YOUR_IP_ADDRESS}:3000`
+3. In `backend.dev.env` change the value of `COOKIE_DOMAIN` to `COOKIE_DOMAIN={YOUR_IP_ADDRESS}`. No http or slashes here.
+4. In both `.env.localdev` and in `env.development` (or `.env.development.local` depending what you're using), change this value:
+   - `NEXT_PUBLIC_API_BASE_URL=http://{YOUR_IP_ADDRESS}:8888`
+5. You'll need to run the backend locally. Spin your docker containers down, then run:
+   - `docker-compose up --build`
+6. Restart your frontend `yarn start`.
+7. Now you should be able to access `http://{YOUR_IP_ADDRESS}:3000/` on your phone and log in to actively see how you local changes effect mobile.


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

Adding instructions for how to run your local dev environment on your phone. I kept needing this to replicate bugs that were only replicable on mobile that the Chrome responsive tool didn't catch.

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
