### PR TITLE
Speed up tests

### DIFF
--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -83,7 +83,7 @@ def create_session(
     if user.is_banned:
         context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "account_suspended")
 
-    # just double check
+    # just double-check
     assert not user.is_deleted
 
     token = cookiesafe_secure_token()

--- a/app/backend/src/couchers/servicers/blocking.py
+++ b/app/backend/src/couchers/servicers/blocking.py
@@ -48,7 +48,7 @@ class Blocking(blocking_pb2_grpc.BlockingServicer):
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "cant_block_self")
 
         if session.execute(
-            select(UserBlock)
+            select(UserBlock.id)
             .where(UserBlock.blocking_user_id == context.user_id)
             .where(UserBlock.blocked_user_id == blockee.id)
         ).scalar_one_or_none():

--- a/app/backend/src/couchers/servicers/blocking.py
+++ b/app/backend/src/couchers/servicers/blocking.py
@@ -1,5 +1,6 @@
 import grpc
 from google.protobuf import empty_pb2
+from sqlalchemy import exists
 from sqlalchemy.sql import not_, or_, union
 
 from couchers import urls
@@ -48,10 +49,12 @@ class Blocking(blocking_pb2_grpc.BlockingServicer):
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "cant_block_self")
 
         if session.execute(
-            select(UserBlock.id)
-            .where(UserBlock.blocking_user_id == context.user_id)
-            .where(UserBlock.blocked_user_id == blockee.id)
-        ).scalar_one_or_none():
+            select(
+                exists()
+                .where(UserBlock.blocking_user_id == context.user_id)
+                .where(UserBlock.blocked_user_id == blockee.id)
+            )
+        ).scalar_one():
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "user_already_blocked")
         else:
             user_block = UserBlock(

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -1006,7 +1006,6 @@ def test_DisableInviteCode(db):
     code = "TEST1234"
     with session_scope() as session:
         session.add(InviteCode(id=code, creator_user_id=user.id))
-        session.commit()
 
     with account_session(token) as account:
         account.DisableInviteCode(account_pb2.DisableInviteCodeReq(code=code))

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import grpc
 import pytest
 from google.protobuf import empty_pb2, wrappers_pb2
+from sqlalchemy import update
 from sqlalchemy.sql import func
 
 from couchers import constants, urls
@@ -57,13 +58,13 @@ def test_GetAccountInfo(db, fast_passwords):
 
 
 def test_donation_banner_no_drive(db):
-    """Test that banner is not shown when DONATION_DRIVE_START is None"""
+    """Test that the banner is not shown when DONATION_DRIVE_START is None"""
 
     original_value = constants.DONATION_DRIVE_START
     try:
         constants.DONATION_DRIVE_START = None
 
-        # User has donated, but drive is disabled so banner should not show
+        # User has donated, but the drive is disabled, so the banner should not show
         user, token = generate_user()
 
         with account_session(token) as account:
@@ -103,9 +104,8 @@ def test_donation_banner_donated_before_drive(db):
 
         # Set donation before drive start
         with session_scope() as session:
-            db_user = session.execute(select(User).where(User.id == user.id)).scalar_one()
-            db_user.last_donated = datetime(2025, 10, 15, tzinfo=UTC)  # Before Nov 1
-            session.commit()
+            last_donated = datetime(2025, 10, 15, tzinfo=UTC)  # Before Nov 1
+            session.execute(update(User).where(User.id == user.id).values(last_donated=last_donated))
 
         with account_session(token) as account:
             res = account.GetAccountInfo(empty_pb2.Empty())
@@ -126,9 +126,8 @@ def test_donation_banner_donated_after_drive(db):
 
         # Set donation after drive start
         with session_scope() as session:
-            db_user = session.execute(select(User).where(User.id == user.id)).scalar_one()
-            db_user.last_donated = datetime(2025, 11, 15, tzinfo=UTC)  # After Nov 1
-            session.commit()
+            last_donated = datetime(2025, 11, 15, tzinfo=UTC)  # After Nov 1
+            session.execute(update(User).where(User.id == user.id).values(last_donated=last_donated))
 
         with account_session(token) as account:
             res = account.GetAccountInfo(empty_pb2.Empty())
@@ -149,9 +148,7 @@ def test_donation_banner_donated_exactly_at_drive_start(db):
 
         # Set donation exactly at drive start
         with session_scope() as session:
-            db_user = session.execute(select(User).where(User.id == user.id)).scalar_one()
-            db_user.last_donated = drive_start
-            session.commit()
+            session.execute(update(User).where(User.id == user.id).values(last_donated=drive_start))
 
         with account_session(token) as account:
             res = account.GetAccountInfo(empty_pb2.Empty())
@@ -513,8 +510,7 @@ def test_ChangeEmailV2_tokens_two_hour_window(db):
         )
 
     with session_scope() as session:
-        user = session.execute(select(User).where(User.id == user.id)).scalar_one()
-        new_email_token = user.new_email_token
+        new_email_token = session.execute(select(User.new_email_token).where(User.id == user.id)).scalar_one()
 
     with patch("couchers.servicers.auth.now", one_minute_ago):
         with auth_api_session() as (auth_api, metadata_interceptor):
@@ -1027,9 +1023,7 @@ def test_ListInviteCodes(db):
     code = "LIST1234"
     with session_scope() as session:
         session.add(InviteCode(id=code, creator_user_id=user.id))
-        db_other_user = session.execute(select(User).where(User.id == another_user.id)).scalar_one()
-        db_other_user.invite_code_id = code
-        session.commit()
+        session.execute(update(User).where(User.id == another_user.id).values(invite_code_id=code))
 
     with account_session(token) as account:
         res = account.ListInviteCodes(empty_pb2.Empty())

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -359,15 +359,15 @@ def test_CreateApiKey(db, push_collector):
     assert e.subject == "[TEST] Your API key for Couchers.org"
 
     with session_scope() as session:
