### PR TITLE
Prevent forwarding of invalid prop

### DIFF
--- a/app/web/features/communities/events/DiscoverEventsList.tsx
+++ b/app/web/features/communities/events/DiscoverEventsList.tsx
@@ -39,22 +39,22 @@ const StyledFilterTagContainer = styled("div")(() => ({
   marginBottom: theme.spacing(2),
 }));
 
-const StyledFilterTag = styled(Typography)<{ isSelected: boolean }>(
-  ({ isSelected }) => ({
-    backgroundColor: isSelected
-      ? theme.palette.secondary.main
-      : theme.palette.grey[200],
-    color: isSelected ? theme.palette.common.white : theme.palette.text.primary,
-    padding: theme.spacing(1, 2),
-    textAlign: "center",
-    fontWeight: "bold",
-    margin: theme.spacing(0.5),
-    borderRadius: theme.shape.borderRadius * 6,
-    "&:hover": {
-      cursor: "pointer",
-    },
-  }),
-);
+const StyledFilterTag = styled(Typography, {
+  shouldForwardProp: (propName) => propName !== "isSelected",
+})<{ isSelected: boolean }>(({ isSelected }) => ({
+  backgroundColor: isSelected
+    ? theme.palette.secondary.main
+    : theme.palette.grey[200],
+  color: isSelected ? theme.palette.common.white : theme.palette.text.primary,
+  padding: theme.spacing(1, 2),
+  textAlign: "center",
+  fontWeight: "bold",
+  margin: theme.spacing(0.5),
+  borderRadius: theme.shape.borderRadius * 6,
+  "&:hover": {
+    cursor: "pointer",
+  },
+}));
 
 const StyledLoadingBox = styled("div")(() => ({
   display: "flex",

--- a/app/web/features/communities/events/MyEventsList.tsx
+++ b/app/web/features/communities/events/MyEventsList.tsx
@@ -18,22 +18,22 @@ const StyledFilterTagContainer = styled("div")(() => ({
   marginBottom: theme.spacing(2),
 }));
 
-const StyledFilterTag = styled(Typography)<{ isSelected: boolean }>(
-  ({ isSelected }) => ({
-    backgroundColor: isSelected
-      ? theme.palette.secondary.main
-      : theme.palette.grey[200],
-    color: isSelected ? theme.palette.common.white : theme.palette.text.primary,
-    padding: theme.spacing(1, 2),
-    textAlign: "center",
-    fontWeight: "bold",
-    margin: theme.spacing(0.5),
-    borderRadius: theme.shape.borderRadius * 6,
-    "&:hover": {
-      cursor: "pointer",
-    },
-  }),
-);
+const StyledFilterTag = styled(Typography, {
+  shouldForwardProp: (propName) => propName !== "isSelected",
+})<{ isSelected: boolean }>(({ isSelected }) => ({
+  backgroundColor: isSelected
+    ? theme.palette.secondary.main
+    : theme.palette.grey[200],
+  color: isSelected ? theme.palette.common.white : theme.palette.text.primary,
+  padding: theme.spacing(1, 2),
+  textAlign: "center",
+  fontWeight: "bold",
+  margin: theme.spacing(0.5),
+  borderRadius: theme.shape.borderRadius * 6,
+  "&:hover": {
+    cursor: "pointer",
+  },
+}));
 
 const StyledEmptyBody = styled(TextBody)(() => ({
   marginBottom: theme.spacing(2),


### PR DESCRIPTION
One of my last PRs introduces styled components with custom props, but I forgot to exclude them from being forwarded, so we get error messages warning about this now.

Can be replicated by simply going to the events page

- [x] Formatted my code with `yarn format`
- [x] There are no warnings from `yarn lint --fix`
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)