### PR TITLE
Fix backend RemoveFriend query

### DIFF
--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -547,8 +547,14 @@ class API(api_pb2_grpc.APIServicer):
             .where_users_column_visible(context, FriendRelationship.to_user_id)
             .where(
                 or_(
-                    FriendRelationship.from_user_id == request.user_id,
-                    FriendRelationship.to_user_id == request.user_id,
+                    and_(
+                        FriendRelationship.from_user_id == request.user_id,
+                        FriendRelationship.to_user_id == context.user_id,
+                    ),
+                    and_(
+                        FriendRelationship.from_user_id == context.user_id,
+                        FriendRelationship.to_user_id == request.user_id,
+                    ),
                 )
             )
             .where(FriendRelationship.status == FriendStatus.accepted)

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -744,6 +744,52 @@ def test_friend_request_flow(db, push_collector):
         assert len(res.user_ids) == 0
 
 
+def test_RemoveFriend_regression(db, push_collector):
+    user1, token1 = generate_user(complete_profile=True)
+    user2, token2 = generate_user(complete_profile=True)
+    user3, token3 = generate_user()
+    user4, token4 = generate_user()
+    user5, token5 = generate_user()
+    user6, token6 = generate_user()
+
+    with api_session(token4) as api:
+        api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user1.id))
+        api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user2.id))
+
+    with api_session(token5) as api:
+        api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user1.id))
+
+    with api_session(token1) as api:
+        api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user2.id))
+        api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user3.id))
+
+        api.RespondFriendRequest(
+            api_pb2.RespondFriendRequestReq(
+                friend_request_id=api.ListFriendRequests(empty_pb2.Empty()).received[0].friend_request_id, accept=True
+            )
+        )
+
+    with api_session(token2) as api:
+        for fr in api.ListFriendRequests(empty_pb2.Empty()).received:
+            api.RespondFriendRequest(
+                api_pb2.RespondFriendRequestReq(friend_request_id=fr.friend_request_id, accept=True)
+            )
+
+    with api_session(token1) as api:
+        res = api.ListFriends(empty_pb2.Empty())
+        assert sorted(res.user_ids) == [2, 4]
+
+        api.RemoveFriend(api_pb2.RemoveFriendReq(user_id=user2.id))
+
+        res = api.ListFriends(empty_pb2.Empty())
+        assert sorted(res.user_ids) == [4]
+
+        api.RemoveFriend(api_pb2.RemoveFriendReq(user_id=user4.id))
+
+        res = api.ListFriends(empty_pb2.Empty())
+        assert not res.user_ids
+
+
 def test_cant_friend_request_twice(db):
     user1, token1 = generate_user()
     user2, token2 = generate_user()


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

The `RemoveFriend` query that finds the friend relationship to remove was returning more than one row and throwing an error since it's `scalar_one_or_none`.

When I logged it, I realized it was returning any relationships that contained the given `user_id`.

We need to make it more specific, tell it we only want the friend relationship with `request.user_id` and `context.user_id`.

**Please give clear steps for how the reviewer can best test this PR**

Please include any necessary dev environment, .env, etc. adjustments.

- There's no frontend yet, but I have tested it against my frontend branch successfully.
- Otherwise we can test it after merging
- Make sure my logic makes sense

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Backend checklist**
- [ x ] Formatted my code by running `ruff check --select I --fix . && ruff check . --fix && ruff format .` in `app/backend`
- [ x ] All tests pass
- [ x ] Run the backend locally and it works

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
