### PR TITLE
Refactor user_model_to_pb and lite_user_to_pb for ghost profiles

### DIFF
--- a/app/backend/src/couchers/constants.py
+++ b/app/backend/src/couchers/constants.py
@@ -71,6 +71,9 @@ COMMUNITIES_SEARCH_FUZZY_SIMILARITY_THRESHOLD = 0.35
 
 UNKNOWN_ERROR_MESSAGE = "An unknown backend error occurred. Please consider filing a bug!"
 
+GHOST_USER_DISPLAY_NAME = "Deleted user"
+GHOST_USERNAME = "ghost"
+
 # Donation drive start date - set to None to disable donation drive banner
 # When set, users who haven't donated since this date will see a donation banner
 DONATION_DRIVE_START = pytz.UTC.localize(datetime(2025, 11, 1))

--- a/app/backend/src/couchers/constants.py
+++ b/app/backend/src/couchers/constants.py
@@ -71,7 +71,6 @@ COMMUNITIES_SEARCH_FUZZY_SIMILARITY_THRESHOLD = 0.35
 
 UNKNOWN_ERROR_MESSAGE = "An unknown backend error occurred. Please consider filing a bug!"
 
-GHOST_USER_DISPLAY_NAME = "Deleted user"
 GHOST_USERNAME = "ghost"
 
 # Donation drive start date - set to None to disable donation drive banner

--- a/app/backend/src/couchers/i18n/locales/en.json
+++ b/app/backend/src/couchers/i18n/locales/en.json
@@ -197,5 +197,9 @@
     "topic_action": "You've been unsubscribed from email notifications of that type.",
     "chat_unsub": "That group chat has been muted.",
     "host_request_quick_decline": "Thank you for responding to the host request!"
+  },
+  "ghost_users": {
+    "display_name": "Ghost user",
+    "about_me": "This user is no longer on the platform. They may have deleted their account, been blocked, or banned. We recommend applying caution with any further interaction with this user, and reaching out to support if you need any help."
   }
 }

