### PR TITLE
Fix: Handle notFound in getStaticProps

### DIFF
--- a/app/web/features/markdown/MarkdownPage.tsx
+++ b/app/web/features/markdown/MarkdownPage.tsx
@@ -174,7 +174,7 @@ export default function MarkdownPage({
           {crumbs.map((crumb, index) => {
             const isLast = index === crumbs.length - 1;
             return isLast ? (
-              <Typography key={crumb.key} color="textPrimary">
+              <Typography key={`${crumb.key}-${index}`} color="textPrimary">
                 {crumb.value}
               </Typography>
             ) : (

--- a/app/web/pages/[...slug].tsx
+++ b/app/web/pages/[...slug].tsx
@@ -14,21 +14,42 @@ async function getMarkdownPageBySlug(
   return { slug, frontmatter: md.attributes, content: md.html };
 }
 
-export const getStaticPaths: GetStaticPaths = () => ({
-  paths: [],
-  fallback: "blocking",
-});
+export const getStaticPaths: GetStaticPaths = () => {
+  // Return empty paths for fast builds
+  // Pages will be generated on-demand with fallback: 'blocking'
+  return {
+    paths: [],
+    fallback: "blocking",
+  };
+};
 
-export const getStaticProps: GetStaticProps = async ({ locale, params }) => ({
-  props: {
-    ...(await serverSideTranslations(
-      locale ?? "en",
-      [GLOBAL, AUTH, NOTIFICATIONS],
-      nextI18nextConfig,
-    )),
-    page: await getMarkdownPageBySlug(params!.slug as Array<string>),
-  },
-});
+export const getStaticProps: GetStaticProps = async ({ locale, params }) => {
+  const slug = params!.slug as Array<string>;
+
+  // Validate slug: only allow alphanumeric, hyphens, and underscores
+  // This prevents webpack files, dot files, etc.
+  const isValidSlug = slug.every((segment) => /^[a-zA-Z0-9_-]+$/.test(segment));
+
+  if (!isValidSlug) {
+    return { notFound: true };
+  }
+
+  try {
+    return {
+      props: {
+        ...(await serverSideTranslations(
+          locale ?? "en",
+          [GLOBAL, AUTH, NOTIFICATIONS],
+          nextI18nextConfig,
+        )),
+        page: await getMarkdownPageBySlug(slug),
+      },
+    };
+  } catch {
+    // Markdown file doesn't exist
+    return { notFound: true };
+  }
+};
 
 export default function Markdown({ page }: { page: MarkdownPageProps }) {
   return <MarkdownPage {...page} />;

--- a/app/web/pages/[...slug].tsx
+++ b/app/web/pages/[...slug].tsx
@@ -26,14 +26,6 @@ export const getStaticPaths: GetStaticPaths = () => {
 export const getStaticProps: GetStaticProps = async ({ locale, params }) => {
   const slug = params!.slug as Array<string>;
 
-  // Validate slug: only allow alphanumeric, hyphens, and underscores
-  // This prevents webpack files, dot files, etc.
-  const isValidSlug = slug.every((segment) => /^[a-zA-Z0-9_-]+$/.test(segment));
-
-  if (!isValidSlug) {
-    return { notFound: true };
-  }
-
   try {
     return {
       props: {
@@ -46,7 +38,7 @@ export const getStaticProps: GetStaticProps = async ({ locale, params }) => {
       },
     };
   } catch {
-    // Markdown file doesn't exist
+    // Markdown file doesn't exist or path is invalid
     return { notFound: true };
   }
 };


### PR DESCRIPTION
Fixing a bug introduced in #6890 .

After PR #6890, the catch-all route `[...slug].tsx` was intercepting internal Next.js/webpack requests during development (e.g., `.webpack.hot-update.json`, `.css.map`), causing build errors.

Solution in this PR:
- Return proper 404s for non-existent markdown files
