### PR TITLE
Automatically upload image without confirm

### DIFF
--- a/app/web/components/ImageInput/ImageInput.test.tsx
+++ b/app/web/components/ImageInput/ImageInput.test.tsx
@@ -1,12 +1,9 @@
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
-  CANCEL_UPLOAD,
-  CONFIRM_UPLOAD,
   COULDNT_READ_FILE,
   getAvatarLabel,
   SELECT_AN_IMAGE,
-  UPLOAD_PENDING_ERROR,
 } from "components/constants";
 import { StatusCode } from "grpc-web";
 import { InitiateMediaUploadRes } from "proto/api_pb";
@@ -103,16 +100,12 @@ describe.each`
     );
   });
 
-  it("uploads upon confirmation and submits key", async () => {
+  it("uploads and submits key", async () => {
     const user = userEvent.setup({ applyAccept: false });
     await user.upload(
       screen.getByLabelText(SELECT_AN_IMAGE) as HTMLInputElement,
       MOCK_FILE,
     );
-
-    expect(await screen.findByLabelText(CONFIRM_UPLOAD)).toBeVisible();
-
-    await user.click(screen.getByLabelText(CONFIRM_UPLOAD));
 
     await waitFor(() => {
       expect(uploadFileMock).toHaveBeenCalledTimes(1);
@@ -154,108 +147,10 @@ describe.each`
       MOCK_FILE,
     );
 
-    expect(await screen.findByLabelText(CONFIRM_UPLOAD)).toBeVisible();
-
-    await user.click(screen.getByLabelText(CONFIRM_UPLOAD));
-
     await waitFor(() => {
       expect(uploadFileMock).toHaveBeenCalledTimes(1);
     });
     await assertErrorAlert("Invalid argument");
