### PR TITLE
Remove contained_user_ids association proxy and replace with utility function

### DIFF
--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -28,6 +28,7 @@ from couchers.models import (
     FriendStatus,
     Node,
     TimezoneArea,
+    User,
 )
 from couchers.sql import couchers_select as select
 
@@ -247,6 +248,24 @@ def can_moderate_at(session: Session, user_id: int, shape: WKBElement) -> bool:
             .join(Cluster, Cluster.id == ClusterSubscription.cluster_id)
             .join(Node, and_(Cluster.is_official_cluster, Node.id == Cluster.parent_node_id))
             .where(func.ST_Contains(Node.geom, shape))
+        ).exists()
+    )
+    return cast(bool, session.execute(query).scalar_one())
+
+
+def is_user_in_node_geography(session: Session, user_id: int, node_id: int) -> bool:
+    """
+    Returns True if the user's location is geographically contained within the node's boundary.
+    This is used to check if a user can leave a community - users cannot leave communities
+    that contain their geographic location.
+    """
+    query = select(
+        (
+            select(True)
+            .select_from(User)
+            .join(Node, func.ST_Contains(Node.geom, User.geom))
+            .where(User.id == user_id)
+            .where(Node.id == node_id)
         ).exists()
     )
     return cast(bool, session.execute(query).scalar_one())

--- a/app/backend/src/couchers/models/clusters.py
+++ b/app/backend/src/couchers/models/clusters.py
@@ -15,7 +15,6 @@ from sqlalchemy import (
     func,
     text,
 )
-from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import Mapped, backref, column_property, deferred, mapped_column, relationship
 from sqlalchemy.sql import expression
 
@@ -45,15 +44,6 @@ class Node(Base):
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     parent_node = relationship("Node", backref="child_nodes", remote_side="Node.id")
-
-    contained_users = relationship(
-        "User",
-        primaryjoin="func.ST_Contains(foreign(Node.geom), User.geom).as_comparison(1, 2)",
-        viewonly=True,
-        uselist=True,
-    )
-
-    contained_user_ids = association_proxy("contained_users", "id")
 
 
 class Cluster(Base):

--- a/app/backend/src/couchers/servicers/communities.py
+++ b/app/backend/src/couchers/servicers/communities.py
@@ -7,7 +7,7 @@ from sqlalchemy.sql import delete, func, or_
 
 from couchers.constants import COMMUNITIES_SEARCH_FUZZY_SIMILARITY_THRESHOLD
 from couchers.crypto import decrypt_page_token, encrypt_page_token
-from couchers.db import can_moderate_node, get_node_parents_recursively
+from couchers.db import can_moderate_node, get_node_parents_recursively, is_user_in_node_geography
 from couchers.materialized_views import ClusterAdminCount, ClusterSubscriptionCount
 from couchers.models import (
     Cluster,
@@ -441,7 +441,7 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         if not current_membership:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "not_in_community")
 
-        if context.user_id in node.contained_user_ids:
+        if is_user_in_node_geography(session, context.user_id, node.id):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "cannot_leave_containing_community")
 
         session.execute(

--- a/app/backend/src/tests/test_communities.py
+++ b/app/backend/src/tests/test_communities.py
@@ -6,7 +6,7 @@ from geoalchemy2 import WKBElement
 from google.protobuf import wrappers_pb2
 from sqlalchemy.orm import Session
 
-from couchers.db import session_scope
+from couchers.db import is_user_in_node_geography, session_scope
 from couchers.materialized_views import refresh_materialized_views
 from couchers.models import (
     Cluster,
@@ -777,10 +777,9 @@ class TestCommunities:
                 assert d.thread.num_responses == 0
 
     @staticmethod
-    def test_node_contained_user_ids_association_proxy(testing_communities):
+    def test_is_user_in_node_geography(testing_communities):
         with session_scope() as session:
             c1_id = get_community_id(session, "Country 1")
-            node = session.execute(select(Node).where(Node.id == c1_id)).scalar_one_or_none()
 
             user1_id, _ = get_user_id_and_token(session, "user1")
             user2_id, _ = get_user_id_and_token(session, "user2")
@@ -788,8 +787,12 @@ class TestCommunities:
             user4_id, _ = get_user_id_and_token(session, "user4")
             user5_id, _ = get_user_id_and_token(session, "user5")
 
-            assert set(node.contained_user_ids) == {user1_id, user2_id, user3_id, user4_id, user5_id}
-            assert len(node.contained_user_ids) == len(node.contained_users)
+            # All these users should be in Country 1's geography
+            assert is_user_in_node_geography(session, user1_id, c1_id)
+            assert is_user_in_node_geography(session, user2_id, c1_id)
+            assert is_user_in_node_geography(session, user3_id, c1_id)
+            assert is_user_in_node_geography(session, user4_id, c1_id)
+            assert is_user_in_node_geography(session, user5_id, c1_id)
 
     @staticmethod
     def test_ListEvents(testing_communities):


### PR DESCRIPTION
Fixes #6374

The `contained_user_ids` association proxy was causing severe performance issues, especially for large communities like the Global Community. When accessed, it would load ALL user IDs whose location falls within the community's geography, potentially triggering full table scans with expensive PostGIS ST_Contains operations.

## Changes
- Created new utility function `is_user_in_node_geography()` in db.py that efficiently checks if a single user is contained in a node's geography using a direct O(1) spatial query
- Replaced usage in communities.py LeaveCommunity endpoint
- Removed `contained_users` relationship and `contained_user_ids` association proxy from Node model
- Updated test to use the new utility function

Generated with [Claude Code](https://claude.ai/code)