### PR TITLE
Redirect authenticated users from index to dashboard

### DIFF
--- a/app/web/appConstants.ts
+++ b/app/web/appConstants.ts
@@ -17,3 +17,5 @@ export const grpcErrorStrings = {
 };
 
 export type ObscureGrpcErrorMessages = keyof typeof grpcErrorStrings;
+
+export const sessionCookieName = "couchers-sesh";

--- a/app/web/components/Footer/Footer.tsx
+++ b/app/web/components/Footer/Footer.tsx
@@ -18,7 +18,6 @@ import { GLOBAL } from "i18n/namespaces";
 import Link from "next/link";
 import { ReactNode } from "react";
 import {
-  baseRoute,
   blogRoute,
   builtWithRoute,
   contactRoute,
@@ -31,6 +30,7 @@ import {
   githubURL,
   helpCenterURL,
   instagramURL,
+  landingRoute,
   missionRoute,
   planRoute,
   redditURL,
@@ -188,7 +188,7 @@ export default function Footer({ bottomMargin }: { bottomMargin?: string }) {
             </Typography>
             <FooterLink href={blogRoute}>{t("nav.blog")}</FooterLink>
             <FooterLink href={teamRoute}>{t("nav.our_team")}</FooterLink>
-            <FooterLink href={baseRoute}>{t("nav.landing_page")}</FooterLink>
+            <FooterLink href={landingRoute}>{t("nav.landing_page")}</FooterLink>
             <FooterLink href={eventsRoute}>
               {t("nav.show_all_events")}
             </FooterLink>

--- a/app/web/middleware.ts
+++ b/app/web/middleware.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { sessionCookieName } from "./appConstants";
 import { allLanguages } from "./i18n/allLanguages";
 
 function getBrowserLocale(
@@ -31,7 +32,7 @@ function getBrowserLocale(
 
 export function middleware(request: NextRequest) {
   if (
-    request.cookies.get("couchers-sesh") &&
+    request.cookies.get(sessionCookieName) &&
     request.nextUrl.pathname === "/"
   ) {
     const url = request.nextUrl.clone();

--- a/app/web/pages/index.tsx
+++ b/app/web/pages/index.tsx
@@ -1,33 +1,18 @@
-import { appGetLayout } from "components/AppRoute";
-import {
-  AUTH,
-  DASHBOARD,
-  GLOBAL,
-  LANDING,
-  NOTIFICATIONS,
-} from "i18n/namespaces";
-import { GetStaticProps } from "next";
-import nextI18nextConfig from "next-i18next.config";
-import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { sessionCookieName } from "appConstants";
+import { GetServerSideProps } from "next";
+import { dashboardRoute, landingRoute } from "routes";
 
-import LandingPage from "../features/landing/LandingPage";
-
-export const getStaticProps: GetStaticProps = async ({ locale }) => ({
-  props: {
-    ...(await serverSideTranslations(
-      locale ?? "en",
-      [AUTH, DASHBOARD, GLOBAL, LANDING, NOTIFICATIONS],
-      nextI18nextConfig,
-    )),
-  },
-});
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  return {
+    redirect: {
+      destination: context.req.cookies[sessionCookieName]
+        ? dashboardRoute
+        : landingRoute,
+      permanent: true,
+    },
+  };
+};
 
 export default function HomePage() {
-  return <LandingPage />;
+  return undefined;
 }
-
-HomePage.getLayout = appGetLayout({
-  isPrivate: false,
-  variant: "full-screen",
-  bottomMargin: "80px",
-});

--- a/app/web/pages/landing.tsx
+++ b/app/web/pages/landing.tsx
@@ -1,0 +1,32 @@
+import { appGetLayout } from "components/AppRoute";
+import LandingPage from "features/landing/LandingPage";
+import {
+  AUTH,
+  DASHBOARD,
+  GLOBAL,
+  LANDING,
+  NOTIFICATIONS,
+} from "i18n/namespaces";
+import { GetStaticProps } from "next";
+import nextI18nextConfig from "next-i18next.config";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
+  props: {
+    ...(await serverSideTranslations(
+      locale ?? "en",
+      [AUTH, DASHBOARD, GLOBAL, LANDING, NOTIFICATIONS],
+      nextI18nextConfig,
+    )),
+  },
+});
+
+export default function HomePage() {
+  return <LandingPage />;
+}
+
+HomePage.getLayout = appGetLayout({
+  isPrivate: false,
+  variant: "full-screen",
+  bottomMargin: "80px",
+});

--- a/app/web/routes.ts
+++ b/app/web/routes.ts
@@ -20,6 +20,7 @@ export const githubUpdatesURL =
 
 export const translateJobURL = "https://couchers.org/volunteer/translator";
 
+export const landingRoute = "/landing";
 export const dashboardRoute = "/dashboard";
 export const blogRoute = "/blog";
 export const faqRoute = "/faq";


### PR DESCRIPTION
Redirect authenticated users from index to `/dashboard`, otherwise redirect them to `/landing` (which renders the landing page that's currently on index).

I decided to do this with `getServerSideProps`, to not affect our SEO (index permanently redirects to `/landing` for unauthenticated users, so crawlers won't be affected at all) and for a better UX (no page is rendered at all before the user is redirected to the correct page, reducing load times and flickering). 
It does increase server load, though I assume the increase will be negligible.
As we handle auth with our Python backend, I can't actually verify the auth cookie, and instead just check for its existence. This is probably desired though, as it reduces server load and redirects previously authenticated users (aka users with expired cookies) to `/login` (via `/dashboard`) instead of to `/landing`, which feels more natural

> [!IMPORTANT]  
> Doesn't work on preview builds, as the session cookie isn't present

Closes #6464

**Web frontend checklist**
- [x] Formatted my code with `yarn format`
- [x] There are no warnings from `yarn lint --fix`
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)