### PR TITLE
Fix bug with geolocationSearchInfo type

### DIFF
--- a/app/web/service/bugs.ts
+++ b/app/web/service/bugs.ts
@@ -46,7 +46,7 @@ export async function geolocationSearchInfo({
   req.setSearchString(searchString);
   req.setNominatimResultJson(nominatimResultJson);
   req.setFormattedResultJson(formattedResultJson);
-  req.setDurationMs(durationMs);
+  req.setDurationMs(Math.max(Math.round(durationMs), 0));
   await client.bugs.geolocationSearchInfo(req);
 }
 


### PR DESCRIPTION
Was getting an error on stage and prod when searching on the map in the browser console. The issue was that duration_ms is defined as uint32 in the protobuf schema, but performance.now() - startTime returns a floating-point number.