### PR TITLE
Fix up datetime without timezone

### DIFF
--- a/app/backend/src/couchers/migrations/versions/f40be9aecae7_fix_datetime_timezone.py
+++ b/app/backend/src/couchers/migrations/versions/f40be9aecae7_fix_datetime_timezone.py
@@ -1,0 +1,39 @@
+"""Fix datetime timezone
+
+Revision ID: f40be9aecae7
+Revises: e3815ef8b1e3
+Create Date: 2025-07-26 13:59:11.384539
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "f40be9aecae7"
+down_revision = "e3815ef8b1e3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "host_requests",
+        "last_sent_request_reminder_time",
+        existing_type=postgresql.TIMESTAMP(),
+        type_=sa.DateTime(timezone=True),
+        existing_nullable=False,
+        existing_server_default=sa.text("now()"),
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "host_requests",
+        "last_sent_request_reminder_time",
+        existing_type=sa.DateTime(timezone=True),
+        type_=postgresql.TIMESTAMP(),
+        existing_nullable=False,
+        existing_server_default=sa.text("now()"),
+    )

--- a/app/backend/src/couchers/models.py
+++ b/app/backend/src/couchers/models.py
@@ -1490,7 +1490,7 @@ class HostRequest(Base):
     host_sent_reference_reminders = Column(BigInteger, nullable=False, server_default=text("0"))
     surfer_sent_reference_reminders = Column(BigInteger, nullable=False, server_default=text("0"))
     host_sent_request_reminders = Column(BigInteger, nullable=False, server_default=text("0"))
-    last_sent_request_reminder_time = Column(DateTime, nullable=False, server_default=func.now())
+    last_sent_request_reminder_time = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
     # reason why the host/surfer marked that they didn't meet up
     # if null then they haven't marked it such


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**

*Please reference any issues this closes with `closes #[issue number]`.*

Closes #6536.

`DateTime(timezone=False)` (the default) will be stored in server timezone. Our server is UTC, so it's the same as `timezone=True`, except if this ever changes: which would cause a big mess, so fixing this here now.

<!---
Please describe the pull request here.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->


**Please give clear steps for how the reviewer can best test this PR**

*Please include any necessary dev environment, .env, etc. adjustments.*

-
-
-

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Backend checklist**
- [ ] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [ ] Formatted my code with `yarn format`
- [ ] There are no warnings from `yarn lint --fix`
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)


<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
