### PR TITLE
Disables save button in edit profile until profile image is done uploading

### DIFF
--- a/app/web/components/ImageInput/ImageInput.test.tsx
+++ b/app/web/components/ImageInput/ImageInput.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   CANCEL_UPLOAD,
@@ -288,6 +288,51 @@ describe.each`
     await user.click(screen.getByLabelText(CONFIRM_UPLOAD));
 
     expect(await screen.findByText("Whoops")).toBeVisible();
+  });
+
+  it("calls onUploading callback during image upload", async () => {
+    const onUploadingMock = jest.fn();
+    const Form = () => {
+      const { control } = useForm();
+      return (
+        <form data-testid="test-form">
+          <ImageInput
+            control={control}
+            id="image-input"
+            initialPreviewSrc={MOCK_INITIAL_SRC}
+            name="imageInput"
+            userName={NAME}
+            type="avatar"
+            onUploading={onUploadingMock}
+          />
+        </form>
+      );
+    };
+    render(<Form />, { wrapper });
+
+    const user = userEvent.setup({ applyAccept: false });
+    const form = screen.getByTestId("test-form");
+
+    // Start upload
+    await user.upload(
+      within(form).getByLabelText(SELECT_AN_IMAGE) as HTMLInputElement,
+      MOCK_FILE,
+    );
+    expect(await within(form).findByLabelText(CONFIRM_UPLOAD)).toBeVisible();
+
+    // Confirm upload
+    await user.click(within(form).getByLabelText(CONFIRM_UPLOAD));
+
+    // Verify onUploading was called with true when upload started
+    expect(onUploadingMock).toHaveBeenCalledWith(true);
+
+    // Wait for upload to complete
+    await waitFor(() => {
+      expect(uploadFileMock).toHaveBeenCalled();
+    });
+
+    // Verify onUploading was called with false when upload completed
+    expect(onUploadingMock).toHaveBeenCalledWith(false);
   });
 
   it("previews the image after cancelling and selecting the same image", async () => {

--- a/app/web/components/ImageInput/ImageInput.tsx
+++ b/app/web/components/ImageInput/ImageInput.tsx
@@ -31,6 +31,7 @@ interface ImageInputProps {
   initialPreviewSrc?: string;
   name: string;
   onSuccess?(data: ImageInputValues): Promise<void>;
+  onUploading?: (isUploading: boolean) => void; //new prop
 }
 
 interface AvatarInputProps extends ImageInputProps {
@@ -112,6 +113,9 @@ export function ImageInput(props: AvatarInputProps | RectImgInputProps) {
         ? service.api.uploadFile(file)
         : Promise.reject(new Error(NO_VALID_FILE)),
     {
+      onMutate: () => {
+        props.onUploading?.(true); //notify form upload has started
+      },
       onSuccess: async (data: ImageInputValues) => {
         field.onChange(data.key);
         setImageUrl(
@@ -120,6 +124,10 @@ export function ImageInput(props: AvatarInputProps | RectImgInputProps) {
         confirmedUpload.current = data;
         setFile(null);
         await props.onSuccess?.(data);
+        props.onUploading?.(false); //notify form upload has finished
+      },
+      onError: () => {
+        props.onUploading?.(false); //notify form upload has failed
       },
     },
   );

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -12,6 +12,7 @@ import {
 import Alert from "components/Alert";
 import Button from "components/Button";
 import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
+import CircularProgress from "components/CircularProgress";
 import { Dialog, DialogActions, DialogTitle } from "components/Dialog";
 import EditLocationMap from "components/EditLocationMap";
 import ImageInput from "components/ImageInput";
@@ -49,6 +50,10 @@ const StyledAlert = styled(Alert)(({ theme }) => ({
   marginTop: theme.spacing(2),
 }));
 
+const StyledCircularProgress = styled(CircularProgress)(({ theme }) => ({
+  position: "absolute",
+}));
+
 export type EditProfileFormValues = Omit<
   UpdateUserProfileData,
   "languageAbilities" | "city" | "lat" | "lng" | "radius"
@@ -79,6 +84,8 @@ export default function EditProfileForm() {
   );
   const [showIncompleteProfileDialog, setShowIncompleteProfileDialog] =
     useState(false);
+
+  const [isUploading, setIsUploading] = useState(false);
 
   const queryClient = useQueryClient();
   const {
@@ -219,6 +226,7 @@ export default function EditProfileForm() {
               initialPreviewSrc={user.avatarUrl}
               userName={user.name}
               type="avatar"
+              onUploading={setIsUploading} //track upload state
               onSuccess={async (data) => {
                 await service.user.updateAvatar(data.key);
                 if (user) queryClient.invalidateQueries(userKey(user.userId));
@@ -526,9 +534,11 @@ export default function EditProfileForm() {
                 variant="contained"
                 color="primary"
                 loading={updateIsLoading}
+                disabled={isUploading || updateIsLoading} //Disable while uploading
               >
                 {t("global:save")}
               </Button>
+              {isUploading && <StyledCircularProgress />}
             </div>
           </form>
           <Dialog

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -12,7 +12,6 @@ import {
 import Alert from "components/Alert";
 import Button from "components/Button";
 import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
-import CircularProgress from "components/CircularProgress";
 import { Dialog, DialogActions, DialogTitle } from "components/Dialog";
 import EditLocationMap from "components/EditLocationMap";
 import ImageInput from "components/ImageInput";
@@ -48,10 +47,6 @@ import useStyles from "./styles";
 
 const StyledAlert = styled(Alert)(({ theme }) => ({
   marginTop: theme.spacing(2),
-}));
-
-const StyledCircularProgress = styled(CircularProgress)(({ theme }) => ({
-  position: "absolute",
 }));
 
 export type EditProfileFormValues = Omit<

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -533,12 +533,11 @@ export default function EditProfileForm() {
                 type="submit"
                 variant="contained"
                 color="primary"
-                loading={updateIsLoading}
-                disabled={isUploading || updateIsLoading} //Disable while uploading
+                loading={updateIsLoading || isUploading}
+                disabled={updateIsLoading || isUploading}
               >
                 {t("global:save")}
               </Button>
-              {isUploading && <StyledCircularProgress />}
             </div>
           </form>
           <Dialog

--- a/app/web/features/profile/edit/EditProfilePage.test.tsx
+++ b/app/web/features/profile/edit/EditProfilePage.test.tsx
@@ -77,7 +77,7 @@ describe("Edit profile", () => {
       () => expect(mockRouter.pathname).toBe(routeToProfile("about")),
       { timeout: 5000 },
     );
-  }, 60000);
+  }, 8000);
 
   it(`should not submit the default headings for the '${t(
     "profile:heading.who_section",

--- a/app/web/features/profile/edit/EditProfilePage.test.tsx
+++ b/app/web/features/profile/edit/EditProfilePage.test.tsx
@@ -77,7 +77,7 @@ describe("Edit profile", () => {
       () => expect(mockRouter.pathname).toBe(routeToProfile("about")),
       { timeout: 5000 },
     );
-  });
+  }, 60000);
 
   it(`should not submit the default headings for the '${t(
     "profile:heading.who_section",


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
Closes #5184 
- Disables save button when profile image is still uploading
- Displays progress circle on save button when disabled during image upload

~~currently (as of 2/13/25) working on removing confirm check/X. intending to write tests after this is figured out.~~
4/10/25: Determined removing confirm check/X should be a separate ticket.

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Backend checklist**
- [ ] Formatted my code by running `ruff check --select I --fix . && ruff check . && ruff format .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [X] Formatted my code with `yarn format`
- [X] There are no warnings from `yarn lint --fix`
- [X] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] All tests pass
- [X] Clicked around my changes running locally and it works
- [X] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
