### PR TITLE
Fix caching

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -125,8 +125,17 @@ build:backend:
     GIT_DEPTH: 0  # needed for "git rev-list --count" in default.before_script
   script:
     - docker pull $BACKEND_RELEASE_TAG || true
-    - docker build --build-arg display_version=$DISPLAY_VERSION --build-arg commit_sha=$COMMIT_SHA --build-arg commit_timestamp=$COMMIT_TIMESTAMP --build-arg version=$SLUG --cache-from $BACKEND_RELEASE_TAG -t $BACKEND_TAG app/backend/
-    - docker push $BACKEND_TAG
+    - docker pull $CI_REGISTRY_IMAGE/backend:xxx || true
+    - docker context create my-builder
+    - docker buildx create my-builder --driver docker-container --use
+    - docker buildx build --push -t $CI_REGISTRY_IMAGE/backend:xxx
+      --build-arg display_version=$DISPLAY_VERSION
+      --build-arg commit_timestamp=$COMMIT_TIMESTAMP
+      --build-arg version=$SLUG
+      --cache-from $CI_REGISTRY_IMAGE/backend:xxx
+      --cache-from $BACKEND_RELEASE_TAG
+      --cache-to type=registry,ref=$CI_REGISTRY_IMAGE/backend:xxx,mode=max
+      app/backend
   rules:
     - if: $CI_COMMIT_BRANCH == $RELEASE_BRANCH
       changes:

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -123,18 +123,26 @@ build:backend:
   stage: build
   variables:
     GIT_DEPTH: 0  # needed for "git rev-list --count" in default.before_script
-  script:
-    - docker pull $BACKEND_RELEASE_TAG || true
-    - docker pull $CI_REGISTRY_IMAGE/backend:xxx || true
-    - docker context create my-builder
-    - docker buildx create my-builder --driver docker-container --use
-    - docker buildx build --push -t $CI_REGISTRY_IMAGE/backend:xxx
-      --build-arg display_version=$DISPLAY_VERSION
-      --build-arg commit_timestamp=$COMMIT_TIMESTAMP
-      --build-arg version=$SLUG
-      --cache-from $CI_REGISTRY_IMAGE/backend:xxx
-      --cache-from $BACKEND_RELEASE_TAG
-      --cache-to type=registry,ref=$CI_REGISTRY_IMAGE/backend:xxx,mode=max
+  script: |
+    # Push image cache only on develop.
+    CACHE_TO=""
+    if [ "$CI_COMMIT_BRANCH" = "$RELEASE_BRANCH" ]; then
+      CACHE_TO="--cache-to type=registry,ref=$BACKEND_RELEASE_TAG,mode=max"
+    fi
+    
+    # Use buildx, as "docker build" does not work with registry cache.
+    docker pull $BACKEND_RELEASE_TAG || true
+    docker context create my-builder
+    docker buildx create my-builder --driver docker-container --use
+  
+    docker buildx build \
+      --push \
+      -t "$BACKEND_TAG" \
+      --build-arg display_version="$DISPLAY_VERSION" \
+      --build-arg commit_timestamp="$COMMIT_TIMESTAMP" \
+      --build-arg version="$SLUG" \
+      --cache-from "$BACKEND_RELEASE_TAG" \
+      $CACHE_TO \
       app/backend
   rules:
     - if: $CI_COMMIT_BRANCH == $RELEASE_BRANCH


### PR DESCRIPTION
Right now docker cache does not work (observe that there's no "CACHED" in https://gitlab.com/couchers/couchers/-/jobs/12036869280).

This is likely because `docker build` does not support registry cache backend, so `--cache-from $BACKEND_RELEASE_TAG` is ignored. Or maybe the release tag does not contain all the layers, and only the resulting image. Anyway, the new form does utilise cache properly, significantly reducing build time.

I want to have the final test for backend, and then will copy the new solution to all builds.