### PR TITLE
Fix running locally by mounting specific directories

### DIFF
--- a/app/backend/Dockerfile
+++ b/app/backend/Dockerfile
@@ -52,13 +52,11 @@ FROM base
 COPY --from=build /usr/local/bin/entr /usr/local/bin/entr
 COPY --from=build /deps/timezone_areas.sql /app/resources/timezone_areas.sql
 COPY --from=build /app /app
-# uv installs itself into /root/.local inside the build image; copy it so entr can invoke uv during dev runs
-COPY --from=build /root/.local /root/.local
 
 WORKDIR /app
 
-# make sure both uv and the virtualenv binaries are on PATH for development
-ENV PATH=/root/.local/bin:/app/.venv/bin:$PATH
+# make sure virtualenv binaries are on PATH
+ENV PATH=/app/.venv/bin:$PATH
 
 ARG version
 ENV VERSION=$version

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -58,6 +58,10 @@ dev = [
 
 [tool.ruff]
 line-length = 120
+exclude = [
+    ".venv",
+    "src/couchers/proto",
+]
 
 [tool.ruff.lint]
 select = [
@@ -90,6 +94,7 @@ extra-standard-library = ["zoneinfo"]
 strict = true
 exclude = [
     "src/couchers/jobs/handlers.py",
+    "src/couchers/proto/*",
 ]
 # pb2_grpc.py files have no stubs as of now :(
 untyped_calls_exclude = [
@@ -116,7 +121,7 @@ module = ["http_ece", "py_vapid", "luhn", "sqlalchemy_utils.*"]
 ignore_missing_imports = true
 
 [tool.coverage.run]
-omit = ["src/proto/*", "src/couchers/migrations/*", "src/dummy_data.py"]
+omit = ["src/couchers/proto/*", "src/couchers/migrations/*", "src/dummy_data.py"]
 
 [build-system]
 requires = ["hatchling"]

--- a/app/backend/src/couchers/descriptor_pool.py
+++ b/app/backend/src/couchers/descriptor_pool.py
@@ -17,7 +17,7 @@ def get_descriptor_pool() -> descriptor_pool.DescriptorPool:
     for each servicer, method, or message.
     """
     # this needs to be imported so the annotations are available in the generated pool...
-    from proto import annotations_pb2  # noqa
+    from couchers.proto import annotations_pb2  # noqa
 
     pool = descriptor_pool.DescriptorPool()
     desc = descriptor_pb2.FileDescriptorSet.FromString(get_descriptors_pb())

--- a/app/backend/src/couchers/descriptor_pool.py
+++ b/app/backend/src/couchers/descriptor_pool.py
@@ -6,7 +6,7 @@ from google.protobuf import descriptor_pb2, descriptor_pool
 
 @functools.cache
 def get_descriptors_pb() -> bytes:
-    with open(Path(__file__).parent / ".." / "proto" / "descriptors.pb", "rb") as descriptor_set_f:
+    with open(Path(__file__).parent / "proto" / "descriptors.pb", "rb") as descriptor_set_f:
         return descriptor_set_f.read()
 
 

--- a/app/backend/src/couchers/email/__init__.py
+++ b/app/backend/src/couchers/email/__init__.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm.session import Session
 from couchers.config import config
 from couchers.jobs.enqueue import queue_job
 from couchers.metrics import emails_counter
-from proto.internal import jobs_pb2
+from couchers.proto.internal import jobs_pb2
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/helpers/badges.py
+++ b/app/backend/src/couchers/helpers/badges.py
@@ -3,8 +3,8 @@ from sqlalchemy.sql import delete
 
 from couchers.models import UserBadge
 from couchers.notifications.notify import notify
+from couchers.proto import notification_data_pb2
 from couchers.resources import get_badge_dict
-from proto import notification_data_pb2
 
 
 def user_add_badge(session: Session, user_id: int, badge_id: str, do_notify: bool = True) -> None:

--- a/app/backend/src/couchers/helpers/strong_verification.py
+++ b/app/backend/src/couchers/helpers/strong_verification.py
@@ -1,8 +1,8 @@
 from sqlalchemy.orm import Session
 
 from couchers.models import StrongVerificationAttempt, User
+from couchers.proto import api_pb2
 from couchers.sql import couchers_select as select
-from proto import api_pb2
 
 
 def has_strong_verification(session: Session, user: User) -> bool:

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -21,6 +21,7 @@ from couchers.db import session_scope
 from couchers.descriptor_pool import get_descriptor_pool
 from couchers.metrics import observe_in_servicer_duration_histogram
 from couchers.models import APICall, User, UserActivity, UserSession
+from couchers.proto import annotations_pb2
 from couchers.sql import couchers_select as select
 from couchers.utils import (
     create_lang_cookie,
@@ -31,7 +32,6 @@ from couchers.utils import (
     parse_ui_lang_cookie,
     parse_user_id_cookie,
 )
-from proto import annotations_pb2
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -85,6 +85,8 @@ from couchers.models import (
 )
 from couchers.notifications.background import handle_email_digests, handle_notification, send_raw_push_notification
 from couchers.notifications.notify import notify
+from couchers.proto import notification_data_pb2
+from couchers.proto.internal import jobs_pb2, verification_pb2
 from couchers.resources import get_badge_dict, get_static_badge_dict
 from couchers.servicers.admin import generate_new_blog_post_notifications
 from couchers.servicers.api import user_model_to_pb
@@ -109,8 +111,6 @@ from couchers.utils import (
     get_coordinates,
     now,
 )
-from proto import notification_data_pb2
-from proto.internal import jobs_pb2, verification_pb2
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/models/notifications.py
+++ b/app/backend/src/couchers/models/notifications.py
@@ -20,7 +20,7 @@ from sqlalchemy.sql import expression
 
 from couchers.constants import DATETIME_INFINITY
 from couchers.models.base import Base
-from proto import notification_data_pb2
+from couchers.proto import notification_data_pb2
 
 
 class NotificationDeliveryType(enum.Enum):

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -28,10 +28,10 @@ from couchers.notifications.quick_links import (
 )
 from couchers.notifications.render import render_notification
 from couchers.notifications.settings import get_preference
+from couchers.proto.internal import jobs_pb2
 from couchers.sql import couchers_select as select
 from couchers.templates.v2 import add_filters
 from couchers.utils import get_tz_as_text, now
-from proto.internal import jobs_pb2
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/notifications/notify.py
+++ b/app/backend/src/couchers/notifications/notify.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from couchers.jobs.enqueue import queue_job
 from couchers.models import Notification
 from couchers.notifications.utils import enum_from_topic_action
-from proto.internal import jobs_pb2
+from couchers.proto.internal import jobs_pb2
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/notifications/push.py
+++ b/app/backend/src/couchers/notifications/push.py
@@ -9,8 +9,8 @@ from couchers.config import config
 from couchers.jobs.enqueue import queue_job
 from couchers.models import PushNotificationSubscription
 from couchers.notifications.push_api import get_vapid_public_key_from_private_key
+from couchers.proto.internal import jobs_pb2
 from couchers.sql import couchers_select as select
-from proto.internal import jobs_pb2
 
 
 @functools.cache

--- a/app/backend/src/couchers/notifications/quick_links.py
+++ b/app/backend/src/couchers/notifications/quick_links.py
@@ -24,11 +24,11 @@ from couchers.models import (
 )
 from couchers.notifications import settings
 from couchers.notifications.utils import enum_from_topic_action
+from couchers.proto import auth_pb2, conversations_pb2, requests_pb2
+from couchers.proto.internal import unsubscribe_pb2
 from couchers.servicers.requests import Requests
 from couchers.sql import couchers_select as select
 from couchers.utils import now
-from proto import auth_pb2, conversations_pb2, requests_pb2
-from proto.internal import unsubscribe_pb2
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/notifications/render.py
+++ b/app/backend/src/couchers/notifications/render.py
@@ -6,9 +6,9 @@ from couchers import urls
 from couchers.i18n.i18n import get_raw_translation_string
 from couchers.models import Notification, User
 from couchers.notifications.quick_links import generate_quick_decline_link, generate_unsub_topic_action
+from couchers.proto import notification_data_pb2
 from couchers.templates.v2 import v2avatar, v2date, v2esc, v2phone, v2timestamp
 from couchers.utils import now, to_aware_datetime
-from proto import notification_data_pb2
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/notifications/settings.py
+++ b/app/backend/src/couchers/notifications/settings.py
@@ -10,8 +10,8 @@ from couchers.models import (
     NotificationTopicAction,
 )
 from couchers.notifications.utils import enum_from_topic_action
+from couchers.proto import notifications_pb2
 from couchers.sql import couchers_select as select
-from proto import notifications_pb2
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/reranker.py
+++ b/app/backend/src/couchers/reranker.py
@@ -1,8 +1,8 @@
 from datetime import timedelta
 from itertools import zip_longest
 
+from couchers.proto import api_pb2, search_pb2
 from couchers.utils import now, to_aware_datetime
-from proto import api_pb2, search_pb2
 
 
 def reranker(users: list[search_pb2.SearchUser]) -> list[search_pb2.SearchUser]:

--- a/app/backend/src/couchers/resources.py
+++ b/app/backend/src/couchers/resources.py
@@ -10,8 +10,8 @@ from sqlalchemy.sql import delete, text
 from couchers.config import config
 from couchers.db import session_scope
 from couchers.models import Language, Region, TimezoneArea
+from couchers.proto import resources_pb2
 from couchers.sql import couchers_select as select
-from proto import resources_pb2
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/server.py
+++ b/app/backend/src/couchers/server.py
@@ -9,31 +9,7 @@ from couchers.interceptors import (
     ErrorSanitizationInterceptor,
     OTelInterceptor,
 )
-from couchers.servicers.account import Account, Iris
-from couchers.servicers.admin import Admin
-from couchers.servicers.api import API
-from couchers.servicers.auth import Auth
-from couchers.servicers.blocking import Blocking
-from couchers.servicers.bugs import Bugs
-from couchers.servicers.communities import Communities
-from couchers.servicers.conversations import Conversations
-from couchers.servicers.discussions import Discussions
-from couchers.servicers.donations import Donations, Stripe
-from couchers.servicers.events import Events
-from couchers.servicers.gis import GIS
-from couchers.servicers.groups import Groups
-from couchers.servicers.jail import Jail
-from couchers.servicers.media import Media, get_media_auth_interceptor
-from couchers.servicers.notifications import Notifications
-from couchers.servicers.pages import Pages
-from couchers.servicers.public import Public
-from couchers.servicers.references import References
-from couchers.servicers.reporting import Reporting
-from couchers.servicers.requests import Requests
-from couchers.servicers.resources import Resources
-from couchers.servicers.search import Search
-from couchers.servicers.threads import Threads
-from proto import (
+from couchers.proto import (
     account_pb2_grpc,
     admin_pb2_grpc,
     api_pb2_grpc,
@@ -61,6 +37,30 @@ from proto import (
     stripe_pb2_grpc,
     threads_pb2_grpc,
 )
+from couchers.servicers.account import Account, Iris
+from couchers.servicers.admin import Admin
+from couchers.servicers.api import API
+from couchers.servicers.auth import Auth
+from couchers.servicers.blocking import Blocking
+from couchers.servicers.bugs import Bugs
+from couchers.servicers.communities import Communities
+from couchers.servicers.conversations import Conversations
+from couchers.servicers.discussions import Discussions
+from couchers.servicers.donations import Donations, Stripe
+from couchers.servicers.events import Events
+from couchers.servicers.gis import GIS
+from couchers.servicers.groups import Groups
+from couchers.servicers.jail import Jail
+from couchers.servicers.media import Media, get_media_auth_interceptor
+from couchers.servicers.notifications import Notifications
+from couchers.servicers.pages import Pages
+from couchers.servicers.public import Public
+from couchers.servicers.references import References
+from couchers.servicers.reporting import Reporting
+from couchers.servicers.requests import Requests
+from couchers.servicers.resources import Resources
+from couchers.servicers.search import Search
+from couchers.servicers.threads import Threads
 
 
 def create_main_server(port: int) -> grpc.Server:

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -54,6 +54,9 @@ from couchers.models import (
 from couchers.notifications.notify import notify
 from couchers.phone import sms
 from couchers.phone.check import is_e164_format, is_known_operator
+from couchers.proto import account_pb2, account_pb2_grpc, auth_pb2, iris_pb2_grpc, notification_data_pb2
+from couchers.proto.google.api import httpbody_pb2
+from couchers.proto.internal import jobs_pb2, verification_pb2
 from couchers.servicers.api import lite_user_to_pb
 from couchers.servicers.references import get_pending_references_to_write, reftype2api
 from couchers.sql import couchers_select as select
@@ -72,9 +75,6 @@ from couchers.utils import (
     now,
     to_aware_datetime,
 )
-from proto import account_pb2, account_pb2_grpc, auth_pb2, iris_pb2_grpc, notification_data_pb2
-from proto.google.api import httpbody_pb2
-from proto.internal import jobs_pb2, verification_pb2
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -41,6 +41,8 @@ from couchers.models import (
     UserBadge,
 )
 from couchers.notifications.notify import notify
+from couchers.proto import admin_pb2, admin_pb2_grpc, notification_data_pb2
+from couchers.proto.internal import jobs_pb2
 from couchers.resources import get_badge_dict
 from couchers.servicers.api import user_model_to_pb
 from couchers.servicers.auth import create_session
@@ -49,8 +51,6 @@ from couchers.servicers.events import get_users_to_notify_for_new_event
 from couchers.servicers.threads import unpack_thread_id
 from couchers.sql import couchers_select as select
 from couchers.utils import Timestamp_from_datetime, date_to_api, now, parse_date, to_aware_datetime
-from proto import admin_pb2, admin_pb2_grpc, notification_data_pb2
-from proto.internal import jobs_pb2
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -35,6 +35,7 @@ from couchers.models import (
 )
 from couchers.notifications.notify import notify
 from couchers.notifications.settings import get_topic_actions_by_delivery_type
+from couchers.proto import api_pb2, api_pb2_grpc, media_pb2, notification_data_pb2, requests_pb2
 from couchers.rate_limits.check import process_rate_limits_and_check_abort
 from couchers.rate_limits.definitions import RATE_LIMIT_INTERVAL_STRING
 from couchers.resources import get_badge_dict, language_is_allowed, region_is_allowed
@@ -48,7 +49,6 @@ from couchers.utils import (
     is_valid_name,
     now,
 )
-from proto import api_pb2, api_pb2_grpc, media_pb2, notification_data_pb2, requests_pb2
 
 MAX_USERS_PER_QUERY = 200
 MAX_PAGINATION_LENGTH = 50

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -35,6 +35,7 @@ from couchers.models import (
 )
 from couchers.notifications.notify import notify
 from couchers.notifications.quick_links import respond_quick_link
+from couchers.proto import auth_pb2, auth_pb2_grpc, notification_data_pb2
 from couchers.servicers.account import abort_on_invalid_password, contributeoption2sql
 from couchers.servicers.api import hostingstatus2sql
 from couchers.sql import couchers_select as select
@@ -54,7 +55,6 @@ from couchers.utils import (
     parse_date,
     parse_session_cookie,
 )
-from proto import auth_pb2, auth_pb2_grpc, notification_data_pb2
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/servicers/blocking.py
+++ b/app/backend/src/couchers/servicers/blocking.py
@@ -4,8 +4,8 @@ from sqlalchemy.sql import not_, or_, union
 
 from couchers import urls
 from couchers.models import Upload, User, UserBlock
+from couchers.proto import blocking_pb2, blocking_pb2_grpc
 from couchers.sql import couchers_select as select
-from proto import blocking_pb2, blocking_pb2_grpc
 
 
 def is_not_visible(session, user1_id, user2_id) -> bool:

--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -6,9 +6,9 @@ from couchers import urls
 from couchers.config import config
 from couchers.descriptor_pool import get_descriptors_pb
 from couchers.models import User
+from couchers.proto import bugs_pb2, bugs_pb2_grpc
+from couchers.proto.google.api import httpbody_pb2
 from couchers.sql import couchers_select as select
-from proto import bugs_pb2, bugs_pb2_grpc
-from proto.google.api import httpbody_pb2
 
 
 class Bugs(bugs_pb2_grpc.BugsServicer):

--- a/app/backend/src/couchers/servicers/communities.py
+++ b/app/backend/src/couchers/servicers/communities.py
@@ -21,13 +21,13 @@ from couchers.models import (
     PageType,
     User,
 )
+from couchers.proto import communities_pb2, communities_pb2_grpc, groups_pb2
 from couchers.servicers.discussions import discussion_to_pb
 from couchers.servicers.events import event_to_pb
 from couchers.servicers.groups import group_to_pb
 from couchers.servicers.pages import page_to_pb
 from couchers.sql import couchers_select as select
 from couchers.utils import Timestamp_from_datetime, dt_from_millis, millis_from_dt, now
-from proto import communities_pb2, communities_pb2_grpc, groups_pb2
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -21,13 +21,13 @@ from couchers.models import (
     User,
 )
 from couchers.notifications.notify import notify
+from couchers.proto import conversations_pb2, conversations_pb2_grpc, notification_data_pb2
+from couchers.proto.internal import jobs_pb2
 from couchers.rate_limits.check import process_rate_limits_and_check_abort
 from couchers.rate_limits.definitions import RATE_LIMIT_INTERVAL_STRING
 from couchers.servicers.api import user_model_to_pb
 from couchers.sql import couchers_select as select
 from couchers.utils import Timestamp_from_datetime, now
-from proto import conversations_pb2, conversations_pb2_grpc, notification_data_pb2
-from proto.internal import jobs_pb2
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ DEFAULT_PAGINATION_LENGTH = 20
 MAX_PAGE_SIZE = 50
 
 
-def _message_to_pb(message: Message):
+def _message_to_pb(message: Message) -> conversations_pb2.Message:
     """
     Turns the given message to a protocol buffer
     """

--- a/app/backend/src/couchers/servicers/discussions.py
+++ b/app/backend/src/couchers/servicers/discussions.py
@@ -7,13 +7,13 @@ from couchers.db import can_moderate_node, session_scope
 from couchers.jobs.enqueue import queue_job
 from couchers.models import Cluster, Discussion, Thread, User
 from couchers.notifications.notify import notify
+from couchers.proto import discussions_pb2, discussions_pb2_grpc, notification_data_pb2
+from couchers.proto.internal import jobs_pb2
 from couchers.servicers.api import user_model_to_pb
 from couchers.servicers.blocking import is_not_visible
 from couchers.servicers.threads import thread_to_pb
 from couchers.sql import couchers_select as select
 from couchers.utils import Timestamp_from_datetime
-from proto import discussions_pb2, discussions_pb2_grpc, notification_data_pb2
-from proto.internal import jobs_pb2
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/servicers/donations.py
+++ b/app/backend/src/couchers/servicers/donations.py
@@ -8,9 +8,9 @@ from couchers import urls
 from couchers.config import config
 from couchers.models import DonationInitiation, DonationType, Invoice, User
 from couchers.notifications.notify import notify
+from couchers.proto import donations_pb2, donations_pb2_grpc, notification_data_pb2, stripe_pb2_grpc
+from couchers.proto.google.api import httpbody_pb2
 from couchers.sql import couchers_select as select
-from proto import donations_pb2, donations_pb2_grpc, notification_data_pb2, stripe_pb2_grpc
-from proto.google.api import httpbody_pb2
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -25,6 +25,8 @@ from couchers.models import (
     User,
 )
 from couchers.notifications.notify import notify
+from couchers.proto import events_pb2, events_pb2_grpc, notification_data_pb2
+from couchers.proto.internal import jobs_pb2
 from couchers.servicers.api import user_model_to_pb
 from couchers.servicers.blocking import is_not_visible
 from couchers.servicers.threads import thread_to_pb
@@ -38,8 +40,6 @@ from couchers.utils import (
     now,
     to_aware_datetime,
 )
-from proto import events_pb2, events_pb2_grpc, notification_data_pb2
-from proto.internal import jobs_pb2
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/servicers/gis.py
+++ b/app/backend/src/couchers/servicers/gis.py
@@ -6,9 +6,9 @@ from sqlalchemy.sql import func
 
 from couchers.materialized_views import ClusteredUser, LiteUser
 from couchers.models import Node, Page, PageType, PageVersion
+from couchers.proto import gis_pb2_grpc
+from couchers.proto.google.api import httpbody_pb2
 from couchers.sql import couchers_select as select
-from proto import gis_pb2_grpc
-from proto.google.api import httpbody_pb2
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/servicers/groups.py
+++ b/app/backend/src/couchers/servicers/groups.py
@@ -17,12 +17,12 @@ from couchers.models import (
     PageType,
     User,
 )
+from couchers.proto import groups_pb2, groups_pb2_grpc
 from couchers.servicers.discussions import discussion_to_pb
 from couchers.servicers.events import event_to_pb
 from couchers.servicers.pages import page_to_pb
 from couchers.sql import couchers_select as select
 from couchers.utils import Timestamp_from_datetime, dt_from_millis, millis_from_dt, now
-from proto import groups_pb2, groups_pb2_grpc
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/servicers/jail.py
+++ b/app/backend/src/couchers/servicers/jail.py
@@ -4,10 +4,10 @@ import grpc
 
 from couchers.constants import GUIDELINES_VERSION, TOS_VERSION
 from couchers.models import ActivenessProbe, ActivenessProbeStatus, HostingStatus, ModNote, User
+from couchers.proto import jail_pb2, jail_pb2_grpc
 from couchers.servicers.account import mod_note_to_pb
 from couchers.sql import couchers_select as select
 from couchers.utils import create_coordinate, now
-from proto import jail_pb2, jail_pb2_grpc
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/servicers/media.py
+++ b/app/backend/src/couchers/servicers/media.py
@@ -6,8 +6,8 @@ from google.protobuf import empty_pb2
 from couchers.crypto import secure_compare
 from couchers.interceptors import MediaInterceptor
 from couchers.models import InitiatedUpload, Upload
+from couchers.proto import media_pb2_grpc
 from couchers.sql import couchers_select as select
-from proto import media_pb2_grpc
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -24,9 +24,9 @@ from couchers.notifications.settings import (
     set_preference,
 )
 from couchers.notifications.utils import enum_from_topic_action
+from couchers.proto import notifications_pb2, notifications_pb2_grpc
 from couchers.sql import couchers_select as select
 from couchers.utils import Timestamp_from_datetime
-from proto import notifications_pb2, notifications_pb2_grpc
 
 logger = logging.getLogger(__name__)
 MAX_PAGINATION_LENGTH = 100

--- a/app/backend/src/couchers/servicers/pages.py
+++ b/app/backend/src/couchers/servicers/pages.py
@@ -3,10 +3,10 @@ from sqlalchemy.orm import Session
 
 from couchers.db import can_moderate_at, can_moderate_node, get_parent_node_at_location
 from couchers.models import Cluster, Node, Page, PageType, PageVersion, Thread, Upload, User
+from couchers.proto import pages_pb2, pages_pb2_grpc
 from couchers.servicers.threads import thread_to_pb
 from couchers.sql import couchers_select as select
 from couchers.utils import Timestamp_from_datetime, create_coordinate, remove_duplicates_retain_order
-from proto import pages_pb2, pages_pb2_grpc
 
 MAX_PAGINATION_LENGTH = 25
 

--- a/app/backend/src/couchers/servicers/public.py
+++ b/app/backend/src/couchers/servicers/public.py
@@ -7,13 +7,13 @@ from sqlalchemy.sql import func, union_all
 from couchers import urls
 from couchers.materialized_views import LiteUser
 from couchers.models import Cluster, Node, ProfilePublicVisibility, Reference, User, Volunteer
+from couchers.proto import api_pb2, public_pb2, public_pb2_grpc
 from couchers.resources import get_static_badge_dict
 from couchers.servicers.account import _format_volunteer_link
 from couchers.servicers.api import fluency2api, hostingstatus2api, meetupstatus2api, user_model_to_pb
 from couchers.servicers.gis import _statement_to_geojson_response
 from couchers.sql import couchers_select as select
 from couchers.utils import Timestamp_from_datetime, make_logged_out_context
-from proto import api_pb2, public_pb2, public_pb2_grpc
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/servicers/references.py
+++ b/app/backend/src/couchers/servicers/references.py
@@ -14,11 +14,11 @@ from couchers.context import make_background_user_context
 from couchers.materialized_views import LiteUser
 from couchers.models import HostRequest, Reference, ReferenceType, User
 from couchers.notifications.notify import notify
+from couchers.proto import notification_data_pb2, references_pb2, references_pb2_grpc
 from couchers.servicers.api import user_model_to_pb
 from couchers.sql import couchers_select as select
 from couchers.tasks import maybe_send_reference_report_email
 from couchers.utils import Timestamp_from_datetime, now
-from proto import notification_data_pb2, references_pb2, references_pb2_grpc
 
 MAX_PAGINATION_LENGTH = 100
 

--- a/app/backend/src/couchers/servicers/reporting.py
+++ b/app/backend/src/couchers/servicers/reporting.py
@@ -2,9 +2,9 @@ import grpc
 from google.protobuf import empty_pb2
 
 from couchers.models import ContentReport, User
+from couchers.proto import reporting_pb2_grpc
 from couchers.sql import couchers_select as select
 from couchers.tasks import send_content_report_email
-from proto import reporting_pb2_grpc
 
 
 class Reporting(reporting_pb2_grpc.ReportingServicer):

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -27,6 +27,7 @@ from couchers.models import (
     User,
 )
 from couchers.notifications.notify import notify
+from couchers.proto import conversations_pb2, notification_data_pb2, requests_pb2, requests_pb2_grpc
 from couchers.rate_limits.check import process_rate_limits_and_check_abort
 from couchers.rate_limits.definitions import RATE_LIMIT_INTERVAL_STRING
 from couchers.servicers.api import response_rate_to_pb, user_model_to_pb
@@ -39,7 +40,6 @@ from couchers.utils import (
     parse_date,
     today_in_timezone,
 )
-from proto import conversations_pb2, notification_data_pb2, requests_pb2, requests_pb2_grpc
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/servicers/resources.py
+++ b/app/backend/src/couchers/servicers/resources.py
@@ -1,5 +1,6 @@
 import logging
 
+from couchers.proto import resources_pb2, resources_pb2_grpc
 from couchers.resources import (
     get_badge_dict,
     get_community_guidelines,
@@ -7,7 +8,6 @@ from couchers.resources import (
     get_region_dict,
     get_terms_of_service,
 )
-from proto import resources_pb2, resources_pb2_grpc
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/servicers/search.py
+++ b/app/backend/src/couchers/servicers/search.py
@@ -28,6 +28,7 @@ from couchers.models import (
     StrongVerificationAttempt,
     User,
 )
+from couchers.proto import search_pb2, search_pb2_grpc
 from couchers.reranker import reranker
 from couchers.servicers.api import (
     fluency2sql,
@@ -57,7 +58,6 @@ from couchers.utils import (
     now,
     to_aware_datetime,
 )
-from proto import search_pb2, search_pb2_grpc
 
 # searches are a bit expensive, we'd rather send back a bunch of results at once than lots of small pages
 MAX_PAGINATION_LENGTH = 100

--- a/app/backend/src/couchers/servicers/threads.py
+++ b/app/backend/src/couchers/servicers/threads.py
@@ -9,12 +9,12 @@ from couchers.db import session_scope
 from couchers.jobs.enqueue import queue_job
 from couchers.models import Comment, Discussion, Event, EventOccurrence, Reply, Thread, User
 from couchers.notifications.notify import notify
+from couchers.proto import notification_data_pb2, threads_pb2, threads_pb2_grpc
+from couchers.proto.internal import jobs_pb2
 from couchers.servicers.api import user_model_to_pb
 from couchers.servicers.blocking import is_not_visible
 from couchers.sql import couchers_select as select
 from couchers.utils import Timestamp_from_datetime
-from proto import notification_data_pb2, threads_pb2, threads_pb2_grpc
-from proto.internal import jobs_pb2
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/dummy_data.py
+++ b/app/backend/src/dummy_data.py
@@ -35,11 +35,11 @@ from couchers.models import (
     User,
     Volunteer,
 )
+from couchers.proto.api_pb2 import HostingStatus
 from couchers.servicers.api import hostingstatus2sql
 from couchers.servicers.auth import create_session
 from couchers.sql import couchers_select as select
 from couchers.utils import create_coordinate, create_polygon_lng_lat, geojson_to_geom, to_multi
-from proto.api_pb2 import HostingStatus
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -19,9 +19,9 @@ from couchers.models import (
     User,
     Volunteer,
 )
+from couchers.proto import account_pb2, api_pb2, auth_pb2, conversations_pb2, requests_pb2
 from couchers.sql import couchers_select as select
 from couchers.utils import now, today
-from proto import account_pb2, api_pb2, auth_pb2, conversations_pb2, requests_pb2
 from tests.test_fixtures import (  # noqa
     account_session,
     auth_api_session,

--- a/app/backend/src/tests/test_activeness_probes.py
+++ b/app/backend/src/tests/test_activeness_probes.py
@@ -9,9 +9,9 @@ from couchers.config import config
 from couchers.db import session_scope
 from couchers.jobs.enqueue import queue_job
 from couchers.models import ActivenessProbe, ActivenessProbeStatus, HostingStatus, MeetupStatus
+from couchers.proto import api_pb2, jail_pb2
 from couchers.sql import couchers_select as select
 from couchers.utils import now
-from proto import api_pb2, jail_pb2
 from tests.test_fixtures import (  # noqa  # noqa
     api_session,
     db,

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -16,9 +16,9 @@ from couchers.models import (
     Reference,
     UserSession,
 )
+from couchers.proto import admin_pb2, auth_pb2, events_pb2, references_pb2, reporting_pb2
 from couchers.sql import couchers_select as select
 from couchers.utils import Timestamp_from_datetime, now, parse_date, timedelta
-from proto import admin_pb2, auth_pb2, events_pb2, references_pb2, reporting_pb2
 from tests.test_communities import create_community
 from tests.test_fixtures import (  # noqa
     add_users_to_new_moderation_list,

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -8,11 +8,11 @@ from couchers.db import session_scope
 from couchers.jobs.handlers import update_badges
 from couchers.materialized_views import refresh_materialized_views_rapid
 from couchers.models import FriendRelationship, FriendStatus, RateLimitAction
+from couchers.proto import api_pb2, jail_pb2, notifications_pb2
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_INTERVAL_STRING
 from couchers.resources import get_badge_dict
 from couchers.sql import couchers_select as select
 from couchers.utils import create_coordinate, to_aware_datetime
-from proto import api_pb2, jail_pb2, notifications_pb2
 from tests.test_fixtures import (  # noqa
     api_session,
     blocking_session,

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -19,8 +19,8 @@ from couchers.models import (
     User,
     UserSession,
 )
+from couchers.proto import api_pb2, auth_pb2
 from couchers.sql import couchers_select as select
-from proto import api_pb2, auth_pb2
 from tests.test_fixtures import (  # noqa
     api_session,
     auth_api_session,

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -40,9 +40,9 @@ from couchers.models import (
     PasswordResetToken,
     UserBadge,
 )
+from couchers.proto import conversations_pb2, requests_pb2
 from couchers.sql import couchers_select as select
 from couchers.utils import now, today
-from proto import conversations_pb2, requests_pb2
 from tests.test_fixtures import (  # noqa
     auth_api_session,
     conversations_session,

--- a/app/backend/src/tests/test_blocking.py
+++ b/app/backend/src/tests/test_blocking.py
@@ -3,8 +3,8 @@ import pytest
 from google.protobuf import empty_pb2
 
 from couchers.models import UserBlock
+from couchers.proto import blocking_pb2
 from couchers.sql import couchers_select as select
-from proto import blocking_pb2
 from tests.test_fixtures import blocking_session, db, generate_user, make_user_block, session_scope, testconfig  # noqa
 
 

--- a/app/backend/src/tests/test_bugs.py
+++ b/app/backend/src/tests/test_bugs.py
@@ -6,7 +6,7 @@ from google.protobuf import empty_pb2
 
 from couchers.config import config
 from couchers.crypto import random_hex
-from proto import bugs_pb2
+from couchers.proto import bugs_pb2
 from tests.test_fixtures import bugs_session, db, generate_user, testconfig  # noqa
 
 

--- a/app/backend/src/tests/test_communities.py
+++ b/app/backend/src/tests/test_communities.py
@@ -18,10 +18,10 @@ from couchers.models import (
     SignupFlow,
     Thread,
 )
+from couchers.proto import api_pb2, auth_pb2, communities_pb2, discussions_pb2, events_pb2, pages_pb2
 from couchers.sql import couchers_select as select
 from couchers.tasks import enforce_community_memberships
 from couchers.utils import Timestamp_from_datetime, create_coordinate, create_polygon_lat_lng, now, to_multi
-from proto import api_pb2, auth_pb2, communities_pb2, discussions_pb2, events_pb2, pages_pb2
 from tests.test_auth import get_session_cookie_tokens
 from tests.test_fixtures import (  # noqa
     auth_api_session,

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -15,10 +15,10 @@ from couchers.models import (
     NotificationTopicAction,
     RateLimitAction,
 )
+from couchers.proto import api_pb2, conversations_pb2, notification_data_pb2, notifications_pb2
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_INTERVAL_STRING
 from couchers.sql import couchers_select as select
 from couchers.utils import Duration_from_timedelta, now, to_aware_datetime
-from proto import api_pb2, conversations_pb2, notification_data_pb2, notifications_pb2
 from tests.test_fixtures import (  # noqa
     api_session,
     conversations_session,

--- a/app/backend/src/tests/test_discussions.py
+++ b/app/backend/src/tests/test_discussions.py
@@ -2,8 +2,8 @@ import grpc
 import pytest
 
 from couchers.db import session_scope
+from couchers.proto import discussions_pb2, notifications_pb2, threads_pb2
 from couchers.utils import now, to_aware_datetime
-from proto import discussions_pb2, notifications_pb2, threads_pb2
 from tests.test_communities import create_community, create_group
 from tests.test_fixtures import (  # noqa
     db,

--- a/app/backend/src/tests/test_donations.py
+++ b/app/backend/src/tests/test_donations.py
@@ -9,9 +9,9 @@ from couchers.config import config
 from couchers.db import session_scope
 from couchers.jobs.handlers import update_badges
 from couchers.models import DonationInitiation, DonationType, Invoice, UserBadge
+from couchers.proto import donations_pb2
+from couchers.proto.google.api import httpbody_pb2
 from couchers.sql import couchers_select as select
-from proto import donations_pb2
-from proto.google.api import httpbody_pb2
 from tests.test_fixtures import db, donations_session, generate_user, real_stripe_session, testconfig  # noqa
 
 

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -18,6 +18,7 @@ from couchers.models import (
     User,
 )
 from couchers.notifications.notify import notify
+from couchers.proto import admin_pb2, api_pb2, events_pb2, notification_data_pb2, notifications_pb2
 from couchers.sql import couchers_select as select
 from couchers.tasks import (
     enforce_community_memberships,
@@ -27,7 +28,6 @@ from couchers.tasks import (
     send_signup_email,
 )
 from couchers.utils import Timestamp_from_datetime, now, timedelta
-from proto import admin_pb2, api_pb2, events_pb2, notification_data_pb2, notifications_pb2
 from tests.test_communities import create_community
 from tests.test_fixtures import (  # noqa
     api_session,

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -8,9 +8,9 @@ from sqlalchemy.sql.expression import update
 
 from couchers.db import session_scope
 from couchers.models import BackgroundJob, EventOccurrence
+from couchers.proto import admin_pb2, events_pb2, threads_pb2
 from couchers.tasks import enforce_community_memberships
 from couchers.utils import Timestamp_from_datetime, now, to_aware_datetime
-from proto import admin_pb2, events_pb2, threads_pb2
 from tests.test_communities import create_community, create_group
 from tests.test_fixtures import (  # noqa
     db,

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -45,33 +45,7 @@ from couchers.models import (
     UserBlock,
     UserSession,
 )
-from couchers.servicers.account import Account, Iris
-from couchers.servicers.admin import Admin
-from couchers.servicers.api import API
-from couchers.servicers.auth import Auth, create_session
-from couchers.servicers.blocking import Blocking
-from couchers.servicers.bugs import Bugs
-from couchers.servicers.communities import Communities
-from couchers.servicers.conversations import Conversations
-from couchers.servicers.discussions import Discussions
-from couchers.servicers.donations import Donations, Stripe
-from couchers.servicers.events import Events
-from couchers.servicers.gis import GIS
-from couchers.servicers.groups import Groups
-from couchers.servicers.jail import Jail
-from couchers.servicers.media import Media, get_media_auth_interceptor
-from couchers.servicers.notifications import Notifications
-from couchers.servicers.pages import Pages
-from couchers.servicers.public import Public
-from couchers.servicers.references import References
-from couchers.servicers.reporting import Reporting
-from couchers.servicers.requests import Requests
-from couchers.servicers.resources import Resources
-from couchers.servicers.search import Search
-from couchers.servicers.threads import Threads
-from couchers.sql import couchers_select as select
-from couchers.utils import create_coordinate, now
-from proto import (
+from couchers.proto import (
     account_pb2_grpc,
     admin_pb2_grpc,
     annotations_pb2,
@@ -100,6 +74,32 @@ from proto import (
     stripe_pb2_grpc,
     threads_pb2_grpc,
 )
+from couchers.servicers.account import Account, Iris
+from couchers.servicers.admin import Admin
+from couchers.servicers.api import API
+from couchers.servicers.auth import Auth, create_session
+from couchers.servicers.blocking import Blocking
+from couchers.servicers.bugs import Bugs
+from couchers.servicers.communities import Communities
+from couchers.servicers.conversations import Conversations
+from couchers.servicers.discussions import Discussions
+from couchers.servicers.donations import Donations, Stripe
+from couchers.servicers.events import Events
+from couchers.servicers.gis import GIS
+from couchers.servicers.groups import Groups
+from couchers.servicers.jail import Jail
+from couchers.servicers.media import Media, get_media_auth_interceptor
+from couchers.servicers.notifications import Notifications
+from couchers.servicers.pages import Pages
+from couchers.servicers.public import Public
+from couchers.servicers.references import References
+from couchers.servicers.reporting import Reporting
+from couchers.servicers.requests import Requests
+from couchers.servicers.resources import Resources
+from couchers.servicers.search import Search
+from couchers.servicers.threads import Threads
+from couchers.sql import couchers_select as select
+from couchers.utils import create_coordinate, now
 
 
 def create_schema_from_models(engine: Engine | None = None) -> None:

--- a/app/backend/src/tests/test_groups.py
+++ b/app/backend/src/tests/test_groups.py
@@ -2,8 +2,8 @@ import grpc
 import pytest
 
 from couchers.db import session_scope
+from couchers.proto import groups_pb2, pages_pb2
 from couchers.tasks import enforce_community_memberships
-from proto import groups_pb2, pages_pb2
 from tests.test_communities import (  # noqa
     create_1d_point,
     create_community,

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -13,10 +13,10 @@ from couchers.interceptors import (
 )
 from couchers.metrics import servicer_duration_histogram
 from couchers.models import APICall, UserSession
+from couchers.proto import account_pb2, admin_pb2, api_pb2, auth_pb2
 from couchers.servicers.account import Account
 from couchers.servicers.api import API
 from couchers.sql import couchers_select as select
-from proto import account_pb2, admin_pb2, api_pb2, auth_pb2
 from tests.test_fixtures import db, generate_user, real_admin_session, testconfig  # noqa
 
 

--- a/app/backend/src/tests/test_jail.py
+++ b/app/backend/src/tests/test_jail.py
@@ -4,9 +4,9 @@ from google.protobuf import empty_pb2
 
 from couchers.constants import TOS_VERSION
 from couchers.models import users
+from couchers.proto import admin_pb2, api_pb2, jail_pb2
 from couchers.servicers import jail as servicers_jail
 from couchers.utils import create_coordinate, to_aware_datetime
-from proto import admin_pb2, api_pb2, jail_pb2
 from tests.test_fixtures import (  # noqa  # noqa
     db,
     email_fields,

--- a/app/backend/src/tests/test_media.py
+++ b/app/backend/src/tests/test_media.py
@@ -6,8 +6,8 @@ from google.protobuf import empty_pb2
 from couchers.crypto import b64decode, random_hex
 from couchers.db import session_scope
 from couchers.models import InitiatedUpload, Upload
+from couchers.proto import media_pb2
 from couchers.sql import couchers_select as select
-from proto import media_pb2
 from tests.test_fixtures import api_session, db, generate_user, media_session, testconfig  # noqa
 
 

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -20,11 +20,19 @@ from couchers.models import (
 )
 from couchers.notifications.notify import notify
 from couchers.notifications.settings import get_topic_actions_by_delivery_type
+from couchers.proto import (
+    admin_pb2,
+    api_pb2,
+    auth_pb2,
+    conversations_pb2,
+    events_pb2,
+    notification_data_pb2,
+    notifications_pb2,
+)
+from couchers.proto.internal import unsubscribe_pb2
 from couchers.servicers.api import user_model_to_pb
 from couchers.sql import couchers_select as select
 from couchers.templates.v2 import v2timestamp
-from proto import admin_pb2, api_pb2, auth_pb2, conversations_pb2, events_pb2, notification_data_pb2, notifications_pb2
-from proto.internal import unsubscribe_pb2
 from tests.test_fixtures import (  # noqa
     api_session,
     auth_api_session,

--- a/app/backend/src/tests/test_pages.py
+++ b/app/backend/src/tests/test_pages.py
@@ -5,8 +5,8 @@ from google.protobuf import wrappers_pb2
 from couchers.crypto import random_hex
 from couchers.db import session_scope
 from couchers.models import Cluster, ClusterRole, ClusterSubscription, Node, Page, PageType, PageVersion, Thread, Upload
+from couchers.proto import pages_pb2
 from couchers.utils import create_polygon_lat_lng, now, to_aware_datetime, to_multi
-from proto import pages_pb2
 from tests.test_communities import create_community
 from tests.test_fixtures import db, generate_user, pages_session, testconfig  # noqa
 

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -17,9 +17,9 @@ from couchers.models import (
     ReferenceType,
     User,
 )
+from couchers.proto import conversations_pb2, references_pb2, requests_pb2
 from couchers.sql import couchers_select as select
 from couchers.utils import create_coordinate, now, to_aware_datetime, today
-from proto import conversations_pb2, references_pb2, requests_pb2
 from tests.test_fixtures import (  # noqa
     account_session,
     db,

--- a/app/backend/src/tests/test_reporting.py
+++ b/app/backend/src/tests/test_reporting.py
@@ -3,8 +3,8 @@ import pytest
 
 from couchers.db import session_scope
 from couchers.models import ContentReport
+from couchers.proto import reporting_pb2
 from couchers.sql import couchers_select as select
-from proto import reporting_pb2
 from tests.test_fixtures import db, generate_user, reporting_session, testconfig  # noqa
 
 

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -14,17 +14,17 @@ from couchers.models import (
     MessageType,
     RateLimitAction,
 )
-from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_INTERVAL_STRING
-from couchers.sql import couchers_select as select
-from couchers.templates.v2 import v2date
-from couchers.utils import create_coordinate, now, today
-from proto import (
+from couchers.proto import (
     api_pb2,
     auth_pb2,
     conversations_pb2,
     requests_pb2,
 )
-from proto.internal import unsubscribe_pb2
+from couchers.proto.internal import unsubscribe_pb2
+from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_INTERVAL_STRING
+from couchers.sql import couchers_select as select
+from couchers.templates.v2 import v2date
+from couchers.utils import create_coordinate, now, today
 from tests.test_fixtures import (  # noqa
     api_session,
     auth_api_session,

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -6,8 +6,8 @@ from google.protobuf import wrappers_pb2
 from couchers.db import session_scope
 from couchers.materialized_views import refresh_materialized_views, refresh_materialized_views_rapid
 from couchers.models import EventOccurrence, HostingStatus, LanguageAbility, LanguageFluency, MeetupStatus
+from couchers.proto import api_pb2, communities_pb2, events_pb2, search_pb2
 from couchers.utils import Timestamp_from_datetime, create_coordinate, millis_from_dt, now
-from proto import api_pb2, communities_pb2, events_pb2, search_pb2
 from tests.test_communities import create_community, testing_communities  # noqa
 from tests.test_fixtures import (  # noqa
     communities_session,

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -23,9 +23,9 @@ from couchers.models import (
     StrongVerificationCallbackEvent,
     User,
 )
+from couchers.proto import account_pb2, admin_pb2, api_pb2
+from couchers.proto.google.api import httpbody_pb2
 from couchers.sql import couchers_select as select
-from proto import account_pb2, admin_pb2, api_pb2
-from proto.google.api import httpbody_pb2
 from tests.test_fixtures import (  # noqa
     account_session,
     api_session,

--- a/app/backend/src/tests/test_threads.py
+++ b/app/backend/src/tests/test_threads.py
@@ -5,8 +5,8 @@ import pytest
 
 from couchers.db import session_scope
 from couchers.models import Thread
+from couchers.proto import threads_pb2
 from couchers.servicers.threads import pack_thread_id
-from proto import threads_pb2
 from tests.test_fixtures import db, generate_user, testconfig, threads_session  # noqa
 
 

--- a/app/backend/src/tests/test_verification.py
+++ b/app/backend/src/tests/test_verification.py
@@ -9,9 +9,9 @@ from couchers.config import config
 from couchers.crypto import random_hex
 from couchers.db import session_scope
 from couchers.models import SMS, User
+from couchers.proto import account_pb2, api_pb2
 from couchers.sql import couchers_select as select
 from couchers.utils import now
-from proto import account_pb2, api_pb2
 from tests.test_fixtures import (  # noqa
     account_session,
     api_session,

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -21,9 +21,11 @@ services:
     build: backend
     env_file: backend.dev.env
     volumes:
-      - "./backend:/app"
+      - "./backend/src:/app/src"
+      - "./backend/resources:/app/resources"
+      - "./backend/templates:/app/templates"
     # see https://github.com/eradman/entr#docker-and-windows-subsystem-for-linux
-    command: bash -c "find src -name '**.py' | ENTR_INOTIFY_WORKAROUND=1 entr -rndz uv run src/app.py && exit 1"
+    command: bash -c "find src -name '**.py' | ENTR_INOTIFY_WORKAROUND=1 entr -rndz python src/app.py && exit 1"
     restart: unless-stopped
     ports:
       # grpc: main apis

--- a/app/generate_protos.sh
+++ b/app/generate_protos.sh
@@ -5,7 +5,7 @@ set -e
 rm -rf proto/gen
 mkdir -p proto/gen/python/proto
 mkdir -p proto/gen/ts/proto
-mkdir -p backend/src/proto/
+mkdir -p backend/src/couchers/proto/
 mkdir -p media/src/media/proto/
 mkdir -p web/proto/
 mkdir -p native/proto/
@@ -25,9 +25,9 @@ find proto -name '*.proto' | protoc -I proto \
   --grpc_python_out=proto/gen/python/proto \
   --pyi_out=proto/gen/python/proto \
   \
-  --python_out=backend/src/proto \
-  --grpc_python_out=backend/src/proto \
-  --pyi_out=backend/src/proto \
+  --python_out=backend/src/couchers/proto \
+  --grpc_python_out=backend/src/couchers/proto \
+  --pyi_out=backend/src/couchers/proto \
   \
   --python_out=client/src/couchers/proto \
   --grpc_python_out=client/src/couchers/proto \
@@ -50,19 +50,19 @@ find proto -name '*.proto' | protoc -I proto \
 
 # protoc only allows passing --descriptor_set_out once...
 cp proto/gen/descriptors.pb proxy/descriptors.pb
-cp proto/gen/descriptors.pb backend/src/proto/descriptors.pb
+cp proto/gen/descriptors.pb backend/src/couchers/proto/descriptors.pb
 
 # create internal backend protos
 (cd backend && find proto -name '*.proto' | protoc -I proto \
-  --python_out=src/proto \
-  --pyi_out=src/proto \
+  --python_out=src/couchers/proto \
+  --pyi_out=src/couchers/proto \
   $(xargs))
 
 # fixup python3 relative imports with oneliner from
 # https://github.com/protocolbuffers/protobuf/issues/1491#issuecomment-690618628
-sed -i -E 's/^import.*_pb2/from . &/' proto/gen/python/proto/*.py backend/src/proto/*.py client/src/couchers/proto/*.py media/src/media/proto/*.py
-sed -i -E 's/^from google.api/from .google.api/' proto/gen/python/proto/*.py backend/src/proto/*.py client/src/couchers/proto/*.py media/src/media/proto/*.py
-sed -i -E 's/^from google.api/from ./' proto/gen/python/proto/google/api/*.py backend/src/proto/google/api/*.py client/src/couchers/proto/google/api/*.py media/src/media/proto/google/api/*.py
+sed -i -E 's/^import.*_pb2/from . &/' proto/gen/python/proto/*.py backend/src/couchers/proto/*.py client/src/couchers/proto/*.py media/src/media/proto/*.py
+sed -i -E 's/^from google.api/from .google.api/' proto/gen/python/proto/*.py backend/src/couchers/proto/*.py client/src/couchers/proto/*.py media/src/media/proto/*.py
+sed -i -E 's/^from google.api/from ./' proto/gen/python/proto/google/api/*.py backend/src/couchers/proto/google/api/*.py client/src/couchers/proto/google/api/*.py media/src/media/proto/google/api/*.py
 
 (cd proto/gen/python && tar czf ../python.tar.gz proto)
 (cd proto/gen/ts && tar czf ../ts.tar.gz proto)


### PR DESCRIPTION
- Mount only specific directories instead of the whole app/backend. This avoids mounting `.venv` to the container.
- Put generated protos inside `couchers`, so that it's part of the package. See updated imports. This is better, because this way we're not relying on `proto` being available on `PYTHONPATH`. 