### PR TITLE
Fix: Landing on middle of page after clicking a link in footer

### DIFF
--- a/app/web/components/AppRoute.tsx
+++ b/app/web/components/AppRoute.tsx
@@ -24,7 +24,6 @@ const globalStyles = (
     styles={{
       "html, body": {
         margin: 0,
-        overflow: "hidden", // Prevents whole-page scrolling
       },
       "#__next": {
         height: "calc(var(--vh, 1vh) * 100)", // Use the dynamic --vh value from _app
@@ -39,7 +38,6 @@ const PageWrapper = styled(Box)({
   display: "flex",
   flexDirection: "column",
   flex: 1,
-  overflowY: "auto",
 });
 
 const ContentWrapper = styled(Container, {


### PR DESCRIPTION
closes #5991 

Note: I have solved this issue by deleting references to overflow. While this fixed the issue, I don't know why those references were there in the first place and it's possible this approach might introduce some other bug.

I've tested things myself but I've not found any newly-introduced bug.

If someone who wrote that code could comment it would be helpful. Otherwise we can go ahead and merge for now and see if there's any impact later.

**Web frontend checklist**
- [x] Formatted my code with `yarn format`
- [x] There are no warnings from `yarn lint --fix`
- [x] There are no console warnings when running the app
- [x] Clicked around my changes running locally and it works
<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
