### PR TITLE
fix help button - set it as  externalLink

### DIFF
--- a/app/web/components/Navigation/Navigation.tsx
+++ b/app/web/components/Navigation/Navigation.tsx
@@ -227,8 +227,9 @@ const loggedInMenuDropDown = (
     hasBottomDivider: true,
   },
   {
-    name: t("nav.help"),
+    name: t("nav.help_center"),
     route: helpCenterURL,
+    externalLink: true,
   },
   {
     name: t("nav.donate"),


### PR DESCRIPTION
Fixed opening of the help page from the hamburger menu, and also changed the displayed text from 'Help' to 'Help Center.'
closes #5307

**Web frontend checklist**
- [x] Formatted my code with `yarn format`
- [x] There are no warnings from `yarn lint --fix`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes
