### PR TITLE
Backend/feature/language preference #5467

### DIFF
--- a/app/backend/src/couchers/migrations/versions/9b738767992c_adds_language_preference_to_user_model.py
+++ b/app/backend/src/couchers/migrations/versions/9b738767992c_adds_language_preference_to_user_model.py
@@ -1,0 +1,24 @@
+"""Adds language preference to User model
+
+Revision ID: 9b738767992c
+Revises: 99aece5bdc42
+Create Date: 2025-02-20 12:56:31.224874
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9b738767992c"
+down_revision = "99aece5bdc42"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("users", sa.Column("ui_language_preference", sa.String(), server_default="", nullable=True))
+
+
+def downgrade():
+    op.drop_column("users", "ui_language_preference")

--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -121,7 +121,7 @@ class User(Base):
     hashed_password = Column(Binary, nullable=False)
     # phone number in E.164 format with leading +, for example "+46701740605"
     phone = Column(String, nullable=True, server_default=text("NULL"))
-    # language preference -- defaults to empty
+    # language preference -- defaults to empty string
     ui_language_preference = Column(String, nullable=True, server_default="")
 
     # timezones should always be UTC

--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -121,6 +121,8 @@ class User(Base):
     hashed_password = Column(Binary, nullable=False)
     # phone number in E.164 format with leading +, for example "+46701740605"
     phone = Column(String, nullable=True, server_default=text("NULL"))
+    # language preference -- defaults to empty
+    ui_language_preference = Column(String, nullable=True, server_default="")
 
     # timezones should always be UTC
     ## location

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -168,6 +168,7 @@ class Account(account_pb2_grpc.AccountServicer):
             profile_complete=user.has_completed_profile,
             timezone=user.timezone,
             is_superuser=user.is_superuser,
+            ui_language_preference=user.ui_language_preference,
             **get_strong_verification_fields(session, user),
         )
 

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -250,7 +250,7 @@ class Account(account_pb2_grpc.AccountServicer):
         user.ui_language_preference = request.ui_language_preference
 
         return empty_pb2.Empty()
-    
+
     def FillContributorForm(self, request, context, session):
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
 

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -242,6 +242,15 @@ class Account(account_pb2_grpc.AccountServicer):
         # session autocommit
         return empty_pb2.Empty()
 
+    def ChangeLanguagePreference(self, request, context, session):
+        # select the user from the db
+        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+
+        # update the user's preference
+        user.ui_language_preference = request.ui_language_preference
+
+        return empty_pb2.Empty()
+    
     def FillContributorForm(self, request, context, session):
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
 

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -528,6 +528,19 @@ def test_ChangeEmailV2_sends_proper_emails(db, fast_passwords, push_collector):
     )
 
 
+def test_ChangePreferredLanguage(db, fast_passwords):
+    # user changes from default to ISO 639-1 language code
+    newLanguageCode = "zh"
+    user, token = generate_user()
+
+    with account_session(token) as account:
+        res = account.GetAccountInfo(empty_pb2.Empty())
+        assert res.ui_language_preference == ""
+
+        account.ChangeLanguagePreference(account_pb2.ChangeLanguagePreferenceReq(ui_language_preference=newLanguageCode))
+        res = account.GetAccountInfo(empty_pb2.Empty())
+        assert res.ui_language_preference == "zh"
+
 def test_contributor_form(db):
     user, token = generate_user()
 

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -45,6 +45,7 @@ def test_GetAccountInfo(db, fast_passwords):
         assert res.birthdate_verification_status == api_pb2.BIRTHDATE_VERIFICATION_STATUS_UNVERIFIED
         assert res.gender_verification_status == api_pb2.GENDER_VERIFICATION_STATUS_UNVERIFIED
         assert not res.is_superuser
+        assert res.ui_language_preference == ""
 
 
 def test_GetAccountInfo_regression(db):

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -537,9 +537,12 @@ def test_ChangePreferredLanguage(db, fast_passwords):
         res = account.GetAccountInfo(empty_pb2.Empty())
         assert res.ui_language_preference == ""
 
-        account.ChangeLanguagePreference(account_pb2.ChangeLanguagePreferenceReq(ui_language_preference=newLanguageCode))
+        account.ChangeLanguagePreference(
+            account_pb2.ChangeLanguagePreferenceReq(ui_language_preference=newLanguageCode)
+        )
         res = account.GetAccountInfo(empty_pb2.Empty())
         assert res.ui_language_preference == "zh"
+
 
 def test_contributor_form(db):
     user, token = generate_user()

--- a/app/proto/account.proto
+++ b/app/proto/account.proto
@@ -117,6 +117,8 @@ message GetAccountInfoRes {
 
   // whether the user is a superuser
   bool is_superuser = 15;
+
+  string ui_language_preference = 16;
 }
 
 message ChangePasswordV2Req {

--- a/app/proto/account.proto
+++ b/app/proto/account.proto
@@ -36,6 +36,10 @@ service Account {
     // Fill the contributor form; this can be done multiple times
   }
 
+  rpc ChangeLanguagePreference(ChangeLanguagePreferenceReq) returns (google.protobuf.Empty) {
+    // Changes the user's interface language
+  }
+
   rpc ChangePhone(ChangePhoneReq) returns (google.protobuf.Empty) {
     // Set/Change/Remove phone number. An verification sms with a 6-digit code will be sent out,
     // And returned in a call to in VerifyPhone() to complete the phone number change.
@@ -129,6 +133,10 @@ message ChangePasswordV2Req {
 message ChangeEmailV2Req {
   string password = 1 [ (sensitive) = true ];
   string new_email = 2;
+}
+
+message ChangeLanguagePreferenceReq {
+  string ui_language_preference = 1;
 }
 
 message GetContributorFormInfoRes {

--- a/app/web/features/auth/email/ChangeEmail.test.tsx
+++ b/app/web/features/auth/email/ChangeEmail.test.tsx
@@ -29,6 +29,7 @@ const accountInfo = {
   doNotEmail: false,
   hasDonated: false,
   isSuperuser: false,
+  uiLanguagePreference: "",
 };
 
 describe("ChangeEmail", () => {

--- a/app/web/features/communities/events/CreateEventPage.test.tsx
+++ b/app/web/features/communities/events/CreateEventPage.test.tsx
@@ -43,6 +43,7 @@ const accountInfo = {
   doNotEmail: false,
   hasDonated: false,
   isSuperuser: false,
+  uiLanguagePreference: "",
 };
 
 describe("Create event page", () => {
@@ -403,6 +404,7 @@ describe("Create event page", () => {
       doNotEmail: false,
       hasDonated: false,
       isSuperuser: false,
+      uiLanguagePreference: "",
     });
 
     render(<CreateEventPage />, { wrapper });

--- a/app/web/features/profile/actions/MessageUserButton.test.tsx
+++ b/app/web/features/profile/actions/MessageUserButton.test.tsx
@@ -35,6 +35,7 @@ const accountInfo = {
   doNotEmail: false,
   hasDonated: false,
   isSuperuser: false,
+  uiLanguagePreference: "",
 };
 
 const incompleteAccountInfo = { ...accountInfo, profileComplete: false };

--- a/app/web/features/profile/view/AdminPanelUserButton.test.tsx
+++ b/app/web/features/profile/view/AdminPanelUserButton.test.tsx
@@ -29,6 +29,7 @@ const baseAccountInfo = {
   genderVerificationStatus: 3,
   doNotEmail: false,
   hasDonated: false,
+  uiLanguagePreference: "",
 };
 
 describe("AdminPanelUserButton", () => {


### PR DESCRIPTION
This change adds a preferred ui language to the User model (defaulting to an empty string), and adds an API call to change the preferred language in account proto for ticket #5467

**Backend checklist**
- [x] Formatted my code by running `ruff check --select I --fix . && ruff check . && ruff format .` in `app/backend`
- [x] Added tests for any new code
- [x] All tests pass
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
