### PR TITLE
Adjust test_migrations for new postgres release

### DIFF
--- a/app/backend/src/tests/test_db.py
+++ b/app/backend/src/tests/test_db.py
@@ -156,6 +156,11 @@ def test_migrations(testconfig):
         # filter out alembic tables
         s = "\n-- ".join(x for x in s.split("\n-- ") if not x.startswith("Name: alembic_"))
 
+        # filter out \restrict and \unrestrict lines (Postgres 16+)
+        s = "\n".join(
+            line for line in s.splitlines() if not line.startswith("\\restrict") and not line.startswith("\\unrestrict")
+        )
+
         return strip_leading_whitespace(s.splitlines())
 
     diff = "\n".join(


### PR DESCRIPTION
Our migration test began failing in CI/CD on August 14th, 2025—the same day PostgreSQL 16.10 was released. This was not due to a code or translation change, but because our CI pipeline always installs the latest PostgreSQL client tool(see line 241 of app/.gitlab-ci.yml).

PostgreSQL 16.10 introduced a change to pg_dump that adds new \restrict and \unrestrict lines with random tokens to its output.

From the [PostgreSQL 16.10 release notes](https://www.postgresql.org/docs/release/16.10/):
> “To provide a positive guarantee that this can't happen, extend psql with a \restrict command that prevents execution of further meta-commands, and teach pg_dump to issue that before any data coming from the source server.”

These lines are not part of our schema and change every run, causing our test (which compared the full pg_dump output) to fail.

This PR updates the test to ignore \restrict and \unrestrict lines, making the test robust to this change in pg_dump.


**TL;DR**: The failure was caused by an upstream Postgres update released on August 14, 2025, that happened to coincide with a translation merge (but is unrelated).