### PR TITLE
Only run migration test if ENV var is set

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -234,6 +234,7 @@ test:backend:
   variables:
     POSTGRES_PASSWORD: c765064a49d18a95
     DATABASE_CONNECTION_STRING: "postgresql://postgres:c765064a49d18a95@postgres/postgres"
+    RUN_MIGRATION_TEST: true
   before_script:
     # install latest postgres from their repos to get pg_dump compatible with later postgres
     - sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list'

--- a/app/backend/.gitignore
+++ b/app/backend/.gitignore
@@ -1,4 +1,5 @@
 venv/
+.venv/
 *db.sqlite
 __pycache__/
 

--- a/app/backend/src/tests/test_db.py
+++ b/app/backend/src/tests/test_db.py
@@ -1,8 +1,8 @@
-import pytest
 import difflib
 import re
 import subprocess
 
+import pytest
 from sqlalchemy.sql import func
 
 from couchers.config import config
@@ -18,7 +18,7 @@ from couchers.utils import (
     parse_date,
 )
 from tests.test_communities import create_1d_point, get_community_id, testing_communities  # noqa
-from tests.test_fixtures import create_schema_from_models, db, drop_all, testconfig, run_migration_test  # noqa
+from tests.test_fixtures import create_schema_from_models, db, drop_all, run_migration_test, testconfig  # noqa
 
 
 def test_is_valid_user_id():
@@ -144,10 +144,13 @@ def test_sort_pg_dump_output():
 def strip_leading_whitespace(lines):
     return [s.lstrip() for s in lines]
 
+
 """
 This test will only run succesfully if you have `pg_dump` installed and everything set up, which only happens if you run
 the test within the container
 """
+
+
 @pytest.mark.skipif(not run_migration_test(), reason="Migration test disabled")
 def test_migrations(testconfig):
     """Compares the database schema built up from migrations, with the

--- a/app/backend/src/tests/test_db.py
+++ b/app/backend/src/tests/test_db.py
@@ -1,3 +1,4 @@
+import pytest
 import difflib
 import re
 import subprocess
@@ -17,7 +18,7 @@ from couchers.utils import (
     parse_date,
 )
 from tests.test_communities import create_1d_point, get_community_id, testing_communities  # noqa
-from tests.test_fixtures import create_schema_from_models, db, drop_all, testconfig  # noqa
+from tests.test_fixtures import create_schema_from_models, db, drop_all, testconfig, run_migration_test  # noqa
 
 
 def test_is_valid_user_id():
@@ -143,7 +144,11 @@ def test_sort_pg_dump_output():
 def strip_leading_whitespace(lines):
     return [s.lstrip() for s in lines]
 
-
+"""
+This test will only run succesfully if you have `pg_dump` installed and everything set up, which only happens if you run
+the test within the container
+"""
+@pytest.mark.skipif(not run_migration_test(), reason="Migration test disabled")
 def test_migrations(testconfig):
     """Compares the database schema built up from migrations, with the
     schema built by models.py. Both scenarios are started from an

--- a/app/backend/src/tests/test_db.py
+++ b/app/backend/src/tests/test_db.py
@@ -145,15 +145,13 @@ def strip_leading_whitespace(lines):
     return [s.lstrip() for s in lines]
 
 
-"""
-This test will only run succesfully if you have `pg_dump` installed and everything set up, which only happens if you run
-the test within the container
-"""
-
-
 @pytest.mark.skipif(not run_migration_test(), reason="Migration test disabled")
 def test_migrations(testconfig):
-    """Compares the database schema built up from migrations, with the
+    """
+    This test will only run succesfully if you have `pg_dump` installed and everything set up, which only happens if the
+    test is being run within Gitlab CI where we do all that setup. So we disable it unless explicitly marked to run.
+
+    Compares the database schema built up from migrations, with the
     schema built by models.py. Both scenarios are started from an
     empty database, and dumped with pg_dump. Any unexplainable
     differences in the output are reported in unified diff format and

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -916,7 +916,7 @@ def testconfig():
 
 
 def run_migration_test():
-    return os.environ.get('RUN_MIGRATION_TEST', 'false').lower() == 'true'
+    return os.environ.get("RUN_MIGRATION_TEST", "false").lower() == "true"
 
 
 @pytest.fixture

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -915,6 +915,10 @@ def testconfig():
     config.update(prevconfig)
 
 
+def run_migration_test():
+    return os.environ.get('RUN_MIGRATION_TEST', 'false').lower() == 'true'
+
+
 @pytest.fixture
 def fast_passwords():
     # password hashing, by design, takes a lot of time, which slows down the tests. here we jump through some hoops to


### PR DESCRIPTION
This test will only run succesfully if you have `pg_dump` installed and everything set up, which only happens if you run
the test within the container

**Backend checklist**
- [ ] Formatted my code by running `ruff check --select I --fix . && ruff check . --fix && ruff format .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history
