### PR TITLE
[slop] fix: translate response time durations on profile page

### DIFF
--- a/app/web/features/profile/view/userLabels.tsx
+++ b/app/web/features/profile/view/userLabels.tsx
@@ -12,7 +12,7 @@ import {
 import { theme } from "theme";
 import { monthFormatter, timestamp2Date } from "utils/date";
 import dayjs from "utils/dayjs";
-import { hourMillis, timeAgoI18n } from "utils/timeAgo";
+import { hourMillis, humanizeDurationI18n, timeAgoI18n } from "utils/timeAgo";
 
 interface Props {
   user: User.AsObject;
@@ -76,6 +76,7 @@ export const ResponseRateText = ({
 
 export const ResponseRateLabel = ({ user }: Props) => {
   const { t } = useTranslation("profile");
+  const { t: tGlobal } = useTranslation(GLOBAL);
 
   let rateText = undefined;
   let timeText = undefined;
@@ -87,29 +88,34 @@ export const ResponseRateLabel = ({ user }: Props) => {
   } else if (user.some) {
     rateText = t("response_rate_text_some");
     timeText = t("response_time_text_some", {
-      p33: dayjs
-        .duration(user.some.responseTimeP33!.seconds, "second")
-        .humanize(),
+      p33: humanizeDurationI18n({
+        seconds: user.some.responseTimeP33!.seconds,
+        t: tGlobal,
+      }),
     });
   } else if (user.most) {
     rateText = t("response_rate_text_most");
     timeText = t("response_time_text_most", {
-      p33: dayjs
-        .duration(user.most.responseTimeP33!.seconds, "second")
-        .humanize(),
-      p66: dayjs
-        .duration(user.most.responseTimeP66!.seconds, "second")
-        .humanize(),
+      p33: humanizeDurationI18n({
+        seconds: user.most.responseTimeP33!.seconds,
+        t: tGlobal,
+      }),
+      p66: humanizeDurationI18n({
+        seconds: user.most.responseTimeP66!.seconds,
+        t: tGlobal,
+      }),
     });
   } else if (user.almostAll) {
     rateText = t("response_rate_text_almost_all");
     timeText = t("response_time_text_almost_all", {
-      p33: dayjs
-        .duration(user.almostAll.responseTimeP33!.seconds, "second")
-        .humanize(),
-      p66: dayjs
-        .duration(user.almostAll.responseTimeP66!.seconds, "second")
-        .humanize(),
+      p33: humanizeDurationI18n({
+        seconds: user.almostAll.responseTimeP33!.seconds,
+        t: tGlobal,
+      }),
+      p66: humanizeDurationI18n({
+        seconds: user.almostAll.responseTimeP66!.seconds,
+        t: tGlobal,
+      }),
     });
   }
 

--- a/app/web/resources/locales/en.json
+++ b/app/web/resources/locales/en.json
@@ -245,6 +245,17 @@
     "one_year_ago": "1 year ago",
     "x_years_ago": "{{date}} years ago"
   },
+  "duration": {
+    "x_minutes": "{{count}} minutes",
+    "one_hour": "an hour",
+    "x_hours": "{{count}} hours",
+    "one_day": "a day",
+    "x_days": "{{count}} days",
+    "one_week": "a week",
+    "x_weeks": "{{count}} weeks",
+    "one_month": "a month",
+    "x_months": "{{count}} months"
+  },
   "location_autocomplete": {
     "more_specific": "Please choose a more specific place",
     "search_location_hint": "Press Enter or click the search icon to choose a location",

--- a/app/web/utils/timeAgo.ts
+++ b/app/web/utils/timeAgo.ts
@@ -63,6 +63,54 @@ interface FuzzySpecT {
   translationKey: Parameters<TFunction<"global", undefined>>[0];
 }
 
+/**
+ * Converts a duration in seconds to a human-readable, translated string.
+ * Unlike dayjs.humanize(), this uses our i18n translations.
+ */
+export function humanizeDurationI18n({
+  seconds,
+  t,
+}: {
+  seconds: number;
+  t: TFunction<"global", undefined>;
+}): string {
+  const minutes = Math.round(seconds / 60);
+  const hours = Math.round(seconds / 3600);
+  const days = Math.round(seconds / 86400);
+  const weeks = Math.round(seconds / 604800);
+  const months = Math.round(seconds / (604800 * 4));
+
+  if (seconds < 3600) {
+    // Less than 1 hour, show minutes
+    return t("duration.x_minutes", { count: Math.max(1, minutes) });
+  }
+  if (hours === 1) {
+    return t("duration.one_hour");
+  }
+  if (seconds < 86400) {
+    // Less than 1 day, show hours
+    return t("duration.x_hours", { count: hours });
+  }
+  if (days === 1) {
+    return t("duration.one_day");
+  }
+  if (seconds < 604800) {
+    // Less than 1 week, show days
+    return t("duration.x_days", { count: days });
+  }
+  if (weeks === 1) {
+    return t("duration.one_week");
+  }
+  if (seconds < 604800 * 4) {
+    // Less than 1 month, show weeks
+    return t("duration.x_weeks", { count: weeks });
+  }
+  if (months === 1) {
+    return t("duration.one_month");
+  }
+  return t("duration.x_months", { count: months });
+}
+
 export function timeAgoI18n({
   input,
   t,


### PR DESCRIPTION
## Summary
- Replace dayjs.humanize() with i18n-aware humanizeDurationI18n function
- Add duration translation keys to English locale
- Fix untranslated "hours" on profile page response time

Fixes #7343

🤖 Generated with [Claude Code](https://claude.ai/code)