### PR TITLE
Annotate all servicers' methods

### DIFF
--- a/app/backend/src/couchers/notifications/quick_links.py
+++ b/app/backend/src/couchers/notifications/quick_links.py
@@ -129,7 +129,7 @@ def respond_quick_link(request: auth_pb2.UnsubscribeReq, context: CouchersContex
         else:
             context.abort_with_error_code(grpc.StatusCode.UNIMPLEMENTED, "cant_unsub_topic")
     if payload.HasField("host_request_quick_decline"):
-        Requests().RespondHostRequest(  # type: ignore[no-untyped-call]
+        Requests().RespondHostRequest(
             request=requests_pb2.RespondHostRequestReq(
                 host_request_id=payload.host_request_quick_decline.host_request_id,
                 status=conversations_pb2.HOST_REQUEST_STATUS_REJECTED,

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -662,7 +662,9 @@ class Account(account_pb2_grpc.AccountServicer):
         )
         return empty_pb2.Empty()
 
-    def SetProfilePublicVisibility(self, request, context, session):
+    def SetProfilePublicVisibility(
+        self, request: account_pb2.SetProfilePublicVisibilityReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
         user.public_visibility = profilepublicitysetting2sql[request.profile_public_visibility]
         user.has_modified_public_visibility = True

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -6,11 +6,12 @@ import grpc
 from geoalchemy2.shape import from_shape
 from google.protobuf import empty_pb2
 from shapely.geometry import shape
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import and_, func, or_, select, update
 from user_agents import parse as user_agents_parse
 
 from couchers import urls
-from couchers.context import make_background_user_context
+from couchers.context import CouchersContext, make_background_user_context
 from couchers.crypto import urlsafe_secure_token
 from couchers.db import session_scope
 from couchers.helpers.badges import user_add_badge, user_remove_badge
@@ -41,7 +42,7 @@ from couchers.models import (
     UserBadge,
 )
 from couchers.notifications.notify import notify
-from couchers.proto import admin_pb2, admin_pb2_grpc, notification_data_pb2
+from couchers.proto import admin_pb2, admin_pb2_grpc, api_pb2, communities_pb2, notification_data_pb2
 from couchers.proto.internal import jobs_pb2
 from couchers.resources import get_badge_dict
 from couchers.servicers.api import user_model_to_pb
@@ -125,19 +126,23 @@ def generate_new_blog_post_notifications(payload: jobs_pb2.GenerateNewBlogPostNo
 
 
 class Admin(admin_pb2_grpc.AdminServicer):
-    def GetUserDetails(self, request, context, session):
+    def GetUserDetails(
+        self, request: admin_pb2.GetUserDetailsReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.UserDetails:
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         return _user_to_details(session, user)
 
-    def GetUser(self, request, context, session):
+    def GetUser(self, request: admin_pb2.GetUserReq, context: CouchersContext, session: Session) -> api_pb2.User:
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         return user_model_to_pb(user, session, context, is_admin_see_ghosts=True)
 
-    def SearchUsers(self, request, context, session):
+    def SearchUsers(
+        self, request: admin_pb2.SearchUsersReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.SearchUsersRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_user_id = int(request.page_token) if request.page_token else 0
         statement = select(User)
@@ -196,7 +201,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
             next_page_token=str(users[-1].id) if len(users) > page_size else None,
         )
 
-    def ChangeUserGender(self, request, context, session):
+    def ChangeUserGender(
+        self, request: admin_pb2.ChangeUserGenderReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.UserDetails:
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -214,7 +221,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         return _user_to_details(session, user)
 
-    def ChangeUserBirthdate(self, request, context, session):
+    def ChangeUserBirthdate(
+        self, request: admin_pb2.ChangeUserBirthdateReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.UserDetails:
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -232,7 +241,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         return _user_to_details(session, user)
 
-    def AddBadge(self, request, context, session):
+    def AddBadge(
+        self, request: admin_pb2.AddBadgeReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.UserDetails:
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -251,7 +262,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         return _user_to_details(session, user)
 
-    def RemoveBadge(self, request, context, session):
+    def RemoveBadge(
+        self, request: admin_pb2.RemoveBadgeReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.UserDetails:
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -273,14 +286,18 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         return _user_to_details(session, user)
 
-    def SetPassportSexGenderException(self, request, context, session):
+    def SetPassportSexGenderException(
+        self, request: admin_pb2.SetPassportSexGenderExceptionReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.UserDetails:
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         user.has_passport_sex_gender_exception = request.passport_sex_gender_exception
         return _user_to_details(session, user)
 
-    def BanUser(self, request, context, session):
+    def BanUser(
+        self, request: admin_pb2.BanUserReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.UserDetails:
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -288,7 +305,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
         user.is_banned = True
         return _user_to_details(session, user)
 
-    def UnbanUser(self, request, context, session):
+    def UnbanUser(
+        self, request: admin_pb2.UnbanUserReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.UserDetails:
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -296,14 +315,18 @@ class Admin(admin_pb2_grpc.AdminServicer):
         user.is_banned = False
         return _user_to_details(session, user)
 
-    def AddAdminNote(self, request, context, session):
+    def AddAdminNote(
+        self, request: admin_pb2.AddAdminNoteReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.UserDetails:
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         append_admin_note(session, context, user, request.admin_note)
         return _user_to_details(session, user)
 
-    def GetContentReport(self, request, context, session):
+    def GetContentReport(
+        self, request: admin_pb2.GetContentReportReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.GetContentReportRes:
         content_report = session.execute(
             select(ContentReport).where(ContentReport.id == request.content_report_id)
         ).scalar_one_or_none()
@@ -313,7 +336,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
             content_report=_content_report_to_pb(content_report),
         )
 
-    def GetContentReportsForAuthor(self, request, context, session):
+    def GetContentReportsForAuthor(
+        self, request: admin_pb2.GetContentReportsForAuthorReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.GetContentReportsForAuthorRes:
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -328,7 +353,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
             content_reports=[_content_report_to_pb(content_report) for content_report in content_reports],
         )
 
-    def SendModNote(self, request, context, session):
+    def SendModNote(
+        self, request: admin_pb2.SendModNoteReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.UserDetails:
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -351,28 +378,36 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         return _user_to_details(session, user)
 
-    def MarkUserNeedsLocationUpdate(self, request, context, session):
+    def MarkUserNeedsLocationUpdate(
+        self, request: admin_pb2.MarkUserNeedsLocationUpdateReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.UserDetails:
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         user.needs_to_update_location = True
         return _user_to_details(session, user)
 
-    def DeleteUser(self, request, context, session):
+    def DeleteUser(
+        self, request: admin_pb2.DeleteUserReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.UserDetails:
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         user.is_deleted = True
         return _user_to_details(session, user)
 
-    def RecoverDeletedUser(self, request, context, session):
+    def RecoverDeletedUser(
+        self, request: admin_pb2.RecoverDeletedUserReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.UserDetails:
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         user.is_deleted = False
         return _user_to_details(session, user)
 
-    def CreateApiKey(self, request, context, session):
+    def CreateApiKey(
+        self, request: admin_pb2.CreateApiKeyReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.CreateApiKeyRes:
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -392,7 +427,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         return _user_to_details(session, user)
 
-    def CreateCommunity(self, request, context, session):
+    def CreateCommunity(
+        self, request: admin_pb2.CreateCommunityReq, context: CouchersContext, session: Session
+    ) -> communities_pb2.Community:
         geom = load_community_geom(request.geojson, context)
 
         parent_node_id = request.parent_node_id if request.parent_node_id != 0 else None
@@ -401,7 +438,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         return community_to_pb(session, node, context)
 
-    def UpdateCommunity(self, request, context, session):
+    def UpdateCommunity(
+        self, request: admin_pb2.UpdateCommunityReq, context: CouchersContext, session: Session
+    ) -> communities_pb2.Community:
         node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
@@ -425,7 +464,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         return community_to_pb(session, cluster.parent_node, context)
 
-    def GetChats(self, request, context, session):
+    def GetChats(
+        self, request: admin_pb2.GetChatsReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.GetChatsRes:
         def format_user(user):
             return f"{user.name} ({user.username}, {user.id})"
 
@@ -515,7 +556,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         return admin_pb2.GetChatsRes(response=format_all_chats_for_user(user.id))
 
-    def ListEventCommunityInviteRequests(self, request, context, session):
+    def ListEventCommunityInviteRequests(
+        self, request: admin_pb2.ListEventCommunityInviteRequestsReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.ListEventCommunityInviteRequestsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_request_id = int(request.page_token) if request.page_token else 0
         requests = (
@@ -545,7 +588,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
             next_page_token=str(requests[-1].id) if len(requests) > page_size else None,
         )
 
-    def DecideEventCommunityInviteRequest(self, request, context, session):
+    def DecideEventCommunityInviteRequest(
+        self, request: admin_pb2.DecideEventCommunityInviteRequestReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.DecideEventCommunityInviteRequestRes:
         req = session.execute(
             select(EventCommunityInviteRequest).where(
                 EventCommunityInviteRequest.id == request.event_community_invite_request_id
@@ -587,7 +632,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         return admin_pb2.DecideEventCommunityInviteRequestRes()
 
-    def DeleteEvent(self, request, context, session):
+    def DeleteEvent(
+        self, request: admin_pb2.DeleteEventReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         res = session.execute(
             select(Event, EventOccurrence)
             .where(EventOccurrence.id == request.event_id)
@@ -612,7 +659,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         return empty_pb2.Empty()
 
-    def ListUserIds(self, request, context, session):
+    def ListUserIds(
+        self, request: admin_pb2.ListUserIdsReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.ListUserIdsRes:
         start_date = to_aware_datetime(request.start_time)
         end_date = to_aware_datetime(request.end_time)
 
@@ -637,7 +686,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
             next_page_token=str(user_ids[-1]) if len(user_ids) > page_size else None,
         )
 
-    def EditReferenceText(self, request, context, session):
+    def EditReferenceText(
+        self, request: admin_pb2.EditReferenceTextReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         reference = session.execute(select(Reference).where(Reference.id == request.reference_id)).scalar_one_or_none()
 
         if reference is None:
@@ -649,7 +700,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
         reference.text = request.new_text.strip()
         return empty_pb2.Empty()
 
-    def DeleteReference(self, request, context, session):
+    def DeleteReference(
+        self, request: admin_pb2.DeleteReferenceReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         reference = session.execute(select(Reference).where(Reference.id == request.reference_id)).scalar_one_or_none()
 
         if reference is None:
@@ -658,7 +711,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
         reference.is_deleted = True
         return empty_pb2.Empty()
 
-    def EditDiscussion(self, request, context, session):
+    def EditDiscussion(
+        self, request: admin_pb2.EditDiscussionReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         discussion = session.execute(
             select(Discussion).where(Discussion.id == request.discussion_id)
         ).scalar_one_or_none()
@@ -670,7 +725,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
             discussion.content = request.new_content.strip()
         return empty_pb2.Empty()
 
-    def EditReply(self, request, context, session):
+    def EditReply(self, request: admin_pb2.EditReplyReq, context: CouchersContext, session: Session) -> empty_pb2.Empty:
         database_id, depth = unpack_thread_id(request.reply_id)
         if depth == 1:
             obj = session.execute(select(Comment).where(Comment.id == database_id)).scalar_one_or_none()
@@ -681,7 +736,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
         obj.content = request.new_content.strip()
         return empty_pb2.Empty()
 
-    def AddUsersToModerationUserList(self, request, context, session):
+    def AddUsersToModerationUserList(
+        self, request: admin_pb2.AddUsersToModerationUserListReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.AddUsersToModerationUserListRes:
         """Add multiple users to a moderation user list. If no moderation list is provided, a new one is created.
         Id of the moderation list is returned."""
         req_users = request.users
@@ -710,7 +767,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         return admin_pb2.AddUsersToModerationUserListRes(moderation_list_id=moderation_user_list.id)
 
-    def ListModerationUserLists(self, request, context, session):
+    def ListModerationUserLists(
+        self, request: admin_pb2.ListModerationUserListsReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.ListModerationUserListsRes:
         """Lists all moderation user lists for a user."""
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
@@ -722,7 +781,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
         ]
         return admin_pb2.ListModerationUserListsRes(moderation_lists=moderation_lists)
 
-    def RemoveUserFromModerationUserList(self, request, context, session):
+    def RemoveUserFromModerationUserList(
+        self, request: admin_pb2.RemoveUserFromModerationUserListReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         """Removes a user from a provided moderation user list."""
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
@@ -743,7 +804,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         return empty_pb2.Empty()
 
-    def CreateAccountDeletionLink(self, request, context, session):
+    def CreateAccountDeletionLink(
+        self, request: admin_pb2.CreateAccountDeletionLinkReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.CreateAccountDeletionLinkRes:
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -754,7 +817,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
             account_deletion_confirm_url=urls.delete_account_link(account_deletion_token=token.token)
         )
 
-    def AccessStats(self, request, context, session):
+    def AccessStats(
+        self, request: admin_pb2.AccessStatsReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.AccessStatsRes:
         user = session.execute(select(User).where_username_or_email_or_id(request.user)).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -803,7 +868,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         return out
 
-    def SendBlogPostNotification(self, request, context, session):
+    def SendBlogPostNotification(
+        self, request: admin_pb2.SendBlogPostNotificationReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         if len(request.title) > 50:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "admin_blog_title_too_long")
         if len(request.blurb) > 100:

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -3,11 +3,13 @@ from urllib.parse import urlencode
 
 import grpc
 from google.protobuf import empty_pb2
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import and_, delete, distinct, func, intersect, or_, union
 
 from couchers import urls
 from couchers.config import config
 from couchers.constants import GHOST_USERNAME
+from couchers.context import CouchersContext
 from couchers.crypto import b64encode, generate_hash_signature, random_hex
 from couchers.helpers.strong_verification import get_strong_verification_fields
 from couchers.materialized_views import LiteUser, UserResponseRate
@@ -154,7 +156,7 @@ fluency2api = {
 
 
 class API(api_pb2_grpc.APIServicer):
-    def Ping(self, request, context, session):
+    def Ping(self, request: api_pb2.PingReq, context: CouchersContext, session: Session) -> api_pb2.PingRes:
         # auth ought to make sure the user exists
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
 
@@ -227,7 +229,7 @@ class API(api_pb2_grpc.APIServicer):
             unseen_notification_count=unseen_notification_count,
         )
 
-    def GetUser(self, request, context, session):
+    def GetUser(self, request: api_pb2.GetUserReq, context: CouchersContext, session: Session) -> api_pb2.User:
         user = session.execute(select(User).where_username_or_id(request.user)).scalar_one_or_none()
 
         if not user:
@@ -235,7 +237,9 @@ class API(api_pb2_grpc.APIServicer):
 
         return user_model_to_pb(user, session, context, is_get_user_return_ghosts=True)
 
-    def GetLiteUser(self, request, context, session):
+    def GetLiteUser(
+        self, request: api_pb2.GetLiteUserReq, context: CouchersContext, session: Session
+    ) -> api_pb2.LiteUser:
         lite_user = session.execute(
             select(LiteUser).where_username_or_id(request.user, table=LiteUser)
         ).scalar_one_or_none()
@@ -245,7 +249,9 @@ class API(api_pb2_grpc.APIServicer):
 
         return lite_user_to_pb(session, lite_user, context, is_get_user_return_ghosts=True)
 
-    def GetLiteUsers(self, request, context, session):
+    def GetLiteUsers(
+        self, request: api_pb2.GetLiteUsersReq, context: CouchersContext, session: Session
+    ) -> api_pb2.GetLiteUsersRes:
         if len(request.users) > MAX_USERS_PER_QUERY:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "requested_too_many_users")
 
@@ -283,7 +289,9 @@ class API(api_pb2_grpc.APIServicer):
 
         return res
 
-    def UpdateProfile(self, request, context, session):
+    def UpdateProfile(
+        self, request: api_pb2.UpdateProfileReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
 
         if request.HasField("name"):
@@ -545,7 +553,9 @@ class API(api_pb2_grpc.APIServicer):
 
         return empty_pb2.Empty()
 
-    def ListFriends(self, request, context, session):
+    def ListFriends(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> api_pb2.ListFriendsRes:
         rels = (
             session.execute(
                 select(FriendRelationship)
@@ -566,7 +576,9 @@ class API(api_pb2_grpc.APIServicer):
             user_ids=[rel.from_user.id if rel.from_user.id != context.user_id else rel.to_user.id for rel in rels],
         )
 
-    def RemoveFriend(self, request, context, session):
+    def RemoveFriend(
+        self, request: api_pb2.RemoveFriendReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         rel = session.execute(
             select(FriendRelationship)
             .where_users_column_visible(context, FriendRelationship.from_user_id)
@@ -593,7 +605,9 @@ class API(api_pb2_grpc.APIServicer):
 
         return empty_pb2.Empty()
 
-    def ListMutualFriends(self, request, context, session):
+    def ListMutualFriends(
+        self, request: api_pb2.ListMutualFriendsReq, context: CouchersContext, session: Session
+    ) -> api_pb2.ListMutualFriendsRes:
         if context.user_id == request.user_id:
             return api_pb2.ListMutualFriendsRes(mutual_friends=[])
 
@@ -645,7 +659,9 @@ class API(api_pb2_grpc.APIServicer):
             ]
         )
 
-    def SendFriendRequest(self, request, context, session):
+    def SendFriendRequest(
+        self, request: api_pb2.SendFriendRequestReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         if context.user_id == request.user_id:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "cant_friend_self")
 
@@ -711,7 +727,9 @@ class API(api_pb2_grpc.APIServicer):
 
         return empty_pb2.Empty()
 
-    def ListFriendRequests(self, request, context, session):
+    def ListFriendRequests(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> api_pb2.ListFriendRequestsRes:
         # both sent and received
         sent_requests = (
             session.execute(
@@ -756,7 +774,9 @@ class API(api_pb2_grpc.APIServicer):
             ],
         )
 
-    def RespondFriendRequest(self, request, context, session):
+    def RespondFriendRequest(
+        self, request: api_pb2.RespondFriendRequestReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         friend_request = session.execute(
             select(FriendRelationship)
             .where_users_column_visible(context, FriendRelationship.from_user_id)
@@ -786,7 +806,9 @@ class API(api_pb2_grpc.APIServicer):
 
         return empty_pb2.Empty()
 
-    def CancelFriendRequest(self, request, context, session):
+    def CancelFriendRequest(
+        self, request: api_pb2.CancelFriendRequestReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         friend_request = session.execute(
             select(FriendRelationship)
             .where_users_column_visible(context, FriendRelationship.to_user_id)
@@ -807,7 +829,9 @@ class API(api_pb2_grpc.APIServicer):
 
         return empty_pb2.Empty()
 
-    def InitiateMediaUpload(self, request, context, session):
+    def InitiateMediaUpload(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> api_pb2.InitiateMediaUploadRes:
         key = random_hex()
 
         created = now()
@@ -836,7 +860,9 @@ class API(api_pb2_grpc.APIServicer):
             expiry=Timestamp_from_datetime(expiry),
         )
 
-    def ListBadgeUsers(self, request, context, session):
+    def ListBadgeUsers(
+        self, request: api_pb2.ListBadgeUsersReq, context: CouchersContext, session: Session
+    ) -> api_pb2.ListBadgeUsersRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_user_id = int(request.page_token) if request.page_token else 0
         badge = get_badge_dict().get(request.badge_id)

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import grpc
 import requests
 from google.protobuf import empty_pb2
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import delete, func, or_
 
 from couchers import urls
@@ -156,7 +157,9 @@ class Auth(auth_pb2_grpc.AuthServicer):
     This class services the Auth service/API.
     """
 
-    def SignupFlow(self, request, context, session):
+    def SignupFlow(
+        self, request: auth_pb2.SignupFlowReq, context: CouchersContext, session: Session
+    ) -> auth_pb2.SignupFlowRes:
         if request.email_token:
             # the email token can either be for verification or just to find an existing signup
             flow = session.execute(
@@ -378,13 +381,15 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 need_accept_community_guidelines=flow.accepted_community_guidelines < GUIDELINES_VERSION,
             )
 
-    def UsernameValid(self, request, context, session):
+    def UsernameValid(
+        self, request: auth_pb2.UsernameValidReq, context: CouchersContext, session: Session
+    ) -> auth_pb2.UsernameValidRes:
         """
         Runs a username availability and validity check.
         """
         return auth_pb2.UsernameValidRes(valid=_username_available(session, request.username.lower()))
 
-    def Authenticate(self, request, context, session):
+    def Authenticate(self, request: auth_pb2.AuthReq, context: CouchersContext, session: Session) -> auth_pb2.AuthRes:
         """
         Authenticates a classic password-based login request.
 
@@ -417,14 +422,16 @@ class Auth(auth_pb2_grpc.AuthServicer):
             logger.debug("Didn't find user")
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "account_not_found")
 
-    def GetAuthState(self, request, context, session):
+    def GetAuthState(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> auth_pb2.GetAuthStateRes:
         if not context.is_logged_in():
             return auth_pb2.GetAuthStateRes(logged_in=False)
         else:
             user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
             return auth_pb2.GetAuthStateRes(logged_in=True, auth_res=_auth_res(user))
 
-    def Deauthenticate(self, request, context, session):
+    def Deauthenticate(self, request: empty_pb2.Empty, context: CouchersContext, session: Session) -> empty_pb2.Empty:
         """
         Removes an active cookie session.
         """
@@ -440,7 +447,9 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
         return empty_pb2.Empty()
 
-    def ResetPassword(self, request, context, session):
+    def ResetPassword(
+        self, request: auth_pb2.ResetPasswordReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         """
         If the user does not exist, do nothing.
 
@@ -474,7 +483,9 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
         return empty_pb2.Empty()
 
-    def CompletePasswordResetV2(self, request, context, session):
+    def CompletePasswordResetV2(
+        self, request: auth_pb2.CompletePasswordResetV2Req, context: CouchersContext, session: Session
+    ) -> auth_pb2.AuthRes:
         """
         Completes the password reset: just clears the user's password
         """
@@ -504,7 +515,9 @@ class Auth(auth_pb2_grpc.AuthServicer):
         else:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "invalid_token")
 
-    def ConfirmChangeEmailV2(self, request, context, session):
+    def ConfirmChangeEmailV2(
+        self, request: auth_pb2.ConfirmChangeEmailV2Req, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         user = session.execute(
             select(User)
             .where(User.new_email_token == request.change_email_token)
@@ -529,7 +542,9 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
         return empty_pb2.Empty()
 
-    def ConfirmDeleteAccount(self, request, context, session):
+    def ConfirmDeleteAccount(
+        self, request: auth_pb2.ConfirmDeleteAccountReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         """
         Confirm account deletion using account delete token
         """
@@ -567,7 +582,9 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
         return empty_pb2.Empty()
 
-    def RecoverAccount(self, request, context, session):
+    def RecoverAccount(
+        self, request: auth_pb2.RecoverAccountReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         """
         Recovers a recently deleted account
         """
@@ -592,10 +609,12 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
         return empty_pb2.Empty()
 
-    def Unsubscribe(self, request, context, session):
+    def Unsubscribe(
+        self, request: auth_pb2.UnsubscribeReq, context: CouchersContext, session: Session
+    ) -> auth_pb2.UnsubscribeRes:
         return auth_pb2.UnsubscribeRes(response=respond_quick_link(request, context, session))
 
-    def AntiBot(self, request, context, session):
+    def AntiBot(self, request: auth_pb2.AntiBotReq, context: CouchersContext, session: Session) -> auth_pb2.AntiBotRes:
         if not config["RECAPTHCA_ENABLED"]:
             return auth_pb2.AntiBotRes()
 
@@ -642,7 +661,9 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
         return auth_pb2.AntiBotRes()
 
-    def AntiBotPolicy(self, request, context, session):
+    def AntiBotPolicy(
+        self, request: auth_pb2.AntiBotPolicyReq, context: CouchersContext, session: Session
+    ) -> auth_pb2.AntiBotPolicyRes:
         if config["RECAPTHCA_ENABLED"]:
             if context.is_logged_in():
                 user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
@@ -651,7 +672,9 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
         return auth_pb2.AntiBotPolicyRes(should_antibot=False)
 
-    def GetInviteCodeInfo(self, request, context, session):
+    def GetInviteCodeInfo(
+        self, request: auth_pb2.GetInviteCodeInfoReq, context: CouchersContext, session: Session
+    ) -> auth_pb2.GetInviteCodeInfoRes:
         invite = session.execute(
             select(InviteCode).where(
                 InviteCode.id == request.code, or_(InviteCode.disabled == None, InviteCode.disabled > func.now())

--- a/app/backend/src/couchers/servicers/blocking.py
+++ b/app/backend/src/couchers/servicers/blocking.py
@@ -1,9 +1,11 @@
 import grpc
 from google.protobuf import empty_pb2
 from sqlalchemy import exists
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import not_, or_, union
 
 from couchers import urls
+from couchers.context import CouchersContext
 from couchers.models import Upload, User, UserBlock
 from couchers.proto import blocking_pb2, blocking_pb2_grpc
 from couchers.sql import couchers_select as select
@@ -37,7 +39,9 @@ def is_not_visible(session, user1_id: int | None, user2_id: int | None) -> bool:
 
 
 class Blocking(blocking_pb2_grpc.BlockingServicer):
-    def BlockUser(self, request, context, session):
+    def BlockUser(
+        self, request: blocking_pb2.BlockUserReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         blockee = session.execute(
             select(User).where(User.is_visible).where(User.username == request.username)
         ).scalar_one_or_none()
@@ -66,7 +70,9 @@ class Blocking(blocking_pb2_grpc.BlockingServicer):
 
         return empty_pb2.Empty()
 
-    def UnblockUser(self, request, context, session):
+    def UnblockUser(
+        self, request: blocking_pb2.UnblockUserReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         blockee = session.execute(
             select(User).where(User.is_visible).where(User.username == request.username)
         ).scalar_one_or_none()
@@ -87,7 +93,9 @@ class Blocking(blocking_pb2_grpc.BlockingServicer):
 
         return empty_pb2.Empty()
 
-    def GetBlockedUsers(self, request, context, session):
+    def GetBlockedUsers(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> blocking_pb2.GetBlockedUsersRes:
         blocked_users = session.execute(
             select(User.username, User.name, Upload.filename)
             .join(UserBlock, UserBlock.blocked_user_id == User.id)

--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -1,10 +1,12 @@
 import grpc
 import requests
 from google.protobuf import empty_pb2
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
 
 from couchers import urls
 from couchers.config import config
+from couchers.context import CouchersContext
 from couchers.descriptor_pool import get_descriptors_pb
 from couchers.models import User
 from couchers.proto import bugs_pb2, bugs_pb2_grpc
@@ -16,10 +18,12 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
     def _version(self):
         return config["VERSION"]
 
-    def Version(self, request, context, session):
+    def Version(self, request: empty_pb2.Empty, context: CouchersContext, session: Session) -> bugs_pb2.VersionInfo:
         return bugs_pb2.VersionInfo(version=self._version())
 
-    def ReportBug(self, request, context, session):
+    def ReportBug(
+        self, request: bugs_pb2.ReportBugReq, context: CouchersContext, session: Session
+    ) -> bugs_pb2.ReportBugRes:
         if not config["BUG_TOOL_ENABLED"]:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "bug_tool_disabled")
 
@@ -62,7 +66,7 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
             bug_id=f"#{issue_number}", bug_url=f"https://github.com/{repo}/issues/{issue_number}"
         )
 
-    def Status(self, request, context, session):
+    def Status(self, request: bugs_pb2.StatusReq, context: CouchersContext, session: Session) -> bugs_pb2.StatusRes:
         coucher_count = session.execute(select(func.count()).select_from(User).where(User.is_visible)).scalar_one()
 
         return bugs_pb2.StatusRes(
@@ -71,14 +75,20 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
             coucher_count=coucher_count,
         )
 
-    def GetDescriptors(self, request, context, session):
+    def GetDescriptors(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> httpbody_pb2.HttpBody:
         return httpbody_pb2.HttpBody(
             content_type="application/octet-stream",
             data=get_descriptors_pb(),
         )
 
-    def GeolocationSearchInfo(self, request, context, session):
+    def GeolocationSearchInfo(
+        self, request: bugs_pb2.GeolocationSearchInfoReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         return empty_pb2.Empty()
 
-    def GeolocationClickInfo(self, request, context, session):
+    def GeolocationClickInfo(
+        self, request: bugs_pb2.GeolocationClickInfoReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         return empty_pb2.Empty()

--- a/app/backend/src/couchers/servicers/communities.py
+++ b/app/backend/src/couchers/servicers/communities.py
@@ -3,9 +3,11 @@ from datetime import timedelta
 
 import grpc
 from google.protobuf import empty_pb2
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import delete, func, or_
 
 from couchers.constants import COMMUNITIES_SEARCH_FUZZY_SIMILARITY_THRESHOLD
+from couchers.context import CouchersContext
 from couchers.crypto import decrypt_page_token, encrypt_page_token
 from couchers.db import can_moderate_node, get_node_parents_recursively
 from couchers.materialized_views import ClusterAdminCount, ClusterSubscriptionCount
@@ -116,14 +118,18 @@ def community_to_pb(session, node: Node, context):
 
 
 class Communities(communities_pb2_grpc.CommunitiesServicer):
-    def GetCommunity(self, request, context, session):
+    def GetCommunity(
+        self, request: communities_pb2.GetCommunityReq, context: CouchersContext, session: Session
+    ) -> communities_pb2.Community:
         node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
 
         return community_to_pb(session, node, context)
 
-    def ListCommunities(self, request, context, session):
+    def ListCommunities(
+        self, request: communities_pb2.ListCommunitiesReq, context: CouchersContext, session: Session
+    ) -> communities_pb2.ListCommunitiesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         offset = int(decrypt_page_token(request.page_token)) if request.page_token else 0
         nodes = (
@@ -144,7 +150,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             next_page_token=encrypt_page_token(str(offset + page_size)) if len(nodes) > page_size else None,
         )
 
-    def SearchCommunities(self, request, context, session):
+    def SearchCommunities(
+        self, request: communities_pb2.SearchCommunitiesReq, context: CouchersContext, session: Session
+    ) -> communities_pb2.SearchCommunitiesRes:
         raw_query = request.query.strip()
         if len(raw_query) < 3:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "query_too_short")
@@ -166,7 +174,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
 
         return communities_pb2.SearchCommunitiesRes(communities=communities_to_pb(session, rows, context))
 
-    def ListGroups(self, request, context, session):
+    def ListGroups(
+        self, request: communities_pb2.ListGroupsReq, context: CouchersContext, session: Session
+    ) -> communities_pb2.ListGroupsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_cluster_id = int(request.page_token) if request.page_token else 0
         clusters = (
@@ -186,7 +196,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             next_page_token=str(clusters[-1].id) if len(clusters) > page_size else None,
         )
 
-    def ListAdmins(self, request, context, session):
+    def ListAdmins(
+        self, request: communities_pb2.ListAdminsReq, context: CouchersContext, session: Session
+    ) -> communities_pb2.ListAdminsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_admin_id = int(request.page_token) if request.page_token else 0
         node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
@@ -211,7 +223,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             next_page_token=str(admins[-1].id) if len(admins) > page_size else None,
         )
 
-    def AddAdmin(self, request, context, session):
+    def AddAdmin(
+        self, request: communities_pb2.AddAdminReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
@@ -239,7 +253,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
 
         return empty_pb2.Empty()
 
-    def RemoveAdmin(self, request, context, session):
+    def RemoveAdmin(
+        self, request: communities_pb2.RemoveAdminReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
@@ -266,7 +282,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
 
         return empty_pb2.Empty()
 
-    def ListMembers(self, request, context, session):
+    def ListMembers(
+        self, request: communities_pb2.ListMembersReq, context: CouchersContext, session: Session
+    ) -> communities_pb2.ListMembersRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_member_id = int(request.page_token) if request.page_token else None
 
@@ -289,7 +307,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             next_page_token=str(members[-1].id) if len(members) > page_size else None,
         )
 
-    def ListNearbyUsers(self, request, context, session):
+    def ListNearbyUsers(
+        self, request: communities_pb2.ListNearbyUsersReq, context: CouchersContext, session: Session
+    ) -> communities_pb2.ListNearbyUsersRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_nearby_id = int(request.page_token) if request.page_token else 0
         node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
@@ -312,7 +332,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             next_page_token=str(nearbys[-1].id) if len(nearbys) > page_size else None,
         )
 
-    def ListPlaces(self, request, context, session):
+    def ListPlaces(
+        self, request: communities_pb2.ListPlacesReq, context: CouchersContext, session: Session
+    ) -> communities_pb2.ListPlacesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_page_id = int(request.page_token) if request.page_token else 0
         node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
@@ -330,7 +352,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             next_page_token=str(places[-1].id) if len(places) > page_size else None,
         )
 
-    def ListGuides(self, request, context, session):
+    def ListGuides(
+        self, request: communities_pb2.ListGuidesReq, context: CouchersContext, session: Session
+    ) -> communities_pb2.ListGuidesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_page_id = int(request.page_token) if request.page_token else 0
         node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
@@ -348,7 +372,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             next_page_token=str(guides[-1].id) if len(guides) > page_size else None,
         )
 
-    def ListEvents(self, request, context, session):
+    def ListEvents(
+        self, request: communities_pb2.ListEventsReq, context: CouchersContext, session: Session
+    ) -> communities_pb2.ListEventsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         # the page token is a unix timestamp of where we left off
         page_token = dt_from_millis(int(request.page_token)) if request.page_token else now()
@@ -394,7 +420,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             next_page_token=str(millis_from_dt(occurrences[-1].end_time)) if len(occurrences) > page_size else None,
         )
 
-    def ListDiscussions(self, request, context, session):
+    def ListDiscussions(
+        self, request: communities_pb2.ListDiscussionsReq, context: CouchersContext, session: Session
+    ) -> communities_pb2.ListDiscussionsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_page_id = int(request.page_token) if request.page_token else 0
         node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
@@ -413,7 +441,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             next_page_token=str(discussions[-1].id) if len(discussions) > page_size else None,
         )
 
-    def JoinCommunity(self, request, context, session):
+    def JoinCommunity(
+        self, request: communities_pb2.JoinCommunityReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
@@ -431,7 +461,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
 
         return empty_pb2.Empty()
 
-    def LeaveCommunity(self, request, context, session):
+    def LeaveCommunity(
+        self, request: communities_pb2.LeaveCommunityReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
@@ -452,7 +484,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
 
         return empty_pb2.Empty()
 
-    def ListUserCommunities(self, request, context, session):
+    def ListUserCommunities(
+        self, request: communities_pb2.ListUserCommunitiesReq, context: CouchersContext, session: Session
+    ) -> communities_pb2.ListUserCommunitiesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_node_id = int(request.page_token) if request.page_token else 0
         user_id = request.user_id or context.user_id
@@ -476,7 +510,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             next_page_token=str(nodes[-1].id) if len(nodes) > page_size else None,
         )
 
-    def ListAllCommunities(self, request, context, session):
+    def ListAllCommunities(
+        self, request: communities_pb2.ListAllCommunitiesReq, context: CouchersContext, session: Session
+    ) -> communities_pb2.ListAllCommunitiesRes:
         """List all communities ordered hierarchically by parent-child relationships"""
         # Get all nodes with their clusters, member counts, and user membership in a single query
         results = session.execute(

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -3,10 +3,11 @@ from datetime import timedelta
 
 import grpc
 from google.protobuf import empty_pb2
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import func, not_, or_
 
 from couchers.constants import DATETIME_INFINITY, DATETIME_MINUS_INFINITY
-from couchers.context import make_background_user_context
+from couchers.context import CouchersContext, make_background_user_context
 from couchers.db import session_scope
 from couchers.jobs.enqueue import queue_job
 from couchers.metrics import sent_messages_counter
@@ -293,7 +294,9 @@ def _mute_info(subscription):
 
 
 class Conversations(conversations_pb2_grpc.ConversationsServicer):
-    def ListGroupChats(self, request, context, session):
+    def ListGroupChats(
+        self, request: conversations_pb2.ListGroupChatsReq, context: CouchersContext, session: Session
+    ) -> conversations_pb2.ListGroupChatsRes:
         page_size = request.number if request.number != 0 else DEFAULT_PAGINATION_LENGTH
         page_size = min(page_size, MAX_PAGE_SIZE)
 
@@ -349,7 +352,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             no_more=len(results) <= page_size,
         )
 
-    def GetGroupChat(self, request, context, session):
+    def GetGroupChat(
+        self, request: conversations_pb2.GetGroupChatReq, context: CouchersContext, session: Session
+    ) -> conversations_pb2.GroupChat:
         result = session.execute(
             select(GroupChat, GroupChatSubscription, Message)
             .join(Message, Message.conversation_id == GroupChatSubscription.group_chat_id)
@@ -380,7 +385,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             can_message=_user_can_message(session, context, result.GroupChat),
         )
 
-    def GetDirectMessage(self, request, context, session):
+    def GetDirectMessage(
+        self, request: conversations_pb2.GetDirectMessageReq, context: CouchersContext, session: Session
+    ) -> conversations_pb2.GroupChat:
         count = func.count(GroupChatSubscription.id).label("count")
         subquery = (
             select(GroupChatSubscription.group_chat_id)
@@ -428,7 +435,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             can_message=_user_can_message(session, context, result.GroupChat),
         )
 
-    def GetUpdates(self, request, context, session):
+    def GetUpdates(
+        self, request: conversations_pb2.GetUpdatesReq, context: CouchersContext, session: Session
+    ) -> conversations_pb2.GetUpdatesRes:
         results = (
             session.execute(
                 select(Message)
@@ -455,7 +464,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             no_more=len(results) <= DEFAULT_PAGINATION_LENGTH,
         )
 
-    def GetGroupChatMessages(self, request, context, session):
+    def GetGroupChatMessages(
+        self, request: conversations_pb2.GetGroupChatMessagesReq, context: CouchersContext, session: Session
+    ) -> conversations_pb2.GetGroupChatMessagesRes:
         page_size = request.number if request.number != 0 else DEFAULT_PAGINATION_LENGTH
         page_size = min(page_size, MAX_PAGE_SIZE)
 
@@ -482,7 +493,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             no_more=len(results) <= page_size,
         )
 
-    def MarkLastSeenGroupChat(self, request, context, session):
+    def MarkLastSeenGroupChat(
+        self, request: conversations_pb2.MarkLastSeenGroupChatReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         subscription = _get_message_subscription(session, context.user_id, request.group_chat_id)
 
         if not subscription:
@@ -497,7 +510,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
 
         return empty_pb2.Empty()
 
-    def MuteGroupChat(self, request, context, session):
+    def MuteGroupChat(
+        self, request: conversations_pb2.MuteGroupChatReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         subscription = _get_message_subscription(session, context.user_id, request.group_chat_id)
 
         if not subscription:
@@ -515,7 +530,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
 
         return empty_pb2.Empty()
 
-    def SearchMessages(self, request, context, session):
+    def SearchMessages(
+        self, request: conversations_pb2.SearchMessagesReq, context: CouchersContext, session: Session
+    ) -> conversations_pb2.SearchMessagesRes:
         page_size = request.number if request.number != 0 else DEFAULT_PAGINATION_LENGTH
         page_size = min(page_size, MAX_PAGE_SIZE)
 
@@ -547,7 +564,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             no_more=len(results) <= page_size,
         )
 
-    def CreateGroupChat(self, request, context, session):
+    def CreateGroupChat(
+        self, request: conversations_pb2.CreateGroupChatReq, context: CouchersContext, session: Session
+    ) -> conversations_pb2.GroupChat:
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
         if not user.has_completed_profile:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "incomplete_profile_send_message")
@@ -631,7 +650,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             can_message=True,
         )
 
-    def SendMessage(self, request, context, session):
+    def SendMessage(
+        self, request: conversations_pb2.SendMessageReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         if request.text == "":
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_message")
 
@@ -658,7 +679,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
 
         return empty_pb2.Empty()
 
-    def SendDirectMessage(self, request, context, session):
+    def SendDirectMessage(
+        self, request: conversations_pb2.SendDirectMessageReq, context: CouchersContext, session: Session
+    ) -> conversations_pb2.SendDirectMessageRes:
         user_id = context.user_id
         user = session.execute(select(User).where(User.id == user_id)).scalar_one()
 
@@ -711,7 +734,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
 
         return conversations_pb2.SendDirectMessageRes(group_chat_id=chat.conversation_id)
 
-    def EditGroupChat(self, request, context, session):
+    def EditGroupChat(
+        self, request: conversations_pb2.EditGroupChatReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         subscription = _get_message_subscription(session, context.user_id, request.group_chat_id)
 
         if not subscription:
@@ -730,7 +755,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
 
         return empty_pb2.Empty()
 
-    def MakeGroupChatAdmin(self, request, context, session):
+    def MakeGroupChatAdmin(
+        self, request: conversations_pb2.MakeGroupChatAdminReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         if not session.execute(
             select(User).where_users_visible(context).where(User.id == request.user_id)
         ).scalar_one_or_none():
@@ -763,7 +790,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
 
         return empty_pb2.Empty()
 
-    def RemoveGroupChatAdmin(self, request, context, session):
+    def RemoveGroupChatAdmin(
+        self, request: conversations_pb2.RemoveGroupChatAdminReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         if not session.execute(
             select(User).where_users_visible(context).where(User.id == request.user_id)
         ).scalar_one_or_none():
@@ -809,7 +838,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
 
         return empty_pb2.Empty()
 
-    def InviteToGroupChat(self, request, context, session):
+    def InviteToGroupChat(
+        self, request: conversations_pb2.InviteToGroupChatReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         if not session.execute(
             select(User).where_users_visible(context).where(User.id == request.user_id)
         ).scalar_one_or_none():
@@ -860,7 +891,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
 
         return empty_pb2.Empty()
 
-    def RemoveGroupChatUser(self, request, context, session):
+    def RemoveGroupChatUser(
+        self, request: conversations_pb2.RemoveGroupChatUserReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         """
         1. Get admin info and check it's correct
         2. Get user data, check it's correct and remove user
@@ -895,7 +928,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
 
         return empty_pb2.Empty()
 
-    def LeaveGroupChat(self, request, context, session):
+    def LeaveGroupChat(
+        self, request: conversations_pb2.LeaveGroupChatReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         subscription = _get_message_subscription(session, context.user_id, request.group_chat_id)
 
         if not subscription:

--- a/app/backend/src/couchers/servicers/discussions.py
+++ b/app/backend/src/couchers/servicers/discussions.py
@@ -1,8 +1,9 @@
 import logging
 
 import grpc
+from sqlalchemy.orm import Session
 
-from couchers.context import make_background_user_context
+from couchers.context import CouchersContext, make_background_user_context
 from couchers.db import can_moderate_node, session_scope
 from couchers.jobs.enqueue import queue_job
 from couchers.models import Cluster, Discussion, Thread, User
@@ -69,7 +70,9 @@ def generate_create_discussion_notifications(payload: jobs_pb2.GenerateCreateDis
 
 
 class Discussions(discussions_pb2_grpc.DiscussionsServicer):
-    def CreateDiscussion(self, request, context, session):
+    def CreateDiscussion(
+        self, request: discussions_pb2.CreateDiscussionReq, context: CouchersContext, session: Session
+    ) -> discussions_pb2.Discussion:
         if not request.title:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "missing_discussion_title")
         if not request.content:
@@ -114,7 +117,9 @@ class Discussions(discussions_pb2_grpc.DiscussionsServicer):
 
         return discussion_to_pb(session, discussion, context)
 
-    def GetDiscussion(self, request, context, session):
+    def GetDiscussion(
+        self, request: discussions_pb2.GetDiscussionReq, context: CouchersContext, session: Session
+    ) -> discussions_pb2.Discussion:
         discussion = session.execute(
             select(Discussion).where(Discussion.id == request.discussion_id)
         ).scalar_one_or_none()

--- a/app/backend/src/couchers/servicers/donations.py
+++ b/app/backend/src/couchers/servicers/donations.py
@@ -3,10 +3,13 @@ import logging
 
 import grpc
 import stripe
+from google.protobuf import empty_pb2
 from sqlalchemy import update
+from sqlalchemy.orm import Session
 
 from couchers import urls
 from couchers.config import config
+from couchers.context import CouchersContext
 from couchers.models import DonationInitiation, DonationType, Invoice, InvoiceType, User
 from couchers.notifications.notify import notify
 from couchers.proto import donations_pb2, donations_pb2_grpc, notification_data_pb2, stripe_pb2_grpc
@@ -31,7 +34,9 @@ def _create_stripe_customer(session, user):
 
 
 class Donations(donations_pb2_grpc.DonationsServicer):
-    def InitiateDonation(self, request, context, session):
+    def InitiateDonation(
+        self, request: donations_pb2.InitiateDonationReq, context: CouchersContext, session: Session
+    ) -> donations_pb2.InitiateDonationRes:
         if not config["ENABLE_DONATIONS"]:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "donations_disabled")
 
@@ -88,7 +93,9 @@ class Donations(donations_pb2_grpc.DonationsServicer):
             stripe_checkout_session_id=checkout_session.id, stripe_checkout_url=checkout_session.url
         )
 
-    def GetDonationPortalLink(self, request, context, session):
+    def GetDonationPortalLink(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> donations_pb2.GetDonationPortalLinkRes:
         if not config["ENABLE_DONATIONS"]:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "donations_disabled")
 

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -4,9 +4,10 @@ from datetime import timedelta
 import grpc
 from google.protobuf import empty_pb2
 from psycopg2.extras import DateTimeTZRange
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import and_, func, or_, select, update
 
-from couchers.context import make_background_user_context
+from couchers.context import CouchersContext, make_background_user_context
 from couchers.db import can_moderate_node, get_parent_node_at_location, session_scope
 from couchers.jobs.enqueue import queue_job
 from couchers.models import (
@@ -369,7 +370,9 @@ def generate_event_delete_notifications(payload: jobs_pb2.GenerateEventDeleteNot
 
 
 class Events(events_pb2_grpc.EventsServicer):
-    def CreateEvent(self, request, context, session):
+    def CreateEvent(
+        self, request: events_pb2.CreateEventReq, context: CouchersContext, session: Session
+    ) -> events_pb2.Event:
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
         if not user.has_completed_profile:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "incomplete_profile_create_event")
@@ -487,7 +490,9 @@ class Events(events_pb2_grpc.EventsServicer):
 
         return event_to_pb(session, occurrence, context)
 
-    def ScheduleEvent(self, request, context, session):
+    def ScheduleEvent(
+        self, request: events_pb2.ScheduleEventReq, context: CouchersContext, session: Session
+    ) -> events_pb2.Event:
         if not request.content:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "missing_event_content")
         if request.HasField("online_information"):
@@ -575,7 +580,9 @@ class Events(events_pb2_grpc.EventsServicer):
 
         return event_to_pb(session, occurrence, context)
 
-    def UpdateEvent(self, request, context, session):
+    def UpdateEvent(
+        self, request: events_pb2.UpdateEventReq, context: CouchersContext, session: Session
+    ) -> events_pb2.Event:
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
         res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id)
         if not res:
@@ -709,7 +716,7 @@ class Events(events_pb2_grpc.EventsServicer):
 
         return event_to_pb(session, occurrence, context)
 
-    def GetEvent(self, request, context, session):
+    def GetEvent(self, request: events_pb2.GetEventReq, context: CouchersContext, session: Session) -> events_pb2.Event:
         occurrence = session.execute(
             select(EventOccurrence).where(EventOccurrence.id == request.event_id).where(~EventOccurrence.is_deleted)
         ).scalar_one_or_none()
@@ -719,7 +726,9 @@ class Events(events_pb2_grpc.EventsServicer):
 
         return event_to_pb(session, occurrence, context)
 
-    def CancelEvent(self, request, context, session):
+    def CancelEvent(
+        self, request: events_pb2.CancelEventReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id)
         if not res:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
@@ -745,7 +754,9 @@ class Events(events_pb2_grpc.EventsServicer):
 
         return empty_pb2.Empty()
 
-    def RequestCommunityInvite(self, request, context, session):
+    def RequestCommunityInvite(
+        self, request: events_pb2.RequestCommunityInviteReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
         res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id)
         if not res:
@@ -787,7 +798,9 @@ class Events(events_pb2_grpc.EventsServicer):
 
         return empty_pb2.Empty()
 
-    def ListEventOccurrences(self, request, context, session):
+    def ListEventOccurrences(
+        self, request: events_pb2.ListEventOccurrencesReq, context: CouchersContext, session: Session
+    ) -> events_pb2.ListEventOccurrencesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         # the page token is a unix timestamp of where we left off
         page_token = dt_from_millis(int(request.page_token)) if request.page_token else now()
@@ -821,7 +834,9 @@ class Events(events_pb2_grpc.EventsServicer):
             next_page_token=str(millis_from_dt(occurrences[-1].end_time)) if len(occurrences) > page_size else None,
         )
 
-    def ListEventAttendees(self, request, context, session):
+    def ListEventAttendees(
+        self, request: events_pb2.ListEventAttendeesReq, context: CouchersContext, session: Session
+    ) -> events_pb2.ListEventAttendeesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_user_id = int(request.page_token) if request.page_token else 0
         occurrence = session.execute(
@@ -846,7 +861,9 @@ class Events(events_pb2_grpc.EventsServicer):
             next_page_token=str(attendees[-1].user_id) if len(attendees) > page_size else None,
         )
 
-    def ListEventSubscribers(self, request, context, session):
+    def ListEventSubscribers(
+        self, request: events_pb2.ListEventSubscribersReq, context: CouchersContext, session: Session
+    ) -> events_pb2.ListEventSubscribersRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_user_id = int(request.page_token) if request.page_token else 0
         res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id)
@@ -870,7 +887,9 @@ class Events(events_pb2_grpc.EventsServicer):
             next_page_token=str(subscribers[-1].user_id) if len(subscribers) > page_size else None,
         )
 
-    def ListEventOrganizers(self, request, context, session):
+    def ListEventOrganizers(
+        self, request: events_pb2.ListEventOrganizersReq, context: CouchersContext, session: Session
+    ) -> events_pb2.ListEventOrganizersRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_user_id = int(request.page_token) if request.page_token else 0
         res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id)
@@ -894,7 +913,9 @@ class Events(events_pb2_grpc.EventsServicer):
             next_page_token=str(organizers[-1].user_id) if len(organizers) > page_size else None,
         )
 
-    def TransferEvent(self, request, context, session):
+    def TransferEvent(
+        self, request: events_pb2.TransferEventReq, context: CouchersContext, session: Session
+    ) -> events_pb2.Event:
         res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id)
         if not res:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
@@ -930,7 +951,9 @@ class Events(events_pb2_grpc.EventsServicer):
         session.commit()
         return event_to_pb(session, occurrence, context)
 
-    def SetEventSubscription(self, request, context, session):
+    def SetEventSubscription(
+        self, request: events_pb2.SetEventSubscriptionReq, context: CouchersContext, session: Session
+    ) -> events_pb2.Event:
         res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id)
         if not res:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
@@ -961,7 +984,9 @@ class Events(events_pb2_grpc.EventsServicer):
 
         return event_to_pb(session, occurrence, context)
 
-    def SetEventAttendance(self, request, context, session):
+    def SetEventAttendance(
+        self, request: events_pb2.SetEventAttendanceReq, context: CouchersContext, session: Session
+    ) -> events_pb2.Event:
         occurrence = session.execute(
             select(EventOccurrence).where(EventOccurrence.id == request.event_id).where(~EventOccurrence.is_deleted)
         ).scalar_one_or_none()
@@ -1001,7 +1026,9 @@ class Events(events_pb2_grpc.EventsServicer):
 
         return event_to_pb(session, occurrence, context)
 
-    def ListMyEvents(self, request, context, session):
+    def ListMyEvents(
+        self, request: events_pb2.ListMyEventsReq, context: CouchersContext, session: Session
+    ) -> events_pb2.ListMyEventsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         # the page token is a unix timestamp of where we left off
         page_token = (
@@ -1086,7 +1113,9 @@ class Events(events_pb2_grpc.EventsServicer):
             total_items=total_items,
         )
 
-    def ListAllEvents(self, request, context, session):
+    def ListAllEvents(
+        self, request: events_pb2.ListAllEventsReq, context: CouchersContext, session: Session
+    ) -> events_pb2.ListAllEventsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         # the page token is a unix timestamp of where we left off
         page_token = dt_from_millis(int(request.page_token)) if request.page_token else now()
@@ -1115,7 +1144,9 @@ class Events(events_pb2_grpc.EventsServicer):
             next_page_token=str(millis_from_dt(occurrences[-1].end_time)) if len(occurrences) > page_size else None,
         )
 
-    def InviteEventOrganizer(self, request, context, session):
+    def InviteEventOrganizer(
+        self, request: events_pb2.InviteEventOrganizerReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
         res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id)
         if not res:
@@ -1160,7 +1191,9 @@ class Events(events_pb2_grpc.EventsServicer):
 
         return empty_pb2.Empty()
 
-    def RemoveEventOrganizer(self, request, context, session):
+    def RemoveEventOrganizer(
+        self, request: events_pb2.RemoveEventOrganizerReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id)
         if not res:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")

--- a/app/backend/src/couchers/servicers/gis.py
+++ b/app/backend/src/couchers/servicers/gis.py
@@ -1,9 +1,12 @@
 import json
 import logging
 
+from google.protobuf import empty_pb2
 from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
 
+from couchers.context import CouchersContext
 from couchers.materialized_views import ClusteredUser, LiteUser
 from couchers.models import Node, Page, PageType, PageVersion
 from couchers.proto import gis_pb2_grpc
@@ -36,19 +39,23 @@ def _statement_to_geojson_response(session, statement):
 
 
 class GIS(gis_pb2_grpc.GISServicer):
-    def GetUsers(self, request, context, session):
+    def GetUsers(self, request: empty_pb2.Empty, context: CouchersContext, session: Session) -> httpbody_pb2.HttpBody:
         statement = select(LiteUser.id, LiteUser.geom, LiteUser.has_completed_profile).where_users_visible(
             context, table=LiteUser
         )
         return _statement_to_geojson_response(session, statement)
 
-    def GetClusteredUsers(self, request, context, session):
+    def GetClusteredUsers(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> httpbody_pb2.HttpBody:
         return _statement_to_geojson_response(session, select(ClusteredUser.geom, ClusteredUser.count))
 
-    def GetCommunities(self, request, context, session):
+    def GetCommunities(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> httpbody_pb2.HttpBody:
         return _statement_to_geojson_response(session, select(Node).where(Node.geom != None))
 
-    def GetPlaces(self, request, context, session):
+    def GetPlaces(self, request: empty_pb2.Empty, context: CouchersContext, session: Session) -> httpbody_pb2.HttpBody:
         # need to do a subquery here so we get pages without a geom, not just versions without geom
         latest_pages = (
             select(func.max(PageVersion.id).label("id"))
@@ -66,7 +73,7 @@ class GIS(gis_pb2_grpc.GISServicer):
 
         return _statement_to_geojson_response(session, statement)
 
-    def GetGuides(self, request, context, session):
+    def GetGuides(self, request: empty_pb2.Empty, context: CouchersContext, session: Session) -> httpbody_pb2.HttpBody:
         latest_pages = (
             select(func.max(PageVersion.id).label("id"))
             .join(Page, Page.id == PageVersion.page_id)

--- a/app/backend/src/couchers/servicers/groups.py
+++ b/app/backend/src/couchers/servicers/groups.py
@@ -3,8 +3,10 @@ from datetime import timedelta
 
 import grpc
 from google.protobuf import empty_pb2
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import delete, func
 
+from couchers.context import CouchersContext
 from couchers.db import can_moderate_node, get_node_parents_recursively
 from couchers.models import (
     Cluster,
@@ -105,7 +107,7 @@ def group_to_pb(session, cluster: Cluster, context):
 
 
 class Groups(groups_pb2_grpc.GroupsServicer):
-    def GetGroup(self, request, context, session):
+    def GetGroup(self, request: groups_pb2.GetGroupReq, context: CouchersContext, session: Session) -> groups_pb2.Group:
         cluster = session.execute(
             select(Cluster)
             .where(~Cluster.is_official_cluster)  # not an official group
@@ -116,7 +118,9 @@ class Groups(groups_pb2_grpc.GroupsServicer):
 
         return group_to_pb(session, cluster, context)
 
-    def ListAdmins(self, request, context, session):
+    def ListAdmins(
+        self, request: groups_pb2.ListAdminsReq, context: CouchersContext, session: Session
+    ) -> groups_pb2.ListAdminsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_admin_id = int(request.page_token) if request.page_token else 0
         cluster = session.execute(
@@ -144,7 +148,9 @@ class Groups(groups_pb2_grpc.GroupsServicer):
             next_page_token=str(admins[-1].id) if len(admins) > page_size else None,
         )
 
-    def ListMembers(self, request, context, session):
+    def ListMembers(
+        self, request: groups_pb2.ListMembersReq, context: CouchersContext, session: Session
+    ) -> groups_pb2.ListMembersRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_member_id = int(request.page_token) if request.page_token else 0
         cluster = session.execute(
@@ -171,7 +177,9 @@ class Groups(groups_pb2_grpc.GroupsServicer):
             next_page_token=str(members[-1].id) if len(members) > page_size else None,
         )
 
-    def ListPlaces(self, request, context, session):
+    def ListPlaces(
+        self, request: groups_pb2.ListPlacesReq, context: CouchersContext, session: Session
+    ) -> groups_pb2.ListPlacesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_page_id = int(request.page_token) if request.page_token else 0
         cluster = session.execute(
@@ -191,7 +199,9 @@ class Groups(groups_pb2_grpc.GroupsServicer):
             next_page_token=str(places[-1].id) if len(places) > page_size else None,
         )
 
-    def ListGuides(self, request, context, session):
+    def ListGuides(
+        self, request: groups_pb2.ListGuidesReq, context: CouchersContext, session: Session
+    ) -> groups_pb2.ListGuidesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_page_id = int(request.page_token) if request.page_token else 0
         cluster = session.execute(
@@ -211,7 +221,9 @@ class Groups(groups_pb2_grpc.GroupsServicer):
             next_page_token=str(guides[-1].id) if len(guides) > page_size else None,
         )
 
-    def ListEvents(self, request, context, session):
+    def ListEvents(
+        self, request: groups_pb2.ListEventsReq, context: CouchersContext, session: Session
+    ) -> groups_pb2.ListEventsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         # the page token is a unix timestamp of where we left off
         page_token = dt_from_millis(int(request.page_token)) if request.page_token else now()
@@ -245,7 +257,9 @@ class Groups(groups_pb2_grpc.GroupsServicer):
             next_page_token=str(millis_from_dt(occurrences[-1].end_time)) if len(occurrences) > page_size else None,
         )
 
-    def ListDiscussions(self, request, context, session):
+    def ListDiscussions(
+        self, request: groups_pb2.ListDiscussionsReq, context: CouchersContext, session: Session
+    ) -> groups_pb2.ListDiscussionsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_page_id = int(request.page_token) if request.page_token else 0
         cluster = session.execute(
@@ -264,7 +278,9 @@ class Groups(groups_pb2_grpc.GroupsServicer):
             next_page_token=str(discussions[-1].id) if len(discussions) > page_size else None,
         )
 
-    def JoinGroup(self, request, context, session):
+    def JoinGroup(
+        self, request: groups_pb2.JoinGroupReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         cluster = session.execute(
             select(Cluster).where(~Cluster.is_official_cluster).where(Cluster.id == request.group_id)
         ).scalar_one_or_none()
@@ -284,7 +300,9 @@ class Groups(groups_pb2_grpc.GroupsServicer):
 
         return empty_pb2.Empty()
 
-    def LeaveGroup(self, request, context, session):
+    def LeaveGroup(
+        self, request: groups_pb2.LeaveGroupReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         cluster = session.execute(
             select(Cluster).where(~Cluster.is_official_cluster).where(Cluster.id == request.group_id)
         ).scalar_one_or_none()
@@ -303,7 +321,9 @@ class Groups(groups_pb2_grpc.GroupsServicer):
 
         return empty_pb2.Empty()
 
-    def ListUserGroups(self, request, context, session):
+    def ListUserGroups(
+        self, request: groups_pb2.ListUserGroupsReq, context: CouchersContext, session: Session
+    ) -> groups_pb2.ListUserGroupsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_cluster_id = int(request.page_token) if request.page_token else 0
         user_id = request.user_id or context.user_id

--- a/app/backend/src/couchers/servicers/jail.py
+++ b/app/backend/src/couchers/servicers/jail.py
@@ -1,8 +1,11 @@
 import logging
 
 import grpc
+from google.protobuf import empty_pb2
+from sqlalchemy.orm import Session
 
 from couchers.constants import GUIDELINES_VERSION, TOS_VERSION
+from couchers.context import CouchersContext
 from couchers.models import ActivenessProbe, ActivenessProbeStatus, HostingStatus, ModNote, User
 from couchers.proto import jail_pb2, jail_pb2_grpc
 from couchers.servicers.account import mod_note_to_pb
@@ -43,11 +46,13 @@ class Jail(jail_pb2_grpc.JailServicer):
     fully active
     """
 
-    def JailInfo(self, request, context, session):
+    def JailInfo(self, request: empty_pb2.Empty, context: CouchersContext, session: Session) -> jail_pb2.JailInfoRes:
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
         return _get_jail_info(session, user)
 
-    def AcceptTOS(self, request, context, session):
+    def AcceptTOS(
+        self, request: jail_pb2.AcceptTOSReq, context: CouchersContext, session: Session
+    ) -> jail_pb2.JailInfoRes:
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
 
         if not request.accept:
@@ -57,7 +62,9 @@ class Jail(jail_pb2_grpc.JailServicer):
 
         return _get_jail_info(session, user)
 
-    def SetLocation(self, request, context, session):
+    def SetLocation(
+        self, request: jail_pb2.SetLocationReq, context: CouchersContext, session: Session
+    ) -> jail_pb2.JailInfoRes:
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
 
         if request.lat == 0 and request.lng == 0:
@@ -71,7 +78,9 @@ class Jail(jail_pb2_grpc.JailServicer):
 
         return _get_jail_info(session, user)
 
-    def AcceptCommunityGuidelines(self, request, context, session):
+    def AcceptCommunityGuidelines(
+        self, request: jail_pb2.AcceptCommunityGuidelinesReq, context: CouchersContext, session: Session
+    ) -> jail_pb2.JailInfoRes:
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
 
         if not request.accept:
@@ -81,7 +90,9 @@ class Jail(jail_pb2_grpc.JailServicer):
 
         return _get_jail_info(session, user)
 
-    def AcknowledgePendingModNote(self, request, context, session):
+    def AcknowledgePendingModNote(
+        self, request: jail_pb2.AcknowledgePendingModNoteReq, context: CouchersContext, session: Session
+    ) -> jail_pb2.JailInfoRes:
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
 
         note = session.execute(
@@ -101,7 +112,9 @@ class Jail(jail_pb2_grpc.JailServicer):
 
         return _get_jail_info(session, user)
 
-    def RespondToActivenessProbe(self, request, context, session):
+    def RespondToActivenessProbe(
+        self, request: jail_pb2.RespondToActivenessProbeReq, context: CouchersContext, session: Session
+    ) -> jail_pb2.JailInfoRes:
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
 
         probe = session.execute(

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -3,9 +3,11 @@ import logging
 
 import grpc
 from google.protobuf import empty_pb2
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import or_
 
 from couchers.config import config
+from couchers.context import CouchersContext
 from couchers.models import (
     HostingStatus,
     MeetupStatus,
@@ -49,14 +51,18 @@ def notification_to_pb(user, notification: Notification):
 
 
 class Notifications(notifications_pb2_grpc.NotificationsServicer):
-    def GetNotificationSettings(self, request, context, session):
+    def GetNotificationSettings(
+        self, request: notifications_pb2.GetNotificationSettingsReq, context: CouchersContext, session: Session
+    ) -> notifications_pb2.GetNotificationSettingsRes:
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
         return notifications_pb2.GetNotificationSettingsRes(
             do_not_email_enabled=user.do_not_email,
             groups=get_user_setting_groups(user.id),
         )
 
-    def SetNotificationSettings(self, request, context, session):
+    def SetNotificationSettings(
+        self, request: notifications_pb2.SetNotificationSettingsReq, context: CouchersContext, session: Session
+    ) -> notifications_pb2.GetNotificationSettingsRes:
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
         user.do_not_email = request.enable_do_not_email
         if request.enable_do_not_email:
@@ -81,7 +87,9 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             groups=get_user_setting_groups(user.id),
         )
 
-    def ListNotifications(self, request, context, session):
+    def ListNotifications(
+        self, request: notifications_pb2.ListNotificationsReq, context: CouchersContext, session: Session
+    ) -> notifications_pb2.ListNotificationsRes:
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_notification_id = int(request.page_token) if request.page_token else 2**50
@@ -107,7 +115,9 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             next_page_token=str(notifications[-1].id) if len(notifications) > page_size else None,
         )
 
-    def MarkNotificationSeen(self, request, context, session):
+    def MarkNotificationSeen(
+        self, request: notifications_pb2.MarkNotificationSeenReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         notification = (
             session.execute(
                 select(Notification)
@@ -122,7 +132,9 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         notification.is_seen = request.set_seen
         return empty_pb2.Empty()
 
-    def MarkAllNotificationsSeen(self, request, context, session):
+    def MarkAllNotificationsSeen(
+        self, request: notifications_pb2.MarkAllNotificationsSeenReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         session.execute(
             Notification.__table__.update()
             .values(is_seen=True)
@@ -131,13 +143,20 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         )
         return empty_pb2.Empty()
 
-    def GetVapidPublicKey(self, request, context, session):
+    def GetVapidPublicKey(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> notifications_pb2.GetVapidPublicKeyRes:
         if not config["PUSH_NOTIFICATIONS_ENABLED"]:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         return notifications_pb2.GetVapidPublicKeyRes(vapid_public_key=get_vapid_public_key())
 
-    def RegisterPushNotificationSubscription(self, request, context, session):
+    def RegisterPushNotificationSubscription(
+        self,
+        request: notifications_pb2.RegisterPushNotificationSubscriptionReq,
+        context: CouchersContext,
+        session: Session,
+    ) -> empty_pb2.Empty:
         if not config["PUSH_NOTIFICATIONS_ENABLED"]:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
@@ -163,7 +182,9 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
 
         return empty_pb2.Empty()
 
-    def SendTestPushNotification(self, request, context, session):
+    def SendTestPushNotification(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         if not config["PUSH_NOTIFICATIONS_ENABLED"]:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 

--- a/app/backend/src/couchers/servicers/pages.py
+++ b/app/backend/src/couchers/servicers/pages.py
@@ -1,6 +1,7 @@
 import grpc
 from sqlalchemy.orm import Session
 
+from couchers.context import CouchersContext
 from couchers.db import can_moderate_at, can_moderate_node, get_parent_node_at_location
 from couchers.models import Cluster, Node, Page, PageType, PageVersion, Thread, Upload, User
 from couchers.proto import pages_pb2, pages_pb2_grpc
@@ -97,7 +98,9 @@ def page_to_pb(session: Session, page: Page, context) -> pages_pb2.Page:
 
 
 class Pages(pages_pb2_grpc.PagesServicer):
-    def CreatePlace(self, request, context, session):
+    def CreatePlace(
+        self, request: pages_pb2.CreatePlaceReq, context: CouchersContext, session: Session
+    ) -> pages_pb2.Page:
         if not request.title:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "missing_page_title")
         if not request.content:
@@ -139,7 +142,9 @@ class Pages(pages_pb2_grpc.PagesServicer):
         session.commit()
         return page_to_pb(session, page, context)
 
-    def CreateGuide(self, request, context, session):
+    def CreateGuide(
+        self, request: pages_pb2.CreateGuideReq, context: CouchersContext, session: Session
+    ) -> pages_pb2.Page:
         if not request.title:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "missing_page_title")
         if not request.content:
@@ -192,14 +197,16 @@ class Pages(pages_pb2_grpc.PagesServicer):
         session.commit()
         return page_to_pb(session, page, context)
 
-    def GetPage(self, request, context, session):
+    def GetPage(self, request: pages_pb2.GetPageReq, context: CouchersContext, session: Session) -> pages_pb2.Page:
         page = session.execute(select(Page).where(Page.id == request.page_id)).scalar_one_or_none()
         if not page:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "page_not_found")
 
         return page_to_pb(session, page, context)
 
-    def UpdatePage(self, request, context, session):
+    def UpdatePage(
+        self, request: pages_pb2.UpdatePageReq, context: CouchersContext, session: Session
+    ) -> pages_pb2.Page:
         page = session.execute(select(Page).where(Page.id == request.page_id)).scalar_one_or_none()
         if not page:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "page_not_found")
@@ -251,7 +258,9 @@ class Pages(pages_pb2_grpc.PagesServicer):
         session.commit()
         return page_to_pb(session, page, context)
 
-    def TransferPage(self, request, context, session):
+    def TransferPage(
+        self, request: pages_pb2.TransferPageReq, context: CouchersContext, session: Session
+    ) -> pages_pb2.Page:
         page = session.execute(
             select(Page).where(Page.id == request.page_id).where(Page.type != PageType.main_page)
         ).scalar_one_or_none()
@@ -285,7 +294,9 @@ class Pages(pages_pb2_grpc.PagesServicer):
         session.commit()
         return page_to_pb(session, page, context)
 
-    def ListUserPlaces(self, request, context, session):
+    def ListUserPlaces(
+        self, request: pages_pb2.ListUserPlacesReq, context: CouchersContext, session: Session
+    ) -> pages_pb2.ListUserPlacesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_page_id = int(request.page_token) if request.page_token else 0
         user_id = request.user_id or context.user_id
@@ -306,7 +317,9 @@ class Pages(pages_pb2_grpc.PagesServicer):
             next_page_token=str(places[-1].id) if len(places) > page_size else None,
         )
 
-    def ListUserGuides(self, request, context, session):
+    def ListUserGuides(
+        self, request: pages_pb2.ListUserGuidesReq, context: CouchersContext, session: Session
+    ) -> pages_pb2.ListUserGuidesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_page_id = int(request.page_token) if request.page_token else 0
         user_id = request.user_id or context.user_id

--- a/app/backend/src/couchers/servicers/public.py
+++ b/app/backend/src/couchers/servicers/public.py
@@ -2,12 +2,16 @@ import logging
 
 import grpc
 from cachetools import TTLCache, cached
+from google.protobuf import empty_pb2
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import func, union_all
 
 from couchers import urls
+from couchers.context import CouchersContext
 from couchers.materialized_views import LiteUser
 from couchers.models import Cluster, Node, ProfilePublicVisibility, Reference, User, Volunteer
 from couchers.proto import api_pb2, public_pb2, public_pb2_grpc
+from couchers.proto.google.api import httpbody_pb2
 from couchers.resources import get_static_badge_dict
 from couchers.servicers.account import _format_volunteer_link
 from couchers.servicers.api import fluency2api, hostingstatus2api, meetupstatus2api, user_model_to_pb
@@ -128,13 +132,17 @@ def _get_volunteers(session):
 
 class Public(public_pb2_grpc.PublicServicer):
     """
-    Public (logged out) APIs for getting public info
+    Public (logged-out) APIs for getting public info
     """
 
-    def GetPublicUsers(self, request, context, session):
+    def GetPublicUsers(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> httpbody_pb2.HttpBody:
         return _get_public_users(session)
 
-    def GetPublicUser(self, request, context, session):
+    def GetPublicUser(
+        self, request: public_pb2.GetPublicUserReq, context: CouchersContext, session: Session
+    ) -> public_pb2.GetPublicUserRes:
         user = session.execute(
             select(User)
             .where(User.is_visible)
@@ -207,8 +215,12 @@ class Public(public_pb2_grpc.PublicServicer):
                 )
             )
 
-    def GetSignupPageInfo(self, request, context, session):
+    def GetSignupPageInfo(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> public_pb2.GetSignupPageInfoRes:
         return _get_signup_page_info(session)
 
-    def GetVolunteers(self, request, context, session):
+    def GetVolunteers(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> public_pb2.GetVolunteersRes:
         return _get_volunteers(session)

--- a/app/backend/src/couchers/servicers/references.py
+++ b/app/backend/src/couchers/servicers/references.py
@@ -7,10 +7,10 @@
 
 import grpc
 from google.protobuf import empty_pb2
-from sqlalchemy.orm import aliased
+from sqlalchemy.orm import Session, aliased
 from sqlalchemy.sql import and_, func, literal, or_, union_all
 
-from couchers.context import make_background_user_context
+from couchers.context import CouchersContext, make_background_user_context
 from couchers.materialized_views import LiteUser
 from couchers.models import HostRequest, Reference, ReferenceType, User
 from couchers.notifications.notify import notify
@@ -150,7 +150,9 @@ def get_pending_references_to_write(session, context):
 
 
 class References(references_pb2_grpc.ReferencesServicer):
-    def ListReferences(self, request, context, session):
+    def ListReferences(
+        self, request: references_pb2.ListReferencesReq, context: CouchersContext, session: Session
+    ) -> references_pb2.ListReferencesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_reference_id = int(request.page_token) if request.page_token else 0
 
@@ -222,7 +224,9 @@ class References(references_pb2_grpc.ReferencesServicer):
             next_page_token=str(references[-1].id) if len(references) > page_size else None,
         )
 
-    def WriteFriendReference(self, request, context, session):
+    def WriteFriendReference(
+        self, request: references_pb2.WriteFriendReferenceReq, context: CouchersContext, session: Session
+    ) -> references_pb2.Reference:
         if context.user_id == request.to_user_id:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "cant_refer_self")
 
@@ -273,7 +277,9 @@ class References(references_pb2_grpc.ReferencesServicer):
 
         return reference_to_pb(reference, context)
 
-    def WriteHostRequestReference(self, request, context, session):
+    def WriteHostRequestReference(
+        self, request: references_pb2.WriteHostRequestReferenceReq, context: CouchersContext, session: Session
+    ) -> references_pb2.Reference:
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
 
         check_valid_reference(request, context)
@@ -328,7 +334,9 @@ class References(references_pb2_grpc.ReferencesServicer):
 
         return reference_to_pb(reference, context)
 
-    def HostRequestIndicateDidntMeetup(self, request, context, session):
+    def HostRequestIndicateDidntMeetup(
+        self, request: references_pb2.HostRequestIndicateDidntMeetupReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         host_request, surfed = get_host_req_and_check_can_write_ref(session, context, request.host_request_id)
 
         reason = request.reason_didnt_meetup.strip()
@@ -340,7 +348,9 @@ class References(references_pb2_grpc.ReferencesServicer):
 
         return empty_pb2.Empty()
 
-    def AvailableWriteReferences(self, request, context, session):
+    def AvailableWriteReferences(
+        self, request: references_pb2.AvailableWriteReferencesReq, context: CouchersContext, session: Session
+    ) -> references_pb2.AvailableWriteReferencesRes:
         # can't write anything for ourselves, but let's return empty so this can be used generically on profile page
         if request.to_user_id == context.user_id:
             return references_pb2.AvailableWriteReferencesRes()
@@ -407,7 +417,9 @@ class References(references_pb2_grpc.ReferencesServicer):
             ],
         )
 
-    def ListPendingReferencesToWrite(self, request, context, session):
+    def ListPendingReferencesToWrite(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> references_pb2.ListPendingReferencesToWriteRes:
         return references_pb2.ListPendingReferencesToWriteRes(
             pending_references=[
                 references_pb2.AvailableWriteReferenceType(
@@ -421,7 +433,9 @@ class References(references_pb2_grpc.ReferencesServicer):
             ],
         )
 
-    def GetHostRequestReferenceStatus(self, request, context, session):
+    def GetHostRequestReferenceStatus(
+        self, request: references_pb2.GetHostRequestReferenceStatusReq, context: CouchersContext, session: Session
+    ) -> references_pb2.GetHostRequestReferenceStatusRes:
         # Compute has_given (whether current user already wrote a reference for this host request)
         has_given = (
             session.execute(

--- a/app/backend/src/couchers/servicers/reporting.py
+++ b/app/backend/src/couchers/servicers/reporting.py
@@ -1,14 +1,16 @@
 import grpc
 from google.protobuf import empty_pb2
+from sqlalchemy.orm import Session
 
+from couchers.context import CouchersContext
 from couchers.models import ContentReport, User
-from couchers.proto import reporting_pb2_grpc
+from couchers.proto import reporting_pb2, reporting_pb2_grpc
 from couchers.sql import couchers_select as select
 from couchers.tasks import send_content_report_email
 
 
 class Reporting(reporting_pb2_grpc.ReportingServicer):
-    def Report(self, request, context, session):
+    def Report(self, request: reporting_pb2.ReportReq, context: CouchersContext, session: Session) -> empty_pb2.Empty:
         # note no filtering on visibility
         author_user = session.execute(select(User).where_username_or_id(request.author_user)).scalar_one_or_none()
 

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -4,9 +4,10 @@ from datetime import timedelta
 import grpc
 from google.protobuf import empty_pb2
 from sqlalchemy import exists
-from sqlalchemy.orm import aliased
+from sqlalchemy.orm import Session, aliased
 from sqlalchemy.sql import and_, func, or_
 
+from couchers.context import CouchersContext
 from couchers.materialized_views import UserResponseRate
 from couchers.metrics import (
     account_age_on_host_request_create_histogram,
@@ -162,7 +163,9 @@ def _possibly_observe_first_response_time(session, host_request, user_id, respon
 
 
 class Requests(requests_pb2_grpc.RequestsServicer):
-    def CreateHostRequest(self, request, context, session):
+    def CreateHostRequest(
+        self, request: requests_pb2.CreateHostRequestReq, context: CouchersContext, session: Session
+    ) -> requests_pb2.CreateHostRequestRes:
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
         if not user.has_completed_profile:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "incomplete_profile_send_request")
@@ -269,7 +272,9 @@ class Requests(requests_pb2_grpc.RequestsServicer):
 
         return requests_pb2.CreateHostRequestRes(host_request_id=host_request.conversation_id)
 
-    def GetHostRequest(self, request, context, session):
+    def GetHostRequest(
+        self, request: requests_pb2.GetHostRequestReq, context: CouchersContext, session: Session
+    ) -> requests_pb2.HostRequest:
         host_request = session.execute(
             select(HostRequest)
             .where_users_column_visible(context, HostRequest.surfer_user_id)
@@ -283,7 +288,9 @@ class Requests(requests_pb2_grpc.RequestsServicer):
 
         return host_request_to_pb(host_request, session, context)
 
-    def ListHostRequests(self, request, context, session):
+    def ListHostRequests(
+        self, request: requests_pb2.ListHostRequestsReq, context: CouchersContext, session: Session
+    ) -> requests_pb2.ListHostRequestsRes:
         if request.only_sent and request.only_received:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "host_request_sent_or_received")
 
@@ -375,7 +382,9 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             last_request_id=last_request_id, no_more=no_more, host_requests=host_requests
         )
 
-    def RespondHostRequest(self, request, context, session):
+    def RespondHostRequest(
+        self, request: requests_pb2.RespondHostRequestReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         def count_host_response(other_user_id, response_type):
             user_gender = session.execute(select(User.gender).where(User.id == context.user_id)).scalar_one()
             other_gender = session.execute(select(User.gender).where(User.id == other_user_id)).scalar_one()
@@ -530,7 +539,9 @@ class Requests(requests_pb2_grpc.RequestsServicer):
 
         return empty_pb2.Empty()
 
-    def GetHostRequestMessages(self, request, context, session):
+    def GetHostRequestMessages(
+        self, request: requests_pb2.GetHostRequestMessagesReq, context: CouchersContext, session: Session
+    ) -> requests_pb2.GetHostRequestMessagesRes:
         host_request = session.execute(
             select(HostRequest).where(HostRequest.conversation_id == request.host_request_id)
         ).scalar_one_or_none()
@@ -566,7 +577,9 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             messages=[message_to_pb(message) for message in messages[:pagination]],
         )
 
-    def SendHostRequestMessage(self, request, context, session):
+    def SendHostRequestMessage(
+        self, request: requests_pb2.SendHostRequestMessageReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         if request.text == "":
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_message")
         host_request = session.execute(
@@ -629,7 +642,9 @@ class Requests(requests_pb2_grpc.RequestsServicer):
 
         return empty_pb2.Empty()
 
-    def GetHostRequestUpdates(self, request, context, session):
+    def GetHostRequestUpdates(
+        self, request: requests_pb2.GetHostRequestUpdatesReq, context: CouchersContext, session: Session
+    ) -> requests_pb2.GetHostRequestUpdatesRes:
         if request.only_sent and request.only_received:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "host_request_sent_or_received")
 
@@ -680,7 +695,9 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             ],
         )
 
-    def MarkLastSeenHostRequest(self, request, context, session):
+    def MarkLastSeenHostRequest(
+        self, request: requests_pb2.MarkLastSeenHostRequestReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         host_request = session.execute(
             select(HostRequest).where(HostRequest.conversation_id == request.host_request_id)
         ).scalar_one_or_none()
@@ -703,7 +720,9 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         session.commit()
         return empty_pb2.Empty()
 
-    def SetHostRequestArchiveStatus(self, request, context, session):
+    def SetHostRequestArchiveStatus(
+        self, request: requests_pb2.SetHostRequestArchiveStatusReq, context: CouchersContext, session: Session
+    ) -> requests_pb2.SetHostRequestArchiveStatusRes:
         host_request: HostRequest = session.execute(
             select(HostRequest)
             .where(HostRequest.conversation_id == request.host_request_id)
@@ -723,7 +742,9 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             is_archived=request.is_archived,
         )
 
-    def GetResponseRate(self, request, context, session):
+    def GetResponseRate(
+        self, request: requests_pb2.GetResponseRateReq, context: CouchersContext, session: Session
+    ) -> requests_pb2.GetResponseRateRes:
         user_res = session.execute(
             select(User.id, UserResponseRate)
             .outerjoin(UserResponseRate, UserResponseRate.user_id == User.id)
@@ -738,7 +759,9 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         user, response_rates = user_res
         return requests_pb2.GetResponseRateRes(**response_rate_to_pb(response_rates))
 
-    def SendHostRequestFeedback(self, request, context, session):
+    def SendHostRequestFeedback(
+        self, request: requests_pb2.SendHostRequestFeedbackReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
         host_request = session.execute(
             select(HostRequest)
             .where(HostRequest.conversation_id == request.host_request_id)

--- a/app/backend/src/couchers/servicers/resources.py
+++ b/app/backend/src/couchers/servicers/resources.py
@@ -1,5 +1,9 @@
 import logging
 
+from google.protobuf import empty_pb2
+from sqlalchemy.orm import Session
+
+from couchers.context import CouchersContext
 from couchers.proto import resources_pb2, resources_pb2_grpc
 from couchers.resources import (
     get_badge_dict,
@@ -13,27 +17,37 @@ logger = logging.getLogger(__name__)
 
 
 class Resources(resources_pb2_grpc.ResourcesServicer):
-    def GetTermsOfService(self, request, context, session):
+    def GetTermsOfService(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> resources_pb2.GetTermsOfServiceRes:
         return resources_pb2.GetTermsOfServiceRes(terms_of_service=get_terms_of_service())
 
-    def GetCommunityGuidelines(self, request, context, session):
+    def GetCommunityGuidelines(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> resources_pb2.GetCommunityGuidelinesRes:
         return resources_pb2.GetCommunityGuidelinesRes(community_guidelines=get_community_guidelines())
 
-    def GetRegions(self, request, context, session):
+    def GetRegions(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> resources_pb2.GetRegionsRes:
         return resources_pb2.GetRegionsRes(
             regions=[
                 resources_pb2.Region(alpha3=alpha3, name=name) for alpha3, name in sorted(get_region_dict().items())
             ]
         )
 
-    def GetLanguages(self, request, context, session):
+    def GetLanguages(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> resources_pb2.GetLanguagesRes:
         return resources_pb2.GetLanguagesRes(
             languages=[
                 resources_pb2.Language(code=code, name=name) for code, name in sorted(get_language_dict().items())
             ]
         )
 
-    def GetBadges(self, request, context, session):
+    def GetBadges(
+        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+    ) -> resources_pb2.GetBadgesRes:
         return resources_pb2.GetBadgesRes(
             badges=[
                 resources_pb2.Badge(

--- a/app/backend/src/couchers/servicers/search.py
+++ b/app/backend/src/couchers/servicers/search.py
@@ -5,9 +5,11 @@ See //docs/search.md for overview.
 from datetime import timedelta
 
 import grpc
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import and_, func, or_
 
 from couchers import urls
+from couchers.context import CouchersContext
 from couchers.crypto import decrypt_page_token, encrypt_page_token
 from couchers.helpers.strong_verification import has_strong_verification
 from couchers.materialized_views import LiteUser, UserResponseRate
@@ -538,7 +540,7 @@ def _user_search_inner(request, context, session):
 
 
 class Search(search_pb2_grpc.SearchServicer):
-    def Search(self, request, context, session):
+    def Search(self, request: search_pb2.SearchReq, context: CouchersContext, session: Session) -> search_pb2.SearchRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         # this is not an ideal page token, some results have equal rank (unlikely)
         next_rank = float(request.page_token) if request.page_token else None
@@ -588,7 +590,9 @@ class Search(search_pb2_grpc.SearchServicer):
             next_page_token=str(all_results[page_size].rank) if len(all_results) > page_size else None,
         )
 
-    def UserSearch(self, request, context, session):
+    def UserSearch(
+        self, request: search_pb2.UserSearchReq, context: CouchersContext, session: Session
+    ) -> search_pb2.UserSearchRes:
         user_ids_to_return, next_page_token, total_items = _user_search_inner(request, context, session)
 
         user_ids_to_users = dict(session.execute(select(User.id, User).where(User.id.in_(user_ids_to_return))).all())
@@ -605,7 +609,9 @@ class Search(search_pb2_grpc.SearchServicer):
             total_items=total_items,
         )
 
-    def UserSearchV2(self, request, context, session):
+    def UserSearchV2(
+        self, request: search_pb2.UserSearchReq, context: CouchersContext, session: Session
+    ) -> search_pb2.UserSearchV2Res:
         user_ids_to_return, next_page_token, total_items = _user_search_inner(request, context, session)
 
         LiteUser_by_id = {
@@ -682,7 +688,9 @@ class Search(search_pb2_grpc.SearchServicer):
             total_items=total_items,
         )
 
-    def EventSearch(self, request, context, session):
+    def EventSearch(
+        self, request: search_pb2.EventSearchReq, context: CouchersContext, session: Session
+    ) -> search_pb2.EventSearchRes:
         statement = (
             select(EventOccurrence).join(Event, Event.id == EventOccurrence.event_id).where(~EventOccurrence.is_deleted)
         )

--- a/app/backend/src/couchers/servicers/threads.py
+++ b/app/backend/src/couchers/servicers/threads.py
@@ -2,9 +2,10 @@ import logging
 
 import grpc
 import sqlalchemy.exc
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import func, select
 
-from couchers.context import make_background_user_context
+from couchers.context import CouchersContext, make_background_user_context
 from couchers.db import session_scope
 from couchers.jobs.enqueue import queue_job
 from couchers.models import Comment, Discussion, Event, EventOccurrence, Reply, Thread, User
@@ -203,7 +204,9 @@ def generate_reply_notifications(payload: jobs_pb2.GenerateReplyNotificationsPay
 
 
 class Threads(threads_pb2_grpc.ThreadsServicer):
-    def GetThread(self, request, context, session):
+    def GetThread(
+        self, request: threads_pb2.GetThreadReq, context: CouchersContext, session: Session
+    ) -> threads_pb2.GetThreadRes:
         database_id, depth = unpack_thread_id(request.thread_id)
         page_size = request.page_size if 0 < request.page_size < 100000 else 1000
         page_start = unpack_thread_id(int(request.page_token))[0] if request.page_token else 2**50
@@ -269,7 +272,9 @@ class Threads(threads_pb2_grpc.ThreadsServicer):
 
         return threads_pb2.GetThreadRes(replies=replies, next_page_token=next_page_token)
 
-    def PostReply(self, request, context, session):
+    def PostReply(
+        self, request: threads_pb2.PostReplyReq, context: CouchersContext, session: Session
+    ) -> threads_pb2.PostReplyRes:
         content = request.content.strip()
 
         if content == "":


### PR DESCRIPTION
Annotates the parameters and the return types of servicers' methods. This was done by automatically copying types from .pyi files generated by `protoc`.

I don't include the script that did the copying, because it's not really generic. 