-        api_key = session.execute(
-            select(UserSession)
+        token = session.execute(
+            select(UserSession.token)
             .where(UserSession.is_valid)
             .where(UserSession.is_api_key == True)
             .where(UserSession.user_id == normal_user.id)
         ).scalar_one()
 
-        assert api_key.token in e.plain
-        assert api_key.token in e.html
+        assert token in e.plain
+        assert token in e.html
 
     assert e.recipient == normal_user.email
     assert "api key" in e.subject.lower()
@@ -486,28 +486,27 @@ def test_UpdateCommunity_invalid_geojson(db):
 def test_UpdateCommunity_invalid_id(db):
     super_user, super_token = generate_user(is_superuser=True)
 
-    with session_scope() as session:
-        with real_admin_session(super_token) as api:
-            api.CreateCommunity(
-                admin_pb2.CreateCommunityReq(
-                    name="test community",
-                    description="community for testing",
-                    admin_ids=[],
+    with real_admin_session(super_token) as api:
+        api.CreateCommunity(
+            admin_pb2.CreateCommunityReq(
+                name="test community",
+                description="community for testing",
+                admin_ids=[],
+                geojson=VALID_GEOJSON_MULTIPOLYGON,
+            )
+        )
+
+        with pytest.raises(grpc.RpcError) as e:
+            api.UpdateCommunity(
+                admin_pb2.UpdateCommunityReq(
+                    community_id=1000,
+                    name="test community 1000",
+                    description="community for testing 1000",
                     geojson=VALID_GEOJSON_MULTIPOLYGON,
                 )
             )
-
-            with pytest.raises(grpc.RpcError) as e:
-                api.UpdateCommunity(
-                    admin_pb2.UpdateCommunityReq(
-                        community_id=1000,
-                        name="test community 1000",
-                        description="community for testing 1000",
-                        geojson=VALID_GEOJSON_MULTIPOLYGON,
-                    )
-                )
-            assert e.value.code() == grpc.StatusCode.NOT_FOUND
-            assert e.value.details() == "Community not found."
+        assert e.value.code() == grpc.StatusCode.NOT_FOUND
+        assert e.value.details() == "Community not found."
 
 
 def test_UpdateCommunity(db):

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -3,11 +3,12 @@ from datetime import timedelta
 import grpc
 import pytest
 from google.protobuf import empty_pb2, wrappers_pb2
+from sqlalchemy import update
 
 from couchers.db import session_scope
 from couchers.jobs.handlers import update_badges
 from couchers.materialized_views import refresh_materialized_views_rapid
-from couchers.models import FriendRelationship, FriendStatus, RateLimitAction, User
+from couchers.models import FriendRelationship, FriendStatus, LanguageFluency, RateLimitAction, User
 from couchers.proto import admin_pb2, api_pb2, blocking_pb2, jail_pb2, notifications_pb2
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_HOURS
 from couchers.resources import get_badge_dict
@@ -180,7 +181,7 @@ def test_user_model_to_pb_ghost_user(db, flag):
     user2, _ = generate_user()
 
     with session_scope() as session:
-        setattr(session.execute(select(User).where(User.id == user2.id)).scalar_one(), flag, True)
+        session.execute(update(User).where(User.id == user2.id).values(**{flag: True}))
 
     refresh_materialized_views_rapid(None)
 
@@ -309,7 +310,7 @@ def test_admin_viewing_ghost_users_sees_full_profile(db, flag):
     user, _ = generate_user()
 
     with session_scope() as session:
-        setattr(session.execute(select(User).where(User.id == user.id)).scalar_one(), flag, True)
+        session.execute(update(User).where(User.id == user.id).values(**{flag: True}))
 
     with admin_session(token_admin) as api:
         user_pb = api.GetUser(admin_pb2.GetUserReq(user=user.username))
@@ -801,7 +802,7 @@ def test_friend_request_flow(db, push_collector):
     user2, token2 = generate_user(complete_profile=True)
     user3, token3 = generate_user()
 
-    # send friend request from user1 to user2
+    # send a friend request from user1 to user2
     with mock_notification_email() as mock:
         with api_session(token1) as api:
             api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user2.id))

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -38,7 +38,14 @@ def _(testconfig):
 
 
 def test_ping(db):
-    user, token = generate_user()
+    user, token = generate_user(
+        regions_lived=["ESP", "FRA", "EST"],
+        regions_visited=["CHE", "REU", "FIN"],
+        language_abilities=[
+            ("fin", LanguageFluency.fluent),
+            ("fra", LanguageFluency.beginner),
+        ],
+    )
 
     with real_api_session(token) as api:
         res = api.Ping(api_pb2.PingReq())
@@ -621,7 +628,12 @@ def test_update_profile_do_not_email(db):
 
 
 def test_language_abilities(db):
-    user, token = generate_user()
+    user, token = generate_user(
+        language_abilities=[
+            ("fin", LanguageFluency.fluent),
+            ("fra", LanguageFluency.beginner),
+        ],
+    )
 
     with api_session(token) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=user.username))

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -258,11 +258,9 @@ def _quick_signup() -> int:
 
     # make sure we got the right token in a cookie
     with session_scope() as session:
-        token = (
-            session.execute(
-                select(UserSession.token).join(User, UserSession.user_id == User.id).where(User.username == "frodo")
-            ).scalar_one()
-        )
+        token = session.execute(
+            select(UserSession.token).join(User, UserSession.user_id == User.id).where(User.username == "frodo")
+        ).scalar_one()
     sesh, uid = get_session_cookie_tokens(metadata_interceptor)
     assert sesh == token
 
@@ -283,15 +281,13 @@ def test_basic_login(db):
     reply_token, _ = get_session_cookie_tokens(metadata_interceptor)
 
     with session_scope() as session:
-        token = (
-            session.execute(
-                select(UserSession.token)
-                .join(User, UserSession.user_id == User.id)
-                .where(User.username == "frodo")
-                .where(UserSession.token == reply_token)
-                .where(UserSession.is_valid)
-            ).scalar_one_or_none()
-        )
+        token = session.execute(
+            select(UserSession.token)
+            .join(User, UserSession.user_id == User.id)
+            .where(User.username == "frodo")
+            .where(UserSession.token == reply_token)
+            .where(UserSession.is_valid)
+        ).scalar_one_or_none()
         assert token
 
     # log out
@@ -468,15 +464,13 @@ def test_password_reset_v2(db, push_collector):
     session_token, _ = get_session_cookie_tokens(metadata_interceptor)
 
     with session_scope() as session:
-        other_session_token = (
-            session.execute(
-                select(UserSession.token)
-                .join(User, UserSession.user_id == User.id)
-                .where(User.username == user.username)
-                .where(UserSession.token == session_token)
-                .where(UserSession.is_valid)
-            ).scalar_one_or_none()
-        )
+        other_session_token = session.execute(
+            select(UserSession.token)
+            .join(User, UserSession.user_id == User.id)
+            .where(User.username == user.username)
+            .where(UserSession.token == session_token)
+            .where(UserSession.is_valid)
+        ).scalar_one_or_none()
         assert other_session_token
 
     # make sure we can't set a password again
@@ -682,9 +676,7 @@ def test_signup_existing_email(db):
 
     with auth_api_session() as (auth_api, metadata_interceptor):
         with pytest.raises(grpc.RpcError) as e:
-            auth_api.SignupFlow(
-                auth_pb2.SignupFlowReq(basic=auth_pb2.SignupBasic(name="frodo", email=user.email))
-            )
+            auth_api.SignupFlow(auth_pb2.SignupFlowReq(basic=auth_pb2.SignupBasic(name="frodo", email=user.email)))
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
         assert e.value.details() == "That email address is already associated with an account. Please log in instead!"
 
@@ -697,9 +689,7 @@ def test_signup_banned_user_email(db):
 
     with auth_api_session() as (auth_api, _):
         with pytest.raises(grpc.RpcError) as e:
-            auth_api.SignupFlow(
-                auth_pb2.SignupFlowReq(basic=auth_pb2.SignupBasic(name="NewName", email=user.email))
-            )
+            auth_api.SignupFlow(auth_pb2.SignupFlowReq(basic=auth_pb2.SignupBasic(name="NewName", email=user.email)))
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
         assert e.value.details() == "You cannot sign up with that email address."
 
@@ -712,9 +702,7 @@ def test_signup_deleted_user_email(db):
 
     with auth_api_session() as (auth_api, _):
         with pytest.raises(grpc.RpcError) as e:
