### PR TITLE
Switch NotificationFeed to update via mutations

### DIFF
--- a/app/web/features/notifications/NotificationsFeed/NotificationItem.test.tsx
+++ b/app/web/features/notifications/NotificationsFeed/NotificationItem.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
+import mockRouter from "next-router-mock";
 import { service } from "service";
-import client from "service/client";
 import testNotifications from "test/fixtures/notifications.json";
 import { getHookWrapperWithClient } from "test/hookWrapper";
 import { listNotifications } from "test/serviceMockDefaults";
@@ -12,10 +12,9 @@ import NotificationItem from "./NotificationItem";
 
 jest.mock("service/client");
 
-const markNotificationSeenMock = client.notifications
-  .markNotificationSeen as jest.Mock<
-  ReturnType<typeof client.notifications.markNotificationSeen>,
-  Parameters<typeof client.notifications.markNotificationSeen>
+const markNotificationIsSeenMock = service.notifications
+  .markNotificationSeen as MockedService<
+  typeof service.notifications.markNotificationSeen
 >;
 
 const listNotificationsMock = service.notifications
@@ -27,11 +26,11 @@ const { wrapper } = getHookWrapperWithClient();
 
 describe("NotificationItem", () => {
   const mockOnClose = jest.fn();
-  const mockOnTouchedNotificationChange = jest.fn();
+  const onMarkIsSeenMock = jest.fn();
 
   beforeEach(() => {
     listNotificationsMock.mockImplementation(listNotifications);
-    markNotificationSeenMock.mockResolvedValue(new Empty());
+    markNotificationIsSeenMock.mockResolvedValue(new Empty());
 
     // Mocking XMLHttpRequest for Jest - this is the call for the avatar image
     global.XMLHttpRequest = jest.fn(() => ({
@@ -55,7 +54,7 @@ describe("NotificationItem", () => {
       <NotificationItem
         notification={testNotifications.notificationsList[0]}
         onClose={mockOnClose}
-        onTouchedNotificationChange={mockOnTouchedNotificationChange}
+        onMarkIsSeen={onMarkIsSeenMock}
       />,
       { wrapper },
     );
@@ -66,26 +65,76 @@ describe("NotificationItem", () => {
 
     await user.hover(notificationItem);
 
-    const markUnreadMenuButton = await screen.findByTestId(
+    const markUnreadMenuButtons = await screen.findAllByTestId(
       "mark-unread-menu-button",
     );
 
-    await user.click(markUnreadMenuButton);
+    await user.click(markUnreadMenuButtons[0]);
 
-    const markUnreadMenuItem = await screen.findByTestId(
+    const markUnreadMenuItems = await screen.findAllByTestId(
       "mark-unread-menu-item",
     );
 
-    await user.click(markUnreadMenuItem);
+    await user.click(markUnreadMenuItems[0]);
 
-    const callArg = markNotificationSeenMock.mock.calls[0][0];
-
-    expect(callArg.toObject()).toMatchObject({
+    expect(onMarkIsSeenMock).toHaveBeenCalledWith({
       notificationId: testNotifications.notificationsList[0].notificationId,
+      isSeen: false,
+    });
+  });
 
-      setSeen: false,
+  it("marks a single notification as seen when clicked", async () => {
+    render(
+      <NotificationItem
+        notification={testNotifications.notificationsList[1]}
+        onClose={mockOnClose}
+        onMarkIsSeen={onMarkIsSeenMock}
+      />,
+      { wrapper },
+    );
+
+    const notificationItem = await screen.findByTestId("notification-item");
+
+    const user = userEvent.setup();
+
+    await user.click(notificationItem);
+
+    expect(onMarkIsSeenMock).toHaveBeenCalledWith({
+      notificationId: testNotifications.notificationsList[1].notificationId,
+      isSeen: true,
+    });
+  });
+
+  it("calls onClose and routes to the notificationUrl when clicked", async () => {
+    mockRouter.setCurrentUrl("/");
+
+    render(
+      <NotificationItem
+        notification={testNotifications.notificationsList[0]}
+        onClose={mockOnClose}
+        onMarkIsSeen={onMarkIsSeenMock}
+      />,
+      { wrapper },
+    );
+
+    const notificationItem = await screen.findByTestId("notification-item");
+
+    const user = userEvent.setup();
+
+    await user.click(notificationItem);
+
+    expect(mockOnClose).toHaveBeenCalled();
+    expect(onMarkIsSeenMock).toHaveBeenCalledWith({
+      notificationId: testNotifications.notificationsList[0].notificationId,
+      isSeen: true,
     });
 
-    expect(mockOnTouchedNotificationChange).toHaveBeenCalled();
+    // gets the part of the URL after the domain
+    const expectedPath = testNotifications.notificationsList[0].url.replace(
+      /^https?:\/\/[^/]+|\/$/g,
+      "",
+    );
+
+    expect(mockRouter.pathname).toBe(expectedPath);
   });
 });

--- a/app/web/features/notifications/NotificationsFeed/NotificationItem.tsx
+++ b/app/web/features/notifications/NotificationsFeed/NotificationItem.tsx
@@ -15,7 +15,6 @@ import { useRouter } from "next/router";
 import { Notification } from "proto/notifications_pb";
 import { useState } from "react";
 import LinesEllipsis from "react-lines-ellipsis";
-import { markNotificationSeen } from "service/notifications";
 import { theme } from "theme";
 import { timestamp2Date } from "utils/date";
 import { timeAgoI18n } from "utils/timeAgo";
@@ -25,7 +24,10 @@ import { mapNotificationFeedTypeToIcon } from "../utils/constants";
 interface NotificationItemProps {
   notification: Notification.AsObject;
   onClose: () => void;
-  onTouchedNotificationChange: () => void;
+  onMarkIsSeen: (args: {
+    notificationId: Notification.AsObject["notificationId"];
+    isSeen: boolean;
+  }) => void;
 }
 
 const StyledMenuItem = styled(MenuItem)(({ theme }) => ({
@@ -70,7 +72,7 @@ const BottomRightIconWrapper = styled(Box)(({ theme }) => ({
 const NotificationItem = ({
   notification,
   onClose,
-  onTouchedNotificationChange,
+  onMarkIsSeen,
 }: NotificationItemProps) => {
   const { t } = useTranslation([GLOBAL]);
   const router = useRouter();
@@ -83,8 +85,11 @@ const NotificationItem = ({
 
   const userName = notification.title.split(" ")[0];
 
-  const handleMenuItemClick = async () => {
-    await markNotificationSeen(notification.notificationId);
+  const handleMenuItemClick = () => {
+    onMarkIsSeen({
+      notificationId: notification.notificationId,
+      isSeen: true,
+    });
     router.push(notification.url);
     onClose();
   };
@@ -103,13 +108,13 @@ const NotificationItem = ({
     setMarkUnseedMenuAnchorEl(null);
   };
 
-  const handleMarkItemUnread = async (
-    event: React.MouseEvent<HTMLLIElement>,
-  ) => {
+  const handleMarkItemUnread = (event: React.MouseEvent<HTMLLIElement>) => {
     event.stopPropagation();
     setMarkUnseedMenuAnchorEl(null);
-    await markNotificationSeen(notification.notificationId, false);
-    onTouchedNotificationChange();
+    onMarkIsSeen({
+      notificationId: notification.notificationId,
+      isSeen: false,
+    });
   };
 
   return (

--- a/app/web/features/notifications/NotificationsFeed/NotificationsFeed.test.tsx
+++ b/app/web/features/notifications/NotificationsFeed/NotificationsFeed.test.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import mockRouter from "next-router-mock";
 import { service } from "service";
-import client from "service/client";
 import { getHookWrapperWithClient } from "test/hookWrapper";
 import i18n from "test/i18n";
 import { listNotifications } from "test/serviceMockDefaults";
@@ -15,10 +14,9 @@ const { t } = i18n;
 
 jest.mock("service/client");
 
-const markNotificationSeenMock = client.notifications
-  .markNotificationSeen as jest.Mock<
-  ReturnType<typeof client.notifications.markNotificationSeen>,
-  Parameters<typeof client.notifications.markNotificationSeen>
+const markNotificationIsSeenMock = service.notifications
+  .markNotificationSeen as MockedService<
+  typeof service.notifications.markNotificationSeen
 >;
 
 const listNotificationsMock = service.notifications
@@ -26,9 +24,9 @@ const listNotificationsMock = service.notifications
   typeof service.notifications.listNotifications
 >;
 
-const markAllNotificationsSeenMock = client.notifications
+const markAllNotificationsIsSeenMock = service.notifications
   .markAllNotificationsSeen as MockedService<
-  typeof client.notifications.markAllNotificationsSeen
+  typeof service.notifications.markAllNotificationsSeen
 >;
 
 const { wrapper } = getHookWrapperWithClient();
@@ -38,8 +36,8 @@ describe("NotificationsFeed", () => {
 
   beforeEach(() => {
     listNotificationsMock.mockImplementation(listNotifications);
-    markNotificationSeenMock.mockResolvedValue(new Empty());
-    markAllNotificationsSeenMock.mockResolvedValue(new Empty());
+    markNotificationIsSeenMock.mockResolvedValue(new Empty());
+    markAllNotificationsIsSeenMock.mockResolvedValue(new Empty());
 
     // Mocking XMLHttpRequest for Jest - this is the call for the avatar image
     global.XMLHttpRequest = jest.fn(() => ({
@@ -75,36 +73,6 @@ describe("NotificationsFeed", () => {
     });
   });
 
-  it("marks single notification as seen when clicked", async () => {
-    const isNotSeenNotificationId = 2; // Assuming this is the ID of a notification that is not seen
-
-    render(
-      <NotificationsFeed
-        anchorEl={document.createElement("div")}
-        isOpen={true}
-        onClose={mockOnClose}
-      />,
-      { wrapper },
-    );
-
-    const notificationItem = await screen.findByText(
-      "You have unseen messages on Couchers.org",
-    );
-
-    await userEvent.click(notificationItem);
-
-    const callArg = markNotificationSeenMock.mock.calls[0][0];
-
-    expect(callArg.toObject()).toMatchObject({
-      notificationId: isNotSeenNotificationId,
-      setSeen: true,
-    });
-
-    expect(mockRouter.pathname).toBe("/messages");
-
-    expect(mockOnClose).toHaveBeenCalled();
-  });
-
   it("marks all notifications as seen when 'Mark all as read' is clicked", async () => {
     const latestNotificationId = 1;
 
@@ -131,13 +99,9 @@ describe("NotificationsFeed", () => {
 
     await userEvent.click(markAllReadButton);
 
-    expect(markAllNotificationsSeenMock).toHaveBeenCalledTimes(1);
-
-    const callArg = markAllNotificationsSeenMock.mock.calls[0][0];
-
-    expect(callArg.toObject()).toMatchObject({
+    expect(markAllNotificationsIsSeenMock).toHaveBeenCalledWith(
       latestNotificationId,
-    });
+    );
   });
 
   it("navigates to notification settings when 'Notification Settings' is clicked", async () => {

--- a/app/web/features/notifications/NotificationsFeed/NotificationsFeed.tsx
+++ b/app/web/features/notifications/NotificationsFeed/NotificationsFeed.tsx
@@ -19,9 +19,12 @@ import { useState } from "react";
 import { useQuery } from "react-query";
 import { notificationSettingsRoute } from "routes";
 import { service } from "service";
-import { markAllNotificationsSeen } from "service/notifications";
 import { theme } from "theme";
 
+import {
+  useMarkAllNotificationsSeen,
+  useMarkSingleNotificationIsSeen,
+} from "../utils/helpers";
 import NotificationItem from "./NotificationItem";
 
 interface NotificationsFeedProps {
@@ -72,16 +75,27 @@ const NotificationsFeed = ({
 
   const isInternalMenuOpen = Boolean(internalMenuAnchorEl);
 
-  const { data, error, isRefetching, isLoading, refetch } = useQuery<
+  const { data, error, isRefetching, isLoading } = useQuery<
     ListNotificationsRes.AsObject,
     RpcError
   >({
-    queryKey: [listNotificationsQueryKey, notificationsFilter],
+    queryKey: listNotificationsQueryKey,
     queryFn: () =>
       service.notifications.listNotifications({
         onlyUnread: notificationsFilter === "unread",
       }),
   });
+
+  const {
+    error: markAllNotificationsSeenError,
+    markAllNotificationsSeenMutation,
+    isLoading: isMarkingAllSeen,
+  } = useMarkAllNotificationsSeen();
+
+  const {
+    error: markSingleNotificationIsSeenError,
+    markSingleNotificationIsSeenMutation,
+  } = useMarkSingleNotificationIsSeen();
 
   const handleNotificationSettingsClick = () => {
     router.push(notificationSettingsRoute);
@@ -93,19 +107,13 @@ const NotificationsFeed = ({
   ) => {
     event.stopPropagation();
 
-    try {
-      const lastestNotificationId =
-        data?.notificationsList?.[0]?.notificationId;
+    const latestNotificationId = data?.notificationsList?.[0]?.notificationId;
 
-      if (!lastestNotificationId) return;
+    if (!latestNotificationId) return;
 
-      setInternalMenuAnchorEl(null);
+    setInternalMenuAnchorEl(null);
 
-      await markAllNotificationsSeen(lastestNotificationId);
-      refetch();
-    } catch (e) {
-      console.error("Error marking all notifications as seen", e);
-    }
+    markAllNotificationsSeenMutation({ latestNotificationId });
   };
 
   const handleInternalMenuOpen = (
@@ -268,7 +276,7 @@ const NotificationsFeed = ({
         </StyledPills>
       </TopContentWrapper>
       <NotificationsListWrapper>
-        {isLoading && !isRefetching ? (
+        {(isLoading || isMarkingAllSeen) && !isRefetching ? (
           <CenteredSpinner />
         ) : (
           <>
@@ -277,6 +285,12 @@ const NotificationsFeed = ({
                 {t("notifications:error_loading")}
               </Alert>
             )}
+            {markAllNotificationsSeenError ||
+              (markSingleNotificationIsSeenError && (
+                <Alert severity="error" sx={{ marginBottom: theme.spacing(2) }}>
+                  {t("notifications:error_updating_notifications")}
+                </Alert>
+              ))}
 
             {(data?.notificationsList ?? []).length > 0 ? (
               data?.notificationsList.map((notification) => (
@@ -284,7 +298,7 @@ const NotificationsFeed = ({
                   key={notification.notificationId}
                   notification={notification}
                   onClose={onClose}
-                  onTouchedNotificationChange={refetch}
+                  onMarkIsSeen={markSingleNotificationIsSeenMutation}
                 />
               ))
             ) : (

--- a/app/web/features/notifications/locales/en.json
+++ b/app/web/features/notifications/locales/en.json
@@ -2,6 +2,7 @@
   "all": "All",
   "unread": "Unread",
   "error_loading": "Error loading notifications",
+  "error_updating_notifications": "Error updating notifications",
   "mark_unread": "Mark unread",
   "mark_all_read": "Mark all as read",
   "no_new_notifications": "No new notifications",

--- a/app/web/features/notifications/utils/helpers.ts
+++ b/app/web/features/notifications/utils/helpers.ts
@@ -1,4 +1,8 @@
+import { listNotificationsQueryKey } from "features/queryKeys";
 import Sentry from "platform/sentry";
+import { ListNotificationsRes } from "proto/notifications_pb";
+import { useMutation, useQueryClient } from "react-query";
+import { service } from "service";
 import {
   getVapidPublicKey,
   registerPushNotificationSubscription,
@@ -142,4 +146,111 @@ export const turnPushNotificationsOff = async () => {
     return true;
   }
   return false;
+};
+
+export const useMarkAllNotificationsSeen = () => {
+  const queryClient = useQueryClient();
+
+  const { error, mutate, isLoading } = useMutation({
+    mutationFn: async ({
+      latestNotificationId,
+    }: {
+      latestNotificationId: number;
+    }) =>
+      await service.notifications.markAllNotificationsSeen(
+        latestNotificationId,
+      ),
+    onMutate: () => {
+      queryClient.cancelQueries(listNotificationsQueryKey);
+
+      const previousData =
+        queryClient.getQueryData<ListNotificationsRes.AsObject>(
+          listNotificationsQueryKey,
+        );
+
+      const newData: ListNotificationsRes.AsObject = {
+        ...previousData,
+        notificationsList: previousData?.notificationsList
+          ? previousData.notificationsList.map((notification) => ({
+              ...notification,
+              isSeen: true,
+            }))
+          : [],
+        nextPageToken: previousData?.nextPageToken ?? "",
+      };
+
+      if (previousData) {
+        queryClient.setQueryData<ListNotificationsRes.AsObject>(
+          listNotificationsQueryKey,
+          newData,
+        );
+      }
+
+      return { previousData };
+    },
+    onError: (error) => {
+      Sentry.captureException(error, {
+        tags: {
+          component: "useMarkAllNotificationsSeen",
+          action: "onMutate",
+        },
+      });
+    },
+  });
+
+  return { error, markAllNotificationsSeenMutation: mutate, isLoading };
+};
+
+export const useMarkSingleNotificationIsSeen = () => {
+  const queryClient = useQueryClient();
+
+  const { error, mutate, isLoading } = useMutation({
+    mutationFn: async ({
+      notificationId,
+      isSeen,
+    }: {
+      notificationId: number;
+      isSeen: boolean;
+    }) =>
+      await service.notifications.markNotificationSeen(notificationId, isSeen),
+    onMutate: ({ notificationId, isSeen }) => {
+      queryClient.cancelQueries(listNotificationsQueryKey);
+
+      const previousData =
+        queryClient.getQueryData<ListNotificationsRes.AsObject>(
+          listNotificationsQueryKey,
+        );
+
+      const newData: ListNotificationsRes.AsObject = {
+        ...previousData,
+        notificationsList: previousData?.notificationsList
+          ? previousData.notificationsList.map((notification) =>
+              notification.notificationId === notificationId
+                ? { ...notification, isSeen: isSeen }
+                : notification,
+            )
+          : [],
+        nextPageToken: previousData?.nextPageToken ?? "",
+      };
+
+      if (previousData) {
+        queryClient.setQueryData<ListNotificationsRes.AsObject>(
+          listNotificationsQueryKey,
+          newData,
+        );
+      }
+
+      return { previousData };
+    },
+    onError: (error) => {
+      Sentry.captureException(error, {
+        tags: {
+          component: "useMarkSingleNotificationSeen",
+          action: "onMutate",
+        },
+      });
+    },
+  });
+
+  return { error, markSingleNotificationIsSeenMutation: mutate, isLoading };
 };

--- a/app/web/test/fixtures/notifications.json
+++ b/app/web/test/fixtures/notifications.json
@@ -11,7 +11,7 @@
       "notificationId": 1,
       "title": "Keanu Reeves wants to be your friend",
       "topic": "friend_request",
-      "url": "https://locathost:3000/connections/friends/"
+      "url": "https://localhost:3000/connections/friends/"
     },
     {
       "action": "missed_messages",


### PR DESCRIPTION
Closes #6056 
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
**Please give clear steps for how the reviewer can best test this PR**

Please include any necessary dev environment, .env, etc. adjustments.

- Mark a notification unread, you should see it change right away
- Mark notification as read by clicking on it (it will go to stage)
- Go back to previous page
- Open notifications feed and check that notification is marked read
- Mark all notifications as read via top right menu
- They should quickly change

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [ x ] Formatted my code with `yarn format`
- [ x ] There are no warnings from `yarn lint --fix`
- [ x ] There are no console warnings when running the app
- [ x ] Added tests where relevant
- [ x ] All tests pass
- [ x ] Clicked around my changes running locally and it works
- [ x ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