--- a/app/backend/src/couchers/materialized_views.py
+++ b/app/backend/src/couchers/materialized_views.py
@@ -173,6 +173,7 @@ lite_users = create_materialized_view_with_different_ddl(
     Base.metadata,
     [
         Index("uq_lite_users_id", lite_users_selectable_create.c.id, unique=True),
+        Index("uq_lite_users_username", lite_users_selectable_create.c.username, unique=True),
         Index(
             "ix_lite_users_id_visible",
             lite_users_selectable_create.c.id,

--- a/app/backend/src/couchers/migrations/versions/941b04198efe_add_new_index_to_lite_users.py
+++ b/app/backend/src/couchers/migrations/versions/941b04198efe_add_new_index_to_lite_users.py
@@ -1,0 +1,23 @@
+"""Add new index to lite users
+
+Revision ID: 941b04198efe
+Revises: f555ed35e4d0
+Create Date: 2025-11-16 17:23:39.481479
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "941b04198efe"
+down_revision = "f555ed35e4d0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("CREATE UNIQUE INDEX uq_lite_users_username ON lite_users(username);")
+
+
+def downgrade():
+    op.execute("DROP INDEX uq_lite_users_username;")

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -742,7 +742,7 @@ class Account(account_pb2_grpc.AccountServicer):
             account_pb2.Reminder(
                 respond_to_host_request_reminder=account_pb2.RespondToHostRequestReminder(
                     host_request_id=host_request_id,
-                    surfer_user=lite_user_to_pb(lite_user),
+                    surfer_user=lite_user_to_pb(session, lite_user, context),
                 )
             )
             for host_request_id, lite_user in pending_host_requests
@@ -754,7 +754,7 @@ class Account(account_pb2_grpc.AccountServicer):
                 write_reference_reminder=account_pb2.WriteReferenceReminder(
                     host_request_id=host_request_id,
                     reference_type=reftype2api[reference_type],
-                    other_user=lite_user_to_pb(lite_user),
+                    other_user=lite_user_to_pb(session, lite_user, context),
                 )
             )
             for host_request_id, reference_type, _, lite_user in get_pending_references_to_write(session, context)

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -135,7 +135,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
-        return user_model_to_pb(user, session, context, is_admin_should_show_invisible=True)
+        return user_model_to_pb(user, session, context, is_admin_see_ghosts=True)
 
     def SearchUsers(self, request, context, session):
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -135,7 +135,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
-        return user_model_to_pb(user, session, context)
+        return user_model_to_pb(user, session, context, is_admin_should_show_invisible=True)
 
     def SearchUsers(self, request, context, session):
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -7,6 +7,7 @@ from sqlalchemy.sql import and_, delete, distinct, func, intersect, or_, union
 
 from couchers import urls
 from couchers.config import config
+from couchers.constants import GHOST_USER_DISPLAY_NAME, GHOST_USERNAME
 from couchers.crypto import b64encode, generate_hash_signature, random_hex
 from couchers.helpers.strong_verification import get_strong_verification_fields
 from couchers.materialized_views import LiteUser, UserResponseRate
@@ -39,6 +40,7 @@ from couchers.proto import api_pb2, api_pb2_grpc, media_pb2, notification_data_p
 from couchers.rate_limits.check import process_rate_limits_and_check_abort
 from couchers.rate_limits.definitions import RATE_LIMIT_INTERVAL_STRING
 from couchers.resources import get_badge_dict, language_is_allowed, region_is_allowed
+from couchers.servicers.blocking import is_not_visible
 from couchers.sql import couchers_select as select
 from couchers.sql import is_valid_user_id, is_valid_username
 from couchers.utils import (
@@ -217,9 +219,7 @@ class API(api_pb2_grpc.APIServicer):
         )
 
     def GetUser(self, request, context, session):
-        user = session.execute(
-            select(User).where_users_visible(context).where_username_or_id(request.user)
-        ).scalar_one_or_none()
+        user = session.execute(select(User).where_username_or_id(request.user)).scalar_one_or_none()
 
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -228,15 +228,13 @@ class API(api_pb2_grpc.APIServicer):
 
     def GetLiteUser(self, request, context, session):
         lite_user = session.execute(
-            select(LiteUser)
-            .where_users_visible(context, table=LiteUser)
-            .where_username_or_id(request.user, table=LiteUser)
+            select(LiteUser).where_username_or_id(request.user, table=LiteUser)
         ).scalar_one_or_none()
 
         if not lite_user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
-        return lite_user_to_pb(lite_user)
+        return lite_user_to_pb(session, lite_user, context)
 
     def GetLiteUsers(self, request, context, session):
         if len(request.users) > MAX_USERS_PER_QUERY:
@@ -246,11 +244,7 @@ class API(api_pb2_grpc.APIServicer):
         ids = {u for u in request.users if is_valid_user_id(u)}
 
         users = (
-            session.execute(
-                select(LiteUser)
-                .where_users_visible(context, table=LiteUser)
-                .where(or_(LiteUser.username.in_(usernames), LiteUser.id.in_(ids)))
-            )
+            session.execute(select(LiteUser).where(or_(LiteUser.username.in_(usernames), LiteUser.id.in_(ids))))
             .scalars()
             .all()
         )
@@ -271,7 +265,7 @@ class API(api_pb2_grpc.APIServicer):
                 api_pb2.LiteUserRes(
                     query=user,
                     not_found=lite_user is None,
-                    user=lite_user_to_pb(lite_user) if lite_user else None,
+                    user=lite_user_to_pb(session, lite_user, context) if lite_user else None,
                 )
             )
 
@@ -904,9 +898,18 @@ def get_num_references(session, user_ids):
     )
 
 
-def user_model_to_pb(db_user, session, context):
+def user_model_to_pb(db_user, session, context, is_admin_should_show_invisible=False):
     # note that this function should work also for banned/deleted users as it's called from Admin.GetUser
     # note that this function is sometimes called by a logged out user, in which case context comes from make_logged_out_context
+
+    if not is_admin_should_show_invisible and is_not_visible(session, context.user_id, db_user.id):
+        # Return an anonymized "ghost" user profile for deleted, banned, and blocked users
+        return api_pb2.User(
+            user_id=db_user.id,
+            username=GHOST_USERNAME,
+            name=GHOST_USER_DISPLAY_NAME,
+        )
+
     num_references = get_num_references(session, [db_user.id]).get(db_user.id, 0)
 
     # returns (lat, lng)
@@ -1081,7 +1084,15 @@ def user_model_to_pb(db_user, session, context):
     return user
 
 
-def lite_user_to_pb(lite_user: LiteUser):
+def lite_user_to_pb(session, lite_user: LiteUser, context):
+    if is_not_visible(session, context.user_id, lite_user.id):
+        # Return an anonymized "ghost" user profile for deleted, banned, and blocked users
+        return api_pb2.LiteUser(
+            user_id=lite_user.id,
+            username=GHOST_USERNAME,
+            name=GHOST_USER_DISPLAY_NAME,
+        )
+
     lat, lng = get_coordinates(lite_user.geom) or (0, 0)
 
     return api_pb2.LiteUser(

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -914,10 +914,7 @@ def user_model_to_pb(db_user, session, context, *, is_admin_see_ghosts=False, is
     # note that this function should work also for banned/deleted users as it's called from Admin.GetUser
     # note that this function is sometimes called by a logged out user, in which case context comes from make_logged_out_context
 
-    # If admin mode, skip visibility check and return full user data
-    if is_admin_see_ghosts:
-        pass
-    elif is_not_visible(session, context.user_id, db_user.id):
+    if not is_admin_see_ghosts and is_not_visible(session, context.user_id, db_user.id):
         # User is not visible (deleted, banned, or blocked)
         if is_get_user_return_ghosts:
             # Return an anonymized "ghost" user profile
@@ -927,12 +924,10 @@ def user_model_to_pb(db_user, session, context, *, is_admin_see_ghosts=False, is
                 name=context.get_localized_string("ghost_users", "display_name"),
                 about_me=context.get_localized_string("ghost_users", "about_me"),
             )
-        else:
-            # Neither flag is set - this is an error
-            raise GhostUserSerializationError(
-                f"Tried to serialize ghost profile in user_model_to_pb without appropriate flags. "
-                f"Context user_id: {context.user_id}, db_user id: {db_user.id} (username: {db_user.username})"
-            )
+        raise GhostUserSerializationError(
+            f"Tried to serialize ghost profile in user_model_to_pb without appropriate flags. "
+            f"Context user_id: {context.user_id}, db_user id: {db_user.id} (username: {db_user.username})"
+        )
 
     num_references = get_num_references(session, [db_user.id]).get(db_user.id, 0)
 
@@ -1111,10 +1106,7 @@ def user_model_to_pb(db_user, session, context, *, is_admin_see_ghosts=False, is
 def lite_user_to_pb(
     session, lite_user: LiteUser, context, *, is_admin_see_ghosts=False, is_get_user_return_ghosts=False
 ):
-    # If admin mode, skip visibility check and return full user data
-    if is_admin_see_ghosts:
-        pass
-    elif is_not_visible(session, context.user_id, lite_user.id):
+    if not is_admin_see_ghosts and is_not_visible(session, context.user_id, lite_user.id):
         # User is not visible (deleted, banned, or blocked)
         if is_get_user_return_ghosts:
             # Return an anonymized "ghost" user profile
@@ -1123,12 +1115,10 @@ def lite_user_to_pb(
                 username=GHOST_USERNAME,
                 name=context.get_localized_string("ghost_users", "display_name"),
             )
-        else:
-            # Neither flag is set - this is an error
-            raise GhostUserSerializationError(
-                f"Tried to serialize ghost profile in lite_user_to_pb without appropriate flags. "
-                f"Context user_id: {context.user_id}, lite_user id: {lite_user.id} (username: {lite_user.username})"
-            )
+        raise GhostUserSerializationError(
+            f"Tried to serialize ghost profile in lite_user_to_pb without appropriate flags. "
+            f"Context user_id: {context.user_id}, lite_user id: {lite_user.id} (username: {lite_user.username})"
+        )
 
     lat, lng = get_coordinates(lite_user.geom) or (0, 0)
 

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -7,7 +7,7 @@ from sqlalchemy.sql import and_, delete, distinct, func, intersect, or_, union
 
 from couchers import urls
 from couchers.config import config
-from couchers.constants import GHOST_USER_DISPLAY_NAME, GHOST_USERNAME
+from couchers.constants import GHOST_USERNAME
 from couchers.crypto import b64encode, generate_hash_signature, random_hex
 from couchers.helpers.strong_verification import get_strong_verification_fields
 from couchers.materialized_views import LiteUser, UserResponseRate
@@ -51,6 +51,15 @@ from couchers.utils import (
     is_valid_name,
     now,
 )
+
+
+class GhostUserSerializationError(Exception):
+    """
+    Raised when attempting to serialize a ghost user (deleted/banned/blocked)
+    """
+
+    pass
+
 
 MAX_USERS_PER_QUERY = 200
 MAX_PAGINATION_LENGTH = 50
@@ -224,7 +233,7 @@ class API(api_pb2_grpc.APIServicer):
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
-        return user_model_to_pb(user, session, context)
+        return user_model_to_pb(user, session, context, is_get_user_return_ghosts=True)
 
     def GetLiteUser(self, request, context, session):
         lite_user = session.execute(
@@ -234,7 +243,7 @@ class API(api_pb2_grpc.APIServicer):
         if not lite_user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
-        return lite_user_to_pb(session, lite_user, context)
+        return lite_user_to_pb(session, lite_user, context, is_get_user_return_ghosts=True)
 
     def GetLiteUsers(self, request, context, session):
         if len(request.users) > MAX_USERS_PER_QUERY:
@@ -243,6 +252,7 @@ class API(api_pb2_grpc.APIServicer):
         usernames = {u for u in request.users if is_valid_username(u)}
         ids = {u for u in request.users if is_valid_user_id(u)}
 
+        # decomposed where_username_or_id...
         users = (
             session.execute(select(LiteUser).where(or_(LiteUser.username.in_(usernames), LiteUser.id.in_(ids))))
             .scalars()
@@ -265,7 +275,9 @@ class API(api_pb2_grpc.APIServicer):
                 api_pb2.LiteUserRes(
                     query=user,
                     not_found=lite_user is None,
-                    user=lite_user_to_pb(session, lite_user, context) if lite_user else None,
+                    user=lite_user_to_pb(session, lite_user, context, is_get_user_return_ghosts=True)
+                    if lite_user
+                    else None,
                 )
             )
 
@@ -898,17 +910,29 @@ def get_num_references(session, user_ids):
     )
 
 
-def user_model_to_pb(db_user, session, context, is_admin_should_show_invisible=False):
+def user_model_to_pb(db_user, session, context, *, is_admin_see_ghosts=False, is_get_user_return_ghosts=False):
     # note that this function should work also for banned/deleted users as it's called from Admin.GetUser
     # note that this function is sometimes called by a logged out user, in which case context comes from make_logged_out_context
 
-    if not is_admin_should_show_invisible and is_not_visible(session, context.user_id, db_user.id):
-        # Return an anonymized "ghost" user profile for deleted, banned, and blocked users
-        return api_pb2.User(
-            user_id=db_user.id,
-            username=GHOST_USERNAME,
-            name=GHOST_USER_DISPLAY_NAME,
-        )
+    # If admin mode, skip visibility check and return full user data
+    if is_admin_see_ghosts:
+        pass
+    elif is_not_visible(session, context.user_id, db_user.id):
+        # User is not visible (deleted, banned, or blocked)
+        if is_get_user_return_ghosts:
+            # Return an anonymized "ghost" user profile
+            return api_pb2.User(
+                user_id=db_user.id,
+                username=GHOST_USERNAME,
+                name=context.get_localized_string("ghost_users", "display_name"),
+                about_me=context.get_localized_string("ghost_users", "about_me"),
+            )
+        else:
+            # Neither flag is set - this is an error
+            raise GhostUserSerializationError(
+                f"Tried to serialize ghost profile in user_model_to_pb without appropriate flags. "
+                f"Context user_id: {context.user_id}, db_user id: {db_user.id} (username: {db_user.username})"
+            )
 
     num_references = get_num_references(session, [db_user.id]).get(db_user.id, 0)
 
@@ -1084,14 +1108,27 @@ def user_model_to_pb(db_user, session, context, is_admin_should_show_invisible=F
     return user
 
 
-def lite_user_to_pb(session, lite_user: LiteUser, context):
-    if is_not_visible(session, context.user_id, lite_user.id):
-        # Return an anonymized "ghost" user profile for deleted, banned, and blocked users
-        return api_pb2.LiteUser(
-            user_id=lite_user.id,
-            username=GHOST_USERNAME,
-            name=GHOST_USER_DISPLAY_NAME,
-        )
+def lite_user_to_pb(
+    session, lite_user: LiteUser, context, *, is_admin_see_ghosts=False, is_get_user_return_ghosts=False
+):
+    # If admin mode, skip visibility check and return full user data
+    if is_admin_see_ghosts:
+        pass
+    elif is_not_visible(session, context.user_id, lite_user.id):
+        # User is not visible (deleted, banned, or blocked)
+        if is_get_user_return_ghosts:
+            # Return an anonymized "ghost" user profile
+            return api_pb2.LiteUser(
+                user_id=lite_user.id,
+                username=GHOST_USERNAME,
+                name=context.get_localized_string("ghost_users", "display_name"),
+            )
+        else:
+            # Neither flag is set - this is an error
+            raise GhostUserSerializationError(
+                f"Tried to serialize ghost profile in lite_user_to_pb without appropriate flags. "
+                f"Context user_id: {context.user_id}, lite_user id: {lite_user.id} (username: {lite_user.username})"
+            )
 
     lat, lng = get_coordinates(lite_user.geom) or (0, 0)
 

--- a/app/backend/src/couchers/servicers/blocking.py
+++ b/app/backend/src/couchers/servicers/blocking.py
@@ -8,25 +8,31 @@ from couchers.proto import blocking_pb2, blocking_pb2_grpc
 from couchers.sql import couchers_select as select
 
 
-def is_not_visible(session, user1_id, user2_id) -> bool:
+def is_not_visible(session, user1_id: int | None, user2_id: int | None) -> bool:
     """
     Check if users are not visible to each other (due to block or because either account is deleted/banned).
     """
-    blocked_users = (
-        select(UserBlock.blocked_user_id)
-        .where(UserBlock.blocking_user_id == user1_id)
-        .where(UserBlock.blocked_user_id == user2_id)
-    )
-    blocking_users = (
-        select(UserBlock.blocking_user_id)
-        .where(UserBlock.blocking_user_id == user2_id)
-        .where(UserBlock.blocked_user_id == user1_id)
-    )
     hidden_users = select(User.id).where(or_(User.id == user1_id, User.id == user2_id)).where(not_(User.is_visible))
-    return (
-        session.execute(select(union(blocked_users, blocking_users, hidden_users).subquery()).limit(1)).one_or_none()
-        is not None
-    )
+    # if either user_id is empty, just check if either user is hidden (as they can't block each other)
+    if not user1_id or not user2_id:
+        return session.execute(select(union(hidden_users).subquery()).limit(1)).one_or_none() is not None
+    else:
+        blocked_users = (
+            select(UserBlock.blocked_user_id)
+            .where(UserBlock.blocking_user_id == user1_id)
+            .where(UserBlock.blocked_user_id == user2_id)
+        )
+        blocking_users = (
+            select(UserBlock.blocking_user_id)
+            .where(UserBlock.blocking_user_id == user2_id)
+            .where(UserBlock.blocked_user_id == user1_id)
+        )
+        return (
+            session.execute(
+                select(union(blocked_users, blocking_users, hidden_users).subquery()).limit(1)
+            ).one_or_none()
+            is not None
+        )
 
 
 class Blocking(blocking_pb2_grpc.BlockingServicer):

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -8,7 +8,7 @@ from couchers.db import session_scope
 from couchers.jobs.handlers import update_badges
 from couchers.materialized_views import refresh_materialized_views_rapid
 from couchers.models import FriendRelationship, FriendStatus, RateLimitAction
-from couchers.proto import api_pb2, jail_pb2, notifications_pb2
+from couchers.proto import admin_pb2, api_pb2, jail_pb2, notifications_pb2
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_INTERVAL_STRING
 from couchers.resources import get_badge_dict
 from couchers.sql import couchers_select as select
@@ -29,6 +29,7 @@ from tests.test_fixtures import (  # noqa
     real_jail_session,
     testconfig,
 )
+from tests.test_fixtures import real_admin_session as admin_session
 
 
 @pytest.fixture(autouse=True)
@@ -164,6 +165,81 @@ def test_get_user(db):
         assert res.user_id == user2.id
         assert res.username == user2.username
         assert res.name == user2.name
+
+
+@pytest.mark.parametrize("flag", ["is_deleted", "is_banned"])
+def test_user_model_to_pb_ghost_user(db, flag):
+    user1, token1 = generate_user()
+    user2, _ = generate_user()
+
+    with session_scope() as session:
+        db_user2 = session.merge(user2)
+        setattr(db_user2, flag, True)
+        session.commit()
+
+    with api_session(token1) as api:
+        user_pb = api.GetUser(api_pb2.GetUserReq(user=user2.username))
+
+    assert user_pb.user_id == user2.id
+    assert user_pb.username == "ghost"
+    assert user_pb.name == "Deleted user"
+    assert user_pb.lat == 0
+    assert user_pb.lng == 0
+    assert user_pb.radius == 0
+    assert user_pb.verification == 0.0
+    assert user_pb.community_standing == 0.0
+    assert user_pb.num_references == 0
+    assert user_pb.age == 0
+    assert user_pb.hosting_status == 0
+    assert user_pb.meetup_status == 0
+    assert user_pb.city == ""
+    assert user_pb.hometown == ""
+    assert user_pb.timezone == ""
+    assert user_pb.gender == ""
+    assert user_pb.pronouns == ""
+    assert user_pb.occupation == ""
+    assert user_pb.education == ""
+    assert user_pb.about_me == ""
+    assert user_pb.things_i_like == ""
+    assert user_pb.about_place == ""
+    assert user_pb.additional_information == ""
+    assert list(user_pb.language_abilities) == []
+    assert list(user_pb.regions_visited) == []
+    assert list(user_pb.regions_lived) == []
+    assert list(user_pb.badges) == []
+    assert user_pb.friends == api_pb2.User.FriendshipStatus.NOT_FRIENDS
+    assert user_pb.avatar_url == ""
+    assert user_pb.avatar_thumbnail_url == ""
+    assert not user_pb.has_strong_verification
+
+
+@pytest.mark.parametrize("flag", ["is_deleted", "is_banned"])
+def test_admin_viewing_ghost_users_sees_full_profile(db, flag):
+    admin, token_admin = generate_user()
+    user, _ = generate_user()
+
+    with session_scope() as session:
+        admin_db = session.merge(admin)
+        user_db = session.merge(user)
+        setattr(user_db, flag, True)
+        admin_db.is_superuser = True
+        session.commit()
+
+    with admin_session(token_admin) as api:
+        user_pb = api.GetUser(admin_pb2.GetUserReq(user=user.username))
+
+    assert user_pb.user_id == user.id
+    assert user_pb.username == user.username
+    assert user_pb.name == user.name
+    assert user_pb.city == user.city
+    assert user_pb.name != "Deleted user"
+    assert user_pb.username != "ghost"
+    assert user_pb.hosting_status in (
+        api_pb2.HOSTING_STATUS_UNKNOWN,
+        api_pb2.HOSTING_STATUS_CAN_HOST,
+        api_pb2.HOSTING_STATUS_MAYBE,
+        api_pb2.HOSTING_STATUS_CANT_HOST,
+    )
 
 
 def test_lite_coords(db):

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -391,9 +391,12 @@ def test_GetLiteUsers(db):
         assert res.responses[7].query == "notreal"
         assert res.responses[7].not_found
 
-        # blocked
+        # blocked - should return ghost profile
         assert res.responses[8].query == user4.username
-        assert res.responses[8].not_found
+        assert not res.responses[8].not_found
+        assert res.responses[8].user.user_id == user4.id
+        assert res.responses[8].user.username == "ghost"
+        assert res.responses[8].user.name == "Deleted user"
 
     with api_session(token1) as api:
         with pytest.raises(grpc.RpcError) as e:
@@ -1383,3 +1386,312 @@ def test_badges(db):
             api_pb2.ListBadgeUsersReq(badge_id=board_member_badge["id"], page_token=res.next_page_token)
         )
         assert res2.user_ids == [2]
+
+
+@pytest.mark.parametrize("flag", ["is_deleted", "is_banned"])
+def test_GetLiteUser_ghost_user_by_username(db, flag):
+    """Test that GetLiteUser returns a ghost profile for deleted/banned users when querying by username."""
+    user1, token1 = generate_user()
+    user2, _ = generate_user()
+
+    # Make user2 invisible
+    with session_scope() as session:
+        db_user2 = session.merge(user2)
+        setattr(db_user2, flag, True)
+        session.commit()
+
+    # Refresh the materialized view
+    refresh_materialized_views_rapid(None)
+
+    with api_session(token1) as api:
+        # Query by username
+        lite_user = api.GetLiteUser(api_pb2.GetLiteUserReq(user=user2.username))
+
+        assert lite_user.user_id == user2.id
+        assert lite_user.username == "ghost"
+        assert lite_user.name == "Deleted user"
+        assert lite_user.lat == 0
+        assert lite_user.lng == 0
+        assert lite_user.radius == 0
+        assert lite_user.city == ""
+        assert lite_user.age == 0
+        assert lite_user.avatar_url == ""
+        assert lite_user.avatar_thumbnail_url == ""
+        assert not lite_user.has_strong_verification
+
+
+@pytest.mark.parametrize("flag", ["is_deleted", "is_banned"])
+def test_GetLiteUser_ghost_user_by_id(db, flag):
+    """Test that GetLiteUser returns a ghost profile for deleted/banned users when querying by ID."""
+    user1, token1 = generate_user()
+    user2, _ = generate_user()
+
+    # Make user2 invisible
+    with session_scope() as session:
+        db_user2 = session.merge(user2)
+        setattr(db_user2, flag, True)
+        session.commit()
+
+    # Refresh the materialized view
+    refresh_materialized_views_rapid(None)
+
+    with api_session(token1) as api:
+        # Query by ID
+        lite_user = api.GetLiteUser(api_pb2.GetLiteUserReq(user=str(user2.id)))
+
+        assert lite_user.user_id == user2.id
+        assert lite_user.username == "ghost"
+        assert lite_user.name == "Deleted user"
+        assert lite_user.lat == 0
+        assert lite_user.lng == 0
+        assert lite_user.radius == 0
+        assert lite_user.city == ""
+        assert lite_user.age == 0
+        assert lite_user.avatar_url == ""
+        assert lite_user.avatar_thumbnail_url == ""
+        assert not lite_user.has_strong_verification
+
+
+def test_GetLiteUser_blocked_user(db):
+    """Test that GetLiteUser returns a ghost profile for blocked users."""
+    user1, token1 = generate_user()
+    user2, _ = generate_user()
+
+    # User1 blocks user2
+    make_user_block(user1, user2)
+
+    # Refresh the materialized view
+    refresh_materialized_views_rapid(None)
+
+    with api_session(token1) as api:
+        # Query by username
+        lite_user = api.GetLiteUser(api_pb2.GetLiteUserReq(user=user2.username))
+
+        assert lite_user.user_id == user2.id
+        assert lite_user.username == "ghost"
+        assert lite_user.name == "Deleted user"
+
+        # Query by ID
+        lite_user = api.GetLiteUser(api_pb2.GetLiteUserReq(user=str(user2.id)))
+
+        assert lite_user.user_id == user2.id
+        assert lite_user.username == "ghost"
+        assert lite_user.name == "Deleted user"
+
+
+def test_GetLiteUser_blocking_user(db):
+    """Test that GetLiteUser returns a ghost profile when the target user has blocked the requester."""
+    user1, token1 = generate_user()
+    user2, _ = generate_user()
+
+    # User2 blocks user1
+    make_user_block(user2, user1)
+
+    # Refresh the materialized view
+    refresh_materialized_views_rapid(None)
+
+    with api_session(token1) as api:
+        # Query by username
+        lite_user = api.GetLiteUser(api_pb2.GetLiteUserReq(user=user2.username))
+
+        assert lite_user.user_id == user2.id
+        assert lite_user.username == "ghost"
+        assert lite_user.name == "Deleted user"
+
+        # Query by ID
+        lite_user = api.GetLiteUser(api_pb2.GetLiteUserReq(user=str(user2.id)))
+
+        assert lite_user.user_id == user2.id
+        assert lite_user.username == "ghost"
+        assert lite_user.name == "Deleted user"
+
+
+@pytest.mark.parametrize("flag", ["is_deleted", "is_banned"])
+def test_GetLiteUsers_ghost_users(db, flag):
+    """Test that GetLiteUsers returns ghost profiles for deleted/banned users."""
+    user1, token1 = generate_user()
+    user2, _ = generate_user()
+    user3, _ = generate_user()
+    user4, _ = generate_user()
+
+    # Make user2 and user4 invisible
+    with session_scope() as session:
+        db_user2 = session.merge(user2)
+        setattr(db_user2, flag, True)
+        db_user4 = session.merge(user4)
+        setattr(db_user4, flag, True)
+        session.commit()
+
+    # Refresh the materialized view
+    refresh_materialized_views_rapid(None)
+
+    with api_session(token1) as api:
+        res = api.GetLiteUsers(
+            api_pb2.GetLiteUsersReq(
+                users=[
+                    user1.username,  # visible
+                    user2.username,  # ghost
+                    str(user3.id),  # visible
+                    str(user4.id),  # ghost
+                ]
+            )
+        )
+
+        assert len(res.responses) == 4
+
+        # user1 - visible, normal profile
+        assert res.responses[0].query == user1.username
+        assert not res.responses[0].not_found
+        assert res.responses[0].user.user_id == user1.id
+        assert res.responses[0].user.username == user1.username
+        assert res.responses[0].user.name == user1.name
+
+        # user2 - ghost by username
+        assert res.responses[1].query == user2.username
+        assert not res.responses[1].not_found
+        assert res.responses[1].user.user_id == user2.id
+        assert res.responses[1].user.username == "ghost"
+        assert res.responses[1].user.name == "Deleted user"
+
+        # user3 - visible, normal profile
+        assert res.responses[2].query == str(user3.id)
+        assert not res.responses[2].not_found
+        assert res.responses[2].user.user_id == user3.id
+        assert res.responses[2].user.username == user3.username
+        assert res.responses[2].user.name == user3.name
+
+        # user4 - ghost by ID
+        assert res.responses[3].query == str(user4.id)
+        assert not res.responses[3].not_found
+        assert res.responses[3].user.user_id == user4.id
+        assert res.responses[3].user.username == "ghost"
+        assert res.responses[3].user.name == "Deleted user"
+
+
+def test_GetLiteUsers_blocked_users(db):
+    """Test that GetLiteUsers returns ghost profiles for blocked users."""
+    user1, token1 = generate_user()
+    user2, _ = generate_user()
+    user3, _ = generate_user()
+    user4, _ = generate_user()
+    user5, _ = generate_user()
+
+    # User1 blocks user2
+    make_user_block(user1, user2)
+    # User4 blocks user1
+    make_user_block(user4, user1)
+
+    # Refresh the materialized view
+    refresh_materialized_views_rapid(None)
+
+    with api_session(token1) as api:
+        res = api.GetLiteUsers(
+            api_pb2.GetLiteUsersReq(
+                users=[
+                    user2.username,  # user1 blocked user2
+                    str(user3.id),  # visible
+                    user4.username,  # user4 blocked user1
+                    str(user5.id),  # visible
+                ]
+            )
+        )
+
+        assert len(res.responses) == 4
+
+        # user2 - blocked by user1, should be ghost
+        assert res.responses[0].query == user2.username
+        assert not res.responses[0].not_found
+        assert res.responses[0].user.user_id == user2.id
+        assert res.responses[0].user.username == "ghost"
+        assert res.responses[0].user.name == "Deleted user"
+
+        # user3 - visible
+        assert res.responses[1].query == str(user3.id)
+        assert not res.responses[1].not_found
+        assert res.responses[1].user.user_id == user3.id
+        assert res.responses[1].user.username == user3.username
+
+        # user4 - user4 blocked user1, should be ghost
+        assert res.responses[2].query == user4.username
+        assert not res.responses[2].not_found
+        assert res.responses[2].user.user_id == user4.id
+        assert res.responses[2].user.username == "ghost"
+        assert res.responses[2].user.name == "Deleted user"
+
+        # user5 - visible
+        assert res.responses[3].query == str(user5.id)
+        assert not res.responses[3].not_found
+        assert res.responses[3].user.user_id == user5.id
+        assert res.responses[3].user.username == user5.username
+
+
+@pytest.mark.parametrize("flag", ["is_deleted", "is_banned"])
+def test_GetUser_ghost_user_by_id(db, flag):
+    """Test that GetUser returns a ghost profile for deleted/banned users when querying by ID."""
+    user1, token1 = generate_user()
+    user2, _ = generate_user()
+
+    # Make user2 invisible
+    with session_scope() as session:
+        db_user2 = session.merge(user2)
+        setattr(db_user2, flag, True)
+        session.commit()
+
+    with api_session(token1) as api:
+        # Query by ID
+        user_pb = api.GetUser(api_pb2.GetUserReq(user=str(user2.id)))
+
+        assert user_pb.user_id == user2.id
+        assert user_pb.username == "ghost"
+        assert user_pb.name == "Deleted user"
+        assert user_pb.city == ""
+        assert user_pb.hosting_status == 0
+        assert user_pb.meetup_status == 0
+
+
+def test_GetUser_blocked_user(db):
+    """Test that GetUser returns a ghost profile for blocked users."""
+    user1, token1 = generate_user()
+    user2, _ = generate_user()
+
+    # User1 blocks user2
+    make_user_block(user1, user2)
+
+    with api_session(token1) as api:
+        # Query by username
+        user_pb = api.GetUser(api_pb2.GetUserReq(user=user2.username))
+
+        assert user_pb.user_id == user2.id
+        assert user_pb.username == "ghost"
+        assert user_pb.name == "Deleted user"
+
+        # Query by ID
+        user_pb = api.GetUser(api_pb2.GetUserReq(user=str(user2.id)))
+
+        assert user_pb.user_id == user2.id
+        assert user_pb.username == "ghost"
+        assert user_pb.name == "Deleted user"
+
+
+def test_GetUser_blocking_user(db):
+    """Test that GetUser returns a ghost profile when the target user has blocked the requester."""
+    user1, token1 = generate_user()
+    user2, _ = generate_user()
+
+    # User2 blocks user1
+    make_user_block(user2, user1)
+
+    with api_session(token1) as api:
+        # Query by username
+        user_pb = api.GetUser(api_pb2.GetUserReq(user=user2.username))
+
+        assert user_pb.user_id == user2.id
+        assert user_pb.username == "ghost"
+        assert user_pb.name == "Deleted user"
+
+        # Query by ID
+        user_pb = api.GetUser(api_pb2.GetUserReq(user=str(user2.id)))
+
+        assert user_pb.user_id == user2.id
+        assert user_pb.username == "ghost"
+        assert user_pb.name == "Deleted user"

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -7,8 +7,8 @@ from google.protobuf import empty_pb2, wrappers_pb2
 from couchers.db import session_scope
 from couchers.jobs.handlers import update_badges
 from couchers.materialized_views import refresh_materialized_views_rapid
-from couchers.models import FriendRelationship, FriendStatus, RateLimitAction
-from couchers.proto import admin_pb2, api_pb2, jail_pb2, notifications_pb2
+from couchers.models import FriendRelationship, FriendStatus, RateLimitAction, User
+from couchers.proto import admin_pb2, api_pb2, blocking_pb2, jail_pb2, notifications_pb2
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_INTERVAL_STRING
 from couchers.resources import get_badge_dict
 from couchers.sql import couchers_select as select
@@ -173,16 +173,21 @@ def test_user_model_to_pb_ghost_user(db, flag):
     user2, _ = generate_user()
 
     with session_scope() as session:
-        db_user2 = session.merge(user2)
-        setattr(db_user2, flag, True)
-        session.commit()
+        setattr(session.execute(select(User).where(User.id == user2.id)).scalar_one(), flag, True)
+
+    refresh_materialized_views_rapid(None)
 
     with api_session(token1) as api:
         user_pb = api.GetUser(api_pb2.GetUserReq(user=user2.username))
 
     assert user_pb.user_id == user2.id
     assert user_pb.username == "ghost"
-    assert user_pb.name == "Deleted user"
+    assert user_pb.name == "Ghost user"
+    assert (
+        user_pb.about_me
+        == "This user is no longer on the platform. They may have deleted their account, been blocked, or banned. We recommend applying caution with any further interaction with this user, and reaching out to support if you need any help."
+    )
+
     assert user_pb.lat == 0
     assert user_pb.lng == 0
     assert user_pb.radius == 0
@@ -199,7 +204,6 @@ def test_user_model_to_pb_ghost_user(db, flag):
     assert user_pb.pronouns == ""
     assert user_pb.occupation == ""
     assert user_pb.education == ""
-    assert user_pb.about_me == ""
     assert user_pb.things_i_like == ""
     assert user_pb.about_place == ""
     assert user_pb.additional_information == ""
@@ -212,18 +216,93 @@ def test_user_model_to_pb_ghost_user(db, flag):
     assert user_pb.avatar_thumbnail_url == ""
     assert not user_pb.has_strong_verification
 
+    with api_session(token1) as api:
+        lite_user_pb = api.GetLiteUser(api_pb2.GetLiteUserReq(user=user2.username))
+
+    assert lite_user_pb.user_id == user2.id
+    assert lite_user_pb.username == "ghost"
+    assert lite_user_pb.name == "Ghost user"
+    assert lite_user_pb.city == ""
+    assert lite_user_pb.age == 0
+    assert lite_user_pb.avatar_url == ""
+    assert lite_user_pb.avatar_thumbnail_url == ""
+    assert lite_user_pb.lat == 0
+    assert lite_user_pb.lng == 0
+    assert lite_user_pb.radius == 0
+    assert not lite_user_pb.has_strong_verification
+
+
+def test_user_model_to_pb_ghost_user_blocked(db):
+    user1, token1 = generate_user()
+    user2, _ = generate_user()
+
+    with blocking_session(token1) as user_blocks:
+        user_blocks.BlockUser(blocking_pb2.BlockUserReq(username=user2.username))
+
+    refresh_materialized_views_rapid(None)
+
+    with api_session(token1) as api:
+        user_pb = api.GetUser(api_pb2.GetUserReq(user=user2.username))
+
+    assert user_pb.user_id == user2.id
+    assert user_pb.username == "ghost"
+    assert user_pb.name == "Ghost user"
+    assert (
+        user_pb.about_me
+        == "This user is no longer on the platform. They may have deleted their account, been blocked, or banned. We recommend applying caution with any further interaction with this user, and reaching out to support if you need any help."
+    )
+
+    assert user_pb.lat == 0
+    assert user_pb.lng == 0
+    assert user_pb.radius == 0
+    assert user_pb.verification == 0.0
+    assert user_pb.community_standing == 0.0
+    assert user_pb.num_references == 0
+    assert user_pb.age == 0
+    assert user_pb.hosting_status == 0
+    assert user_pb.meetup_status == 0
+    assert user_pb.city == ""
+    assert user_pb.hometown == ""
+    assert user_pb.timezone == ""
+    assert user_pb.gender == ""
+    assert user_pb.pronouns == ""
+    assert user_pb.occupation == ""
+    assert user_pb.education == ""
+    assert user_pb.things_i_like == ""
+    assert user_pb.about_place == ""
+    assert user_pb.additional_information == ""
+    assert list(user_pb.language_abilities) == []
+    assert list(user_pb.regions_visited) == []
+    assert list(user_pb.regions_lived) == []
+    assert list(user_pb.badges) == []
+    assert user_pb.friends == api_pb2.User.FriendshipStatus.NOT_FRIENDS
+    assert user_pb.avatar_url == ""
+    assert user_pb.avatar_thumbnail_url == ""
+    assert not user_pb.has_strong_verification
+
+    with api_session(token1) as api:
+        lite_user_pb = api.GetLiteUser(api_pb2.GetLiteUserReq(user=user2.username))
+
+    assert lite_user_pb.user_id == user2.id
+    assert lite_user_pb.username == "ghost"
+    assert lite_user_pb.name == "Ghost user"
+    assert lite_user_pb.city == ""
+    assert lite_user_pb.age == 0
+    assert lite_user_pb.avatar_url == ""
+    assert lite_user_pb.avatar_thumbnail_url == ""
+    assert lite_user_pb.lat == 0
+    assert lite_user_pb.lng == 0
+    assert lite_user_pb.radius == 0
+    assert not lite_user_pb.has_strong_verification
+
 
 @pytest.mark.parametrize("flag", ["is_deleted", "is_banned"])
 def test_admin_viewing_ghost_users_sees_full_profile(db, flag):
-    admin, token_admin = generate_user()
+    admin, token_admin = generate_user(is_superuser=True)
     user, _ = generate_user()
 
     with session_scope() as session:
-        admin_db = session.merge(admin)
-        user_db = session.merge(user)
-        setattr(user_db, flag, True)
-        admin_db.is_superuser = True
-        session.commit()
+        setattr(session.execute(select(User).where(User.id == user.id)).scalar_one(), flag, True)
 
     with admin_session(token_admin) as api:
         user_pb = api.GetUser(admin_pb2.GetUserReq(user=user.username))
@@ -232,7 +311,7 @@ def test_admin_viewing_ghost_users_sees_full_profile(db, flag):
     assert user_pb.username == user.username
     assert user_pb.name == user.name
     assert user_pb.city == user.city
-    assert user_pb.name != "Deleted user"
+    assert user_pb.name != "Ghost user"
     assert user_pb.username != "ghost"
     assert user_pb.hosting_status in (
         api_pb2.HOSTING_STATUS_UNKNOWN,
@@ -396,7 +475,7 @@ def test_GetLiteUsers(db):
         assert not res.responses[8].not_found
         assert res.responses[8].user.user_id == user4.id
         assert res.responses[8].user.username == "ghost"
-        assert res.responses[8].user.name == "Deleted user"
+        assert res.responses[8].user.name == "Ghost user"
 
     with api_session(token1) as api:
         with pytest.raises(grpc.RpcError) as e:
@@ -1409,7 +1488,7 @@ def test_GetLiteUser_ghost_user_by_username(db, flag):
 
         assert lite_user.user_id == user2.id
         assert lite_user.username == "ghost"
-        assert lite_user.name == "Deleted user"
+        assert lite_user.name == "Ghost user"
         assert lite_user.lat == 0
         assert lite_user.lng == 0
         assert lite_user.radius == 0
@@ -1441,7 +1520,7 @@ def test_GetLiteUser_ghost_user_by_id(db, flag):
 
         assert lite_user.user_id == user2.id
         assert lite_user.username == "ghost"
-        assert lite_user.name == "Deleted user"
+        assert lite_user.name == "Ghost user"
         assert lite_user.lat == 0
         assert lite_user.lng == 0
         assert lite_user.radius == 0
@@ -1469,14 +1548,14 @@ def test_GetLiteUser_blocked_user(db):
 
         assert lite_user.user_id == user2.id
         assert lite_user.username == "ghost"
-        assert lite_user.name == "Deleted user"
+        assert lite_user.name == "Ghost user"
 
         # Query by ID
         lite_user = api.GetLiteUser(api_pb2.GetLiteUserReq(user=str(user2.id)))
 
         assert lite_user.user_id == user2.id
         assert lite_user.username == "ghost"
-        assert lite_user.name == "Deleted user"
+        assert lite_user.name == "Ghost user"
 
 
 def test_GetLiteUser_blocking_user(db):
@@ -1496,14 +1575,14 @@ def test_GetLiteUser_blocking_user(db):
 
         assert lite_user.user_id == user2.id
         assert lite_user.username == "ghost"
-        assert lite_user.name == "Deleted user"
+        assert lite_user.name == "Ghost user"
 
         # Query by ID
         lite_user = api.GetLiteUser(api_pb2.GetLiteUserReq(user=str(user2.id)))
 
         assert lite_user.user_id == user2.id
         assert lite_user.username == "ghost"
-        assert lite_user.name == "Deleted user"
+        assert lite_user.name == "Ghost user"
 
 
 @pytest.mark.parametrize("flag", ["is_deleted", "is_banned"])
@@ -1551,7 +1630,7 @@ def test_GetLiteUsers_ghost_users(db, flag):
         assert not res.responses[1].not_found
         assert res.responses[1].user.user_id == user2.id
         assert res.responses[1].user.username == "ghost"
-        assert res.responses[1].user.name == "Deleted user"
+        assert res.responses[1].user.name == "Ghost user"
 
         # user3 - visible, normal profile
         assert res.responses[2].query == str(user3.id)
@@ -1565,7 +1644,7 @@ def test_GetLiteUsers_ghost_users(db, flag):
         assert not res.responses[3].not_found
         assert res.responses[3].user.user_id == user4.id
         assert res.responses[3].user.username == "ghost"
-        assert res.responses[3].user.name == "Deleted user"
+        assert res.responses[3].user.name == "Ghost user"
 
 
 def test_GetLiteUsers_blocked_users(db):
@@ -1603,7 +1682,7 @@ def test_GetLiteUsers_blocked_users(db):
         assert not res.responses[0].not_found
         assert res.responses[0].user.user_id == user2.id
         assert res.responses[0].user.username == "ghost"
-        assert res.responses[0].user.name == "Deleted user"
+        assert res.responses[0].user.name == "Ghost user"
 
         # user3 - visible
         assert res.responses[1].query == str(user3.id)
@@ -1616,7 +1695,7 @@ def test_GetLiteUsers_blocked_users(db):
         assert not res.responses[2].not_found
         assert res.responses[2].user.user_id == user4.id
         assert res.responses[2].user.username == "ghost"
-        assert res.responses[2].user.name == "Deleted user"
+        assert res.responses[2].user.name == "Ghost user"
 
         # user5 - visible
         assert res.responses[3].query == str(user5.id)
@@ -1643,7 +1722,7 @@ def test_GetUser_ghost_user_by_id(db, flag):
 
         assert user_pb.user_id == user2.id
         assert user_pb.username == "ghost"
-        assert user_pb.name == "Deleted user"
+        assert user_pb.name == "Ghost user"
         assert user_pb.city == ""
         assert user_pb.hosting_status == 0
         assert user_pb.meetup_status == 0
@@ -1663,14 +1742,14 @@ def test_GetUser_blocked_user(db):
 
         assert user_pb.user_id == user2.id
         assert user_pb.username == "ghost"
-        assert user_pb.name == "Deleted user"
+        assert user_pb.name == "Ghost user"
 
         # Query by ID
         user_pb = api.GetUser(api_pb2.GetUserReq(user=str(user2.id)))
 
         assert user_pb.user_id == user2.id
         assert user_pb.username == "ghost"
-        assert user_pb.name == "Deleted user"
+        assert user_pb.name == "Ghost user"
 
 
 def test_GetUser_blocking_user(db):
@@ -1687,11 +1766,11 @@ def test_GetUser_blocking_user(db):
 
         assert user_pb.user_id == user2.id
         assert user_pb.username == "ghost"
-        assert user_pb.name == "Deleted user"
+        assert user_pb.name == "Ghost user"
 
         # Query by ID
         user_pb = api.GetUser(api_pb2.GetUserReq(user=str(user2.id)))
 
         assert user_pb.user_id == user2.id
         assert user_pb.username == "ghost"
-        assert user_pb.name == "Deleted user"
+        assert user_pb.name == "Ghost user"

--- a/app/backend/src/tests/test_blocking.py
+++ b/app/backend/src/tests/test_blocking.py
@@ -2,8 +2,9 @@ import grpc
 import pytest
 from google.protobuf import empty_pb2
 
-from couchers.models import UserBlock
+from couchers.models import User, UserBlock
 from couchers.proto import blocking_pb2
+from couchers.servicers.blocking import is_not_visible
 from couchers.sql import couchers_select as select
 from tests.test_fixtures import blocking_session, db, generate_user, make_user_block, session_scope, testconfig  # noqa
 
@@ -127,3 +128,158 @@ def test_relationships_userblock_dot_user(db):
     assert blocked_user_username == user2.username
     assert blocking_user_name == user1.name
     assert blocked_user_name == user2.name
+
+
+def test_is_not_visible(db):
+    """
+    Comprehensive tests for is_not_visible function covering:
+    1. Normal visible users (not blocked, not banned, not deleted) - should be visible to each other
+    2. User1 blocks User2 - not visible
+    3. User2 blocks User1 - not visible
+    4. Mutual blocking - not visible
+    5. User1 is deleted - not visible
+    6. User2 is deleted - not visible
+    7. Both users deleted - not visible
+    8. User1 is banned - not visible
+    9. User2 is banned - not visible
+    10. Both users banned - not visible
+    11. Mixed: User1 deleted and User2 banned - not visible
+    12. None user_id cases with visible users
+    13. None user_id cases with hidden users (banned/deleted)
+    14. Ensure we have extra users in DB to avoid edge cases with empty database
+    """
+
+    # Create extra users to ensure the database is not empty - these should remain visible
+    extra_user1, _ = generate_user()
+    extra_user2, _ = generate_user()
+    extra_user3, _ = generate_user()
+
+    # Create users for testing - all start as visible
+    normal_user1, _ = generate_user()
+    normal_user2, _ = generate_user()
+
+    # Users for blocking tests
+    blocker_user, _ = generate_user()
+    blockee_user, _ = generate_user()
+
+    # Users for reverse blocking tests
+    reverse_blocker, _ = generate_user()
+    reverse_blockee, _ = generate_user()
+
+    # Users for mutual blocking tests
+    mutual_blocker1, _ = generate_user()
+    mutual_blocker2, _ = generate_user()
+
+    # Users for deletion tests
+    deleted_user1, _ = generate_user()
+    visible_for_deleted, _ = generate_user()
+    deleted_user2, _ = generate_user()
+    both_deleted1, _ = generate_user()
+    both_deleted2, _ = generate_user()
+
+    # Users for ban tests
+    banned_user1, _ = generate_user()
+    visible_for_banned, _ = generate_user()
+    banned_user2, _ = generate_user()
+    both_banned1, _ = generate_user()
+    both_banned2, _ = generate_user()
+
+    # User for mixed test
+    mixed_deleted, _ = generate_user()
+    mixed_banned, _ = generate_user()
+
+    with session_scope() as session:
+        # Test 1: Two normal visible users - should be visible to each other
+        assert not is_not_visible(session, normal_user1.id, normal_user2.id)
+        assert not is_not_visible(session, normal_user2.id, normal_user1.id)
+
+        # Test 2: User1 blocks User2 - should not be visible
+        make_user_block(blocker_user, blockee_user)
+        assert is_not_visible(session, blocker_user.id, blockee_user.id)
+        assert is_not_visible(session, blockee_user.id, blocker_user.id)  # symmetric
+
+        # Test 3: User2 blocks User1 (reverse block) - should not be visible
+        make_user_block(reverse_blockee, reverse_blocker)
+        assert is_not_visible(session, reverse_blocker.id, reverse_blockee.id)
+        assert is_not_visible(session, reverse_blockee.id, reverse_blocker.id)  # symmetric
+
+        # Test 4: Mutual blocking - should not be visible
+        make_user_block(mutual_blocker1, mutual_blocker2)
+        make_user_block(mutual_blocker2, mutual_blocker1)
+        assert is_not_visible(session, mutual_blocker1.id, mutual_blocker2.id)
+        assert is_not_visible(session, mutual_blocker2.id, mutual_blocker1.id)
+
+        # Test 5: User1 is deleted - should not be visible
+        deleted_user1_db = session.get(User, deleted_user1.id)
+        deleted_user1_db.is_deleted = True
+        session.commit()
+        assert is_not_visible(session, deleted_user1.id, visible_for_deleted.id)
+        assert is_not_visible(session, visible_for_deleted.id, deleted_user1.id)
+
+        # Test 6: User2 is deleted - should not be visible
+        deleted_user2_db = session.get(User, deleted_user2.id)
+        deleted_user2_db.is_deleted = True
+        session.commit()
+        assert is_not_visible(session, normal_user1.id, deleted_user2.id)
+        assert is_not_visible(session, deleted_user2.id, normal_user1.id)
+
+        # Test 7: Both users deleted - should not be visible
+        both_deleted1_db = session.get(User, both_deleted1.id)
+        both_deleted2_db = session.get(User, both_deleted2.id)
+        both_deleted1_db.is_deleted = True
+        both_deleted2_db.is_deleted = True
+        session.commit()
+        assert is_not_visible(session, both_deleted1.id, both_deleted2.id)
+        assert is_not_visible(session, both_deleted2.id, both_deleted1.id)
+
+        # Test 8: User1 is banned - should not be visible
+        banned_user1_db = session.get(User, banned_user1.id)
+        banned_user1_db.is_banned = True
+        session.commit()
+        assert is_not_visible(session, banned_user1.id, visible_for_banned.id)
+        assert is_not_visible(session, visible_for_banned.id, banned_user1.id)
+
+        # Test 9: User2 is banned - should not be visible
+        banned_user2_db = session.get(User, banned_user2.id)
+        banned_user2_db.is_banned = True
+        session.commit()
+        assert is_not_visible(session, normal_user2.id, banned_user2.id)
+        assert is_not_visible(session, banned_user2.id, normal_user2.id)
+
+        # Test 10: Both users banned - should not be visible
+        both_banned1_db = session.get(User, both_banned1.id)
+        both_banned2_db = session.get(User, both_banned2.id)
+        both_banned1_db.is_banned = True
+        both_banned2_db.is_banned = True
+        session.commit()
+        assert is_not_visible(session, both_banned1.id, both_banned2.id)
+        assert is_not_visible(session, both_banned2.id, both_banned1.id)
+
+        # Test 11: Mixed - one deleted, one banned - should not be visible
+        mixed_deleted_db = session.get(User, mixed_deleted.id)
+        mixed_banned_db = session.get(User, mixed_banned.id)
+        mixed_deleted_db.is_deleted = True
+        mixed_banned_db.is_banned = True
+        session.commit()
+        assert is_not_visible(session, mixed_deleted.id, mixed_banned.id)
+        assert is_not_visible(session, mixed_banned.id, mixed_deleted.id)
+
+        # Test 12: None user_id cases with visible users - should be visible
+        assert not is_not_visible(session, None, normal_user1.id)
+        assert not is_not_visible(session, normal_user1.id, None)
+        assert not is_not_visible(session, None, None)
+
+        # Test 13: None user_id cases with hidden users (deleted/banned) - should not be visible
+        assert is_not_visible(session, None, deleted_user1.id)
+        assert is_not_visible(session, deleted_user1.id, None)
+        assert is_not_visible(session, None, banned_user1.id)
+        assert is_not_visible(session, banned_user1.id, None)
+
+        # Test 14: Verify extra users are still visible (database not empty)
+        assert not is_not_visible(session, extra_user1.id, extra_user2.id)
+        assert not is_not_visible(session, extra_user2.id, extra_user3.id)
+        assert not is_not_visible(session, extra_user1.id, extra_user3.id)
+
+        # Additional edge case: Check that normal users are still visible to each other after all the above
+        assert not is_not_visible(session, normal_user1.id, normal_user2.id)
+        assert not is_not_visible(session, normal_user1.id, extra_user1.id)


### PR DESCRIPTION
PR is doing:
Refactored user_model_to_pb and lite_user_to_pb to ensure consistent handling of deleted and banned users (ghost profiles).
Previously, ghost profile data was not fully aligned between these two functions. This PR unifies the approach and ensures that all relevant fields are set to safe default values for deleted/banned users.

Tests:
Added test_user_model_to_pb_ghost_user and test_lite_user_to_pb_ghost_user to verify that both functions return the correct proto for ghost profiles.

PR closes #4297.

How to test PR:
    - Create a test user.
    - Mark the user as is_deleted = True or is_banned = True in the database.
    - Call user_model_to_pb and verify the returned proto contains only ghost profile defaults.
    - Call lite_user_to_pb and verify the returned proto contains only ghost profile defaults.
    - Run the new tests — all should pass.

Closes #4297