### PR TITLE
Web/refactor/convert mui components to styled

### DIFF
--- a/app/web/components/Alert.tsx
+++ b/app/web/components/Alert.tsx
@@ -6,7 +6,6 @@ import {
 import { grpcErrorStrings, ObscureGrpcErrorMessages } from "appConstants";
 import classNames from "classnames";
 import React from "react";
-// import makeStyles from "utils/makeStyles";
 
 const StyledAlert = styled(MuiAlert)(({ theme }) => ({
   marginBottom: theme.spacing(2),
@@ -22,8 +21,6 @@ export default function Alert({
   children,
   ...otherProps
 }: AlertProps) {
-  // const classes = useStyles();
-
   const oldErrorKey = Object.keys(grpcErrorStrings).find(
     (oldError): oldError is ObscureGrpcErrorMessages =>
       children.includes(oldError)

--- a/app/web/components/Alert.tsx
+++ b/app/web/components/Alert.tsx
@@ -2,13 +2,14 @@ import { Alert as MuiAlert, AlertProps as MuiAlertProps } from "@mui/material";
 import { grpcErrorStrings, ObscureGrpcErrorMessages } from "appConstants";
 import classNames from "classnames";
 import React from "react";
-import makeStyles from "utils/makeStyles";
+import { theme } from "theme";
+// import makeStyles from "utils/makeStyles";
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    marginBottom: theme.spacing(2),
-  },
-}));
+// const useStyles = makeStyles((theme) => ({
+//   root: {
+//     marginBottom: theme.spacing(2),
+//   },
+// }));
 
 interface AlertProps extends MuiAlertProps {
   severity: MuiAlertProps["severity"];
@@ -20,7 +21,7 @@ export default function Alert({
   children,
   ...otherProps
 }: AlertProps) {
-  const classes = useStyles();
+  // const classes = useStyles();
 
   const oldErrorKey = Object.keys(grpcErrorStrings).find(
     (oldError): oldError is ObscureGrpcErrorMessages =>
@@ -28,7 +29,7 @@ export default function Alert({
   );
 
   return (
-    <MuiAlert {...otherProps} className={classNames(classes.root, className)}>
+    <MuiAlert {...otherProps} className={classNames(className)} sx={{marginBottom: theme.spacing(2)}}>
       {
         // Search for the error in the ugly grpc error object keys
         // Replace it with the nice error if found

--- a/app/web/components/Alert.tsx
+++ b/app/web/components/Alert.tsx
@@ -4,7 +4,6 @@ import {
   styled,
 } from "@mui/material";
 import { grpcErrorStrings, ObscureGrpcErrorMessages } from "appConstants";
-import classNames from "classnames";
 import React from "react";
 
 const StyledAlert = styled(MuiAlert)(({ theme }) => ({
@@ -27,7 +26,7 @@ export default function Alert({
   );
 
   return (
-    <StyledAlert {...otherProps} className={classNames(className)}>
+    <StyledAlert {...otherProps} className={className}>
       {
         // Search for the error in the ugly grpc error object keys
         // Replace it with the nice error if found

--- a/app/web/components/Alert.tsx
+++ b/app/web/components/Alert.tsx
@@ -1,15 +1,16 @@
-import { Alert as MuiAlert, AlertProps as MuiAlertProps } from "@mui/material";
+import {
+  Alert as MuiAlert,
+  AlertProps as MuiAlertProps,
+  styled,
+} from "@mui/material";
 import { grpcErrorStrings, ObscureGrpcErrorMessages } from "appConstants";
 import classNames from "classnames";
 import React from "react";
-import { theme } from "theme";
 // import makeStyles from "utils/makeStyles";
 
-// const useStyles = makeStyles((theme) => ({
-//   root: {
-//     marginBottom: theme.spacing(2),
-//   },
-// }));
+const StyledAlert = styled(MuiAlert)(({ theme }) => ({
+  marginBottom: theme.spacing(2),
+}));
 
 interface AlertProps extends MuiAlertProps {
   severity: MuiAlertProps["severity"];
@@ -29,12 +30,12 @@ export default function Alert({
   );
 
   return (
-    <MuiAlert {...otherProps} className={classNames(className)} sx={{marginBottom: theme.spacing(2)}}>
+    <StyledAlert {...otherProps} className={classNames(className)}>
       {
         // Search for the error in the ugly grpc error object keys
         // Replace it with the nice error if found
         oldErrorKey ? grpcErrorStrings[oldErrorKey] : children
       }
-    </MuiAlert>
+    </StyledAlert>
   );
 }


### PR DESCRIPTION
Change styling from JSS to Emotion so we can upgrade MUI.

part of #5299 


**Web frontend checklist**
- [x] Formatted my code with `yarn format`
- [x] There are no warnings from `yarn lint --fix`
- [x] There are no console warnings when running the app
- [ ] Added any new components to storybook
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

