### PR TITLE
Report button for Communities discussions and comments

### DIFF
--- a/app/web/.env.development
+++ b/app/web/.env.development
@@ -1,7 +1,10 @@
-NEXT_PUBLIC_COUCHERS_ENV=preview
-NEXT_PUBLIC_API_BASE_URL="https://next.couchershq.org/api"
-NEXT_PUBLIC_MEDIA_BASE_URL="https://dev-user-media.couchershq.org"
-NEXT_PUBLIC_CONSOLE_BASE_URL="https://next-console.couchershq.org"
+NEXT_PUBLIC_COUCHERS_ENV=dev
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8888
+NEXT_PUBLIC_MEDIA_BASE_URL="http://localhost:5001"
+NEXT_PUBLIC_CONSOLE_BASE_URL="http://localhost:10027"
+NEXT_PUBLIC_IS_POST_BETA_ENABLED=true
 NEXT_PUBLIC_NOMINATIM_URL="https://nominatim.openstreetmap.org/"
+NEXT_PUBLIC_IS_VERIFICATION_ENABLED=true
+NEXT_PUBLIC_IS_COMMUNITIES_PART2_ENABLED=true
 NEXT_PUBLIC_STRIPE_KEY="pk_test_51KEzByIfR5z29g5khFE5samD8XKOGLcCrM1lhCkfOomGPUFAEYOw8uAqI2Nkv33wYdPM2FgTQNTC07IiNfHY1kLJ00Jqm8Ppai"
-NEXT_PUBLIC_GLOBAL_MESSAGE_URL="https://gm.couchershq.org/next.json"
+NEXT_PUBLIC_GLOBAL_MESSAGE_URL="https://gm.couchershq.org/localdev.json"