-            auth_api.SignupFlow(
-                auth_pb2.SignupFlowReq(basic=auth_pb2.SignupBasic(name="NewName", email=user.email))
-            )
+            auth_api.SignupFlow(auth_pb2.SignupFlowReq(basic=auth_pb2.SignupBasic(name="NewName", email=user.email)))
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
         assert e.value.details() == "You cannot sign up with that email address."
 
@@ -982,9 +970,9 @@ def test_signup_token_regression(db):
 
     # 2. Confirm the email
     with session_scope() as session:
-        email_token = (
-            session.execute(select(SignupFlow.email_token).where(SignupFlow.flow_token == flow_token)).scalar_one()
-        )
+        email_token = session.execute(
+            select(SignupFlow.email_token).where(SignupFlow.flow_token == flow_token)
+        ).scalar_one()
 
     with auth_api_session() as (auth_api, metadata_interceptor):
         auth_api.SignupFlow(
@@ -997,9 +985,7 @@ def test_signup_token_regression(db):
     # 3. Start a new signup with the same email
     with auth_api_session() as (auth_api, metadata_interceptor):
         with pytest.raises(grpc.RpcError) as e:
-            auth_api.SignupFlow(
-                auth_pb2.SignupFlowReq(basic=auth_pb2.SignupBasic(name="frodo", email=testing_email))
-            )
+            auth_api.SignupFlow(auth_pb2.SignupFlowReq(basic=auth_pb2.SignupBasic(name="frodo", email=testing_email)))
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
         assert e.value.details() == "Please check your email for a link to continue signing up."
 
@@ -1029,9 +1015,9 @@ def test_opt_out_of_newsletter(db, opt_out):
         )
 
     with session_scope() as session:
-        email_token = (
-            session.execute(select(SignupFlow.email_token).where(SignupFlow.flow_token == res.flow_token)).scalar_one()
-        )
+        email_token = session.execute(
+            select(SignupFlow.email_token).where(SignupFlow.flow_token == res.flow_token)
+        ).scalar_one()
 
     with auth_api_session() as (auth_api, metadata_interceptor):
         res = auth_api.SignupFlow(auth_pb2.SignupFlowReq(email_token=email_token))
@@ -1129,11 +1115,9 @@ def test_signup_no_feedback_regression(db):
 
     # make sure we got the right token in a cookie
     with session_scope() as session:
-        token = (
-            session.execute(
-                select(UserSession.token).join(User, UserSession.user_id == User.id).where(User.username == "frodo")
-            ).scalar_one()
-        )
+        token = session.execute(
+            select(UserSession.token).join(User, UserSession.user_id == User.id).where(User.username == "frodo")
+        ).scalar_one()
     sesh, uid = get_session_cookie_tokens(metadata_interceptor)
     assert sesh == token
 
@@ -1252,9 +1236,9 @@ def test_SignupFlow_invite_code(db):
 
         # Confirm email
         with session_scope() as session:
-            email_token = (
-                session.execute(select(SignupFlow.email_token).where(SignupFlow.flow_token == flow_token)).scalar_one()
-            )
+            email_token = session.execute(
+                select(SignupFlow.email_token).where(SignupFlow.flow_token == flow_token)
+            ).scalar_one()
 
         auth_api.SignupFlow(auth_pb2.SignupFlowReq(email_token=email_token))
 

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -3,6 +3,7 @@ import http.cookies
 import grpc
 import pytest
 from google.protobuf import empty_pb2, wrappers_pb2
+from sqlalchemy import update
 from sqlalchemy.sql import delete, func
 
 from couchers import urls
@@ -205,7 +206,7 @@ def test_signup_incremental(db):
         assert form.expertise == "I'd love to be your server: I can compute very fast, but only simple opcodes"
 
 
-def _quick_signup():
+def _quick_signup() -> int:
     with auth_api_session() as (auth_api, metadata_interceptor):
         res = auth_api.SignupFlow(
             auth_pb2.SignupFlowReq(
@@ -259,11 +260,13 @@ def _quick_signup():
     with session_scope() as session:
         token = (
             session.execute(
-                select(UserSession).join(User, UserSession.user_id == User.id).where(User.username == "frodo")
+                select(UserSession.token).join(User, UserSession.user_id == User.id).where(User.username == "frodo")
             ).scalar_one()
-        ).token
+        )
     sesh, uid = get_session_cookie_tokens(metadata_interceptor)
     assert sesh == token
+
+    return res.auth_res.user_id
 
 
 def test_signup(db):
@@ -282,13 +285,13 @@ def test_basic_login(db):
     with session_scope() as session:
         token = (
             session.execute(
-                select(UserSession)
+                select(UserSession.token)
                 .join(User, UserSession.user_id == User.id)
                 .where(User.username == "frodo")
                 .where(UserSession.token == reply_token)
                 .where(UserSession.is_valid)
             ).scalar_one_or_none()
-        ).token
+        )
         assert token
 
     # log out
@@ -383,10 +386,10 @@ def test_banned_user(db):
 
 
 def test_deleted_user(db):
-    _quick_signup()
+    user_id = _quick_signup()
 
     with session_scope() as session:
-        session.execute(select(User)).scalar_one().is_deleted = True
+        session.execute(update(User).where(User.id == user_id).values(is_deleted=True))
 
     with auth_api_session() as (auth_api, metadata_interceptor):
         with pytest.raises(grpc.RpcError) as e:
@@ -416,7 +419,7 @@ def test_password_reset_v2(db, push_collector):
             res = auth_api.ResetPassword(auth_pb2.ResetPasswordReq(user=user.username))
 
     with session_scope() as session:
-        password_reset_token = session.execute(select(PasswordResetToken)).scalar_one().token
+        password_reset_token = session.execute(select(PasswordResetToken.token)).scalar_one()
 
     assert mock.call_count == 1
     e = email_fields(mock)
@@ -467,13 +470,13 @@ def test_password_reset_v2(db, push_collector):
     with session_scope() as session:
         other_session_token = (
             session.execute(
-                select(UserSession)
+                select(UserSession.token)
                 .join(User, UserSession.user_id == User.id)
                 .where(User.username == user.username)
                 .where(UserSession.token == session_token)
                 .where(UserSession.is_valid)
             ).scalar_one_or_none()
-        ).token
+        )
         assert other_session_token
 
     # make sure we can't set a password again
@@ -679,7 +682,7 @@ def test_signup_existing_email(db):
 
     with auth_api_session() as (auth_api, metadata_interceptor):
         with pytest.raises(grpc.RpcError) as e:
