### PR TITLE
Add total_items to UserSearch

### DIFF
--- a/app/backend/src/couchers/servicers/search.py
+++ b/app/backend/src/couchers/servicers/search.py
@@ -553,6 +553,7 @@ class Search(search_pb2_grpc.SearchServicer):
 
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_recommendation_score = float(decrypt_page_token(request.page_token)) if request.page_token else 1e10
+        total_items = session.execute(select(func.count()).select_from(statement.subquery())).scalar()
 
         statement = (
             statement.where(User.recommendation_score <= next_recommendation_score)
@@ -572,6 +573,7 @@ class Search(search_pb2_grpc.SearchServicer):
             next_page_token=(
                 encrypt_page_token(str(users[-1].recommendation_score)) if len(users) > page_size else None
             ),
+            total_items=total_items,
         )
 
     def EventSearch(self, request, context, session):

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -56,6 +56,7 @@ def test_UserSearch(testing_communities):
     with search_session(token) as api:
         res = api.UserSearch(search_pb2.UserSearchReq())
         assert len(res.results) > 0
+        assert res.total_items == len(res.results)
 
 
 def test_regression_search_in_area(db):

--- a/app/proto/search.proto
+++ b/app/proto/search.proto
@@ -160,6 +160,7 @@ message UserSearchRes {
   repeated Result results = 1;
 
   string next_page_token = 2;
+  uint32 total_items = 3;
 }
 
 message EventSearchReq {

--- a/app/web/features/search/SearchResultsList.test.tsx
+++ b/app/web/features/search/SearchResultsList.test.tsx
@@ -40,6 +40,7 @@ function mockTestResults() {
             user: users[0],
           },
         ],
+        totalItems: 1,
       },
     ],
   };


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
More backend pagination work to be done, but adding `total_items` for now so I can display it to the user as an indication of how many results there are when they paginate.

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Backend checklist**
- [ x ] Formatted my code by running `ruff check --select I --fix . && ruff check . && ruff format .` in `app/backend`
- [ x ] Added tests for any new code or added a regression test if fixing a bug
- [ x ] All tests pass
- [ x ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
