### PR TITLE
Revert "Enable turbopack to speed up "next build""

### DIFF
--- a/app/web/next.config.js
+++ b/app/web/next.config.js
@@ -28,17 +28,6 @@ const nextConfig = {
     });
     return config;
   },
-  turbopack: {
-    resolveAlias: {
-      "@/*": "./*",
-    },
-    rules: {
-      "*.md": {
-        loaders: ["frontmatter-markdown-loader"],
-        as: "*.js",
-      },
-    },
-  },
   redirects: async () => redirects,
   headers: async () => [
     {

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -6,9 +6,9 @@
     "node": "22.x"
   },
   "scripts": {
-    "build": "next build --turbo",
+    "build": "next build",
     "injectsourcemaps": "sentry-cli sourcemaps inject .next/",
-    "dev": "next dev --turbo",
+    "dev": "next dev",
     "start": "yarn dev",
     "format": "prettier --write '**/*.{ts,tsx,js,jsx,json,css}'",
     "format:check": "prettier --check '**/*.{ts,tsx,js,jsx,json,css}'",


### PR DESCRIPTION
Reverts Couchers-org/couchers#7190 Closes #7214 

This took down the core map search functionality so reverting.

Why: Turbopack changes how Next.js chunks the client bundle. Enabling Turbopack made SWC’s (the compiler Next uses under the hood) `_define_property` helper load from its own chunk, so when that chunk wasn’t fetched (due to stale cache/CDN) the browser saw an undefined helper and MUI code crashed. Switching back away from turbopack inlines the helper again, preventing the runtime from depending on a missing asset.