### PR TITLE
Add beta flag to empty profile filter

### DIFF
--- a/app/web/features/search/FilterDialog.tsx
+++ b/app/web/features/search/FilterDialog.tsx
@@ -255,9 +255,12 @@ const FilterDialog = ({
       </IconButton>
       <FilterItemsContainer>
         <FilterItemRow>
-          <Typography>
-            {t("search:form.empty_profile_filters.title")}
-          </Typography>
+          <Box sx={{ display: "flex", alignItems: "center" }}>
+            <Typography>
+              {t("search:form.empty_profile_filters.title")}
+            </Typography>
+            <BetaFlag />
+          </Box>
           <CustomColorSwitch
             checked={filters.showEmptyProfile || false}
             onClick={handleShowEmptyProfileChange}

--- a/app/web/features/search/SearchResultListContent.tsx
+++ b/app/web/features/search/SearchResultListContent.tsx
@@ -8,6 +8,7 @@ import {
   Typography,
   useMediaQuery,
 } from "@mui/material";
+import BetaFlag from "components/BetaFlag";
 import { DEFAULT_DRAWER_WIDTH } from "components/ResizeableDrawer";
 import { RpcError } from "grpc-web";
 import { useTranslation } from "i18n";
@@ -192,9 +193,12 @@ const SearchResultListContent = ({
             marginBottom: theme.spacing(2),
           }}
         >
-          <Typography variant="body2">
-            {t("search:search_result.few_results_suggestion")}
-          </Typography>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            <BetaFlag />
+            <Typography variant="body2">
+              {t("search:search_result.few_results_suggestion")}
+            </Typography>
+          </Box>
           <Button
             variant="contained"
             size="small"


### PR DESCRIPTION
Adding new beta flag to the filter empty profiles functionality to indicate it's still experimental.

<img width="342" height="131" alt="Screenshot 2025-10-24 at 11 25 32 AM" src="https://github.com/user-attachments/assets/613f3265-169f-41fa-9c7c-15cfb6472a3d" />
<img width="279" height="175" alt="Screenshot 2025-10-24 at 11 25 23 AM" src="https://github.com/user-attachments/assets/eed65fbf-1d0e-4ba2-a291-d45b7e7743d2" />
