### PR TITLE
Fix event card title and menu item close

### DIFF
--- a/app/web/components/Navigation/LoggedInMenu.tsx
+++ b/app/web/components/Navigation/LoggedInMenu.tsx
@@ -157,6 +157,7 @@ function LinkMenuItemView({
       ) : (
         <Link
           href={route}
+          onClick={closeMenu}
           style={{
             width: "100%",
             color: theme.palette.text.primary,
@@ -174,6 +175,7 @@ function DialogMenuItemView({
   name,
   dialogComponent: DialogComponent,
   dialogLabel,
+  closeMenu,
 }: LoggedInMenuDialogItem & { closeMenu: () => unknown }) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
@@ -182,6 +184,7 @@ function DialogMenuItemView({
       <StyledMenuItemDialog
         onClick={() => {
           setIsDialogOpen(true);
+          closeMenu();
         }}
       >
         {name}

--- a/app/web/features/communities/events/EventCard.tsx
+++ b/app/web/features/communities/events/EventCard.tsx
@@ -55,11 +55,11 @@ const EventTime = styled(Typography)(({ theme }) => ({
 const Content = styled(Typography)({
   display: "-webkit-box",
   WebkitBoxOrient: "vertical",
-  WebkitLineClamp: 4,
+  WebkitLineClamp: 3,
   overflow: "hidden",
   textOverflow: "ellipsis",
   wordBreak: "break-word",
-  maxHeight: "6em",
+  maxHeight: "4.5em",
 });
 
 const CancelledChip = styled(Chip)(({ theme }) => ({


### PR DESCRIPTION
Closes #7081 
Fixes title in #7062 

- Closes main logged in menu after user clicks item
- Fixes wonky long title in event card getting cut off