### PR TITLE
Fix discussion reply notification issue

### DIFF
--- a/app/backend/src/couchers/notifications/render.py
+++ b/app/backend/src/couchers/notifications/render.py
@@ -634,10 +634,11 @@ def render_notification(user, notification) -> RenderedNotification:
                 push_url=discussion_link,
             )
     elif notification.topic_action.display == "thread:reply":
-        if data.HasField("event"):
+        parent = data.WhichOneof("reply_parent")
+        if parent == "event":
             title = data.event.title
             view_link = urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug)
-        elif data.HasField("discussion"):
+        elif parent == "discussion":
             title = data.discussion.title
             view_link = urls.discussion_link(discussion_id=data.discussion.discussion_id, slug=data.discussion.slug)
         else:

--- a/app/backend/src/couchers/notifications/render.py
+++ b/app/backend/src/couchers/notifications/render.py
@@ -634,10 +634,10 @@ def render_notification(user, notification) -> RenderedNotification:
                 push_url=discussion_link,
             )
     elif notification.topic_action.display == "thread:reply":
-        if data.event:
+        if data.HasField("event"):
             title = data.event.title
             view_link = urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug)
-        elif data.discussion:
+        elif data.HasField("discussion"):
             title = data.discussion.title
             view_link = urls.discussion_link(discussion_id=data.discussion.discussion_id, slug=data.discussion.slug)
         else:

--- a/app/backend/src/tests/test_discussions.py
+++ b/app/backend/src/tests/test_discussions.py
@@ -4,7 +4,7 @@ import pytest
 from couchers import errors
 from couchers.db import session_scope
 from couchers.utils import now, to_aware_datetime
-from proto import discussions_pb2, notifications_pb2
+from proto import discussions_pb2, notifications_pb2, threads_pb2
 from tests.test_communities import create_community, create_group
 from tests.test_fixtures import (  # noqa
     db,
@@ -14,6 +14,7 @@ from tests.test_fixtures import (  # noqa
     process_jobs,
     push_collector,
     testconfig,
+    threads_session,
 )
 
 
@@ -149,3 +150,51 @@ def test_create_and_get_discussion(db, push_collector):
         assert time_before_create <= to_aware_datetime(res.created) <= time_after_create
         assert res.creator_user_id == user.id
         assert res.owner_group_id == group_id
+
+
+def test_discussion_notifications_regression(db, push_collector):
+    generate_user()
+    user, token = generate_user()
+    user2, token2 = generate_user()
+    generate_user()
+    generate_user()
+
+    with session_scope() as session:
+        community = create_community(session, 0, 1, "Testing Community", [user2], [], None)
+        group_id = create_group(session, "Testing Group", [user2], [], community).id
+        community_id = community.id
+        user2_id = user2.id
+
+    with discussions_session(token) as api:
+        time_before_create = now()
+        res = api.CreateDiscussion(
+            discussions_pb2.CreateDiscussionReq(
+                title="dummy title",
+                content="dummy content",
+                owner_community_id=community_id,
+            )
+        )
+        time_after_create = now()
+
+        assert res.title == "dummy title"
+        assert res.content == "dummy content"
+        assert res.slug == "dummy-title"
+        assert time_before_create <= to_aware_datetime(res.created) <= time_after_create
+        assert res.creator_user_id == user.id
+        assert res.owner_community_id == community_id
+
+        discussion_id = res.discussion_id
+        thread_id = res.thread.thread_id
+
+    with threads_session(token2) as api:
+        reply_id = api.PostReply(threads_pb2.PostReplyReq(thread_id=thread_id, content="hi")).thread_id
+
+    with threads_session(token) as api:
+        api.PostReply(threads_pb2.PostReplyReq(thread_id=reply_id, content="what a silly comment"))
+
+    process_jobs()
+
+    push_collector.assert_user_has_single_matching(
+        user2_id,
+        title="dummy title",
+    )


### PR DESCRIPTION
Closes #5698

I was checking for which part of the proto was there incorrectly: this fixes that. (`data.event` and `data.discussion` both evaluate to truthy things, I had to explicilty check with `HasField`). See the docs for details:

https://protobuf.dev/reference/python/python-generated/#oneof

**Backend checklist**
- [x] Formatted my code by running `ruff check --select I --fix . && ruff check . --fix && ruff format .` in `app/backend`
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] All tests pass
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history
