### PR TITLE
Fix new report event placeholder image style

### DIFF
--- a/app/web/features/communities/events/LongEventCard.tsx
+++ b/app/web/features/communities/events/LongEventCard.tsx
@@ -127,15 +127,11 @@ const LongEventCard = ({
           component="img"
           image={event.photoUrl || eventImagePlaceholderUrl}
           title={event.title}
-          sx={(theme) => ({
-            height: theme.spacing(20),
+          sx={{
+            height: "100%",
             width: "25%",
-            objectFit: "cover",
-            [theme.breakpoints.down("sm")]: {
-              width: "100%",
-              height: theme.spacing(25),
-            },
-          })}
+            objectFit: "fill",
+          }}
         />
         <FlagWrapper>
           <FlagButton


### PR DESCRIPTION
Hey @ColleenLillian this will fix the image issue, don't wanna make you keeping going back-and-forth! I just copied and pasted the old style from the previous `useStyles` here. Probably something just got changed while updating the styled component.

If you're happy with it, feel free to approve and merge, it will merge into your existing PR.