### PR TITLE
Add type annotations for SQLAlchemy models

### DIFF
--- a/app/backend/Makefile
+++ b/app/backend/Makefile
@@ -31,6 +31,7 @@ mypy:
 		src/couchers/resources.py \
 		src/couchers/urls.py \
 		src/couchers/utils.py \
+		src/couchers/models \
 		src/couchers/context.py
 
 # Downgrade the local database to the previous migration. Good if you ran a migration on a branch and will run the backend on another branch after.

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -93,6 +93,13 @@ untyped_calls_exclude = [
     "proto",
 ]
 
+[[tool.mypy.overrides]]
+module = "couchers.models.*"
+# SQLAlchemy hybrid_property intentionally redefines names for instance/class expressions
+disable_error_code = [
+    "no-redef",
+]
+
 [tool.coverage.run]
 omit = ["src/proto/*", "src/couchers/migrations/*", "src/dummy_data.py"]
 

--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -2,14 +2,16 @@ import functools
 import inspect
 import logging
 import os
+from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from os import getpid
 from threading import get_ident
 
 from alembic import command
 from alembic.config import Config
+from geoalchemy2 import WKBElement
 from opentelemetry import trace
-from sqlalchemy import Engine, create_engine, text
+from sqlalchemy import Engine, Row, Subquery, create_engine, text
 from sqlalchemy.orm.session import Session
 from sqlalchemy.pool import QueuePool
 from sqlalchemy.sql import and_, func, literal, or_
@@ -32,7 +34,7 @@ logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
 
 
-def apply_migrations():
+def apply_migrations() -> None:
     alembic_dir = os.path.dirname(__file__) + "/../.."
     cwd = os.getcwd()
     try:
@@ -60,7 +62,7 @@ def _get_base_engine() -> Engine:
 
 
 @contextmanager
-def session_scope():
+def session_scope() -> Generator[Session]:
     with tracer.start_as_current_span("session_scope") as rollspan:
         with Session(_get_base_engine()) as session:
             session.begin()
@@ -89,7 +91,7 @@ def session_scope():
 
 
 @contextmanager
-def worker_repeatable_read_session_scope():
+def worker_repeatable_read_session_scope() -> Generator[Session]:
     """
     This is a separate session scope that is isolated from the main one since otherwise we end up nesting transactions,
     this causes two different connections to be used
@@ -124,7 +126,7 @@ def worker_repeatable_read_session_scope():
                     logger.debug(f"SScope (worker): closed {backend_pid=}")
 
 
-def db_post_fork():
+def db_post_fork() -> None:
     """
     Fix post-fork issues with sqlalchemy
     """
@@ -132,7 +134,7 @@ def db_post_fork():
     _get_base_engine().dispose(close=False)
 
 
-def are_friends(session, context, other_user):
+def are_friends(session: Session, context, other_user: int) -> bool:
     return (
         session.execute(
             select(FriendRelationship)
@@ -154,7 +156,7 @@ def are_friends(session, context, other_user):
     )
 
 
-def get_parent_node_at_location(session, shape):
+def get_parent_node_at_location(session: Session, shape: WKBElement) -> Node | None:
     """
     Finds the smallest node containing the shape.
 
@@ -172,7 +174,7 @@ def get_parent_node_at_location(session, shape):
     )
 
 
-def _get_node_parents_recursive_cte_subquery(session, node_id):
+def _get_node_parents_recursive_cte_subquery(node_id: int) -> Subquery:
     parents = (
         select(Node.id, Node.parent_node_id, literal(0).label("level"))
         .where(Node.id == node_id)
@@ -188,8 +190,8 @@ def _get_node_parents_recursive_cte_subquery(session, node_id):
     ).subquery()
 
 
-def get_node_parents_recursively(session, node_id):
-    subquery = _get_node_parents_recursive_cte_subquery(session, node_id)
+def get_node_parents_recursively(session: Session, node_id: int) -> Sequence[Row[tuple[int, int, int, Cluster]]]:
+    subquery = _get_node_parents_recursive_cte_subquery(node_id)
     return session.execute(
         select(subquery, Cluster)
         .join(Cluster, Cluster.parent_node_id == subquery.c.id)
@@ -198,7 +200,7 @@ def get_node_parents_recursively(session, node_id):
     ).all()
 
 
