### PR TITLE
Speed up tests on mac by building an ARM postgis image locally

### DIFF
--- a/app/backend/Makefile
+++ b/app/backend/Makefile
@@ -32,11 +32,14 @@ upgrade:
 	DATABASE_CONNECTION_STRING="postgresql://postgres:203d805f4b62c0a1b2f1f6b82d4583dfe563ec1619b83ce22ee414e8376a25e7@localhost:6545/postgres" \
 	uv run alembic upgrade +1
 
+# Starts a Postgres container for backend tests. On Mac, it builds a Postgis image locally,
+# because there are no official images for ARM, and using amd64 image makes tests 4x slower.
+# Note: creating postgis extension takes several seconds, and we don't want to do it on
+# every test run.
 setup-db:
-	docker compose -f ../docker-compose.test.yml up -d --wait --no-deps postgres_tests
-	# Creating postgis extension takes several seconds, and we don't want to do it on
-	# every test run.
-	docker compose -f ../docker-compose.test.yml exec postgres_tests psql -U postgres -c \
+	$(eval COMPOSE_FILES := -f ../docker-compose.test.yml $(if $(filter Darwin,$(shell uname -s)),-f ../docker-compose.testmac.yml))
+	docker compose $(COMPOSE_FILES) up -d --wait --no-deps postgres_tests
+	docker compose $(COMPOSE_FILES) exec postgres_tests psql -U postgres -c \
 		"CREATE EXTENSION IF NOT EXISTS postgis; \
 		 CREATE EXTENSION IF NOT EXISTS pg_trgm; \
 		 CREATE EXTENSION IF NOT EXISTS btree_gist"

--- a/app/docker-compose.test.yml
+++ b/app/docker-compose.test.yml
@@ -21,7 +21,7 @@ services:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 1s
       timeout: 10s
-      start_period: 10s
+      start_period: 3s
       retries: 10
   backend_tests:
     build: backend

--- a/app/docker-compose.testmac.yml
+++ b/app/docker-compose.testmac.yml
@@ -1,0 +1,5 @@
+services:
+  postgres_tests:
+    build:
+      context: postgis
+    platform: linux/arm64/v8

--- a/app/postgis/Dockerfile
+++ b/app/postgis/Dockerfile
@@ -1,0 +1,27 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "make update"! PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM postgres:17-bullseye
+
+LABEL maintainer="PostGIS Project - https://postgis.net" \
+      org.opencontainers.image.description="PostGIS 3.5.2+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 17 bullseye" \
+      org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
+
+ENV POSTGIS_MAJOR=3
+ENV POSTGIS_VERSION=3.5.2+dfsg-1.pgdg110+1
+
+RUN apt-get update \
+      && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
+      && apt-get install -y --no-install-recommends \
+           # ca-certificates: for accessing remote raster files;
+           #   fix: https://github.com/postgis/docker-postgis/issues/307
+           ca-certificates \
+           \
+           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
+           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
+      && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /docker-entrypoint-initdb.d
+COPY initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
+COPY update-postgis.sh /usr/local/bin

--- a/app/postgis/initdb-postgis.sh
+++ b/app/postgis/initdb-postgis.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+# Perform all actions as $POSTGRES_USER
+export PGUSER="$POSTGRES_USER"
+
+# Create the 'template_postgis' template db
+"${psql[@]}" <<- 'EOSQL'
+CREATE DATABASE template_postgis IS_TEMPLATE true;
+EOSQL
+
+# Load PostGIS into both template_database and $POSTGRES_DB
+for DB in template_postgis "$POSTGRES_DB"; do
+	echo "Loading PostGIS extensions into $DB"
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
+		CREATE EXTENSION IF NOT EXISTS postgis;
+		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
+		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
+EOSQL
+done

--- a/app/postgis/readme.md
+++ b/app/postgis/readme.md
@@ -1,0 +1,3 @@
+Copied from https://github.com/postgis/docker-postgis/tree/master/17-3.5. 
+
+See a note about `setup-db` command in [app/backend/Makefile](../backend/Makefile) for details.

--- a/app/postgis/update-postgis.sh
+++ b/app/postgis/update-postgis.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+# Perform all actions as $POSTGRES_USER
+export PGUSER="$POSTGRES_USER"
+
+POSTGIS_VERSION="${POSTGIS_VERSION%%+*}"
+
+# Load PostGIS into both template_database and $POSTGRES_DB
+for DB in template_postgis "$POSTGRES_DB" "${@}"; do
+    echo "Updating PostGIS extensions '$DB' to $POSTGIS_VERSION"
+    psql --dbname="$DB" -c "
+        -- Upgrade PostGIS (includes raster)
+        CREATE EXTENSION IF NOT EXISTS postgis VERSION '$POSTGIS_VERSION';
+        ALTER EXTENSION postgis UPDATE TO '$POSTGIS_VERSION';
+
+        -- Upgrade Topology
+        CREATE EXTENSION IF NOT EXISTS postgis_topology VERSION '$POSTGIS_VERSION';
+        ALTER EXTENSION postgis_topology UPDATE TO '$POSTGIS_VERSION';
+
+        -- Install Tiger dependencies in case not already installed
+        CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+        -- Upgrade US Tiger Geocoder
+        CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder VERSION '$POSTGIS_VERSION';
+        ALTER EXTENSION postgis_tiger_geocoder UPDATE TO '$POSTGIS_VERSION';
+    "
+done


### PR DESCRIPTION
Turns out the amd64 Postgis image on ARM macs is really slow! After building an image locally, test time goes from 6 minutes to 1:40. 

This PR makes it so `make setup-db` on Mac builds a Postgis image instead of pulling one from dockerhub.