### PR TITLE
Send native app message when user logs out

### DIFF
--- a/app/web/features/auth/useAuthStore.ts
+++ b/app/web/features/auth/useAuthStore.ts
@@ -9,6 +9,8 @@ import { useMemo, useRef, useState } from "react";
 import { service } from "service";
 import isGrpcError from "service/utils/isGrpcError";
 
+import { useIsNativeEmbed } from "../../platform/nativeLink";
+
 export default function useAuthStore() {
   const [authenticated, setAuthenticated] = usePersistedState(
     "auth.authenticated",
@@ -27,6 +29,7 @@ export default function useAuthStore() {
   //this is used to set the current user in the user cache
   //may as well not waste the api call since it is needed for userId
   const queryClient = useQueryClient();
+  const isNativeEmbed = useIsNativeEmbed();
 
   const { t } = useTranslation(GLOBAL);
   const fatalErrorMessage = useRef(t("error.fatal_message"));
@@ -46,6 +49,13 @@ export default function useAuthStore() {
           setAuthenticated(false);
           setUserId(null);
           Sentry.setUser({ id: undefined });
+
+          // Notify mobile app if running in embed
+          if (isNativeEmbed) {
+            window.ReactNativeWebView?.postMessage(
+              JSON.stringify({ type: "LOGOUT" }),
+            );
+          }
         } catch (e) {
           Sentry.captureException(e, {
             tags: {
@@ -134,7 +144,14 @@ export default function useAuthStore() {
     }),
     //note: there should be no dependenices on the state or t, or
     //some useEffects will break. Eg. the token login in Login.tsx
-    [setAuthenticated, setJailed, setUserId, setFlowState, queryClient],
+    [
+      setAuthenticated,
+      setJailed,
+      setUserId,
+      setFlowState,
+      queryClient,
+      isNativeEmbed,
+    ],
   );
 
   return {


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**

Part of #6403 

<!---
Please describe the pull request here.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

Since the authentication is handled in the web app and we're using WebEmbed, we need a way to tell the mobile app when the user logged out for conditional rendering, blocking certain routes, etc.

[Based on these docs](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Guide.md#communicating-between-js-and-native), this seems to be the way to do it. We'll send a message to the web app saying "LOGOUT" and then I'll receive in in the mobile app (in a separate PR).

This needs to merge and deploy first before I have access to test in the mobile code.

**Please give clear steps for how the reviewer can best test this PR**

*Please include any necessary dev environment, .env, etc. adjustments.*

Not much to test yet.