-def _can_moderate_any_cluster(session, user_id, cluster_ids):
+def _can_moderate_any_cluster(session: Session, user_id: int, cluster_ids: list[int]) -> bool:
     return session.execute(
         select(
             (
@@ -212,11 +214,11 @@ def _can_moderate_any_cluster(session, user_id, cluster_ids):
     ).scalar_one()
 
 
-def can_moderate_node(session, user_id, node_id):
+def can_moderate_node(session: Session, user_id: int, node_id: int) -> bool:
     """
     Returns True if the user_id can moderate the given node (i.e., if they are admin of any community that is a parent of the node)
     """
-    subquery = _get_node_parents_recursive_cte_subquery(session, node_id)
+    subquery = _get_node_parents_recursive_cte_subquery(node_id)
     return session.execute(
         select(
             (
@@ -236,7 +238,7 @@ def can_moderate_node(session, user_id, node_id):
     )
 
 
-def can_moderate_at(session, user_id, shape):
+def can_moderate_at(session: Session, user_id: int, shape: WKBElement) -> bool:
     """
     Returns True if the user_id can moderate a given geo-shape (i.e., if the shape is contained in any Node that the user is an admin of)
     """
@@ -255,7 +257,7 @@ def can_moderate_at(session, user_id, shape):
     ).scalar_one()
 
 
-def timezone_at_coordinate(session, geom):
+def timezone_at_coordinate(session: Session, geom: WKBElement) -> str | None:
     area = session.execute(
         select(TimezoneArea.tzid).where(func.ST_Contains(TimezoneArea.geom, geom))
     ).scalar_one_or_none()

--- a/app/backend/src/couchers/models/activeness_probe.py
+++ b/app/backend/src/couchers/models/activeness_probe.py
@@ -1,10 +1,15 @@
 import enum
+from datetime import datetime
+from typing import TYPE_CHECKING
 
-from sqlalchemy import BigInteger, CheckConstraint, Column, DateTime, Enum, ForeignKey, Index, Integer, func
+from sqlalchemy import BigInteger, CheckConstraint, DateTime, Enum, ForeignKey, Index, Integer, func
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from couchers.models.base import Base
+
+if TYPE_CHECKING:
+    from couchers.models.users import User
 
 
 class ActivenessProbeStatus(enum.Enum):
@@ -30,24 +35,26 @@ class ActivenessProbe(Base):
 
     __tablename__ = "activeness_probes"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
     # the time this probe was initiated
-    probe_initiated = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    probe_initiated: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     # the number of reminders sent for this probe
-    notifications_sent = Column(Integer, nullable=False, server_default="0")
+    notifications_sent: Mapped[int] = mapped_column(Integer, server_default="0")
 
     # the time of response
-    responded = Column(DateTime(timezone=True), nullable=True, default=None)
+    responded: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
     # the response value
-    response = Column(Enum(ActivenessProbeStatus), nullable=False, default=ActivenessProbeStatus.pending)
+    response: Mapped[ActivenessProbeStatus] = mapped_column(
+        Enum(ActivenessProbeStatus), default=ActivenessProbeStatus.pending
+    )
 
     @hybrid_property
-    def is_pending(self):
+    def is_pending(self) -> bool:
         return self.responded == None
 
-    user = relationship("User", back_populates="pending_activeness_probe")
+    user: Mapped["User"] = relationship("User", back_populates="pending_activeness_probe")
 
     __table_args__ = (
         # a user can have at most one pending activeness probe at a time
@@ -55,7 +62,7 @@ class ActivenessProbe(Base):
             "ix_activeness_probe_unique_pending_response",
             user_id,
             unique=True,
-            postgresql_where=responded == None,
+            postgresql_where=responded.is_(None),
         ),
         # response time is none iff response is pending
         CheckConstraint(

--- a/app/backend/src/couchers/models/auth.py
+++ b/app/backend/src/couchers/models/auth.py
@@ -1,10 +1,16 @@
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer, String, func, text
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, func, text
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import expression
 
 from couchers.models.base import Base
 from couchers.utils import now
+
+if TYPE_CHECKING:
+    from couchers.models.users import User
 
 
 class UserSession(Base):
@@ -23,44 +29,46 @@ class UserSession(Base):
     """
 
     __tablename__ = "sessions"
-    token = Column(String, primary_key=True)
 
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    token: Mapped[str] = mapped_column(String, primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
     # sessions are either "api keys" or "session cookies", otherwise identical
     # an api key is put in the authorization header (e.g. "authorization: Bearer <token>")
     # a session cookie is set in the "couchers-sesh" cookie (e.g. "cookie: couchers-sesh=<token>")
     # when a session is created, it's fixed as one or the other for security reasons
     # for api keys to be useful, they should be long-lived and have a long expiry
-    is_api_key = Column(Boolean, nullable=False, server_default=expression.false())
+    is_api_key: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
 
     # whether it's a long-lived or short-lived session
-    long_lived = Column(Boolean, nullable=False)
+    long_lived: Mapped[bool] = mapped_column(Boolean)
 
     # the time at which the session was created
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     # the expiry of the session: the session *cannot* be refreshed past this
-    expiry = Column(DateTime(timezone=True), nullable=False, server_default=func.now() + text("interval '730 days'"))
+    expiry: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now() + text("interval '730 days'")
+    )
 
     # the time at which the token was invalidated, allows users to delete sessions
-    deleted = Column(DateTime(timezone=True), nullable=True, default=None)
+    deleted: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
 
     # the last time this session was used
-    last_seen = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    last_seen: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     # count of api calls made with this token/session (if we're updating last_seen, might as well update this too)
-    api_calls = Column(Integer, nullable=False, default=0)
+    api_calls: Mapped[int] = mapped_column(Integer, default=0)
 
     # details of the browser, if available
     # these are from the request creating the session, not used for anything else
-    ip_address = Column(String, nullable=True)
-    user_agent = Column(String, nullable=True)
+    ip_address: Mapped[str | None] = mapped_column(String, default=None)
+    user_agent: Mapped[str | None] = mapped_column(String, default=None)
 
-    user = relationship("User", backref="sessions")
+    user: Mapped["User"] = relationship("User", backref="sessions")
 
     @hybrid_property
-    def is_valid(self):
+    def is_valid(self) -> Any:
         """
         It must have been created and not be expired or deleted.
 
@@ -72,7 +80,7 @@ class UserSession(Base):
             (self.created <= func.now())
             & (self.expiry >= func.now())
             & (self.deleted == None)
-            & (self.long_lived | (func.now() - self.last_seen < text("interval '168 hours'")))
+            & (self.long_lived | (func.now() - self.last_seen < text("interval '168 hours'")))  # type: ignore[operator]
         )
 
     __table_args__ = (
@@ -90,38 +98,38 @@ class LoginToken(Base):
     """
 
     __tablename__ = "login_tokens"
-    token = Column(String, primary_key=True)
 
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    token: Mapped[str] = mapped_column(String, primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
     # timezones should always be UTC
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    expiry = Column(DateTime(timezone=True), nullable=False)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    expiry: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
-    user = relationship("User", backref="login_tokens")
+    user: Mapped["User"] = relationship("User", backref="login_tokens")
 
     @hybrid_property
-    def is_valid(self):
+    def is_valid(self) -> Any:
         return (self.created <= now()) & (self.expiry >= now())
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"LoginToken(token={self.token}, user={self.user}, created={self.created}, expiry={self.expiry})"
 
 
 class PasswordResetToken(Base):
     __tablename__ = "password_reset_tokens"
-    token = Column(String, primary_key=True)
 
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    token: Mapped[str] = mapped_column(String, primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    expiry = Column(DateTime(timezone=True), nullable=False)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    expiry: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
-    user = relationship("User", backref="password_reset_tokens")
+    user: Mapped["User"] = relationship("User", backref="password_reset_tokens")
 
     @hybrid_property
-    def is_valid(self):
+    def is_valid(self) -> Any:
         return (self.created <= now()) & (self.expiry >= now())
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"PasswordResetToken(token={self.token}, user={self.user}, created={self.created}, expiry={self.expiry})"

--- a/app/backend/src/couchers/models/background_jobs.py
+++ b/app/backend/src/couchers/models/background_jobs.py
@@ -1,8 +1,11 @@
 import enum
+from datetime import datetime
+from typing import Any
 
-from sqlalchemy import BigInteger, Column, DateTime, Enum, Index, Integer, String, func, text
+from sqlalchemy import BigInteger, DateTime, Enum, Index, Integer, String, func, text
 from sqlalchemy import LargeBinary as Binary
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.orm import Mapped, mapped_column
 
 from couchers.models.base import Base
 
@@ -25,31 +28,31 @@ class BackgroundJob(Base):
 
     __tablename__ = "background_jobs"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
     # used to discern which function should be triggered to service it
-    job_type = Column(String, nullable=False)
-    state = Column(Enum(BackgroundJobState), nullable=False, default=BackgroundJobState.pending)
+    job_type: Mapped[str] = mapped_column(String)
+    state: Mapped[BackgroundJobState] = mapped_column(Enum(BackgroundJobState), default=BackgroundJobState.pending)
 
     # time queued
-    queued = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    queued: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     # time at which we may next attempt it, for implementing exponential backoff
-    next_attempt_after = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    next_attempt_after: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     # used to count number of retries for failed jobs
-    try_count = Column(Integer, nullable=False, default=0)
+    try_count: Mapped[int] = mapped_column(Integer, default=0)
 
-    max_tries = Column(Integer, nullable=False, default=5)
+    max_tries: Mapped[int] = mapped_column(Integer, default=5)
 
     # higher is more important
-    priority = Column(Integer, nullable=False, server_default=text("10"))
+    priority: Mapped[int] = mapped_column(Integer, server_default=text("10"))
 
     # protobuf encoded job payload
-    payload = Column(Binary, nullable=False)
+    payload: Mapped[bytes] = mapped_column(Binary)
 
     # if the job failed, we write that info here
-    failure_info = Column(String, nullable=True)
+    failure_info: Mapped[str | None] = mapped_column(String, nullable=True)
 
     __table_args__ = (
         # used in looking up background jobs to attempt
@@ -64,12 +67,12 @@ class BackgroundJob(Base):
     )
 
     @hybrid_property
-    def ready_for_retry(self):
+    def ready_for_retry(self) -> Any:
         return (
             (self.next_attempt_after <= func.now())
             & (self.try_count < self.max_tries)
             & ((self.state == BackgroundJobState.pending) | (self.state == BackgroundJobState.error))
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"BackgroundJob(id={self.id}, job_type={self.job_type}, state={self.state}, next_attempt_after={self.next_attempt_after}, try_count={self.try_count}, failure_info={self.failure_info})"

--- a/app/backend/src/couchers/models/base.py
+++ b/app/backend/src/couchers/models/base.py
@@ -1,3 +1,4 @@
+from geoalchemy2 import WKBElement, WKTElement
 from sqlalchemy import MetaData, Sequence
 from sqlalchemy.orm import DeclarativeBase
 
@@ -17,3 +18,4 @@ class Base(DeclarativeBase):
 
 
 communities_seq = Sequence("communities_seq")
+Geom = WKBElement | WKTElement

--- a/app/backend/src/couchers/models/clusters.py
+++ b/app/backend/src/couchers/models/clusters.py
@@ -1,11 +1,11 @@
 import enum
+from datetime import datetime
 
 from geoalchemy2 import Geometry
 from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
-    Column,
     DateTime,
     Enum,
     ForeignKey,
@@ -16,10 +16,10 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.orm import backref, column_property, deferred, relationship
+from sqlalchemy.orm import Mapped, backref, column_property, deferred, mapped_column, relationship
 from sqlalchemy.sql import expression
 
-from couchers.models.base import Base, communities_seq
+from couchers.models.base import Base, Geom, communities_seq
 from couchers.utils import get_coordinates
 
 
@@ -32,12 +32,17 @@ class Node(Base):
 
     __tablename__ = "nodes"
 
-    id = Column(BigInteger, communities_seq, primary_key=True, server_default=communities_seq.next_value())
+    id: Mapped[int] = mapped_column(
+        BigInteger,
+        communities_seq,
+        primary_key=True,
+        server_default=communities_seq.next_value(),
+    )
 
-    # name and description come from official cluster
-    parent_node_id = Column(ForeignKey("nodes.id"), nullable=True, index=True)
-    geom = deferred(Column(Geometry(geometry_type="MULTIPOLYGON", srid=4326), nullable=False))
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    # name and description come from the official cluster
+    parent_node_id: Mapped[int | None] = mapped_column(ForeignKey("nodes.id"), nullable=True, index=True)
+    geom: Mapped[Geom] = deferred(mapped_column(Geometry(geometry_type="MULTIPOLYGON", srid=4326), nullable=False))
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     parent_node = relationship("Node", backref="child_nodes", remote_side="Node.id")
 
@@ -58,17 +63,19 @@ class Cluster(Base):
 
     __tablename__ = "clusters"
 
-    id = Column(BigInteger, communities_seq, primary_key=True, server_default=communities_seq.next_value())
-    parent_node_id = Column(ForeignKey("nodes.id"), nullable=False, index=True)
-    name = Column(String, nullable=False)
+    id: Mapped[int] = mapped_column(
+        BigInteger, communities_seq, primary_key=True, server_default=communities_seq.next_value()
+    )
+    parent_node_id: Mapped[int] = mapped_column(ForeignKey("nodes.id"), index=True)
+    name: Mapped[str] = mapped_column(String)
     # short description
-    description = Column(String, nullable=False)
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    description: Mapped[str] = mapped_column(String)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    is_official_cluster = Column(Boolean, nullable=False, default=False)
+    is_official_cluster: Mapped[bool] = mapped_column(Boolean, default=False)
 
-    discussions_enabled = Column(Boolean, nullable=False, default=True, server_default=expression.true())
-    events_enabled = Column(Boolean, nullable=False, default=True, server_default=expression.true())
+    discussions_enabled: Mapped[bool] = mapped_column(Boolean, default=True, server_default=expression.true())
+    events_enabled: Mapped[bool] = mapped_column(Boolean, default=True, server_default=expression.true())
 
     slug = column_property(func.slugify(name))
 
@@ -154,10 +161,10 @@ class NodeClusterAssociation(Base):
     __tablename__ = "node_cluster_associations"
     __table_args__ = (UniqueConstraint("node_id", "cluster_id"),)
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    node_id = Column(ForeignKey("nodes.id"), nullable=False, index=True)
-    cluster_id = Column(ForeignKey("clusters.id"), nullable=False, index=True)
+    node_id: Mapped[int] = mapped_column(ForeignKey("nodes.id"), index=True)
+    cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
 
     node = relationship("Node", backref="node_cluster_associations")
     cluster = relationship("Cluster", backref="node_cluster_associations")
@@ -175,11 +182,11 @@ class ClusterSubscription(Base):
 
     __tablename__ = "cluster_subscriptions"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    cluster_id = Column(ForeignKey("clusters.id"), nullable=False, index=True)
-    role = Column(Enum(ClusterRole), nullable=False)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
+    role: Mapped[ClusterRole] = mapped_column(Enum(ClusterRole))
 
     user = relationship("User", backref="cluster_subscriptions")
     cluster = relationship("Cluster", backref="cluster_subscriptions")
@@ -209,10 +216,10 @@ class ClusterPageAssociation(Base):
     __tablename__ = "cluster_page_associations"
     __table_args__ = (UniqueConstraint("page_id", "cluster_id"),)
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    page_id = Column(ForeignKey("pages.id"), nullable=False, index=True)
-    cluster_id = Column(ForeignKey("clusters.id"), nullable=False, index=True)
+    page_id: Mapped[int] = mapped_column(ForeignKey("pages.id"), index=True)
+    cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
 
     page = relationship("Page", backref="cluster_page_associations")
     cluster = relationship("Cluster", backref="cluster_page_associations")
@@ -231,15 +238,17 @@ class Page(Base):
 
     __tablename__ = "pages"
 
-    id = Column(BigInteger, communities_seq, primary_key=True, server_default=communities_seq.next_value())
+    id: Mapped[int] = mapped_column(
+        BigInteger, communities_seq, primary_key=True, server_default=communities_seq.next_value()
+    )
 
-    parent_node_id = Column(ForeignKey("nodes.id"), nullable=False, index=True)
-    type = Column(Enum(PageType), nullable=False)
-    creator_user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    owner_user_id = Column(ForeignKey("users.id"), nullable=True, index=True)
-    owner_cluster_id = Column(ForeignKey("clusters.id"), nullable=True, index=True)
+    parent_node_id: Mapped[int] = mapped_column(ForeignKey("nodes.id"), index=True)
+    type: Mapped[PageType] = mapped_column(Enum(PageType))
+    creator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    owner_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True, index=True)
+    owner_cluster_id: Mapped[int | None] = mapped_column(ForeignKey("clusters.id"), nullable=True, index=True)
 
-    thread_id = Column(ForeignKey("threads.id"), nullable=False, unique=True)
+    thread_id: Mapped[int] = mapped_column(ForeignKey("threads.id"), unique=True)
 
     parent_node = relationship("Node", backref="child_pages", remote_side="Node.id", foreign_keys="Page.parent_node_id")
 
@@ -273,7 +282,7 @@ class Page(Base):
         ),
     )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Page({self.id=})"
 
 
@@ -284,17 +293,17 @@ class PageVersion(Base):
 
     __tablename__ = "page_versions"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    page_id = Column(ForeignKey("pages.id"), nullable=False, index=True)
-    editor_user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    title = Column(String, nullable=False)
-    content = Column(String, nullable=False)  # CommonMark without images
-    photo_key = Column(ForeignKey("uploads.key"), nullable=True)
-    geom = Column(Geometry(geometry_type="POINT", srid=4326), nullable=True)
+    page_id: Mapped[int] = mapped_column(ForeignKey("pages.id"), index=True)
+    editor_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    title: Mapped[str] = mapped_column(String)
+    content: Mapped[str] = mapped_column(String)  # CommonMark without images
+    photo_key: Mapped[str | None] = mapped_column(ForeignKey("uploads.key"), nullable=True)
+    geom: Mapped[Geom | None] = mapped_column(Geometry(geometry_type="POINT", srid=4326), nullable=True)
     # the human-readable address
-    address = Column(String, nullable=True)
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    address: Mapped[str | None] = mapped_column(String, nullable=True)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     slug = column_property(func.slugify(title))
 
@@ -311,9 +320,9 @@ class PageVersion(Base):
     )
 
     @property
-    def coordinates(self):
+    def coordinates(self) -> tuple[float, float] | None:
         # returns (lat, lng) or None
         return get_coordinates(self.geom)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"PageVersion({self.id=}, {self.page_id=})"

--- a/app/backend/src/couchers/models/conversations.py
+++ b/app/backend/src/couchers/models/conversations.py
@@ -1,8 +1,10 @@
 import enum
+from datetime import datetime
+from typing import Any
 
-from sqlalchemy import BigInteger, Boolean, Column, DateTime, Enum, ForeignKey, String, func
+from sqlalchemy import BigInteger, Boolean, DateTime, Enum, ForeignKey, String, func
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import backref, relationship
+from sqlalchemy.orm import Mapped, backref, mapped_column, relationship
 
 from couchers.constants import DATETIME_INFINITY, DATETIME_MINUS_INFINITY
 from couchers.models.base import Base
@@ -17,11 +19,11 @@ class Conversation(Base):
 
     __tablename__ = "conversations"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     # timezone should always be UTC
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Conversation(id={self.id}, created={self.created})"
 
 
@@ -32,17 +34,17 @@ class GroupChat(Base):
 
     __tablename__ = "group_chats"
 
-    conversation_id = Column("id", ForeignKey("conversations.id"), nullable=False, primary_key=True)
+    conversation_id: Mapped[int] = mapped_column("id", ForeignKey("conversations.id"), primary_key=True)
 
-    title = Column(String, nullable=True)
-    only_admins_invite = Column(Boolean, nullable=False, default=True)
-    creator_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    is_dm = Column(Boolean, nullable=False)
+    title: Mapped[str | None] = mapped_column(String, nullable=True)
+    only_admins_invite: Mapped[bool] = mapped_column(Boolean, default=True)
+    creator_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    is_dm: Mapped[bool] = mapped_column(Boolean)
 
     conversation = relationship("Conversation", backref="group_chat")
     creator = relationship("User", backref="created_group_chats")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"GroupChat(conversation={self.conversation}, title={self.title or 'None'}, only_admins_invite={self.only_admins_invite}, creator={self.creator}, is_dm={self.is_dm})"
 
 
@@ -57,27 +59,29 @@ class GroupChatSubscription(Base):
     """
 
     __tablename__ = "group_chat_subscriptions"
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
     # TODO: DB constraint on only one user+group_chat combo at a given time
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    group_chat_id = Column(ForeignKey("group_chats.id"), nullable=False, index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    group_chat_id: Mapped[int] = mapped_column(ForeignKey("group_chats.id"), index=True)
 
     # timezones should always be UTC
-    joined = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    left = Column(DateTime(timezone=True), nullable=True)
+    joined: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    left: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
-    role = Column(Enum(GroupChatRole), nullable=False)
+    role: Mapped[GroupChatRole] = mapped_column(Enum(GroupChatRole))
 
-    last_seen_message_id = Column(BigInteger, nullable=False, default=0)
+    last_seen_message_id: Mapped[int] = mapped_column(BigInteger, default=0)
 
     # when this chat is muted until, DATETIME_INFINITY for "forever"
-    muted_until = Column(DateTime(timezone=True), nullable=False, server_default=DATETIME_MINUS_INFINITY.isoformat())
+    muted_until: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=DATETIME_MINUS_INFINITY.isoformat()
+    )
 
     user = relationship("User", backref="group_chat_subscriptions")
     group_chat = relationship("GroupChat", backref=backref("subscriptions", lazy="dynamic"))
 
-    def muted_display(self):
+    def muted_display(self) -> tuple[bool, datetime | None]:
         """
         Returns (muted, muted_until) display values:
         1. If not muted, returns (False, None)
@@ -92,10 +96,10 @@ class GroupChatSubscription(Base):
             return (True, self.muted_until)
 
     @hybrid_property
-    def is_muted(self):
+    def is_muted(self) -> Any:
         return self.muted_until > func.now()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"GroupChatSubscription(id={self.id}, user={self.user}, joined={self.joined}, left={self.left}, role={self.role}, group_chat={self.group_chat})"
 
 
@@ -124,39 +128,39 @@ class Message(Base):
 
     __tablename__ = "messages"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
     # which conversation the message belongs in
-    conversation_id = Column(ForeignKey("conversations.id"), nullable=False, index=True)
+    conversation_id: Mapped[int] = mapped_column(ForeignKey("conversations.id"), index=True)
 
     # the user that sent the message/command
-    author_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    author_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
     # the message type, "text" is a text message, otherwise a "control message"
-    message_type = Column(Enum(MessageType), nullable=False)
+    message_type: Mapped[MessageType] = mapped_column(Enum(MessageType))
 
     # the target if a control message and requires target, e.g. if inviting a user, the user invited is the target
-    target_id = Column(ForeignKey("users.id"), nullable=True, index=True)
+    target_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True, index=True)
 
     # time sent, timezone should always be UTC
-    time = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    time: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     # the plain-text message text if not control
-    text = Column(String, nullable=True)
+    text: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # the new host request status if the message type is host_request_status_changed
-    host_request_status_target = Column(Enum(HostRequestStatus), nullable=True)
+    host_request_status_target: Mapped[HostRequestStatus | None] = mapped_column(Enum(HostRequestStatus), nullable=True)
 
     conversation = relationship("Conversation", backref="messages", order_by="Message.time.desc()")
     author = relationship("User", foreign_keys="Message.author_id")
     target = relationship("User", foreign_keys="Message.target_id")
 
     @property
-    def is_normal_message(self):
+    def is_normal_message(self) -> bool:
         """
         There's only one normal type atm, text
         """
         return self.message_type == MessageType.text
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Message(id={self.id}, time={self.time}, text={self.text}, author={self.author}, conversation={self.conversation})"

--- a/app/backend/src/couchers/models/discussions.py
+++ b/app/backend/src/couchers/models/discussions.py
@@ -1,5 +1,7 @@
-from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, String, UniqueConstraint, func
-from sqlalchemy.orm import backref, column_property, relationship
+from datetime import datetime
+
+from sqlalchemy import BigInteger, DateTime, ForeignKey, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, backref, column_property, mapped_column, relationship
 
 from couchers.models.base import Base, communities_seq
 
@@ -11,15 +13,17 @@ class Discussion(Base):
 
     __tablename__ = "discussions"
 
-    id = Column(BigInteger, communities_seq, primary_key=True, server_default=communities_seq.next_value())
+    id: Mapped[int] = mapped_column(
+        BigInteger, communities_seq, primary_key=True, server_default=communities_seq.next_value()
+    )
 
-    title = Column(String, nullable=False)
-    content = Column(String, nullable=False)
-    thread_id = Column(ForeignKey("threads.id"), nullable=False, unique=True)
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    title: Mapped[str] = mapped_column(String)
+    content: Mapped[str] = mapped_column(String)
+    thread_id: Mapped[int] = mapped_column(ForeignKey("threads.id"), unique=True)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    creator_user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    owner_cluster_id = Column(ForeignKey("clusters.id"), nullable=False, index=True)
+    creator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    owner_cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
 
     slug = column_property(func.slugify(title))
 
@@ -39,12 +43,12 @@ class DiscussionSubscription(Base):
     __tablename__ = "discussion_subscriptions"
     __table_args__ = (UniqueConstraint("discussion_id", "user_id"),)
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    discussion_id = Column(ForeignKey("discussions.id"), nullable=False, index=True)
-    joined = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    left = Column(DateTime(timezone=True), nullable=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    discussion_id: Mapped[int] = mapped_column(ForeignKey("discussions.id"), index=True)
+    joined: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    left: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     user = relationship("User", backref="discussion_subscriptions")
     discussion = relationship("Discussion", backref="discussion_subscriptions")
@@ -57,10 +61,10 @@ class Thread(Base):
 
     __tablename__ = "threads"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    deleted = Column(DateTime(timezone=True), nullable=True)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    deleted: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
 
 class Comment(Base):
@@ -70,13 +74,13 @@ class Comment(Base):
 
     __tablename__ = "comments"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    thread_id = Column(ForeignKey("threads.id"), nullable=False, index=True)
-    author_user_id = Column(ForeignKey("users.id"), nullable=False)
-    content = Column(String, nullable=False)  # CommonMark without images
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    deleted = Column(DateTime(timezone=True), nullable=True)
+    thread_id: Mapped[int] = mapped_column(ForeignKey("threads.id"), index=True)
+    author_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    content: Mapped[str] = mapped_column(String)  # CommonMark without images
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    deleted: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     thread = relationship("Thread", backref="comments")
 
@@ -88,13 +92,13 @@ class Reply(Base):
 
     __tablename__ = "replies"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    comment_id = Column(ForeignKey("comments.id"), nullable=False, index=True)
-    author_user_id = Column(ForeignKey("users.id"), nullable=False)
-    content = Column(String, nullable=False)  # CommonMark without images
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    deleted = Column(DateTime(timezone=True), nullable=True)
+    comment_id: Mapped[int] = mapped_column(ForeignKey("comments.id"), index=True)
+    author_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    content: Mapped[str] = mapped_column(String)  # CommonMark without images
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    deleted: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     comment = relationship("Comment", backref="replies")
 
@@ -107,10 +111,10 @@ class ClusterDiscussionAssociation(Base):
     __tablename__ = "cluster_discussion_associations"
     __table_args__ = (UniqueConstraint("discussion_id", "cluster_id"),)
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    discussion_id = Column(ForeignKey("discussions.id"), nullable=False, index=True)
-    cluster_id = Column(ForeignKey("clusters.id"), nullable=False, index=True)
+    discussion_id: Mapped[int] = mapped_column(ForeignKey("discussions.id"), index=True)
+    cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
 
     discussion = relationship("Discussion", backref="cluster_discussion_associations")
     cluster = relationship("Cluster", backref="cluster_discussion_associations")

--- a/app/backend/src/couchers/models/donations.py
+++ b/app/backend/src/couchers/models/donations.py
@@ -1,9 +1,14 @@
 import enum
+from datetime import datetime
+from typing import TYPE_CHECKING
 
-from sqlalchemy import BigInteger, Column, DateTime, Enum, Float, ForeignKey, Integer, String, func
-from sqlalchemy.orm import relationship
+from sqlalchemy import BigInteger, DateTime, Enum, Float, ForeignKey, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from couchers.models import Base
+from couchers.models.base import Base
+
+if TYPE_CHECKING:
+    from couchers.models.users import User
 
 
 class DonationType(enum.Enum):
@@ -17,18 +22,18 @@ class DonationInitiation(Base):
     """
 
     __tablename__ = "donation_initiations"
-    id = Column(BigInteger, primary_key=True)
 
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    amount = Column(Integer, nullable=False)
-    stripe_checkout_session_id = Column(String, nullable=False)
+    amount: Mapped[int] = mapped_column(Integer)
+    stripe_checkout_session_id: Mapped[str] = mapped_column(String)
 
-    donation_type = Column(Enum(DonationType), nullable=False)
-    source = Column(String, nullable=True)
+    donation_type: Mapped[DonationType] = mapped_column(Enum(DonationType))
+    source: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    user = relationship("User", backref="donation_initiations")
+    user: Mapped["User"] = relationship("User", backref="donation_initiations")
 
 
 class Invoice(Base):
@@ -40,13 +45,13 @@ class Invoice(Base):
 
     __tablename__ = "invoices"
 
-    id = Column(BigInteger, primary_key=True)
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    user_id = Column(ForeignKey("users.id"), nullable=False)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
 
-    amount = Column(Float, nullable=False)
+    amount: Mapped[float] = mapped_column(Float)
 
-    stripe_payment_intent_id = Column(String, nullable=False, unique=True)
-    stripe_receipt_url = Column(String, nullable=False)
+    stripe_payment_intent_id: Mapped[str] = mapped_column(String, unique=True)
+    stripe_receipt_url: Mapped[str] = mapped_column(String)
 
-    user = relationship("User", backref="invoices")
+    user: Mapped["User"] = relationship("User", backref="invoices")

--- a/app/backend/src/couchers/models/events.py
+++ b/app/backend/src/couchers/models/events.py
@@ -1,11 +1,13 @@
 import enum
+from datetime import datetime
+from typing import Any
 
 from geoalchemy2 import Geometry
+from psycopg2.extras import DateTimeTZRange  # type: ignore[import-untyped]
 from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
-    Column,
     DateTime,
     Enum,
     ForeignKey,
@@ -17,10 +19,10 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import TSTZRANGE, ExcludeConstraint
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import backref, column_property, relationship
+from sqlalchemy.orm import Mapped, backref, column_property, mapped_column, relationship
 from sqlalchemy.sql import expression
 
-from couchers.models.base import Base, communities_seq
+from couchers.models.base import Base, Geom, communities_seq
 from couchers.utils import get_coordinates
 
 
@@ -32,10 +34,10 @@ class ClusterEventAssociation(Base):
     __tablename__ = "cluster_event_associations"
     __table_args__ = (UniqueConstraint("event_id", "cluster_id"),)
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    event_id = Column(ForeignKey("events.id"), nullable=False, index=True)
-    cluster_id = Column(ForeignKey("clusters.id"), nullable=False, index=True)
+    event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), index=True)
+    cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
 
     event = relationship("Event", backref="cluster_event_associations")
     cluster = relationship("Cluster", backref="cluster_event_associations")
@@ -54,18 +56,20 @@ class Event(Base):
 
     __tablename__ = "events"
 
-    id = Column(BigInteger, communities_seq, primary_key=True, server_default=communities_seq.next_value())
-    parent_node_id = Column(ForeignKey("nodes.id"), nullable=False, index=True)
+    id: Mapped[int] = mapped_column(
+        BigInteger, communities_seq, primary_key=True, server_default=communities_seq.next_value()
+    )
+    parent_node_id: Mapped[int] = mapped_column(ForeignKey("nodes.id"), index=True)
 
-    title = Column(String, nullable=False)
+    title: Mapped[str] = mapped_column(String)
 
     slug = column_property(func.slugify(title))
 
-    creator_user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    owner_user_id = Column(ForeignKey("users.id"), nullable=True, index=True)
-    owner_cluster_id = Column(ForeignKey("clusters.id"), nullable=True, index=True)
-    thread_id = Column(ForeignKey("threads.id"), nullable=False, unique=True)
+    creator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    owner_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True, index=True)
+    owner_cluster_id: Mapped[int | None] = mapped_column(ForeignKey("clusters.id"), nullable=True, index=True)
+    thread_id: Mapped[int] = mapped_column(ForeignKey("threads.id"), unique=True)
 
     parent_node = relationship(
         "Node", backref="child_events", remote_side="Node.id", foreign_keys="Event.parent_node_id"
@@ -98,32 +102,34 @@ class Event(Base):
 class EventOccurrence(Base):
     __tablename__ = "event_occurrences"
 
-    id = Column(BigInteger, communities_seq, primary_key=True, server_default=communities_seq.next_value())
-    event_id = Column(ForeignKey("events.id"), nullable=False, index=True)
+    id: Mapped[int] = mapped_column(
+        BigInteger, communities_seq, primary_key=True, server_default=communities_seq.next_value()
+    )
+    event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), index=True)
 
     # the user that created this particular occurrence of a repeating event (same as event.creator_user_id if single event)
-    creator_user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    content = Column(String, nullable=False)  # CommonMark without images
-    photo_key = Column(ForeignKey("uploads.key"), nullable=True)
+    creator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    content: Mapped[str] = mapped_column(String)  # CommonMark without images
+    photo_key: Mapped[str | None] = mapped_column(ForeignKey("uploads.key"), nullable=True)
 
-    is_cancelled = Column(Boolean, nullable=False, default=False, server_default=expression.false())
-    is_deleted = Column(Boolean, nullable=False, default=False, server_default=expression.false())
+    is_cancelled: Mapped[bool] = mapped_column(Boolean, default=False, server_default=expression.false())
+    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False, server_default=expression.false())
 
     # a null geom is an online-only event
-    geom = Column(Geometry(geometry_type="POINT", srid=4326), nullable=True)
+    geom: Mapped[Geom | None] = mapped_column(Geometry(geometry_type="POINT", srid=4326), nullable=True)
     # physical address, iff geom is not null
-    address = Column(String, nullable=True)
+    address: Mapped[str | None] = mapped_column(String, nullable=True)
     # videoconferencing link, etc, must be specified if no geom, otherwise optional
-    link = Column(String, nullable=True)
+    link: Mapped[str | None] = mapped_column(String, nullable=True)
 
     timezone = "Etc/UTC"
 
     # time during which the event takes place; this is a range type (instead of separate start+end times) which
     # simplifies database constraints, etc
-    during = Column(TSTZRANGE, nullable=False)
+    during: Mapped["DateTimeTZRange"] = mapped_column(TSTZRANGE)
 
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    last_edited = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    last_edited: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     creator_user = relationship(
         "User", backref="created_event_occurrences", foreign_keys="EventOccurrence.creator_user_id"
@@ -151,28 +157,28 @@ class EventOccurrence(Base):
             name="link_or_geom",
         ),
         # Can't have overlapping occurrences in the same Event
-        ExcludeConstraint(("event_id", "="), ("during", "&&"), name="event_occurrences_event_id_during_excl"),
+        ExcludeConstraint(("event_id", "="), ("during", "&&"), name="event_occurrences_event_id_during_excl"),  # type: ignore[no-untyped-call]
     )
 
     @property
-    def coordinates(self):
+    def coordinates(self) -> tuple[float, float] | None:
         # returns (lat, lng) or None
         return get_coordinates(self.geom)
 
     @hybrid_property
-    def start_time(self):
+    def start_time(self) -> Any:
         return self.during.lower
 
     @start_time.expression
-    def start_time(cls):
+    def start_time(cls) -> Any:  # noqa: ARG003,D102
         return func.lower(cls.during)
 
     @hybrid_property
-    def end_time(self):
+    def end_time(self) -> Any:
         return self.during.upper
 
     @end_time.expression
-    def end_time(cls):
+    def end_time(cls) -> Any:  # noqa: ARG003,D102
         return func.upper(cls.during)
 
 
@@ -184,11 +190,11 @@ class EventSubscription(Base):
     __tablename__ = "event_subscriptions"
     __table_args__ = (UniqueConstraint("event_id", "user_id"),)
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    event_id = Column(ForeignKey("events.id"), nullable=False, index=True)
-    joined = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), index=True)
+    joined: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     user = relationship("User")
     event = relationship("Event")
@@ -202,11 +208,11 @@ class EventOrganizer(Base):
     __tablename__ = "event_organizers"
     __table_args__ = (UniqueConstraint("event_id", "user_id"),)
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    event_id = Column(ForeignKey("events.id"), nullable=False, index=True)
-    joined = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), index=True)
+    joined: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     user = relationship("User")
     event = relationship("Event")
@@ -225,17 +231,17 @@ class EventOccurrenceAttendee(Base):
     __tablename__ = "event_occurrence_attendees"
     __table_args__ = (UniqueConstraint("occurrence_id", "user_id"),)
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    occurrence_id = Column(ForeignKey("event_occurrences.id"), nullable=False, index=True)
-    responded = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    attendee_status = Column(Enum(AttendeeStatus), nullable=False)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    occurrence_id: Mapped[int] = mapped_column(ForeignKey("event_occurrences.id"), index=True)
+    responded: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    attendee_status: Mapped[AttendeeStatus] = mapped_column(Enum(AttendeeStatus))
 
     user = relationship("User")
     occurrence = relationship("EventOccurrence", backref=backref("attendances", lazy="dynamic"))
 
-    reminder_sent = Column(Boolean, nullable=False, default=False, server_default=expression.false())
+    reminder_sent: Mapped[bool] = mapped_column(Boolean, default=False, server_default=expression.false())
 
 
 class EventCommunityInviteRequest(Base):
