### PR TITLE
Fix cookie banner overlap issue

### DIFF
--- a/app/web/components/CookieBanner.tsx
+++ b/app/web/components/CookieBanner.tsx
@@ -14,10 +14,11 @@ const StyledWrapper = styled("div")(({ theme }) => ({
   zIndex: theme.zIndex.snackbar,
   left: theme.spacing(0),
   right: theme.spacing(0),
-  transform: "translateY(-100%)",
   backgroundColor: theme.palette.primary.contrastText,
-  top: "100vh",
+  bottom: 0,
   padding: theme.spacing(2, 4),
+  boxShadow: `0 -1px 4px ${theme.palette.primary.dark}33`,
+
   "& .content": {
     width: "75%",
     margin: "0 auto",
@@ -52,7 +53,7 @@ export default function CookieBanner() {
         <CloseIcon />
       </StyledCloseButton>
       <div className="content">
-        <Typography variant="body1">
+        <Typography variant="body2">
           <Trans t={t} i18nKey="cookie_message">
             We use cookies to ensure that we give you the best experience on our
             website. If you continue to use this site, we will assume that you


### PR DESCRIPTION
<!---
Please describe the pull request below.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

I also made the font smaller. Especially for mobile it took up a lot of space.

**Please give clear steps for how the reviewer can best test this PR**

Please include any necessary dev environment, .env, etc. adjustments.

- This only shows on the real phone, not the chrome dev simulator
- You can probably copy the vercel link to your phone
- Open couchers in an incognito window so cookie banner shows
- It should not overlap

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [ x ] Formatted my code with `yarn format`
- [ x ] There are no warnings from `yarn lint --fix`
- [ x ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ x ] All tests pass
- [ x ] Clicked around my changes running locally and it works
- [ x ] Checked Desktop, Mobile and Tablet screen sizes

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
