### PR TITLE
Add locales to markdown static paths

### DIFF
--- a/app/web/pages/[...slug].tsx
+++ b/app/web/pages/[...slug].tsx
@@ -6,21 +6,21 @@ import { AUTH, GLOBAL, NOTIFICATIONS } from "i18n/namespaces";
 import { GetStaticPaths, GetStaticProps } from "next";
 import nextI18nextConfig from "next-i18next.config";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { getAllMarkdownSlugs } from "utils/markdownPages";
+import { getAllMarkdownPathsWithLocales } from "utils/markdownPages";
 
-export async function getMarkdownPageBySlug(
+async function getMarkdownPageBySlug(
   slug: Array<string>,
 ): Promise<MarkdownPageProps> {
   const md = await import(`markdown/${slug.join("/")}.md`);
   return {
-    slug: slug,
+    slug,
     frontmatter: md.attributes,
     content: md.html,
   };
 }
 
 export const getStaticPaths: GetStaticPaths = () => ({
-  paths: getAllMarkdownSlugs().map((slug) => ({ params: { slug } })),
+  paths: getAllMarkdownPathsWithLocales(),
   fallback: false,
 });
 

--- a/app/web/utils/markdownPages.ts
+++ b/app/web/utils/markdownPages.ts
@@ -1,4 +1,5 @@
 import { glob } from "glob";
+import { allLanguages } from "i18n/allLanguages";
 
 export function getAllMarkdownFiles(): Array<string> {
   return glob.sync("markdown/**/*.md");
@@ -22,6 +23,25 @@ export function filenameToSlug(filename: string) {
     .split("/");
 }
 
-export function getAllMarkdownSlugs(): Array<Array<string>> {
-  return getAllMarkdownFiles().map(filenameToSlug);
+export function getAllMarkdownPathsWithLocales(): {
+  params: { slug: string[] };
+  locale: string;
+}[] {
+  const baseSlugs = getAllMarkdownFiles().map(filenameToSlug);
+
+  // console.log("Base slugs:", baseSlugs);
+
+  // Combine each slug with all languages
+  const paths = [];
+
+  for (const lang of allLanguages) {
+    for (const slug of baseSlugs) {
+      // console.log("Combining language", lang, "with slug", slug);
+      paths.push({ params: { slug }, locale: lang });
+    }
+  }
+
+  // console.log("Localized slugs:", localizedSlugs);
+
+  return paths;
 }

--- a/app/web/utils/markdownPages.ts
+++ b/app/web/utils/markdownPages.ts
@@ -23,25 +23,21 @@ export function filenameToSlug(filename: string) {
     .split("/");
 }
 
+// From Next.js documentation:
+// https://nextjs.org/docs/pages/guides/internationalization#how-does-this-work-with-static-generation
 export function getAllMarkdownPathsWithLocales(): {
   params: { slug: string[] };
   locale: string;
 }[] {
   const baseSlugs = getAllMarkdownFiles().map(filenameToSlug);
 
-  // console.log("Base slugs:", baseSlugs);
-
-  // Combine each slug with all languages
   const paths = [];
 
   for (const lang of allLanguages) {
     for (const slug of baseSlugs) {
-      // console.log("Combining language", lang, "with slug", slug);
       paths.push({ params: { slug }, locale: lang });
     }
   }
-
-  // console.log("Localized slugs:", localizedSlugs);
 
   return paths;
 }


### PR DESCRIPTION
Closes #6223 

Markdown pages were all giving a 404 when another language is selected. This fixes it.

<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
**Please give clear steps for how the reviewer can best test this PR**

Please include any necessary dev environment, .env, etc. adjustments.

- Go to the markdown pages: blog, mission, terms, faq, most of the links in the footer - they should work
- Change the language to something else
- Those pages should still work (they will default to english)

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [ x ] Formatted my code with `yarn format`
- [ x ] There are no warnings from `yarn lint --fix`
- [ x ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ x ] All tests pass
- [ x ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
