### PR TITLE
Don't allow click send message when empty

### DIFF
--- a/app/web/.cursorrules
+++ b/app/web/.cursorrules
@@ -14,6 +14,19 @@ This project uses **yarn** as the package manager. Always use `yarn` commands in
 ## Testing
 Run tests with: `yarn test`
 
+### Testing Best Practices
+- **Use fixture data when available**: Import test data from `test/fixtures/` (e.g., `hostRequest.json`, `messages.json`, `groupChat.json`) instead of creating mock data inline
+- **Query elements by label**: Prefer `getByLabelText()` for form inputs as it tests accessibility
+  - When there's ambiguity (e.g., both a label and aria-label), use the `selector` option: `getByLabelText(label, { selector: "textarea" })`
+- **Text matching with embedded elements**: When text is split by child elements (e.g., links inside text), use function matchers:
+  ```typescript
+  screen.getByText((content, element) => {
+    return element?.textContent === "Full text including embedded link text";
+  })
+  ```
+- **Type safety**: Explicitly type mock mutations (e.g., `UseMutationResult<...>`) without using `any`
+- **Async queries**: Use `await screen.findByText()` when waiting for elements after loading states, instead of `getByText()` after `waitForElementToBeRemoved()`
+
 ## Development
 To run the app locally in development, use `yarn start` (not Docker)
 

