### PR TITLE
Automatically log in user after password reset

### DIFF
--- a/app/web/features/auth/password/CompleteResetPassword.test.tsx
+++ b/app/web/features/auth/password/CompleteResetPassword.test.tsx
@@ -26,6 +26,7 @@ jest.mock("@sentry/nextjs", () => ({
 }));
 
 const mockUseRouter = useRouter as jest.Mock;
+const mockPush = jest.fn();
 
 describe("CompletePasswordReset page", () => {
   beforeEach(() => {
@@ -33,6 +34,7 @@ describe("CompletePasswordReset page", () => {
 
     mockUseRouter.mockReturnValue({
       query: { token: "aaa123" },
+      push: mockPush,
     });
   });
 
@@ -58,6 +60,7 @@ describe("CompletePasswordReset page", () => {
   it("shows a warning when empty token", () => {
     mockUseRouter.mockReturnValue({
       query: { token: "" },
+      push: mockPush,
     });
 
     render(<CompletePasswordReset />, { wrapper });
@@ -112,6 +115,7 @@ describe("CompletePasswordReset page", () => {
   it("submits the reset password request successfully", async () => {
     mockUseRouter.mockReturnValue({
       query: { token: "aaa123" },
+      push: mockPush,
     });
 
     render(<CompletePasswordReset />, { wrapper });
@@ -145,6 +149,7 @@ describe("CompletePasswordReset page", () => {
 
     mockUseRouter.mockReturnValue({
       query: { token: "aaa123" },
+      push: mockPush,
     });
 
     render(<CompletePasswordReset />, { wrapper });

--- a/app/web/features/auth/password/CompleteResetPassword.test.tsx
+++ b/app/web/features/auth/password/CompleteResetPassword.test.tsx
@@ -28,8 +28,32 @@ jest.mock("@sentry/nextjs", () => ({
 const mockUseRouter = useRouter as jest.Mock;
 const mockPush = jest.fn();
 
+// Mock localStorage to ensure tests start with clean state
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value.toString();
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, "localStorage", {
+  value: localStorageMock,
+});
+
 describe("CompletePasswordReset page", () => {
   beforeEach(() => {
+    // Clear localStorage to ensure unauthenticated state
+    localStorageMock.clear();
+
     CompletePasswordResetMock.mockResolvedValue(new AuthRes());
 
     mockUseRouter.mockReturnValue({

--- a/app/web/features/auth/password/CompleteResetPassword.tsx
+++ b/app/web/features/auth/password/CompleteResetPassword.tsx
@@ -80,7 +80,7 @@ export default function CompleteResetPassword() {
     mutate(newPassword);
   });
 
-  if (authState.authenticated) {
+  if (authState.authenticated && !isSuccess) {
     return (
       <StyledContainer>
         <Alert severity="error">

--- a/app/web/features/auth/password/CompleteResetPassword.tsx
+++ b/app/web/features/auth/password/CompleteResetPassword.tsx
@@ -3,16 +3,15 @@ import { useMutation } from "@tanstack/react-query";
 import Alert from "components/Alert";
 import Button from "components/Button";
 import HtmlMeta from "components/HtmlMeta";
-import StyledLink from "components/StyledLink";
 import TextField from "components/TextField";
 import { useAuthContext } from "features/auth/AuthProvider";
-import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { RpcError } from "grpc-web";
 import { useTranslation } from "i18n";
 import { AUTH, GLOBAL } from "i18n/namespaces";
 import { useRouter } from "next/router";
+import { AuthRes } from "proto/auth_pb";
 import { useForm } from "react-hook-form";
-import { loginRoute } from "routes";
+import { dashboardRoute } from "routes";
 import { service } from "service";
 import { theme } from "theme";
 import stringOrFirstString from "utils/stringOrFirstString";
@@ -42,7 +41,7 @@ const StyledTextField = styled(TextField)(() => ({
 }));
 
 export default function CompleteResetPassword() {
-  const { authState } = useAuthContext();
+  const { authState, authActions } = useAuthContext();
   const { t } = useTranslation([AUTH, GLOBAL]);
   const { handleSubmit, register } = useForm<{
     newPassword: string;
@@ -55,15 +54,21 @@ export default function CompleteResetPassword() {
     !!resetToken && typeof resetToken === "string" && resetToken !== "";
 
   const { error, isPending, isSuccess, mutate } = useMutation<
-    Empty,
+    AuthRes,
     RpcError,
     string
   >({
-    mutationFn: (newPassword) =>
-      service.account.CompletePasswordResetV2(
+    mutationFn: async (newPassword) => {
+      const res = await service.account.CompletePasswordResetV2(
         resetToken as string,
         newPassword,
-      ),
+      );
+      return res;
+    },
+    onSuccess: (authRes) => {
+      authActions.firstLogin(authRes.toObject());
+      router.push(dashboardRoute);
+    },
   });
 
   const onSubmit = handleSubmit(({ newPassword, newPasswordCheck }) => {
@@ -104,12 +109,9 @@ export default function CompleteResetPassword() {
       )}
 
       {isSuccess && (
-        <>
-          <Alert severity="success">
-            {t("auth:change_password_form.reset_password_success")}
-          </Alert>
-          <StyledLink href={loginRoute}>{t("auth:login_prompt")}</StyledLink>
-        </>
+        <Alert severity="success">
+          {t("auth:change_password_form.reset_password_success")}
+        </Alert>
       )}
 
       <Typography variant="h1" gutterBottom>


### PR DESCRIPTION
Fixes #4477

### Summary
Users are now automatically logged in after resetting their password, eliminating the need to manually log in again.

### Changes
- Modified `CompleteResetPassword` to use `AuthRes` instead of `Empty`
- Call `authActions.firstLogin()` on successful password reset
- Redirect to dashboard after password reset
- Updated tests to mock router.push

The backend already returns `AuthRes` and sets the session cookie, so the user no longer needs to manually log in after resetting their password.

----

Generated with [Claude Code](https://claude.ai/code)