### PR TITLE
Speed up tests by truncating tables instead of dropping them

### DIFF
--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -9,7 +9,7 @@ from threading import get_ident
 from alembic import command
 from alembic.config import Config
 from opentelemetry import trace
-from sqlalchemy import create_engine, text
+from sqlalchemy import Engine, create_engine, text
 from sqlalchemy.orm.session import Session
 from sqlalchemy.pool import QueuePool
 from sqlalchemy.sql import and_, func, literal, or_
@@ -46,7 +46,7 @@ def apply_migrations():
 
 
 @functools.cache
-def _get_base_engine():
+def _get_base_engine() -> Engine:
     return create_engine(
         config["DATABASE_CONNECTION_STRING"],
         # checks that the connections in the pool are alive before using them, which avoids the "server closed the
@@ -91,7 +91,7 @@ def session_scope():
 @contextmanager
 def worker_repeatable_read_session_scope():
     """
-    This is a separate sesson scope that is isolated from the main one since otherwise we end up nesting transactions,
+    This is a separate session scope that is isolated from the main one since otherwise we end up nesting transactions,
     this causes two different connections to be used
 
     This operates in a `REPEATABLE READ` isolation level so that we can do a `SELECT ... FOR UPDATE SKIP LOCKED` in the

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -3,6 +3,21 @@ from tempfile import TemporaryDirectory
 
 prometheus_multiproc_dir = TemporaryDirectory()
 
+environ["PROMETHEUS_MULTIPROC_DIR"] = prometheus_multiproc_dir.name
 
-def pytest_sessionstart(session):
-    environ["PROMETHEUS_MULTIPROC_DIR"] = prometheus_multiproc_dir.name
+from tests.test_fixtures import (  # noqa
+    account_session,
+    auth_api_session,
+    db,
+    create_database,
+    email_fields,
+    fast_passwords,
+    generate_user,
+    mock_notification_email,
+    process_jobs,
+    public_session,
+    push_collector,
+    real_account_session,
+    requests_session,
+    testconfig,
+)

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -1047,8 +1047,11 @@ def test_reminders(db):
 
 
 def test_volunteer_stuff(db):
+    # taken from couchers/app/backend/resources/badges.json
+    board_member_id = 8347
+
     # with password
-    user, token = generate_user(name="Von Tester", username="tester", city="Amsterdam")
+    user, token = generate_user(name="Von Tester", username="tester", city="Amsterdam", id=board_member_id)
 
     with account_session(token) as account:
         res = account.GetAccountInfo(empty_pb2.Empty())

--- a/app/backend/src/tests/test_communities.py
+++ b/app/backend/src/tests/test_communities.py
@@ -32,8 +32,8 @@ from tests.test_fixtures import (  # noqa
     generate_user,
     get_user_id_and_token,
     pages_session,
-    recreate_database,
     testconfig,
+    truncate_all_tables,
 )
 
 
@@ -215,7 +215,7 @@ def get_group_id(session, group_name):
 
 @pytest.fixture(scope="class")
 def testing_communities(testconfig):
-    recreate_database()
+    truncate_all_tables()
     user1, token1 = generate_user(username="user1", geom=create_1d_point(1), geom_radius=0.1)
     user2, token2 = generate_user(username="user2", geom=create_1d_point(2), geom_radius=0.1)
     user3, token3 = generate_user(username="user3", geom=create_1d_point(3), geom_radius=0.1)

--- a/app/backend/src/tests/test_db.py
+++ b/app/backend/src/tests/test_db.py
@@ -15,7 +15,15 @@ from couchers.utils import (
     parse_date,
 )
 from tests.test_communities import create_1d_point, get_community_id, testing_communities  # noqa
-from tests.test_fixtures import create_schema_from_models, db, drop_all, run_migration_test, testconfig  # noqa
+from tests.test_fixtures import (  # noqa
+    create_schema_from_models,
+    db,
+    drop_database,
+    recreate_database,
+    run_migration_test,
+    testconfig,
+    truncate_all_tables,
+)
 
 
 def test_is_valid_user_id():
@@ -125,10 +133,21 @@ def strip_leading_whitespace(lines):
     return [s.lstrip() for s in lines]
 
 
-@pytest.mark.skipif(not run_migration_test(), reason="Migration test disabled")
-def test_migrations(testconfig):
+@pytest.fixture
+def restore_database_after_testing_migrations(testconfig):
     """
-    This test will only run succesfully if you have `pg_dump` installed and everything set up, which only happens if the
+    Make sure the database exists for other tests after test_migrations runs.
+    """
+    try:
+        yield
+    finally:
+        recreate_database()
+
+
+@pytest.mark.skipif(not run_migration_test(), reason="Migration test disabled")
+def test_migrations(testconfig, restore_database_after_testing_migrations):
+    """
+    This test will only run successfully if you have `pg_dump` installed and everything set up, which only happens if the
     test is being run within Gitlab CI where we do all that setup. So we disable it unless explicitly marked to run.
 
     Compares the database schema built up from migrations, with the
@@ -137,13 +156,13 @@ def test_migrations(testconfig):
     differences in the output are reported in unified diff format and
     fails the test.
     """
-    drop_all()
+    drop_database()
     # rebuild it with alembic migrations
     apply_migrations()
 
     with_migrations = pg_dump()
 
-    drop_all()
+    drop_database()
     # create everything from the current models, not incrementally
     # through migrations
     create_schema_from_models()

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -99,24 +99,14 @@ from proto import (
 )
 
 
-def drop_all():
+def truncate_all_tables():
     """drop everything currently in the database"""
     with session_scope() as session:
-        # postgis is required for all the Geographic Information System (GIS) stuff
-        # pg_trgm is required for trigram based search
-        # btree_gist is required for gist-based exclusion constraints
-        session.execute(
-            text(
-                "DROP SCHEMA IF EXISTS public CASCADE;"
-                "DROP SCHEMA IF EXISTS logging CASCADE;"
-                "DROP EXTENSION IF EXISTS postgis CASCADE;"
-                "CREATE SCHEMA public;"
-                "CREATE SCHEMA logging;"
-                "CREATE EXTENSION postgis;"
-                "CREATE EXTENSION pg_trgm;"
-                "CREATE EXTENSION btree_gist;"
-            )
-        )
+        for table in Base.metadata.tables.values():
+            if table.name in ("regions", "languages", "timezone_areas"):
+                continue
+            name = f'"{table.schema}"."{table.name}"' if table.schema else f'"{table.name}"'
+            session.execute(text(f"TRUNCATE TABLE {name} RESTART IDENTITY CASCADE"))
 
     # this resets the database connection pool, which caches some stuff postgres-side about objects and will otherwise
     # sometimes error out with "ERROR:  no spatial operator found for 'st_contains': opfamily 203699 type 203585"
@@ -210,16 +200,30 @@ def populate_testing_resources(session):
     session.execute(text(tz_sql))
 
 
-def recreate_database():
-    """
-    Connect to a running Postgres database, build it using metadata.create_all()
-    """
+def drop_database() -> None:
+    with session_scope() as session:
+        # postgis is required for all the Geographic Information System (GIS) stuff
+        # pg_trgm is required for trigram-based search
+        # btree_gist is required for gist-based exclusion constraints
+        session.execute(
+            text(
+                "DROP SCHEMA IF EXISTS public CASCADE;"
+                "DROP SCHEMA IF EXISTS logging CASCADE;"
+                "DROP EXTENSION IF EXISTS postgis CASCADE;"
+                "CREATE SCHEMA public;"
+                "CREATE SCHEMA logging;"
+                "CREATE EXTENSION postgis;"
+                "CREATE EXTENSION pg_trgm;"
+                "CREATE EXTENSION btree_gist;"
+            )
+        )
 
+
+def recreate_database():
     # running in non-UTC catches some timezone errors
     os.environ["TZ"] = "America/New_York"
 
-    # drop everything currently in the database
-    drop_all()
+    drop_database()
 
     # create everything from the current models, not incrementally through migrations
     create_schema_from_models()
@@ -228,13 +232,17 @@ def recreate_database():
         populate_testing_resources(session)
 
 
-@pytest.fixture()
-def db():
+@pytest.fixture(scope="session")
+def create_database():
+    recreate_database()
+
+
+@pytest.fixture
+def db(create_database):
     """
     Pytest fixture to connect to a running Postgres database and build it using metadata.create_all()
     """
-
-    recreate_database()
+    truncate_all_tables()
 
 
 def generate_user(*, delete_user=False, complete_profile=True, strong_verification=False, **kwargs):


### PR DESCRIPTION
This cuts running time from 20 to 7 minutes.