### PR TITLE
Fix passing env vars to yarn build

### DIFF
--- a/app/web/Dockerfile
+++ b/app/web/Dockerfile
@@ -16,9 +16,7 @@ RUN cp .env.$environment env && \
     rm .env.* && \
     mv env .env.local
 
-RUN yarn build
-
-# These are at the end so as to not invalidate Docker build cache
+# These are used during yarn build by Next.js
 ARG version
 ENV NEXT_PUBLIC_VERSION=$version
 ENV SENTRY_RELEASE=$version
@@ -31,3 +29,7 @@ ENV NEXT_PUBLIC_COMMIT_SHA=$commit_sha
 
 ARG commit_timestamp
 ENV NEXT_PUBLIC_COMMIT_TIMESTAMP=$commit_timestamp
+
+RUN yarn build
+
+

--- a/app/web/Dockerfile.prod
+++ b/app/web/Dockerfile.prod
@@ -18,6 +18,20 @@ RUN cp .env.$environment env && \
 
 RUN if [ "$environment" = "production" ]; then cp public/robots-prod.txt public/robots.txt; fi
 
+# These are used during yarn build by Next.js
+ARG version
+ENV NEXT_PUBLIC_VERSION=$version
+ENV SENTRY_RELEASE=$version
+
+ARG display_version
+ENV NEXT_PUBLIC_DISPLAY_VERSION=$display_version
+
+ARG commit_sha
+ENV NEXT_PUBLIC_COMMIT_SHA=$commit_sha
+
+ARG commit_timestamp
+ENV NEXT_PUBLIC_COMMIT_TIMESTAMP=$commit_timestamp
+
 RUN yarn build
 
 RUN yarn injectsourcemaps
@@ -38,20 +52,6 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 COPY --from=builder /app/.env.local ./
 COPY --from=builder /app/proto ./proto
-
-# These are at the end so as to not invalidate Docker build cache
-ARG version
-ENV NEXT_PUBLIC_VERSION=$version
-ENV SENTRY_RELEASE=$version
-
-ARG display_version
-ENV NEXT_PUBLIC_DISPLAY_VERSION=$display_version
-
-ARG commit_sha
-ENV NEXT_PUBLIC_COMMIT_SHA=$commit_sha
-
-ARG commit_timestamp
-ENV NEXT_PUBLIC_COMMIT_TIMESTAMP=$commit_timestamp
 
 EXPOSE 3000
 


### PR DESCRIPTION
NEXT_ env variables are used by Next.js during the build. They are embedded into the frontend bundle.

This is mostly fine, since if frontend is changed, and we trigger a build job, we probably want to rebiuld :) The only case when we'd like to avoid a rebuild is a build for `develop` when we start all builds, even if stuff hasn't changed. Ideally we'd use a cached image there. 

Thoughts: maybe we don't really need these variables on the web site? I guess we can have a separate static file with these values - it would be easy to put that into `.next/static` as a separate RUN stage in Dockerfile. The only issue is SENTRY_RELEASE, but OTOH we should proxy requests to Sentry because of the adblockers - and then we can inject sentry release on the backend.