### PR TITLE
Update backend cookie logic to work better on dev

### DIFF
--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -224,8 +224,13 @@ def _create_tasty_cookie(name: str, value, expiry: datetime, httponly: bool):
     cookie.set(name, str(value), str(value))
     # tell the browser when to stop sending the cookie
     cookie["expires"] = http_date(expiry)
-    # restrict to our domain, note if there's no domain, it won't include subdomains
-    cookie["domain"] = config["COOKIE_DOMAIN"]
+    # Set the cookie domain explicitly if configured.
+    # - If COOKIE_DOMAIN is set (e.g., "couchers.org"), the cookie is sent to that domain and its subdomains.
+    # - If COOKIE_DOMAIN is unset or blank, the cookie defaults to the host that set it (e.g., "localhost" during dev),
+    # which avoids browser rejections (since "localhost" is not a valid cookie domain).
+    # - Limiting the domain to the root domain (e.g., "couchers.org") ensures cookies are shared across subdomains when necessary.
+    if config["COOKIE_DOMAIN"]:
+        cookie["domain"] = config["COOKIE_DOMAIN"]
     # path so that it's accessible for all API requests, otherwise defaults to something like /org.couchers.auth/
     cookie["path"] = "/"
     if config["DEV"]:


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

This PR updates the `_create_tasty_cookie` utility to only set the domain attribute on cookies when `COOKIE_DOMAIN` is explicitly configured.

Setting the domain to something like localhost (commonly configured in dev) makes the cookie invalid and causes it to be rejected by browsers.

By not setting the domain when unnecessary, cookies will still work on localhost, Vercel preview URLs, and other dynamic environments.

This improves reliability of cookie-based features (e.g., language preference, session management) in development and staging, while preserving cross-subdomain support in production.

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Backend checklist**
- [ x ] Formatted my code by running `ruff check --select I --fix . && ruff check . --fix && ruff format .` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ x ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