--- a/app/web/features/messages/groupchats/GroupChatSendField.test.tsx
+++ b/app/web/features/messages/groupchats/GroupChatSendField.test.tsx
@@ -1,0 +1,265 @@
+import { UseMutationResult } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Empty } from "google-protobuf/google/protobuf/empty_pb";
+import { RpcError } from "grpc-web";
+import groupChat from "test/fixtures/groupChat.json";
+import wrapper from "test/hookWrapper";
+import i18n from "test/i18n";
+
+import GroupChatSendField from "./GroupChatSendField";
+
+const { t } = i18n;
+
+const mockSendMutation: UseMutationResult<
+  string | undefined | Empty,
+  RpcError,
+  string
+> = {
+  mutate: jest.fn(),
+  mutateAsync: jest.fn(),
+  isPending: false,
+  isIdle: true,
+  isError: false,
+  isSuccess: false,
+  data: undefined,
+  error: null,
+  failureCount: 0,
+  failureReason: null,
+  isPaused: false,
+  status: "idle" as const,
+  variables: undefined,
+  submittedAt: 0,
+  context: undefined,
+  reset: jest.fn(),
+};
+
+describe("GroupChatSendField", () => {
+  const chatId = groupChat.groupChatId;
+  const currentUserId = groupChat.memberUserIdsList[0];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("disables the send button when the input field is empty", () => {
+    render(
+      <GroupChatSendField
+        sendMutation={mockSendMutation}
+        chatId={chatId}
+        currentUserId={currentUserId}
+      />,
+      { wrapper },
+    );
+
+    const sendButton = screen.getByRole("button", { name: t("global:send") });
+    expect(sendButton).toBeDisabled();
+  });
+
+  it("disables the send button when the input contains only whitespace", async () => {
+    render(
+      <GroupChatSendField
+        sendMutation={mockSendMutation}
+        chatId={chatId}
+        currentUserId={currentUserId}
+      />,
+      { wrapper },
+    );
+
+    const user = userEvent.setup();
+    const input = screen.getByLabelText(t("messages:chat_input.label"));
+    const sendButton = screen.getByRole("button", { name: t("global:send") });
+
+    await user.type(input, "   ");
+
+    expect(sendButton).toBeDisabled();
+  });
+
+  it("enables the send button when there is text in the input field", async () => {
+    render(
+      <GroupChatSendField
+        sendMutation={mockSendMutation}
+        chatId={chatId}
+        currentUserId={currentUserId}
+      />,
+      { wrapper },
+    );
+
+    const user = userEvent.setup();
+    const input = screen.getByLabelText(t("messages:chat_input.label"));
+    const sendButton = screen.getByRole("button", { name: t("global:send") });
+
+    await user.type(input, "Hello, world!");
+
+    expect(sendButton).toBeEnabled();
+  });
+
+  it("sends the message when the send button is clicked", async () => {
+    render(
+      <GroupChatSendField
+        sendMutation={mockSendMutation}
+        chatId={chatId}
+        currentUserId={currentUserId}
+      />,
+      { wrapper },
+    );
+
+    const user = userEvent.setup();
+    const input = screen.getByLabelText(t("messages:chat_input.label"));
+    const sendButton = screen.getByRole("button", { name: t("global:send") });
+
+    await user.type(input, "Hello, world!");
+    await user.click(sendButton);
+
+    await waitFor(() => {
+      expect(mockSendMutation.mutate).toHaveBeenCalledTimes(1);
+    });
+    expect(mockSendMutation.mutate).toHaveBeenCalledWith("Hello, world!");
+  });
+
+  it("clears the input field after sending a message", async () => {
+    render(
+      <GroupChatSendField
+        sendMutation={mockSendMutation}
+        chatId={chatId}
+        currentUserId={currentUserId}
+      />,
+      { wrapper },
+    );
+
+    const user = userEvent.setup();
+    const input = screen.getByLabelText(
+      t("messages:chat_input.label"),
+    ) as HTMLInputElement;
+    const sendButton = screen.getByRole("button", { name: t("global:send") });
+
+    await user.type(input, "Hello, world!");
+    await user.click(sendButton);
+
+    await waitFor(() => {
+      expect(input.value).toBe("");
+    });
+  });
+
+  it("sends message on Ctrl+Enter key combination", async () => {
+    render(
+      <GroupChatSendField
+        sendMutation={mockSendMutation}
+        chatId={chatId}
+        currentUserId={currentUserId}
+      />,
+      { wrapper },
+    );
+
+    const user = userEvent.setup();
+    const input = screen.getByLabelText(t("messages:chat_input.label"));
+
+    await user.type(input, "Hello, world!");
+    await user.type(input, "{Control>}{Enter}{/Control}");
+
+    await waitFor(() => {
+      expect(mockSendMutation.mutate).toHaveBeenCalledWith("Hello, world!");
+    });
+  });
+
+  it("trims trailing whitespace from the message before sending", async () => {
+    render(
+      <GroupChatSendField
+        sendMutation={mockSendMutation}
+        chatId={chatId}
+        currentUserId={currentUserId}
+      />,
+      { wrapper },
+    );
+
+    const user = userEvent.setup();
+    const input = screen.getByLabelText(t("messages:chat_input.label"));
+    const sendButton = screen.getByRole("button", { name: t("global:send") });
+
+    await user.type(input, "Hello, world!   ");
+    await user.click(sendButton);
+
+    await waitFor(() => {
+      expect(mockSendMutation.mutate).toHaveBeenCalledWith("Hello, world!");
+    });
+  });
+
+  it("disables the send button while a message is being sent", () => {
+    const pendingSendMutation: UseMutationResult<
+      string | undefined | Empty,
+      RpcError,
+      string
+    > = {
+      ...mockSendMutation,
+      isPending: true,
+      isIdle: false,
+      status: "pending" as const,
+      variables: "test message",
+    };
+
+    render(
+      <GroupChatSendField
+        sendMutation={pendingSendMutation}
+        chatId={chatId}
+        currentUserId={currentUserId}
+      />,
+      { wrapper },
+    );
+
+    const sendButton = screen.getByRole("button", { name: t("global:send") });
+    expect(sendButton).toBeDisabled();
+  });
+
+  it("persists message text in session storage", async () => {
+    render(
+      <GroupChatSendField
+        sendMutation={mockSendMutation}
+        chatId={chatId}
+        currentUserId={currentUserId}
+      />,
+      { wrapper },
+    );
+
+    const user = userEvent.setup();
+    const input = screen.getByLabelText(t("messages:chat_input.label"));
+
+    await user.type(input, "Draft message");
+
+    await waitFor(() => {
+      const persisted = sessionStorage.getItem(
+        `messages.${currentUserId}.${chatId}`,
+      );
+      expect(persisted).toBe('"Draft message"');
+    });
+  });
+
+  it("clears persisted message from session storage after sending", async () => {
+    render(
+      <GroupChatSendField
+        sendMutation={mockSendMutation}
+        chatId={chatId}
+        currentUserId={currentUserId}
+      />,
+      { wrapper },
+    );
+
+    const user = userEvent.setup();
+    const input = screen.getByLabelText(t("messages:chat_input.label"));
+    const sendButton = screen.getByRole("button", { name: t("global:send") });
+
+    await user.type(input, "Hello, world!");
+    await user.click(sendButton);
+
+    await waitFor(() => {
+      const persisted = sessionStorage.getItem(
+        `messages.${currentUserId}.${chatId}`,
+      );
+      expect(persisted).toBeNull();
+    });
+  });
+});

