### PR TITLE
Add alembic upgrade downgrade commands

### DIFF
--- a/app/backend/Makefile
+++ b/app/backend/Makefile
@@ -3,14 +3,14 @@
 format:
 	ruff check --select I --fix . && ruff check . --fix && ruff format .
 
-# Downgrade the database to the previous migration. Good if you ran a migration on a branch and will run the backend on another branch after.
+# Downgrade the local database to the previous migration. Good if you ran a migration on a branch and will run the backend on another branch after.
 # Usage:
 # make downgrade
 downgrade:
 	DATABASE_CONNECTION_STRING="postgresql://postgres:203d805f4b62c0a1b2f1f6b82d4583dfe563ec1619b83ce22ee414e8376a25e7@localhost:6545/postgres" \
 	alembic downgrade -1
 
-# Upgrade the database to the next migration. Upgrade already happens automatically when you run the backend via docker compose.
+# Upgrade the local database to the next migration. Upgrade already happens automatically when you run the backend via docker compose.
 # Usage:
 # make upgrade
 upgrade:

--- a/app/backend/Makefile
+++ b/app/backend/Makefile
@@ -2,6 +2,21 @@
 # Run 'make [command]' in app/backend to execute the specified command
 format:
 	ruff check --select I --fix . && ruff check . --fix && ruff format .
+
+# Downgrade the database to the previous migration. Good if you ran a migration on a branch and will run the backend on another branch after.
+# Usage:
+# make downgrade
+downgrade:
+	DATABASE_CONNECTION_STRING="postgresql://postgres:203d805f4b62c0a1b2f1f6b82d4583dfe563ec1619b83ce22ee414e8376a25e7@localhost:6545/postgres" \
+	alembic downgrade -1
+
+# Upgrade the database to the next migration. Upgrade already happens automatically when you run the backend via docker compose.
+# Usage:
+# make upgrade
+upgrade:
+	DATABASE_CONNECTION_STRING="postgresql://postgres:203d805f4b62c0a1b2f1f6b82d4583dfe563ec1619b83ce22ee414e8376a25e7@localhost:6545/postgres" \
+	alembic upgrade +1
+
 # Run backend tests with optional file argument
 # Usage:
 # make test                    → runs all tests


### PR DESCRIPTION
I wanted a more granular way to run the alembic upgrades and downgrades.

Specifically when I run a migration on one branch, then go in another backend branch, it will have a bunch of errors and it wasn't clear how to downgrade.

Now I can just run the downgrade after testing a branch that includes a migration.

Or run an upgrade with the command without having to rebuild docker.