### PR TITLE
Fix style for signup and cookie banner

### DIFF
--- a/app/web/components/CookieBanner.tsx
+++ b/app/web/components/CookieBanner.tsx
@@ -27,7 +27,7 @@ const StyledWrapper = styled("div")(({ theme }) => ({
 
 const StyledCloseButton = styled(IconButton)(({ theme }) => ({
   position: "absolute",
-  top: "50%",
+  top: theme.spacing(4),
   transform: "translateY(-50%)",
   right: theme.spacing(1),
 }));

--- a/app/web/features/auth/signup/Signup.tsx
+++ b/app/web/features/auth/signup/Signup.tsx
@@ -35,7 +35,6 @@ const StyledScrollingContent = styled("div")(({ theme }) => ({
   position: "relative",
   zIndex: 2,
   justifyContent: "center",
-  minHeight: `calc(100vh - ${theme.shape.navPaddingXs})`,
   display: "flex",
   flexDirection: "column",
   padding: theme.spacing(1, 4),
@@ -43,9 +42,6 @@ const StyledScrollingContent = styled("div")(({ theme }) => ({
 
   [theme.breakpoints.down("sm")]: {
     padding: theme.spacing(1, 2),
-  },
-  [theme.breakpoints.up("sm")]: {
-    minHeight: `calc(100vh - ${theme.shape.navPaddingSmUp})`,
   },
 }));
 


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
**Please give clear steps for how the reviewer can best test this PR**

Please include any necessary dev environment, .env, etc. adjustments.

- Open an incognito window in the browser (so you have no cookies yet)
- In dev tools - put it in mobile simulator, a larger mobile screen like iPhone XR
- Go to signup page and go til the end
- You should see and be able to scroll to and click the signup button
- You should be able to close the cookie banner

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [ x ] Formatted my code with `yarn format`
- [ x ] There are no warnings from `yarn lint --fix`
- [ x ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] All tests pass
- [ x ] Clicked around my changes running locally and it works
- [ x ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
