### PR TITLE
fix: ensure loading state is cleared when email confirmation fails

### DIFF
--- a/app/web/features/auth/signup/Signup.tsx
+++ b/app/web/features/auth/signup/Signup.tsx
@@ -80,8 +80,9 @@ export default function Signup() {
           );
           router.push(signupRoute);
           return;
+        } finally {
+          setLoading(false);
         }
-        setLoading(false);
       }
     })();
     // next-router-mock router isn't memoized, so putting router in the dependencies


### PR DESCRIPTION
## Summary

Fixed infinite loading spinner issue when clicking email confirmation link multiple times.

**Change made:**
- Moved `setLoading(false)` into a `finally` block in `app/web/features/auth/signup/Signup.tsx`

This ensures the loading state is always cleared, even when email token verification fails and throws an error.

Fixes #7303

🤖 Generated with [Claude Code](https://claude.ai/code)