### PR TITLE
More landing page design fixes

### DIFF
--- a/app/web/components/StaticMap.tsx
+++ b/app/web/components/StaticMap.tsx
@@ -26,6 +26,10 @@ const MapWrapper = styled("div")(({ theme }) => ({
   position: "relative",
   borderRadius: "10px",
   overflow: "hidden",
+
+  [theme.breakpoints.down("md")]: {
+    height: 350,
+  },
 }));
 
 const StaticMap = () => {
@@ -60,6 +64,7 @@ const StaticMap = () => {
         ref={mapRef}
         onLoad={onLoad}
         scrollZoom={false}
+        {...(isMobile && { attributionControl: false })}
       >
         <Source
           id={USERS_SOURCE_ID}

--- a/app/web/features/auth/signup/SignupFormContent.tsx
+++ b/app/web/features/auth/signup/SignupFormContent.tsx
@@ -53,7 +53,11 @@ export default function SignupFormContent() {
         <Typography gutterBottom sx={{ marginBottom: 2 }}>
           <Trans
             i18nKey="landing:signup_description"
-            values={{ user_count: signupInfo?.userCount || "56k" }}
+            values={{
+              user_count: signupInfo?.userCount
+                ? Number(signupInfo.userCount).toLocaleString()
+                : "56k+",
+            }}
             components={{
               2: <Link href={baseRoute} underline="hover" />,
             }}

--- a/app/web/features/landing/SocialProof.tsx
+++ b/app/web/features/landing/SocialProof.tsx
@@ -105,7 +105,9 @@ const SocialProof = () => {
           ) : (
             <Typography sx={{ fontSize: "1.5rem", fontWeight: 500 }}>
               {t("landing:num_users", {
-                numUsers: signupInfo?.userCount || "56k+",
+                numUsers: signupInfo?.userCount
+                  ? Number(signupInfo.userCount).toLocaleString()
+                  : "56k+",
               })}
             </Typography>
           )}


### PR DESCRIPTION
- Remove Couchers map attribution on mobile to save space
- Make map smaller on mobile
- Add commas to userCount number, e.g. "56,232 members" instead of "56232 members".