### PR TITLE
Mobile style fixes for references list

### DIFF
--- a/app/web/components/TabBar/TabBar.tsx
+++ b/app/web/components/TabBar/TabBar.tsx
@@ -5,7 +5,7 @@ import makeStyles from "utils/makeStyles";
 export const useStyles = makeStyles((theme) => ({
   messagesTab: {
     [theme.breakpoints.down("md")]: {
-      overflow: "visible",
+      // overflow: "visible",
       margin: `0 ${theme.spacing(2)}`,
     },
   },
@@ -34,7 +34,8 @@ export default function TabBar<T extends Record<string, React.ReactNode>>({
       onChange={handleChange}
       indicatorColor="primary"
       textColor="primary"
-      scrollButtons="auto"
+      scrollButtons={true}
+      allowScrollButtonsMobile
       variant="scrollable"
     >
       {Object.entries(labels).map(([value, label]) => (

--- a/app/web/components/TabBar/TabBar.tsx
+++ b/app/web/components/TabBar/TabBar.tsx
@@ -5,7 +5,7 @@ import makeStyles from "utils/makeStyles";
 export const useStyles = makeStyles((theme) => ({
   messagesTab: {
     [theme.breakpoints.down("md")]: {
-      // overflow: "visible",
+      overflow: "visible",
       margin: `0 ${theme.spacing(2)}`,
     },
   },

--- a/app/web/components/TabBar/TabBar.tsx
+++ b/app/web/components/TabBar/TabBar.tsx
@@ -34,7 +34,7 @@ export default function TabBar<T extends Record<string, React.ReactNode>>({
       onChange={handleChange}
       indicatorColor="primary"
       textColor="primary"
-      scrollButtons={true}
+      scrollButtons="auto"
       allowScrollButtonsMobile
       variant="scrollable"
     >

--- a/app/web/features/profile/view/ReferenceList.tsx
+++ b/app/web/features/profile/view/ReferenceList.tsx
@@ -11,6 +11,7 @@ const useStyles = makeStyles((theme) => ({
       paddingBlockEnd: theme.spacing(3),
     },
     width: "100%",
+    overflow: "hidden"
   },
 }));
 

--- a/app/web/features/profile/view/ReferenceList.tsx
+++ b/app/web/features/profile/view/ReferenceList.tsx
@@ -11,7 +11,7 @@ const useStyles = makeStyles((theme) => ({
       paddingBlockEnd: theme.spacing(3),
     },
     width: "100%",
-    overflow: "hidden"
+    overflow: "hidden",
   },
 }));
 

--- a/app/web/features/profile/view/ReferenceListItem.tsx
+++ b/app/web/features/profile/view/ReferenceListItem.tsx
@@ -36,8 +36,8 @@ const useStyles = makeStyles((theme) => ({
   },
   referenceText: {
     whiteSpace: "pre-wrap",
-    width: "100%",  
-    overflow: "hidden"
+    width: "100%",
+    overflow: "hidden",
   },
 }));
 

--- a/app/web/features/profile/view/ReferenceListItem.tsx
+++ b/app/web/features/profile/view/ReferenceListItem.tsx
@@ -36,6 +36,8 @@ const useStyles = makeStyles((theme) => ({
   },
   referenceText: {
     whiteSpace: "pre-wrap",
+    width: "100%",  
+    overflow: "hidden"
   },
 }));
 


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

I was clicking around the references list to answer some questions about it and noticed the reference text and tab scrollbar where overflowing the view on mobile. Decided to quickly throw up a fix here.

* Shows the tab scrollable arrows also on mobile view. Before IMO it wasn't clear there were more tabs on mobile.
* Prevent reference text from overflowing view on mobile

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [ x ] Formatted my code with `yarn format`
- [ x ] There are no warnings from `yarn lint --fix`
- [ x ] There are no console warnings when running the app
- [ x ] All tests pass
- [ x ] Clicked around my changes running locally and it works
- [ x ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
