### PR TITLE
Fix test_send_request_notifications_blocked_users_no_notification

### DIFF
--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -1248,7 +1248,7 @@ def test_send_request_notifications_blocked_users_no_notification(db):
     with requests_session(token1) as requests:
         host_request_id = requests.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
-                host_user_id=user2.id, from_date=today_plus_2, to_date=today_plus_3, text="Test request"
+                host_user_id=user2.id, from_date=today_plus_2, to_date=today_plus_3, text=valid_request_text()
             )
         ).host_request_id
 


### PR DESCRIPTION
Update the test to use valid_request_text() helper function instead of hardcoded "Test request" string. This ensures the host request meets the 250-character minimum length requirement.

Fixes #7311

Generated with [Claude Code](https://claude.ai/code)