### PR TITLE
Update password reset message to clarify when email is sent

### DIFF
--- a/app/native/features/auth/locales/en.json
+++ b/app/native/features/auth/locales/en.json
@@ -47,7 +47,7 @@
   },
   "reset_password_form": {
     "enter_email": "Enter your username/email",
-    "success_message": "Check your email for a reset password link!"
+    "success_message": "A password reset link has been sent to the email associated with that account, if it exists and is active. Note that the email may sometimes end up in spam."
   },
   "login_page": {
     "title": "Log in",

--- a/app/web/features/auth/locales/en.json
+++ b/app/web/features/auth/locales/en.json
@@ -42,7 +42,7 @@
   },
   "reset_password_form": {
     "enter_email": "Enter your username/email",
-    "success_message": "Check your email for a reset password link!"
+    "success_message": "A password reset link has been sent to the email associated with that account, if it exists and is active. Note that the email may sometimes end up in spam."
   },
   "login_page": {
     "title": "Log in",


### PR DESCRIPTION
Changed the success message to be more accurate and informative:
"If an account with that email or username exists and is not deactivated, a password reset email was sent."

This prevents misleading users when they enter invalid or non-existent usernames/emails, while still maintaining security by not confirming whether an account exists.

Updated in both web and mobile apps.

Fixes #6785

---
Generated with [Claude Code](https://claude.ai/code)