### PR TITLE
Add aboutMe profile character count

### DIFF
--- a/app/web/features/profile/ProfileMarkdownInput.tsx
+++ b/app/web/features/profile/ProfileMarkdownInput.tsx
@@ -1,8 +1,8 @@
 import { Typography } from "@mui/material";
+import Alert from "components/Alert";
 import MarkdownInput from "components/MarkdownInput";
 import React from "react";
 import { Control } from "react-hook-form";
-import { theme } from "theme";
 
 interface ProfileMarkdownInputProps {
   className?: string;
@@ -12,7 +12,7 @@ interface ProfileMarkdownInputProps {
   id: string;
   label: string;
   name: string;
-  error?: boolean;
+  warning?: boolean;
   helperText?: string;
 }
 
@@ -23,7 +23,7 @@ export default function ProfileMarkdownInput({
   id,
   label,
   name,
-  error,
+  warning,
   helperText,
 }: ProfileMarkdownInputProps) {
   return (
@@ -31,14 +31,7 @@ export default function ProfileMarkdownInput({
       <Typography variant="h2" id={`${id}-label`}>
         {label}
       </Typography>
-      {error && (
-        <Typography
-          variant="subtitle1"
-          sx={{ color: theme.palette.error.main, fontSize: "0.75rem" }}
-        >
-          {helperText}
-        </Typography>
-      )}
+      {warning && helperText && <Alert severity="warning">{helperText}</Alert>}
       <MarkdownInput
         control={control}
         defaultValue={defaultValue}

--- a/app/web/features/profile/ProfileMarkdownInput.tsx
+++ b/app/web/features/profile/ProfileMarkdownInput.tsx
@@ -13,7 +13,7 @@ interface ProfileMarkdownInputProps {
   label: string;
   name: string;
   error?: boolean;
-  helperText?: string | undefined;
+  helperText?: string;
 }
 
 export default function ProfileMarkdownInput({

--- a/app/web/features/profile/ProfileMarkdownInput.tsx
+++ b/app/web/features/profile/ProfileMarkdownInput.tsx
@@ -2,6 +2,7 @@ import { Typography } from "@mui/material";
 import MarkdownInput from "components/MarkdownInput";
 import React from "react";
 import { Control } from "react-hook-form";
+import { theme } from "theme";
 
 interface ProfileMarkdownInputProps {
   className?: string;
@@ -11,6 +12,8 @@ interface ProfileMarkdownInputProps {
   id: string;
   label: string;
   name: string;
+  error?: boolean;
+  helperText?: string | undefined;
 }
 
 export default function ProfileMarkdownInput({
@@ -20,12 +23,22 @@ export default function ProfileMarkdownInput({
   id,
   label,
   name,
+  error,
+  helperText,
 }: ProfileMarkdownInputProps) {
   return (
     <div className={className}>
       <Typography variant="h2" id={`${id}-label`}>
         {label}
       </Typography>
+      {error && (
+        <Typography
+          variant="subtitle1"
+          sx={{ color: theme.palette.error.main, fontSize: "0.75rem" }}
+        >
+          {helperText}
+        </Typography>
+      )}
       <MarkdownInput
         control={control}
         defaultValue={defaultValue}

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -89,7 +89,6 @@ export default function EditProfileForm() {
     formState: { errors, isDirty, isSubmitted },
   } = useForm<EditProfileFormValues>({
     defaultValues: {
-      avatarKey: user?.avatarUrl,
       location: {
         city: user?.city,
         lat: user?.lat,
@@ -101,9 +100,9 @@ export default function EditProfileForm() {
     shouldFocusError: true,
   });
 
-  const [avatarKeyField, aboutMeField] = useWatch({
+  const aboutMeField = useWatch({
     control,
-    name: ["avatarKey", "aboutMe"],
+    name: "aboutMe",
   });
 
   useUnsavedChangesWarning({
@@ -168,7 +167,7 @@ export default function EditProfileForm() {
   const handleSubmitButtonClick = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (aboutMeField?.length < ABOUT_ME_MIN_LENGTH || !avatarKeyField) {
+    if (aboutMeField?.length < ABOUT_ME_MIN_LENGTH || !user?.avatarUrl) {
       setShowIncompleteProfileDialog(true);
     } else {
       onSubmit();
@@ -187,6 +186,11 @@ export default function EditProfileForm() {
           {errors.avatarKey?.message || t("global:error.unknown")}
         </Alert>
       )}
+      {!user?.avatarUrl && (
+        <StyledAlert severity="warning">
+          {t("profile:helper_text.missing_profile_photo")}
+        </StyledAlert>
+      )}
       {user ? (
         <>
           <div className={classes.helpTextContainer}>
@@ -199,11 +203,6 @@ export default function EditProfileForm() {
                 .
               </Trans>
             </Typography>
-            {!avatarKeyField && (
-              <StyledAlert severity="warning">
-                {t("profile:helper_text.missing_profile_photo")}
-              </StyledAlert>
-            )}
           </div>
           <form onSubmit={onSubmit} className={classes.topFormContainer}>
             <ImageInput
@@ -543,7 +542,7 @@ export default function EditProfileForm() {
                     {`• ${t("profile:incomplete_dialog.about_me_message")}`}
                   </ListItem>
                 )}
-                {!avatarKeyField && (
+                {!user.avatarUrl && (
                   <ListItem key={2} style={{ display: "list-item" }}>
                     {`• ${t(
                       "profile:incomplete_dialog.missing_photo_message"

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -95,7 +95,7 @@ export default function EditProfileForm() {
         lng: user?.lng,
         radius: user?.radius,
       },
-      aboutMe: user?.aboutMe,
+      aboutMe: user?.aboutMe || DEFAULT_ABOUT_ME_HEADINGS,
     },
     shouldFocusError: true,
   });
@@ -104,6 +104,12 @@ export default function EditProfileForm() {
     control,
     name: "aboutMe",
   });
+
+  // @TODO(NA) This is not entirely perfect, it will pass if they have the default headings
+  // but added just enough to make 150 chars. Will fail if only default headers though. Avoiding
+  // doing a complicated parsing function to count everything expect the default headigns since it'll be mixed in.
+  const aboutMeFieldLength =
+    aboutMeField === DEFAULT_ABOUT_ME_HEADINGS ? 0 : aboutMeField.length;
 
   useUnsavedChangesWarning({
     isDirty,
@@ -167,7 +173,7 @@ export default function EditProfileForm() {
   const handleSubmitButtonClick = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (aboutMeField?.length < ABOUT_ME_MIN_LENGTH || !user?.avatarUrl) {
+    if (aboutMeFieldLength < ABOUT_ME_MIN_LENGTH || !user?.avatarUrl) {
       setShowIncompleteProfileDialog(true);
     } else {
       onSubmit();
@@ -454,9 +460,9 @@ export default function EditProfileForm() {
               defaultValue={user.aboutMe || DEFAULT_ABOUT_ME_HEADINGS}
               control={control}
               className={classes.field}
-              warning={aboutMeField?.length < ABOUT_ME_MIN_LENGTH}
+              warning={aboutMeFieldLength < ABOUT_ME_MIN_LENGTH}
               helperText={t("profile:helper_text.characters_remaining", {
-                count: ABOUT_ME_MIN_LENGTH - aboutMeField?.length,
+                count: ABOUT_ME_MIN_LENGTH - aboutMeFieldLength,
               })}
             />
             <ProfileMarkdownInput
@@ -529,6 +535,7 @@ export default function EditProfileForm() {
             aria-labelledby={t("profile:incomplete_dialog.title")}
             maxWidth="xs"
             open={showIncompleteProfileDialog}
+            data-testid="incomplete-profile-dialog"
           >
             <DialogTitle>{t("profile:incomplete_dialog.title")}</DialogTitle>
             <DialogContent>
@@ -537,7 +544,7 @@ export default function EditProfileForm() {
                 <Typography paragraph>
                   {t("profile:incomplete_dialog.description")}
                 </Typography>
-                {aboutMeField.length < ABOUT_ME_MIN_LENGTH && (
+                {aboutMeFieldLength < ABOUT_ME_MIN_LENGTH && (
                   <ListItem key={1} style={{ display: "list-item" }}>
                     {`• ${t("profile:incomplete_dialog.about_me_message")}`}
                   </ListItem>

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -73,6 +73,7 @@ export default function EditProfileForm() {
     register,
     handleSubmit,
     setValue,
+    watch,
     formState: { errors, isDirty, isSubmitted },
   } = useForm<EditProfileFormValues>({
     defaultValues: {
@@ -85,6 +86,8 @@ export default function EditProfileForm() {
     },
     shouldFocusError: true,
   });
+
+  const aboutMeField = watch("aboutMe");
 
   useUnsavedChangesWarning({
     isDirty,
@@ -413,6 +416,10 @@ export default function EditProfileForm() {
               defaultValue={user.aboutMe || DEFAULT_ABOUT_ME_HEADINGS}
               control={control}
               className={classes.field}
+              error={aboutMeField?.length < 150}
+              helperText={t("profile:helper_text.characters_remaining", {
+                count: 150 - aboutMeField?.length,
+              })}
             />
             <ProfileMarkdownInput
               id="thingsILike"

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -1,4 +1,5 @@
 import {
+  DialogContent,
   FormControlLabel,
   Radio,
   RadioGroup,
@@ -8,6 +9,7 @@ import {
 import Alert from "components/Alert";
 import Button from "components/Button";
 import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
+import { Dialog, DialogActions, DialogTitle } from "components/Dialog";
 import EditLocationMap from "components/EditLocationMap";
 import ImageInput from "components/ImageInput";
 import StyledLink from "components/StyledLink";
@@ -22,7 +24,7 @@ import useCurrentUser from "features/userQueries/useCurrentUser";
 import { Trans, useTranslation } from "i18n";
 import { AUTH, GLOBAL, PROFILE } from "i18n/namespaces";
 import { HostingStatus, LanguageAbility, MeetupStatus } from "proto/api_pb";
-import React from "react";
+import React, { FormEvent, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useQueryClient } from "react-query";
 import { howToMakeGreatProfileUrl } from "routes";
@@ -67,6 +69,9 @@ export default function EditProfileForm() {
     isMounted,
     null
   );
+  const [showIncompleteProfileDialog, setShowIncompleteProfileDialog] =
+    useState(false);
+
   const queryClient = useQueryClient();
   const {
     control,
@@ -83,6 +88,7 @@ export default function EditProfileForm() {
         lng: user?.lng,
         radius: user?.radius,
       },
+      aboutMe: user?.aboutMe,
     },
     shouldFocusError: true,
   });
@@ -137,12 +143,25 @@ export default function EditProfileForm() {
           },
         }
       );
+
+      if (showIncompleteProfileDialog) {
+        setShowIncompleteProfileDialog(false);
+      }
     },
     // All field validation errors should scroll to their respective field
     // Except the avatar, so this scrolls to top on avatar validation error
     (errors) =>
       errors.avatarKey && window.scroll({ top: 0, behavior: "smooth" })
   );
+
+  const handleSubmitButtonClick = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (aboutMeField?.length < 150) {
+      setShowIncompleteProfileDialog(true);
+    } else {
+      onSubmit();
+    }
+  };
 
   return (
     <>
@@ -234,7 +253,10 @@ export default function EditProfileForm() {
               />
             )}
           />
-          <form onSubmit={onSubmit} className={classes.bottomFormContainer}>
+          <form
+            onSubmit={handleSubmitButtonClick}
+            className={classes.bottomFormContainer}
+          >
             <Controller
               control={control}
               defaultValue={user.hostingStatus}
@@ -482,12 +504,31 @@ export default function EditProfileForm() {
                 variant="contained"
                 color="primary"
                 loading={updateIsLoading}
-                onClick={onSubmit}
               >
                 {t("global:save")}
               </Button>
             </div>
           </form>
+          <Dialog
+            aria-labelledby={t("profile:incomplete_dialog.title")}
+            maxWidth="xs"
+            open={showIncompleteProfileDialog}
+          >
+            <DialogTitle>{t("profile:incomplete_dialog.title")}</DialogTitle>
+            <DialogContent>
+              <Typography align="center">
+                {t("profile:incomplete_dialog.message")}
+              </Typography>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={() => setShowIncompleteProfileDialog(false)}>
+                {t("profile:cancel")}
+              </Button>
+              <Button onClick={onSubmit}>
+                {t("profile:incomplete_dialog.save_anyway")}
+              </Button>
+            </DialogActions>
+          </Dialog>
         </>
       ) : (
         <CenteredSpinner />

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -1,8 +1,11 @@
 import {
   DialogContent,
   FormControlLabel,
+  List,
+  ListItem,
   Radio,
   RadioGroup,
+  styled,
   TextField,
   Typography,
 } from "@mui/material";
@@ -25,7 +28,7 @@ import { Trans, useTranslation } from "i18n";
 import { AUTH, GLOBAL, PROFILE } from "i18n/namespaces";
 import { HostingStatus, LanguageAbility, MeetupStatus } from "proto/api_pb";
 import React, { FormEvent, useState } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { Controller, useForm, useWatch } from "react-hook-form";
 import { useQueryClient } from "react-query";
 import { howToMakeGreatProfileUrl } from "routes";
 import { service, UpdateUserProfileData } from "service/index";
@@ -36,10 +39,15 @@ import {
 } from "utils/hooks";
 
 import {
+  ABOUT_ME_MIN_LENGTH,
   DEFAULT_ABOUT_ME_HEADINGS,
   DEFAULT_HOBBIES_HEADINGS,
 } from "./constants";
 import useStyles from "./styles";
+
+const StyledAlert = styled(Alert)(({ theme }) => ({
+  marginTop: theme.spacing(2),
+}));
 
 export type EditProfileFormValues = Omit<
   UpdateUserProfileData,
@@ -78,10 +86,10 @@ export default function EditProfileForm() {
     register,
     handleSubmit,
     setValue,
-    watch,
     formState: { errors, isDirty, isSubmitted },
   } = useForm<EditProfileFormValues>({
     defaultValues: {
+      avatarKey: user?.avatarUrl,
       location: {
         city: user?.city,
         lat: user?.lat,
@@ -93,7 +101,10 @@ export default function EditProfileForm() {
     shouldFocusError: true,
   });
 
-  const aboutMeField = watch("aboutMe");
+  const [avatarKeyField, aboutMeField] = useWatch({
+    control,
+    name: ["avatarKey", "aboutMe"],
+  });
 
   useUnsavedChangesWarning({
     isDirty,
@@ -156,7 +167,8 @@ export default function EditProfileForm() {
 
   const handleSubmitButtonClick = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (aboutMeField?.length < 150) {
+
+    if (aboutMeField?.length < ABOUT_ME_MIN_LENGTH || !avatarKeyField) {
       setShowIncompleteProfileDialog(true);
     } else {
       onSubmit();
@@ -187,6 +199,11 @@ export default function EditProfileForm() {
                 .
               </Trans>
             </Typography>
+            {!avatarKeyField && (
+              <StyledAlert severity="warning">
+                {t("profile:helper_text.missing_profile_photo")}
+              </StyledAlert>
+            )}
           </div>
           <form onSubmit={onSubmit} className={classes.topFormContainer}>
             <ImageInput
@@ -438,9 +455,9 @@ export default function EditProfileForm() {
               defaultValue={user.aboutMe || DEFAULT_ABOUT_ME_HEADINGS}
               control={control}
               className={classes.field}
-              error={aboutMeField?.length < 150}
+              warning={aboutMeField?.length < ABOUT_ME_MIN_LENGTH}
               helperText={t("profile:helper_text.characters_remaining", {
-                count: 150 - aboutMeField?.length,
+                count: ABOUT_ME_MIN_LENGTH - aboutMeField?.length,
               })}
             />
             <ProfileMarkdownInput
@@ -516,13 +533,28 @@ export default function EditProfileForm() {
           >
             <DialogTitle>{t("profile:incomplete_dialog.title")}</DialogTitle>
             <DialogContent>
-              <Typography align="center">
-                {t("profile:incomplete_dialog.message")}
-              </Typography>
+              <Typography></Typography>
+              <List>
+                <Typography paragraph>
+                  {t("profile:incomplete_dialog.description")}
+                </Typography>
+                {aboutMeField.length < ABOUT_ME_MIN_LENGTH && (
+                  <ListItem key={1} style={{ display: "list-item" }}>
+                    {`• ${t("profile:incomplete_dialog.about_me_message")}`}
+                  </ListItem>
+                )}
+                {!avatarKeyField && (
+                  <ListItem key={2} style={{ display: "list-item" }}>
+                    {`• ${t(
+                      "profile:incomplete_dialog.missing_photo_message"
+                    )}`}
+                  </ListItem>
+                )}
+              </List>
             </DialogContent>
             <DialogActions>
               <Button onClick={() => setShowIncompleteProfileDialog(false)}>
-                {t("profile:cancel")}
+                {t("profile:incomplete_dialog.continue_editing")}
               </Button>
               <Button onClick={onSubmit}>
                 {t("profile:incomplete_dialog.save_anyway")}

--- a/app/web/features/profile/edit/EditProfilePage.test.tsx
+++ b/app/web/features/profile/edit/EditProfilePage.test.tsx
@@ -1,6 +1,5 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import mockRouter from "next-router-mock";
 import { routeToProfile } from "routes";
 import { service } from "service";
@@ -29,30 +28,51 @@ const updateProfileMock = service.user.updateProfile as jest.MockedFunction<
   typeof service.user.updateProfile
 >;
 
-const renderPage = () => {
-  render(<EditProfilePage />, { wrapper });
+const renderPage = async () => {
+  act(() => render(<EditProfilePage />, { wrapper }));
 };
 
 describe("Edit profile", () => {
   beforeEach(() => {
     addDefaultUser();
-    getUserMock.mockImplementation(getUser);
     getRegionsMock.mockImplementation(getRegions);
     getLanguagesMock.mockImplementation(getLanguages);
-    updateProfileMock.mockResolvedValue(new Empty());
   });
 
-  it("should redirect to the user profile page after a successful update", async () => {
+  it("Should update and redirect to the user profile page when aboutMe and avatar filled out on first go", async () => {
+    // prevent the unsavedChanged pop up by mocking window.confirm
+    jest.spyOn(window, "confirm").mockImplementation(() => true);
+    const aboutMeText =
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam. Ad nauseum.";
+
+    getUserMock.mockImplementation(getUser);
+
     renderPage();
 
     const user = userEvent.setup();
+
+    const aboutMeInput = await screen.findByLabelText(
+      t("profile:heading.who_section")
+    );
+
+    await user.clear(aboutMeInput);
+    await user.type(aboutMeInput, aboutMeText);
+
+    await waitFor(() => expect(aboutMeInput).toHaveValue(aboutMeText), {
+      timeout: 5000,
+    });
 
     await user.click(
       await screen.findByRole("button", { name: t("global:save") })
     );
 
-    await waitFor(() =>
-      expect(mockRouter.pathname).toBe(routeToProfile("about"))
+    expect(updateProfileMock).toHaveBeenCalledWith(
+      expect.objectContaining({ aboutMe: aboutMeText })
+    );
+
+    await waitFor(
+      () => expect(mockRouter.pathname).toBe(routeToProfile("about")),
+      { timeout: 5000 }
     );
   });
 
@@ -71,6 +91,13 @@ describe("Edit profile", () => {
     await user.click(
       await screen.findByRole("button", { name: t("global:save") })
     );
+
+    const saveAnywayButton = await screen.findByRole("button", {
+      name: t("profile:incomplete_dialog.save_anyway"),
+    });
+
+    await user.click(saveAnywayButton);
+
     await waitFor(() =>
       expect(mockRouter.pathname).toBe(routeToProfile("about"))
     );
@@ -81,5 +108,28 @@ describe("Edit profile", () => {
         thingsILike: "",
       })
     );
+  });
+
+  it("Should not update profile automatically if the user has not filled out aboutMe section besides deafault headers", async () => {
+    getUserMock.mockImplementation(async (user) => ({
+      ...(await getUser(user)),
+      aboutMe: "",
+      thingsILike: "",
+    }));
+
+    await renderPage();
+
+    const user = userEvent.setup();
+
+    await user.click(
+      await screen.findByRole("button", { name: t("global:save") })
+    );
+
+    const profileIncompleteDialog = await screen.findByTestId(
+      "incomplete-profile-dialog"
+    );
+
+    expect(profileIncompleteDialog).toBeVisible();
+    expect(updateProfileMock).not.toHaveBeenCalled();
   });
 });

--- a/app/web/features/profile/edit/constants.ts
+++ b/app/web/features/profile/edit/constants.ts
@@ -34,3 +34,5 @@ export const DEFAULT_ABOUT_HOME_HEADINGS = `# What I can share with guests
 e.g. I can share...
 <br>
 `;
+
+export const ABOUT_ME_MIN_LENGTH = 150;

--- a/app/web/features/profile/locales/en.json
+++ b/app/web/features/profile/locales/en.json
@@ -34,6 +34,9 @@
     "gender_verification_verified": "This user has verified their gender",
     "gender_verification_mismatch": "User provided gender does not match verified gender"
   },
+  "helper_text": {
+    "characters_remaining": "You need to write {{count}} more characters about yourself to be able to send requests, messages, or create events."
+  },
   "section_tabs_a11y_label": "tabs for user's details",
   "home_info_headings": {
     "about_home": "About my home",

--- a/app/web/features/profile/locales/en.json
+++ b/app/web/features/profile/locales/en.json
@@ -38,6 +38,11 @@
     "characters_remaining": "You need to write {{count}} more characters about yourself to be able to send requests, messages, or create events."
   },
   "section_tabs_a11y_label": "tabs for user's details",
+  "incomplete_dialog": {
+    "title": "Profile Incomplete",
+    "message": "Your \"Who I Am\" section is still too empty. You won't be able to send requests, messages or create events until this section is at least 150 characters long.",
+    "save_anyway": "Save anyway?"
+  },
   "home_info_headings": {
     "about_home": "About my home",
     "general": "General",

--- a/app/web/features/profile/locales/en.json
+++ b/app/web/features/profile/locales/en.json
@@ -35,13 +35,18 @@
     "gender_verification_mismatch": "User provided gender does not match verified gender"
   },
   "helper_text": {
-    "characters_remaining": "You need to write {{count}} more characters about yourself to be able to send requests, messages, or create events."
+    "characters_remaining": "Please write {{count}} more character to complete your profile.",
+    "characters_remaining_plural": "Please write {{count}} more characters to complete your profile.",
+    "missing_profile_photo": "Please add a photo to complete your profile."
   },
   "section_tabs_a11y_label": "tabs for user's details",
   "incomplete_dialog": {
     "title": "Profile Incomplete",
-    "message": "Your \"Who I Am\" section is still too empty. You won't be able to send requests, messages or create events until this section is at least 150 characters long.",
-    "save_anyway": "Save anyway?"
+    "description": "You won't be able to send requests, messages or create events until you:",
+    "about_me_message": "Make your \"Who I Am\" section at least 150 characters long.",
+    "missing_photo_message": "Add a profile photo.",
+    "save_anyway": "Save anyway?",
+    "continue_editing": "Continue editing"
   },
   "home_info_headings": {
     "about_home": "About my home",


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

User's aren't realizing the reason they can't send messages, etc. is because they need a longer profile. This PR adds a warning text on the EditProfile page aboutMe section if the user is under the limit and same with the missing profile photo:

![Screenshot 2024-12-22 at 7 42 54 PM](https://github.com/user-attachments/assets/95ad6acf-4997-46db-ba98-98e74bab45b7)

![Screenshot 2024-12-22 at 8 08 19 PM](https://github.com/user-attachments/assets/625291cb-afec-42a1-85a4-4849b114c870)

![Screenshot 2024-12-22 at 8 09 46 PM](https://github.com/user-attachments/assets/e5ee5dcb-1c1e-4a85-9576-12a4ac2b1057)

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [ x ] Formatted my code with `yarn format`
- [ x ] There are no warnings from `yarn lint --fix`
- [ x ] There are no console warnings when running the app
- [ x ] All tests pass
- [ x ] Clicked around my changes running locally and it works
- [ x ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
