### PR TITLE
Turn off flat ESLint config in VS Code plugin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,5 +43,6 @@
   "editor.tabSize": 2,
   "editor.insertSpaces": true,
   "files.trimTrailingWhitespace": true,
-  "files.trimFinalNewlines": true
+  "files.trimFinalNewlines": true,
+  "eslint.useFlatConfig": false
 }


### PR DESCRIPTION
ESLint 9.x+ uses the new [flat config](https://eslint.org/docs/latest/use/configure/migration-guide) by default. Currently I have flat config support for the ESLint VSCode plugin enabled in my user settings to work with other projects of mine. But since we are using an older version of ESLint without a flat config at Couchers, this breaks the plugin for me (`Error: Could not find config file.`), and I have to add this line locally.
Shouldn't break anything for anyone not having this set to `true` in their user settings, as `false` is the default. Once we upgrade to ESLint 9.x+, we can remove or change this to `true`, depending on how the plugin interacts with the version we upgrade to.

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)