### PR TITLE
feat(events): added optional should_notify flag in UpdateEventReq, updated proto.

### DIFF
--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -674,17 +674,20 @@ class Events(events_pb2_grpc.EventsServicer):
         session.flush()
 
         if notify_updated:
-            logger.info(f"Fields {','.join(notify_updated)} updated in event {event.id=}, notifying")
+            if request.should_notify:
+                logger.info(f"Fields {','.join(notify_updated)} updated in event {event.id=}, notifying")
 
-            queue_job(
-                session,
-                "generate_event_update_notifications",
-                payload=jobs_pb2.GenerateEventUpdateNotificationsPayload(
-                    updating_user_id=user.id,
-                    occurrence_id=occurrence.id,
-                    updated_items=notify_updated,
-                ),
-            )
+                queue_job(
+                    session,
+                    "generate_event_update_notifications",
+                    payload=jobs_pb2.GenerateEventUpdateNotificationsPayload(
+                        updating_user_id=user.id,
+                        occurrence_id=occurrence.id,
+                        updated_items=notify_updated,
+                    ),
+                )
+            else:
+                logger.info(f"Fields {','.join(notify_updated)} updated in event {event.id=}, but skipping notifications")
 
         # since we have synchronize_session=False, we have to refresh the object
         session.refresh(occurrence)

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -687,7 +687,9 @@ class Events(events_pb2_grpc.EventsServicer):
                     ),
                 )
             else:
-                logger.info(f"Fields {','.join(notify_updated)} updated in event {event.id=}, but skipping notifications")
+                logger.info(
+                    f"Fields {','.join(notify_updated)} updated in event {event.id=}, but skipping notifications"
+                )
 
         # since we have synchronize_session=False, we have to refresh the object
         session.refresh(occurrence)

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -8,7 +8,7 @@ from sqlalchemy.sql.expression import update
 
 from couchers import errors
 from couchers.db import session_scope
-from couchers.models import EventOccurrence
+from couchers.models import BackgroundJob, EventOccurrence
 from couchers.tasks import enforce_community_memberships
 from couchers.utils import Timestamp_from_datetime, now, to_aware_datetime
 from proto import admin_pb2, events_pb2, threads_pb2
@@ -2362,3 +2362,62 @@ def test_community_invite_requests(db):
             api.RequestCommunityInvite(events_pb2.RequestCommunityInviteReq(event_id=event_id))
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
         assert e.value.details() == errors.EVENT_COMMUNITY_INVITE_ALREADY_APPROVED
+
+
+def test_update_event_should_notify_queues_job():
+    user, token = generate_user()
+    start = now()
+
+    with session_scope() as session:
+        c_id = create_community(session, 0, 2, "Community", [user], [], None).id
+
+    # create an event
+    with events_session(token) as api:
+        create_res = api.CreateEvent(
+            events_pb2.CreateEventReq(
+                title="Dummy Title",
+                content="Dummy content.",
+                parent_community_id=c_id,
+                offline_information=events_pb2.OfflineEventInformation(
+                    address="https://couchers.org/meet/",
+                    lat=1.0,
+                    lng=2.0,
+                ),
+                start_time=Timestamp_from_datetime(start + timedelta(hours=3)),
+                end_time=Timestamp_from_datetime(start + timedelta(hours=6)),
+                timezone="UTC",
+            )
+        )
+
+        event_id = create_res.event_id
+
+    # measure initial background job queue length
+    with session_scope() as session:
+        jobs = session.query(BackgroundJob).all()
+        job_length_before_update = len(jobs)
+
+    # update with should_notify=False, expect no change in background job queue
+    api.UpdateEvent(
+        events_pb2.UpdateEventReq(
+            event_id=event_id,
+            start_time=Timestamp_from_datetime(start + timedelta(hours=4)),
+            should_notify=False,
+        )
+    )
+
+    with session_scope() as session:
+        jobs = session.query(BackgroundJob).all()
+        assert len(jobs) == job_length_before_update
+
+    # update with should_notify=True, expect one new background job added
+    api.UpdateEvent(
+        events_pb2.UpdateEventReq(
+            event_id=event_id,
+            start_time=Timestamp_from_datetime(start + timedelta(hours=4)),
+            should_notify=True,
+        )
+    )
+
+    with session_scope() as session:
+        jobs = session.query(BackgroundJob).all()
+        assert len(jobs) == job_length_before_update + 1

--- a/app/proto/events.proto
+++ b/app/proto/events.proto
@@ -212,7 +212,7 @@ message UpdateEventReq {
   google.protobuf.StringValue timezone = 11;
 
   // whether to notify all attendees about the change
-  optional bool should_notify = 12;
+  bool should_notify = 12;
 }
 
 message GetEventReq {

--- a/app/proto/events.proto
+++ b/app/proto/events.proto
@@ -212,7 +212,7 @@ message UpdateEventReq {
   google.protobuf.StringValue timezone = 11;
 
   // whether to notify all attendees about the change
-  // bool notify_attendees = 12;
+  optional bool should_notify = 12;
 }
 
 message GetEventReq {


### PR DESCRIPTION
Description

Fixed logic in UpdateEvent to handle should_notify correctly and adjusted handling of UpdateEventReq in the backend service.
Also updated the proto definition to reflect the new optional flag.
Closes #4414

Basic functionality is unchanged: if the value is missing or set to true, notifications are sent. Only if the value is explicitly false, no notification is sent. Because of this, additional tests may not be necessary.

How to test
    1. Send a valid UpdateEventReq with different values for should_notify using Kreya or gRPCurl.
    2. Confirm expected behavior:
        ◦ If should_notify=true or the field is not provided, a notification email is triggered.
        ◦ If should_notify=false, no notification is sent.
    3. Check the logs or the database to verify that the event was updated correctly.
    4. (Optional) Log in as another user and verify the changes.