### PR TITLE
Make explicit reference to the search icon; capitalize the Enter key

### DIFF
--- a/app/native/resources/locales/en.json
+++ b/app/native/resources/locales/en.json
@@ -154,8 +154,8 @@
   },
   "location_autocomplete": {
     "more_specific": "Please choose a more specific place",
-    "search_location_hint": "Press enter or click the icon to choose a location",
+    "search_location_hint": "Press Enter or click the search icon to choose a location",
     "search_location_button": "Search location",
-    "select_location_hint": "Press enter or click the icon, then select a location from the list"
+    "select_location_hint": "Press Enter or click the search icon, then select a location from the list"
   }
 }

--- a/app/web/resources/locales/en.json
+++ b/app/web/resources/locales/en.json
@@ -158,9 +158,9 @@
   },
   "location_autocomplete": {
     "more_specific": "Please choose a more specific place",
-    "search_location_hint": "Press enter or click the icon to choose a location",
+    "search_location_hint": "Press Enter or click the search icon to choose a location",
     "search_location_button": "Search location",
-    "select_location_hint": "Press enter or click the icon, then select a location from the list"
+    "select_location_hint": "Press Enter or click the search icon, then select a location from the list"
   },
   "strong_verification": {
     "helper_text": "This user has verified their identity using a biometric passport"


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
Just a small tweak to the UI message about searching the map, to avoid an ambiguous reference to "the icon".

Happy to make any adjustments that may be necessary!

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Backend checklist**
- [ ] Formatted my code by running `ruff check --select I --fix . && ruff check . && ruff format .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [ ] Formatted my code with `yarn format`
- [ ] There are no warnings from `yarn lint --fix`
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
