### PR TITLE
Fix frontend and backend errors

### DIFF
--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -333,9 +333,10 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                 couchers_context._send_cookies()
             except grpc.RpcError as e:
                 # Log details when client disconnects during cookie sending
-                logger.exception(
-                    f"RpcError during _send_cookies(): code={e.code()}, details={e.details()}, method={method}"
-                )
+                # Some RpcErrors don't have code() or details() methods, so use getattr
+                code = getattr(e, "code", lambda: "unknown")()
+                details = getattr(e, "details", lambda: "unknown")()
+                logger.exception(f"RpcError during _send_cookies(): code={code}, details={details}, method={method}")
                 raise
 
             return res

--- a/app/web/features/auth/verification/StartStrongVerificationButton.tsx
+++ b/app/web/features/auth/verification/StartStrongVerificationButton.tsx
@@ -29,6 +29,7 @@ export default function StartStrongVerificationButton() {
     error,
     isPending,
     mutate: startStrongVerification,
+    reset,
   } = useMutation<InitiateStrongVerificationRes.AsObject, RpcError>({
     mutationFn: () => service.account.initiateStrongVerification(),
     onSuccess: async (data) => {
@@ -36,18 +37,23 @@ export default function StartStrongVerificationButton() {
     },
   });
 
+  const handleClose = () => {
+    reset();
+    setOpen(false);
+  };
+
   return (
     <>
-      <Dialog aria-labelledby="strong-verification-start-dialog" open={open}>
+      <Dialog
+        aria-labelledby="strong-verification-start-dialog"
+        open={open}
+        onClose={handleClose}
+      >
         <DialogTitle id="strong-verification-start-dialog">
           {t("auth:strong_verification.title")}
         </DialogTitle>
         <DialogContent>
-          {error && (
-            <DialogContentText>
-              <Alert severity="error">{error.message}</Alert>
-            </DialogContentText>
-          )}
+          {error && <Alert severity="error">{error.message}</Alert>}
           <DialogContentText>
             <Trans i18nKey="auth:strong_verification.information_text1">
               You will need a <strong>biometric passport</strong> (other types
@@ -80,7 +86,7 @@ export default function StartStrongVerificationButton() {
           <Button onClick={() => startStrongVerification()} loading={isPending}>
             {t("auth:strong_verification.begin_button")}
           </Button>
-          <Button variant="outlined" onClick={() => setOpen(false)}>
+          <Button variant="outlined" onClick={handleClose}>
             {t("global:cancel")}
           </Button>
         </DialogActions>


### PR DESCRIPTION
Appreciate a second set of eyes as my python is still in progress...

Strong verification is not working on stage and prod. Saw this error in the prod logs related to the log change. I'm honestly not sure how this is related to the strong verification error as it is downstream but maybe it's throwing for something else and preventing the API call to IRIS ID?

To replicate:
- Go to Account Settings page via top right menu
- Click "Start Strong Verification"
- Click button "Complete Strong Verification with Iris ID"
- See "Unknown backend error"

Guess I can't hurt to fix anyway.

I tried calling IRIS ID via Postman with the same request body we have in the code and it works fine and returns status 200 so that's not the issue.

```
 2025-11-02 11:29:50,610: couchers.interceptors:442: 'RpcError' object has no attribute 'code'
Traceback (most recent call last):
  File "/app/src/couchers/interceptors.py", line 333, in function_without_couchers_stuff
    couchers_context._send_cookies()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/app/src/couchers/context.py", line 114, in _send_cookies
    self._grpc_context.send_initial_metadata([("set-cookie", cookie) for cookie in self.__cookies])
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/opentelemetry/instrumentation/grpc/_server.py", line 114, in send_initial_metadata
    return self._servicer_context.send_initial_metadata(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/grpc/_server.py", line 428, in send_initial_metadata
    _raise_rpc_error(self._state)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/grpc/_server.py", line 220, in _raise_rpc_error
    raise rpc_error
grpc.RpcError
```

Also fixed a frontend browser error related to html drama.

