### PR TITLE
Specify yarn version

### DIFF
--- a/app/web/package.json
+++ b/app/web/package.json
@@ -112,5 +112,6 @@
   },
   "resolutions": {
     "@types/react": "^18.3.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
Specify the yarn version used to allow people with newer/incompatible versions to automatically install and switch to the correct one. (This is not optional if you have a newer version installed and I currently have this change locally to be able to work with the project at all)

The version chosen (1.22.22) is the latest stable version of yarn classic and in theory should work automatically for everyone who worked on the project until now if they weren't using an old yarn version. If their version is incompatible they will receive a prompt to install the correct one and can then continue working as before.

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)