### PR TITLE
Revert dashboard news

### DIFF
--- a/app/web/dashboardNews.json
+++ b/app/web/dashboardNews.json
@@ -1,8 +1,4 @@
 {
-  "2025-07-01": {
-    "title": "Exciting news! Couchers.org version 1.0 released—we're officially out of beta!",
-    "link": "https://couchers.org/blog/2025/07/01/releasing-couchers-v1"
-  },
   "2025-05-26": "It's now possible to block users and remove friends via your \"My connections\" page in your profile.",
   "2025-05-12": {
     "title": "Couchers.org v0.9.9 Released",

--- a/app/web/features/dashboard/Dashboard.tsx
+++ b/app/web/features/dashboard/Dashboard.tsx
@@ -45,10 +45,22 @@ export default function Dashboard() {
 
             <Alert severity="info" sx={{ marginBottom: theme.spacing(2) }}>
               <Typography variant="body1">
+                <b>New Release Alert!</b> {dashboardNews["2025-05-26"]}
+              </Typography>
+            </Alert>
+
+            <Alert severity="info" sx={{ marginBottom: theme.spacing(2) }}>
+              <Typography variant="body1">
                 <b>New Blog Post!</b> Read it here:{" "}
-                <StyledLink href={dashboardNews["2025-07-01"].link}>
-                  {dashboardNews["2025-07-01"].title}
+                <StyledLink href={dashboardNews["2025-05-12"].link}>
+                  {dashboardNews["2025-05-12"].title}
                 </StyledLink>
+              </Typography>
+            </Alert>
+
+            <Alert severity="info" sx={{ marginBottom: theme.spacing(2) }}>
+              <Typography variant="body1">
+                <b>New Release Alert!</b> {dashboardNews["2025-04-24"]}
               </Typography>
             </Alert>
 


### PR DESCRIPTION
So we can deploy the new landing page first, see Slack post.

I've moved the patch instead to #6240 