### PR TITLE
GroupChatView - Fix console warning and select behavior

### DIFF
--- a/app/web/features/messages/groupchats/CreateGroupChat.tsx
+++ b/app/web/features/messages/groupchats/CreateGroupChat.tsx
@@ -146,8 +146,10 @@ export default function CreateGroupChat({ className }: { className?: string }) {
                   render={({ field }) => {
                     return (
                       <Autocomplete
-                        {...field}
                         id="users-autocomplete"
+                        isOptionEqualToValue={(friend, value) => {
+                          return friend?.name === value?.name;
+                        }}
                         onChange={(_, newValue) => {
                           field.onChange(newValue);
                           setIsGroup((newValue?.length ?? 0) > 1);


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
Closes #5379 

Bug introduced during the React v18 upgrade. Fixing here. There were two issues:

- When it's a multiselect spreading the `field` messes with the `options` being passed. For this specific component passing explicit `field.value` and `field.onChange` is enough.
- The values weren't being shown as selected (i.e. highlighted in green in dropdown). This is because they were objects and MUI didn't know the value. Adding `isOptionEqualToValue` fixes it.

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [ x ] Formatted my code with `yarn format`
- [ x ] There are no warnings from `yarn lint --fix`
- [ x ] There are no console warnings when running the app
- [ x ] All tests pass
- [ x ] Clicked around my changes running locally and it works
- [ x ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
