### PR TITLE
Adjust order and color of host request response buttons

### DIFF
--- a/app/web/.env.development
+++ b/app/web/.env.development
@@ -1,6 +1,5 @@
 NEXT_PUBLIC_COUCHERS_ENV=preview
-# NEXT_PUBLIC_API_BASE_URL="https://next.couchershq.org/api"
-NEXT_PUBLIC_API_BASE_URL=http://localhost:8888
+NEXT_PUBLIC_API_BASE_URL="https://next.couchershq.org/api"
 NEXT_PUBLIC_MEDIA_BASE_URL="https://dev-user-media.couchershq.org"
 NEXT_PUBLIC_CONSOLE_BASE_URL="https://next-console.couchershq.org"
 NEXT_PUBLIC_NOMINATIM_URL="https://nominatim.openstreetmap.org/"

--- a/app/web/features/messages/requests/FieldButton.tsx
+++ b/app/web/features/messages/requests/FieldButton.tsx
@@ -18,12 +18,14 @@ const FieldButton = ({
   disabled,
   isLoading,
   isSubmit,
+  variant = "contained",
 }: {
   children: string;
   callback: () => void;
   disabled?: boolean;
   isLoading: boolean;
   isSubmit?: boolean;
+  variant?: "text" | "outlined" | "contained";
 }) => {
   return (
     <StyledButton
@@ -32,7 +34,7 @@ const FieldButton = ({
       loading={isLoading}
       onClick={callback}
       type={isSubmit ? "submit" : "button"}
-      variant="contained"
+      variant={variant}
     >
       {children}
     </StyledButton>

--- a/app/web/features/messages/requests/HostRequestRespondButtons.tsx
+++ b/app/web/features/messages/requests/HostRequestRespondButtons.tsx
@@ -44,11 +44,6 @@ export default function HostRequestRespondButtons({
 
     return (
       <>
-        {canAccept && (
-          <FieldButton callback={handleAccept} isLoading={isLoading}>
-            {t("global:accept")}
-          </FieldButton>
-        )}
         {canReject && (
           <ConfirmationDialogWrapper
             title={t("messages:close_request_dialog_title")}
@@ -59,11 +54,17 @@ export default function HostRequestRespondButtons({
               <FieldButton
                 isLoading={isLoading}
                 callback={() => setIsOpen(true)}
+                variant="outlined"
               >
                 {t("messages:close_request_button_text")}
               </FieldButton>
             )}
           </ConfirmationDialogWrapper>
+        )}
+        {canAccept && (
+          <FieldButton callback={handleAccept} isLoading={isLoading}>
+            {t("global:accept")}
+          </FieldButton>
         )}
       </>
     );


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**


<!---
Please describe the pull request here.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->
Closes #6445 

Changes order so accept is on the right (more common) and to have accept be green and decline be outlined for differentiation.

<img width="362" height="110" alt="Screenshot 2025-10-10 at 1 37 25 PM" src="https://github.com/user-attachments/assets/978dcbbd-2205-4572-94c4-dbc215d1d2bb" />



**Please give clear steps for how the reviewer can best test this PR**

*Please include any necessary dev environment, .env, etc. adjustments.*

- Send a host request to yourself or get someone to host request you on stage
- Go look at the buttons
- Make sure they look okay



<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [x] Formatted my code with `yarn format`
- [x] There are no warnings from `yarn lint --fix`
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)


<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
