### PR TITLE
Prep markdown file structure for translation

### DIFF
--- a/app/web/markdown/locales/ca/volunteer.md
+++ b/app/web/markdown/locales/ca/volunteer.md
@@ -15,15 +15,15 @@ We are always looking for more people to join us, in positions such as software 
 
 Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
 
-* **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
 
-* **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
 
-* **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
 
-* **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
 
-* **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
 
 We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
 
@@ -31,7 +31,7 @@ You can read more about our [Mission & Values here](/mission).
 
 ## How to join us as a volunteer ― our recruitment process
 
-*If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code.*
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
 
 1. Find one of the open positions below and apply via the form!
 

--- a/app/web/markdown/locales/cs/volunteer.md
+++ b/app/web/markdown/locales/cs/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission) our plan and mission
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/de/volunteer.md
+++ b/app/web/markdown/locales/de/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/en/volunteer.md
+++ b/app/web/markdown/locales/en/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/es-419/volunteer.md
+++ b/app/web/markdown/locales/es-419/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/es/volunteer.md
+++ b/app/web/markdown/locales/es/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/fr-CA/volunteer.md
+++ b/app/web/markdown/locales/fr-CA/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/fr/volunteer.md
+++ b/app/web/markdown/locales/fr/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/hi/volunteer.md
+++ b/app/web/markdown/locales/hi/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/it/volunteer.md
+++ b/app/web/markdown/locales/it/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/ja/volunteer.md
+++ b/app/web/markdown/locales/ja/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/nb-NO/volunteer.md
+++ b/app/web/markdown/locales/nb-NO/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/nl/volunteer.md
+++ b/app/web/markdown/locales/nl/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/pl/volunteer.md
+++ b/app/web/markdown/locales/pl/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/pt-BR/volunteer.md
+++ b/app/web/markdown/locales/pt-BR/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/pt/volunteer.md
+++ b/app/web/markdown/locales/pt/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/ru/volunteer.md
+++ b/app/web/markdown/locales/ru/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/sv/volunteer.md
+++ b/app/web/markdown/locales/sv/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/uk/volunteer.md
+++ b/app/web/markdown/locales/uk/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/zh-Hans/volunteer.md
+++ b/app/web/markdown/locales/zh-Hans/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/markdown/locales/zh-Hant/volunteer.md
+++ b/app/web/markdown/locales/zh-Hant/volunteer.md
@@ -1,0 +1,92 @@
+---
+title: "Volunteer: be part of bringing the next generation of couch surfing to life"
+crumb: Volunteer
+description: "Join the global Couchers.org team. Work with passionate professionals and make a huge impact on the couch surfing community."
+type: general
+---
+
+## Our Team
+
+Couchers.org is built and run by a passionate team of volunteers, with everyone contributing their professional skills in their spare time.
+
+We are always looking for more people to join us, in positions such as software engineering, data science, operations, design, marketing, finance, events, volunteer coordination and more!
+
+## Why volunteer with Couchers? The Volunteering Experience.
+
+Volunteering with Couchers means contributing to something meaningful — **building a platform that helps people connect in genuine, non-transactional ways**. We get to focus on projects that help real people, with priorities shaped by our community — not by shareholders or profit motives. We care deeply about what we're doing and about the people we do it with. We're always glad to welcome volunteers and do our best to make your experience enriching and worthwhile. We focus especially on:
+
+- **Professional & personal development**: Volunteering with Couchers offers a chance to build your skills alongside a diverse, global team of smart, committed volunteers. Our volunteers come from a wide range of backgrounds — from top tech companies to startups, and from all over the world. Whether you're looking to deepen your expertise or explore something new, you'll find opportunities to learn, contribute, and grow in a collaborative, international, real-world environment.
+
+- **Have fun & grow your network**: Our volunteers share a passion for the project and a belief in its mission, and come from a wide range of backgrounds and experiences. We create space for connection through casual virtual events and community chats, and have big plans for in-person meetups to bring volunteers and alumni together. It's a chance to connect with thoughtful, like-minded people while contributing to something meaningful.
+
+- **Build real things that matter to the world**: At Couchers, volunteers don't just watch from the sidelines — they take ownership of meaningful work. Whether you're contributing to the platform, shaping community initiatives, or improving internal systems, you'll have the chance to make independent contributions that directly impact our mission. It's a great opportunity to apply your skills in a real-world setting, explore new challenges, and grow by doing. And while we're a volunteer-led team, we're always happy to support your professional goals however we can — whether that's feedback, a reference, or helping showcase your work.
+
+- **Leadership & ownership**: Our volunteers take a leadership role to see complex projects to completion, taking ownership of projects and tasks and learning how to get things done effectively in resourceful and innovative ways.
+
+- **Remote work**: All work is done remotely, with everyone working to their own schedules. We have a couple of regular calls each week where team members can connect, align on priorities, and get unblocked. We try to maintain great documentation and are always working to improve our asynchronous practices to make the remote experience as smooth as possible.
+
+We value being highly collaborative in order to learn and develop together while being honest and transparent, kind, welcoming, and enthusiastic. Our team is made up of dedicated, thoughtful people who take ownership of their work and share a common goal of supporting the couch surfing community while having fun along the way.
+
+You can read more about our [Mission & Values here](/mission).
+
+## How to join us as a volunteer ― our recruitment process
+
+_If you are software engineer, feel free to hop over to [GitHub](https://github.com/Couchers-org/couchers/) and contribute code._
+
+1. Find one of the open positions below and apply via the form!
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.
+
+## Open positions
+
+### General Application
+
+Want to help but don't see anything listed for you? [Fill out this form](/volunteer/form)
+
+### Core Team
+
+#### Community
+
+- [Community Builder Program Manager](/volunteer/community-builder-program-manager)
+
+#### Development
+
+- [Backend Developer (Python)](/volunteer/backend-developer)
+- [Frontend (web) Developer (React/Typescript)](/volunteer/frontend-developer)
+- [Mobile Development Lead](/volunteer/mobile-development-lead)
+
+#### Operations
+
+- [Volunteer Coordinator](/volunteer/volunteer-coordinator)
+- [Translator](/volunteer/translator)
+
+#### Design
+
+- [UI/UX Designer](/volunteer/ui-ux-designer)
+
+#### Marketing
+
+- [Head of Marketing](/volunteer/head-of-marketing)
+- [PR Manager](/volunteer/pr-manager)
+- [Social Media Community Manager](/volunteer/social-media-community-manager)
+- [Blog Writer](/volunteer/blog-writer)
+
+#### Support
+
+- [Technical Support Analyst](/volunteer/technical-support-analyst)
+
+### Community Building
+
+One of the best ways to get involved is to become a Community Builder for your local Couchers community. You can even do this in addition to volunteering in a different role. A Community Builder is an ambassador to the community who helps support, moderate, and grow the community. Learn more [here](https://help.couchers.org/hc/couchersorg-help-center/articles/1743977410-what-is-a-community-builder). If this sounds like something you're interested in, fill out the form here:
+
+#### [Community Builder application form](/community-builder-form)
+
+### [Our Plan](/plan) and [Our Mission & Values](/mission)
+
+Read about [Our Plan](/plan) and [Our Mission & Values](/mission).
+
+### [Meet our volunteers](/team)
+
+You can see our current and past volunteers on [our team page](/team).

--- a/app/web/pages/[...slug].tsx
+++ b/app/web/pages/[...slug].tsx
@@ -10,13 +10,32 @@ import { getAllMarkdownPathsWithLocales } from "utils/markdownPages";
 
 async function getMarkdownPageBySlug(
   slug: Array<string>,
+  locale: string,
 ): Promise<MarkdownPageProps> {
-  const md = await import(`markdown/${slug.join("/")}.md`);
-  return {
-    slug,
-    frontmatter: md.attributes,
-    content: md.html,
-  };
+  // Try new format first: markdown/locales/<locale>/<slug>.md
+  try {
+    const md = await import(`markdown/locales/${locale}/${slug.join("/")}.md`);
+    return {
+      slug,
+      frontmatter: md.attributes,
+      content: md.html,
+    };
+  } catch (error) {
+    // Fallback to old format: markdown/<slug>.md (default English)
+    try {
+      const md = await import(`markdown/${slug.join("/")}.md`);
+      return {
+        slug,
+        frontmatter: md.attributes,
+        content: md.html,
+      };
+    } catch (e3) {
+      // Not found in any location
+      throw new Error(
+        `Markdown file not found for slug: ${slug.join("/")} and locale: ${locale}`,
+      );
+    }
+  }
 }
 
 export const getStaticPaths: GetStaticPaths = () => ({
@@ -24,16 +43,19 @@ export const getStaticPaths: GetStaticPaths = () => ({
   fallback: false,
 });
 
-export const getStaticProps: GetStaticProps = async ({ locale, params }) => ({
-  props: {
-    ...(await serverSideTranslations(
-      locale ?? "en",
-      [GLOBAL, AUTH, NOTIFICATIONS],
-      nextI18nextConfig,
-    )),
-    page: await getMarkdownPageBySlug(params!.slug as Array<string>),
-  },
-});
+export const getStaticProps: GetStaticProps = async ({ locale, params }) => {
+  const lang = locale ?? "en";
+  return {
+    props: {
+      ...(await serverSideTranslations(
+        lang,
+        [GLOBAL, AUTH, NOTIFICATIONS],
+        nextI18nextConfig,
+      )),
+      page: await getMarkdownPageBySlug(params!.slug as Array<string>, lang),
+    },
+  };
+};
 
 export default function Markdown({ page }: { page: MarkdownPageProps }) {
   return <MarkdownPage {...page} />;

--- a/app/web/pages/[...slug].tsx
+++ b/app/web/pages/[...slug].tsx
@@ -20,7 +20,7 @@ async function getMarkdownPageBySlug(
       frontmatter: md.attributes,
       content: md.html,
     };
-  } catch (error) {
+  } catch {
     // Fallback to old format: markdown/<slug>.md (default English)
     try {
       const md = await import(`markdown/${slug.join("/")}.md`);
@@ -29,7 +29,7 @@ async function getMarkdownPageBySlug(
         frontmatter: md.attributes,
         content: md.html,
       };
-    } catch (e3) {
+    } catch {
       // Not found in any location
       throw new Error(
         `Markdown file not found for slug: ${slug.join("/")} and locale: ${locale}`,

--- a/app/web/utils/markdownPages.ts
+++ b/app/web/utils/markdownPages.ts
@@ -1,26 +1,37 @@
 import { glob } from "glob";
 import { allLanguages } from "i18n/allLanguages";
 
+// Support both old and new formats:
+// - Old: markdown/<slug>.md (default to 'en')
+// - New: markdown/locales/<lang>/<slug>.md
 export function getAllMarkdownFiles(): Array<string> {
-  return glob.sync("markdown/**/*.md");
+  const oldFormat = glob.sync("markdown/*.md");
+  const oldLangFormat = glob.sync("markdown/*/*.md");
+  const newFormat = glob.sync("markdown/locales/*/**/*.md");
+  return [...oldFormat, ...oldLangFormat, ...newFormat];
 }
 
 /*
-Turns
-
-markdown/issues/communities-and-trust.md
-
-into
-
-['issues', 'communities-and-trust']
+Converts filename to { locale, slug } for both formats.
 */
-export function filenameToSlug(filename: string) {
+export function filenameToLocaleAndSlug(filename: string) {
   if (!(filename.startsWith("markdown/") && filename.endsWith(".md"))) {
     throw Error(`Invalid filename ${filename}`);
   }
-  return filename
+  // New format: markdown/locales/<lang>/<slug>.md
+  if (filename.startsWith("markdown/locales/")) {
+    const withoutPrefix = filename.substring(
+      "markdown/locales/".length,
+      filename.length - ".md".length,
+    );
+    const [locale, ...slugParts] = withoutPrefix.split("/");
+    return { locale, slug: slugParts };
+  }
+  // Old format: markdown/<slug>.md (default to 'en')
+  const slug = filename
     .substring("markdown/".length, filename.length - ".md".length)
     .split("/");
+  return { locale: "en", slug };
 }
 
 // From Next.js documentation:
@@ -29,15 +40,41 @@ export function getAllMarkdownPathsWithLocales(): {
   params: { slug: string[] };
   locale: string;
 }[] {
-  const baseSlugs = getAllMarkdownFiles().map(filenameToSlug);
+  // Collect all unique slugs from all formats
+  const files = getAllMarkdownFiles();
+  const slugs = new Set();
+  for (const file of files) {
+    // Use the existing logic to extract slug (ignore locale)
+    let slugArr;
+    if (file.startsWith("markdown/locales/")) {
+      const withoutPrefix = file.substring(
+        "markdown/locales/".length,
+        file.length - ".md".length,
+      );
+      const [, ...slugParts] = withoutPrefix.split("/");
+      slugArr = slugParts;
+    } else if (file.startsWith("markdown/")) {
+      const rest = file.substring(
+        "markdown/".length,
+        file.length - ".md".length,
+      );
+      const parts = rest.split("/");
+      // If old per-language format, skip the first part (the lang)
+      if (parts.length > 1 && parts[0].length === 2) {
+        slugArr = parts.slice(1);
+      } else {
+        slugArr = parts;
+      }
+    }
+    slugs.add(JSON.stringify(slugArr));
+  }
 
   const paths = [];
-
   for (const lang of allLanguages) {
-    for (const slug of baseSlugs) {
+    for (const slugStr of slugs) {
+      const slug = JSON.parse(slugStr as string);
       paths.push({ params: { slug }, locale: lang });
     }
   }
-
   return paths;
 }


### PR DESCRIPTION
Preps the markdown folder to allow us to add files for translation one-by-one. For now I am just adding the volunteer page as the text has been reviewed. This means the markdown files need to be reachable via the route `/en/volunteer`, `/de/volunteer`, etc.

It's a bit messy for now, because we need to support the older future structure and allow adding files one-by-one to the new structure.

I didn't want Weblate to automatically import stuff that's not ready. There will probably also be markdown files we don't want to translate. That's why I didn't move everything into the new folder structure yet.

Part of #6232.

**TO TEST**: 
- Go to volunteer page and switch languages via the language picker to a few different things. It should work. (new folder structure)
- Go to other markdown pages like FAQ, Mission, etc. and switch languages to a few different things. Should also work. (old folder structure)
- Make sure regular pages still translate: i.e. Profile, Messages, Dashboard, etc. Switch to German, etc.