### PR TITLE
Separate creating DISPLAY_VERSION and docker login; rebuild everything on changes to gitlab-ci.yml

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -44,12 +44,17 @@ default:
   image: docker
   services:
     - docker:dind
-  before_script:
+  before_script: |
+    # Error out when accessing an undefined variable
+    set -u  
+    
     # All jobs that use this must have full git history to correctly set the version number.
-    - if [ "$GIT_DEPTH" != "0" ]; then echo "GIT_DEPTH must be 0"; exit 1; fi
-    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
-    - export DISPLAY_VERSION=$(base_ver=$(cat app/version); if [ "$CI_COMMIT_BRANCH" == "$RELEASE_BRANCH" ]; then echo "${base_ver}.$(git rev-list --count "origin/$RELEASE_BRANCH")"; else echo "${base_ver}-$SLUG"; fi)
-    - echo $DISPLAY_VERSION
+    if [ "$GIT_DEPTH" == "0" ]; then 
+        export DISPLAY_VERSION=$(base_ver=$(cat app/version); if [ "$CI_COMMIT_BRANCH" == "$RELEASE_BRANCH" ]; then echo "${base_ver}.$(git rev-list --count "origin/$RELEASE_BRANCH")"; else echo "${base_ver}-$SLUG"; fi)
+        echo $DISPLAY_VERSION
+    fi
+    
+    docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
 
 protos:
   needs: []
@@ -81,6 +86,7 @@ build:proxy:
       changes:
         - app/proto/**/*
         - app/proxy/**/*
+        - app/.gitlab-ci.yml
 
 build:nginx:
   needs: []
@@ -95,6 +101,7 @@ build:nginx:
     - if: $CI_COMMIT_BRANCH == $RELEASE_BRANCH
       changes:
         - app/**/*
+        - app/.gitlab-ci.yml
 
 build:prometheus:
   needs: []
@@ -109,6 +116,7 @@ build:prometheus:
     - if: $CI_COMMIT_BRANCH == $RELEASE_BRANCH
       changes:
         - app/**/*
+        - app/.gitlab-ci.yml
 
 build:backend:
   needs: ["protos"]
@@ -127,6 +135,7 @@ build:backend:
       changes:
         - app/proto/**/*
         - app/backend/**/*
+        - app/.gitlab-ci.yml
 
 build:media:
   needs: ["protos"]
@@ -145,6 +154,7 @@ build:media:
       changes:
         - app/proto/**/*
         - app/media/**/*
+        - app/.gitlab-ci.yml
 
 build:web-dev:
   needs: ["protos"]
@@ -165,6 +175,7 @@ build:web-dev:
       changes:
         - app/proto/**/*
         - app/web/**/*
+        - app/.gitlab-ci.yml
   artifacts:
     paths:
       - artifacts/web-dev/
@@ -194,6 +205,7 @@ build:web:
       changes:
         - app/proto/**/*
         - app/web/**/*
+        - app/.gitlab-ci.yml
   artifacts:
     paths:
       - artifacts/
@@ -221,6 +233,7 @@ build:web-next:
       changes:
         - app/proto/**/*
         - app/web/**/*
+        - app/.gitlab-ci.yml
   artifacts:
     paths:
       - artifacts/
@@ -242,6 +255,7 @@ build:nginx-next:
       changes:
         - app/proto/**/*
         - app/nginx/**/*
+        - app/.gitlab-ci.yml
 
 test:backend:
   needs: ["build:backend"]
@@ -419,8 +433,6 @@ test:web-linting:
 test:proxy:
   needs: ["build:proxy"]
   stage: test
-  variables:
-    GIT_DEPTH: 0
   script:
     - docker run --name envoy-config-test -d -p 8888:8888 -p 9901:9901 $PROXY_TAG
     - sleep 10
@@ -629,8 +641,6 @@ wait:before-release:
 release:proxy:
   needs: ["wait:before-release"]
   stage: release
-  variables:
-    GIT_DEPTH: 0
   script:
     - docker pull $PROXY_TAG
     - docker tag $PROXY_TAG $PROXY_RELEASE_TAG
@@ -643,8 +653,6 @@ release:proxy:
 release:nginx:
   needs: ["wait:before-release"]
   stage: release
-  variables:
-    GIT_DEPTH: 0
   script:
     - docker pull $NGINX_TAG
     - docker tag $NGINX_TAG $NGINX_RELEASE_TAG
@@ -657,8 +665,6 @@ release:nginx:
 release:prometheus:
   needs: ["wait:before-release"]
   stage: release
-  variables:
-    GIT_DEPTH: 0
   script:
     - docker pull $PROMETHEUS_TAG
     - docker tag $PROMETHEUS_TAG $PROMETHEUS_RELEASE_TAG
@@ -671,8 +677,6 @@ release:prometheus:
 release:backend:
   needs: ["wait:before-release"]
   stage: release
-  variables:
-    GIT_DEPTH: 0
   script:
     - docker pull $BACKEND_TAG
     - docker tag $BACKEND_TAG $BACKEND_RELEASE_TAG
@@ -685,8 +689,6 @@ release:backend:
 release:media:
   needs: ["wait:before-release"]
   stage: release
-  variables:
-    GIT_DEPTH: 0
   script:
     - docker pull $MEDIA_TAG
     - docker tag $MEDIA_TAG $MEDIA_RELEASE_TAG
@@ -699,8 +701,6 @@ release:media:
 release:web-dev:
   needs: ["wait:before-release"]
   stage: release
-  variables:
-    GIT_DEPTH: 0
   script:
     - docker pull $WEB_DEV_TAG
     - docker tag $WEB_DEV_TAG $WEB_DEV_RELEASE_TAG
@@ -713,8 +713,6 @@ release:web-dev:
 release:web:
   needs: ["wait:before-release"]
   stage: release
-  variables:
-    GIT_DEPTH: 0
   script:
     - docker pull $WEB_TAG
     - docker tag $WEB_TAG $WEB_RELEASE_TAG
@@ -727,8 +725,6 @@ release:web:
 release:web-next:
   needs: ["wait:before-release"]
   stage: release
-  variables:
-    GIT_DEPTH: 0
   script:
     - docker pull $WEB_NEXT_TAG
     - docker tag $WEB_NEXT_TAG $WEB_NEXT_RELEASE_TAG
@@ -742,8 +738,6 @@ release:web-next:
 release:nginx-next:
   needs: ["wait:before-release"]
   stage: release
-  variables:
-    GIT_DEPTH: 0
   script:
     - docker pull $NGINX_NEXT_TAG
     - docker tag $NGINX_NEXT_TAG $NGINX_NEXT_RELEASE_TAG


### PR DESCRIPTION
This untangles doing a `docker login` by default from exporting `DISPLAY_VERSION`. It is now exported only if `GIT_DEPTH` is set to 0 by the job; but `docker login` is done unless the job opts out by setting `inherit: false`.

We protect ourselves against jobs requiring `DISPLAY_VERSION`, but forgetting to set `GIT_DEPTH` by `set -u` which raises an error when an undefined variable is accessed.

Also, we now rebuild everything if .gitlab-ci.yml is changed to make sure that changes don't break any builds.