-  });
-
-  it("cancels when cancel button pressed and doesn't submit key", async () => {
-    const user = userEvent.setup({ applyAccept: false });
-
-    await user.upload(
-      screen.getByLabelText(SELECT_AN_IMAGE) as HTMLInputElement,
-      MOCK_FILE,
-    );
-
-    expect(await screen.findByLabelText(CANCEL_UPLOAD)).toBeVisible();
-
-    await user.click(screen.getByLabelText(CANCEL_UPLOAD));
-
-    await waitFor(() => {
-      expect(uploadFileMock).not.toHaveBeenCalled();
-    });
-
-    await user.click(screen.getByRole("button", { name: t("global:submit") }));
-
-    await waitFor(() => {
-      expect(submitForm).toHaveBeenCalledWith({ imageInput: "" });
-    });
-    expect(screen.getByAltText(getAvatarLabel(NAME))).toHaveProperty(
-      "src",
-      MOCK_INITIAL_SRC,
-    );
-  });
-
-  it(`uploading, confirming, then uploading again, then cancelling, goes back to the first upload instead of the original`, async () => {
-    const OTHER_MOCK_FILE = new File([], "firstImage.jpg");
-    uploadFileMock.mockResolvedValueOnce({
-      file: OTHER_MOCK_FILE,
-      filename: OTHER_MOCK_FILE.name,
-      key: "firstKey",
-      thumbnail_url: "thumb0.jpg",
-      full_url: "full0.jpg",
-    });
-
-    let expectedImage = /full0.jpg/;
-    if (type === "avatar") {
-      expectedImage = /thumb0.jpg/;
-    }
-
-    //first upload and confirm
-    const user = userEvent.setup({ applyAccept: false });
-
-    await user.upload(
-      screen.getByLabelText(SELECT_AN_IMAGE) as HTMLInputElement,
-      OTHER_MOCK_FILE,
-    );
-    expect(await screen.findByLabelText(CONFIRM_UPLOAD)).toBeVisible();
-    await user.click(screen.getByLabelText(CONFIRM_UPLOAD));
-
-    await waitFor(() => {
-      expect(uploadFileMock).toHaveBeenCalled();
-    });
-    expect(
-      screen.getByAltText(getAvatarLabel(NAME)).getAttribute("src"),
-    ).toMatch(expectedImage);
-
-    //2nd upload and cancel
-    await user.upload(
-      screen.getByLabelText(SELECT_AN_IMAGE) as HTMLInputElement,
-      MOCK_FILE,
-    );
-    expect(await screen.findByLabelText(CANCEL_UPLOAD)).toBeVisible();
-    await user.click(screen.getByLabelText(CANCEL_UPLOAD));
-    expect(
-      (await screen.findByAltText(getAvatarLabel(NAME))).getAttribute("src"),
-    ).toMatch(expectedImage);
-
-    //submit
-    await user.click(screen.getByRole("button", { name: t("global:submit") }));
-
-    await waitFor(() => {
-      expect(submitForm).toHaveBeenCalledWith({ imageInput: "firstKey" });
-    });
-  });
-
-  it("doesn't submit without confirming/cancelling", async () => {
-    const user = userEvent.setup({ applyAccept: false });
-
-    await user.upload(
-      screen.getByLabelText(SELECT_AN_IMAGE) as HTMLInputElement,
-      MOCK_FILE,
-    );
-
-    expect(await screen.findByLabelText(CONFIRM_UPLOAD)).toBeVisible();
-
-    await user.click(screen.getByRole("button", { name: t("global:submit") }));
-
-    expect(await screen.findByText(UPLOAD_PENDING_ERROR)).toBeVisible();
-    expect(submitForm).not.toHaveBeenCalled();
   });
 
   it("displays an error for an invalid file", async () => {
@@ -284,8 +179,6 @@ describe.each`
       screen.getByLabelText(SELECT_AN_IMAGE) as HTMLInputElement,
       new File([new Blob(undefined)], ""),
     );
-    expect(await screen.findByLabelText(CONFIRM_UPLOAD)).toBeVisible();
-    await user.click(screen.getByLabelText(CONFIRM_UPLOAD));
 
     expect(await screen.findByText("Whoops")).toBeVisible();
   });
@@ -318,10 +211,6 @@ describe.each`
       within(form).getByLabelText(SELECT_AN_IMAGE) as HTMLInputElement,
       MOCK_FILE,
     );
-    expect(await within(form).findByLabelText(CONFIRM_UPLOAD)).toBeVisible();
-
-    // Confirm upload
-    await user.click(within(form).getByLabelText(CONFIRM_UPLOAD));
 
     // Verify onUploading was called with true when upload started
     expect(onUploadingMock).toHaveBeenCalledWith(true);
@@ -333,27 +222,6 @@ describe.each`
 
     // Verify onUploading was called with false when upload completed
     expect(onUploadingMock).toHaveBeenCalledWith(false);
-  });
-
-  it("previews the image after cancelling and selecting the same image", async () => {
-    const user = userEvent.setup({ applyAccept: false });
-
-    await user.upload(
-      screen.getByLabelText(SELECT_AN_IMAGE) as HTMLInputElement,
-      MOCK_FILE,
-    );
-    expect(await screen.findByLabelText(CANCEL_UPLOAD)).toBeVisible();
-    await user.click(screen.getByLabelText(CANCEL_UPLOAD));
-
-    await user.upload(
-      screen.getByLabelText(SELECT_AN_IMAGE) as HTMLInputElement,
-      MOCK_FILE,
-    );
-
-    expect(await screen.findByLabelText(CANCEL_UPLOAD)).toBeVisible();
-    expect(
-      screen.getByAltText(getAvatarLabel(NAME)).getAttribute("src"),
-    ).toMatch(/base64/);
   });
 });
 
@@ -410,9 +278,6 @@ describe("ImageInput http error tests", () => {
       MOCK_FILE,
     );
 
-    expect(await screen.findByLabelText(CONFIRM_UPLOAD)).toBeVisible();
-    await user.click(screen.getByLabelText(CONFIRM_UPLOAD));
-
     await assertErrorAlert(IMAGE_TOO_LARGE);
   });
 
@@ -432,9 +297,6 @@ describe("ImageInput http error tests", () => {
       screen.getByLabelText(SELECT_AN_IMAGE) as HTMLInputElement,
       MOCK_FILE,
     );
-
-    expect(await screen.findByLabelText(CONFIRM_UPLOAD)).toBeVisible();
-    await user.click(screen.getByLabelText(CONFIRM_UPLOAD));
 
     await assertErrorAlert(SERVER_ERROR);
   });
@@ -458,9 +320,6 @@ describe("ImageInput http error tests", () => {
       screen.getByLabelText(SELECT_AN_IMAGE) as HTMLInputElement,
       MOCK_FILE,
     );
-
-    expect(await screen.findByLabelText(CONFIRM_UPLOAD)).toBeVisible();
-    await user.click(screen.getByLabelText(CONFIRM_UPLOAD));
 
     await assertErrorAlert(INTERNAL_ERROR);
   });

--- a/app/web/components/ImageInput/ImageInput.tsx
+++ b/app/web/components/ImageInput/ImageInput.tsx
@@ -1,4 +1,5 @@
-import { styled } from "@mui/material";
+import { Edit } from "@mui/icons-material";
+import { styled, Tooltip } from "@mui/material";
 import Avatar from "@mui/material/Avatar";
 import MuiIconButton from "@mui/material/IconButton";
 import Alert from "components/Alert";
@@ -8,6 +9,8 @@ import {
   getAvatarLabel,
   SELECT_AN_IMAGE,
 } from "components/constants";
+import { useTranslation } from "i18n";
+import { PROFILE } from "i18n/namespaces";
 import Sentry from "platform/sentry";
 import React, { useRef, useState } from "react";
 import { Control, useController } from "react-hook-form";
@@ -68,6 +71,17 @@ const StyledImage = styled("img", {
   ...(grow && { maxWidth: "100%", height: "auto" }),
 }));
 
+const EditIconButton = styled(MuiIconButton)(({ theme }) => ({
+  position: "absolute",
+  bottom: theme.spacing(1),
+  right: theme.spacing(1),
+  backgroundColor: theme.palette.background.paper,
+  boxShadow: theme.shadows[1],
+  "&:hover": {
+    backgroundColor: theme.palette.grey[200],
+  },
+}));
+
 const StyledLabel = styled("label")(({ theme }) => ({
   alignItems: "center",
   display: "flex",
@@ -85,6 +99,8 @@ const StyledInput = styled("input")(({ theme }) => ({
 
 export function ImageInput(props: AvatarInputProps | RectImgInputProps) {
   const { className, control, id, initialPreviewSrc, name } = props;
+
+  const { t } = useTranslation([PROFILE]);
 
   const [imageUrl, setImageUrl] = useState(initialPreviewSrc);
   const [readerError, setReaderError] = useState("");
@@ -168,16 +184,28 @@ export function ImageInput(props: AvatarInputProps | RectImgInputProps) {
         />
         <StyledLabel htmlFor={id} ref={field.ref}>
           {props.type === "avatar" ? (
-            <MuiIconButton component="span">
-              <Avatar
-                className={className}
-                src={imageUrl}
-                alt={getAvatarLabel(props.userName ?? "")}
-                sx={{ "& img": { objectFit: "cover" } }}
-              >
-                {props.userName?.split(/\s+/).map((name) => name[0])}
-              </Avatar>
-            </MuiIconButton>
+            <Tooltip title={t("profile:click_replace_image")} placement="top">
+              <MuiIconButton component="span" sx={{ position: "relative" }}>
+                <Avatar
+                  className={className}
+                  src={imageUrl}
+                  alt={getAvatarLabel(props.userName ?? "")}
+                  sx={{ "& img": { objectFit: "cover" } }}
+                >
+                  {props.userName?.split(/\s+/).map((name) => name[0])}
+                </Avatar>
+
+                <EditIconButton
+                  size="small"
+                  onClick={(e) => {
+                    e.preventDefault(); // prevent triggering label click again
+                    inputRef.current?.click();
+                  }}
+                >
+                  <Edit fontSize="small" />
+                </EditIconButton>
+              </MuiIconButton>
+            </Tooltip>
           ) : (
             <StyledImage
               className={className}

--- a/app/web/components/ImageInput/ImageInput.tsx
+++ b/app/web/components/ImageInput/ImageInput.tsx
@@ -4,16 +4,10 @@ import MuiIconButton from "@mui/material/IconButton";
 import Alert from "components/Alert";
 import CircularProgress from "components/CircularProgress";
 import {
-  CANCEL_UPLOAD,
-  CONFIRM_UPLOAD,
   COULDNT_READ_FILE,
   getAvatarLabel,
-  NO_VALID_FILE,
   SELECT_AN_IMAGE,
-  UPLOAD_PENDING_ERROR,
 } from "components/constants";
-import IconButton from "components/IconButton";
-import { CheckIcon, CrossIcon } from "components/Icons";
 import Sentry from "platform/sentry";
 import React, { useRef, useState } from "react";
 import { Control, useController } from "react-hook-form";
@@ -58,15 +52,6 @@ const FlexWrapper = styled("div")(({ theme }) => ({
   width: "100%",
 }));
 
-const ConfirmationButtonContainer = styled("div")(({ theme }) => ({
-  display: "flex",
-  flexDirection: "column",
-  justifyContent: "center",
-  "& > * + *": {
-    marginTop: theme.spacing(1),
-  },
-}));
-
 const StyledImage = styled("img", {
   shouldForwardProp: (prop) => prop !== "grow",
 })<{ grow: boolean | undefined }>(({ theme, grow }) => ({
@@ -100,18 +85,12 @@ const StyledInput = styled("input")(({ theme }) => ({
 
 export function ImageInput(props: AvatarInputProps | RectImgInputProps) {
   const { className, control, id, initialPreviewSrc, name } = props;
-  //this ref handles the case where the user uploads an image, selects another image,
-  //but then cancels - it should go to the previous image rather than the original
-  const confirmedUpload = useRef<ImageInputValues>();
+
   const [imageUrl, setImageUrl] = useState(initialPreviewSrc);
-  const [file, setFile] = useState<File | null>(null);
   const [readerError, setReaderError] = useState("");
 
-  const mutation = useMutation<ImageInputValues, Error>(
-    () =>
-      file
-        ? service.api.uploadFile(file)
-        : Promise.reject(new Error(NO_VALID_FILE)),
+  const mutation = useMutation<ImageInputValues, Error, File>(
+    (file) => service.api.uploadFile(file),
     {
       onMutate: () => {
         props.onUploading?.(true); //notify form upload has started
@@ -121,8 +100,6 @@ export function ImageInput(props: AvatarInputProps | RectImgInputProps) {
         setImageUrl(
           props.type === "avatar" ? data.thumbnail_url : data.full_url,
         );
-        confirmedUpload.current = data;
-        setFile(null);
         await props.onSuccess?.(data);
         props.onUploading?.(false); //notify form upload has finished
       },
@@ -131,13 +108,13 @@ export function ImageInput(props: AvatarInputProps | RectImgInputProps) {
       },
     },
   );
-  const isConfirming = !mutation.isLoading && file !== null;
+
   const { field } = useController({
     name,
     control,
     defaultValue: "",
     rules: {
-      validate: () => !isConfirming || UPLOAD_PENDING_ERROR,
+      validate: () => !mutation.isLoading,
     },
   });
 
@@ -153,7 +130,7 @@ export function ImageInput(props: AvatarInputProps | RectImgInputProps) {
         reader.readAsDataURL(file);
       });
       setImageUrl(base64);
-      setFile(file);
+      mutation.mutate(file);
     } catch (e) {
       Sentry.captureException(
         new Error((e as ProgressEvent<FileReader>).toString()),
@@ -171,16 +148,6 @@ export function ImageInput(props: AvatarInputProps | RectImgInputProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const handleClick = () => {
     if (inputRef.current) inputRef.current.value = "";
-  };
-
-  const handleCancel = () => {
-    field.onChange(confirmedUpload.current?.key ?? "");
-    const imageUrl =
-      props.type === "avatar"
-        ? confirmedUpload.current?.thumbnail_url
-        : confirmedUpload.current?.full_url;
-    setImageUrl(imageUrl ?? initialPreviewSrc);
-    setFile(null);
   };
 
   return (
@@ -224,24 +191,6 @@ export function ImageInput(props: AvatarInputProps | RectImgInputProps) {
           )}
           {mutation.isLoading && <StyledCircularProgress />}
         </StyledLabel>
-        {isConfirming && (
-          <ConfirmationButtonContainer>
-            <IconButton
-              aria-label={CANCEL_UPLOAD}
-              onClick={handleCancel}
-              size="small"
-            >
-              <CrossIcon />
-            </IconButton>
-            <IconButton
-              aria-label={CONFIRM_UPLOAD}
-              onClick={() => mutation.mutate()}
-              size="small"
-            >
-              <CheckIcon />
-            </IconButton>
-          </ConfirmationButtonContainer>
-        )}
       </FlexWrapper>
     </StyledWrapper>
   );

--- a/app/web/components/MarkdownInput/MarkdownInput.test.tsx
+++ b/app/web/components/MarkdownInput/MarkdownInput.test.tsx
@@ -6,7 +6,7 @@ import {
   within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { CONFIRM_UPLOAD, SELECT_AN_IMAGE } from "components/constants";
+import { SELECT_AN_IMAGE } from "components/constants";
 import {
   IMAGE_DESCRIPTION,
   INSERT_IMAGE,
@@ -69,13 +69,8 @@ describe("MarkdownInput", () => {
       within(dialog).getByLabelText(IMAGE_DESCRIPTION),
       "description",
     );
-    await user.click(
-      await within(dialog).findByRole("button", { name: CONFIRM_UPLOAD }),
-    );
     await waitForElementToBeRemoved(dialog);
     await user.click(screen.getByRole("button", { name: "Submit" }));
-    await waitFor(() =>
-      expect(onSubmit).toBeCalledWith("![description](full.jpg)"),
-    );
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith("![](full.jpg)"));
   });
 });

--- a/app/web/components/constants.ts
+++ b/app/web/components/constants.ts
@@ -1,11 +1,6 @@
-export const CANCEL_UPLOAD = "Cancel upload";
-export const CONFIRM_UPLOAD = "Confirm upload";
 export const getAvatarLabel = (name: string) => `${name}'s profile picture`;
 export const COULDNT_READ_FILE = "Couldn't read file";
-export const NO_VALID_FILE = "Didn't have a valid file to send";
 export const SELECT_AN_IMAGE = "Select an image";
-export const UPLOAD_PENDING_ERROR =
-  "Confirm or cancel the picture upload before saving.";
 
 export const DISPLAY_LOCATION = "Display location";
 export const INVALID_COORDINATE =

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -114,9 +114,11 @@ export default function EditProfileForm() {
     aboutMeField === DEFAULT_ABOUT_ME_HEADINGS ? 0 : aboutMeField.length;
 
   useUnsavedChangesWarning({
-    isDirty,
-    isSubmitted,
-    warningMessage: t("profile:unsaved_changes_warning"),
+    isDirty: isDirty || isUploading,
+    isSubmitted: isSubmitted,
+    warningMessage: isUploading
+      ? t("profile:image_uploading_warning")
+      : t("profile:unsaved_changes_warning"),
   });
 
   const { regions, regionsLookup } = useRegions();

--- a/app/web/features/profile/locales/en.json
+++ b/app/web/features/profile/locales/en.json
@@ -208,6 +208,8 @@
   "response_time_text_most": "Usually in {{p33}} to {{p66}}",
   "response_time_text_almost_all": "Usually in {{p33}} to {{p66}}",
   "unsaved_changes_warning": "You haven't saved your changes. Are you sure you want to leave the page?",
+  "image_uploading_warning": "Your profile image is still uploading. Are you sure you want to leave the page?",
+  "click_replace_image": "Click to replace image",
   "profile_tag_input": {
     "header_text": "Press 'Enter' to add\n<support_link>Email us</support_link> to add an entry",
     "remove_button_a11y_text": "Remove {{tag}}"


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

Closes #5804 

**Please give clear steps for how the reviewer can best test this PR**

Please include any necessary dev environment, .env, etc. adjustments.

- Go to profile and click "edit"
- Click image, upload a new image
- Should show spinner while uploading, then see image uploaded
- Click save
- New image should be uploaded

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [ x ] Formatted my code with `yarn format`
- [ x ] There are no warnings from `yarn lint --fix`
- [ x ] There are no console warnings when running the app
- [ x ] All tests pass
- [ x ] Clicked around my changes running locally and it works
- [ x ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
