### PR TITLE
Fix scroll to middle issue

### DIFF
--- a/app/web/components/AppRoute.tsx
+++ b/app/web/components/AppRoute.tsx
@@ -7,7 +7,7 @@ import Footer from "components/Footer";
 import { useAuthContext } from "features/auth/AuthProvider";
 import { useRouter } from "next/router";
 import { useIsNativeEmbed } from "platform/nativeLink";
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useEffect, useRef, useState } from "react";
 import { jailRoute, loginRoute } from "routes";
 
 import Navigation from "./Navigation";
@@ -72,6 +72,7 @@ export default function AppRoute({
   variant = "standard",
 }: AppRouteProps) {
   const router = useRouter();
+  const pageWrapperRef = useRef<HTMLDivElement>(null);
   const { pathname } = router;
   const { authState, authActions } = useAuthContext();
   const isAuthenticated = authState.authenticated;
@@ -94,6 +95,12 @@ export default function AppRoute({
     }
   }, [isAuthenticated, isJailed, isPrivate, authActions, router, pathname]);
 
+  useEffect(() => {
+    if (pageWrapperRef.current) {
+      pageWrapperRef.current.scrollTo(0, 0);
+    }
+  }, [router.asPath]); // scroll to top on route change
+
   return (
     <ErrorBoundary>
       {isPrivate && (!isMounted || !isAuthenticated) ? (
@@ -105,7 +112,7 @@ export default function AppRoute({
           {/* Temporary container injected for marketing to test dynamic "announcements".
            * Find a better spot to componentise this code once plan is more finalised with this */}
           <div id="announcements"></div>
-          <PageWrapper>
+          <PageWrapper ref={pageWrapperRef}>
             <ContentWrapper
               disableGutters
               isNativeEmbed={isNativeEmbed}


### PR DESCRIPTION
Closes #5991 

<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
**Please give clear steps for how the reviewer can best test this PR**

Please include any necessary dev environment, .env, etc. adjustments.

- Go click the footer links and make sure all of them load at the top
- Click around some other stuff, make sure nothing is broken

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->

Why was this happening? When I originally did the fixes to the app layout, I added `overflow: auto` to `PageWrapper` to prevent the NavigationBar from scrolling.

This is fine and standard, but it triggers a pitfall of Next.js, where it stops handling the scrolling since it's being handles in a component.

The fix is to tell it manually to scroll to the top in a ref on `PageWrapper` in `AppRoute`.

**Web frontend checklist**
- [ x ] Formatted my code with `yarn format`
- [ x ] There are no warnings from `yarn lint --fix`
- [ x ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ x ] All tests pass
- [ x ] Clicked around my changes running locally and it works
- [ x ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
