### PR TITLE
Update email change confirmation template, closes #5327

### DIFF
--- a/app/backend/templates/v2/email_changed_confirmation_new_email.mjml
+++ b/app/backend/templates/v2/email_changed_confirmation_new_email.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
     <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text>You requested that your email be changed to this email address on Couchers.org. Your old email address is <code>{{ user.email|v2esc }}</code>. This is the final step in the process.</mj-text>
+    <mj-text>You requested that your email be changed to this email address on Couchers.org. Your old email address is <b>{{ user.email|v2esc }}</b>. This is the final step in the process.</mj-text>
     <mj-text>To complete this change, please confirm your email by clicking the following link:</mj-text>
   </mj-column>
 </mj-section>

--- a/app/backend/templates/v2/generated_html/email_changed_confirmation_new_email.html
+++ b/app/backend/templates/v2/generated_html/email_changed_confirmation_new_email.html
@@ -172,7 +172,7 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">You requested that your email be changed to this email address on Couchers.org. Your old email address is <code>{{ user.email|v2esc }}</code>. This is the final step in the process.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">You requested that your email be changed to this email address on Couchers.org. Your old email address is <b>{{ user.email|v2esc }}</b>. This is the final step in the process.</div>
                                 </td>
                               </tr>
                               <tr>


### PR DESCRIPTION
It's hard to see the new email in the old style with `<code>`, and it's inconsistent with security emails that use bold.

**Backend checklist**
- [ ] Formatted my code by running `ruff check --select I --fix . && ruff check . && ruff format .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history
