### PR TITLE
Add reply IDs for admins

### DIFF
--- a/app/web/features/communities/discussions/Comment.tsx
+++ b/app/web/features/communities/discussions/Comment.tsx
@@ -4,6 +4,8 @@ import Button from "components/Button";
 import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
 import Markdown from "components/Markdown";
 import FlagButton from "features/FlagButton";
+import CopyOnClick from "features/mod/CopyOnClick";
+import ModVisibleComponent from "features/mod/ModVisibleComponent";
 import { useLiteUser } from "features/userQueries/useLiteUsers";
 import { useTranslation } from "i18n";
 import { COMMUNITIES, GLOBAL } from "i18n/namespaces";
@@ -136,6 +138,14 @@ export default function Comment({ topLevel = false, comment }: CommentProps) {
                 name: user?.name ?? t("communities:unknown_user"),
               })}
               {` • ${postedTime}`}
+              <ModVisibleComponent>
+                {" "}
+                •{" "}
+                <code>
+                  threadId:
+                  <CopyOnClick text={comment.threadId.toString()} />
+                </code>
+              </ModVisibleComponent>
             </Typography>
           )}
           {isUserLoading ? <Skeleton /> : <Markdown source={comment.content} />}

--- a/app/web/features/communities/discussions/DiscussionCard.tsx
+++ b/app/web/features/communities/discussions/DiscussionCard.tsx
@@ -1,6 +1,8 @@
 import { Card, CardContent, Skeleton, styled, Typography } from "@mui/material";
 import Avatar from "components/Avatar";
 import FlagButton from "features/FlagButton";
+import CopyOnClick from "features/mod/CopyOnClick";
+import ModVisibleComponent from "features/mod/ModVisibleComponent";
 import { useLiteUser } from "features/userQueries/useLiteUsers";
 import { useTranslation } from "i18n";
 import { COMMUNITIES } from "i18n/namespaces";
@@ -107,6 +109,14 @@ export default function DiscussionCard({
                 <Skeleton sx={{ display: "inline-block", width: 80 }} />
               )}{" "}
               {postedTime && `• ${postedTime}`}
+              <ModVisibleComponent>
+                {" "}
+                •{" "}
+                <code>
+                  discussionId:
+                  <CopyOnClick text={discussion.discussionId.toString()} />
+                </code>
+              </ModVisibleComponent>
             </Typography>
             <Typography variant="h2" component="h3">
               {discussion.title}

--- a/app/web/features/mod/CopyOnClick.tsx
+++ b/app/web/features/mod/CopyOnClick.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+export default function CopyOnClick({ text }: { text: string }) {
+  return (
+    <span onClick={() => navigator.clipboard.writeText(text)}>{text}</span>
+  );
+}

--- a/app/web/features/mod/ModVisibleComponent.tsx
+++ b/app/web/features/mod/ModVisibleComponent.tsx
@@ -1,0 +1,13 @@
+import useAccountInfo from "features/auth/useAccountInfo";
+import { ReactNode } from "react";
+
+export interface ModVisibleComponentProps {
+  children: ReactNode;
+}
+
+export default function ModVisibleComponent({
+  children,
+}: ModVisibleComponentProps) {
+  const { data: accountInfo } = useAccountInfo();
+  return accountInfo?.isSuperuser ? children : null;
+}

--- a/app/web/features/profile/view/AdminPanelUserButton.tsx
+++ b/app/web/features/profile/view/AdminPanelUserButton.tsx
@@ -1,6 +1,6 @@
 import IconButton from "components/IconButton";
 import { SettingsIcon } from "components/Icons";
-import useAccountInfo from "features/auth/useAccountInfo";
+import ModVisibleComponent from "features/mod/ModVisibleComponent";
 import { useTranslation } from "i18n";
 import { PROFILE } from "i18n/namespaces";
 import { useRouter } from "next/router";
@@ -16,19 +16,16 @@ export default function AdminPanelUserButton({
 }: AdminPanelUserButtonProps) {
   const { t } = useTranslation(PROFILE);
   const router = useRouter();
-  const { data: accountInfo } = useAccountInfo();
 
   return (
-    <>
-      {accountInfo?.isSuperuser && (
-        <IconButton
-          aria-label={t("view_in_admin_console")}
-          onClick={() => router.push(adminPanelUserLink(username))}
-          color="primary"
-        >
-          <SettingsIcon />
-        </IconButton>
-      )}
-    </>
+    <ModVisibleComponent>
+      <IconButton
+        aria-label={t("view_in_admin_console")}
+        onClick={() => router.push(adminPanelUserLink(username))}
+        color="primary"
+      >
+        <SettingsIcon />
+      </IconButton>
+    </ModVisibleComponent>
   );
 }


### PR DESCRIPTION

![Screenshot from 2025-05-06 17-49-25](https://github.com/user-attachments/assets/20b8f94b-1604-4b36-9807-3807e0c030cc)


<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
**Please give clear steps for how the reviewer can best test this PR**

Please include any necessary dev environment, .env, etc. adjustments.

- Be mod
- View discussions/comments
- Check that all of them have `replyId:XXX` or `discussionId:XXX`

**Web frontend checklist**
- [ ] Formatted my code with `yarn format`
- [ ] There are no warnings from `yarn lint --fix`
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
