### PR TITLE
Change wget to curl in Makefile

### DIFF
--- a/app/backend/Makefile
+++ b/app/backend/Makefile
@@ -8,7 +8,7 @@ protos:
 	docker run --rm -w /app -v $(realpath ${ROOT_DIR}..):/app registry.gitlab.com/couchers/grpc ./generate_protos.sh
 
 setup:
-	wget -qO- https://astral.sh/uv/${UV_VERSION}/install.sh | sh
+	curl -fsSL https://astral.sh/uv/${UV_VERSION}/install.sh | sh
 
 
 # Connect to the local development database


### PR DESCRIPTION
`wget` in `make setup` was not working on my mac. `curl` seems to work on everything so suggesting we change it here.