### PR TITLE
Add username to profile

### DIFF
--- a/app/web/features/profile/view/UserOverview.test.tsx
+++ b/app/web/features/profile/view/UserOverview.test.tsx
@@ -26,6 +26,16 @@ describe("UserOverview", () => {
       expect(screen.getByText(defaultUser.name)).toBeInTheDocument();
     });
 
+    it("should display the user username with a leading @", () => {
+      render(
+        <ProfileUserProvider user={defaultUser}>
+          <UserOverview showHostAndMeetAvailability={false} />
+        </ProfileUserProvider>,
+        { wrapper },
+      );
+      expect(screen.getByText(`@${defaultUser.username}`)).toBeInTheDocument();
+    });
+
     it("should display the user location", () => {
       render(
         <ProfileUserProvider user={defaultUser}>

--- a/app/web/features/profile/view/UserOverview.tsx
+++ b/app/web/features/profile/view/UserOverview.tsx
@@ -103,6 +103,9 @@ export default function UserOverview({
           </span>
         </Typography>
         <Typography variant="body1" className={classes.intro}>
+          @{user.username}
+        </Typography>
+        <Typography variant="body1" className={classes.intro}>
           {user.city}
         </Typography>
         <Badges user={user} />

--- a/app/web/features/profile/view/UserOverview.tsx
+++ b/app/web/features/profile/view/UserOverview.tsx
@@ -40,6 +40,7 @@ const useStyles = makeStyles((theme) => ({
     wordBreak: "break-word",
     overflowWrap: "break-word",
     textAlign: "center",
+    marginBottom: theme.spacing(1),
   },
 
   wrapper: {


### PR DESCRIPTION
It closes issue #5700 

> Add the user name under the name in the left side of the profile, where the red line is below.
> Add an "@" before the username to signal it's a username.

I also added a margin bottom to the css intro class to get a layout result much similar to the Jesse's mockup.

Below the final result

![username-added](https://github.com/user-attachments/assets/c88ea35c-624e-4c78-a20c-f8c5ede25c45)

**Please give clear steps for how the reviewer can best test this PR**

- no particular steps needed


**Web frontend checklist**
- [x] Formatted my code with `yarn format`
- [x] There are no warnings from `yarn lint --fix`
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
