### PR TITLE
sort community names alphabetically on "browse communities" page

### DIFF
--- a/app/backend/src/couchers/servicers/communities.py
+++ b/app/backend/src/couchers/servicers/communities.py
@@ -404,7 +404,7 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
 
     def ListUserCommunities(self, request, context, session):
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
-        offset = int(request.page_token) if request.page_token else 0
+        next_node_id = int(request.page_token) if request.page_token else 0
         user_id = request.user_id or context.user_id
         nodes = (
             session.execute(
@@ -413,9 +413,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
                 .join(ClusterSubscription, ClusterSubscription.cluster_id == Cluster.id)
                 .where(ClusterSubscription.user_id == user_id)
                 .where(Cluster.is_official_cluster)
-                .order_by(Cluster.name)
+                .where(Node.id >= next_node_id)
+                .order_by(Cluster.id)
                 .limit(page_size + 1)
-                .offset(offset)
             )
             .scalars()
             .all()
@@ -423,5 +423,5 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
 
         return communities_pb2.ListUserCommunitiesRes(
             communities=[community_to_pb(session, node, context) for node in nodes[:page_size]],
-            next_page_token=str(offset + page_size) if len(nodes) > page_size else None,
+            next_page_token=str(nodes[-1].id) if len(nodes) > page_size else None,
         )

--- a/app/backend/src/couchers/servicers/communities.py
+++ b/app/backend/src/couchers/servicers/communities.py
@@ -110,22 +110,23 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
 
     def ListCommunities(self, request, context, session):
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
-        next_node_id = int(request.page_token) if request.page_token else 0
+        offset = int(request.page_token) if request.page_token else 0
         nodes = (
             session.execute(
                 select(Node)
-                .join(Node.official_cluster)
+                .join(Cluster, Cluster.parent_node_id == Node.id)
                 .where(or_(Node.parent_node_id == request.community_id, request.community_id == 0))
-                .where(Node.id >= next_node_id)
+                .where(Cluster.is_official_cluster)
                 .order_by(Cluster.name)
                 .limit(page_size + 1)
+                .offset(offset)
             )
             .scalars()
             .all()
         )
         return communities_pb2.ListCommunitiesRes(
             communities=[community_to_pb(session, node, context) for node in nodes[:page_size]],
-            next_page_token=str(nodes[-1].id) if len(nodes) > page_size else None,
+            next_page_token=str(offset + page_size) if len(nodes) > page_size else None,
         )
 
     def ListGroups(self, request, context, session):
@@ -402,7 +403,7 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
 
     def ListUserCommunities(self, request, context, session):
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
-        next_node_id = int(request.page_token) if request.page_token else 0
+        offset = int(request.page_token) if request.page_token else 0
         user_id = request.user_id or context.user_id
         nodes = (
             session.execute(
@@ -411,9 +412,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
                 .join(ClusterSubscription, ClusterSubscription.cluster_id == Cluster.id)
                 .where(ClusterSubscription.user_id == user_id)
                 .where(Cluster.is_official_cluster)
-                .where(Node.id >= next_node_id)
                 .order_by(Cluster.name)
                 .limit(page_size + 1)
+                .offset(offset)
             )
             .scalars()
             .all()
@@ -421,5 +422,5 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
 
         return communities_pb2.ListUserCommunitiesRes(
             communities=[community_to_pb(session, node, context) for node in nodes[:page_size]],
-            next_page_token=str(nodes[-1].id) if len(nodes) > page_size else None,
+            next_page_token=str(offset + page_size) if len(nodes) > page_size else None,
         )

--- a/app/backend/src/couchers/servicers/communities.py
+++ b/app/backend/src/couchers/servicers/communities.py
@@ -414,7 +414,7 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
                 .where(ClusterSubscription.user_id == user_id)
                 .where(Cluster.is_official_cluster)
                 .where(Node.id >= next_node_id)
-                .order_by(Cluster.id)
+                .order_by(Node.id)
                 .limit(page_size + 1)
             )
             .scalars()

--- a/app/backend/src/couchers/servicers/communities.py
+++ b/app/backend/src/couchers/servicers/communities.py
@@ -114,9 +114,10 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         nodes = (
             session.execute(
                 select(Node)
+                .join(Node.official_cluster)
                 .where(or_(Node.parent_node_id == request.community_id, request.community_id == 0))
                 .where(Node.id >= next_node_id)
-                .order_by(Node.id)
+                .order_by(Cluster.name)
                 .limit(page_size + 1)
             )
             .scalars()
@@ -411,7 +412,7 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
                 .where(ClusterSubscription.user_id == user_id)
                 .where(Cluster.is_official_cluster)
                 .where(Node.id >= next_node_id)
-                .order_by(Node.id)
+                .order_by(Cluster.name)
                 .limit(page_size + 1)
             )
             .scalars()

--- a/app/backend/src/couchers/servicers/communities.py
+++ b/app/backend/src/couchers/servicers/communities.py
@@ -6,6 +6,7 @@ from google.protobuf import empty_pb2
 from sqlalchemy.sql import delete, func, or_
 
 from couchers import errors
+from couchers.crypto import decrypt_page_token, encrypt_page_token
 from couchers.db import can_moderate_node, get_node_parents_recursively
 from couchers.materialized_views import cluster_admin_counts, cluster_subscription_counts
 from couchers.models import (
@@ -110,7 +111,7 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
 
     def ListCommunities(self, request, context, session):
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
-        offset = int(request.page_token) if request.page_token else 0
+        offset = int(decrypt_page_token(request.page_token)) if request.page_token else 0
         nodes = (
             session.execute(
                 select(Node)
@@ -126,7 +127,7 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         )
         return communities_pb2.ListCommunitiesRes(
             communities=[community_to_pb(session, node, context) for node in nodes[:page_size]],
-            next_page_token=str(offset + page_size) if len(nodes) > page_size else None,
+            next_page_token=encrypt_page_token(str(offset + page_size)) if len(nodes) > page_size else None,
         )
 
     def ListGroups(self, request, context, session):

--- a/app/backend/src/tests/test_communities.py
+++ b/app/backend/src/tests/test_communities.py
@@ -441,6 +441,7 @@ class TestCommunities:
             c2r1_id = get_community_id(session, "Country 2, Region 1")
             c2r1c1_id = get_community_id(session, "Country 2, Region 1, City 1")
 
+        # Fetch all communities ordered by name
         with communities_session(token1) as api:
             res = api.ListCommunities(
                 communities_pb2.ListCommunitiesReq(
@@ -475,17 +476,17 @@ class TestCommunities:
             c1r2_id = get_community_id(session, "Country 1, Region 2")
             c1r2c1_id = get_community_id(session, "Country 1, Region 2, City 1")
 
-        # Fetch user2's communities from user2's account ordered by name
+        # Fetch user2's communities from user2's account
         with communities_session(token2) as api:
             res = api.ListUserCommunities(communities_pb2.ListUserCommunitiesReq())
             assert [c.community_id for c in res.communities] == [
+                w_id,
                 c1_id,
                 c1r1_id,
                 c1r1c1_id,
                 c1r1c2_id,
                 c1r2_id,
                 c1r2c1_id,
-                w_id,
             ]
 
     @staticmethod
@@ -501,17 +502,17 @@ class TestCommunities:
             c1r2_id = get_community_id(session, "Country 1, Region 2")
             c1r2c1_id = get_community_id(session, "Country 1, Region 2, City 1")
 
-        # Fetch user2's communities from user1's account ordered by name
+        # Fetch user2's communities from user1's account
         with communities_session(token1) as api:
             res = api.ListUserCommunities(communities_pb2.ListUserCommunitiesReq(user_id=user2_id))
             assert [c.community_id for c in res.communities] == [
+                w_id,
                 c1_id,
                 c1r1_id,
                 c1r1c1_id,
                 c1r1c2_id,
                 c1r2_id,
                 c1r2c1_id,
-                w_id,
             ]
 
     @staticmethod
@@ -1004,7 +1005,7 @@ def test_enforce_community_memberships_for_user(testing_communities):
 
     with communities_session(token) as api:
         res = api.ListUserCommunities(communities_pb2.ListUserCommunitiesReq())
-        assert [c.community_id for c in res.communities] == [c1_id, c1r1_id, c1r1c2_id, w_id]
+        assert [c.community_id for c in res.communities] == [w_id, c1_id, c1r1_id, c1r1c2_id]
 
 
 # TODO: requires transferring of content

--- a/app/backend/src/tests/test_communities.py
+++ b/app/backend/src/tests/test_communities.py
@@ -227,15 +227,15 @@ def testing_communities(testconfig):
 
     with session_scope() as session:
         w = create_community(session, 0, 100, "Global", [user1, user3, user7], [], None)
+        c2 = create_community(session, 52, 100, "Country 2", [user6, user7], [], w)
+        c2r1 = create_community(session, 52, 71, "Country 2, Region 1", [user6], [user8], c2)
+        c2r1c1 = create_community(session, 53, 70, "Country 2, Region 1, City 1", [user8], [], c2r1)
         c1 = create_community(session, 0, 50, "Country 1", [user1, user2], [], w)
         c1r1 = create_community(session, 0, 10, "Country 1, Region 1", [user1, user2], [], c1)
         c1r1c1 = create_community(session, 0, 5, "Country 1, Region 1, City 1", [user2], [], c1r1)
         c1r1c2 = create_community(session, 7, 10, "Country 1, Region 1, City 2", [user4, user5], [user2], c1r1)
         c1r2 = create_community(session, 20, 25, "Country 1, Region 2", [user2], [], c1)
         c1r2c1 = create_community(session, 21, 23, "Country 1, Region 2, City 1", [user2], [], c1r2)
-        c2 = create_community(session, 52, 100, "Country 2", [user6, user7], [], w)
-        c2r1 = create_community(session, 52, 71, "Country 2, Region 1", [user6], [user8], c2)
-        c2r1c1 = create_community(session, 53, 70, "Country 2, Region 1, City 1", [user8], [], c2r1)
 
         h = create_group(session, "Hitchhikers", [user1, user2], [user5, user8], w)
         create_group(session, "Country 1, Region 1, Foodies", [user1], [user2, user4], c1r1)
@@ -447,21 +447,21 @@ class TestCommunities:
                     page_size=5,
                 )
             )
-            assert [c.community_id for c in res.communities] == [w_id, c1_id, c1r1_id, c1r1c1_id, c1r1c2_id]
+            assert [c.community_id for c in res.communities] == [c1_id, c1r1_id, c1r1c1_id, c1r1c2_id, c1r2_id]
             res = api.ListCommunities(
                 communities_pb2.ListCommunitiesReq(
                     page_size=2,
                     page_token=res.next_page_token,
                 )
             )
-            assert [c.community_id for c in res.communities] == [c1r2_id, c1r2c1_id]
+            assert [c.community_id for c in res.communities] == [c1r2c1_id, c2_id]
             res = api.ListCommunities(
                 communities_pb2.ListCommunitiesReq(
                     page_size=5,
                     page_token=res.next_page_token,
                 )
             )
-            assert [c.community_id for c in res.communities] == [c2_id, c2r1_id, c2r1c1_id]
+            assert [c.community_id for c in res.communities] == [c2r1_id, c2r1c1_id, w_id]
 
     @staticmethod
     def test_ListUserCommunities(testing_communities):
@@ -475,17 +475,17 @@ class TestCommunities:
             c1r2_id = get_community_id(session, "Country 1, Region 2")
             c1r2c1_id = get_community_id(session, "Country 1, Region 2, City 1")
 
-        # Fetch user2's communities from user2's account
+        # Fetch user2's communities from user2's account ordered by name
         with communities_session(token2) as api:
             res = api.ListUserCommunities(communities_pb2.ListUserCommunitiesReq())
             assert [c.community_id for c in res.communities] == [
-                w_id,
                 c1_id,
                 c1r1_id,
                 c1r1c1_id,
                 c1r1c2_id,
                 c1r2_id,
                 c1r2c1_id,
+                w_id,
             ]
 
     @staticmethod
@@ -501,17 +501,17 @@ class TestCommunities:
             c1r2_id = get_community_id(session, "Country 1, Region 2")
             c1r2c1_id = get_community_id(session, "Country 1, Region 2, City 1")
 
-        # Fetch user2's communities from user1's account
+        # Fetch user2's communities from user1's account ordered by name
         with communities_session(token1) as api:
             res = api.ListUserCommunities(communities_pb2.ListUserCommunitiesReq(user_id=user2_id))
             assert [c.community_id for c in res.communities] == [
-                w_id,
                 c1_id,
                 c1r1_id,
                 c1r1c1_id,
                 c1r1c2_id,
                 c1r2_id,
                 c1r2c1_id,
+                w_id,
             ]
 
     @staticmethod
@@ -1004,7 +1004,7 @@ def test_enforce_community_memberships_for_user(testing_communities):
 
     with communities_session(token) as api:
         res = api.ListUserCommunities(communities_pb2.ListUserCommunitiesReq())
-        assert [c.community_id for c in res.communities] == [w_id, c1_id, c1r1_id, c1r1c2_id]
+        assert [c.community_id for c in res.communities] == [c1_id, c1r1_id, c1r1c2_id, w_id]
 
 
 # TODO: requires transferring of content


### PR DESCRIPTION
It closes #5124.
At the end I am not sure if it was a good idea to sort the communities by name in the backend instead of in the frontend. But if we see it is needed we can  always add an index on the name attribute later on.
Regarding the somehow related issue #5177 I leave it for another time because the intended ordering logic is more complex and it requires work in the frontend.

**Please give clear steps for how the reviewer can best test this PR**

- no particular steps needed

**Backend checklist**
- [x] Formatted my code by running `ruff check --select I --fix . && ruff check . --fix && ruff format .` in `app/backend`
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] All tests pass
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

