### PR TITLE
Add expand all to notification settings

### DIFF
--- a/app/web/features/notifications/EditNotificationSettingsPage.tsx
+++ b/app/web/features/notifications/EditNotificationSettingsPage.tsx
@@ -1,10 +1,5 @@
-import { ExpandLess,ExpandMore } from "@mui/icons-material";
-import {
-  Button,
-  CircularProgress,
-  styled,
-  Typography,
-} from "@mui/material";
+import { ExpandLess, ExpandMore } from "@mui/icons-material";
+import { Button, CircularProgress, styled, Typography } from "@mui/material";
 import Snackbar from "components/Snackbar";
 import { NOTIFICATIONS } from "i18n/namespaces";
 import { useTranslation } from "next-i18next";
@@ -43,6 +38,11 @@ const StyledNotificationSettingsContainer = styled("div")(({ theme }) => ({
   padding: theme.spacing(4),
   margin: "0 auto",
   width: "100%",
+
+  [theme.breakpoints.down("sm")]: {
+    padding: theme.spacing(2),
+  },
+
   [theme.breakpoints.up("md")]: {
     width: "50%",
   },
@@ -53,6 +53,23 @@ const StyledHeaderContainer = styled("div")(({ theme }) => ({
   justifyContent: "space-between",
   alignItems: "center",
   marginBottom: theme.spacing(1),
+
+  [theme.breakpoints.down("sm")]: {
+    gap: theme.spacing(1),
+  },
+}));
+
+const StyledTitle = styled(Typography)(({ theme }) => ({
+  [theme.breakpoints.down("sm")]: {
+    flex: "0 0 50%",
+    fontSize: "1.1rem",
+  },
+}));
+
+const StyledButton = styled(Button)(({ theme }) => ({
+  [theme.breakpoints.down("sm")]: {
+    fontSize: "0.75rem",
+  },
 }));
 
 const StyledNotificationDescription = styled(Typography)(({ theme }) => ({
@@ -149,16 +166,15 @@ export default function EditNotificationSettingsPage() {
         {t("description")}
       </StyledNotificationDescription>
       <StyledHeaderContainer>
-        <Typography variant="h3">{t("list_heading")}</Typography>
-        <Button
+        <StyledTitle variant="h3">{t("list_heading")}</StyledTitle>
+        <StyledButton
           variant="outlined"
           size="small"
           onClick={handleToggleAll}
           startIcon={allExpanded ? <ExpandLess /> : <ExpandMore />}
-          sx={{ minWidth: "auto" }}
         >
           {allExpanded ? t("collapse_all") : t("expand_all")}
-        </Button>
+        </StyledButton>
       </StyledHeaderContainer>
       {isError && (
         <Snackbar severity="error">

--- a/app/web/features/notifications/EditNotificationSettingsPage.tsx
+++ b/app/web/features/notifications/EditNotificationSettingsPage.tsx
@@ -1,4 +1,10 @@
-import { CircularProgress, List, styled, Typography } from "@mui/material";
+import { ExpandLess,ExpandMore } from "@mui/icons-material";
+import {
+  Button,
+  CircularProgress,
+  styled,
+  Typography,
+} from "@mui/material";
 import Snackbar from "components/Snackbar";
 import { NOTIFICATIONS } from "i18n/namespaces";
 import { useTranslation } from "next-i18next";
@@ -42,17 +48,23 @@ const StyledNotificationSettingsContainer = styled("div")(({ theme }) => ({
   },
 }));
 
+const StyledHeaderContainer = styled("div")(({ theme }) => ({
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  marginBottom: theme.spacing(1),
+}));
+
 const StyledNotificationDescription = styled(Typography)(({ theme }) => ({
   margin: theme.spacing(1, 0),
   paddingBottom: theme.spacing(3),
 }));
 
-const StyledCustomList = styled(List)(({ theme }) => ({
+const StyledAccordionContainer = styled("div")(({ theme }) => ({
   border: `1px solid ${theme.palette.divider}`,
   marginTop: theme.spacing(1),
-  display: "flex",
-  flexDirection: "column",
-  padding: `0 ${theme.spacing(1)}`,
+  borderRadius: theme.shape.borderRadius,
+  overflow: "hidden",
 }));
 
 const StyledLoadingSpinner = styled(CircularProgress)({
@@ -79,6 +91,7 @@ export default function EditNotificationSettingsPage() {
   const { data, isLoading, isError } = useNotificationSettings();
   const [groups, setGroups] = useState<GroupsByType>({});
   const [areGroupsLoading, setAreGroupsLoading] = useState<boolean>(true);
+  const [allExpanded, setAllExpanded] = useState<boolean>(false);
 
   useEffect(() => {
     if (!data) {
@@ -113,6 +126,10 @@ export default function EditNotificationSettingsPage() {
     setAreGroupsLoading(false);
   }, [data]);
 
+  const handleToggleAll = () => {
+    setAllExpanded(!allExpanded);
+  };
+
   const renderNotificationListItems = () =>
     Object.keys(groups)
       .filter((key) => groups[key].length > 0)
@@ -121,6 +138,7 @@ export default function EditNotificationSettingsPage() {
           key={key}
           items={groups[key]}
           type={key as NotificationType}
+          isExpanded={allExpanded}
         />
       ));
 
@@ -130,14 +148,27 @@ export default function EditNotificationSettingsPage() {
       <StyledNotificationDescription variant="body1">
         {t("description")}
       </StyledNotificationDescription>
-      <Typography variant="h3">{t("list_heading")}</Typography>
+      <StyledHeaderContainer>
+        <Typography variant="h3">{t("list_heading")}</Typography>
+        <Button
+          variant="outlined"
+          size="small"
+          onClick={handleToggleAll}
+          startIcon={allExpanded ? <ExpandLess /> : <ExpandMore />}
+          sx={{ minWidth: "auto" }}
+        >
+          {allExpanded ? t("collapse_all") : t("expand_all")}
+        </Button>
+      </StyledHeaderContainer>
       {isError && (
         <Snackbar severity="error">
           <Typography>{t("error_loading")}</Typography>
         </Snackbar>
       )}
       {!isLoading && !areGroupsLoading ? (
-        <StyledCustomList>{renderNotificationListItems()}</StyledCustomList>
+        <StyledAccordionContainer>
+          {renderNotificationListItems()}
+        </StyledAccordionContainer>
       ) : (
         <StyledLoadingSpinner />
       )}

--- a/app/web/features/notifications/NotificationSettingsListItem.tsx
+++ b/app/web/features/notifications/NotificationSettingsListItem.tsx
@@ -1,4 +1,4 @@
-import {ExpandMore } from "@mui/icons-material";
+import { ExpandMore } from "@mui/icons-material";
 import {
   Accordion,
   AccordionDetails,

--- a/app/web/features/notifications/NotificationSettingsListItem.tsx
+++ b/app/web/features/notifications/NotificationSettingsListItem.tsx
@@ -1,16 +1,14 @@
+import {ExpandMore } from "@mui/icons-material";
 import {
-  Collapse,
-  ListItem,
-  ListItemIcon,
-  ListItemProps,
-  ListItemText,
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   styled,
   Typography,
 } from "@mui/material";
-import { ExpandLessIcon, ExpandMoreIcon } from "components/Icons";
 import { NOTIFICATIONS } from "i18n/namespaces";
 import { useTranslation } from "next-i18next";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { GroupAction, NotificationType } from "./EditNotificationSettingsPage";
 import NotificationSettingsSubListItem from "./NotificationSettingsSubListItem";
@@ -19,23 +17,29 @@ import { mapNotificationSettingsTypeToIcon } from "./utils/constants";
 export interface NotificationSettingsListItemProps {
   items: GroupAction[];
   type: NotificationType;
+  isExpanded?: boolean;
 }
 
-const StyledListItem = styled(ListItem)<ListItemProps>(({ theme }) => ({
-  background: "transparent",
-  border: "none",
-
-  "&:hover": {
-    backgroundColor: "transparent",
-  },
+const StyledAccordion = styled(Accordion)(({ theme }) => ({
   "&:not(:first-of-type)": {
     borderTop: `1px solid ${theme.palette.divider}`,
+  },
+  "&:before": {
+    display: "none",
+  },
+  boxShadow: "none",
+}));
+
+const StyledAccordionSummary = styled(AccordionSummary)(({ theme }) => ({
+  "& .MuiAccordionSummary-content": {
+    alignItems: "center",
   },
 }));
 
 export default function NotificationSettingsListItem({
   items,
   type,
+  isExpanded = false,
 }: NotificationSettingsListItemProps) {
   const notificationType =
     type as `notifications:notification_settings.edit_preferences.list_items.${NotificationType}`;
@@ -44,6 +48,11 @@ export default function NotificationSettingsListItem({
     keyPrefix: "notification_settings.edit_preferences.list_items",
   });
   const [isCollapseOpen, setIsCollapseOpen] = useState<boolean>(false);
+
+  // Update local state when global state changes
+  useEffect(() => {
+    setIsCollapseOpen(isExpanded);
+  }, [isExpanded]);
 
   const handleCollapseClick = () => {
     setIsCollapseOpen(!isCollapseOpen);
@@ -63,15 +72,14 @@ export default function NotificationSettingsListItem({
       ));
 
   return (
-    <>
-      <StyledListItem component="button" onClick={handleCollapseClick}>
-        <ListItemIcon>{mapNotificationSettingsTypeToIcon[type]}</ListItemIcon>
-        <ListItemText>
+    <StyledAccordion expanded={isCollapseOpen} onChange={handleCollapseClick}>
+      <StyledAccordionSummary expandIcon={<ExpandMore />}>
+        <div style={{ display: "flex", alignItems: "center", gap: "16px" }}>
+          {mapNotificationSettingsTypeToIcon[type]}
           <Typography variant="h3">{t(notificationType)}</Typography>
-        </ListItemText>
-        {isCollapseOpen ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-      </StyledListItem>
-      <Collapse in={isCollapseOpen}>{renderItems()}</Collapse>
-    </>
+        </div>
+      </StyledAccordionSummary>
+      <AccordionDetails>{renderItems()}</AccordionDetails>
+    </StyledAccordion>
   );
 }

--- a/app/web/features/notifications/locales/en.json
+++ b/app/web/features/notifications/locales/en.json
@@ -12,7 +12,7 @@
     "go_to_button": "Manage notification settings",
     "edit_preferences": {
       "title": "Notification Settings",
-      "description": "You may still receive important notifications about your account and content outside of your preferred notification settings.",
+      "description": "Any changes you make below are saved automatically. Please note that you may still receive important notifications about your account and content outside of your preferred notification settings.",
       "list_heading": "Notifications you may receive",
       "expand_all": "Expand all",
       "collapse_all": "Collapse all",

--- a/app/web/features/notifications/locales/en.json
+++ b/app/web/features/notifications/locales/en.json
@@ -14,6 +14,8 @@
       "title": "Notification Settings",
       "description": "You may still receive important notifications about your account and content outside of your preferred notification settings.",
       "list_heading": "Notifications you may receive",
+      "expand_all": "Expand all",
+      "collapse_all": "Collapse all",
       "error_loading": "Error loading notification settings",
       "list_items": {
         "account_security": "Account security",


### PR DESCRIPTION
Closes #6485 

Adds ability to expand and collapse all notification settings accordion items at once.

<img width="624" height="538" alt="Screenshot 2025-07-19 at 11 27 30 AM" src="https://github.com/user-attachments/assets/003725cc-35c4-4368-b8e1-50583ba23082" />

<img width="599" height="573" alt="Screenshot 2025-07-19 at 11 27 35 AM" src="https://github.com/user-attachments/assets/f36b0d8e-e187-465a-ab46-7e6dd6821723" />