-            reply = auth_api.SignupFlow(
+            auth_api.SignupFlow(
                 auth_pb2.SignupFlowReq(basic=auth_pb2.SignupBasic(name="frodo", email=user.email))
             )
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
@@ -690,11 +693,11 @@ def test_signup_banned_user_email(db):
     user, _ = generate_user()
 
     with session_scope() as session:
-        session.execute(select(User)).scalar_one().is_banned = True
+        session.execute(update(User).where(User.id == user.id).values(is_banned=True))
 
     with auth_api_session() as (auth_api, _):
         with pytest.raises(grpc.RpcError) as e:
-            reply = auth_api.SignupFlow(
+            auth_api.SignupFlow(
                 auth_pb2.SignupFlowReq(basic=auth_pb2.SignupBasic(name="NewName", email=user.email))
             )
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
@@ -705,11 +708,11 @@ def test_signup_deleted_user_email(db):
     user, _ = generate_user()
 
     with session_scope() as session:
-        session.execute(select(User)).scalar_one().is_deleted = True
+        session.execute(update(User).where(User.id == user.id).values(is_deleted=True))
 
     with auth_api_session() as (auth_api, _):
         with pytest.raises(grpc.RpcError) as e:
-            reply = auth_api.SignupFlow(
+            auth_api.SignupFlow(
                 auth_pb2.SignupFlowReq(basic=auth_pb2.SignupBasic(name="NewName", email=user.email))
             )
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
@@ -859,7 +862,7 @@ def test_complete_signup(db):
     with auth_api_session() as (auth_api, metadata_interceptor):
         # Invalid username
         with pytest.raises(grpc.RpcError) as e:
-            reply = auth_api.SignupFlow(
+            auth_api.SignupFlow(
                 auth_pb2.SignupFlowReq(
                     flow_token=flow_token,
                     account=auth_pb2.SignupAccount(
@@ -882,7 +885,7 @@ def test_complete_signup(db):
     with auth_api_session() as (auth_api, metadata_interceptor):
         # Invalid name
         with pytest.raises(grpc.RpcError) as e:
-            reply = auth_api.SignupFlow(
+            auth_api.SignupFlow(
                 auth_pb2.SignupFlowReq(
                     basic=auth_pb2.SignupBasic(name=" ", email=f"{random_hex(12)}@couchers.org.invalid")
                 )
@@ -893,7 +896,7 @@ def test_complete_signup(db):
     with auth_api_session() as (auth_api, metadata_interceptor):
         # Hosting status required
         with pytest.raises(grpc.RpcError) as e:
-            reply = auth_api.SignupFlow(
+            auth_api.SignupFlow(
                 auth_pb2.SignupFlowReq(
                     flow_token=flow_token,
                     account=auth_pb2.SignupAccount(
@@ -917,7 +920,7 @@ def test_complete_signup(db):
     with auth_api_session() as (auth_api, metadata_interceptor):
         # Username unavailable
         with pytest.raises(grpc.RpcError) as e:
-            reply = auth_api.SignupFlow(
+            auth_api.SignupFlow(
                 auth_pb2.SignupFlowReq(
                     flow_token=flow_token,
                     account=auth_pb2.SignupAccount(
@@ -940,7 +943,7 @@ def test_complete_signup(db):
     with auth_api_session() as (auth_api, metadata_interceptor):
         # Invalid coordinate
         with pytest.raises(grpc.RpcError) as e:
-            reply = auth_api.SignupFlow(
+            auth_api.SignupFlow(
                 auth_pb2.SignupFlowReq(
                     flow_token=flow_token,
                     account=auth_pb2.SignupAccount(
@@ -980,11 +983,11 @@ def test_signup_token_regression(db):
     # 2. Confirm the email
     with session_scope() as session:
         email_token = (
-            session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one().email_token
+            session.execute(select(SignupFlow.email_token).where(SignupFlow.flow_token == flow_token)).scalar_one()
         )
 
     with auth_api_session() as (auth_api, metadata_interceptor):
-        res = auth_api.SignupFlow(
+        auth_api.SignupFlow(
             auth_pb2.SignupFlowReq(
                 flow_token=flow_token,
                 email_token=email_token,
@@ -994,7 +997,7 @@ def test_signup_token_regression(db):
     # 3. Start a new signup with the same email
     with auth_api_session() as (auth_api, metadata_interceptor):
         with pytest.raises(grpc.RpcError) as e:
-            res = auth_api.SignupFlow(
+            auth_api.SignupFlow(
                 auth_pb2.SignupFlowReq(basic=auth_pb2.SignupBasic(name="frodo", email=testing_email))
             )
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
@@ -1027,7 +1030,7 @@ def test_opt_out_of_newsletter(db, opt_out):
 
     with session_scope() as session:
         email_token = (
-            session.execute(select(SignupFlow).where(SignupFlow.flow_token == res.flow_token)).scalar_one().email_token
+            session.execute(select(SignupFlow.email_token).where(SignupFlow.flow_token == res.flow_token)).scalar_one()
         )
 
     with auth_api_session() as (auth_api, metadata_interceptor):
@@ -1128,9 +1131,9 @@ def test_signup_no_feedback_regression(db):
     with session_scope() as session:
         token = (
             session.execute(
-                select(UserSession).join(User, UserSession.user_id == User.id).where(User.username == "frodo")
+                select(UserSession.token).join(User, UserSession.user_id == User.id).where(User.username == "frodo")
             ).scalar_one()
-        ).token
+        )
     sesh, uid = get_session_cookie_tokens(metadata_interceptor)
     assert sesh == token
 
@@ -1147,7 +1150,7 @@ def test_banned_username(db):
     with auth_api_session() as (auth_api, metadata_interceptor):
         # Banned username
         with pytest.raises(grpc.RpcError) as e:
-            reply = auth_api.SignupFlow(
+            auth_api.SignupFlow(
                 auth_pb2.SignupFlowReq(
                     flow_token=flow_token,
                     account=auth_pb2.SignupAccount(
@@ -1184,12 +1187,10 @@ def test_GetInviteCodeInfo(db):
         session.add(avatar)
         session.flush()
 
-        db_user = session.execute(select(User).where(User.id == user.id)).scalar_one()
-        db_user.avatar_key = avatar.key
+        session.execute(update(User).where(User.id == user.id).values(avatar_key=avatar.key))
 
         code = InviteCode(id=code_id, creator_user_id=user.id)
         session.add(code)
-        session.commit()
 
     with auth_api_session() as (auth, _):
         res = auth.GetInviteCodeInfo(auth_pb2.GetInviteCodeInfoReq(code=code_id))
@@ -1204,12 +1205,10 @@ def test_GetInviteCodeInfo_no_avatar(db):
     code_id = "NOAVTR1"
 
     with session_scope() as session:
-        db_user = session.execute(select(User).where(User.id == user.id)).scalar_one()
-        db_user.avatar_key = None
+        session.execute(update(User).where(User.id == user.id).values(avatar_key=None))
 
         code = InviteCode(id="NOAVTR1", creator_user_id=user.id)
         session.add(code)
-        session.commit()
 
     with auth_api_session() as (auth, _):
         res = auth.GetInviteCodeInfo(auth_pb2.GetInviteCodeInfoReq(code=code_id))
@@ -1220,7 +1219,7 @@ def test_GetInviteCodeInfo_no_avatar(db):
 
 
 def test_GetInviteCodeInfo_not_found(db):
-    user, token = generate_user()
+    generate_user()
 
     with auth_api_session() as (auth, _):
         with pytest.raises(grpc.RpcError) as e:
@@ -1236,7 +1235,6 @@ def test_SignupFlow_invite_code(db):
         session.flush()
         invite = InviteCode(id=invite_code, creator_user_id=user.id)
         session.add(invite)
-        session.commit()
 
     with auth_api_session() as (auth_api, _):
         # Signup basic step with invite code
@@ -1255,7 +1253,7 @@ def test_SignupFlow_invite_code(db):
         # Confirm email
         with session_scope() as session:
             email_token = (
-                session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one().email_token
+                session.execute(select(SignupFlow.email_token).where(SignupFlow.flow_token == flow_token)).scalar_one()
             )
 
         auth_api.SignupFlow(auth_pb2.SignupFlowReq(email_token=email_token))
@@ -1280,8 +1278,6 @@ def test_SignupFlow_invite_code(db):
                 accept_community_guidelines=wrappers_pb2.BoolValue(value=True),
             )
         )
-    with session_scope() as session:
-        users = session.execute(select(User)).scalars().all()
 
     # Check that invite_code_id is stored in the final User object
     with session_scope() as session:

--- a/app/backend/src/tests/test_donations.py
+++ b/app/backend/src/tests/test_donations.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 
 import pytest
 from google.protobuf import empty_pb2
-from sqlalchemy import update
 
 import couchers.servicers.donations
 from couchers.config import config

--- a/app/backend/src/tests/test_donations.py
+++ b/app/backend/src/tests/test_donations.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 from google.protobuf import empty_pb2
+from sqlalchemy import update
 
 import couchers.servicers.donations
 from couchers.config import config
@@ -118,9 +119,8 @@ def test_one_time_donation_flow(db, monkeypatch):
     update_badges(empty_pb2.Empty())
     with session_scope() as session:
         assert (
-            session.execute(select(UserBadge).where(UserBadge.user_id == user_id, UserBadge.badge_id == "donor"))
+            session.execute(select(UserBadge.user_id).where(UserBadge.user_id == user_id, UserBadge.badge_id == "donor"))
             .scalar_one()
-            .user_id
             == user_id
         )
 
@@ -243,9 +243,8 @@ def test_recurring_donation_flow(db, monkeypatch):
     update_badges(empty_pb2.Empty())
     with session_scope() as session:
         assert (
-            session.execute(select(UserBadge).where(UserBadge.user_id == user_id, UserBadge.badge_id == "donor"))
+            session.execute(select(UserBadge.user_id).where(UserBadge.user_id == user_id, UserBadge.badge_id == "donor"))
             .scalar_one()
-            .user_id
             == user_id
         )
 

--- a/app/backend/src/tests/test_donations.py
+++ b/app/backend/src/tests/test_donations.py
@@ -119,8 +119,9 @@ def test_one_time_donation_flow(db, monkeypatch):
     update_badges(empty_pb2.Empty())
     with session_scope() as session:
         assert (
-            session.execute(select(UserBadge.user_id).where(UserBadge.user_id == user_id, UserBadge.badge_id == "donor"))
-            .scalar_one()
+            session.execute(
+                select(UserBadge.user_id).where(UserBadge.user_id == user_id, UserBadge.badge_id == "donor")
+            ).scalar_one()
             == user_id
         )
 
@@ -243,8 +244,9 @@ def test_recurring_donation_flow(db, monkeypatch):
     update_badges(empty_pb2.Empty())
     with session_scope() as session:
         assert (
-            session.execute(select(UserBadge.user_id).where(UserBadge.user_id == user_id, UserBadge.badge_id == "donor"))
-            .scalar_one()
+            session.execute(
+                select(UserBadge.user_id).where(UserBadge.user_id == user_id, UserBadge.badge_id == "donor")
+            ).scalar_one()
             == user_id
         )
 

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from sqlalchemy import update
 
 import couchers.email
 import couchers.jobs.handlers
@@ -446,8 +447,8 @@ def test_email_deleted_users_regression(db):
         assert res.requests[0].approx_users_to_notify == 5
 
     with session_scope() as session:
-        session.execute(select(User).where(User.id == ban_user.id)).scalar_one().is_banned = True
-        session.execute(select(User).where(User.id == delete_user.id)).scalar_one().is_deleted = True
+        session.execute(update(User).where(User.id == ban_user.id).values(is_banned=True))
+        session.execute(update(User).where(User.id == delete_user.id).values(is_deleted=True))
 
     with real_admin_session(super_token) as admin:
         res = admin.ListEventCommunityInviteRequests(admin_pb2.ListEventCommunityInviteRequestsReq())

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -376,8 +376,6 @@ def generate_user(
             session.add(LanguageAbility(user_id=user.id, language_code=lang, fluency=fluency))
 
         # this expires the user, so now it's "dirty"
-        session.commit()
-
         token, _ = create_session(_MockCouchersContext(), session, user, False, set_cookie=False)
 
         # deleted user aborts session creation, hence this follows and necessitates a second commit

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -1,12 +1,12 @@
 import os
 import re
-from collections.abc import Generator
+from collections.abc import Generator, Sequence
 from concurrent import futures
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import date, timedelta
 from pathlib import Path
-from typing import Sequence, Any
+from typing import Any
 from unittest.mock import patch
 
 import grpc
@@ -315,7 +315,10 @@ class _MockCouchersContext:
 
 
 def generate_user(
-    *, delete_user=False, complete_profile=True, strong_verification=False,
+    *,
+    delete_user=False,
+    complete_profile=True,
+    strong_verification=False,
     regions_visited: Sequence[str] = (),
     regions_lived: Sequence[str] = (),
     language_abilities: Sequence[tuple[str, LanguageFluency]] = (),
@@ -663,7 +666,7 @@ class FakeRpcError(grpc.RpcError):
         return self._details
 
 
-def _check_user_perms(method, user_id, is_jailed, is_superuser, token_expiry):
+def _check_user_perms(method: str, user_id: int, is_jailed: bool, is_superuser: bool) -> None:
     # method is of the form "/org.couchers.api.core.API/GetUser"
     _, service_name, method_name = method.split("/")
 
@@ -726,20 +729,21 @@ class FakeChannel:
     def unary_unary(self, uri, request_serializer, response_deserializer):
         handler = self.handlers[uri]
 
-        user_id = None
-        is_jailed = None
-        is_superuser = None
-        token_expiry = None
-        ui_language_preference = None
-
-        if self._token:
-            user_id, is_jailed, is_superuser, token_expiry, ui_language_preference = _try_get_and_update_user_details(
-                self._token, is_api_key=False, ip_address="127.0.0.1", user_agent="Testing User-Agent"
-            )
-
-        _check_user_perms(uri, user_id, is_jailed, is_superuser, token_expiry)
-
         def fake_handler(request):
+            if self._token:
+                user_id, is_jailed, is_superuser, token_expiry, ui_language_preference = (
+                    _try_get_and_update_user_details(
+                        self._token, is_api_key=False, ip_address="127.0.0.1", user_agent="Testing User-Agent"
+                    )
+                )
+            else:
+                user_id = None
+                is_jailed = None
+                is_superuser = None
+                ui_language_preference = None
+
+            _check_user_perms(uri, user_id, is_jailed, is_superuser)
+
             # Do a full serialization cycle on the request and the
             # response to catch accidental use of unserializable data.
             request = handler.request_deserializer(request_serializer(request))

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 import grpc
 import pytest
 from grpc._server import _validate_generic_rpc_handlers
-from sqlalchemy import Connection, Engine, create_engine
+from sqlalchemy import Connection, Engine, create_engine, update
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import or_, text
 
@@ -459,12 +459,11 @@ def make_user_block(user1: User, user2: User) -> None:
             blocked_user_id=user2.id,
         )
         session.add(user_block)
-        session.commit()
 
 
 def make_user_invisible(user_id: int) -> None:
     with session_scope() as session:
-        session.execute(select(User).where(User.id == user_id)).scalar_one().is_banned = True
+        session.execute(update(User).where(User.id == user_id).values(is_banned=True))
 
 
 # This doubles as get_FriendRequest, since a friend request is just a pending friend relationship

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import date, timedelta
 from pathlib import Path
+from typing import Sequence, Any
 from unittest.mock import patch
 
 import grpc
@@ -307,7 +308,13 @@ def db_class(template_db: str, postgres_conn: Connection) -> None:
     postgres_conn.execute(text(f"CREATE DATABASE testdb WITH TEMPLATE {template_db}"))
 
 
-def generate_user(*, delete_user=False, complete_profile=True, strong_verification=False, **kwargs):
+def generate_user(
+    *, delete_user=False, complete_profile=True, strong_verification=False,
+    regions_visited: Sequence[str] = (),
+    regions_lived: Sequence[str] = (),
+    language_abilities: Sequence[tuple[str, LanguageFluency]] = (),
+    **kwargs: Any,
+) -> tuple[User, str]:
     """
     Create a new user, return session token
 
@@ -349,25 +356,20 @@ def generate_user(*, delete_user=False, complete_profile=True, strong_verificati
             "onboarding_emails_sent": 1,
             "last_onboarding_email_sent": now(),
             "last_donated": now(),
-        }
-
-        for key, value in kwargs.items():
-            user_opts[key] = value
+        } | kwargs
 
         user = User(**user_opts)
         session.add(user)
         session.flush()
 
-        session.add(RegionVisited(user_id=user.id, region_code="CHE"))
-        session.add(RegionVisited(user_id=user.id, region_code="REU"))
-        session.add(RegionVisited(user_id=user.id, region_code="FIN"))
+        for region in regions_visited:
+            session.add(RegionVisited(user_id=user.id, region_code=region))
 
-        session.add(RegionLived(user_id=user.id, region_code="ESP"))
-        session.add(RegionLived(user_id=user.id, region_code="FRA"))
-        session.add(RegionLived(user_id=user.id, region_code="EST"))
+        for region in regions_lived:
+            session.add(RegionLived(user_id=user.id, region_code=region))
 
-        session.add(LanguageAbility(user_id=user.id, language_code="fin", fluency=LanguageFluency.fluent))
-        session.add(LanguageAbility(user_id=user.id, language_code="fra", fluency=LanguageFluency.beginner))
+        for lang, fluency in language_abilities:
+            session.add(LanguageAbility(user_id=user.id, language_code=lang, fluency=fluency))
 
         # this expires the user, so now it's "dirty"
         session.commit()

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -308,6 +308,12 @@ def db_class(template_db: str, postgres_conn: Connection) -> None:
     postgres_conn.execute(text(f"CREATE DATABASE testdb WITH TEMPLATE {template_db}"))
 
 
+class _MockCouchersContext:
+    @property
+    def headers(self):
+        return {}
+
+
 def generate_user(
     *, delete_user=False, complete_profile=True, strong_verification=False,
     regions_visited: Sequence[str] = (),
@@ -322,8 +328,6 @@ def generate_user(
 
     Use this most of the time
     """
-    auth = Auth()
-
     with session_scope() as session:
         # default args
         username = "test_user_" + random_hex(16)
@@ -373,11 +377,6 @@ def generate_user(
 
         # this expires the user, so now it's "dirty"
         session.commit()
-
-        class _MockCouchersContext:
-            @property
-            def headers(self):
-                return {}
 
         token, _ = create_session(_MockCouchersContext(), session, user, False, set_cookie=False)
 
@@ -510,6 +509,17 @@ class CookieMetadataPlugin(grpc.AuthMetadataPlugin):
         callback((("cookie", f"couchers-sesh={self.token}"),), None)
 
 
+class _MetadataKeeperInterceptor(grpc.UnaryUnaryClientInterceptor):
+    def __init__(self):
+        self.latest_headers = {}
+
+    def intercept_unary_unary(self, continuation, client_call_details, request):
+        call = continuation(client_call_details, request)
+        self.latest_headers = dict(call.initial_metadata())
+        self.latest_header_raw = call.initial_metadata()
+        return call
+
+
 @contextmanager
 def auth_api_session(
     grpc_channel_options=(),
@@ -529,17 +539,6 @@ def auth_api_session(
             with grpc.secure_channel(
                 f"localhost:{port}", grpc.local_channel_credentials(), options=grpc_channel_options
             ) as channel:
-
-                class _MetadataKeeperInterceptor(grpc.UnaryUnaryClientInterceptor):
-                    def __init__(self):
-                        self.latest_headers = {}
-
-                    def intercept_unary_unary(self, continuation, client_call_details, request):
-                        call = continuation(client_call_details, request)
-                        self.latest_headers = dict(call.initial_metadata())
-                        self.latest_header_raw = call.initial_metadata()
-                        return call
-
                 metadata_interceptor = _MetadataKeeperInterceptor()
                 channel = grpc.intercept_channel(channel, metadata_interceptor)
                 yield auth_pb2_grpc.AuthStub(channel), metadata_interceptor
@@ -1109,56 +1108,57 @@ def email_fields(mock, call_ix=0):
     )
 
 
+class Push:
+    """
+    This allows nice access to the push info via e.g. push.title instead of push["title"]
+    """
+
+    def __init__(self, kwargs):
+        self.kwargs = kwargs
+
+    def __getattr__(self, attr):
+        try:
+            return self.kwargs[attr]
+        except KeyError:
+            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{attr}'") from None
+
+    def __repr__(self):
+        kwargs_disp = ", ".join(f"'{key}'='{val}'" for key, val in self.kwargs.items())
+        return f"Push({kwargs_disp})"
+
+
+class PushCollector:
+    def __init__(self):
+        # pairs of (user_id, push)
+        self.pushes = []
+
+    def by_user(self, user_id):
+        return [kwargs for uid, kwargs in self.pushes if uid == user_id]
+
+    def push_to_user(self, session, user_id, **kwargs):
+        self.pushes.append((user_id, Push(kwargs=kwargs)))
+
+    def assert_user_has_count(self, user_id, count):
+        assert len(self.by_user(user_id)) == count
+
+    def assert_user_push_matches_fields(self, user_id, ix=0, **kwargs):
+        push = self.by_user(user_id)[ix]
+        for kwarg in kwargs:
+            assert kwarg in push.kwargs, f"Push notification {user_id=}, {ix=} missing field '{kwarg}'"
+            assert push.kwargs[kwarg] == kwargs[kwarg], (
+                f"Push notification {user_id=}, {ix=} mismatch in field '{kwarg}', expected '{kwargs[kwarg]}' but got '{push.kwargs[kwarg]}'"
+            )
+
+    def assert_user_has_single_matching(self, user_id, **kwargs):
+        self.assert_user_has_count(user_id, 1)
+        self.assert_user_push_matches_fields(user_id, ix=0, **kwargs)
+
+
 @pytest.fixture
 def push_collector():
     """
     See test_SendTestPushNotification for an example on how to use this fixture
     """
-
-    class Push:
-        """
-        This allows nice access to the push info via e.g. push.title instead of push["title"]
-        """
-
-        def __init__(self, kwargs):
-            self.kwargs = kwargs
-
-        def __getattr__(self, attr):
-            try:
-                return self.kwargs[attr]
-            except KeyError:
-                raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{attr}'") from None
-
-        def __repr__(self):
-            kwargs_disp = ", ".join(f"'{key}'='{val}'" for key, val in self.kwargs.items())
-            return f"Push({kwargs_disp})"
-
-    class PushCollector:
-        def __init__(self):
-            # pairs of (user_id, push)
-            self.pushes = []
-
-        def by_user(self, user_id):
-            return [kwargs for uid, kwargs in self.pushes if uid == user_id]
-
-        def push_to_user(self, session, user_id, **kwargs):
-            self.pushes.append((user_id, Push(kwargs=kwargs)))
-
-        def assert_user_has_count(self, user_id, count):
-            assert len(self.by_user(user_id)) == count
-
-        def assert_user_push_matches_fields(self, user_id, ix=0, **kwargs):
-            push = self.by_user(user_id)[ix]
-            for kwarg in kwargs:
-                assert kwarg in push.kwargs, f"Push notification {user_id=}, {ix=} missing field '{kwarg}'"
-                assert push.kwargs[kwarg] == kwargs[kwarg], (
-                    f"Push notification {user_id=}, {ix=} mismatch in field '{kwarg}', expected '{kwargs[kwarg]}' but got '{push.kwargs[kwarg]}'"
-                )
-
-        def assert_user_has_single_matching(self, user_id, **kwargs):
-            self.assert_user_has_count(user_id, 1)
-            self.assert_user_push_matches_fields(user_id, ix=0, **kwargs)
-
     collector = PushCollector()
 
     with patch("couchers.notifications.push._push_to_user", collector.push_to_user):

--- a/app/backend/src/tests/test_model_constraints.py
+++ b/app/backend/src/tests/test_model_constraints.py
@@ -187,5 +187,4 @@ def test_activeness_probes_cant_have_multiple(db):
     with pytest.raises(IntegrityError) as e:
         with session_scope() as session:
             session.add(ActivenessProbe(user_id=user.id))
-            session.commit()
     assert "violates unique constraint" in str(e.value)

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 import grpc
 import pytest
 from google.protobuf import empty_pb2
+from sqlalchemy import update
+from sqlalchemy.orm import Session
 
 from couchers.db import session_scope
 from couchers.materialized_views import refresh_materialized_views_rapid
@@ -183,7 +185,7 @@ def create_host_reference(session, from_user_id, to_user_id, reference_age, *, s
     return reference.id, actual_host_request_id
 
 
-def create_friend_reference(session, from_user_id, to_user_id, reference_age):
+def create_friend_reference(session: Session, from_user_id: int, to_user_id: int, reference_age: timedelta) -> int:
     reference = Reference(
         time=now() - reference_age,
         from_user_id=from_user_id,
@@ -380,9 +382,7 @@ def test_ListReference_banned_deleted_users(db):
 
     # ban user2
     with session_scope() as session:
-        user2 = session.execute(select(User).where(User.username == user2.username)).scalar_one()
-        user2.is_banned = True
-        session.commit()
+        session.execute(update(User).where(User.username == user2.username).values(is_banned=True))
 
     # reference to and from banned user is hidden
     with references_session(token1) as api:
@@ -393,9 +393,7 @@ def test_ListReference_banned_deleted_users(db):
 
     # delete user3
     with session_scope() as session:
-        user3 = session.execute(select(User).where(User.username == user3.username)).scalar_one()
-        user3.is_deleted = True
-        session.commit()
+        session.execute(update(User).where(User.username == user3.username).values(is_deleted=True))
 
     # doesn't change; references to and from deleted users remain
     with references_session(token1) as api:

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -118,14 +118,6 @@ def create_host_request_by_date(
         )
     )
 
-    message = Message(
-        time=from_date + timedelta(seconds=2),
-        conversation_id=conversation.id,
-        author_id=surfer_user_id,
-        text="Hi, I'm requesting to be hosted.",
-        message_type=MessageType.text,
-    )
-
     host_request = HostRequest(
         conversation_id=conversation.id,
         surfer_user_id=surfer_user_id,

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -118,6 +118,15 @@ def create_host_request_by_date(
         )
     )
 
+    # Unused for now, but every host request must have a message.
+    message = Message(
+        time=from_date + timedelta(seconds=2),
+        conversation_id=conversation.id,
+        author_id=surfer_user_id,
+        text="Hi, I'm requesting to be hosted.",
+        message_type=MessageType.text,
+    )
+
     host_request = HostRequest(
         conversation_id=conversation.id,
         surfer_user_id=surfer_user_id,

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 import grpc
 import pytest
 from google.protobuf import empty_pb2
+from sqlalchemy import update
 from sqlalchemy.sql import or_
 
 import couchers.jobs.handlers
@@ -318,8 +319,7 @@ def test_strong_verification_happy_path(db, monkeypatch):
 
     # wrong dob = no badge
     with session_scope() as session:
-        user_ = session.execute(select(User).where(User.id == user.id)).scalar_one()
-        user_.birthdate = date(1988, 1, 2)
+        session.execute(update(User).where(User.id == user.id).values(birthdate=date(1988, 1, 2)))
 
     update_badges(empty_pb2.Empty())
     refresh_materialized_views_rapid(None)
@@ -337,9 +337,7 @@ def test_strong_verification_happy_path(db, monkeypatch):
 
     # bad gender-sex correspondence = no badge
     with session_scope() as session:
-        user_ = session.execute(select(User).where(User.id == user.id)).scalar_one()
-        user_.birthdate = date(1988, 1, 1)
-        user_.gender = "Woman"
+        session.execute(update(User).where(User.id == user.id).values(birthdate=date(1988, 1, 1), gender="Woman"))
 
     update_badges(empty_pb2.Empty())
     refresh_materialized_views_rapid(None)
@@ -363,8 +361,7 @@ def test_strong_verification_happy_path(db, monkeypatch):
 
     # back to should have a badge
     with session_scope() as session:
-        user_ = session.execute(select(User).where(User.id == user.id)).scalar_one()
-        user_.gender = "Man"
+        session.execute(update(User).where(User.id == user.id).values(gender="Man"))
 
     update_badges(empty_pb2.Empty())
     refresh_materialized_views_rapid(None)

--- a/app/backend/src/tests/test_threads.py
+++ b/app/backend/src/tests/test_threads.py
@@ -1,4 +1,5 @@
 import string
+import textwrap
 
 import grpc
 import pytest
@@ -118,7 +119,6 @@ def pagination_test(api, parent_id):
 
     # Get it with pagination
     token = ""
-    import textwrap
 
     for expected_page in textwrap.wrap(string.ascii_lowercase, 5):
         ret = api.GetThread(threads_pb2.GetThreadReq(thread_id=parent_id, page_size=5, page_token=token))

--- a/app/backend/src/tests/test_utils.py
+++ b/app/backend/src/tests/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+from sqlalchemy import update
 from sqlalchemy.sql import func
 
 from couchers.db import session_scope
@@ -19,12 +20,11 @@ def test_page_token_time_python():
 
 
 def test_page_token_time_db(db):
-    generate_user()
+    user, _ = generate_user()
 
     # generate a timestamp in postgres (note use of `func`)
     with session_scope() as session:
-        user = session.execute(select(User)).scalar_one()
-        user.joined = func.now()
+        session.execute(update(User).where(User.id == user.id).values(joined=func.now()))
 
     with session_scope() as session:
         # pull it back into python
@@ -124,7 +124,6 @@ def test_wrap_coordinate():
         ((45, 90), (45, 90)),
     ]
 
-    with session_scope() as session:
-        for coords, coords_expected in test_coords:
-            coords_wrapped = wrap_coordinate(*coords)
-            assert coords_expected == coords_wrapped
+    for coords, coords_expected in test_coords:
+        coords_wrapped = wrap_coordinate(*coords)
+        assert coords_expected == coords_wrapped

--- a/app/backend/src/tests/test_verification.py
+++ b/app/backend/src/tests/test_verification.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 import grpc
 import pytest
 from google.protobuf import empty_pb2
+from sqlalchemy import update
 
 import couchers.phone.sms
 from couchers.config import config
@@ -122,31 +123,31 @@ def test_ChangePhone_ratelimit(db, monkeypatch):
 
 def test_VerifyPhone(push_collector):
     user, token = generate_user()
-    user_id = user.id
     with account_session(token) as account, api_session(token) as api:
         with pytest.raises(grpc.RpcError) as e:
             account.VerifyPhone(account_pb2.VerifyPhoneReq(token="123455"))
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
 
-        res = api.GetUser(api_pb2.GetUserReq(user=str(user_id)))
+        res = api.GetUser(api_pb2.GetUserReq(user=str(user.id)))
         assert res.verification == 0.0
 
         with session_scope() as session:
-            user = session.execute(select(User).where(User.id == user_id)).scalar_one()
-            user.phone = "+46701740605"
-            user.phone_verification_token = "111112"
-            user.phone_verification_sent = now()
+            session.execute(
+                update(User)
+                .where(User.id == user.id)
+                .values(phone_verification_token="111112", phone_verification_sent=now(), phone="+46701740605")
+            )
 
         account.VerifyPhone(account_pb2.VerifyPhoneReq(token="111112"))
 
         process_jobs()
         push_collector.assert_user_has_single_matching(
-            user_id,
+            user.id,
             title="Phone successfully verified",
             body="Your phone was successfully verified as +46 70 174 06 05 on Couchers.org.",
         )
 
-        res = api.GetUser(api_pb2.GetUserReq(user=str(user_id)))
+        res = api.GetUser(api_pb2.GetUserReq(user=str(user.id)))
         assert res.verification == 1.0
 
         # Phone number should finally show up on in your profile settings
@@ -156,13 +157,13 @@ def test_VerifyPhone(push_collector):
 
 def test_VerifyPhone_antibrute():
     user, token = generate_user()
-    user_id = user.id
-    with account_session(token) as account, api_session(token) as api:
+    with account_session(token) as account:
         with session_scope() as session:
-            user = session.execute(select(User).where(User.id == user_id)).scalar_one()
-            user.phone_verification_token = "111112"
-            user.phone_verification_sent = now()
-            user.phone = "+46701740605"
+            session.execute(
+                update(User)
+                .where(User.id == user.id)
+                .values(phone_verification_token="111112", phone_verification_sent=now(), phone="+46701740605")
+            )
 
         for _ in range(10):
             with pytest.raises(grpc.RpcError) as e:
@@ -184,8 +185,7 @@ def test_phone_uniqueness(monkeypatch):
 
         account1.ChangePhone(account_pb2.ChangePhoneReq(phone="+46701740605"))
         with session_scope() as session:
-            user = session.execute(select(User).where(User.id == user1.id)).scalar_one()
-            token = user.phone_verification_token
+            token = session.execute(select(User.phone_verification_token).where(User.id == user1.id)).scalar_one()
         account1.VerifyPhone(account_pb2.VerifyPhoneReq(token=token))
         res = account1.GetAccountInfo(empty_pb2.Empty())
         assert res.phone == "+46701740605"
@@ -204,8 +204,7 @@ def test_phone_uniqueness(monkeypatch):
         assert not res.phone_verified
 
         with session_scope() as session:
-            user = session.execute(select(User).where(User.id == user2.id)).scalar_one()
-            token = user.phone_verification_token
+            token = session.execute(select(User.phone_verification_token).where(User.id == user2.id)).scalar_one()
         account2.VerifyPhone(account_pb2.VerifyPhoneReq(token=token))
 
         # number gets wiped when it's stolen

--- a/app/backend/src/tests/test_visible_users.py
+++ b/app/backend/src/tests/test_visible_users.py
@@ -1,5 +1,7 @@
+from sqlalchemy import update
 from sqlalchemy.sql import func
 
+from couchers.db import session_scope
 from couchers.models import FriendRelationship, User
 from couchers.sql import couchers_select as select
 from tests.test_fixtures import (  # noqa
@@ -8,7 +10,6 @@ from tests.test_fixtures import (  # noqa
     make_friends,
     make_user_block,
     make_user_invisible,
-    session_scope,
 )
 
 
@@ -26,13 +27,13 @@ def test_is_visible_property(db):
     user5, token5 = generate_user(delete_user=True)
 
     with session_scope() as session:
-        session.execute(select(User).where(User.id == user2.id)).scalar_one().is_banned = True
-        session.execute(select(User).where(User.id == user3.id)).scalar_one().is_deleted = True
+        session.execute(update(User).where(User.id == user2.id).values(is_banned=True))
+        session.execute(update(User).where(User.id == user3.id).values(is_deleted=True))
+        session.execute(update(User).where(User.id == user4.id).values(is_banned=True))
 
-        make_user_invisible(user4.id)
+        visible_users = session.execute(select(User.id).where(User.is_visible)).scalars().all()
 
-        visible_users = session.execute(select(User).where(User.is_visible)).scalars().all()
-        assert len(visible_users) == 1
+        assert visible_users[0] == user1.id
 
 
 def test_select_dot_where_users_visible(db):


### PR DESCRIPTION
A bunch of small speedups for tests:

- Don't add regions and languages to users unless needed (actually needed by 2 tests)
- Move class creating out of frequently called functions (the speedup is tiny, but why not have it)
- Remove superfluous commits (session.commit() just before session_scope closes)
- Don't pull data unnecessarily from the db in tests (`update(User).where(...).values(is_deleted=True)` instead of `user = select(User); user.is_deleted = True`

This all saves around 5s on my machine.
