### PR TITLE
Fix backend Docker build cache

### DIFF
--- a/app/backend/Dockerfile
+++ b/app/backend/Dockerfile
@@ -28,6 +28,8 @@ RUN apt-get update -qy && apt-get install -qyy zstd wget build-essential \
     && zstd -d timezone_areas.sql.zst \
     && wget -qO- https://astral.sh/uv/${UV_VERSION}/install.sh | sh
 
+WORKDIR /app
+
 # Synchronize DEPENDENCIES without the application itself.
 # This layer is cached until uv.lock or pyproject.toml change, which are
 # only temporarily mounted into the build container since we don't need
@@ -41,7 +43,6 @@ RUN --mount=type=cache,target=/root/.cache \
 
 # Now install the rest from `/app`: The APPLICATION w/o dependencies.
 COPY . /app
-WORKDIR /app
 RUN --mount=type=cache,target=/root/.cache \
     /root/.local/bin/uv sync \
         --locked \

--- a/app/media/Dockerfile
+++ b/app/media/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.13-slim-trixie AS base
 
-ENV UV_VERSION=0.9.8
-
 RUN <<EOT
 apt-get update -qy
 apt-get install -qyy \
@@ -17,7 +15,8 @@ FROM base AS build
 
 ENV UV_VERSION=0.9.8
 
-WORKDIR /deps
+WORKDIR /app
+
 RUN apt-get update -qy && apt-get install -qyy wget build-essential \
     && wget -qO- https://astral.sh/uv/${UV_VERSION}/install.sh | sh
 
@@ -34,7 +33,6 @@ RUN --mount=type=cache,target=/root/.cache \
 
 # Now install the rest from `/app`: The APPLICATION w/o dependencies.
 COPY . /app
-WORKDIR /app
 RUN --mount=type=cache,target=/root/.cache \
     /root/.local/bin/uv sync \
         --locked \


### PR DESCRIPTION
First uv sync was happening on inside `/deps`, and so the second sync was reinstalling all the dependencies even when uv.lock did not change 🤦 