### PR TITLE
Fixed docker services not working on Apple silicon

### DIFF
--- a/app/docker-compose.test.yml
+++ b/app/docker-compose.test.yml
@@ -20,10 +20,8 @@ services:
       - postgres_tests
     links:
       - postgres_tests
-    platform: linux/amd64
   media_tests:
     build: media
     env_file: media.test.env
     command: pytest src
     restart: unless-stopped
-    platform: linux/amd64

--- a/app/docker-compose.test.yml
+++ b/app/docker-compose.test.yml
@@ -8,6 +8,7 @@ services:
     restart: unless-stopped
     ports:
       - 6544:6544
+    platform: linux/amd64
   backend_tests:
     build: backend
     env_file: backend.test.env
@@ -19,8 +20,10 @@ services:
       - postgres_tests
     links:
       - postgres_tests
+    platform: linux/amd64
   media_tests:
     build: media
     env_file: media.test.env
     command: pytest src
     restart: unless-stopped
+    platform: linux/amd64

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - 8888:8888
       - 9901:9901
     dns_search: ""
+    platform: linux/amd64
   postgres:
     image: postgis/postgis:17-3.5
     env_file: postgres.dev.env
@@ -16,6 +17,7 @@ services:
     restart: unless-stopped
     ports:
       - 6545:6545
+    platform: linux/amd64
   backend:
     build: backend
     env_file: backend.dev.env
@@ -35,6 +37,7 @@ services:
       - postgres
     links:
       - postgres
+    platform: linux/amd64
   media:
     build: media
     restart: unless-stopped
@@ -45,14 +48,14 @@ services:
       - 5001:5001
     depends_on:
       - backend
-
+    platform: linux/amd64
   maildev:
     image: maildev/maildev
     restart: unless-stopped
     ports:
       - 1025:1025
       - 1080:1080
-
+    platform: linux/amd64
   jaeger:
     image: jaegertracing/all-in-one:1.60
     ports:
@@ -61,3 +64,4 @@ services:
       - 4317
     environment:
       - COLLECTOR_OTLP_ENABLED=true
+    platform: linux/amd64

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -6,7 +6,6 @@ services:
       - 8888:8888
       - 9901:9901
     dns_search: ""
-    platform: linux/amd64
   postgres:
     image: postgis/postgis:17-3.5
     env_file: postgres.dev.env
@@ -37,7 +36,6 @@ services:
       - postgres
     links:
       - postgres
-    platform: linux/amd64
   media:
     build: media
     restart: unless-stopped
@@ -48,14 +46,12 @@ services:
       - 5001:5001
     depends_on:
       - backend
-    platform: linux/amd64
   maildev:
     image: maildev/maildev
     restart: unless-stopped
     ports:
       - 1025:1025
       - 1080:1080
-    platform: linux/amd64
   jaeger:
     image: jaegertracing/all-in-one:1.60
     ports:
@@ -64,4 +60,3 @@ services:
       - 4317
     environment:
       - COLLECTOR_OTLP_ENABLED=true
-    platform: linux/amd64


### PR DESCRIPTION
The docker services for local dev don't work on apple silicon (tested on M1 MacBook Pro). Adding the target platform fixes the issue. 

- [x] Test on MacOS ARM
- [ ] Test on MacOS x86 
- [x] Test on Linux x86
- [ ] Test on Windows x86

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)