### PR TITLE
Mobile - Make app friendlier for offline

### DIFF
--- a/app/mobile/assets.d.ts
+++ b/app/mobile/assets.d.ts
@@ -1,0 +1,4 @@
+declare module "*.png" {
+  const value: number;
+  export default value;
+}

--- a/app/mobile/components/WebEmbed.tsx
+++ b/app/mobile/components/WebEmbed.tsx
@@ -1,15 +1,25 @@
-import { StyleSheet, View, useColorScheme, Text } from "react-native";
-import { useRef } from "react";
+import { useRouter } from "expo-router";
+import { useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Image,
+  Pressable,
+  StyleSheet,
+  Text,
+  useColorScheme,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   WebView,
   WebViewMessageEvent,
   WebViewNavigation,
 } from "react-native-webview";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useRouter } from "expo-router";
 
-import { theme } from "@/theme";
 import { useAuthContext } from "@/features/auth/AuthContext";
+import { theme } from "@/theme";
+
+import errorGraphic from "@/resources/404graphic.png";
 
 type WebEmbedProps = {
   path: string;
@@ -24,11 +34,17 @@ export default function WebEmbed({ path }: WebEmbedProps) {
   const router = useRouter();
   const { markLoggedOut, setUserId, setJailed, markAuthenticated } =
     useAuthContext();
+  const [hasError, setHasError] = useState(false);
 
   const backgroundColor =
     colorScheme === "dark"
       ? theme.palette.common.black
       : theme.palette.common.white;
+
+  const handleRetry = () => {
+    setHasError(false);
+    webviewRef.current?.reload();
+  };
 
   const handleNavigationStateChange = (navState: WebViewNavigation) => {
     const { url } = navState;
@@ -68,6 +84,31 @@ export default function WebEmbed({ path }: WebEmbedProps) {
     }
   };
 
+  // Show error screen
+  if (hasError) {
+    return (
+      <View style={[styles.container, { backgroundColor }]}>
+        <View style={{ height: insets.top, backgroundColor }} />
+        <View style={styles.errorContainer}>
+          <Image source={errorGraphic} style={styles.errorImage} />
+          <Text style={styles.errorTitle}>Failed to load</Text>
+          <Text style={styles.errorText}>
+            Check your internet connection and try again.
+          </Text>
+          <Pressable
+            style={({ pressed }) => [
+              styles.retryButton,
+              pressed && styles.retryButtonPressed,
+            ]}
+            onPress={handleRetry}
+          >
+            <Text style={styles.retryButtonText}>Try Again</Text>
+          </Pressable>
+        </View>
+      </View>
+    );
+  }
+
   return (
     <View style={[styles.container, { backgroundColor }]}>
       <View style={{ height: insets.top, backgroundColor }} />
@@ -76,10 +117,22 @@ export default function WebEmbed({ path }: WebEmbedProps) {
         style={styles.webview}
         source={{ uri: WEB_BASE_URL + path }}
         sharedCookiesEnabled
+        cacheEnabled
+        cacheMode="LOAD_CACHE_ELSE_NETWORK"
+        startInLoadingState
+        renderLoading={() => (
+          <View style={styles.loadingContainer}>
+            <ActivityIndicator
+              size="large"
+              color={theme.palette.primary.main}
+            />
+          </View>
+        )}
         onNavigationStateChange={handleNavigationStateChange}
         injectedJavaScriptObject={{ isCouchersNativeEmbed: true }}
         onMessage={handleMessage}
         onError={(syntheticEvent) => {
+          setHasError(true);
           if (__DEV__) {
             const { nativeEvent } = syntheticEvent;
             console.error("WebView error:", nativeEvent);
@@ -92,24 +145,21 @@ export default function WebEmbed({ path }: WebEmbedProps) {
             console.error(
               "WebView HTTP error:",
               nativeEvent.statusCode,
-              nativeEvent.url
+              nativeEvent.url,
             );
           }
         }}
         renderError={(errorDomain, errorCode, errorDesc) => {
+          setHasError(true);
           if (__DEV__) {
             console.error(
               "WebView render error:",
               errorDomain,
               errorCode,
-              errorDesc
+              errorDesc,
             );
           }
-          return (
-            <View style={styles.errorContainer}>
-              <Text style={styles.errorText}>Failed to load page</Text>
-            </View>
-          );
+          return <View />; // We handle this with hasError state
         }}
       />
     </View>
@@ -123,14 +173,51 @@ const styles = StyleSheet.create({
   webview: {
     flex: 1,
   },
+  loadingContainer: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    justifyContent: "center",
+    alignItems: "center",
+  },
   errorContainer: {
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
-    backgroundColor: "#f5f5f5",
+    padding: 24,
+  },
+  errorImage: {
+    width: "70%",
+    height: 200,
+    resizeMode: "contain",
+    marginBottom: 24,
+  },
+  errorTitle: {
+    fontSize: 20,
+    fontWeight: "600",
+    marginBottom: 8,
+    color: "#333",
   },
   errorText: {
-    color: "#666",
     fontSize: 16,
+    color: "#666",
+    textAlign: "center",
+    marginBottom: 24,
+  },
+  retryButton: {
+    backgroundColor: theme.palette.primary.main,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+  },
+  retryButtonPressed: {
+    opacity: 0.8,
+  },
+  retryButtonText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "600",
   },
 });

--- a/app/mobile/features/auth/AuthContext.tsx
+++ b/app/mobile/features/auth/AuthContext.tsx
@@ -14,6 +14,7 @@ import client from "@/service/client";
 import i18n from "@/i18n";
 
 const BIOMETRICS_ENABLED_KEY = "biometrics_enabled";
+const CACHED_AUTH_STATE_KEY = "cached_auth_state";
 
 // Lazy import LocalAuthentication to handle Expo Go gracefully
 let LocalAuthentication: typeof import("expo-local-authentication") | null =
@@ -42,7 +43,7 @@ type AuthContextValue = {
   /** Whether biometrics are available (native module loaded) */
   biometricsAvailable: boolean;
   markAuthenticated: () => void;
-  markLoggedOut: () => void;
+  markLoggedOut: () => Promise<void>;
   setUserId: (id: number | null) => void;
   setJailed: (jailed: boolean) => void;
   /** Enable biometrics for quick login */
@@ -67,7 +68,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       try {
         // Check if biometrics are enabled (stored preference)
         const storedBiometrics = await SecureStore.getItemAsync(
-          BIOMETRICS_ENABLED_KEY
+          BIOMETRICS_ENABLED_KEY,
         );
         const biometricsEnabledPref = storedBiometrics === "true";
         setBiometricsEnabled(biometricsEnabledPref);
@@ -82,6 +83,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const authState = response.toObject();
 
         if (authState.loggedIn && authState.authRes) {
+          // Cache auth state for offline use
+          await SecureStore.setItemAsync(
+            CACHED_AUTH_STATE_KEY,
+            JSON.stringify({
+              userId: authState.authRes.userId,
+              jailed: authState.authRes.jailed,
+            }),
+          );
+
           // Session is valid - check if we need biometric auth
           if (biometricsEnabledPref && localAuth) {
             // Check if biometrics are available on device
@@ -120,12 +130,31 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             setJailedState(authState.authRes.jailed);
             setAuthenticated(true);
           }
+        } else {
+          // Not logged in - clear cached auth state
+          await SecureStore.deleteItemAsync(CACHED_AUTH_STATE_KEY);
         }
-        // If not logged in, authenticated stays false and user sees login screen
       } catch (error) {
-        // Network error or session invalid - user will see login screen
+        // Network error - try to use cached auth state for offline access
         if (__DEV__) {
           console.error("Error checking auth status:", error);
+        }
+
+        try {
+          const cachedAuthState = await SecureStore.getItemAsync(
+            CACHED_AUTH_STATE_KEY,
+          );
+          if (cachedAuthState) {
+            const { userId, jailed } = JSON.parse(cachedAuthState);
+            setUserIdState(userId);
+            setJailedState(jailed);
+            setAuthenticated(true);
+            if (__DEV__) {
+              console.log("Using cached auth state for offline access");
+            }
+          }
+        } catch {
+          // Failed to parse cached state - ignore
         }
       } finally {
         setCheckedAuthStatus(true);
@@ -139,10 +168,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setAuthenticated(true);
   }, []);
 
-  const markLoggedOut = useCallback(() => {
+  const markLoggedOut = useCallback(async () => {
     setAuthenticated(false);
     setUserIdState(null);
     setJailedState(false);
+    // Clear cached auth state on logout
+    await SecureStore.deleteItemAsync(CACHED_AUTH_STATE_KEY);
   }, []);
 
   const setUserId = useCallback((id: number | null) => {
@@ -191,7 +222,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setJailed,
       enableBiometrics,
       disableBiometrics,
-    ]
+    ],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**

Closes #6402 

<!---
Please describe the pull request here.
If it closes an issue, make sure to write "closes #1234"
If there is an issue but it isn't completely closed, still refer to the issue number, eg. "part of #1234"
--->

There are limits too how offline friendly we can make the app using a WebEmbed, since it just wraps around the we app which needs to be online. That said, this adds a few improvements:

- Shows a connection error screen with a retry button for intermittent errors
- Stores regular login auth offline in ios/android in SecureStore (biometrics login already does this)
- Adds a loading indicator at top level

<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