--- a/app/web/features/messages/groupchats/GroupChatSendField.tsx
+++ b/app/web/features/messages/groupchats/GroupChatSendField.tsx
@@ -46,7 +46,7 @@ export default function GroupChatSendField({
 
   const { mutate: handleSend, isPending } = sendMutation;
 
-  const { register, handleSubmit, reset } = useForm<MessageFormData>();
+  const { register, handleSubmit, reset, watch } = useForm<MessageFormData>();
 
   const [persistedMessage, setPersistedMessage, clearPersistedMessage] =
     usePersistedState(
@@ -54,6 +54,8 @@ export default function GroupChatSendField({
       "",
       "sessionStorage",
     );
+
+  const messageText = watch("text", persistedMessage ?? "");
 
   const onSubmit = handleSubmit(async (data: MessageFormData) => {
     handleSend(data.text.trimEnd());
@@ -95,6 +97,7 @@ export default function GroupChatSendField({
         color="primary"
         onClick={onSubmit}
         loading={isPending}
+        disabled={!messageText.trim() || isPending}
       >
         {t("global:send")}
       </StyledButton>

--- a/app/web/features/messages/requests/HostRequestSendField.test.tsx
+++ b/app/web/features/messages/requests/HostRequestSendField.test.tsx
@@ -1,0 +1,371 @@
+import { UseMutationResult } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Empty } from "google-protobuf/google/protobuf/empty_pb";
+import { RpcError } from "grpc-web";
+import { HostRequestStatus } from "proto/conversations_pb";
+import { HostRequest, RespondHostRequestReq } from "proto/requests_pb";
+import { service } from "service";
+import hostRequest from "test/fixtures/hostRequest.json";
+import wrapper from "test/hookWrapper";
+import i18n from "test/i18n";
+
+import HostRequestSendField from "./HostRequestSendField";
+
+const { t } = i18n;
+
+const getAvailableReferencesMock = service.references
+  .getAvailableReferences as jest.MockedFunction<
+  typeof service.references.getAvailableReferences
+>;
+
+const mockHostRequest: HostRequest.AsObject = {
+  ...hostRequest,
+  hostingCity: "Los Angeles",
+  hostingLat: 34.0522,
+  hostingLng: -118.2437,
+  hostingRadius: 100,
+  needHostRequestFeedback: false,
+};
+
+const mockSendMutation: UseMutationResult<
+  string | undefined | Empty,
+  RpcError,
+  string
+> = {
+  mutate: jest.fn(),
+  mutateAsync: jest.fn(),
+  isPending: false,
+  isIdle: true,
+  isError: false,
+  isSuccess: false,
+  data: undefined,
+  error: null,
+  failureCount: 0,
+  failureReason: null,
+  isPaused: false,
+  status: "idle" as const,
+  variables: undefined,
+  submittedAt: 0,
+  context: undefined,
+  reset: jest.fn(),
+};
+
+const mockRespondMutation: UseMutationResult<
+  unknown,
+  RpcError,
+  Required<RespondHostRequestReq.AsObject>
+> = {
+  mutate: jest.fn(),
+  mutateAsync: jest.fn(),
+  isPending: false,
+  isIdle: true,
+  isError: false,
+  isSuccess: false,
+  data: undefined,
+  error: null,
+  failureCount: 0,
+  failureReason: null,
+  isPaused: false,
+  status: "idle" as const,
+  variables: undefined,
+  submittedAt: 0,
+  context: undefined,
+  reset: jest.fn(),
+};
+
+describe("HostRequestSendField", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getAvailableReferencesMock.mockResolvedValue({
+      availableWriteReferencesList: [],
+      canWriteFriendReference: false,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the message input and send button", () => {
+    render(
+      <HostRequestSendField
+        hostRequest={mockHostRequest}
+        sendMutation={mockSendMutation}
+        respondMutation={mockRespondMutation}
+      />,
+      { wrapper },
+    );
+
+    expect(
+      screen.getByLabelText(t("messages:chat_input.label"), {
+        selector: "textarea",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: t("global:send") }),
+    ).toBeInTheDocument();
+  });
+
+  it("disables the send button when the input field is empty", () => {
+    render(
+      <HostRequestSendField
+        hostRequest={mockHostRequest}
+        sendMutation={mockSendMutation}
+        respondMutation={mockRespondMutation}
+      />,
+      { wrapper },
+    );
+
+    const sendButton = screen.getByRole("button", { name: t("global:send") });
+    expect(sendButton).toBeDisabled();
+  });
+
+  it("disables the send button when the input contains only whitespace", async () => {
+    render(
+      <HostRequestSendField
+        hostRequest={mockHostRequest}
+        sendMutation={mockSendMutation}
+        respondMutation={mockRespondMutation}
+      />,
+      { wrapper },
+    );
+
+    const user = userEvent.setup();
+    const input = screen.getByLabelText(t("messages:chat_input.label"), {
+      selector: "textarea",
+    });
+    const sendButton = screen.getByRole("button", { name: t("global:send") });
+
+    await user.type(input, "   ");
+
+    expect(sendButton).toBeDisabled();
+  });
+
+  it("enables the send button when there is text in the input field", async () => {
+    render(
+      <HostRequestSendField
+        hostRequest={mockHostRequest}
+        sendMutation={mockSendMutation}
+        respondMutation={mockRespondMutation}
+      />,
+      { wrapper },
+    );
+
+    const user = userEvent.setup();
+    const input = screen.getByLabelText(t("messages:chat_input.label"), {
+      selector: "textarea",
+    });
+    const sendButton = screen.getByRole("button", { name: t("global:send") });
+
+    await user.type(input, "Hello, world!");
+
+    expect(sendButton).toBeEnabled();
+  });
+
+  it("sends the message when the send button is clicked", async () => {
+    render(
+      <HostRequestSendField
+        hostRequest={mockHostRequest}
+        sendMutation={mockSendMutation}
+        respondMutation={mockRespondMutation}
+      />,
+      { wrapper },
+    );
+
+    const user = userEvent.setup();
+
+    await user.type(
+      screen.getByLabelText(t("messages:chat_input.label"), {
+        selector: "textarea",
+      }),
+      "Hello, world!",
+    );
+    await user.click(screen.getByRole("button", { name: t("global:send") }));
+
+    await waitFor(() => {
+      expect(mockSendMutation.mutate).toHaveBeenCalledTimes(1);
+    });
+    expect(mockSendMutation.mutate).toHaveBeenCalledWith("Hello, world!");
+  });
+
+  it("clears the input field after sending a message", async () => {
+    render(
+      <HostRequestSendField
+        hostRequest={mockHostRequest}
+        sendMutation={mockSendMutation}
+        respondMutation={mockRespondMutation}
+      />,
+      { wrapper },
+    );
+
+    const user = userEvent.setup();
+    const input = screen.getByLabelText(t("messages:chat_input.label"), {
+      selector: "textarea",
+    }) as HTMLTextAreaElement;
+    const sendButton = screen.getByRole("button", { name: t("global:send") });
+
+    await user.type(input, "Hello, world!");
+    await user.click(sendButton);
+
+    await waitFor(() => {
+      expect(input.value).toBe("");
+    });
+  });
+
+  it("sends message on Ctrl+Enter key combination", async () => {
+    render(
+      <HostRequestSendField
+        hostRequest={mockHostRequest}
+        sendMutation={mockSendMutation}
+        respondMutation={mockRespondMutation}
+      />,
+      { wrapper },
+    );
+
+    const user = userEvent.setup();
+    const input = screen.getByLabelText(t("messages:chat_input.label"), {
+      selector: "textarea",
+    });
+
+    await user.type(input, "Hello, world!");
+    await user.type(input, "{Control>}{Enter}{/Control}");
+
+    await waitFor(() => {
+      expect(mockSendMutation.mutate).toHaveBeenCalledWith("Hello, world!");
+    });
+  });
+
+  it("disables the send button and input when request is closed (cancelled)", () => {
+    const cancelledRequest = {
+      ...mockHostRequest,
+      status: HostRequestStatus.HOST_REQUEST_STATUS_CANCELLED,
+    };
+
+    render(
+      <HostRequestSendField
+        hostRequest={cancelledRequest}
+        sendMutation={mockSendMutation}
+        respondMutation={mockRespondMutation}
+      />,
+      { wrapper },
+    );
+
+    const input = document.getElementById(
+      "host-request-message",
+    ) as HTMLTextAreaElement;
+    const sendButton = screen.getByRole("button", { name: t("global:send") });
+
+    expect(input).toBeDisabled();
+    expect(sendButton).toBeDisabled();
+  });
+
+  it("disables the send button and input when request is closed (rejected)", () => {
+    const rejectedRequest = {
+      ...mockHostRequest,
+      status: HostRequestStatus.HOST_REQUEST_STATUS_REJECTED,
+    };
+
+    render(
+      <HostRequestSendField
+        hostRequest={rejectedRequest}
+        sendMutation={mockSendMutation}
+        respondMutation={mockRespondMutation}
+      />,
+      { wrapper },
+    );
+
+    const input = document.getElementById(
+      "host-request-message",
+    ) as HTMLTextAreaElement;
+    const sendButton = screen.getByRole("button", { name: t("global:send") });
+
+    expect(input).toBeDisabled();
+    expect(sendButton).toBeDisabled();
+  });
+
+  it("displays request closed message when request is cancelled", () => {
+    const cancelledRequest = {
+      ...mockHostRequest,
+      status: HostRequestStatus.HOST_REQUEST_STATUS_CANCELLED,
+    };
+
+    render(
+      <HostRequestSendField
+        hostRequest={cancelledRequest}
+        sendMutation={mockSendMutation}
+        respondMutation={mockRespondMutation}
+      />,
+      { wrapper },
+    );
+
+    const input = document.getElementById(
+      "host-request-message",
+    ) as HTMLTextAreaElement;
+    expect(input.value).toBe(t("messages:request_closed_message"));
+  });
+
+  it("disables the send button while a message is being sent", async () => {
+    const pendingSendMutation: UseMutationResult<
+      string | undefined | Empty,
+      RpcError,
+      string
+    > = {
+      ...mockSendMutation,
+      isPending: true,
+      isIdle: false,
+      status: "pending" as const,
+      variables: "test message",
+    };
+
+    render(
+      <HostRequestSendField
+        hostRequest={mockHostRequest}
+        sendMutation={pendingSendMutation}
+        respondMutation={mockRespondMutation}
+      />,
+      { wrapper },
+    );
+
+    const user = userEvent.setup();
+    const input = screen.getByLabelText(t("messages:chat_input.label"), {
+      selector: "textarea",
+    });
+
+    // Type some text first
+    await user.type(input, "Test message");
+
+    const sendButton = screen.getByRole("button", { name: t("global:send") });
+    expect(sendButton).toBeDisabled();
+  });
+
+  it("shows Write Reference button when reference is available", async () => {
+    const confirmedRequest = {
+      ...mockHostRequest,
+      status: HostRequestStatus.HOST_REQUEST_STATUS_CONFIRMED,
+    };
+
+    getAvailableReferencesMock.mockResolvedValue({
+      availableWriteReferencesList: [
+        {
+          hostRequestId: mockHostRequest.hostRequestId,
+          referenceType: 0,
+        },
+      ],
+      canWriteFriendReference: false,
+    });
+
+    render(
+      <HostRequestSendField
+        hostRequest={confirmedRequest}
+        sendMutation={mockSendMutation}
+        respondMutation={mockRespondMutation}
+      />,
+      { wrapper },
+    );
+
+    expect(
+      await screen.findByText(t("messages:write_reference_button_text")),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/web/features/messages/requests/HostRequestSendField.tsx
+++ b/app/web/features/messages/requests/HostRequestSendField.tsx
@@ -76,7 +76,8 @@ export default function HostRequestSendField({
   const { mutate: handleRespond, isPending: isResponseLoading } =
     respondMutation;
 
-  const { register, handleSubmit, reset } = useForm<MessageFormData>();
+  const { register, handleSubmit, reset, watch } = useForm<MessageFormData>();
+  const messageText = watch("text", "");
   const onSubmit = handleSubmit(async (data: MessageFormData) => {
     handleSend(data.text);
     reset();
@@ -174,7 +175,7 @@ export default function HostRequestSendField({
         />
         <FieldButton
           callback={onSubmit}
-          disabled={isRequestClosed}
+          disabled={isRequestClosed || !messageText.trim()}
           isLoading={isButtonLoading}
           isSubmit
         >


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**

Closes #6805 

<!---
Please describe the pull request here.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

The backend was implemented awhile ago to not allow empty messages, just catching up here with the frontend.

This PR makes the send button deactivated for chat messages and host request messages if there is no text in the textfield. It also adds tests.


**Please give clear steps for how the reviewer can best test this PR**

*Please include any necessary dev environment, .env, etc. adjustments.*

- Go in a chat and try to send an empty message
- Go in a host request chat and try to send an empty message
- Type in each and send, it should work

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [ x ] Formatted my code with `yarn format`
- [ x ] There are no warnings from `yarn lint --fix`
- [ x ] There are no console warnings when running the app
- [ x ] Added tests where relevant
- [ x ] All tests pass
- [ x ] Clicked around my changes running locally and it works
- [ x ] Checked Desktop, Mobile and Tablet screen sizes

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)


<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
