### PR TITLE
Fix missing notification banner translation strings

### DIFF
--- a/app/web/features/notifications/PushNotificationBanner.tsx
+++ b/app/web/features/notifications/PushNotificationBanner.tsx
@@ -19,7 +19,7 @@ const Wrapper = styled("div")({
 });
 
 export function PushNotificationBanner() {
-  const { t } = useTranslation([NOTIFICATIONS]);
+  const { t } = useTranslation(NOTIFICATIONS);
   // the epoch value of the last time this banner was dismissed
   const [lastDismissedEpoch, setLastDismissedEpoch] = usePersistedState<
     number | null
@@ -76,7 +76,7 @@ export function PushNotificationBanner() {
 
   return shouldPromptAllow ? (
     <Alert severity="info" onClose={dismiss}>
-      {t("notification_settings.push_notifications.allow_push")}
+      {t("notifications:notification_settings.push_notifications.allow_push")}
     </Alert>
   ) : (
     <Alert
@@ -85,13 +85,13 @@ export function PushNotificationBanner() {
       sx={{ alignItems: "center", ".MuiAlert-message": { width: "100%" } }}
     >
       <Wrapper>
-        <Trans i18nKey="global:push_notification_banner.message" />
+        <Trans i18nKey="notifications:push_notification_banner.message" />
         <Button
           variant="outlined"
           sx={{ backgroundColor: theme.palette.common.white }}
           onClick={turnPushNotificationsOnWrap}
         >
-          {t("global:push_notification_banner.confirm")}
+          {t("notifications:push_notification_banner.confirm")}
         </Button>
       </Wrapper>
     </Alert>

--- a/app/web/features/notifications/locales/en.json
+++ b/app/web/features/notifications/locales/en.json
@@ -145,5 +145,9 @@
         }
       }
     }
+  },
+  "push_notification_banner": {
+    "message": "Don't miss requests, responses or messages; can we send you push notifications?",
+    "confirm": "Yes, please!"
   }
 }

--- a/app/web/resources/locales/en.json
+++ b/app/web/resources/locales/en.json
@@ -350,10 +350,6 @@
         }
       }
     },
-    "push_notification_banner": {
-      "message": "Don't miss requests, responses or messages; can we send you push notifications?",
-      "confirm": "Yes, please!"
-    },
     "error_loading_languages": "Failed to load language options",
     "language_names": {
       "ca": "Catalan",


### PR DESCRIPTION
I noticed when testing on Vercel that the push notification banner text translations were missing. Fixing that here.

Also moved the banner translations into the notifications translation file so they're all together.