### PR TITLE
Bugfix - Stop propagation on open profile new tab click

### DIFF
--- a/app/web/features/search/SeachResultUserCard.tsx
+++ b/app/web/features/search/SeachResultUserCard.tsx
@@ -173,6 +173,7 @@ const SearchResultUserCard = ({
                 target="_blank"
                 rel="noopener noreferrer"
                 sx={{ fontSize: "1.1rem", overflow: "hidden" }}
+                onClick={(e) => e.stopPropagation()}
               >
                 <Typography
                   variant="h2"
@@ -193,6 +194,7 @@ const SearchResultUserCard = ({
               href={routeToUser(user.username)}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
             >
               <Tooltip title={t("profile:open_profile_new_tab")}>
                 <StyledOpenInNewIcon


### PR DESCRIPTION
Closes #6623 

There was a bug, where if you search a location on the map, then click either the user name link or the open in new tab icon, it would select that user and reset the filters every time.

I added stop propagation to those elements so it's fixed.

You should be able to click to open a profile from map search results in a new tab now without it messing up any existing filters.

**To Test:**

- Go to map search and search a location
- Set a filter, i.e. "last active" or something
- Click either the username link or the icon to pen profile at the top right
- It should open the profile in a new tab and not mess with any filters
- If you click elsewhere on the user card, it will select that user and show them on the map as usual (previously it was also doing this on open in new tab profile click)