### PR TITLE
Add backend validation for friend references to require active friendship

### DIFF
--- a/app/backend/src/couchers/i18n/locales/en.json
+++ b/app/backend/src/couchers/i18n/locales/en.json
@@ -25,6 +25,7 @@
     "cant_friend_self": "You can't befriend yourself!",
     "cant_invite_self": "You can't invite yourself to a chat.",
     "cant_invite_to_dm": "You can't invite other users to a direct message.",
+    "can_only_refer_friends": "You can only write friend references for confirmed friends.",
     "cant_make_self_admin": "You can't make yourself an admin.",
     "cant_message_in_chat": "You can't send a message in this chat.",
     "cant_mute_past": "You can't mute until a date in the past.",

--- a/app/backend/src/couchers/servicers/references.py
+++ b/app/backend/src/couchers/servicers/references.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import aliased
 from sqlalchemy.sql import and_, func, literal, or_, union_all
 
 from couchers.context import make_background_user_context
+from couchers.db import are_friends
 from couchers.materialized_views import LiteUser
 from couchers.models import HostRequest, Reference, ReferenceType, User
 from couchers.notifications.notify import notify
@@ -234,6 +235,9 @@ class References(references_pb2_grpc.ReferencesServicer):
             select(User).where_users_visible(context).where(User.id == request.to_user_id)
         ).scalar_one_or_none():
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
+
+        if not are_friends(session, context, request.to_user_id):
+            context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "can_only_refer_friends")
 
         if session.execute(
             select(Reference)

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -26,6 +26,7 @@ from tests.test_fixtures import (  # noqa
     events_session,
     generate_user,
     get_user_id_and_token,
+    make_friends,
     mock_notification_email,
     push_collector,
     real_admin_session,
@@ -515,6 +516,7 @@ def test_EditReferenceText(db):
 
     user1, user1_token = generate_user()
     user2, user2_token = generate_user()
+    make_friends(user1, user2)
 
     with session_scope() as session:
         with references_session(user1_token) as api:
@@ -542,6 +544,7 @@ def test_DeleteReference(db):
 
     user1, user1_token = generate_user()
     user2, user2_token = generate_user()
+    make_friends(user1, user2)
 
     with references_session(user1_token) as api:
         reference = api.WriteFriendReference(

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -6,11 +6,14 @@ import pytest
 from google.protobuf import empty_pb2
 from sqlalchemy import update
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import and_, or_
 
 from couchers.db import session_scope
 from couchers.materialized_views import refresh_materialized_views_rapid
 from couchers.models import (
     Conversation,
+    FriendRelationship,
+    FriendStatus,
     HostRequest,
     HostRequestStatus,
     Message,
@@ -558,8 +561,6 @@ def test_WriteFriendReference_requires_friendship(db):
         assert res.to_user_id == user2.id
 
     # Test the unfriending scenario: delete the friendship
-    from couchers.models import FriendRelationship, FriendStatus
-
     with session_scope() as session:
         # Change the friendship status to cancelled (simulating unfriending)
         friendship = session.execute(

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -27,6 +27,7 @@ from tests.test_fixtures import (  # noqa
     db,
     email_fields,
     generate_user,
+    make_friends,
     make_user_block,
     mock_notification_email,
     push_collector,
@@ -409,6 +410,9 @@ def test_WriteFriendReference(db):
     user2, token2 = generate_user()
     user3, token3 = generate_user()
 
+    # Make user1 and user2 friends
+    make_friends(user1, user2)
+
     with references_session(token1) as api:
         # can write normal friend reference
         res = api.WriteFriendReference(
@@ -488,6 +492,9 @@ def test_WriteFriendReference_with_private_text(db, push_collector):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
 
+    # Make users friends
+    make_friends(user1, user2)
+
     with references_session(token1) as api:
         with patch("couchers.email.queue_email") as mock1:
             with mock_notification_email() as mock2:
@@ -513,6 +520,78 @@ def test_WriteFriendReference_with_private_text(db, push_collector):
         title=f"You've received a friend reference from {user1.name}!",
         body="They were nice!",
     )
+
+
+def test_WriteFriendReference_requires_friendship(db):
+    """Test that users must be friends to write friend references"""
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    # Try to write friend reference without being friends
+    with references_session(token1) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.WriteFriendReference(
+                references_pb2.WriteFriendReferenceReq(
+                    to_user_id=user2.id,
+                    text="A test reference",
+                    was_appropriate=True,
+                    rating=0.5,
+                )
+            )
+        assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+        assert e.value.details() == "You can only write friend references for confirmed friends."
+
+    # Now make them friends
+    make_friends(user1, user2)
+
+    # Should now be able to write a reference
+    with references_session(token1) as api:
+        res = api.WriteFriendReference(
+            references_pb2.WriteFriendReferenceReq(
+                to_user_id=user2.id,
+                text="A test reference",
+                was_appropriate=True,
+                rating=0.5,
+            )
+        )
+        assert res.from_user_id == user1.id
+        assert res.to_user_id == user2.id
+
+    # Test the unfriending scenario: delete the friendship
+    from couchers.models import FriendRelationship, FriendStatus
+
+    with session_scope() as session:
+        # Change the friendship status to cancelled (simulating unfriending)
+        friendship = session.execute(
+            select(FriendRelationship).where(
+                or_(
+                    and_(
+                        FriendRelationship.from_user_id == user1.id,
+                        FriendRelationship.to_user_id == user2.id,
+                    ),
+                    and_(
+                        FriendRelationship.from_user_id == user2.id,
+                        FriendRelationship.to_user_id == user1.id,
+                    ),
+                )
+            )
+        ).scalar_one()
+        friendship.status = FriendStatus.cancelled
+
+    # Try to write another friend reference after unfriending
+    # (Note: This assumes user1 didn't already write a reference, or we test with user2 writing to user1)
+    with references_session(token2) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.WriteFriendReference(
+                references_pb2.WriteFriendReferenceReq(
+                    to_user_id=user1.id,
+                    text="Another test reference",
+                    was_appropriate=True,
+                    rating=0.8,
+                )
+            )
+        assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+        assert e.value.details() == "You can only write friend references for confirmed friends."
 
 
 def test_host_request_states_references(db):

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -6,7 +6,6 @@ import pytest
 from google.protobuf import empty_pb2
 from sqlalchemy import update
 from sqlalchemy.orm import Session
-from sqlalchemy.sql import and_, or_
 
 from couchers.db import session_scope
 from couchers.materialized_views import refresh_materialized_views_rapid
@@ -563,21 +562,11 @@ def test_WriteFriendReference_requires_friendship(db):
     # Test the unfriending scenario: delete the friendship
     with session_scope() as session:
         # Change the friendship status to cancelled (simulating unfriending)
-        friendship = session.execute(
-            select(FriendRelationship).where(
-                or_(
-                    and_(
-                        FriendRelationship.from_user_id == user1.id,
-                        FriendRelationship.to_user_id == user2.id,
-                    ),
-                    and_(
-                        FriendRelationship.from_user_id == user2.id,
-                        FriendRelationship.to_user_id == user1.id,
-                    ),
-                )
-            )
-        ).scalar_one()
-        friendship.status = FriendStatus.cancelled
+        session.execute(
+            update(FriendRelationship)
+            .where(FriendRelationship.from_user_id == user1.id, FriendRelationship.to_user_id == user2.id)
+            .values(status=FriendStatus.cancelled)
+        )
 
     # Try to write another friend reference after unfriending
     # (Note: This assumes user1 didn't already write a reference, or we test with user2 writing to user1)


### PR DESCRIPTION
## Summary

This PR fixes a security issue where users could submit friend references after being unfriended if the reference form was already open.

## Changes

- Add friendship validation in `WriteFriendReference` using `are_friends()` helper
- Return FAILED_PRECONDITION error if users are not confirmed friends
- Add error message "You can only write friend references for confirmed friends."
- Update existing tests to establish friendships before writing references
- Add comprehensive test for friendship validation including unfriending scenario

Fixes #6900

----

Generated with [Claude Code](https://claude.ai/code)