### PR TITLE
Use high-res (full) avatar image in profile

### DIFF
--- a/app/web/components/Avatar/Avatar.tsx
+++ b/app/web/components/Avatar/Avatar.tsx
@@ -6,6 +6,31 @@ import { routeToUser } from "routes";
 
 import { getProfileLinkA11yLabel } from "./constants";
 
+type UserWithAvatarUrl = Pick<
+  LiteUser.AsObject,
+  "username" | "name" | "avatarUrl"
+>;
+type UserWithAvatarThumbnailUrl = Pick<
+  LiteUser.AsObject,
+  "username" | "name" | "avatarThumbnailUrl"
+>;
+interface AvatarPropsHighRes {
+  children?: React.ReactNode;
+  highRes?: true;
+  user?: UserWithAvatarUrl;
+  grow?: boolean;
+  className?: string;
+  isProfileLink?: boolean;
+  style?: React.CSSProperties;
+  openInNewTab?: boolean;
+}
+
+interface AvatarPropsLowRes
+  extends Omit<AvatarPropsHighRes, "highRes" | "user"> {
+  highRes?: false | undefined;
+  user?: UserWithAvatarThumbnailUrl;
+}
+
 const StyledWrapper = styled("div")<{
   isDefaultSize: boolean;
   grow: boolean | undefined;
@@ -31,20 +56,6 @@ const StyledMuiAvatar = styled(MuiAvatar)(() => ({
   maxHeight: "18rem",
 }));
 
-export interface AvatarProps {
-  children?: React.ReactNode;
-  user?: Pick<
-    LiteUser.AsObject,
-    "username" | "name" | "avatarUrl" | "avatarThumbnailUrl"
-  >;
-  highRes?: boolean;
-  grow?: boolean;
-  className?: string;
-  isProfileLink?: boolean;
-  style?: React.CSSProperties;
-  openInNewTab?: boolean;
-}
-
 export default function Avatar({
   user,
   highRes,
@@ -53,7 +64,7 @@ export default function Avatar({
   isProfileLink = true,
   openInNewTab = false,
   ...otherProps
-}: AvatarProps) {
+}: AvatarPropsHighRes | AvatarPropsLowRes) {
   return (
     <StyledWrapper
       isDefaultSize={!className}
@@ -70,7 +81,11 @@ export default function Avatar({
           >
             <StyledMuiAvatar
               alt={user.name}
-              src={!!highRes ? user.avatarUrl : user.avatarThumbnailUrl}
+              src={
+                !!highRes
+                  ? (user as UserWithAvatarUrl).avatarUrl
+                  : (user as UserWithAvatarThumbnailUrl).avatarThumbnailUrl
+              }
             >
               {user.name.split(/\s+/).map((name) => name[0])}
             </StyledMuiAvatar>
@@ -78,7 +93,11 @@ export default function Avatar({
         ) : (
           <StyledMuiAvatar
             alt={user.name}
-            src={!!highRes ? user.avatarUrl : user.avatarThumbnailUrl}
+            src={
+              !!highRes
+                ? (user as UserWithAvatarUrl).avatarUrl
+                : (user as UserWithAvatarThumbnailUrl).avatarThumbnailUrl
+            }
           >
             {user.name.split(/\s+/).map((name) => name[0])}
           </StyledMuiAvatar>

--- a/app/web/components/Avatar/Avatar.tsx
+++ b/app/web/components/Avatar/Avatar.tsx
@@ -33,7 +33,11 @@ const StyledMuiAvatar = styled(MuiAvatar)(() => ({
 
 export interface AvatarProps {
   children?: React.ReactNode;
-  user?: Pick<LiteUser.AsObject, "username" | "name" | "avatarThumbnailUrl">;
+  user?: Pick<
+    LiteUser.AsObject,
+    "username" | "name" | "avatarUrl" | "avatarThumbnailUrl"
+  >;
+  highRes?: boolean;
   grow?: boolean;
   className?: string;
   isProfileLink?: boolean;
@@ -43,6 +47,7 @@ export interface AvatarProps {
 
 export default function Avatar({
   user,
+  highRes,
   grow,
   className,
   isProfileLink = true,
@@ -63,12 +68,18 @@ export default function Avatar({
             aria-label={getProfileLinkA11yLabel(user.name)}
             target={openInNewTab ? "_blank" : undefined}
           >
-            <StyledMuiAvatar alt={user.name} src={user.avatarThumbnailUrl}>
+            <StyledMuiAvatar
+              alt={user.name}
+              src={!!highRes ? user.avatarUrl : user.avatarThumbnailUrl}
+            >
               {user.name.split(/\s+/).map((name) => name[0])}
             </StyledMuiAvatar>
           </StyledLink>
         ) : (
-          <StyledMuiAvatar alt={user.name} src={user.avatarThumbnailUrl}>
+          <StyledMuiAvatar
+            alt={user.name}
+            src={!!highRes ? user.avatarUrl : user.avatarThumbnailUrl}
+          >
             {user.name.split(/\s+/).map((name) => name[0])}
           </StyledMuiAvatar>
         )

--- a/app/web/features/dashboard/MinimalUserProfileCard.tsx
+++ b/app/web/features/dashboard/MinimalUserProfileCard.tsx
@@ -31,7 +31,7 @@ export default function MinimalUserProfileCard({
   const classes = useStyles();
   return (
     <Card className={classes.container}>
-      <Avatar user={user} />
+      <Avatar user={user} highRes />
       <div className={classes.textFieldsContainer}>
         <div>
           <Typography noWrap align="right">

--- a/app/web/features/profile/view/UserOverview.tsx
+++ b/app/web/features/profile/view/UserOverview.tsx
@@ -94,7 +94,7 @@ export default function UserOverview({
   return (
     <Card className={classes.card}>
       <div className={classes.avatarContainer}>
-        <Avatar user={user} grow />
+        <Avatar user={user} highRes grow />
       </div>
 
       <div className={classes.wrapper}>


### PR DESCRIPTION
Closes #6135

On prod:

![image](https://github.com/user-attachments/assets/4d0d72a6-434e-4766-9543-891e53a98c3b)

This branch:

![image](https://github.com/user-attachments/assets/8ea62ac3-595b-4f83-b89c-67b5949e97cb)


<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
**Please give clear steps for how the reviewer can best test this PR**

Please include any necessary dev environment, .env, etc. adjustments.

- Make sure everything builds and passes TS checks/tests
- Go to someone's profile and make sure their avatar loads in full res
- (Optional) go to the map page, open network tools, load a user list and make sure those avatars are loaded with the `thumbnail` URL

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Backend checklist**
- [ ] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [ ] Formatted my code with `yarn format`
- [ ] There are no warnings from `yarn lint --fix`
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