--- a/app/web/features/communities/discussions/Comment.tsx
+++ b/app/web/features/communities/discussions/Comment.tsx
@@ -34,6 +34,13 @@ const useStyles = makeStyles((theme) => ({
     gridTemplateRows: "auto",
     padding: theme.spacing(2),
     width: "100%",
+
+    // Align avatar and flag button in a column
+    "& > .avatar-container": {
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center", // Center-align Avatar and FlagButton
+    },
   },
   commentContent: {
     "& > * + *": {
@@ -115,7 +122,7 @@ export default function Comment({ topLevel = false, comment }: CommentProps) {
     <>
       <Card className={classes.commentContainer} data-testid={COMMENT_TEST_ID}>
       {/* Wrapping Avatar and FlagButton in a container for alignment */}
-      <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+      <div className="avatar-container">
         <Avatar user={user} className={classes.avatar} />
         <FlagButton
           contentRef={`comment/${comment.threadId}`}

--- a/app/web/features/communities/discussions/Comment.tsx
+++ b/app/web/features/communities/discussions/Comment.tsx
@@ -11,6 +11,7 @@ import { timestamp2Date } from "utils/date";
 import hasAtLeastOnePage from "utils/hasAtLeastOnePage";
 import makeStyles from "utils/makeStyles";
 import { timeAgo } from "utils/timeAgo";
+import FlagButton from "features/FlagButton";
 
 import { useThread } from "../hooks";
 import CommentForm from "./CommentForm";
@@ -113,7 +114,14 @@ export default function Comment({ topLevel = false, comment }: CommentProps) {
   return (
     <>
       <Card className={classes.commentContainer} data-testid={COMMENT_TEST_ID}>
+      {/* Wrapping Avatar and FlagButton in a container for alignment */}
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
         <Avatar user={user} className={classes.avatar} />
+        <FlagButton
+          contentRef={`comment/${comment.threadId}`}
+          authorUser={comment.authorUserId}
+        />
+      </div>
         <div className={classes.commentContent}>
           {isUserLoading ? (
             <Skeleton />

--- a/app/web/features/communities/discussions/DiscussionCard.tsx
+++ b/app/web/features/communities/discussions/DiscussionCard.tsx
@@ -27,6 +27,11 @@ const useStyles = makeStyles((theme) => ({
     },
     width: "100%",
   },
+  avatarFlagContainer: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+  },
   discussionSummary: {
     display: "flex",
     flexDirection: "column",
@@ -86,7 +91,7 @@ export default function DiscussionCard({
         <a>
           <CardContent className={classes.cardContent}>
             {/* Wrapping Avatar and FlagButton in a container for alignment */}
-            <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+            <div className={classes.avatarFlagContainer}>
               <Avatar
                 user={creator}
                 className={classes.avatar}

--- a/app/web/features/communities/discussions/DiscussionCard.tsx
+++ b/app/web/features/communities/discussions/DiscussionCard.tsx
@@ -11,6 +11,7 @@ import { routeToDiscussion } from "routes";
 import { timestamp2Date } from "utils/date";
 import makeStyles from "utils/makeStyles";
 import { timeAgo } from "utils/timeAgo";
+import FlagButton from "features/FlagButton";
 
 import getContentSummary from "../getContentSummary";
 
@@ -88,6 +89,11 @@ export default function DiscussionCard({
               user={creator}
               className={classes.avatar}
               isProfileLink={false}
+            />
+            {/* Adding the FlagButton below the avatar */}
+            <FlagButton
+              contentRef={`discussion/${discussion.discussionId}`}
+              authorUser={discussion.creatorUserId}
             />
             <div className={classes.discussionSummary}>
               <Typography

--- a/app/web/features/communities/discussions/DiscussionCard.tsx
+++ b/app/web/features/communities/discussions/DiscussionCard.tsx
@@ -85,16 +85,19 @@ export default function DiscussionCard({
       <Link href={routeToDiscussion(discussion.discussionId, discussion.slug)}>
         <a>
           <CardContent className={classes.cardContent}>
-            <Avatar
-              user={creator}
-              className={classes.avatar}
-              isProfileLink={false}
-            />
-            {/* Adding the FlagButton below the avatar */}
-            <FlagButton
-              contentRef={`discussion/${discussion.discussionId}`}
-              authorUser={discussion.creatorUserId}
-            />
+            {/* Wrapping Avatar and FlagButton in a container for alignment */}
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+              <Avatar
+                user={creator}
+                className={classes.avatar}
+                isProfileLink={false}
+              />
+              {/* Adding the FlagButton below the avatar */}
+              <FlagButton
+                contentRef={`discussion/${discussion.discussionId}`}
+                authorUser={discussion.creatorUserId}
+              />
+            </div>
             <div className={classes.discussionSummary}>
               <Typography
                 variant="body2"


### PR DESCRIPTION
## **Issue Reference**
Closes #5122 – Add Flag Button for Discussions and Comments in Communities.

---

## **Description**
This pull request implements the ability for users to flag both **discussions** and **comments** in community forums. The flagging functionality reuses the existing `FlagButton` component, ensuring consistency with the current design and behavior. This feature also aligns with existing grid layouts and CSS patterns for seamless integration.

---

## **Key Changes**
1. **Discussions**
   - Added a `FlagButton` below the user avatar in the `DiscussionCard` component.
   - Updated CSS in `DiscussionCard` to vertically align the avatar and flag button using a flex container.
   - Used a `contentRef` format of `discussion/{discussionId}` for discussions.

2. **Comments**
   - Added a `FlagButton` below the user avatar in the `Comment` component.
   - Enhanced the existing `commentContainer` CSS class to align the avatar and flag button vertically.
   - Used `contentRef` format of `comment/{comment.threadId}` for comments.

---
Flag button is functional and positioned correctly for discussion cards and discussion comments:
[
<img width="1185" alt="Screenshot 2024-12-12 at 09 45 23" src="https://github.com/user-attachments/assets/41d5e3ca-8080-4fde-90f8-f1dde2e2f007" />
](url)

<img width="1424" alt="Screenshot 2024-12-12 at 09 44 48" src="https://github.com/user-attachments/assets/d7078cd3-fa38-4340-a3dd-aa095d86858e" />

<img width="593" alt="Screenshot 2024-12-12 at 09 44 09" src="https://github.com/user-attachments/assets/e402ab1f-dfe9-473e-8fbc-b4e9a225d832" />

<img width="537" alt="Screenshot 2024-12-12 at 09 44 14" src="https://github.com/user-attachments/assets/dbacc97e-e677-4390-bd3e-f89a43ce393c" />

The flag button is checked for positioning with mobile and tablet sizes:

<img width="213" alt="Screenshot 2024-12-12 at 10 54 08" src="https://github.com/user-attachments/assets/e3c9a3ac-7a43-423f-b3a1-d67dccbc46e0" />

<img width="346" alt="Screenshot 2024-12-12 at 10 54 18" src="https://github.com/user-attachments/assets/bfcd1868-a643-46e9-824a-186b4f2b5d3c" />

There are no console warnings when running locally:
<img width="223" alt="Screenshot 2024-12-12 at 10 23 18" src="https://github.com/user-attachments/assets/9ac97aa9-51c2-47a0-97f4-22f16584b0f0" />


<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->

**Web frontend checklist**
- [x] Formatted my code with `yarn format`
- [x] There are no warnings from `yarn lint --fix`
- [x] There are no console warnings when running the app
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes
