### PR TITLE
Events: Add back button and use new event empty state string

### DIFF
--- a/app/web/.cursorrules
+++ b/app/web/.cursorrules
@@ -17,6 +17,9 @@ Run tests with: `yarn test`
 ## Development
 To run the app locally in development, use `yarn start` (not Docker)
 
+# File imports
+- Use our import aliases, e.g. "components/" instead of "../../../components/" and "routes" instead of "../../../routes"
+
 ## Code Style
 - Do not use the `any` type in TypeScript - it's considered bad practice
 - Remove extra unnecessary style declarations, including anything that's already a default of MUI or the theme

--- a/app/web/features/communities/events/CommunityEventsList.test.tsx
+++ b/app/web/features/communities/events/CommunityEventsList.test.tsx
@@ -68,7 +68,18 @@ describe("Events list", () => {
     render(<CommunityEventsList community={community} />, { wrapper });
     await waitForElementToBeRemoved(screen.getByRole("progressbar"));
 
-    expect(screen.getByText(t("communities:events_empty_state"))).toBeVisible();
+    expect(
+      screen.getByText((content, element) => {
+        // Match text split across multiple elements by checking the full text content
+        return (
+          element?.tagName === "P" &&
+          element?.textContent ===
+            "No events at the moment. Why don't you create one ✨?"
+        );
+      }),
+    ).toBeVisible();
+    // Check that there's a link to create a new event
+    expect(screen.getByRole("link", { name: "create" })).toBeInTheDocument();
   });
 
   it(`takes user to the page if the "${t(
@@ -95,7 +106,12 @@ describe("Events list", () => {
 
     await assertErrorAlert(errorMessage);
     expect(
-      screen.queryByText(t("communities:events_empty_state")),
+      screen.queryByText((content, element) => {
+        return (
+          element?.textContent ===
+          "No events at the moment. Why don't you create one ✨?"
+        );
+      }),
     ).not.toBeInTheDocument();
   });
 

--- a/app/web/features/communities/events/CommunityEventsList.tsx
+++ b/app/web/features/communities/events/CommunityEventsList.tsx
@@ -3,8 +3,9 @@ import Alert from "components/Alert";
 import Button from "components/Button";
 import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
 import { CalendarIcon } from "components/Icons";
+import StyledLink from "components/StyledLink";
 import TextBody from "components/TextBody";
-import { useTranslation } from "i18n";
+import { Trans, useTranslation } from "i18n";
 import { COMMUNITIES } from "i18n/namespaces";
 import { useRouter } from "next/router";
 import { Community } from "proto/communities_pb";
@@ -65,7 +66,17 @@ export default function CommunityEventsList({
             .filter((event) => !event.isCancelled)
             .map((event) => <LongEventCard event={event} key={event.eventId} />)
         ) : (
-          !error && <TextBody>{t("communities:events_empty_state")}</TextBody>
+          !error && (
+            <TextBody>
+              <Trans
+                t={t}
+                i18nKey="communities:events_empty_state"
+                components={[
+                  <StyledLink key="create-link" href={routeToNewEvent()} />,
+                ]}
+              />
+            </TextBody>
+          )
         )}
       </StyledEventsListContainer>
       {hasNextPage && (

--- a/app/web/features/communities/events/CreateEventPage.tsx
+++ b/app/web/features/communities/events/CreateEventPage.tsx
@@ -1,23 +1,32 @@
-import { Typography } from "@mui/material";
+import { styled, Typography } from "@mui/material";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import Button from "components/Button";
+import HeaderButton from "components/HeaderButton";
 import HtmlMeta from "components/HtmlMeta";
+import { BackIcon } from "components/Icons";
 import ProfileIncompleteDialog from "components/ProfileIncompleteDialog/ProfileIncompleteDialog";
 import useAccountInfo from "features/auth/useAccountInfo";
 import { RpcError } from "grpc-web";
 import { useTranslation } from "i18n";
 import { COMMUNITIES, GLOBAL } from "i18n/namespaces";
 import { useRouter } from "next/router";
-import { dashboardRoute, routeToEvent } from "routes";
+import { Event } from "proto/events_pb";
+import { dashboardRoute, eventsRoute, routeToEvent } from "routes";
 import { service } from "service";
 import type { CreateEventInput } from "service/events";
 import { theme } from "theme";
 import dayjs, { TIME_FORMAT } from "utils/dayjs";
 import stringOrFirstString from "utils/stringOrFirstString";
 
-import { Event } from "../../../proto/events_pb";
 import { communityEventsBaseKey } from "../../queryKeys";
 import EventForm, { CreateEventVariables } from "./EventForm";
+
+const StyledBackButton = styled(HeaderButton)(() => ({
+  gridArea: "backButton",
+  width: "2.5rem",
+  height: "2.5rem",
+  marginTop: theme.spacing(2),
+}));
 
 export default function CreateEventPage() {
   const { t } = useTranslation([GLOBAL, COMMUNITIES]);
@@ -110,6 +119,14 @@ export default function CreateEventPage() {
   const { data: accountInfo, isLoading: isAccountInfoLoading } =
     useAccountInfo();
 
+  const handleBackClick = () => {
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.push(eventsRoute);
+    }
+  };
+
   return (
     <>
       <HtmlMeta title={t("communities:create_event_page_title")} />
@@ -118,6 +135,9 @@ export default function CreateEventPage() {
         onClose={() => router.push(dashboardRoute)}
         attempted_action="create_event"
       />
+      <StyledBackButton onClick={handleBackClick}>
+        <BackIcon />
+      </StyledBackButton>
       <EventForm
         error={error}
         isMutationLoading={isPending}

--- a/app/web/features/communities/events/DiscoverEventsList.test.tsx
+++ b/app/web/features/communities/events/DiscoverEventsList.test.tsx
@@ -77,8 +77,16 @@ describe("DiscoverEventsList", () => {
       await screen.findByTestId("location-autocomplete"),
     ).toBeInTheDocument();
     expect(
-      await screen.getByText(t("communities:events_empty_state")),
+      screen.getByText((content, element) => {
+        // Match text split across multiple elements by checking the full text content
+        return (
+          element?.textContent ===
+          "No events at the moment. Why don't you create one ✨?"
+        );
+      }),
     ).toBeInTheDocument();
+    // Check that there's a link to create a new event
+    expect(screen.getByRole("link", { name: "create" })).toBeInTheDocument();
   });
 
   it("Renders error message when there is an error", async () => {

--- a/app/web/features/communities/events/DiscoverEventsList.tsx
+++ b/app/web/features/communities/events/DiscoverEventsList.tsx
@@ -2,11 +2,13 @@ import { Pagination, styled, Typography, useMediaQuery } from "@mui/material";
 import Alert from "components/Alert";
 import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
 import LocationAutocomplete from "components/LocationAutocomplete";
+import StyledLink from "components/StyledLink";
 import TextBody from "components/TextBody";
-import { useTranslation } from "i18n";
+import { Trans, useTranslation } from "i18n";
 import { COMMUNITIES, GLOBAL } from "i18n/namespaces";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
+import { routeToNewEvent } from "routes";
 import { theme } from "theme";
 import { GeocodeResult } from "utils/hooks";
 
@@ -166,7 +168,15 @@ const DiscoverEventsList = () => {
         {isMobile && renderLocationAutoComplete()}
       </StyledColumn>
       {!hasEvents && !isLoading && (
-        <TextBody>{t("communities:events_empty_state")}</TextBody>
+        <TextBody>
+          <Trans
+            t={t}
+            i18nKey="communities:events_empty_state"
+            components={[
+              <StyledLink key="create-link" href={routeToNewEvent()} />,
+            ]}
+          />
+        </TextBody>
       )}
       {error && <Alert severity="error">{error.message}</Alert>}
       {isLoading && (

--- a/app/web/features/communities/events/EventsSection.test.tsx
+++ b/app/web/features/communities/events/EventsSection.test.tsx
@@ -76,7 +76,17 @@ describe("Events section", () => {
     renderEventsSection();
     await waitForElementToBeRemoved(screen.getByRole("progressbar"));
 
-    expect(screen.getByText(t("communities:events_empty_state"))).toBeVisible();
+    expect(
+      screen.getByText((content, element) => {
+        // Match text split across multiple elements by checking the full text content
+        return (
+          element?.textContent ===
+          "No events at the moment. Why don't you create one ✨?"
+        );
+      }),
+    ).toBeVisible();
+    // Check that there's a link to create a new event
+    expect(screen.getByRole("link", { name: "create" })).toBeInTheDocument();
   });
 
   it("takes the user to the events tab when 'See more events' is clicked", async () => {

--- a/app/web/features/communities/events/EventsSection.tsx
+++ b/app/web/features/communities/events/EventsSection.tsx
@@ -6,7 +6,7 @@ import HorizontalScroller from "components/HorizontalScroller";
 import { CalendarIcon } from "components/Icons";
 import StyledLink from "components/StyledLink";
 import TextBody from "components/TextBody";
-import { useTranslation } from "i18n";
+import { Trans, useTranslation } from "i18n";
 import { COMMUNITIES, GLOBAL } from "i18n/namespaces";
 import { useRouter } from "next/router";
 import { Community } from "proto/communities_pb";
@@ -104,7 +104,17 @@ export default function EventsSection({
           )}
         </>
       ) : (
-        !error && <TextBody>{t("communities:events_empty_state")}</TextBody>
+        !error && (
+          <TextBody>
+            <Trans
+              t={t}
+              i18nKey="communities:events_empty_state"
+              components={[
+                <StyledLink key="create-link" href={routeToNewEvent()} />,
+              ]}
+            />
+          </TextBody>
+        )
       )}
       <StyledSelfCenteredButton
         onClick={() => router.push(routeToNewEvent(community.communityId))}

--- a/app/web/features/communities/events/MyEventsList.test.tsx
+++ b/app/web/features/communities/events/MyEventsList.test.tsx
@@ -45,8 +45,16 @@ describe("MyEventsList", () => {
     render(<MyEventsList />, { wrapper });
 
     expect(
-      await screen.findByText(t("communities:events_empty_state")),
+      await screen.findByText((content, element) => {
+        // Match text split across multiple elements by checking the full text content
+        return (
+          element?.textContent ===
+          "No events at the moment. Why don't you create one ✨?"
+        );
+      }),
     ).toBeInTheDocument();
+    // Check that there's a link to create a new event
+    expect(screen.getByRole("link", { name: "create" })).toBeInTheDocument();
   });
 
   it("Renders events list when events are available", async () => {

--- a/app/web/features/communities/events/MyEventsList.tsx
+++ b/app/web/features/communities/events/MyEventsList.tsx
@@ -1,11 +1,13 @@
 import { Pagination, styled, Typography } from "@mui/material";
 import Alert from "components/Alert";
 import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
+import StyledLink from "components/StyledLink";
 import TextBody from "components/TextBody";
 import { EventsType } from "features/queryKeys";
-import { useTranslation } from "i18n";
+import { Trans, useTranslation } from "i18n";
 import { COMMUNITIES } from "i18n/namespaces";
 import { useState } from "react";
+import { routeToNewEvent } from "routes";
 import { theme } from "theme";
 
 import EventsList from "./EventsList";
@@ -104,7 +106,15 @@ const MyEventsList = () => {
         </StyledFilterTag>
       </StyledFilterTagContainer>
       {!hasEvents && !isLoading && (
-        <StyledEmptyBody>{t("communities:events_empty_state")}</StyledEmptyBody>
+        <StyledEmptyBody>
+          <Trans
+            t={t}
+            i18nKey="communities:events_empty_state"
+            components={[
+              <StyledLink key="create-link" href={routeToNewEvent()} />,
+            ]}
+          />
+        </StyledEmptyBody>
       )}
       {error && <Alert severity="error">{error.message}</Alert>}
       {isLoading && <CenteredSpinner minHeight="theme.spacing(20)" />}

--- a/app/web/features/communities/locales/en.json
+++ b/app/web/features/communities/locales/en.json
@@ -39,7 +39,7 @@
   "edit_event": "Edit event",
   "edit_info_page_title": "Edit local info",
   "error_loading_community": "Error loading the community.",
-  "events_empty_state": "No events at the moment.",
+  "events_empty_state": "No events at the moment. Why don't you <0>create</0> one ✨?",
   "find_host": "Find host",
   "finished": "Finished",
   "community_info_page_title": "General information",


### PR DESCRIPTION
Use the same `events_empty_state` string with the prompt to create an event that we use on the dashboard everywhere.

Add a back button the the `CreateEventPage`.