### PR TITLE
Notification Settings - Move all reply notifications to replies section

### DIFF
--- a/app/web/components/Icons/index.ts
+++ b/app/web/components/Icons/index.ts
@@ -61,6 +61,7 @@ export { default as PinIcon } from "@mui/icons-material/LocationOn";
 export { default as ReminderIcon } from "@mui/icons-material/Notifications";
 export { default as SatisfiedIcon } from "@mui/icons-material/SentimentSatisfiedAltOutlined";
 export { default as SearchIcon } from "@mui/icons-material/SearchOutlined";
+export { default as SegmentIcon } from "@mui/icons-material/Segment";
 export { default as SettingsIcon } from "@mui/icons-material/SettingsOutlined";
 export { default as SinglePersonIcon } from "@mui/icons-material/Person";
 export { default as SlightlyDissatisfiedIcon } from "@mui/icons-material/SentimentDissatisfied";

--- a/app/web/features/auth/locales/en.json
+++ b/app/web/features/auth/locales/en.json
@@ -215,7 +215,7 @@
         "host_request": "Host requests",
         "reference": "References",
         "discussion": "Discussions",
-        "thread": "Threads"
+        "reply": "Replies"
       },
       "item_descriptions": {
         "host_request": {

--- a/app/web/features/auth/notifications/EditNotificationSettingsPage.tsx
+++ b/app/web/features/auth/notifications/EditNotificationSettingsPage.tsx
@@ -14,7 +14,8 @@ export type NotificationType =
   | "event"
   | "reference"
   | "friend_request"
-  | "host_request";
+  | "host_request"
+  | "reply";
 
 export interface GroupAction {
   action: string;
@@ -80,7 +81,10 @@ export default function EditNotificationSettingsPage() {
                   ? "account_security"
                   : group.heading === "Account Settings"
                     ? "account_settings"
-                    : topic.topic;
+                    : subTopic.action === "reply" ||
+                        subTopic.action === "comment"
+                      ? "reply"
+                      : topic.topic;
 
               if (!acc[key]) {
                 acc[key] = [];

--- a/app/web/features/auth/notifications/NotificationSettingsListItem.tsx
+++ b/app/web/features/auth/notifications/NotificationSettingsListItem.tsx
@@ -16,8 +16,8 @@ import {
   EventIcon,
   ExpandLessIcon,
   ExpandMoreIcon,
-  MessageIcon,
   PenIcon,
+  SegmentIcon,
   SinglePersonIcon,
 } from "components/Icons";
 import { AUTH } from "i18n/namespaces";
@@ -53,7 +53,7 @@ const mapTypeToIcon: { [key: string]: JSX.Element } = {
   friend_request: <SinglePersonIcon fontSize="large" color="action" />,
   host_request: <CouchFilledIcon fontSize="large" color="action" />,
   discussion: <CommentIcon fontSize="large" color="action" />,
-  thread: <MessageIcon fontSize="large" color="action" />,
+  reply: <SegmentIcon fontSize="large" color="action" />,
 };
 
 export default function NotificationSettingsListItem({


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

Closes #5731 

**Please give clear steps for how the reviewer can best test this PR**

Please include any necessary dev environment, .env, etc. adjustments.

- Go to Account Settings > Notification Settings
- There should be a "Replies" section
- The "Threads" section should be gone.
- All replies to events, discussions and, etc. go under "Replies"
- The replies should be moved out of events, threads, discussions and go here instead
- It should work

<img width="522" alt="Screenshot 2025-04-14 at 9 06 48 PM" src="https://github.com/user-attachments/assets/b24d0048-a390-402d-a7f8-8b81845434a8" />


<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [ x ] Formatted my code with `yarn format`
- [ x ] There are no warnings from `yarn lint --fix`
- [ x ] There are no console warnings when running the app
- [ x ] All tests pass
- [ x ] Clicked around my changes running locally and it works
- [ x ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
