### PR TITLE
Fix mission bubble point

### DIFF
--- a/app/web/features/landing/CouchersMission.tsx
+++ b/app/web/features/landing/CouchersMission.tsx
@@ -173,7 +173,6 @@ const CouchersMission = () => {
             gap: 2,
             justifyContent: { xs: "flex-start", md: "center" },
             overflowX: { xs: "auto", md: "visible" },
-            overflowY: "hidden",
             flexWrap: { xs: "nowrap", md: "wrap" },
             WebkitOverflowScrolling: "touch",
             width: "100%",


### PR DESCRIPTION
I accidentally covered the point for the selected mission bubble on desktop by adding overflowY hidden. Fixing it.