### PR TITLE
Add to script to add language name to translation file

### DIFF
--- a/app/web/scripts/create-translation-files.js
+++ b/app/web/scripts/create-translation-files.js
@@ -526,6 +526,47 @@ function getFlagCode(code) {
   return FLAG_CODES[baseCode] || FLAG_CODES[code] || null;
 }
 
+function addToResourceLanguageNames(languageCode) {
+  const resourcesEnPath = path.join(
+    __dirname,
+    "..",
+    "resources",
+    "locales",
+    "en.json",
+  );
+
+  try {
+    const raw = fs.readFileSync(resourcesEnPath, "utf8");
+    const json = JSON.parse(raw);
+
+    if (!json.language_names) {
+      json.language_names = {};
+    }
+
+    if (json.language_names[languageCode]) {
+      console.log(
+        `⚠️  language_names already contains "${languageCode}" in resources en.json`,
+      );
+      return false;
+    }
+
+    const displayName = getLanguageName(languageCode);
+    json.language_names[languageCode] = displayName;
+
+    // Write pretty-printed JSON with trailing newline
+    fs.writeFileSync(resourcesEnPath, JSON.stringify(json, null, 2) + "\n");
+    console.log(
+      `✅ Added "${languageCode}": "${displayName}" to en.json translation file`,
+    );
+    return true;
+  } catch (error) {
+    console.error(
+      `❌ Failed to update resources language_names: ${error.message}`,
+    );
+    return false;
+  }
+}
+
 function addToAllLanguages(languageCode) {
   const allLanguagesPath = path.join(
     __dirname,
@@ -698,8 +739,11 @@ function main() {
       flagCode,
     );
 
+    // Also add to web resources language_names
+    const addedToResourceNames = addToResourceLanguageNames(languageCode);
+
     console.log("\n📋 Summary:");
-    if (addedToAllLanguages && addedToConstants) {
+    if (addedToAllLanguages && addedToConstants && addedToResourceNames) {
       console.log("✅ Language successfully added to translation system!");
     } else {
       console.log(

--- a/app/web/scripts/delete-translation-files.js
+++ b/app/web/scripts/delete-translation-files.js
@@ -146,6 +146,38 @@ function removeFromNativeAllLanguages(languageCode) {
   }
 }
 
+function removeFromResourceLanguageNames(languageCode) {
+  const resourcesEnPath = path.join(
+    __dirname,
+    "..",
+    "resources",
+    "locales",
+    "en.json",
+  );
+
+  try {
+    const raw = fs.readFileSync(resourcesEnPath, "utf8");
+    const json = JSON.parse(raw);
+
+    if (!json.language_names || !json.language_names[languageCode]) {
+      console.log(
+        `⚠️  language_names does not contain "${languageCode}" in resources en.json`,
+      );
+      return false;
+    }
+
+    delete json.language_names[languageCode];
+    fs.writeFileSync(resourcesEnPath, JSON.stringify(json, null, 2) + "\n");
+    console.log(`✅ Removed "${languageCode}" from resources language_names`);
+    return true;
+  } catch (error) {
+    console.error(
+      `❌ Failed to update resources language_names: ${error.message}`,
+    );
+    return false;
+  }
+}
+
 function main() {
   try {
     const languageCode = process.argv[2];
@@ -189,9 +221,16 @@ function main() {
 
     // Remove from native allLanguages.js
     const removedFromNative = removeFromNativeAllLanguages(languageCode);
+    const removedFromResourceNames =
+      removeFromResourceLanguageNames(languageCode);
 
     console.log("\n📋 Summary:");
-    if (removedFromAllLanguages && removedFromConstants && removedFromNative) {
+    if (
+      removedFromAllLanguages &&
+      removedFromConstants &&
+      removedFromNative &&
+      removedFromResourceNames
+    ) {
       console.log("✅ Language successfully removed from translation system!");
     } else {
       console.log(


### PR DESCRIPTION
Adding to the `create-translation-files` and `delete-translation-files` so it also adds the English language name to the translation files.

We added language name translations after this script was written so adding this as I keep forgetting the language name when we add new languages to be translated.