### PR TITLE
Notify mobile app when login succeeded

### DIFF
--- a/app/web/features/auth/useAuthStore.ts
+++ b/app/web/features/auth/useAuthStore.ts
@@ -93,6 +93,13 @@ export default function useAuthStore() {
           //userId to be set.
           setJailed(auth.jailed);
           setAuthenticated(true);
+
+          // Notify mobile app that login succeeded
+          if (window.ReactNativeWebView) {
+            window.ReactNativeWebView.postMessage(
+              JSON.stringify({ type: "LOGIN" }),
+            );
+          }
         } catch (e) {
           Sentry.captureException(e, {
             tags: {

--- a/app/web/features/notifications/PushNotificationBanner.tsx
+++ b/app/web/features/notifications/PushNotificationBanner.tsx
@@ -35,7 +35,11 @@ export function PushNotificationBanner() {
 
   useEffect(() => {
     const checkPush = async () => {
-      if (!authenticated || isNativeEmbed) return;
+      if (!authenticated) return;
+
+      // Skip push notification check in native embed (WebView doesn't support it)
+      if (isNativeEmbed) return;
+
       try {
         if (!(await checkPushEnabled())) {
           setBannerVisible(
@@ -44,7 +48,15 @@ export function PushNotificationBanner() {
           );
         }
       } catch (error) {
-        console.error("Error checking for push notification state:", error);
+        // Only log errors for web browsers, not mobile WebView
+        if (isNativeEmbed) {
+          console.debug(
+            "Push notifications not available in mobile app:",
+            error,
+          );
+        } else {
+          console.error("Error checking for push notification state:", error);
+        }
       }
     };
 


### PR DESCRIPTION
- Notifies mobile app when login succeeds similar to how we go for logout.
- Silences push notification console error on mobile and changes to debug level

Part of #6403 