### PR TITLE
Differentiate host request accept and cancel buttons

### DIFF
--- a/app/web/features/messages/requests/HostRequestRespondButtons.tsx
+++ b/app/web/features/messages/requests/HostRequestRespondButtons.tsx
@@ -81,11 +81,6 @@ export default function HostRequestRespondButtons({
 
     return (
       <>
-        {canConfirm && (
-          <FieldButton callback={handleConfirm} isLoading={isLoading}>
-            {t("messages:confirm_request_button_text")}
-          </FieldButton>
-        )}
         {canCancel && (
           <ConfirmationDialogWrapper
             title={t("messages:close_request_dialog_title")}
@@ -96,11 +91,17 @@ export default function HostRequestRespondButtons({
               <FieldButton
                 isLoading={isLoading}
                 callback={() => setIsOpen(true)}
+                variant="outlined"
               >
                 {t("global:cancel")}
               </FieldButton>
             )}
           </ConfirmationDialogWrapper>
+        )}
+        {canConfirm && (
+          <FieldButton callback={handleConfirm} isLoading={isLoading}>
+            {t("messages:confirm_request_button_text")}
+          </FieldButton>
         )}
       </>
     );

--- a/app/web/features/profile/view/NewHostRequest.tsx
+++ b/app/web/features/profile/view/NewHostRequest.tsx
@@ -194,7 +194,7 @@ export default function NewHostRequest({
             }
           />
           <StyledSendActions>
-            <Button onClick={() => setIsRequesting(false)}>
+            <Button onClick={() => setIsRequesting(false)} variant="outlined">
               {t("global:cancel")}
             </Button>
             <Button type="submit" onClick={onSubmit}>


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**

Making the accept and decline/cancel buttons different colors to differentiate and swapping the sides.

<!---
Please describe the pull request here.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

<img width="1088" height="227" alt="Screenshot 2025-10-13 at 4 53 45 PM" src="https://github.com/user-attachments/assets/af85ef40-c7c0-4b4b-8209-e882419bdd31" />
<img width="696" height="577" alt="Screenshot 2025-10-13 at 4 58 46 PM" src="https://github.com/user-attachments/assets/5d15c33d-26ec-49d7-826c-153c27a73201" />

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [x] Formatted my code with `yarn format`
- [x] There are no warnings from `yarn lint --fix`
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] All tests pass
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)


<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
