### PR TITLE
Add password visibility toggle

### DIFF
--- a/app/web/features/auth/locales/en.json
+++ b/app/web/features/auth/locales/en.json
@@ -53,7 +53,9 @@
       "password_field_label": "Password",
       "no_password_login_prompt": "Check your email for a link to log in! :)",
       "remember_me": "Remember me",
-      "forgot_password": "Forgot password?"
+      "forgot_password": "Forgot password?",
+      "show_password": "Show password",
+      "hide_password": "Hide password"
     }
   },
   "basic_sign_up_form": {

--- a/app/web/features/auth/login/LoginForm.test.tsx
+++ b/app/web/features/auth/login/LoginForm.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { service } from "service";
+import wrapper from "test/hookWrapper";
+import i18n from "test/i18n";
+import { MockedService } from "test/utils";
+
+import LoginForm from "./LoginForm";
+
+const { t } = i18n;
+
+const passwordLoginMock = service.user.passwordLogin as MockedService<
+  typeof service.user.passwordLogin
+>;
+
+describe("LoginForm", () => {
+  beforeEach(() => {
+    passwordLoginMock.mockResolvedValue({
+      userId: 1,
+      jailed: false,
+    });
+  });
+
+  describe("password visibility toggle", () => {
+    beforeEach(() => {
+      render(<LoginForm />, { wrapper });
+    });
+
+    it("renders the password visibility toggle button", async () => {
+      const toggleButton = await screen.findByLabelText(
+        t("auth:login_page.form.show_password"),
+      );
+      expect(toggleButton).toBeInTheDocument();
+    });
+
+    it("toggles password visibility when clicking the button", async () => {
+      const user = userEvent.setup();
+      const passwordField = await screen.findByLabelText(
+        t("auth:login_page.form.password_field_label"),
+      );
+
+      // Initially password should be hidden
+      expect(passwordField).toHaveAttribute("type", "password");
+
+      const showButton = screen.getByLabelText(
+        t("auth:login_page.form.show_password"),
+      );
+      await user.click(showButton);
+
+      await waitFor(() => {
+        expect(passwordField).toHaveAttribute("type", "text");
+      });
+
+      const hideButton = screen.getByLabelText(
+        t("auth:login_page.form.hide_password"),
+      );
+      await user.click(hideButton);
+
+      // Password should be hidden again
+      await waitFor(() => {
+        expect(passwordField).toHaveAttribute("type", "password");
+      });
+    });
+
+    it("changes aria-label when toggling password visibility", async () => {
+      const user = userEvent.setup();
+
+      const showButton = await screen.findByLabelText(
+        t("auth:login_page.form.show_password"),
+      );
+      expect(showButton).toHaveAttribute(
+        "aria-label",
+        t("auth:login_page.form.show_password"),
+      );
+
+      await user.click(showButton);
+
+      await waitFor(() => {
+        const hideButton = screen.getByLabelText(
+          t("auth:login_page.form.hide_password"),
+        );
+        expect(hideButton).toHaveAttribute(
+          "aria-label",
+          t("auth:login_page.form.hide_password"),
+        );
+      });
+    });
+
+    it("allows typing visible text in the password field when toggled", async () => {
+      const user = userEvent.setup();
+      const passwordField = await screen.findByLabelText(
+        t("auth:login_page.form.password_field_label"),
+      );
+
+      await user.type(passwordField, "mypassword");
+      expect(passwordField).toHaveValue("mypassword");
+      expect(passwordField).toHaveAttribute("type", "password");
+
+      const showButton = screen.getByLabelText(
+        t("auth:login_page.form.show_password"),
+      );
+      await user.click(showButton);
+
+      // Verify text is still there and type is now text
+      await waitFor(() => {
+        expect(passwordField).toHaveValue("mypassword");
+        expect(passwordField).toHaveAttribute("type", "text");
+      });
+    });
+  });
+
+  describe("form submission", () => {
+    it("submits login form with correct credentials", async () => {
+      render(<LoginForm />, { wrapper });
+      const user = userEvent.setup();
+
+      const usernameField = await screen.findByLabelText(
+        t("auth:login_page.form.username_field_label"),
+      );
+      const passwordField = screen.getByLabelText(
+        t("auth:login_page.form.password_field_label"),
+      );
+
+      await user.type(usernameField, "testuser");
+      await user.type(passwordField, "testpassword");
+
+      const loginButton = screen.getByRole("button", {
+        name: t("global:login"),
+      });
+      await user.click(loginButton);
+
+      await waitFor(() => {
+        expect(passwordLoginMock).toHaveBeenCalledWith(
+          "testuser",
+          "testpassword",
+          true,
+        );
+      });
+    });
+  });
+});

--- a/app/web/features/auth/login/LoginForm.tsx
+++ b/app/web/features/auth/login/LoginForm.tsx
@@ -1,4 +1,10 @@
-import { FormControlLabel, styled } from "@mui/material";
+import { Visibility, VisibilityOff } from "@mui/icons-material";
+import {
+  FormControlLabel,
+  IconButton,
+  InputAdornment,
+  styled,
+} from "@mui/material";
 import CustomColorSwitch from "components/CustomColorSwitch";
 import StyledLink from "components/StyledLink";
 import { doAntibot } from "features/antibot/antibot";
@@ -42,6 +48,7 @@ export default function LoginForm() {
   const { authState, authActions } = useAuthContext();
   const authLoading = authState.loading;
   const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
 
   const { handleSubmit, register, control } = useForm<{
     username: string;
@@ -100,10 +107,28 @@ export default function LoginForm() {
           {...register("password", { required: true })}
           fullWidth
           name="password"
-          type="password"
+          type={showPassword ? "text" : "password"}
           variant="outlined"
           autoComplete="current-password"
-          placeholder="*********"
+          slotProps={{
+            input: {
+              endAdornment: (
+                <InputAdornment position="end" sx={{ marginRight: 1 }}>
+                  <IconButton
+                    aria-label={
+                      showPassword
+                        ? t("auth:login_page.form.hide_password")
+                        : t("auth:login_page.form.show_password")
+                    }
+                    onClick={() => setShowPassword(!showPassword)}
+                    edge="end"
+                  >
+                    {showPassword ? <VisibilityOff /> : <Visibility />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            },
+          }}
         />
         <StyledLoginOptions>
           <Controller

--- a/app/web/features/auth/signup/AccountForm.test.tsx
+++ b/app/web/features/auth/signup/AccountForm.test.tsx
@@ -338,6 +338,92 @@ describe("AccountForm", () => {
       );
       await assertErrorAlert("Generic error");
     });
+
+    it("renders the password visibility toggle button", async () => {
+      const toggleButton = await screen.findByLabelText(
+        t("auth:login_page.form.show_password"),
+      );
+      expect(toggleButton).toBeInTheDocument();
+    });
+
+    it("toggles password visibility when clicking the button", async () => {
+      const user = userEvent.setup();
+      const passwordField = screen.getByLabelText(
+        t("auth:account_form.password.field_label"),
+      );
+
+      // Initially password should be hidden
+      expect(passwordField).toHaveAttribute("type", "password");
+
+      // Click to show password
+      const showButton = screen.getByLabelText(
+        t("auth:login_page.form.show_password"),
+      );
+      await user.click(showButton);
+
+      // Password should now be visible
+      await waitFor(() => {
+        expect(passwordField).toHaveAttribute("type", "text");
+      });
+
+      // Click to hide password again
+      const hideButton = screen.getByLabelText(
+        t("auth:login_page.form.hide_password"),
+      );
+      await user.click(hideButton);
+
+      // Password should be hidden again
+      await waitFor(() => {
+        expect(passwordField).toHaveAttribute("type", "password");
+      });
+    });
+
+    it("changes aria-label when toggling password visibility", async () => {
+      const user = userEvent.setup();
+
+      const showButton = screen.getByLabelText(
+        t("auth:login_page.form.show_password"),
+      );
+      expect(showButton).toHaveAttribute(
+        "aria-label",
+        t("auth:login_page.form.show_password"),
+      );
+
+      await user.click(showButton);
+
+      await waitFor(() => {
+        const hideButton = screen.getByLabelText(
+          t("auth:login_page.form.hide_password"),
+        );
+        expect(hideButton).toHaveAttribute(
+          "aria-label",
+          t("auth:login_page.form.hide_password"),
+        );
+      });
+    });
+
+    it("allows typing visible text in the password field when toggled", async () => {
+      const user = userEvent.setup();
+      const passwordField = screen.getByLabelText(
+        t("auth:account_form.password.field_label"),
+      );
+
+      await user.clear(passwordField);
+      await user.type(passwordField, "secretpassword");
+      expect(passwordField).toHaveValue("secretpassword");
+      expect(passwordField).toHaveAttribute("type", "password");
+
+      const showButton = screen.getByLabelText(
+        t("auth:login_page.form.show_password"),
+      );
+      await user.click(showButton);
+
+      // Verify text is still there and type is now text
+      await waitFor(() => {
+        expect(passwordField).toHaveValue("secretpassword");
+        expect(passwordField).toHaveAttribute("type", "text");
+      });
+    });
   });
 
   // Separating as you can't unselect a radio group once clicked

--- a/app/web/features/auth/signup/AccountForm.tsx
+++ b/app/web/features/auth/signup/AccountForm.tsx
@@ -1,3 +1,4 @@
+import { Visibility, VisibilityOff } from "@mui/icons-material";
 import {
   Checkbox,
   FormControl,
@@ -5,6 +6,8 @@ import {
   FormHelperText,
   FormLabel,
   FormLabelProps,
+  IconButton,
+  InputAdornment,
   Radio,
   RadioGroup,
   styled,
@@ -29,7 +32,7 @@ import { RpcError } from "grpc-web";
 import { Trans, useTranslation } from "i18n";
 import { AUTH, GLOBAL } from "i18n/namespaces";
 import { HostingStatus } from "proto/api_pb";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { service } from "service";
 import { theme } from "theme";
@@ -110,6 +113,7 @@ export default function AccountForm() {
   const { t } = useTranslation([AUTH, GLOBAL]);
   const { authState, authActions } = useAuthContext();
   const authLoading = authState.loading;
+  const [showPassword, setShowPassword] = useState(false);
 
   const {
     control,
@@ -228,11 +232,30 @@ export default function AccountForm() {
               t("auth:account_form.password.validation_error"),
           })}
           variant="outlined"
-          type="password"
+          type={showPassword ? "text" : "password"}
           fullWidth
           helperText={errors?.password?.message ?? " "}
           error={!!errors?.password?.message}
           autoComplete="new-password"
+          slotProps={{
+            input: {
+              endAdornment: (
+                <InputAdornment position="end" sx={{ marginRight: 1 }}>
+                  <IconButton
+                    aria-label={
+                      showPassword
+                        ? t("auth:login_page.form.hide_password")
+                        : t("auth:login_page.form.show_password")
+                    }
+                    onClick={() => setShowPassword(!showPassword)}
+                    edge="end"
+                  >
+                    {showPassword ? <VisibilityOff /> : <Visibility />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            },
+          }}
         />
         <StyledInputLabel htmlFor="birthdate">
           {t("auth:account_form.birthday.field_label")}


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**

Closes #7263 
<!---
Please describe the pull request here.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

Adds a password visibility toggle so user can see their password by clicking the eye.

**Please give clear steps for how the reviewer can best test this PR**

*Please include any necessary dev environment, .env, etc. adjustments.*

- Go to signup and login forms and make sure login still works and you can toggle your password on both

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Web frontend checklist**
- [ x ] Formatted my code with `yarn format`
- [ x ] There are no warnings from `yarn lint --fix`
- [ x ] There are no console warnings when running the app
- [ x ] Added tests where relevant
- [ x ] All tests pass
- [ x ] Clicked around my changes running locally and it works
- [ x ] Checked Desktop, Mobile and Tablet screen sizes

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)


<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
