### PR TITLE
Restrict ellipsis menu item types

### DIFF
--- a/app/web/components/EllipsisMenu.tsx
+++ b/app/web/components/EllipsisMenu.tsx
@@ -1,29 +1,38 @@
-import { MoreHoriz } from "@mui/icons-material";
-import { IconButton, Menu, styled } from "@mui/material";
+import { MoreHoriz, SvgIconComponent } from "@mui/icons-material";
+import { IconButton, Menu, styled, Typography } from "@mui/material";
+import { theme } from "theme";
+
+import { MenuItem } from "./Menu";
+
+export interface EllipsisMenuItem {
+  icon: SvgIconComponent;
+  label: string;
+  onClick: () => unknown;
+  id?: string;
+}
 
 interface EllipsisMenuProps {
-  children: React.ReactNode;
   idName: string;
   isMenuOpen: boolean;
   menuAnchorEl: Element | null;
   onMenuOpen: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onMenuClose: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  items: EllipsisMenuItem[];
 }
 
-const MenuWrapper = styled("div")(({ theme }) => ({
+const MenuWrapper = styled("div")(() => ({
   display: "flex",
   justifyContent: "flex-end",
   flexDirection: "column",
 }));
 
-//** @param {children} should be the  MenuItems */
 const EllipsisMenu = ({
-  children,
   idName,
   isMenuOpen,
   menuAnchorEl,
   onMenuOpen,
   onMenuClose,
+  items,
 }: EllipsisMenuProps) => {
   return (
     <MenuWrapper>
@@ -76,7 +85,26 @@ const EllipsisMenu = ({
           transformOrigin={{ horizontal: "right", vertical: "top" }}
           anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
         >
-          {children}
+          {items.map((item, index) => (
+            <MenuItem
+              key={index}
+              onClick={item.onClick}
+              {...(item.id
+                ? {
+                    id: `${idName}-${item.id}`,
+                    "data-testid": `${idName}-${item.id}`,
+                  }
+                : {})}
+            >
+              <item.icon fontSize="small" />
+              <Typography
+                variant="body2"
+                sx={{ marginLeft: theme.spacing(1), fontWeight: 500 }}
+              >
+                {item.label}
+              </Typography>
+            </MenuItem>
+          ))}
         </Menu>
       </>
     </MenuWrapper>

--- a/app/web/features/connections/friends/BlockedUsersList.test.tsx
+++ b/app/web/features/connections/friends/BlockedUsersList.test.tsx
@@ -75,7 +75,9 @@ describe("BlockedUsersList", () => {
 
     await user.click(moreOptionsButtons[1]);
 
-    const unblockButtons = await screen.findAllByTestId("unblock-user");
+    const unblockButtons = await screen.findAllByTestId(
+      "blocked-user-item-unblock-user",
+    );
 
     expect(unblockButtons).toHaveLength(3);
 

--- a/app/web/features/connections/friends/BlockedUsersList.tsx
+++ b/app/web/features/connections/friends/BlockedUsersList.tsx
@@ -1,5 +1,4 @@
 import { People } from "@mui/icons-material";
-import { MenuItem, Typography } from "@mui/material";
 import EllipsisMenu from "components/EllipsisMenu";
 import { blockedUsersKey } from "features/queryKeys";
 import { RpcError } from "grpc-web";
@@ -9,7 +8,6 @@ import { BlockedUser, GetBlockedUsersRes } from "proto/blocking_pb";
 import { useState } from "react";
 import { useQuery } from "react-query";
 import { service } from "service";
-import { theme } from "theme";
 
 import ConnectionActionDialog from "./ConnectionActionDialog";
 import FriendSummaryView from "./FriendSummaryView";
@@ -76,17 +74,15 @@ function BlockedUsersList({ refetchFriends }: { refetchFriends: () => void }) {
               menuAnchorEl={menuAnchorEl}
               onMenuOpen={handleMenuOpen}
               onMenuClose={handleMenuClose}
-            >
-              <MenuItem onClick={handleDialogOpen} data-testid="unblock-user">
-                <People fontSize="small" />
-                <Typography
-                  variant="body2"
-                  sx={{ marginLeft: theme.spacing(1), fontWeight: 500 }}
-                >
-                  {t("connections:unblock_user")}
-                </Typography>
-              </MenuItem>
-            </EllipsisMenu>
+              items={[
+                {
+                  icon: People,
+                  label: t("connections:unblock_user"),
+                  onClick: handleDialogOpen,
+                  id: "unblock-user",
+                },
+              ]}
+            />
             <ConnectionActionDialog
               isOpen={isDialogOpen}
               onClose={handleDialogClose}

--- a/app/web/features/connections/friends/FriendItem.test.tsx
+++ b/app/web/features/connections/friends/FriendItem.test.tsx
@@ -23,7 +23,9 @@ describe("FriendItem", () => {
 
     user.click(screen.getByTestId("friend-item-more-options"));
 
-    const removeMenuItems = await screen.findAllByTestId("remove-friend");
+    const removeMenuItems = await screen.findAllByTestId(
+      "friend-item-remove-friend",
+    );
     const removeMenuItem = removeMenuItems[0];
 
     expect(removeMenuItem).toBeVisible();

--- a/app/web/features/connections/friends/FriendItem.tsx
+++ b/app/web/features/connections/friends/FriendItem.tsx
@@ -1,11 +1,9 @@
 import { Block, PersonRemove } from "@mui/icons-material";
-import { MenuItem, Typography } from "@mui/material";
 import EllipsisMenu from "components/EllipsisMenu";
 import { useTranslation } from "i18n";
 import { CONNECTIONS, GLOBAL } from "i18n/namespaces";
 import { LiteUser } from "proto/api_pb";
 import { useState } from "react";
-import { theme } from "theme";
 
 import ConnectionActionDialog from "./ConnectionActionDialog";
 import FriendSummaryView from "./FriendSummaryView";
@@ -79,26 +77,21 @@ const FriendItem = ({ friend, onError }: FriendItemProps) => {
         menuAnchorEl={menuAnchorEl}
         onMenuOpen={handleMenuOpen}
         onMenuClose={handleMenuClose}
-      >
-        <MenuItem onClick={handleRemoveFriend} data-testid="remove-friend">
-          <PersonRemove fontSize="small" />
-          <Typography
-            variant="body2"
-            sx={{ marginLeft: theme.spacing(1), fontWeight: 500 }}
-          >
-            {t("connections:remove_friend")}
-          </Typography>
-        </MenuItem>
-        <MenuItem onClick={handleBlockUser} data-testid="remove-friend">
-          <Block fontSize="small" />
-          <Typography
-            variant="body2"
-            sx={{ marginLeft: theme.spacing(1), fontWeight: 500 }}
-          >
-            {t("connections:block_user")}
-          </Typography>
-        </MenuItem>
-      </EllipsisMenu>
+        items={[
+          {
+            icon: PersonRemove,
+            label: t("connections:remove_friend"),
+            onClick: handleRemoveFriend,
+            id: "remove-friend",
+          },
+          {
+            icon: Block,
+            label: t("connections:block_user"),
+            onClick: handleBlockUser,
+            id: "block-user",
+          },
+        ]}
+      />
       {openDialog === "remove-friend" && (
         <ConnectionActionDialog
           dialogConfirm={t(


### PR DESCRIPTION
Restrict the type of ellipsis menu items to make it easier to build menus, with an obvious interface, reducing redundancy/duplication and preventing unintended usage as well as inconsistent styling.

**Web frontend checklist**
- [x] Formatted my code with `yarn format`
- [x] There are no warnings from `yarn lint --fix`
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)