### PR TITLE
Make dialogs prettier

### DIFF
--- a/app/web/components/Dialog.tsx
+++ b/app/web/components/Dialog.tsx
@@ -19,7 +19,7 @@ import makeStyles from "utils/makeStyles";
 const useStyles = makeStyles((theme) => ({
   actions: {
     display: "flex",
-    justifyContent: "space-around",
+    justifyContent: "center",
     margin: 0,
     padding: theme.spacing(2),
     paddingTop: 0,
@@ -27,18 +27,15 @@ const useStyles = makeStyles((theme) => ({
   content: {
     height: "fit-content",
     padding: theme.spacing(3),
+    paddingTop: 0,
     width: "100%",
   },
   contentText: {
     padding: theme.spacing(2),
   },
   title: {
-    "& > h2": theme.typography.h2,
-    "&:not(:nth-child(1))": {
-      paddingTop: 0,
-    },
+    "&": theme.typography.h2,
     padding: theme.spacing(2),
-    paddingBottom: 0,
     textAlign: "center",
   },
   closeButton: {


### PR DESCRIPTION
* Fixes the dialog title font being tiny.
* Makes action buttons centered instead of spread apart

---

Before:

![Screenshot from 2024-12-13 19-20-40](https://github.com/user-attachments/assets/e3deba95-2197-45d7-88cd-8e4d25abfc89)

---

After:

![Screenshot from 2024-12-13 19-20-16](https://github.com/user-attachments/assets/bbc6a357-044a-42a7-a892-60ac07542590)
