### PR TITLE
Allow delete-account route when jailed

### DIFF
--- a/app/web/components/AppRoute.tsx
+++ b/app/web/components/AppRoute.tsx
@@ -88,7 +88,12 @@ export default function AppRoute({
       authActions.authError("Please log in.");
       router.push({ pathname: loginRoute, query: { from: location.pathname } });
     }
-    if (isAuthenticated && isJailed && router.pathname !== jailRoute) {
+    if (
+      isAuthenticated &&
+      isJailed &&
+      isPrivate &&
+      router.pathname !== jailRoute
+    ) {
       router.push(jailRoute);
     }
   }, [isAuthenticated, isJailed, isPrivate, authActions, router]);

--- a/app/web/features/auth/AuthProvider.tsx
+++ b/app/web/features/auth/AuthProvider.tsx
@@ -8,6 +8,7 @@ import useStablePush from "utils/useStablePush";
 
 import { JAILED_ERROR_MESSAGE } from "./constants";
 import useAuthStore, { AuthStoreType } from "./useAuthStore";
+import { useRouter } from "next/router";
 
 export const AuthContext = React.createContext<null | AuthStoreType>(null);
 
@@ -22,6 +23,7 @@ function useAppContext<T>(context: Context<T | null>) {
 export default function AuthProvider({ children }: { children: ReactNode }) {
   const { t } = useTranslation(AUTH);
   const store = useAuthStore();
+  const router = useRouter();
 
   const push = useStablePush();
 
@@ -29,8 +31,15 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
     setUnauthenticatedErrorHandler(async (e: RpcError) => {
       // the backend will return "Permission denied" if you're just jailed, and "Unauthorized" otherwise
       if (e.message === JAILED_ERROR_MESSAGE) {
+        const isJailRouteException = router.pathname.includes("delete-account");
+
         await store.authActions.updateJailStatus();
-        push(jailRoute);
+
+        if (!isJailRouteException) {
+          // if the user is jailed, redirect them to the jail route
+          store.authActions.authError(t("jailed_message"));
+          push(jailRoute);
+        }
       } else {
         // completely logged out
         await store.authActions.logout();


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

Make adjustment so user can still delete account while jailed.

**Please give clear steps for how the reviewer can best test this PR**

Please include any necessary dev environment, .env, etc. adjustments.

-
-
-

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [ ] Formatted my code with `yarn format`
- [ ] There are no warnings from `yarn lint --fix`
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
