### PR TITLE
Fix Portuguese fallback

### DIFF
--- a/app/web/next-i18next.config.js
+++ b/app/web/next-i18next.config.js
@@ -3,8 +3,8 @@ const { allLanguages } = require("./i18n/allLanguages");
 
 const fallbackLng = {
   default: ["en"],
-  "pt-BR": ["pt_PT"],
-  "pt-PT": ["pt_BR"],
+  "pt-BR": ["pt", "en"],
+  "pt-PT": ["pt_BR", "en"],
   "es-419": ["es", "en"],
   "fr-CA": ["fr", "en"],
   zh: ["zh-Hans", "en"],


### PR DESCRIPTION
Closes #6631 

Update language code for pt-pt to pt for the pt-br fallback. Add "en" as the final fallback, was missing for Portuguese.