### PR TITLE
refactor: fix readme button hidden cookiebanner

### DIFF
--- a/app/web/features/landing/LandingPage.tsx
+++ b/app/web/features/landing/LandingPage.tsx
@@ -252,10 +252,10 @@ export default function LandingPage() {
                 variant="text"
                 size="medium"
                 sx={{
+                  "&.MuiButtonBase-root:hover": {
+                    bgcolor: "transparent"
+                  },
                   color: theme.palette.common.white,
-                  background: "none",
-                  border: "none",
-                  textAlign: "center",
                 }}
               >
                 Read more
@@ -264,9 +264,10 @@ export default function LandingPage() {
                 onClick={scrollToMore}
                 size="small"
                 sx={{
+                  "&.MuiButtonBase-root:hover": {
+                    bgcolor: "transparent"
+                  },
                   color: theme.palette.common.white,
-                  background: "none",
-                  border: "none",
                 }}
               >
                 <ExpandMoreIcon fontSize="large" />
@@ -323,9 +324,11 @@ export default function LandingPage() {
               variant="text"
               sx={{
                 color: theme.palette.common.white,
-                background: "none",
-                border: "none",
+                "&.MuiButtonBase-root:hover": {
+                  bgcolor: "transparent"
+                }
               }}
+              disableRipple
             >
               Read more
             </MuiButton>
@@ -334,8 +337,9 @@ export default function LandingPage() {
               size="small"
               sx={{
                 color: theme.palette.common.white,
-                background: "none",
-                border: "none",
+                "&.MuiButtonBase-root:hover": {
+                  bgcolor: "transparent"
+                }
               }}
             >
               <ExpandMoreIcon />

--- a/app/web/features/landing/LandingPage.tsx
+++ b/app/web/features/landing/LandingPage.tsx
@@ -214,60 +214,60 @@ export default function LandingPage() {
           <StyledIntroduction>
             <StyledIntroductionText>
               <Typography
-                  variant="h1"
-                  component="h1"
-                  sx={{
-                    [theme.breakpoints.up("md")]: {
-                      fontSize: "2rem",
-                      lineHeight: "1.15",
-                      textAlign: "left",
-                    },
-                  }}
+                variant="h1"
+                component="h1"
+                sx={{
+                  [theme.breakpoints.up("md")]: {
+                    fontSize: "2rem",
+                    lineHeight: "1.15",
+                    textAlign: "left",
+                  },
+                }}
               >
                 {t("landing:introduction_title")}
               </Typography>
               <Typography
-                  variant="h2"
-                  component="span"
-                  sx={{
-                    [theme.breakpoints.up("md")]: {
-                      display: "inline-block",
-                      marginTop: theme.spacing(4),
-                      position: "relative",
-                    },
-                  }}
+                variant="h2"
+                component="span"
+                sx={{
+                  [theme.breakpoints.up("md")]: {
+                    display: "inline-block",
+                    marginTop: theme.spacing(4),
+                    position: "relative",
+                  },
+                }}
               >
                 {t("landing:introduction_subtitle")}
                 <StyledDivider />
               </Typography>
             </StyledIntroductionText>
             <Box
-                display={{ xs: "none", md: "flex" }}
-                flexDirection="column"
-                width="100%"
-                mt={2}
+              display={{ xs: "none", md: "flex" }}
+              flexDirection="column"
+              width="100%"
+              mt={2}
             >
               <MuiButton
-                  onClick={scrollToMore}
-                  variant="text"
-                  size="medium"
-                  sx={{
-                    color: theme.palette.common.white,
-                    background: "none",
-                    border: "none",
-                    textAlign: "center",
-                  }}
+                onClick={scrollToMore}
+                variant="text"
+                size="medium"
+                sx={{
+                  color: theme.palette.common.white,
+                  background: "none",
+                  border: "none",
+                  textAlign: "center",
+                }}
               >
                 Read more
               </MuiButton>
               <IconButton
-                  onClick={scrollToMore}
-                  size="small"
-                  sx={{
-                    color: theme.palette.common.white,
-                    background: "none",
-                    border: "none",
-                  }}
+                onClick={scrollToMore}
+                size="small"
+                sx={{
+                  color: theme.palette.common.white,
+                  background: "none",
+                  border: "none",
+                }}
               >
                 <ExpandMoreIcon fontSize="large" />
               </IconButton>
@@ -313,30 +313,30 @@ export default function LandingPage() {
             </Typography>
           </StyledFormWrapper>
           <Box
-              display={{ xs: "flex", md: "none" }}
-              flexDirection="column"
-              width="100%"
-              mt={2}
+            display={{ xs: "flex", md: "none" }}
+            flexDirection="column"
+            width="100%"
+            mt={2}
           >
             <MuiButton
-                onClick={scrollToMore}
-                variant="text"
-                sx={{
-                  color: theme.palette.common.white,
-                  background: "none",
-                  border: "none",
-                }}
+              onClick={scrollToMore}
+              variant="text"
+              sx={{
+                color: theme.palette.common.white,
+                background: "none",
+                border: "none",
+              }}
             >
               Read more
             </MuiButton>
             <IconButton
-                onClick={scrollToMore}
-                size="small"
-                sx={{
-                  color: theme.palette.common.white,
-                  background: "none",
-                  border: "none",
-                }}
+              onClick={scrollToMore}
+              size="small"
+              sx={{
+                color: theme.palette.common.white,
+                background: "none",
+                border: "none",
+              }}
             >
               <ExpandMoreIcon />
             </IconButton>

--- a/app/web/features/landing/LandingPage.tsx
+++ b/app/web/features/landing/LandingPage.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button as MuiButton,
   Container,
   ContainerProps,
@@ -54,6 +55,9 @@ const StyledSection = styled("section")(({ theme }) => ({
 }));
 
 const StyledContent = styled("div")(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
   width: "100%",
   marginBottom: theme.spacing(2),
   [theme.breakpoints.up("md")]: {
@@ -87,6 +91,10 @@ const StyledIntroduction = styled("div")(({ theme }) => ({
   width: "45%",
   maxWidth: theme.breakpoints.values.lg / 2,
   marginInlineEnd: "10%",
+  gap: theme.spacing(2),
+}));
+
+const StyledIntroductionText = styled("div")(({ theme }) => ({
   [theme.breakpoints.down("md")]: {
     display: "none",
   },
@@ -204,33 +212,66 @@ export default function LandingPage() {
       <StyledSection>
         <StyledContent>
           <StyledIntroduction>
-            <Typography
-              variant="h1"
-              component="h1"
-              sx={{
-                [theme.breakpoints.up("md")]: {
-                  fontSize: "2rem",
-                  lineHeight: "1.15",
-                  textAlign: "left",
-                },
-              }}
+            <StyledIntroductionText>
+              <Typography
+                  variant="h1"
+                  component="h1"
+                  sx={{
+                    [theme.breakpoints.up("md")]: {
+                      fontSize: "2rem",
+                      lineHeight: "1.15",
+                      textAlign: "left",
+                    },
+                  }}
+              >
+                {t("landing:introduction_title")}
+              </Typography>
+              <Typography
+                  variant="h2"
+                  component="span"
+                  sx={{
+                    [theme.breakpoints.up("md")]: {
+                      display: "inline-block",
+                      marginTop: theme.spacing(4),
+                      position: "relative",
+                    },
+                  }}
+              >
+                {t("landing:introduction_subtitle")}
+                <StyledDivider />
+              </Typography>
+            </StyledIntroductionText>
+            <Box
+                display={{ xs: "none", md: "flex" }}
+                flexDirection="column"
+                width="100%"
+                mt={2}
             >
-              {t("landing:introduction_title")}
-            </Typography>
-            <Typography
-              variant="h2"
-              component="span"
-              sx={{
-                [theme.breakpoints.up("md")]: {
-                  display: "inline-block",
-                  marginTop: theme.spacing(4),
-                  position: "relative",
-                },
-              }}
-            >
-              {t("landing:introduction_subtitle")}
-              <StyledDivider />
-            </Typography>
+              <MuiButton
+                  onClick={scrollToMore}
+                  variant="text"
+                  size="medium"
+                  sx={{
+                    color: theme.palette.common.white,
+                    background: "none",
+                    border: "none",
+                    textAlign: "center",
+                  }}
+              >
+                Read more
+              </MuiButton>
+              <IconButton
+                  onClick={scrollToMore}
+                  size="small"
+                  sx={{
+                    color: theme.palette.common.white,
+                    background: "none",
+                    border: "none",
+                  }}
+              >
+                <ExpandMoreIcon fontSize="large" />
+              </IconButton>
+            </Box>
           </StyledIntroduction>
           <StyledFormWrapper>
             <Typography variant="h2" component="h3">
@@ -271,30 +312,36 @@ export default function LandingPage() {
               </Trans>
             </Typography>
           </StyledFormWrapper>
+          <Box
+              display={{ xs: "flex", md: "none" }}
+              flexDirection="column"
+              width="100%"
+              mt={2}
+          >
+            <MuiButton
+                onClick={scrollToMore}
+                variant="text"
+                sx={{
+                  color: theme.palette.common.white,
+                  background: "none",
+                  border: "none",
+                }}
+            >
+              Read more
+            </MuiButton>
+            <IconButton
+                onClick={scrollToMore}
+                size="small"
+                sx={{
+                  color: theme.palette.common.white,
+                  background: "none",
+                  border: "none",
+                }}
+            >
+              <ExpandMoreIcon />
+            </IconButton>
+          </Box>
         </StyledContent>
-
-        <MuiButton
-          onClick={scrollToMore}
-          variant="text"
-          sx={{
-            color: theme.palette.common.white,
-            background: "none",
-            border: "none",
-          }}
-        >
-          Read more
-        </MuiButton>
-        <IconButton
-          onClick={scrollToMore}
-          size="small"
-          sx={{
-            color: theme.palette.common.white,
-            background: "none",
-            border: "none",
-          }}
-        >
-          <ExpandMoreIcon />
-        </IconButton>
         {process.env.NEXT_PUBLIC_COUCHERS_ENV !== "prod" && (
           <StyledVercelLink
             rel="noopener noreferrer"

--- a/app/web/features/landing/LandingPage.tsx
+++ b/app/web/features/landing/LandingPage.tsx
@@ -253,19 +253,19 @@ export default function LandingPage() {
                 size="medium"
                 sx={{
                   "&.MuiButtonBase-root:hover": {
-                    bgcolor: "transparent"
+                    bgcolor: "transparent",
                   },
                   color: theme.palette.common.white,
                 }}
               >
-                Read more
+                {t("global:read_more")}
               </MuiButton>
               <IconButton
                 onClick={scrollToMore}
                 size="small"
                 sx={{
                   "&.MuiButtonBase-root:hover": {
-                    bgcolor: "transparent"
+                    bgcolor: "transparent",
                   },
                   color: theme.palette.common.white,
                 }}
@@ -325,12 +325,12 @@ export default function LandingPage() {
               sx={{
                 color: theme.palette.common.white,
                 "&.MuiButtonBase-root:hover": {
-                  bgcolor: "transparent"
-                }
+                  bgcolor: "transparent",
+                },
               }}
               disableRipple
             >
-              Read more
+              {t("global:read_more")}
             </MuiButton>
             <IconButton
               onClick={scrollToMore}
@@ -338,8 +338,8 @@ export default function LandingPage() {
               sx={{
                 color: theme.palette.common.white,
                 "&.MuiButtonBase-root:hover": {
-                  bgcolor: "transparent"
-                }
+                  bgcolor: "transparent",
+                },
               }}
             >
               <ExpandMoreIcon />

--- a/app/web/resources/locales/en.json
+++ b/app/web/resources/locales/en.json
@@ -23,6 +23,7 @@
   "submit": "Submit",
   "confirm": "Confirm",
   "load_more": "Load more",
+  "read_more": "Read more",
   "cookie_message": "We use cookies to ensure that we give you the best experience on our website. If you continue to use this site, we will assume that you are happy with it. You can read more about our <1>Terms of Service</1>.",
   "hosting_status": {
     "any": "Any",


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
Closes [#4128](https://github.com/Couchers-org/couchers/issues/4128)

1. Move read more button into a container to allow for flexbox to handle sizing and spacing
2. Fix width sizing on mobile, tablet, and ultra wide screens of the introduction on landing page

Not sure how to run tests or when to add them so please feel free to comment or feedback!

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Backend checklist**
- [ ] Formatted my code by running `ruff check --select I --fix . && ruff check . && ruff format .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [x] Formatted my code with `yarn format`
- [x] There are no warnings from `yarn lint --fix`
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
