### PR TITLE
Correct country code for PSE

### DIFF
--- a/app/web/public/regions.json
+++ b/app/web/public/regions.json
@@ -1145,7 +1145,7 @@
         {
           "type": "Polygon",
           "arcs": [[-417, -404]],
-          "id": "PSX",
+          "id": "PSE",
           "properties": { "name": "West Bank" }
         },
         {


### PR DESCRIPTION
Closes https://github.com/Couchers-org/couchers/issues/5619 at least partially

Not sure why the regions file we had in the frontend had the wrong country code. Confirmed that it's "PS/PSE" from [here](https://www.iso.org/obp/ui/#iso:code:3166:PS)