### PR TITLE
Shrink backend image by not including uv

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -322,9 +322,9 @@ test:backend:
     - apt-get -qy update
     - apt-get -qyy install postgresql-client
   script:
-    - cd /app && uv run pytest --junitxml=junit.xml --cov=src src
+    - cd /app && pytest --junitxml=junit.xml --cov=src src
   after_script:
-    - cd /app && uv run coverage xml && uv run coverage html
+    - cd /app && coverage xml && coverage html
     - cp /app/junit.xml $CI_PROJECT_DIR/
     - cp /app/coverage.xml $CI_PROJECT_DIR/
     - mkdir -p $CI_PROJECT_DIR/artifacts/htmlcov && cp -a /app/htmlcov $CI_PROJECT_DIR/artifacts/
@@ -357,9 +357,9 @@ test:backend-format:
     default: false
   script:
     - cd app/backend
-    - uv run ruff check .
-    - uv run ruff check --diff .
-    - uv run ruff format --diff .
+    - ruff check .
+    - ruff check --diff .
+    - ruff format --diff .
   rules:
     - if: ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
       changes:

--- a/app/backend/.dockerignore
+++ b/app/backend/.dockerignore
@@ -1,1 +1,15 @@
-venv/**
+# Ignore everything
+**
+**/__pycache__*
+
+# Allow specific files and directories
+!proto
+!src
+!resources
+!templates
+!alembic.ini
+
+# These are not included into the final image, but are still needed here
+# for "--mount=type=bind"
+!uv.lock
+!pyproject.toml

--- a/app/backend/Dockerfile
+++ b/app/backend/Dockerfile
@@ -28,21 +28,34 @@ RUN apt-get update -qy && apt-get install -qyy zstd wget build-essential \
     && zstd -d timezone_areas.sql.zst \
     && wget -qO- https://astral.sh/uv/${UV_VERSION}/install.sh | sh
 
+# Synchronize DEPENDENCIES without the application itself.
+# This layer is cached until uv.lock or pyproject.toml change, which are
+# only temporarily mounted into the build container since we don't need
+# them in the production one.
+RUN --mount=type=cache,target=/root/.cache \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    /root/.local/bin/uv sync \
+        --locked \
+        --no-install-project
+
+# Now install the rest from `/app`: The APPLICATION w/o dependencies.
+COPY . /app
+WORKDIR /app
+RUN --mount=type=cache,target=/root/.cache \
+    /root/.local/bin/uv sync \
+        --locked \
+        --no-editable
+
 FROM base
 
 COPY --from=build /usr/local/bin/entr /usr/local/bin/entr
-COPY --from=build /root/.local/bin/uv /usr/local/bin/uv
 COPY --from=build /deps/timezone_areas.sql /app/resources/timezone_areas.sql
+COPY --from=build /app /app
 
 WORKDIR /app
 
-# Install dependencies
-COPY pyproject.toml uv.lock /app/
-RUN uv sync --locked --no-cache --no-install-project
-
-# Install the app itself
-COPY . /app
-RUN uv sync --locked --no-cache
+ENV PATH=/app/.venv/bin:$PATH
 
 ARG version
 ENV VERSION=$version
@@ -56,4 +69,4 @@ ENV COMMIT_SHA=$commit_sha
 ARG commit_timestamp
 ENV COMMIT_TIMESTAMP=$commit_timestamp
 
-CMD ["uv", "run", "src/app.py"]
+CMD ["python", "src/app.py"]


### PR DESCRIPTION
- Don't include uv into the final image
- Only include specific files and directories when doing `COPY` in the Dockerfile, to avoid unnecessary rebuilds when e.g., a Makefile or a Readme is changed