@@ -245,16 +251,16 @@ class EventCommunityInviteRequest(Base):
 
     __tablename__ = "event_community_invite_requests"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    occurrence_id = Column(ForeignKey("event_occurrences.id"), nullable=False, index=True)
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    occurrence_id: Mapped[int] = mapped_column(ForeignKey("event_occurrences.id"), index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    decided = Column(DateTime(timezone=True), nullable=True)
-    decided_by_user_id = Column(ForeignKey("users.id"), nullable=True)
-    approved = Column(Boolean, nullable=True)
+    decided: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    decided_by_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
+    approved: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
 
     occurrence = relationship("EventOccurrence", backref=backref("community_invite_requests", lazy="dynamic"))
     user = relationship("User", foreign_keys="EventCommunityInviteRequest.user_id")

--- a/app/backend/src/couchers/models/host_requests.py
+++ b/app/backend/src/couchers/models/host_requests.py
@@ -1,13 +1,19 @@
 import enum
+from datetime import date, datetime
+from typing import TYPE_CHECKING, Any
 
 from geoalchemy2 import Geometry
-from sqlalchemy import BigInteger, Boolean, Column, Date, DateTime, Enum, Float, ForeignKey, Index, String, func, text
+from sqlalchemy import BigInteger, Boolean, Date, DateTime, Enum, Float, ForeignKey, Index, String, func, text
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import column_property, relationship
+from sqlalchemy.orm import Mapped, column_property, mapped_column, relationship
 from sqlalchemy.sql import expression
 
 from couchers.models.base import Base
 from couchers.utils import date_in_timezone, now
+
+if TYPE_CHECKING:
+    from couchers.models.conversations import Conversation
+    from couchers.models.users import User
 
 
 class HostRequestStatus(enum.Enum):
@@ -31,49 +37,55 @@ class HostRequest(Base):
 
     __tablename__ = "host_requests"
 
-    conversation_id = Column("id", ForeignKey("conversations.id"), nullable=False, primary_key=True)
-    surfer_user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    host_user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    conversation_id: Mapped[int] = mapped_column("id", ForeignKey("conversations.id"), primary_key=True)
+    surfer_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    host_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    hosting_city = Column(String, nullable=False)
-    hosting_location = Column(Geometry("POINT", srid=4326), nullable=False)
-    hosting_radius = Column(Float, nullable=False)
+    hosting_city: Mapped[str] = mapped_column(String)
+    hosting_location: Mapped[Geometry] = mapped_column(Geometry("POINT", srid=4326))
+    hosting_radius: Mapped[float] = mapped_column(Float)
 
     # TODO: proper timezone handling
     timezone = "Etc/UTC"
 
     # dates in the timezone above
-    from_date = Column(Date, nullable=False)
-    to_date = Column(Date, nullable=False)
+    from_date: Mapped[date] = mapped_column(Date)
+    to_date: Mapped[date] = mapped_column(Date)
 
     # timezone aware start and end times of the request, can be compared to now()
-    start_time = column_property(date_in_timezone(from_date, timezone))
-    end_time = column_property(date_in_timezone(to_date, timezone) + text("interval '1 days'"))
-    start_time_to_write_reference = column_property(date_in_timezone(to_date, timezone))
+    start_time = column_property(date_in_timezone(from_date, timezone))  # type: ignore[arg-type]
+    end_time = column_property(date_in_timezone(to_date, timezone) + text("interval '1 days'"))  # type: ignore[arg-type]
+    start_time_to_write_reference = column_property(date_in_timezone(to_date, timezone))  # type: ignore[arg-type]
     # notice 1 day for midnight at the *end of the day*, then 14 days to write a ref
-    end_time_to_write_reference = column_property(date_in_timezone(to_date, timezone) + text("interval '15 days'"))
+    end_time_to_write_reference = column_property(date_in_timezone(to_date, timezone) + text("interval '15 days'"))  # type: ignore[arg-type]
 
-    status = Column(Enum(HostRequestStatus), nullable=False)
-    is_host_archived = Column(Boolean, nullable=False, default=False, server_default=expression.false())
-    is_surfer_archived = Column(Boolean, nullable=False, default=False, server_default=expression.false())
+    status: Mapped[HostRequestStatus] = mapped_column(Enum(HostRequestStatus))
+    is_host_archived: Mapped[bool] = mapped_column(Boolean, default=False, server_default=expression.false())
+    is_surfer_archived: Mapped[bool] = mapped_column(Boolean, default=False, server_default=expression.false())
 
-    host_last_seen_message_id = Column(BigInteger, nullable=False, default=0)
-    surfer_last_seen_message_id = Column(BigInteger, nullable=False, default=0)
+    host_last_seen_message_id: Mapped[int] = mapped_column(BigInteger, default=0)
+    surfer_last_seen_message_id: Mapped[int] = mapped_column(BigInteger, default=0)
 
     # number of reference reminders sent out
-    host_sent_reference_reminders = Column(BigInteger, nullable=False, server_default=text("0"))
-    surfer_sent_reference_reminders = Column(BigInteger, nullable=False, server_default=text("0"))
-    host_sent_request_reminders = Column(BigInteger, nullable=False, server_default=text("0"))
-    last_sent_request_reminder_time = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    host_sent_reference_reminders: Mapped[int] = mapped_column(BigInteger, server_default=text("0"))
+    surfer_sent_reference_reminders: Mapped[int] = mapped_column(BigInteger, server_default=text("0"))
+    host_sent_request_reminders: Mapped[int] = mapped_column(BigInteger, server_default=text("0"))
+    last_sent_request_reminder_time: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
 
     # reason why the host/surfer marked that they didn't meet up
     # if null then they haven't marked it such
-    host_reason_didnt_meetup = Column(String, nullable=True)
-    surfer_reason_didnt_meetup = Column(String, nullable=True)
+    host_reason_didnt_meetup: Mapped[str | None] = mapped_column(String, nullable=True)
+    surfer_reason_didnt_meetup: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    surfer = relationship("User", backref="host_requests_sent", foreign_keys="HostRequest.surfer_user_id")
-    host = relationship("User", backref="host_requests_received", foreign_keys="HostRequest.host_user_id")
-    conversation = relationship("Conversation")
+    surfer: Mapped["User"] = relationship(
+        "User", backref="host_requests_sent", foreign_keys="HostRequest.surfer_user_id"
+    )
+    host: Mapped["User"] = relationship(
+        "User", backref="host_requests_received", foreign_keys="HostRequest.host_user_id"
+    )
+    conversation: Mapped["Conversation"] = relationship("Conversation")
 
     __table_args__ = (
         # allows fast lookup as to whether they didn't meet up
@@ -96,7 +108,7 @@ class HostRequest(Base):
     )
 
     @hybrid_property
-    def can_write_reference(self):
+    def can_write_reference(self) -> Any:
         return (
             ((self.status == HostRequestStatus.confirmed) | (self.status == HostRequestStatus.accepted))
             & (now() >= self.start_time_to_write_reference)
@@ -104,14 +116,14 @@ class HostRequest(Base):
         )
 
     @can_write_reference.expression
-    def can_write_reference(cls):
+    def can_write_reference_expr(cls) -> Any:  # noqa: ARG003,D102
         return (
             ((cls.status == HostRequestStatus.confirmed) | (cls.status == HostRequestStatus.accepted))
             & (func.now() >= cls.start_time_to_write_reference)
             & (func.now() <= cls.end_time_to_write_reference)
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"HostRequest(id={self.conversation_id}, surfer_user_id={self.surfer_user_id}, host_user_id={self.host_user_id}...)"
 
 
@@ -122,17 +134,17 @@ class HostRequestFeedback(Base):
 
     __tablename__ = "host_request_feedbacks"
 
-    id = Column(BigInteger, primary_key=True)
-    time = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    host_request_id = Column(ForeignKey("host_requests.id"), nullable=False)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    time: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    host_request_id: Mapped[int] = mapped_column(ForeignKey("host_requests.id"))
 
-    from_user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    to_user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    from_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    to_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    request_quality = Column(Enum(HostRequestQuality), nullable=True)
-    decline_reason = Column(String, nullable=True)  # plain text
+    request_quality: Mapped[HostRequestQuality | None] = mapped_column(Enum(HostRequestQuality), nullable=True)
+    decline_reason: Mapped[str | None] = mapped_column(String, nullable=True)  # plain text
 
-    host_request = relationship("HostRequest")
+    host_request: Mapped["HostRequest"] = relationship("HostRequest")
 
     __table_args__ = (
         # Each user can leave at most one friend reference to another user

--- a/app/backend/src/couchers/models/logging.py
+++ b/app/backend/src/couchers/models/logging.py
@@ -1,5 +1,8 @@
-from sqlalchemy import BigInteger, Boolean, Column, DateTime, Float, String, func
+from datetime import datetime
+
+from sqlalchemy import BigInteger, Boolean, DateTime, Float, String, func
 from sqlalchemy import LargeBinary as Binary
+from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import expression
 
 from couchers.config import config
@@ -14,45 +17,45 @@ class APICall(Base):
     __tablename__ = "api_calls"
     __table_args__ = {"schema": "logging"}
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
     # whether the call was made using an api key or session cookies
-    is_api_key = Column(Boolean, nullable=False, server_default=expression.false())
+    is_api_key: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
 
     # backend version (normally e.g. develop-31469e3), allows us to figure out which proto definitions were used
     # note that `default` is a python side default, not hardcoded into DB schema
-    version = Column(String, nullable=False, default=config["VERSION"])
+    version: Mapped[str] = mapped_column(String, default=config["VERSION"])
 
     # approximate time of the call
-    time = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    time: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     # the method call name, e.g. "/org.couchers.api.core.API/ListFriends"
-    method = Column(String, nullable=False)
+    method: Mapped[str] = mapped_column(String)
 
     # gRPC status code name, e.g. FAILED_PRECONDITION, None if success
-    status_code = Column(String, nullable=True)
+    status_code: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # handler duration (excluding serialization, etc)
-    duration = Column(Float, nullable=False)
+    duration: Mapped[float] = mapped_column(Float)
 
     # user_id of caller, None means not logged in
-    user_id = Column(BigInteger, nullable=True)
+    user_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
 
     # sanitized request bytes
-    request = Column(Binary, nullable=True)
+    request: Mapped[bytes | None] = mapped_column(Binary, nullable=True)
 
     # sanitized response bytes
-    response = Column(Binary, nullable=True)
+    response: Mapped[bytes | None] = mapped_column(Binary, nullable=True)
 
     # whether response bytes have been truncated
-    response_truncated = Column(Boolean, nullable=False, server_default=expression.false())
+    response_truncated: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
 
     # the exception traceback, if any
-    traceback = Column(String, nullable=True)
+    traceback: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # human readable perf report
-    perf_report = Column(String, nullable=True)
+    perf_report: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # details of the browser, if available
-    ip_address = Column(String, nullable=True)
-    user_agent = Column(String, nullable=True)
+    ip_address: Mapped[str | None] = mapped_column(String, nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/app/backend/src/couchers/models/mod_note.py
+++ b/app/backend/src/couchers/models/mod_note.py
@@ -1,8 +1,14 @@
-from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, Index, String, func
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Index, String, func
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import backref, relationship
+from sqlalchemy.orm import Mapped, backref, mapped_column, relationship
 
 from couchers.models.base import Base
+
+if TYPE_CHECKING:
+    from couchers.models.users import User
 
 
 class ModNote(Base):
@@ -13,27 +19,29 @@ class ModNote(Base):
     """
 
     __tablename__ = "mod_notes"
-    id = Column(BigInteger, primary_key=True)
 
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    acknowledged = Column(DateTime(timezone=True), nullable=True)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    acknowledged: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # this is an internal ID to allow the mods to track different types of notes
-    internal_id = Column(String, nullable=False)
+    internal_id: Mapped[str] = mapped_column(String)
     # the admin that left this note
-    creator_user_id = Column(ForeignKey("users.id"), nullable=False)
+    creator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
 
-    note_content = Column(String, nullable=False)  # CommonMark without images
+    note_content: Mapped[str] = mapped_column(String)  # CommonMark without images
 
-    user = relationship("User", backref=backref("mod_notes", lazy="dynamic"), foreign_keys="ModNote.user_id")
+    user: Mapped["User"] = relationship(
+        "User", foreign_keys="ModNote.user_id", backref=backref("mod_notes", lazy="dynamic")
+    )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"ModeNote(id={self.id}, user={self.user}, created={self.created}, ack'd={self.acknowledged})"
 
     @hybrid_property
-    def is_pending(self):
+    def is_pending(self) -> bool:
         return self.acknowledged == None
 
     __table_args__ = (

--- a/app/backend/src/couchers/models/notifications.py
+++ b/app/backend/src/couchers/models/notifications.py
@@ -1,10 +1,10 @@
 import enum
+from datetime import datetime
 
 from google.protobuf import empty_pb2
 from sqlalchemy import (
     BigInteger,
     Boolean,
-    Column,
     DateTime,
     Enum,
     ForeignKey,
@@ -15,7 +15,7 @@ from sqlalchemy import (
     func,
 )
 from sqlalchemy import LargeBinary as Binary
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import expression
 
 from couchers.constants import DATETIME_INFINITY
@@ -36,10 +36,13 @@ dt = NotificationDeliveryType
 nd = notification_data_pb2
 dt_sec = [dt.email, dt.push]
 dt_all = [dt.email, dt.push, dt.digest]
+dt_empty: list[NotificationDeliveryType] = []
 
 
 class NotificationTopicAction(enum.Enum):
-    def __init__(self, topic_action, defaults, user_editable, data_type):
+    def __init__(
+        self, topic_action: str, defaults: list[NotificationDeliveryType], user_editable: bool, data_type: type
+    ) -> None:
         self.topic, self.action = topic_action.split(":")
         self.defaults = defaults
         # for now user editable == not a security notification
@@ -47,14 +50,14 @@ class NotificationTopicAction(enum.Enum):
 
         self.data_type = data_type
 
-    def unpack(self):
+    def unpack(self) -> tuple[str, str]:
         return self.topic, self.action
 
     @property
-    def display(self):
+    def display(self) -> str:
         return f"{self.topic}:{self.action}"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.display
 
     # topic, action, default delivery types
@@ -96,7 +99,7 @@ class NotificationTopicAction(enum.Enum):
     # approved by mods
     event__create_approved = ("event:create_approved", dt_all, True, nd.EventCreate)
     # any user creates any event, default to no notifications
-    event__create_any = ("event:create_any", [], True, nd.EventCreate)
+    event__create_any = ("event:create_any", dt_empty, True, nd.EventCreate)
     event__update = ("event:update", dt_all, True, nd.EventUpdate)
     event__cancel = ("event:cancel", dt_all, True, nd.EventCancel)
     event__delete = ("event:delete", dt_all, True, nd.EventDelete)
@@ -151,12 +154,12 @@ class NotificationTopicAction(enum.Enum):
 class NotificationPreference(Base):
     __tablename__ = "notification_preferences"
 
-    id = Column(BigInteger, primary_key=True)
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    topic_action = Column(Enum(NotificationTopicAction), nullable=False)
-    delivery_type = Column(Enum(NotificationDeliveryType), nullable=False)
-    deliver = Column(Boolean, nullable=False)
+    topic_action: Mapped[NotificationTopicAction] = mapped_column(Enum(NotificationTopicAction))
+    delivery_type: Mapped[NotificationDeliveryType] = mapped_column(Enum(NotificationDeliveryType))
+    deliver: Mapped[bool] = mapped_column(Boolean)
 
     user = relationship("User", foreign_keys="NotificationPreference.user_id")
 
@@ -170,19 +173,19 @@ class Notification(Base):
 
     __tablename__ = "notifications"
 
-    id = Column(BigInteger, primary_key=True)
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     # recipient user id
-    user_id = Column(ForeignKey("users.id"), nullable=False)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
 
-    topic_action = Column(Enum(NotificationTopicAction), nullable=False)
-    key = Column(String, nullable=False)
+    topic_action: Mapped[NotificationTopicAction] = mapped_column(Enum(NotificationTopicAction))
+    key: Mapped[str] = mapped_column(String)
 
-    data = Column(Binary, nullable=False)
+    data: Mapped[bytes] = mapped_column(Binary)
 
     # whether the user has marked this notification as seen or not
-    is_seen = Column(Boolean, nullable=False, server_default=expression.false())
+    is_seen: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
 
     user = relationship("User", foreign_keys="Notification.user_id")
 
@@ -209,24 +212,24 @@ class Notification(Base):
     )
 
     @property
-    def topic(self):
+    def topic(self) -> str:
         return self.topic_action.topic
 
     @property
-    def action(self):
+    def action(self) -> str:
         return self.topic_action.action
 
 
 class NotificationDelivery(Base):
     __tablename__ = "notification_deliveries"
 
-    id = Column(BigInteger, primary_key=True)
-    notification_id = Column(ForeignKey("notifications.id"), nullable=False, index=True)
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    delivered = Column(DateTime(timezone=True), nullable=True)
-    read = Column(DateTime(timezone=True), nullable=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    notification_id: Mapped[int] = mapped_column(ForeignKey("notifications.id"), index=True)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    delivered: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    read: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     # todo: enum of "phone, web, digest"
-    delivery_type = Column(Enum(NotificationDeliveryType), nullable=False)
+    delivery_type: Mapped[NotificationDeliveryType] = mapped_column(Enum(NotificationDeliveryType))
     # todo: device id
     # todo: receipt id, etc
     notification = relationship("Notification", foreign_keys="NotificationDelivery.notification_id")
@@ -251,27 +254,27 @@ class NotificationDelivery(Base):
 class PushNotificationSubscription(Base):
     __tablename__ = "push_notification_subscriptions"
 
-    id = Column(BigInteger, primary_key=True)
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     # which user this is connected to
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
     # these come from https://developer.mozilla.org/en-US/docs/Web/API/PushSubscription
     # the endpoint
-    endpoint = Column(String, nullable=False)
+    endpoint: Mapped[str] = mapped_column(String)
     # the "auth" key
-    auth_key = Column(Binary, nullable=False)
+    auth_key: Mapped[bytes] = mapped_column(Binary)
     # the "p256dh" key
-    p256dh_key = Column(Binary, nullable=False)
+    p256dh_key: Mapped[bytes] = mapped_column(Binary)
 
-    full_subscription_info = Column(String, nullable=False)
+    full_subscription_info: Mapped[str] = mapped_column(String)
 
     # the browse user-agent, so we can tell the user what browser notifications are going to
-    user_agent = Column(String, nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # when it was disabled
-    disabled_at = Column(DateTime(timezone=True), nullable=False, server_default=DATETIME_INFINITY.isoformat())
+    disabled_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=DATETIME_INFINITY.isoformat())
 
     user = relationship("User")
 
@@ -279,18 +282,18 @@ class PushNotificationSubscription(Base):
 class PushNotificationDeliveryAttempt(Base):
     __tablename__ = "push_notification_delivery_attempt"
 
-    id = Column(BigInteger, primary_key=True)
-    time = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    time: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    push_notification_subscription_id = Column(
-        ForeignKey("push_notification_subscriptions.id"), nullable=False, index=True
+    push_notification_subscription_id: Mapped[int] = mapped_column(
+        ForeignKey("push_notification_subscriptions.id"), index=True
     )
 
-    success = Column(Boolean, nullable=False)
+    success: Mapped[bool] = mapped_column(Boolean)
     # the HTTP status code, 201 is success
-    status_code = Column(Integer, nullable=False)
+    status_code: Mapped[int] = mapped_column(Integer)
 
     # can be null if it was a success
-    response = Column(String, nullable=True)
+    response: Mapped[str | None] = mapped_column(String, nullable=True)
 
     push_notification_subscription = relationship("PushNotificationSubscription")

--- a/app/backend/src/couchers/models/rest.py
+++ b/app/backend/src/couchers/models/rest.py
@@ -1,4 +1,6 @@
 import enum
+from datetime import date, datetime
+from typing import Any
 
 from geoalchemy2 import Geometry
 from sqlalchemy import (
@@ -7,7 +9,6 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
-    Column,
     Date,
     DateTime,
     Enum,
@@ -23,11 +24,11 @@ from sqlalchemy import (
 from sqlalchemy import LargeBinary as Binary
 from sqlalchemy.dialects.postgresql import INET
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import expression
 
 from couchers.constants import GUIDELINES_VERSION
-from couchers.models.base import Base
+from couchers.models.base import Base, Geom
 from couchers.models.users import HostingStatus
 from couchers.utils import now
 
@@ -40,14 +41,14 @@ class UserBadge(Base):
     __tablename__ = "user_badges"
     __table_args__ = (UniqueConstraint("user_id", "badge_id"),)
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
     # corresponds to "id" in badges.json
-    badge_id = Column(String, nullable=False, index=True)
+    badge_id: Mapped[str] = mapped_column(String, index=True)
 
     # take this with a grain of salt, someone may get then lose a badge for whatever reason
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     user = relationship("User", backref="badges")
 
@@ -69,16 +70,16 @@ class FriendRelationship(Base):
 
     __tablename__ = "friend_relationships"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    from_user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    to_user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    from_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    to_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    status = Column(Enum(FriendStatus), nullable=False, default=FriendStatus.pending)
+    status: Mapped[FriendStatus] = mapped_column(Enum(FriendStatus), default=FriendStatus.pending)
 
     # timezones should always be UTC
-    time_sent = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    time_responded = Column(DateTime(timezone=True), nullable=True)
+    time_sent: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    time_responded: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     from_user = relationship("User", backref="friends_from", foreign_keys="FriendRelationship.from_user_id")
     to_user = relationship("User", backref="friends_to", foreign_keys="FriendRelationship.to_user_id")
@@ -107,22 +108,22 @@ class ContributorForm(Base):
 
     __tablename__ = "contributor_forms"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    ideas = Column(String, nullable=True)
-    features = Column(String, nullable=True)
-    experience = Column(String, nullable=True)
-    contribute = Column(Enum(ContributeOption), nullable=True)
-    contribute_ways = Column(ARRAY(String), nullable=False)
-    expertise = Column(String, nullable=True)
+    ideas: Mapped[str | None] = mapped_column(String, nullable=True)
+    features: Mapped[str | None] = mapped_column(String, nullable=True)
+    experience: Mapped[str | None] = mapped_column(String, nullable=True)
+    contribute: Mapped[ContributeOption | None] = mapped_column(Enum(ContributeOption), nullable=True)
+    contribute_ways: Mapped[list[str]] = mapped_column(ARRAY(String))
+    expertise: Mapped[str | None] = mapped_column(String, nullable=True)
 
     user = relationship("User", backref="contributor_forms")
 
     @hybrid_property
-    def is_filled(self):
+    def is_filled(self) -> Any:
         """
         Whether the form counts as having been filled
         """
@@ -136,7 +137,7 @@ class ContributorForm(Base):
         )
 
     @property
-    def should_notify(self):
+    def should_notify(self) -> bool:
         """
         If this evaluates to true, we send an email to the recruitment team.
 
@@ -154,55 +155,55 @@ class SignupFlow(Base):
 
     __tablename__ = "signup_flows"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
     # housekeeping
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    flow_token = Column(String, nullable=False, unique=True)
-    email_verified = Column(Boolean, nullable=False, default=False)
-    email_sent = Column(Boolean, nullable=False, default=False)
-    email_token = Column(String, nullable=True)
-    email_token_expiry = Column(DateTime(timezone=True), nullable=True)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    flow_token: Mapped[str] = mapped_column(String, unique=True)
+    email_verified: Mapped[bool] = mapped_column(Boolean, default=False)
+    email_sent: Mapped[bool] = mapped_column(Boolean, default=False)
+    email_token: Mapped[str | None] = mapped_column(String, nullable=True)
+    email_token_expiry: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     ## Basic
-    name = Column(String, nullable=False)
+    name: Mapped[str] = mapped_column(String)
     # TODO: unique across both tables
-    email = Column(String, nullable=False, unique=True)
+    email: Mapped[str] = mapped_column(String, unique=True)
     # TODO: invitation, attribution
 
     ## Account
     # TODO: unique across both tables
-    username = Column(String, nullable=True, unique=True)
-    hashed_password = Column(Binary, nullable=True)
-    birthdate = Column(Date, nullable=True)  # in the timezone of birthplace
-    gender = Column(String, nullable=True)
-    hosting_status = Column(Enum(HostingStatus), nullable=True)
-    city = Column(String, nullable=True)
-    geom = Column(Geometry(geometry_type="POINT", srid=4326), nullable=True)
-    geom_radius = Column(Float, nullable=True)
+    username: Mapped[str | None] = mapped_column(String, nullable=True, unique=True)
+    hashed_password: Mapped[bytes | None] = mapped_column(Binary, nullable=True)
+    birthdate: Mapped[date | None] = mapped_column(Date, nullable=True)  # in the timezone of birthplace
+    gender: Mapped[str | None] = mapped_column(String, nullable=True)
+    hosting_status: Mapped[HostingStatus | None] = mapped_column(Enum(HostingStatus), nullable=True)
+    city: Mapped[str | None] = mapped_column(String, nullable=True)
+    geom: Mapped[Geom | None] = mapped_column(Geometry(geometry_type="POINT", srid=4326), nullable=True)
+    geom_radius: Mapped[float | None] = mapped_column(Float, nullable=True)
 
-    accepted_tos = Column(Integer, nullable=True)
-    accepted_community_guidelines = Column(Integer, nullable=False, server_default="0")
+    accepted_tos: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    accepted_community_guidelines: Mapped[int] = mapped_column(Integer, server_default="0")
 
-    opt_out_of_newsletter = Column(Boolean, nullable=True)
+    opt_out_of_newsletter: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
 
     ## Feedback (now unused)
-    filled_feedback = Column(Boolean, nullable=False, default=False)
-    ideas = Column(String, nullable=True)
-    features = Column(String, nullable=True)
-    experience = Column(String, nullable=True)
-    contribute = Column(Enum(ContributeOption), nullable=True)
-    contribute_ways = Column(ARRAY(String), nullable=True)
-    expertise = Column(String, nullable=True)
+    filled_feedback: Mapped[bool] = mapped_column(Boolean, default=False)
+    ideas: Mapped[str | None] = mapped_column(String, nullable=True)
+    features: Mapped[str | None] = mapped_column(String, nullable=True)
+    experience: Mapped[str | None] = mapped_column(String, nullable=True)
+    contribute: Mapped[ContributeOption | None] = mapped_column(Enum(ContributeOption), nullable=True)
+    contribute_ways: Mapped[list[str] | None] = mapped_column(ARRAY(String), nullable=True)
+    expertise: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    invite_code_id = Column(ForeignKey("invite_codes.id"), nullable=True)
-
-    @hybrid_property
-    def token_is_valid(self):
-        return (self.email_token != None) & (self.email_token_expiry >= now())
+    invite_code_id: Mapped[str | None] = mapped_column(ForeignKey("invite_codes.id"), nullable=True)
 
     @hybrid_property
-    def account_is_filled(self):
+    def token_is_valid(self) -> Any:
+        return (self.email_token != None) & (self.email_token_expiry >= now())  # type: ignore[operator]
+
+    @hybrid_property
+    def account_is_filled(self) -> Any:
         return (
             (self.username != None)
             & (self.birthdate != None)
@@ -216,27 +217,27 @@ class SignupFlow(Base):
         )
 
     @hybrid_property
-    def is_completed(self):
+    def is_completed(self) -> Any:
         return self.email_verified & self.account_is_filled & (self.accepted_community_guidelines == GUIDELINES_VERSION)
 
 
 class AccountDeletionToken(Base):
     __tablename__ = "account_deletion_tokens"
 
-    token = Column(String, primary_key=True)
+    token: Mapped[str] = mapped_column(String, primary_key=True)
 
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    expiry = Column(DateTime(timezone=True), nullable=False)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    expiry: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
     user = relationship("User", backref="account_deletion_tokens")
 
     @hybrid_property
-    def is_valid(self):
+    def is_valid(self) -> Any:
         return (self.created <= now()) & (self.expiry >= now())
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"AccountDeletionToken(token={self.token}, user_id={self.user_id}, created={self.created}, expiry={self.expiry})"
 
 
@@ -249,18 +250,18 @@ class UserActivity(Base):
 
     __tablename__ = "user_activity"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    user_id = Column(ForeignKey("users.id"), nullable=False)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     # the start of a period of time, e.g. 1 hour during which we bin activeness
-    period = Column(DateTime(timezone=True), nullable=False)
+    period: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
     # details of the browser, if available
-    ip_address = Column(INET, nullable=True)
-    user_agent = Column(String, nullable=True)
+    ip_address: Mapped[str | None] = mapped_column(INET, nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # count of api calls made with this ip, user_agent, and period
-    api_calls = Column(Integer, nullable=False, default=0)
+    api_calls: Mapped[int] = mapped_column(Integer, default=0)
 
     __table_args__ = (
         # helps look up this tuple quickly
@@ -278,10 +279,10 @@ class UserActivity(Base):
 class InviteCode(Base):
     __tablename__ = "invite_codes"
 
-    id = Column(String, primary_key=True)
-    creator_user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    created = Column(DateTime(timezone=True), nullable=False, default=func.now())
-    disabled = Column(DateTime(timezone=True), nullable=True)
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    creator_user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"))
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=func.now())
+    disabled: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     creator = relationship("User", foreign_keys=[creator_user_id])
 
@@ -293,27 +294,27 @@ class ContentReport(Base):
 
     __tablename__ = "content_reports"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    time = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    time: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     # the user who reported or flagged the content
-    reporting_user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    reporting_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
     # reason, e.g. spam, inappropriate, etc
-    reason = Column(String, nullable=False)
+    reason: Mapped[str] = mapped_column(String)
     # a short description
-    description = Column(String, nullable=False)
+    description: Mapped[str] = mapped_column(String)
 
     # a reference to the content, see //docs/content_ref.md
-    content_ref = Column(String, nullable=False)
+    content_ref: Mapped[str] = mapped_column(String)
     # the author of the content (e.g. the user who wrote the comment itself)
-    author_user_id = Column(ForeignKey("users.id"), nullable=False)
+    author_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
 
     # details of the browser, if available
-    user_agent = Column(String, nullable=False)
+    user_agent: Mapped[str] = mapped_column(String)
     # the URL the user was on when reporting the content
-    page = Column(String, nullable=False)
+    page: Mapped[str] = mapped_column(String)
 
     # see comments above for reporting vs author
     reporting_user = relationship("User", foreign_keys="ContentReport.reporting_user_id")
@@ -327,22 +328,22 @@ class Email(Base):
 
     __tablename__ = "emails"
 
-    id = Column(String, primary_key=True)
+    id: Mapped[str] = mapped_column(String, primary_key=True)
 
     # timezone should always be UTC
-    time = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    time: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    sender_name = Column(String, nullable=False)
-    sender_email = Column(String, nullable=False)
+    sender_name: Mapped[str] = mapped_column(String)
+    sender_email: Mapped[str] = mapped_column(String)
 
-    recipient = Column(String, nullable=False)
-    subject = Column(String, nullable=False)
+    recipient: Mapped[str] = mapped_column(String)
+    subject: Mapped[str] = mapped_column(String)
 
-    plain = Column(String, nullable=False)
-    html = Column(String, nullable=False)
+    plain: Mapped[str] = mapped_column(String)
+    html: Mapped[str] = mapped_column(String)
 
-    list_unsubscribe_header = Column(String, nullable=True)
-    source_data = Column(String, nullable=True)
+    list_unsubscribe_header: Mapped[str | None] = mapped_column(String, nullable=True)
+    source_data: Mapped[str | None] = mapped_column(String, nullable=True)
 
 
 class SMS(Base):
@@ -352,17 +353,17 @@ class SMS(Base):
 
     __tablename__ = "smss"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
     # timezone should always be UTC
-    time = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    time: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     # AWS message id
-    message_id = Column(String, nullable=False)
+    message_id: Mapped[str] = mapped_column(String)
 
     # the SMS sender ID sent to AWS, name that the SMS appears to come from
-    sms_sender_id = Column(String, nullable=False)
-    number = Column(String, nullable=False)
-    message = Column(String, nullable=False)
+    sms_sender_id: Mapped[str] = mapped_column(String)
+    number: Mapped[str] = mapped_column(String)
+    message: Mapped[str] = mapped_column(String)
 
 
 class ReferenceType(enum.Enum):
@@ -378,25 +379,25 @@ class Reference(Base):
 
     __tablename__ = "references"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     # timezone should always be UTC
-    time = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    time: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    from_user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    to_user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    from_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    to_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    reference_type = Column(Enum(ReferenceType), nullable=False)
+    reference_type: Mapped[ReferenceType] = mapped_column(Enum(ReferenceType))
 
-    host_request_id = Column(ForeignKey("host_requests.id"), nullable=True)
+    host_request_id: Mapped[int | None] = mapped_column(ForeignKey("host_requests.id"), nullable=True)
 
-    text = Column(String, nullable=False)  # plain text
+    text: Mapped[str] = mapped_column(String)  # plain text
     # text that's only visible to mods
-    private_text = Column(String, nullable=True)  # plain text
+    private_text: Mapped[str | None] = mapped_column(String, nullable=True)  # plain text
 
-    rating = Column(Float, nullable=False)
-    was_appropriate = Column(Boolean, nullable=False)
+    rating: Mapped[float] = mapped_column(Float)
+    was_appropriate: Mapped[bool] = mapped_column(Boolean)
 
-    is_deleted = Column(Boolean, nullable=False, default=False, server_default=expression.false())
+    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False, server_default=expression.false())
 
     from_user = relationship("User", backref="references_from", foreign_keys="Reference.from_user_id")
     to_user = relationship("User", backref="references_to", foreign_keys="Reference.to_user_id")
@@ -435,11 +436,11 @@ class Reference(Base):
     )
 
     @property
-    def should_report(self):
+    def should_report(self) -> bool:
         """
         If this evaluates to true, we send a report to the moderation team.
         """
-        return self.rating <= 0.4 or not self.was_appropriate or self.private_text
+        return bool(self.rating <= 0.4 or not self.was_appropriate or self.private_text)
 
 
 class UserBlock(Base):
@@ -449,11 +450,11 @@ class UserBlock(Base):
 
     __tablename__ = "user_blocks"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    blocking_user_id = Column(ForeignKey("users.id"), nullable=False)
-    blocked_user_id = Column(ForeignKey("users.id"), nullable=False)
-    time_blocked = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    blocking_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    blocked_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    time_blocked: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     blocking_user = relationship("User", foreign_keys="UserBlock.blocking_user_id")
     blocked_user = relationship("User", foreign_keys="UserBlock.blocked_user_id")
@@ -468,10 +469,10 @@ class UserBlock(Base):
 class AccountDeletionReason(Base):
     __tablename__ = "account_deletion_reason"
 
-    id = Column(BigInteger, primary_key=True)
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    user_id = Column(ForeignKey("users.id"), nullable=False)
-    reason = Column(String, nullable=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    reason: Mapped[str | None] = mapped_column(String, nullable=True)
 
     user = relationship("User")
 
@@ -483,8 +484,8 @@ class ModerationUserList(Base):
 
     __tablename__ = "moderation_user_lists"
 
-    id = Column(BigInteger, primary_key=True)
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     # Relationships
     users = relationship("User", secondary="moderation_user_list_members", back_populates="moderation_user_lists")
@@ -497,8 +498,8 @@ class ModerationUserListMember(Base):
 
     __tablename__ = "moderation_user_list_members"
 
-    user_id = Column(ForeignKey("users.id"), primary_key=True)
-    moderation_list_id = Column(ForeignKey("moderation_user_lists.id"), primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), primary_key=True)
+    moderation_list_id: Mapped[int] = mapped_column(ForeignKey("moderation_user_lists.id"), primary_key=True)
 
     __table_args__ = (UniqueConstraint("user_id", "moderation_list_id"),)
 
@@ -506,18 +507,18 @@ class ModerationUserListMember(Base):
 class AntiBotLog(Base):
     __tablename__ = "antibot_logs"
 
-    id = Column(BigInteger, primary_key=True)
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    user_id = Column(ForeignKey("users.id"), nullable=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
 
-    ip_address = Column(String, nullable=True)
-    user_agent = Column(String, nullable=True)
+    ip_address: Mapped[str | None] = mapped_column(String, nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    action = Column(String, nullable=False)
-    token = Column(String, nullable=False)
+    action: Mapped[str] = mapped_column(String)
+    token: Mapped[str] = mapped_column(String)
 
-    score = Column(Float, nullable=False)
-    provider_data = Column(JSON, nullable=False)
+    score: Mapped[float] = mapped_column(Float)
+    provider_data: Mapped[dict[str, Any]] = mapped_column(JSON)
 
 
 class RateLimitAction(enum.Enum):
@@ -531,11 +532,11 @@ class RateLimitAction(enum.Enum):
 class RateLimitViolation(Base):
     __tablename__ = "rate_limit_violations"
 
-    id = Column(BigInteger, primary_key=True)
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    user_id = Column(ForeignKey("users.id"), nullable=False)
-    action = Column(Enum(RateLimitAction), nullable=False)
-    is_hard_limit = Column(Boolean, nullable=False)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    action: Mapped[RateLimitAction] = mapped_column(Enum(RateLimitAction))
+    is_hard_limit: Mapped[bool] = mapped_column(Boolean)
 
     user = relationship("User")
 
@@ -548,25 +549,25 @@ class RateLimitViolation(Base):
 class Volunteer(Base):
     __tablename__ = "volunteers"
 
-    id = Column(BigInteger, primary_key=True)
-    user_id = Column(ForeignKey("users.id"), nullable=False, unique=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), unique=True)
 
-    display_name = Column(String, nullable=True)
-    display_location = Column(String, nullable=True)
+    display_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    display_location: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    role = Column(String, nullable=False)
+    role: Mapped[str] = mapped_column(String)
 
     # custom sort order on team page, sorted ascending
-    sort_key = Column(Float, nullable=True)
+    sort_key: Mapped[float | None] = mapped_column(Float, nullable=True)
 
-    started_volunteering = Column(Date, nullable=False, server_default=text("CURRENT_DATE"))
-    stopped_volunteering = Column(Date, nullable=True, default=None)
+    started_volunteering: Mapped[date] = mapped_column(Date, server_default=text("CURRENT_DATE"))
+    stopped_volunteering: Mapped[date | None] = mapped_column(Date, nullable=True, default=None)
 
-    link_type = Column(String, nullable=True)
-    link_text = Column(String, nullable=True)
-    link_url = Column(String, nullable=True)
+    link_type: Mapped[str | None] = mapped_column(String, nullable=True)
+    link_text: Mapped[str | None] = mapped_column(String, nullable=True)
+    link_url: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    show_on_team_page = Column(Boolean, nullable=False, server_default=expression.true())
+    show_on_team_page: Mapped[bool] = mapped_column(Boolean, server_default=expression.true())
 
     __table_args__ = (
         # Link type, text, url should all be null or all not be null

--- a/app/backend/src/couchers/models/static.py
+++ b/app/backend/src/couchers/models/static.py
@@ -1,7 +1,8 @@
 from geoalchemy2 import Geometry
-from sqlalchemy import BigInteger, Column, Index, String
+from sqlalchemy import BigInteger, Index, String
+from sqlalchemy.orm import Mapped, mapped_column
 
-from couchers.models.base import Base
+from couchers.models.base import Base, Geom
 
 
 class Language(Base):
@@ -12,18 +13,18 @@ class Language(Base):
     __tablename__ = "languages"
 
     # ISO639-3 language code, in lowercase, e.g. fin, eng
-    code = Column(String(3), primary_key=True)
+    code: Mapped[str] = mapped_column(String(3), primary_key=True)
 
     # the english name
-    name = Column(String, nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(String, unique=True)
 
 
 class TimezoneArea(Base):
     __tablename__ = "timezone_areas"
-    id = Column(BigInteger, primary_key=True)
 
-    tzid = Column(String)
-    geom = Column(Geometry(geometry_type="MULTIPOLYGON", srid=4326), nullable=False)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    tzid: Mapped[str | None] = mapped_column(String)
+    geom: Mapped[Geom] = mapped_column(Geometry(geometry_type="MULTIPOLYGON", srid=4326))
 
     __table_args__ = (
         Index(
@@ -43,8 +44,8 @@ class Region(Base):
     __tablename__ = "regions"
 
     # iso 3166-1 alpha3 code in uppercase, e.g. FIN, USA
-    code = Column(String(3), primary_key=True)
+    code: Mapped[str] = mapped_column(String(3), primary_key=True)
 
     # the name, e.g. Finland, United States
     # this is the display name in English, should be the "common name", not "Republic of Finland"
-    name = Column(String, nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(String, unique=True)

--- a/app/backend/src/couchers/models/uploads.py
+++ b/app/backend/src/couchers/models/uploads.py
@@ -1,9 +1,15 @@
-from sqlalchemy import Column, DateTime, ForeignKey, String, func
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import DateTime, ForeignKey, String, func
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from couchers import urls
 from couchers.models.base import Base
+
+if TYPE_CHECKING:
+    from couchers.models.users import User
 
 
 class InitiatedUpload(Base):
@@ -13,18 +19,18 @@ class InitiatedUpload(Base):
 
     __tablename__ = "initiated_uploads"
 
-    key = Column(String, primary_key=True)
+    key: Mapped[str] = mapped_column(String, primary_key=True)
 
     # timezones should always be UTC
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    expiry = Column(DateTime(timezone=True), nullable=False)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    expiry: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
-    initiator_user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    initiator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    initiator_user = relationship("User")
+    initiator_user: Mapped["User"] = relationship("User")
 
     @hybrid_property
-    def is_valid(self):
+    def is_valid(self) -> Any:
         return (self.created <= func.now()) & (self.expiry >= func.now())
 
 
@@ -34,24 +40,25 @@ class Upload(Base):
     """
 
     __tablename__ = "uploads"
-    key = Column(String, primary_key=True)
 
-    filename = Column(String, nullable=False)
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    creator_user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
+    key: Mapped[str] = mapped_column(String, primary_key=True)
+
+    filename: Mapped[str] = mapped_column(String)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    creator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
     # photo credit, etc
-    credit = Column(String, nullable=True)
+    credit: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    creator_user = relationship("User", backref="uploads", foreign_keys="Upload.creator_user_id")
+    creator_user: Mapped["User"] = relationship("User", backref="uploads", foreign_keys="Upload.creator_user_id")
 
-    def _url(self, size):
+    def _url(self, size: str) -> str:
         return urls.media_url(filename=self.filename, size=size)
 
     @property
-    def thumbnail_url(self):
+    def thumbnail_url(self) -> str:
         return self._url("thumbnail")
 
     @property
-    def full_url(self):
+    def full_url(self) -> str:
         return self._url("full")

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -1,11 +1,12 @@
 import enum
+from datetime import date, datetime, timedelta
+from typing import TYPE_CHECKING, Any
 
-from geoalchemy2 import Geometry
+from geoalchemy2 import Geometry, WKBElement, WKTElement
 from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
-    Column,
     Date,
     DateTime,
     Enum,
@@ -25,7 +26,7 @@ from sqlalchemy import (
 from sqlalchemy import LargeBinary as Binary
 from sqlalchemy import select as sa_select
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import column_property, relationship
+from sqlalchemy.orm import Mapped, column_property, mapped_column, relationship
 from sqlalchemy.sql import expression
 
 from couchers.constants import (
@@ -38,8 +39,12 @@ from couchers.constants import (
 from couchers.models.activeness_probe import ActivenessProbe
 from couchers.models.base import Base
 from couchers.models.mod_note import ModNote
-from couchers.models.static import TimezoneArea
+from couchers.models.static import Language, Region, TimezoneArea
+from couchers.models.uploads import Upload
 from couchers.utils import get_coordinates, last_active_coarsen, now
+
+if TYPE_CHECKING:
+    from couchers.models.rest import InviteCode, ModerationUserList
 
 
 class HostingStatus(enum.Enum):
@@ -87,6 +92,9 @@ class ProfilePublicVisibility(enum.Enum):
     full = enum.auto()
 
 
+Geom = WKBElement | WKTElement
+
+
 class User(Base):
     """
     Basic user and profile details
@@ -94,144 +102,150 @@ class User(Base):
 
     __tablename__ = "users"
 
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    username = Column(String, nullable=False, unique=True)
-    email = Column(String, nullable=False, unique=True)
+    username: Mapped[str] = mapped_column(String, unique=True)
+    email: Mapped[str] = mapped_column(String, unique=True)
     # stored in libsodium hash format, can be null for email login
-    hashed_password = Column(Binary, nullable=False)
+    hashed_password: Mapped[bytes] = mapped_column(Binary)
     # phone number in E.164 format with leading +, for example "+46701740605"
-    phone = Column(String, nullable=True, server_default=expression.null())
+    phone: Mapped[str | None] = mapped_column(String, nullable=True, server_default=expression.null())
     # language preference -- defaults to empty string
-    ui_language_preference = Column(String, nullable=True, server_default="")
+    ui_language_preference: Mapped[str | None] = mapped_column(String, nullable=True, server_default="")
 
     # timezones should always be UTC
     ## location
     # point describing their location. EPSG4326 is the SRS (spatial ref system, = way to describe a point on earth) used
     # by GPS, it has the WGS84 geoid with lat/lon
-    geom = Column(Geometry(geometry_type="POINT", srid=4326), nullable=False)
+    geom: Mapped[Geom] = mapped_column(Geometry(geometry_type="POINT", srid=4326))
     # randomized coordinates within a radius of 0.02-0.1 degrees, equates to about 2-10 km
-    randomized_geom = Column(Geometry(geometry_type="POINT", srid=4326), nullable=True)
+    randomized_geom: Mapped[Geom | None] = mapped_column(Geometry(geometry_type="POINT", srid=4326), nullable=True)
     # their display location (displayed to other users), in meters
-    geom_radius = Column(Float, nullable=False)
+    geom_radius: Mapped[float] = mapped_column(Float)
     # the display address (text) shown on their profile
-    city = Column(String, nullable=False)
+    city: Mapped[str] = mapped_column(String)
     # "Grew up in" on profile
-    hometown = Column(String, nullable=True)
+    hometown: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    regions_visited = relationship("Region", secondary="regions_visited", order_by="Region.name")
-    regions_lived = relationship("Region", secondary="regions_lived", order_by="Region.name")
+    regions_visited: Mapped[list["Region"]] = relationship(
+        "Region", secondary="regions_visited", order_by="Region.name"
+    )
+    regions_lived: Mapped[list["Region"]] = relationship("Region", secondary="regions_lived", order_by="Region.name")
 
     timezone = column_property(
         sa_select(TimezoneArea.tzid).where(func.ST_Contains(TimezoneArea.geom, geom)).limit(1).scalar_subquery(),
         deferred=True,
     )
 
-    joined = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    last_active = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    joined: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    last_active: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    public_visibility = Column(Enum(ProfilePublicVisibility), nullable=False, server_default="map_only")
-    has_modified_public_visibility = Column(Boolean, nullable=False, server_default=expression.false())
+    public_visibility: Mapped[ProfilePublicVisibility] = mapped_column(
+        Enum(ProfilePublicVisibility), server_default="map_only"
+    )
+    has_modified_public_visibility: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
 
     # id of the last message that they received a notification about
-    last_notified_message_id = Column(BigInteger, nullable=False, default=0)
+    last_notified_message_id: Mapped[int] = mapped_column(BigInteger, default=0)
     # same as above for host requests
-    last_notified_request_message_id = Column(BigInteger, nullable=False, server_default=text("0"))
+    last_notified_request_message_id: Mapped[int] = mapped_column(BigInteger, server_default=text("0"))
 
     # display name
-    name = Column(String, nullable=False)
-    gender = Column(String, nullable=False)
-    pronouns = Column(String, nullable=True)
-    birthdate = Column(Date, nullable=False)  # in the timezone of birthplace
+    name: Mapped[str] = mapped_column(String)
+    gender: Mapped[str] = mapped_column(String)
+    pronouns: Mapped[str | None] = mapped_column(String, nullable=True)
+    birthdate: Mapped[date] = mapped_column(Date)  # in the timezone of birthplace
 
-    avatar_key = Column(ForeignKey("uploads.key"), nullable=True)
+    avatar_key: Mapped[str | None] = mapped_column(ForeignKey("uploads.key"), nullable=True)
 
-    hosting_status = Column(Enum(HostingStatus), nullable=False)
-    meetup_status = Column(Enum(MeetupStatus), nullable=False, server_default="open_to_meetup")
+    hosting_status: Mapped[HostingStatus] = mapped_column(Enum(HostingStatus))
+    meetup_status: Mapped[MeetupStatus] = mapped_column(Enum(MeetupStatus), server_default="open_to_meetup")
 
     # community standing score
-    community_standing = Column(Float, nullable=True)
+    community_standing: Mapped[float | None] = mapped_column(Float, nullable=True)
 
-    occupation = Column(String, nullable=True)  # CommonMark without images
-    education = Column(String, nullable=True)  # CommonMark without images
+    occupation: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
+    education: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
 
     # "Who I am" under "About Me" tab
-    about_me = Column(String, nullable=True)  # CommonMark without images
+    about_me: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
     # "What I do in my free time" under "About Me" tab
-    things_i_like = Column(String, nullable=True)  # CommonMark without images
+    things_i_like: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
     # "About my home" under "My Home" tab
-    about_place = Column(String, nullable=True)  # CommonMark without images
+    about_place: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
     # "Additional information" under "About Me" tab
-    additional_information = Column(String, nullable=True)  # CommonMark without images
+    additional_information: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
 
-    is_banned = Column(Boolean, nullable=False, server_default=expression.false())
-    is_deleted = Column(Boolean, nullable=False, server_default=expression.false())
-    is_superuser = Column(Boolean, nullable=False, server_default=expression.false())
+    is_banned: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
+    is_deleted: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
+    is_superuser: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
 
     # the undelete token allows a user to recover their account for a couple of days after deletion in case it was
     # accidental or they changed their mind
     # constraints make sure these are non-null only if is_deleted and that these are null in unison
-    undelete_token = Column(String, nullable=True)
+    undelete_token: Mapped[str | None] = mapped_column(String, nullable=True)
     # validity of the undelete token
-    undelete_until = Column(DateTime(timezone=True), nullable=True)
+    undelete_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # hosting preferences
-    max_guests = Column(Integer, nullable=True)
-    last_minute = Column(Boolean, nullable=True)
-    has_pets = Column(Boolean, nullable=True)
-    accepts_pets = Column(Boolean, nullable=True)
-    pet_details = Column(String, nullable=True)  # CommonMark without images
-    has_kids = Column(Boolean, nullable=True)
-    accepts_kids = Column(Boolean, nullable=True)
-    kid_details = Column(String, nullable=True)  # CommonMark without images
-    has_housemates = Column(Boolean, nullable=True)
-    housemate_details = Column(String, nullable=True)  # CommonMark without images
-    wheelchair_accessible = Column(Boolean, nullable=True)
-    smoking_allowed = Column(Enum(SmokingLocation), nullable=True)
-    smokes_at_home = Column(Boolean, nullable=True)
-    drinking_allowed = Column(Boolean, nullable=True)
-    drinks_at_home = Column(Boolean, nullable=True)
+    max_guests: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    last_minute: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    has_pets: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    accepts_pets: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    pet_details: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
+    has_kids: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    accepts_kids: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    kid_details: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
+    has_housemates: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    housemate_details: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
+    wheelchair_accessible: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    smoking_allowed: Mapped[SmokingLocation | None] = mapped_column(Enum(SmokingLocation), nullable=True)
+    smokes_at_home: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    drinking_allowed: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    drinks_at_home: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     # "Additional information" under "My Home" tab
-    other_host_info = Column(String, nullable=True)  # CommonMark without images
+    other_host_info: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
 
     # "Sleeping privacy" (not long-form text)
-    sleeping_arrangement = Column(Enum(SleepingArrangement), nullable=True)
+    sleeping_arrangement: Mapped[SleepingArrangement | None] = mapped_column(Enum(SleepingArrangement), nullable=True)
     # "Sleeping arrangement" under "My Home" tab
-    sleeping_details = Column(String, nullable=True)  # CommonMark without images
+    sleeping_details: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
     # "Local area information" under "My Home" tab
-    area = Column(String, nullable=True)  # CommonMark without images
+    area: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
     # "House rules" under "My Home" tab
-    house_rules = Column(String, nullable=True)  # CommonMark without images
-    parking = Column(Boolean, nullable=True)
-    parking_details = Column(Enum(ParkingDetails), nullable=True)  # CommonMark without images
-    camping_ok = Column(Boolean, nullable=True)
+    house_rules: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
+    parking: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    parking_details: Mapped[ParkingDetails | None] = mapped_column(
+        Enum(ParkingDetails), nullable=True
+    )  # CommonMark without images
+    camping_ok: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
 
-    accepted_tos = Column(Integer, nullable=False, default=0)
-    accepted_community_guidelines = Column(Integer, nullable=False, server_default="0")
-    # whether the user has yet filled in the contributor form
-    filled_contributor_form = Column(Boolean, nullable=False, server_default=expression.false())
+    accepted_tos: Mapped[int] = mapped_column(Integer, default=0)
+    accepted_community_guidelines: Mapped[int] = mapped_column(Integer, server_default="0")
+    # whether the user has filled in the contributor form
+    filled_contributor_form: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
 
     # number of onboarding emails sent
-    onboarding_emails_sent = Column(Integer, nullable=False, server_default="0")
-    last_onboarding_email_sent = Column(DateTime(timezone=True), nullable=True)
+    onboarding_emails_sent: Mapped[int] = mapped_column(Integer, server_default="0")
+    last_onboarding_email_sent: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # whether we need to sync the user's newsletter preferences with the newsletter server
-    in_sync_with_newsletter = Column(Boolean, nullable=False, server_default=expression.false())
+    in_sync_with_newsletter: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
     # opted out of the newsletter
-    opt_out_of_newsletter = Column(Boolean, nullable=False, server_default=expression.false())
+    opt_out_of_newsletter: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
 
     # set to null to receive no digests
-    digest_frequency = Column(Interval, nullable=True)
-    last_digest_sent = Column(DateTime(timezone=True), nullable=False, server_default=text("to_timestamp(0)"))
+    digest_frequency: Mapped[timedelta | None] = mapped_column(Interval, nullable=True)
+    last_digest_sent: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=text("to_timestamp(0)"))
 
     # for changing their email
-    new_email = Column(String, nullable=True)
+    new_email: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    new_email_token = Column(String, nullable=True)
-    new_email_token_created = Column(DateTime(timezone=True), nullable=True)
-    new_email_token_expiry = Column(DateTime(timezone=True), nullable=True)
+    new_email_token: Mapped[str | None] = mapped_column(String, nullable=True)
+    new_email_token_created: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    new_email_token_expiry: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
-    recommendation_score = Column(Float, nullable=False, server_default="0")
+    recommendation_score: Mapped[float] = mapped_column(Float, server_default="0")
 
     # Columns for verifying their phone number. State chart:
     #                                       ,-------------------,
@@ -257,45 +271,52 @@ class User(Base):
     # '-----------------'                   '-------------------'                      '-----------------------'
 
     # randomly generated Luhn 6-digit string
-    phone_verification_token = Column(String(6), nullable=True, server_default=expression.null())
+    phone_verification_token: Mapped[str | None] = mapped_column(
+        String(6), nullable=True, server_default=expression.null()
+    )
 
-    phone_verification_sent = Column(DateTime(timezone=True), nullable=False, server_default=text("to_timestamp(0)"))
-    phone_verification_verified = Column(DateTime(timezone=True), nullable=True, server_default=expression.null())
-    phone_verification_attempts = Column(Integer, nullable=False, server_default=text("0"))
+    phone_verification_sent: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=text("to_timestamp(0)")
+    )
+    phone_verification_verified: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, server_default=expression.null()
+    )
+    phone_verification_attempts: Mapped[int] = mapped_column(Integer, server_default=text("0"))
 
     # the stripe customer identifier if the user has donated to Couchers
     # e.g. cus_JjoXHttuZopv0t
     # for new US entity
-    stripe_customer_id = Column(String, nullable=True)
+    stripe_customer_id: Mapped[str | None] = mapped_column(String, nullable=True)
     # for old AU entity
-    stripe_customer_id_old = Column(String, nullable=True)
+    stripe_customer_id_old: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    has_passport_sex_gender_exception = Column(Boolean, nullable=False, server_default=expression.false())
+    has_passport_sex_gender_exception: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
 
     #  checking for phone verification
-    has_donated = Column(Boolean, nullable=False, server_default=expression.false())
+    has_donated: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
 
     # whether this user has all emails turned off
-    do_not_email = Column(Boolean, nullable=False, server_default=expression.false())
+    do_not_email: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
 
-    avatar = relationship("Upload", foreign_keys="User.avatar_key")
+    avatar: Mapped[Upload | None] = relationship("Upload", foreign_keys="User.avatar_key")
 
-    admin_note = Column(String, nullable=False, server_default=text("''"))
+    admin_note: Mapped[str] = mapped_column(String, server_default=text("''"))
 
     # whether mods have marked this user has having to update their location
-    needs_to_update_location = Column(Boolean, nullable=False, server_default=expression.false())
+    needs_to_update_location: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
 
-    last_antibot = Column(DateTime(timezone=True), nullable=False, server_default=text("to_timestamp(0)"))
+    last_antibot: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=text("to_timestamp(0)"))
 
     age = column_property(func.date_part("year", func.age(birthdate)))
 
     # ID of the invite code used to sign up (if any)
-    invite_code_id = Column(ForeignKey("invite_codes.id"), nullable=True)
-    invite_code = relationship("InviteCode", foreign_keys=[invite_code_id])
+    invite_code_id: Mapped[int | None] = mapped_column(ForeignKey("invite_codes.id"), nullable=True)
+    invite_code: Mapped["InviteCode | None"] = relationship("InviteCode", foreign_keys=[invite_code_id])
 
-    moderation_user_lists = relationship(
+    moderation_user_lists: Mapped[list["ModerationUserList"]] = relationship(
         "ModerationUserList", secondary="moderation_user_list_members", back_populates="users"
     )
+    language_abilities: Mapped[list["LanguageAbility"]] = relationship("LanguageAbility", back_populates="user")
 
     __table_args__ = (
         # Verified phone numbers should be unique
@@ -361,7 +382,7 @@ class User(Base):
     )
 
     @hybrid_property
-    def has_completed_profile(self):
+    def has_completed_profile(self) -> bool:
         return self.avatar_key is not None and self.about_me is not None and len(self.about_me) >= 150
 
     @has_completed_profile.expression
@@ -369,7 +390,7 @@ class User(Base):
         return (cls.avatar_key != None) & (func.character_length(cls.about_me) >= 150)
 
     @hybrid_property
-    def has_completed_my_home(self):
+    def has_completed_my_home(self) -> bool:
         # completed my profile means that:
         # 1. has filled out max_guests
         # 2. has filled out sleeping_arrangement (sleeping privacy)
@@ -401,23 +422,25 @@ class User(Base):
         )
 
     @hybrid_property
-    def jailed_missing_tos(self):
+    def jailed_missing_tos(self) -> bool:
         return self.accepted_tos < TOS_VERSION
 
     @hybrid_property
-    def jailed_missing_community_guidelines(self):
+    def jailed_missing_community_guidelines(self) -> bool:
         return self.accepted_community_guidelines < GUIDELINES_VERSION
 
     @hybrid_property
-    def jailed_pending_mod_notes(self):
-        return self.mod_notes.where(ModNote.is_pending).count() > 0
+    def jailed_pending_mod_notes(self) -> Any:
+        # mod_notes come from a backref in ModNote
+        return self.mod_notes.where(ModNote.is_pending).count() > 0  # type: ignore[attr-defined]
 
     @hybrid_property
-    def jailed_pending_activeness_probe(self):
-        return self.pending_activeness_probe != None
+    def jailed_pending_activeness_probe(self) -> Any:
+        # search for User.pending_activeness_probe
+        return self.pending_activeness_probe != None  # type: ignore[attr-defined]
 
     @hybrid_property
-    def is_jailed(self):
+    def is_jailed(self) -> Any:
         return (
             self.jailed_missing_tos
             | self.jailed_missing_community_guidelines
@@ -427,11 +450,11 @@ class User(Base):
         )
 
     @hybrid_property
-    def is_missing_location(self):
+    def is_missing_location(self) -> bool:
         return self.needs_to_update_location
 
     @hybrid_property
-    def is_visible(self):
+    def is_visible(self) -> bool:
         return not self.is_banned and not self.is_deleted
 
     @is_visible.expression
@@ -439,25 +462,25 @@ class User(Base):
         return ~(cls.is_banned | cls.is_deleted)
 
     @property
-    def coordinates(self):
+    def coordinates(self) -> tuple[int, int] | None:
         return get_coordinates(self.geom)
 
     @property
-    def display_joined(self):
+    def display_joined(self) -> datetime:
         """
         Returns the last active time rounded down to the nearest hour.
         """
         return self.joined.replace(minute=0, second=0, microsecond=0)
 
     @property
-    def display_last_active(self):
+    def display_last_active(self) -> datetime:
         """
         Returns the last active time rounded down whatever is the "last active" coarsening.
         """
         return last_active_coarsen(self.last_active)
 
     @hybrid_property
-    def phone_is_verified(self):
+    def phone_is_verified(self) -> bool:
         return (
             self.phone_verification_verified is not None
             and now() - self.phone_verification_verified < PHONE_VERIFICATION_LIFETIME
@@ -470,10 +493,10 @@ class User(Base):
         )
 
     @hybrid_property
-    def phone_code_expired(self):
+    def phone_code_expired(self) -> bool:
         return now() - self.phone_verification_sent > SMS_CODE_LIFETIME
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"User(id={self.id}, email={self.email}, username={self.username})"
 
 
@@ -499,28 +522,28 @@ class LanguageAbility(Base):
         UniqueConstraint("user_id", "language_code"),
     )
 
-    id = Column(BigInteger, primary_key=True)
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    language_code = Column(ForeignKey("languages.code", deferrable=True), nullable=False)
-    fluency = Column(Enum(LanguageFluency), nullable=False)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    language_code: Mapped[str] = mapped_column(ForeignKey("languages.code", deferrable=True))
+    fluency: Mapped[LanguageFluency] = mapped_column(Enum(LanguageFluency))
 
-    user = relationship("User", backref="language_abilities")
-    language = relationship("Language")
+    user: Mapped["User"] = relationship("User", back_populates="language_abilities")
+    language: Mapped[Language] = relationship("Language")
 
 
 class RegionVisited(Base):
     __tablename__ = "regions_visited"
     __table_args__ = (UniqueConstraint("user_id", "region_code"),)
 
-    id = Column(BigInteger, primary_key=True)
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    region_code = Column(ForeignKey("regions.code", deferrable=True), nullable=False)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    region_code: Mapped[str] = mapped_column(ForeignKey("regions.code", deferrable=True))
 
 
 class RegionLived(Base):
     __tablename__ = "regions_lived"
     __table_args__ = (UniqueConstraint("user_id", "region_code"),)
 
-    id = Column(BigInteger, primary_key=True)
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    region_code = Column(ForeignKey("regions.code", deferrable=True), nullable=False)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    region_code: Mapped[str] = mapped_column(ForeignKey("regions.code", deferrable=True))

--- a/app/backend/src/couchers/models/verification.py
+++ b/app/backend/src/couchers/models/verification.py
@@ -1,10 +1,11 @@
 import enum
+from datetime import date, datetime
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
-    Column,
     Date,
     DateTime,
     Enum,
@@ -15,10 +16,13 @@ from sqlalchemy import (
 )
 from sqlalchemy import LargeBinary as Binary
 from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
-from sqlalchemy.orm import column_property, relationship
+from sqlalchemy.orm import Mapped, column_property, mapped_column, relationship
 
 from couchers.models.base import Base
 from couchers.utils import date_in_timezone, now
+
+if TYPE_CHECKING:
+    from couchers.models.users import User
 
 
 class StrongVerificationAttemptStatus(enum.Enum):
@@ -62,69 +66,68 @@ class StrongVerificationAttempt(Base):
     __tablename__ = "strong_verification_attempts"
 
     # our verification id
-    id = Column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
     # this is returned in the callback, and we look up the attempt via this
-    verification_attempt_token = Column(String, nullable=False, unique=True)
+    verification_attempt_token: Mapped[str] = mapped_column(String, unique=True)
 
-    user_id = Column(ForeignKey("users.id"), nullable=False, index=True)
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    status = Column(
+    status: Mapped[StrongVerificationAttemptStatus] = mapped_column(
         Enum(StrongVerificationAttemptStatus),
-        nullable=False,
         default=StrongVerificationAttemptStatus.in_progress_waiting_on_user_to_open_app,
     )
 
     ## full data
-    has_full_data = Column(Boolean, nullable=False, default=False)
+    has_full_data: Mapped[bool] = mapped_column(Boolean, default=False)
     # the data returned from iris, encrypted with a public key whose private key is kept offline
-    passport_encrypted_data = Column(Binary, nullable=True)
-    passport_date_of_birth = Column(Date, nullable=True)
-    passport_sex = Column(Enum(PassportSex), nullable=True)
+    passport_encrypted_data: Mapped[bytes | None] = mapped_column(Binary, nullable=True)
+    passport_date_of_birth: Mapped[date | None] = mapped_column(Date, nullable=True)
+    passport_sex: Mapped[PassportSex | None] = mapped_column(Enum(PassportSex), nullable=True)
 
     ## minimal data: this will not be deleted
-    has_minimal_data = Column(Boolean, nullable=False, default=False)
-    passport_expiry_date = Column(Date, nullable=True)
-    passport_nationality = Column(String, nullable=True)
+    has_minimal_data: Mapped[bool] = mapped_column(Boolean, default=False)
+    passport_expiry_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    passport_nationality: Mapped[str | None] = mapped_column(String, nullable=True)
     # last three characters of the passport number
-    passport_last_three_document_chars = Column(String, nullable=True)
+    passport_last_three_document_chars: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    iris_token = Column(String, nullable=False, unique=True)
-    iris_session_id = Column(BigInteger, nullable=False, unique=True)
+    iris_token: Mapped[str] = mapped_column(String, unique=True)
+    iris_session_id: Mapped[int] = mapped_column(BigInteger, unique=True)
 
-    passport_expiry_datetime = column_property(date_in_timezone(passport_expiry_date, "Etc/UTC"))
+    passport_expiry_datetime = column_property(date_in_timezone(passport_expiry_date, "Etc/UTC"))  # type: ignore[arg-type]
 
-    user = relationship("User")
+    user: Mapped["User"] = relationship("User")
 
     @hybrid_property
-    def is_valid(self):
+    def is_valid(self) -> Any:
         """
         This only checks whether the attempt is a success and the passport is not expired, use `has_strong_verification` for full check
         """
         return (self.status == StrongVerificationAttemptStatus.succeeded) and (self.passport_expiry_datetime >= now())
 
     @is_valid.expression
-    def is_valid(cls):
+    def is_valid(cls) -> Any:  # noqa: ARG003,D102
         return (cls.status == StrongVerificationAttemptStatus.succeeded) & (
             func.coalesce(cls.passport_expiry_datetime >= func.now(), False)
         )
 
     @hybrid_property
-    def is_visible(self):
+    def is_visible(self) -> bool:
         return self.status != StrongVerificationAttemptStatus.deleted
 
     @hybrid_method
-    def _raw_birthdate_match(self, user):
+    def _raw_birthdate_match(self, user: "User") -> Any:
         """Does not check whether the SV attempt itself is not expired"""
         return self.passport_date_of_birth == user.birthdate
 
     @hybrid_method
-    def matches_birthdate(self, user):
+    def matches_birthdate(self, user: "User") -> Any:
         return self.is_valid & self._raw_birthdate_match(user)
 
     @hybrid_method
-    def _raw_gender_match(self, user):
+    def _raw_gender_match(self, user: "User") -> Any:
         """Does not check whether the SV attempt itself is not expired"""
         return (
             ((user.gender == "Woman") & (self.passport_sex == PassportSex.female))
@@ -134,11 +137,11 @@ class StrongVerificationAttempt(Base):
         )
 
     @hybrid_method
-    def matches_gender(self, user):
+    def matches_gender(self, user: "User") -> Any:
         return self.is_valid & self._raw_gender_match(user)
 
     @hybrid_method
-    def has_strong_verification(self, user):
+    def has_strong_verification(self, user: "User") -> Any:
         return self.is_valid & self._raw_birthdate_match(user) & self._raw_gender_match(user)
 
     __table_args__ = (
@@ -200,9 +203,9 @@ class StrongVerificationAttempt(Base):
 class StrongVerificationCallbackEvent(Base):
     __tablename__ = "strong_verification_callback_events"
 
-    id = Column(BigInteger, primary_key=True)
-    created = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    verification_attempt_id = Column(ForeignKey("strong_verification_attempts.id"), nullable=False, index=True)
+    verification_attempt_id: Mapped[int] = mapped_column(ForeignKey("strong_verification_attempts.id"), index=True)
 
-    iris_status = Column(String, nullable=False)
+    iris_status: Mapped[str] = mapped_column(String)

--- a/app/backend/src/couchers/rate_limits/check.py
+++ b/app/backend/src/couchers/rate_limits/check.py
@@ -1,21 +1,17 @@
 import logging
-from typing import TYPE_CHECKING
 
 from sqlalchemy import exists, select
+from sqlalchemy.orm import Session
 
 from couchers.models import RateLimitAction, RateLimitViolation
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_INTERVAL
 from couchers.tasks import send_rate_limit_violation_report_email
 from couchers.utils import now
 
-if TYPE_CHECKING:
-    from sqlalchemy.orm import Session
-
-
 logger = logging.getLogger(__name__)
 
 
-def _get_user_events_in_past_time_interval(session, user_id: int) -> dict[RateLimitAction, list[dict]]:
+def _get_user_events_in_past_time_interval(session: Session, user_id: int) -> dict[RateLimitAction, list[dict]]:
     """Get all relevant events for the user in the last rate limit interval for the mod email."""
     return {
         action: RATE_LIMIT_DEFINITIONS[action].mod_email_information_query(session, user_id)
@@ -24,7 +20,7 @@ def _get_user_events_in_past_time_interval(session, user_id: int) -> dict[RateLi
 
 
 def _save_rate_limit_violation(
-    session: "Session", user_id: int, action: RateLimitAction, is_hard_limit: bool
+    session: Session, user_id: int, action: RateLimitAction, is_hard_limit: bool
 ) -> RateLimitViolation:
     """Save a rate limit violation to the database and return it."""
     violation = RateLimitViolation(
@@ -38,7 +34,7 @@ def _save_rate_limit_violation(
 
 
 def _user_has_violated_rate_limit_in_past_time_interval(
-    session: "Session", user_id: int, action: RateLimitAction, is_hard_limit: bool
+    session: Session, user_id: int, action: RateLimitAction, is_hard_limit: bool
 ) -> bool:
     """Check if a RateLimitViolation for the user for the given action exists in the last RATE_LIMIT_INTERVAL."""
     return session.execute(
@@ -53,7 +49,7 @@ def _user_has_violated_rate_limit_in_past_time_interval(
     ).scalar_one()
 
 
-def process_rate_limits_and_check_abort(session: "Session", user_id: int, action: RateLimitAction) -> bool:
+def process_rate_limits_and_check_abort(session: Session, user_id: int, action: RateLimitAction) -> bool:
     """
     Check if the user has reached a rate limit. Notify the moderation team in a separate background job if so.
 

--- a/app/backend/src/couchers/servicers/pages.py
+++ b/app/backend/src/couchers/servicers/pages.py
@@ -1,4 +1,5 @@
 import grpc
+from sqlalchemy.orm import Session
 
 from couchers import errors
 from couchers.db import can_moderate_at, can_moderate_node, get_parent_node_at_location
@@ -23,7 +24,7 @@ pagetype2api = {
 }
 
 
-def _is_page_owner(page: Page, user_id):
+def _is_page_owner(page: Page, user_id: int) -> bool:
     """
     Checks whether the user can act as an owner of the page
     """
@@ -33,7 +34,7 @@ def _is_page_owner(page: Page, user_id):
     return page.owner_cluster.admins.where(User.id == user_id).one_or_none() is not None
 
 
-def _can_moderate_page(session, page: Page, user_id):
+def _can_moderate_page(session: Session, page: Page, user_id: int) -> bool:
     """
     Checks if the user is allowed to moderate this page
     """
@@ -52,7 +53,7 @@ def _can_moderate_page(session, page: Page, user_id):
     return can_moderate_node(session, user_id, page.parent_node_id)
 
 
-def page_to_pb(session, page: Page, context):
+def page_to_pb(session: Session, page: Page, context) -> pages_pb2.Page:
     first_version = page.versions[0]
     current_version = page.versions[-1]
 

--- a/app/backend/src/tests/test_communities.py
+++ b/app/backend/src/tests/test_communities.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 import grpc
 import pytest
+from geoalchemy2 import WKBElement
 from google.protobuf import wrappers_pb2
 
 from couchers import errors
@@ -47,12 +48,12 @@ def _(testconfig):
 # mostly fine
 
 
-def create_1d_polygon(lb, ub):
+def create_1d_polygon(lb: int, ub: int) -> WKBElement:
     # given a lower bound and upper bound on x, creates the given interval
     return create_polygon_lat_lng([[lb, 0], [lb, 2], [ub, 2], [ub, 0], [lb, 0]])
 
 
-def create_1d_point(x):
+def create_1d_point(x: int) -> WKBElement:
     return create_coordinate(x, 1)
 
 


### PR DESCRIPTION
Adds type annotations for models, and converts them to mypy-compatible syntax, e.g.,

```python
# was 
id = Column(BigInteger, primary_key=True)

# now
id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
```