### PR TITLE
Bug - adjust app height for mobile

### DIFF
--- a/app/web/components/AppRoute.tsx
+++ b/app/web/components/AppRoute.tsx
@@ -23,12 +23,11 @@ const globalStyles = (
   <GlobalStyles
     styles={{
       "html, body": {
-        height: "-webkit-fill-available",
         margin: 0,
         overflow: "hidden", // Prevents whole-page scrolling
       },
       "#__next": {
-        height: "-webkit-fill-available",
+        height: "calc(var(--vh, 1vh) * 100)", // Use the dynamic --vh value from _app
         display: "flex",
         flexDirection: "column",
       },

--- a/app/web/components/AppRoute.tsx
+++ b/app/web/components/AppRoute.tsx
@@ -23,12 +23,12 @@ const globalStyles = (
   <GlobalStyles
     styles={{
       "html, body": {
-        height: "100vh",
+        height: "-webkit-fill-available",
         margin: 0,
         overflow: "hidden", // Prevents whole-page scrolling
       },
       "#__next": {
-        height: "100vh",
+        height: "-webkit-fill-available",
         display: "flex",
         flexDirection: "column",
       },


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

Closes #5702

**Please give clear steps for how the reviewer can best test this PR**

Please include any necessary dev environment, .env, etc. adjustments.
- This bug is only replicated on a real phone, not the mobile simulator. This means you need to access the Vercel preview on your phone, or if you pull the branch you need to follow the steps in `docs/run-local-app-on-mobile.md`.
- Go to sign up to couchers - previously even after scrolling the sign up button was blocked by the url bar on the phone.
- You should be able to sign up and click the sign up button now.
- I adjusted the height value for the whole app, so click around on mobile and desktop and make sure nothing got weird (I already did this but second set of eyes can't hurt).

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [ x ] Formatted my code with `yarn format`
- [ x ] There are no warnings from `yarn lint --fix`
- [ x ] There are no console warnings when running the app
- [ x ] All tests pass
- [ x ] Clicked around my changes running locally and it works
- [ x ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
