### PR TITLE
Add disconnect logging

### DIFF
--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -329,7 +329,14 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                 if ui_language_preference and ui_language_preference != parse_ui_lang_cookie(headers):
                     couchers_context.set_cookies(create_lang_cookie(ui_language_preference))
 
-            couchers_context._send_cookies()
+            try:
+                couchers_context._send_cookies()
+            except grpc.RpcError as e:
+                # Log details when client disconnects during cookie sending
+                logger.exception(
+                    f"RpcError during _send_cookies(): code={e.code()}, details={e.details()}, method={method}"
+                )
+                raise
 
             return res
 


### PR DESCRIPTION
I believe what happens is that if the client disconnects during an RPC, this will fail (the first time we send stuff back to the client). This is littering sentry and (possibly) hiding other issues.

This adds some debug logging so we can further look into what's going on and how to catch these particular errors.