### PR TITLE
Pass user_id instead of the whole context to CouchersSelect methods

### DIFF
--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -140,8 +140,8 @@ def are_friends(session: Session, context: CouchersContext, other_user: int) -> 
     return (
         session.execute(
             select(FriendRelationship)
-            .where_users_column_visible(context, FriendRelationship.from_user_id)
-            .where_users_column_visible(context, FriendRelationship.to_user_id)
+            .where_users_column_visible(context.user_id, FriendRelationship.from_user_id)
+            .where_users_column_visible(context.user_id, FriendRelationship.to_user_id)
             .where(
                 or_(
                     and_(

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -732,7 +732,7 @@ class Account(account_pb2_grpc.AccountServicer):
         pending_host_requests = session.execute(
             select(HostRequest.conversation_id, LiteUser)
             .join(LiteUser, LiteUser.id == HostRequest.surfer_user_id)
-            .where_users_column_visible(context, HostRequest.surfer_user_id)
+            .where_users_column_visible(context.user_id, HostRequest.surfer_user_id)
             .where(HostRequest.host_user_id == context.user_id)
             .where(HostRequest.status == HostRequestStatus.pending)
             .where(HostRequest.start_time > func.now())

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -161,7 +161,7 @@ class API(api_pb2_grpc.APIServicer):
         sent_reqs_last_seen_message_ids = (
             select(HostRequest.conversation_id, HostRequest.surfer_last_seen_message_id)
             .where(HostRequest.surfer_user_id == context.user_id)
-            .where_users_column_visible(context, HostRequest.host_user_id)
+            .where_users_column_visible(context.user_id, HostRequest.host_user_id)
         ).subquery()
 
         unseen_sent_host_request_count = session.execute(
@@ -177,7 +177,7 @@ class API(api_pb2_grpc.APIServicer):
         received_reqs_last_seen_message_ids = (
             select(HostRequest.conversation_id, HostRequest.host_last_seen_message_id)
             .where(HostRequest.host_user_id == context.user_id)
-            .where_users_column_visible(context, HostRequest.surfer_user_id)
+            .where_users_column_visible(context.user_id, HostRequest.surfer_user_id)
         ).subquery()
 
         unseen_received_host_request_count = session.execute(
@@ -202,7 +202,7 @@ class API(api_pb2_grpc.APIServicer):
         pending_friend_request_count = session.execute(
             select(func.count(FriendRelationship.id))
             .where(FriendRelationship.to_user_id == context.user_id)
-            .where_users_column_visible(context, FriendRelationship.from_user_id)
+            .where_users_column_visible(context.user_id, FriendRelationship.from_user_id)
             .where(FriendRelationship.status == FriendStatus.pending)
         ).scalar_one()
 
@@ -549,8 +549,8 @@ class API(api_pb2_grpc.APIServicer):
         rels = (
             session.execute(
                 select(FriendRelationship)
-                .where_users_column_visible(context, FriendRelationship.from_user_id)
-                .where_users_column_visible(context, FriendRelationship.to_user_id)
+                .where_users_column_visible(context.user_id, FriendRelationship.from_user_id)
+                .where_users_column_visible(context.user_id, FriendRelationship.to_user_id)
                 .where(
                     or_(
                         FriendRelationship.from_user_id == context.user_id,
@@ -569,8 +569,8 @@ class API(api_pb2_grpc.APIServicer):
     def RemoveFriend(self, request, context, session):
         rel = session.execute(
             select(FriendRelationship)
-            .where_users_column_visible(context, FriendRelationship.from_user_id)
-            .where_users_column_visible(context, FriendRelationship.to_user_id)
+            .where_users_column_visible(context.user_id, FriendRelationship.from_user_id)
+            .where_users_column_visible(context.user_id, FriendRelationship.to_user_id)
             .where(
                 or_(
                     and_(
@@ -598,7 +598,7 @@ class API(api_pb2_grpc.APIServicer):
             return api_pb2.ListMutualFriendsRes(mutual_friends=[])
 
         user = session.execute(
-            select(User).where_users_visible(context).where(User.id == request.user_id)
+            select(User).where_users_visible(context.user_id).where(User.id == request.user_id)
         ).scalar_one_or_none()
 
         if not user:
@@ -635,7 +635,9 @@ class API(api_pb2_grpc.APIServicer):
         mutual = select(intersect(union(q1, q2), union(q3, q4)).subquery())
 
         mutual_friends = (
-            session.execute(select(User).where_users_visible(context).where(User.id.in_(mutual))).scalars().all()
+            session.execute(select(User).where_users_visible(context.user_id).where(User.id.in_(mutual)))
+            .scalars()
+            .all()
         )
 
         return api_pb2.ListMutualFriendsRes(
@@ -651,7 +653,7 @@ class API(api_pb2_grpc.APIServicer):
 
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
         to_user = session.execute(
-            select(User).where_users_visible(context).where(User.id == request.user_id)
+            select(User).where_users_visible(context.user_id).where(User.id == request.user_id)
         ).scalar_one_or_none()
 
         if not to_user:
@@ -716,7 +718,7 @@ class API(api_pb2_grpc.APIServicer):
         sent_requests = (
             session.execute(
                 select(FriendRelationship)
-                .where_users_column_visible(context, FriendRelationship.to_user_id)
+                .where_users_column_visible(context.user_id, FriendRelationship.to_user_id)
                 .where(FriendRelationship.from_user_id == context.user_id)
                 .where(FriendRelationship.status == FriendStatus.pending)
             )
@@ -727,7 +729,7 @@ class API(api_pb2_grpc.APIServicer):
         received_requests = (
             session.execute(
                 select(FriendRelationship)
-                .where_users_column_visible(context, FriendRelationship.from_user_id)
+                .where_users_column_visible(context.user_id, FriendRelationship.from_user_id)
                 .where(FriendRelationship.to_user_id == context.user_id)
                 .where(FriendRelationship.status == FriendStatus.pending)
             )
@@ -759,7 +761,7 @@ class API(api_pb2_grpc.APIServicer):
     def RespondFriendRequest(self, request, context, session):
         friend_request = session.execute(
             select(FriendRelationship)
-            .where_users_column_visible(context, FriendRelationship.from_user_id)
+            .where_users_column_visible(context.user_id, FriendRelationship.from_user_id)
             .where(FriendRelationship.to_user_id == context.user_id)
             .where(FriendRelationship.status == FriendStatus.pending)
             .where(FriendRelationship.id == request.friend_request_id)
@@ -789,7 +791,7 @@ class API(api_pb2_grpc.APIServicer):
     def CancelFriendRequest(self, request, context, session):
         friend_request = session.execute(
             select(FriendRelationship)
-            .where_users_column_visible(context, FriendRelationship.to_user_id)
+            .where_users_column_visible(context.user_id, FriendRelationship.to_user_id)
             .where(FriendRelationship.from_user_id == context.user_id)
             .where(FriendRelationship.status == FriendStatus.pending)
             .where(FriendRelationship.id == request.friend_request_id)

--- a/app/backend/src/couchers/servicers/communities.py
+++ b/app/backend/src/couchers/servicers/communities.py
@@ -196,7 +196,7 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             session.execute(
                 select(User)
                 .join(ClusterSubscription, ClusterSubscription.user_id == User.id)
-                .where_users_visible(context)
+                .where_users_visible(context.user_id)
                 .where(ClusterSubscription.cluster_id == node.official_cluster.id)
                 .where(ClusterSubscription.role == ClusterRole.admin)
                 .where(User.id >= next_admin_id)
@@ -219,7 +219,7 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "node_moderate_permission_denied")
 
         user = session.execute(
-            select(User).where_users_visible(context).where(User.id == request.user_id)
+            select(User).where_users_visible(context.user_id).where(User.id == request.user_id)
         ).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -247,7 +247,7 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "node_moderate_permission_denied")
 
         user = session.execute(
-            select(User).where_users_visible(context).where(User.id == request.user_id)
+            select(User).where_users_visible(context.user_id).where(User.id == request.user_id)
         ).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -277,7 +277,7 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         query = (
             select(User)
             .join(ClusterSubscription, ClusterSubscription.user_id == User.id)
-            .where_users_visible(context)
+            .where_users_visible(context.user_id)
             .where(ClusterSubscription.cluster_id == node.official_cluster.id)
         )
         if next_member_id is not None:
@@ -298,7 +298,7 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         nearbys = (
             session.execute(
                 select(User)
-                .where_users_visible(context)
+                .where_users_visible(context.user_id)
                 .where(func.ST_Contains(node.geom, User.geom))
                 .where(User.id >= next_nearby_id)
                 .order_by(User.id)

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -129,7 +129,7 @@ def _get_visible_admins_for_subscription(subscription):
         ]
 
 
-def _user_can_message(session, context, group_chat: GroupChat) -> bool:
+def _user_can_message(session, user_id: int, group_chat: GroupChat) -> bool:
     """
     If it is a true group chat (not a DM), user can always message. For a DM, user can message if the other participant
     - Is not deleted/banned
@@ -141,8 +141,8 @@ def _user_can_message(session, context, group_chat: GroupChat) -> bool:
     return session.execute(
         func.exists(
             select(GroupChatSubscription)
-            .where_users_column_visible(context=context, column=GroupChatSubscription.user_id)
-            .where(GroupChatSubscription.user_id != context.user_id)
+            .where_users_column_visible(user_id, column=GroupChatSubscription.user_id)
+            .where(GroupChatSubscription.user_id != user_id)
             .where(GroupChatSubscription.group_chat_id == group_chat.conversation_id)
             .where(GroupChatSubscription.left == None)
         )
@@ -170,7 +170,7 @@ def generate_message_notifications(payload: jobs_pb2.GenerateMessageNotification
         user_ids_to_notify = (
             session.execute(
                 select(GroupChatSubscription.user_id)
-                .where_users_column_visible(context=context, column=GroupChatSubscription.user_id)
+                .where_users_column_visible(context.user_id, column=GroupChatSubscription.user_id)
                 .where(GroupChatSubscription.group_chat_id == message.conversation_id)
                 .where(GroupChatSubscription.user_id != message.author_id)
                 .where(GroupChatSubscription.joined <= message.time)
@@ -339,7 +339,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
                     last_seen_message_id=result.GroupChatSubscription.last_seen_message_id,
                     latest_message=_message_to_pb(result.Message) if result.Message else None,
                     mute_info=_mute_info(result.GroupChatSubscription),
-                    can_message=_user_can_message(session, context, result.GroupChat),
+                    can_message=_user_can_message(session, context.user_id, result.GroupChat),
                 )
                 for result in results[:page_size]
             ],
@@ -377,7 +377,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             last_seen_message_id=result.GroupChatSubscription.last_seen_message_id,
             latest_message=_message_to_pb(result.Message) if result.Message else None,
             mute_info=_mute_info(result.GroupChatSubscription),
-            can_message=_user_can_message(session, context, result.GroupChat),
+            can_message=_user_can_message(session, context.user_id, result.GroupChat),
         )
 
     def GetDirectMessage(self, request, context, session):
@@ -425,7 +425,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             last_seen_message_id=result.GroupChatSubscription.last_seen_message_id,
             latest_message=_message_to_pb(result.Message) if result.Message else None,
             mute_info=_mute_info(result.GroupChatSubscription),
-            can_message=_user_can_message(session, context, result.GroupChat),
+            can_message=_user_can_message(session, context.user_id, result.GroupChat),
         )
 
     def GetUpdates(self, request, context, session):
@@ -553,7 +553,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "incomplete_profile_send_message")
 
         recipient_user_ids = list(
-            session.execute(select(User.id).where_users_visible(context).where(User.id.in_(request.recipient_user_ids)))
+            session.execute(
+                select(User.id).where_users_visible(context.user_id).where(User.id.in_(request.recipient_user_ids))
+            )
             .scalars()
             .all()
         )
@@ -646,7 +648,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "chat_not_found")
 
         subscription, group_chat = result
-        if not _user_can_message(session, context, group_chat):
+        if not _user_can_message(session, context.user_id, group_chat):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "cant_message_in_chat")
 
         _add_message_to_subscription(session, subscription, message_type=MessageType.text, text=request.text)
@@ -671,7 +673,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "no_recipients")
 
         recipient_user_id = session.execute(
-            select(User.id).where_users_visible(context).where(User.id == recipient_id)
+            select(User.id).where_users_visible(context.user_id).where(User.id == recipient_id)
         ).scalar_one_or_none()
 
         if not recipient_user_id:
@@ -732,7 +734,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
 
     def MakeGroupChatAdmin(self, request, context, session):
         if not session.execute(
-            select(User).where_users_visible(context).where(User.id == request.user_id)
+            select(User).where_users_visible(context.user_id).where(User.id == request.user_id)
         ).scalar_one_or_none():
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
@@ -765,7 +767,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
 
     def RemoveGroupChatAdmin(self, request, context, session):
         if not session.execute(
-            select(User).where_users_visible(context).where(User.id == request.user_id)
+            select(User).where_users_visible(context.user_id).where(User.id == request.user_id)
         ).scalar_one_or_none():
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
@@ -811,7 +813,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
 
     def InviteToGroupChat(self, request, context, session):
         if not session.execute(
-            select(User).where_users_visible(context).where(User.id == request.user_id)
+            select(User).where_users_visible(context.user_id).where(User.id == request.user_id)
         ).scalar_one_or_none():
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -119,14 +119,14 @@ def event_to_pb(session, occurrence: EventOccurrence, context):
     going_count = session.execute(
         select(func.count())
         .select_from(EventOccurrenceAttendee)
-        .where_users_column_visible(context, EventOccurrenceAttendee.user_id)
+        .where_users_column_visible(context.user_id, EventOccurrenceAttendee.user_id)
         .where(EventOccurrenceAttendee.occurrence_id == occurrence.id)
         .where(EventOccurrenceAttendee.attendee_status == AttendeeStatus.going)
     ).scalar_one()
     maybe_count = session.execute(
         select(func.count())
         .select_from(EventOccurrenceAttendee)
-        .where_users_column_visible(context, EventOccurrenceAttendee.user_id)
+        .where_users_column_visible(context.user_id, EventOccurrenceAttendee.user_id)
         .where(EventOccurrenceAttendee.occurrence_id == occurrence.id)
         .where(EventOccurrenceAttendee.attendee_status == AttendeeStatus.maybe)
     ).scalar_one()
@@ -134,13 +134,13 @@ def event_to_pb(session, occurrence: EventOccurrence, context):
     organizer_count = session.execute(
         select(func.count())
         .select_from(EventOrganizer)
-        .where_users_column_visible(context, EventOrganizer.user_id)
+        .where_users_column_visible(context.user_id, EventOrganizer.user_id)
         .where(EventOrganizer.event_id == event.id)
     ).scalar_one()
     subscriber_count = session.execute(
         select(func.count())
         .select_from(EventSubscription)
-        .where_users_column_visible(context, EventSubscription.user_id)
+        .where_users_column_visible(context.user_id, EventSubscription.user_id)
         .where(EventSubscription.event_id == event.id)
     ).scalar_one()
 
@@ -832,7 +832,7 @@ class Events(events_pb2_grpc.EventsServicer):
         attendees = (
             session.execute(
                 select(EventOccurrenceAttendee)
-                .where_users_column_visible(context, EventOccurrenceAttendee.user_id)
+                .where_users_column_visible(context.user_id, EventOccurrenceAttendee.user_id)
                 .where(EventOccurrenceAttendee.occurrence_id == occurrence.id)
                 .where(EventOccurrenceAttendee.user_id >= next_user_id)
                 .order_by(EventOccurrenceAttendee.user_id)
@@ -856,7 +856,7 @@ class Events(events_pb2_grpc.EventsServicer):
         subscribers = (
             session.execute(
                 select(EventSubscription)
-                .where_users_column_visible(context, EventSubscription.user_id)
+                .where_users_column_visible(context.user_id, EventSubscription.user_id)
                 .where(EventSubscription.event_id == event.id)
                 .where(EventSubscription.user_id >= next_user_id)
                 .order_by(EventSubscription.user_id)
@@ -880,7 +880,7 @@ class Events(events_pb2_grpc.EventsServicer):
         organizers = (
             session.execute(
                 select(EventOrganizer)
-                .where_users_column_visible(context, EventOrganizer.user_id)
+                .where_users_column_visible(context.user_id, EventOrganizer.user_id)
                 .where(EventOrganizer.event_id == event.id)
                 .where(EventOrganizer.user_id >= next_user_id)
                 .order_by(EventOrganizer.user_id)
@@ -1133,7 +1133,7 @@ class Events(events_pb2_grpc.EventsServicer):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "event_cant_update_old_event")
 
         if not session.execute(
-            select(User).where_users_visible(context).where(User.id == request.user_id)
+            select(User).where_users_visible(context.user_id).where(User.id == request.user_id)
         ).scalar_one_or_none():
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 

--- a/app/backend/src/couchers/servicers/gis.py
+++ b/app/backend/src/couchers/servicers/gis.py
@@ -38,7 +38,7 @@ def _statement_to_geojson_response(session, statement):
 class GIS(gis_pb2_grpc.GISServicer):
     def GetUsers(self, request, context, session):
         statement = select(LiteUser.id, LiteUser.geom, LiteUser.has_completed_profile).where_users_visible(
-            context, table=LiteUser
+            context.user_id, table=LiteUser
         )
         return _statement_to_geojson_response(session, statement)
 

--- a/app/backend/src/couchers/servicers/groups.py
+++ b/app/backend/src/couchers/servicers/groups.py
@@ -59,7 +59,7 @@ def group_to_pb(session, cluster: Cluster, context):
     member_count = session.execute(
         select(func.count())
         .select_from(ClusterSubscription)
-        .where_users_column_visible(context, ClusterSubscription.user_id)
+        .where_users_column_visible(context.user_id, ClusterSubscription.user_id)
         .where(ClusterSubscription.cluster_id == cluster.id)
     ).scalar_one()
     is_member = (
@@ -74,7 +74,7 @@ def group_to_pb(session, cluster: Cluster, context):
     admin_count = session.execute(
         select(func.count())
         .select_from(ClusterSubscription)
-        .where_users_column_visible(context, ClusterSubscription.user_id)
+        .where_users_column_visible(context.user_id, ClusterSubscription.user_id)
         .where(ClusterSubscription.cluster_id == cluster.id)
         .where(ClusterSubscription.role == ClusterRole.admin)
     ).scalar_one()
@@ -128,7 +128,7 @@ class Groups(groups_pb2_grpc.GroupsServicer):
         admins = (
             session.execute(
                 select(User)
-                .where_users_visible(context)
+                .where_users_visible(context.user_id)
                 .join(ClusterSubscription, ClusterSubscription.user_id == User.id)
                 .where(ClusterSubscription.cluster_id == cluster.id)
                 .where(ClusterSubscription.role == ClusterRole.admin)
@@ -157,7 +157,7 @@ class Groups(groups_pb2_grpc.GroupsServicer):
             session.execute(
                 select(User)
                 .join(ClusterSubscription, ClusterSubscription.user_id == User.id)
-                .where_users_visible(context)
+                .where_users_visible(context.user_id)
                 .where(ClusterSubscription.cluster_id == cluster.id)
                 .where(User.id >= next_member_id)
                 .order_by(User.id)

--- a/app/backend/src/couchers/servicers/references.py
+++ b/app/backend/src/couchers/servicers/references.py
@@ -57,8 +57,8 @@ def get_host_req_and_check_can_write_ref(session, context, host_request_id):
     """
     host_request = session.execute(
         select(HostRequest)
-        .where_users_column_visible(context, HostRequest.surfer_user_id)
-        .where_users_column_visible(context, HostRequest.host_user_id)
+        .where_users_column_visible(context.user_id, HostRequest.surfer_user_id)
+        .where_users_column_visible(context.user_id, HostRequest.host_user_id)
         .where(HostRequest.conversation_id == host_request_id)
         .where(or_(HostRequest.surfer_user_id == context.user_id, HostRequest.host_user_id == context.user_id))
     ).scalar_one_or_none()
@@ -110,7 +110,7 @@ def get_pending_references_to_write(session, context):
             ),
         )
         .join(LiteUser, LiteUser.id == HostRequest.host_user_id)
-        .where_users_column_visible(context, HostRequest.host_user_id)
+        .where_users_column_visible(context.user_id, HostRequest.host_user_id)
         .where(Reference.id == None)
         .where(HostRequest.can_write_reference)
         .where(HostRequest.surfer_user_id == context.user_id)
@@ -127,7 +127,7 @@ def get_pending_references_to_write(session, context):
             ),
         )
         .join(LiteUser, LiteUser.id == HostRequest.surfer_user_id)
-        .where_users_column_visible(context, HostRequest.surfer_user_id)
+        .where_users_column_visible(context.user_id, HostRequest.surfer_user_id)
         .where(Reference.id == None)
         .where(HostRequest.can_write_reference)
         .where(HostRequest.host_user_id == context.user_id)
@@ -231,7 +231,7 @@ class References(references_pb2_grpc.ReferencesServicer):
         check_valid_reference(request, context)
 
         if not session.execute(
-            select(User).where_users_visible(context).where(User.id == request.to_user_id)
+            select(User).where_users_visible(context.user_id).where(User.id == request.to_user_id)
         ).scalar_one_or_none():
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
@@ -346,7 +346,7 @@ class References(references_pb2_grpc.ReferencesServicer):
             return references_pb2.AvailableWriteReferencesRes()
 
         if not session.execute(
-            select(User).where_users_visible(context).where(User.id == request.to_user_id)
+            select(User).where_users_visible(context.user_id).where(User.id == request.to_user_id)
         ).scalar_one_or_none():
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -170,9 +170,9 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         if request.host_user_id == context.user_id:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "cant_request_self")
 
-        # just to check host exists and is visible
+        # just to check the host exists and is visible
         host = session.execute(
-            select(User).where_users_visible(context).where(User.id == request.host_user_id)
+            select(User).where_users_visible(context.user_id).where(User.id == request.host_user_id)
         ).scalar_one_or_none()
         if not host:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -272,8 +272,8 @@ class Requests(requests_pb2_grpc.RequestsServicer):
     def GetHostRequest(self, request, context, session):
         host_request = session.execute(
             select(HostRequest)
-            .where_users_column_visible(context, HostRequest.surfer_user_id)
-            .where_users_column_visible(context, HostRequest.host_user_id)
+            .where_users_column_visible(context.user_id, HostRequest.surfer_user_id)
+            .where_users_column_visible(context.user_id, HostRequest.host_user_id)
             .where(HostRequest.conversation_id == request.host_request_id)
             .where(or_(HostRequest.surfer_user_id == context.user_id, HostRequest.host_user_id == context.user_id))
         ).scalar_one_or_none()
@@ -299,8 +299,8 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             .outerjoin(message_2, and_(Message.conversation_id == message_2.conversation_id, Message.id < message_2.id))
             .join(HostRequest, HostRequest.conversation_id == Message.conversation_id)
             .join(Conversation, Conversation.id == HostRequest.conversation_id)
-            .where_users_column_visible(context, HostRequest.surfer_user_id)
-            .where_users_column_visible(context, HostRequest.host_user_id)
+            .where_users_column_visible(context.user_id, HostRequest.surfer_user_id)
+            .where_users_column_visible(context.user_id, HostRequest.host_user_id)
             .where(message_2.id == None)
             .where(or_(Message.id < request.last_request_id, request.last_request_id == 0))
         )
@@ -384,8 +384,8 @@ class Requests(requests_pb2_grpc.RequestsServicer):
 
         host_request = session.execute(
             select(HostRequest)
-            .where_users_column_visible(context, HostRequest.surfer_user_id)
-            .where_users_column_visible(context, HostRequest.host_user_id)
+            .where_users_column_visible(context.user_id, HostRequest.surfer_user_id)
+            .where_users_column_visible(context.user_id, HostRequest.host_user_id)
             .where(HostRequest.conversation_id == request.host_request_id)
         ).scalar_one_or_none()
 
@@ -727,7 +727,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         user_res = session.execute(
             select(User.id, UserResponseRate)
             .outerjoin(UserResponseRate, UserResponseRate.user_id == User.id)
-            .where_users_visible(context)
+            .where_users_visible(context.user_id)
             .where(User.id == request.user_id)
         ).one_or_none()
 

--- a/app/backend/src/couchers/servicers/search.py
+++ b/app/backend/src/couchers/servicers/search.py
@@ -210,7 +210,7 @@ def _search_users(session, search_statement, title_only, next_rank, page_size, c
         [User.things_i_like, User.about_place, User.additional_information],
     )
 
-    users = execute_search_statement(session, select(User, rank, snippet).where_users_visible(context))
+    users = execute_search_statement(session, select(User, rank, snippet).where_users_visible(context.user_id))
 
     return [
         search_pb2.Result(
@@ -350,7 +350,7 @@ def _user_search_inner(request, context, session):
     user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
 
     # Base statement with visibility filter
-    statement = select(User.id, User.recommendation_score).where_users_visible(context)
+    statement = select(User.id, User.recommendation_score).where_users_visible(context.user_id)
     # make sure that only users who are in LiteUser show up
     statement = statement.join(LiteUser, LiteUser.id == User.id)
 
@@ -502,7 +502,7 @@ def _user_search_inner(request, context, session):
         if request.only_with_references:
             references = (
                 select(Reference.to_user_id.label("user_id"))
-                .where_users_column_visible(context, Reference.from_user_id)
+                .where_users_column_visible(context.user_id, Reference.from_user_id)
                 .distinct()
                 .subquery()
             )

--- a/app/backend/src/couchers/servicers/threads.py
+++ b/app/backend/src/couchers/servicers/threads.py
@@ -137,7 +137,7 @@ def generate_reply_notifications(payload: jobs_pb2.GenerateReplyNotificationsPay
             thread_replies_author_user_ids = (
                 session.execute(
                     select(Reply.author_user_id)
-                    .where_users_column_visible(context, Reply.author_user_id)
+                    .where_users_column_visible(context.user_id, Reply.author_user_id)
                     .where(Reply.comment_id == parent_comment.id)
                 )
                 .scalars()

--- a/app/backend/src/couchers/sql.py
+++ b/app/backend/src/couchers/sql.py
@@ -4,7 +4,6 @@ from sqlalchemy import false
 from sqlalchemy.orm import InstrumentedAttribute, aliased
 from sqlalchemy.sql import Select, union
 
-from couchers.context import CouchersContext
 from couchers.models import SignupFlow, User, UserBlock
 from couchers.utils import is_valid_email, is_valid_user_id, is_valid_username
 
@@ -51,20 +50,20 @@ class CouchersSelect(Select[Any]):
         # no fields match, this will return no rows
         return self.where(false())
 
-    def where_users_visible(self, context: CouchersContext, table: "_User" = User) -> Self:
+    def where_users_visible(self, user_id: int, table: "_User" = User) -> Self:
         """
         Filters out users that should not be visible: blocked, deleted, or banned
 
         Filters the given table, assuming it's already joined/selected from
         """
-        hidden_users = _relevant_user_blocks(context.user_id)
+        hidden_users = _relevant_user_blocks(user_id)
         return self.where(table.is_visible).where(~table.id.in_(hidden_users))
 
-    def where_users_column_visible(self, context: CouchersContext, column: InstrumentedAttribute[int]) -> Self:
+    def where_users_column_visible(self, user_id: int, column: InstrumentedAttribute[int]) -> Self:
         """
         Filters the given column, not yet joined/selected from
         """
-        hidden_users = _relevant_user_blocks(context.user_id)
+        hidden_users = _relevant_user_blocks(user_id)
         aliased_user = aliased(User)
         return (
             self.join(aliased_user, aliased_user.id == column)

--- a/app/backend/src/tests/test_visible_users.py
+++ b/app/backend/src/tests/test_visible_users.py
@@ -12,11 +12,6 @@ from tests.test_fixtures import (  # noqa
 )
 
 
-class _FakeContext:
-    def __init__(self, user_id):
-        self.user_id = user_id
-
-
 # Also tests different ways to make users invisible
 def test_is_visible_property(db):
     user1, token1 = generate_user()
@@ -44,9 +39,8 @@ def test_select_dot_where_users_visible(db):
     make_user_block(user1, user3)
     make_user_block(user4, user1)
 
-    context = _FakeContext(user1.id)
     with session_scope() as session:
-        assert session.execute(select(func.count()).select_from(User).where_users_visible(context)).scalar_one() == 1
+        assert session.execute(select(func.count()).select_from(User).where_users_visible(user1.id)).scalar_one() == 1
 
 
 def test_select_dot_where_users_column_visible(db):
@@ -65,13 +59,12 @@ def test_select_dot_where_users_column_visible(db):
     make_user_block(user1, user4)
     make_user_block(user5, user1)
 
-    context = _FakeContext(user1.id)
     with session_scope() as session:
         assert (
             session.execute(
                 select(func.count())
                 .select_from(FriendRelationship)
-                .where_users_column_visible(context, FriendRelationship.to_user_id)
+                .where_users_column_visible(user1.id, FriendRelationship.to_user_id)
             ).scalar_one()
             == 1
         )


### PR DESCRIPTION
There's no reason to pass the whole context object from the servicers layer