### PR TITLE
Basic email translation infrastructure

### DIFF
--- a/app/backend/src/couchers/i18n/i18n.py
+++ b/app/backend/src/couchers/i18n/i18n.py
@@ -125,9 +125,11 @@ def get_raw_translation_string(
     except KeyError as e:
         raise MissingTranslationError(lang, component, string_name) from e
 
-    # Perform substitutions by replacing {{key}} with the corresponding value
+    return perform_substitutions(template, substitutions)
+
+def perform_substitutions(template: str, substitutions: dict[str, str] | None = None) -> str:
+    """Replaces {{key}} placeholders with the corresponding value."""
     if substitutions:
         for key, value in substitutions.items():
             template = template.replace(f"{{{{{key}}}}}", str(value))
-
     return template

--- a/app/backend/src/couchers/i18n/i18n.py
+++ b/app/backend/src/couchers/i18n/i18n.py
@@ -125,11 +125,9 @@ def get_raw_translation_string(
     except KeyError as e:
         raise MissingTranslationError(lang, component, string_name) from e
 
-    return perform_substitutions(template, substitutions)
-
-def perform_substitutions(template: str, substitutions: dict[str, str] | None = None) -> str:
-    """Replaces {{key}} placeholders with the corresponding value."""
+    # Perform substitutions by replacing {{key}} with the corresponding value
     if substitutions:
         for key, value in substitutions.items():
             template = template.replace(f"{{{{{key}}}}}", str(value))
+
     return template

--- a/app/backend/src/couchers/i18n/locales/en.json
+++ b/app/backend/src/couchers/i18n/locales/en.json
@@ -259,16 +259,16 @@
     "no_money_title": "Keep money out of it",
     "no_money_guideline": "Keep things non-transactional. Don't exchange money while staying or hosting. Couchers.org is about learning, experiences, and getting to know people."
   },
-  "notification_donation_received": {
-    "title": "Thank you for your donation to Couchers.org!",
-    "greeting": "Dear {{name}},",
-    "thanks_donation": "Thank you so much for your donation of ${{amount}} to Couchers.org.",
-    "donation_purpose": "Your contribution will go towards building and sustaining the Couchers.org platform and community, and is vital for our goal of a completely free and non-profit generation of couch surfing.",
-    "invoice_receipt_info": "You can download an invoice and receipt for the donation here:",
-    "download_invoice": "Download invoice",
-    "questions_contact": "If you have any questions about your donation, please email us at <a href=\"mailto:donations@couchers.org\">donations@couchers.org</a>.",
-    "generosity_helps": "Your generosity will help deliver the platform for everyone.",
+  "notifications": {
+    "donation_received_title": "Thank you for your donation to Couchers.org!",
+    "dear_name": "Dear {{name}},",
+    "donation_received_thanks_amount": "Thank you so much for your donation of ${{amount}} to Couchers.org.",
+    "donation_received_purpose": "Your contribution will go towards building and sustaining the Couchers.org platform and community, and is vital for our goal of a completely free and non-profit generation of couch surfing.",
+    "donation_received_invoice_receipt_info": "You can download an invoice and receipt for the donation here:",
+    "donation_received_download_invoice": "Download invoice",
+    "donation_received_questions_contact": "If you have any questions about your donation, please email us at <a href=\"mailto:donations@couchers.org\">donations@couchers.org</a>.",
+    "donation_received_generosity_helps": "Your generosity will help deliver the platform for everyone.",
     "thank_you": "Thank you!",
-    "signature": "Aapeli and Itsi,\nCouchers.org Founders"
+    "founders_signature": "Aapeli and Itsi,\nCouchers.org Founders"
   }
 }

--- a/app/backend/src/couchers/i18n/locales/en.json
+++ b/app/backend/src/couchers/i18n/locales/en.json
@@ -258,5 +258,17 @@
     "be_safe_guideline": "Read profiles, references, and resources. Report any inappropriate content or behavior.",
     "no_money_title": "Keep money out of it",
     "no_money_guideline": "Keep things non-transactional. Don't exchange money while staying or hosting. Couchers.org is about learning, experiences, and getting to know people."
+  },
+  "notification_donation_received": {
+    "title": "Thank you for your donation to Couchers.org!",
+    "greeting": "Dear {{name}},",
+    "thanks_donation": "Thank you so much for your donation of ${{amount}} to Couchers.org.",
+    "donation_purpose": "Your contribution will go towards building and sustaining the Couchers.org platform and community, and is vital for our goal of a completely free and non-profit generation of couch surfing.",
+    "invoice_receipt_info": "You can download an invoice and receipt for the donation here:",
+    "download_invoice": "Download invoice",
+    "questions_contact": "If you have any questions about your donation, please email us at <a href=\"mailto:donations@couchers.org\">donations@couchers.org</a>.",
+    "generosity_helps": "Your generosity will help deliver the platform for everyone.",
+    "thank_you": "Thank you!",
+    "signature": "Aapeli and Itsi,\nCouchers.org Founders"
   }
 }

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -27,7 +27,7 @@ from couchers.notifications.render import render_notification
 from couchers.notifications.settings import get_preference
 from couchers.proto.internal import jobs_pb2
 from couchers.sql import couchers_select as select
-from couchers.templates.v2 import add_filters
+from couchers.templates.v2 import add_filters, CONTEXT_PLAINTEXT_KEY, CONTEXT_LANGUAGE_KEY, CONTEXT_COMPONENT_KEY, CONTEXT_YEAR_KEY, CONTEXT_TIMEZONE_DISPLAY_KEY
 from couchers.utils import get_tz_as_text, now
 
 logger = logging.getLogger(__name__)
@@ -46,9 +46,10 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         "user": user,
         "time": notification.created,
         # Lookup strings for this notification
-        "_component": f"notification_{rendered.email_template_name}",
-        "_year": now().year,
-        "_timezone_display": get_tz_as_text(user.timezone or "Etc/UTC"),
+        CONTEXT_LANGUAGE_KEY: user.ui_language_preference or "en",
+        CONTEXT_COMPONENT_KEY: f"notification_{rendered.email_template_name}",
+        CONTEXT_YEAR_KEY: now().year,
+        CONTEXT_TIMEZONE_DISPLAY_KEY: get_tz_as_text(user.timezone or "Etc/UTC"),
         **rendered.email_template_args,
     }
 
@@ -78,7 +79,7 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         html_unsub_section += f'<br /><a href="{dne_link}">Do not email me (disables hosting)</a>.'
 
     plain_tmplt = (template_folder / f"{rendered.email_template_name}.txt").read_text()
-    plain_template_args = {**template_args, "_plain": True}  # Strip html from translations.
+    plain_template_args = {**template_args, CONTEXT_PLAINTEXT_KEY: True}  # Strip html from translations.
     plain = env.from_string(plain_tmplt + plain_unsub_section).render(plain_template_args)
 
     html_tmplt = (template_folder / "generated_html" / f"{rendered.email_template_name}.html").read_text()

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -27,7 +27,14 @@ from couchers.notifications.render import render_notification
 from couchers.notifications.settings import get_preference
 from couchers.proto.internal import jobs_pb2
 from couchers.sql import couchers_select as select
-from couchers.templates.v2 import add_filters, CONTEXT_PLAINTEXT_KEY, CONTEXT_LANGUAGE_KEY, CONTEXT_COMPONENT_KEY, CONTEXT_YEAR_KEY, CONTEXT_TIMEZONE_DISPLAY_KEY
+from couchers.templates.v2 import (
+    CONTEXT_COMPONENT_KEY,
+    CONTEXT_LANGUAGE_KEY,
+    CONTEXT_PLAINTEXT_KEY,
+    CONTEXT_TIMEZONE_DISPLAY_KEY,
+    CONTEXT_YEAR_KEY,
+    add_filters,
+)
 from couchers.utils import get_tz_as_text, now
 
 logger = logging.getLogger(__name__)

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -28,10 +28,10 @@ from couchers.notifications.settings import get_preference
 from couchers.proto.internal import jobs_pb2
 from couchers.sql import couchers_select as select
 from couchers.templates.v2 import (
-    CONTEXT_COMPONENT_KEY,
-    CONTEXT_LANGUAGE_KEY,
     CONTEXT_PLAINTEXT_KEY,
     CONTEXT_TIMEZONE_DISPLAY_KEY,
+    CONTEXT_TRANSLATION_COMPONENT_KEY,
+    CONTEXT_TRANSLATION_LANGUAGE_KEY,
     CONTEXT_YEAR_KEY,
     add_filters,
 )
@@ -52,9 +52,8 @@ def _send_email_notification(session: Session, user: User, notification: Notific
     template_args = {
         "user": user,
         "time": notification.created,
-        # Lookup strings for this notification
-        CONTEXT_LANGUAGE_KEY: user.ui_language_preference or "en",
-        CONTEXT_COMPONENT_KEY: f"notification_{rendered.email_template_name}",
+        CONTEXT_TRANSLATION_LANGUAGE_KEY: user.ui_language_preference or "en",
+        CONTEXT_TRANSLATION_COMPONENT_KEY: "notifications",
         CONTEXT_YEAR_KEY: now().year,
         CONTEXT_TIMEZONE_DISPLAY_KEY: get_tz_as_text(user.timezone or "Etc/UTC"),
         **rendered.email_template_args,

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -45,6 +45,8 @@ def _send_email_notification(session: Session, user: User, notification: Notific
     template_args = {
         "user": user,
         "time": notification.created,
+        # Lookup strings for this notification
+        "_component": f"notification_{rendered.email_template_name}",
         "_year": now().year,
         "_timezone_display": get_tz_as_text(user.timezone or "Etc/UTC"),
         **rendered.email_template_args,
@@ -76,7 +78,9 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         html_unsub_section += f'<br /><a href="{dne_link}">Do not email me (disables hosting)</a>.'
 
     plain_tmplt = (template_folder / f"{rendered.email_template_name}.txt").read_text()
-    plain = env.from_string(plain_tmplt + plain_unsub_section).render(template_args)
+    plain_template_args = {**template_args, "_plain": True}
+    plain = env.from_string(plain_tmplt + plain_unsub_section).render(plain_template_args)
+
     html_tmplt = (template_folder / "generated_html" / f"{rendered.email_template_name}.html").read_text()
     html = env.from_string(html_tmplt.replace("___UNSUB_SECTION___", html_unsub_section)).render(template_args)
 

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -78,7 +78,7 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         html_unsub_section += f'<br /><a href="{dne_link}">Do not email me (disables hosting)</a>.'
 
     plain_tmplt = (template_folder / f"{rendered.email_template_name}.txt").read_text()
-    plain_template_args = {**template_args, "_plain": True}
+    plain_template_args = {**template_args, "_plain": True}  # Strip html from translations.
     plain = env.from_string(plain_tmplt + plain_unsub_section).render(plain_template_args)
 
     html_tmplt = (template_folder / "generated_html" / f"{rendered.email_template_name}.html").read_text()

--- a/app/backend/src/couchers/notifications/render.py
+++ b/app/backend/src/couchers/notifications/render.py
@@ -365,10 +365,10 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
             email_list_unsubscribe_url=generate_unsub_topic_action(notification),
         )
     elif notification.topic_action.display == "donation:received":
-        title = get_localized_string("notification_donation_received", "title")
+        title = get_localized_string("notifications", "donation_received_title")
         message = get_localized_string(
-            "notification_donation_received",
-            "thanks_donation",
+            "notifications",
+            "donation_received_thanks_amount",
             substitutions={
                 "amount": data.amount,
             },

--- a/app/backend/src/couchers/notifications/render.py
+++ b/app/backend/src/couchers/notifications/render.py
@@ -365,8 +365,14 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
             email_list_unsubscribe_url=generate_unsub_topic_action(notification),
         )
     elif notification.topic_action.display == "donation:received":
-        title = "Thank you for your donation to Couchers.org!"
-        message = f"Thank you so much for your donation of ${data.amount} to Couchers.org."
+        title = get_localized_string("notification_donation_received", "title")
+        message = get_localized_string(
+            "notification_donation_received",
+            "thanks_donation",
+            substitutions={
+                "amount": data.amount,
+            },
+        )
         return RenderedNotification(
             is_critical=True,
             email_subject=title,

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -132,8 +132,9 @@ def v2translate(context: Context, key: str, **kwargs: Any) -> str:
         translated = re.sub(r"<br\s*/?>", "\n", translated)
 
     else:
-        # HTML support
-        translated = translated.replace("\n", "<br />")
+        # HTML support, email flavored
+        # mjml rendering converts <br /> to <br>, so prefer that form.
+        translated = translated.replace("\n", "<br>")
 
     return translated
 

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -3,6 +3,7 @@ template mailer/push notification formatter v2
 """
 
 import logging
+import re
 from datetime import date, datetime
 from html import escape
 from pathlib import Path
@@ -11,13 +12,15 @@ from zoneinfo import ZoneInfo
 
 import phonenumbers
 from google.protobuf.timestamp_pb2 import Timestamp
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, pass_context
+from jinja2.runtime import Context
 from markdown_it import MarkdownIt
 from sqlalchemy.orm import Session
 
 from couchers import urls
 from couchers.config import config
 from couchers.email import queue_email
+from couchers.i18n.i18n import get_raw_translation_string
 from couchers.models import User
 from couchers.utils import get_tz_as_text, now, to_aware_datetime
 
@@ -85,6 +88,47 @@ def v2markdown(value: str) -> str:
     return md.render(value)  # type: ignore[no-any-return]
 
 
+@pass_context
+def v2translate(context: Context, key: str, **kwargs: Any) -> str:
+    """
+    Jinja2 filter to translate a string key with substitutions.
+
+    Usage in template:
+        {{ "greeting_key"|v2translate(name=user.name) }}
+    """
+
+    user: User = context.parent["user"]
+    component = context.parent.get("_component")
+    if component is None:
+        raise ValueError("Component not found in jinja context for v2translate")
+
+    # Prevent html injection
+    escaped_substitutions = {k: escape(str(v)) for k, v in kwargs.items()}
+
+    translated = get_raw_translation_string(
+        user.ui_language_preference or "en", component, key, substitutions=escaped_substitutions
+    )
+
+    # Translations may include simple formatting HTML like <b> or <a>,
+    # but those should not appear in plain text emails.
+    if context.parent.get("_plain") == True:
+
+        def replace_tag(match: re.Match) -> str:
+            tag = match.group(1)
+            inner_text = match.group(2)
+            if tag.lower() == "a":
+                # <a href="url">text</a> -> <text>
+                return f"<{inner_text}>"
+            else:
+                # <b>hello</b> -> hello
+                return inner_text
+
+        # Doesn't support nesting, but should be sufficient for our needs
+        translated = re.sub(r"<(\w+).*?>(.*?)</\1>", replace_tag, translated)
+
+    return translated
+
+
 def add_filters(env: Environment) -> None:
     env.filters["v2esc"] = v2esc
     env.filters["v2multiline"] = v2multiline
@@ -97,6 +141,7 @@ def add_filters(env: Environment) -> None:
     env.filters["v2avatar"] = v2avatar
     env.filters["v2quote"] = v2quote
     env.filters["v2markdown"] = v2markdown
+    env.filters["v2translate"] = v2translate
 
 
 add_filters(env)
@@ -118,6 +163,7 @@ def send_simple_pretty_email(
 
     plain_tmplt = (template_folder / f"{template_name}.txt").read_text()
     plain = env.from_string(plain_tmplt + plain_unsub_section).render(template_args)
+
     html_tmplt = (template_folder / "generated_html" / f"{template_name}.html").read_text()
     html = env.from_string(html_tmplt.replace("___UNSUB_SECTION___", html_unsub_section)).render(template_args)
 

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -111,9 +111,7 @@ def v2translate(context: Context, key: str, **kwargs: Any) -> str:
     # Prevent html injection
     escaped_substitutions = {k: escape(str(v)) for k, v in kwargs.items()}
 
-    translated = get_raw_translation_string(
-        lang, component, key, substitutions=escaped_substitutions
-    )
+    translated = get_raw_translation_string(lang, component, key, substitutions=escaped_substitutions)
 
     # Translations may include simple formatting HTML like <b> or <a>,
     # but those should not appear in plain text emails.

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -125,6 +125,11 @@ def v2translate(context: Context, key: str, **kwargs: Any) -> str:
 
         # Doesn't support nesting, but should be sufficient for our needs
         translated = re.sub(r"<(\w+).*?>(.*?)</\1>", replace_tag, translated)
+        translated = re.sub(r"<br\s*/?>", "\n", translated)
+
+    else:
+        # HTML support
+        translated = translated.replace("\n", "<br />")
 
     return translated
 

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -37,8 +37,8 @@ md = MarkdownIt("zero", {"typographer": True}).enable(["smartquotes", "heading",
 # Special context values expected by v2 filters
 CONTEXT_YEAR_KEY = "_year"
 CONTEXT_TIMEZONE_DISPLAY_KEY = "_timezone_display"
-CONTEXT_COMPONENT_KEY = "_component"
-CONTEXT_LANGUAGE_KEY = "_lang"
+CONTEXT_TRANSLATION_COMPONENT_KEY = "_component"
+CONTEXT_TRANSLATION_LANGUAGE_KEY = "_lang"
 CONTEXT_PLAINTEXT_KEY = "_plain"
 
 
@@ -105,8 +105,8 @@ def v2translate(context: Context, key: str, **kwargs: Any) -> str:
         {{ "greeting_key"|v2translate(name=user.name) }}
     """
 
-    lang: str = context[CONTEXT_LANGUAGE_KEY]
-    component: str = context[CONTEXT_COMPONENT_KEY]
+    lang: str = context[CONTEXT_TRANSLATION_LANGUAGE_KEY]
+    component: str = context[CONTEXT_TRANSLATION_COMPONENT_KEY]
 
     # Prevent html injection
     escaped_substitutions = {k: escape(str(v)) for k, v in kwargs.items()}

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -34,6 +34,14 @@ env = Environment(loader=loader, trim_blocks=True)
 md = MarkdownIt("zero", {"typographer": True}).enable(["smartquotes", "heading", "hr", "list", "link", "emphasis"])
 
 
+# Special context values expected by v2 filters
+CONTEXT_YEAR_KEY = "_year"
+CONTEXT_TIMEZONE_DISPLAY_KEY = "_timezone_display"
+CONTEXT_COMPONENT_KEY = "_component"
+CONTEXT_LANGUAGE_KEY = "_lang"
+CONTEXT_PLAINTEXT_KEY = "_plain"
+
+
 def v2esc(value: Any) -> str:
     return escape(str(value))
 
@@ -97,21 +105,19 @@ def v2translate(context: Context, key: str, **kwargs: Any) -> str:
         {{ "greeting_key"|v2translate(name=user.name) }}
     """
 
-    user: User = context.parent["user"]
-    component = context.parent.get("_component")
-    if component is None:
-        raise ValueError("Component not found in jinja context for v2translate")
+    lang: str = context[CONTEXT_LANGUAGE_KEY]
+    component: str = context[CONTEXT_COMPONENT_KEY]
 
     # Prevent html injection
     escaped_substitutions = {k: escape(str(v)) for k, v in kwargs.items()}
 
     translated = get_raw_translation_string(
-        user.ui_language_preference or "en", component, key, substitutions=escaped_substitutions
+        lang, component, key, substitutions=escaped_substitutions
     )
 
     # Translations may include simple formatting HTML like <b> or <a>,
     # but those should not appear in plain text emails.
-    if context.parent.get("_plain") == True:
+    if context.parent.get(CONTEXT_PLAINTEXT_KEY) == True:
 
         def replace_tag(match: re.Match) -> str:
             tag = match.group(1)
@@ -160,8 +166,8 @@ def send_simple_pretty_email(
 
     It's for the few security emails where we don't have a user to email but send directly to an email address.
     """
-    template_args["_year"] = now().year
-    template_args["_timezone_display"] = get_tz_as_text("Etc/UTC")
+    template_args[CONTEXT_YEAR_KEY] = now().year
+    template_args[CONTEXT_TIMEZONE_DISPLAY_KEY] = get_tz_as_text("Etc/UTC")
 
     plain_unsub_section = "\n\n---\n\nThis is a security email, you cannot unsubscribe from it."
     html_unsub_section = "This is a security email, you cannot unsubscribe from it."

--- a/app/backend/src/tests/test_templates.py
+++ b/app/backend/src/tests/test_templates.py
@@ -86,7 +86,7 @@ def test_v2translate_newlines_br() -> None:
     translated = _render_template(
         template_str='{{ "greeting"|v2translate }}', translation_dict=_greeting_dict("Hello!\nWelcome!")
     )
-    assert translated == "Hello!<br />Welcome!"
+    assert translated == "Hello!<br>Welcome!"
 
 
 def test_v2translate_plain_strip_tags() -> None:

--- a/app/backend/src/tests/test_templates.py
+++ b/app/backend/src/tests/test_templates.py
@@ -1,0 +1,107 @@
+# Tests jinja template rendering
+
+from dataclasses import dataclass
+from typing import Any
+from couchers.i18n.i18n import perform_substitutions
+from couchers.templates.v2 import add_filters, CONTEXT_LANGUAGE_KEY, CONTEXT_COMPONENT_KEY, CONTEXT_PLAINTEXT_KEY
+from jinja2 import Environment
+from unittest.mock import patch
+
+_env = Environment()
+add_filters(_env)
+
+def _render_template(template_str: str, translation_dict: dict, template_args: dict[str, Any] | None = None, plain: bool = False, lang: str = "en") -> str:
+    template = _env.from_string(template_str)
+    template_args = {
+        **(template_args or {}),
+        CONTEXT_LANGUAGE_KEY: lang,
+        CONTEXT_COMPONENT_KEY: "test_component", # Ignored in mocking
+    }
+    if plain:
+        template_args[CONTEXT_PLAINTEXT_KEY] = True
+
+    def mock_get_translation(lang: str, component: str, string_name: str, *, substitutions: dict[str, str] | None = None) -> str:
+        template = translation_dict[lang][string_name]
+        return perform_substitutions(template, substitutions)
+
+    with patch("couchers.templates.v2.get_raw_translation_string", new=mock_get_translation):
+        return template.render(template_args)
+
+
+def test_v2translate_no_substitutions() -> None:
+    translated = _render_template(
+        template_str='{{ "greeting"|v2translate }}',
+        translation_dict={
+            "en" : {"greeting": "Hello!"}
+        }
+    )
+    assert translated == "Hello!"
+
+def test_v2translate_multiple_languages() -> None:
+    translated = _render_template(
+        template_str='{{ "greeting"|v2translate }}',
+        lang="fr",
+        translation_dict={
+            "en" : {"greeting": "Hello!"},
+            "fr" : {"greeting": "Bonjour!"}
+        }
+    )
+    assert translated == "Bonjour!"
+
+def test_v2translate_with_substitutions() -> None:
+    translated = _render_template(
+        template_str='{{ "greeting"|v2translate(name=user_name) }}',
+        template_args={"user_name": "Jack"},
+        translation_dict={
+            "en" : {"greeting": "Hello, {{name}}!"}
+        }
+    )
+    assert translated == "Hello, Jack!"
+
+def test_v2translate_escaping() -> None:
+    translated = _render_template(
+        template_str='{{ "greeting"|v2translate(name=name) }}',
+        template_args={"name": "<script />"},
+        translation_dict={
+            "en" : {"greeting": "Hello, {{name}}!"}
+        }
+    )
+    assert translated == "Hello, &lt;script /&gt;!"
+
+def test_v2translate_translation_tags() -> None:
+    translated = _render_template(
+        template_str='{{ "greeting"|v2translate }}',
+        translation_dict={
+            "en" : {"greeting": "<b>Hello!</b>"}
+        }
+    )
+    assert translated == "<b>Hello!</b>"
+
+def test_v2translate_newlines_br() -> None:
+    translated = _render_template(
+        template_str='{{ "greeting"|v2translate }}',
+        translation_dict={
+            "en" : {"greeting": "Hello!\nWelcome!"}
+        }
+    )
+    assert translated == "Hello!<br />Welcome!"
+
+def test_v2translate_plain_strip_tags() -> None:
+    translated = _render_template(
+        template_str='{{ "greeting"|v2translate }}',
+        plain=True,
+        translation_dict={
+            "en" : {"greeting": "<b>Hello!</b>"}
+        }
+    )
+    assert translated == "Hello!"
+
+def test_v2translate_plain_strip_links() -> None:
+    translated = _render_template(
+        template_str='{{ "greeting"|v2translate }}',
+        plain=True,
+        translation_dict={
+            "en" : {"greeting": '<a href="#foo">Hello!</a>'}
+        }
+    )
+    assert translated == "<Hello!>"

--- a/app/backend/src/tests/test_templates.py
+++ b/app/backend/src/tests/test_templates.py
@@ -5,7 +5,12 @@ from unittest.mock import patch
 
 from jinja2 import Environment
 
-from couchers.templates.v2 import CONTEXT_COMPONENT_KEY, CONTEXT_LANGUAGE_KEY, CONTEXT_PLAINTEXT_KEY, add_filters
+from couchers.templates.v2 import (
+    CONTEXT_PLAINTEXT_KEY,
+    CONTEXT_TRANSLATION_COMPONENT_KEY,
+    CONTEXT_TRANSLATION_LANGUAGE_KEY,
+    add_filters,
+)
 
 _env = Environment()
 add_filters(_env)
@@ -22,8 +27,8 @@ def _render_template(
     template = _env.from_string(template_str)
     template_args = {
         **(template_args or {}),
-        CONTEXT_LANGUAGE_KEY: lang,
-        CONTEXT_COMPONENT_KEY: component,
+        CONTEXT_TRANSLATION_LANGUAGE_KEY: lang,
+        CONTEXT_TRANSLATION_COMPONENT_KEY: component,
     }
     if plain:
         template_args[CONTEXT_PLAINTEXT_KEY] = True

--- a/app/backend/src/tests/test_templates.py
+++ b/app/backend/src/tests/test_templates.py
@@ -1,107 +1,100 @@
 # Tests jinja template rendering
 
-from dataclasses import dataclass
 from typing import Any
-from couchers.i18n.i18n import perform_substitutions
-from couchers.templates.v2 import add_filters, CONTEXT_LANGUAGE_KEY, CONTEXT_COMPONENT_KEY, CONTEXT_PLAINTEXT_KEY
-from jinja2 import Environment
 from unittest.mock import patch
+
+from jinja2 import Environment
+
+from couchers.templates.v2 import CONTEXT_COMPONENT_KEY, CONTEXT_LANGUAGE_KEY, CONTEXT_PLAINTEXT_KEY, add_filters
 
 _env = Environment()
 add_filters(_env)
 
-def _render_template(template_str: str, translation_dict: dict, template_args: dict[str, Any] | None = None, plain: bool = False, lang: str = "en") -> str:
+
+def _render_template(
+    template_str: str,
+    translation_dict: dict,
+    template_args: dict[str, Any] | None = None,
+    plain: bool = False,
+    component: str = "component",
+    lang: str = "en",
+) -> str:
     template = _env.from_string(template_str)
     template_args = {
         **(template_args or {}),
         CONTEXT_LANGUAGE_KEY: lang,
-        CONTEXT_COMPONENT_KEY: "test_component", # Ignored in mocking
+        CONTEXT_COMPONENT_KEY: component,
     }
     if plain:
         template_args[CONTEXT_PLAINTEXT_KEY] = True
 
-    def mock_get_translation(lang: str, component: str, string_name: str, *, substitutions: dict[str, str] | None = None) -> str:
-        template = translation_dict[lang][string_name]
-        return perform_substitutions(template, substitutions)
-
-    with patch("couchers.templates.v2.get_raw_translation_string", new=mock_get_translation):
+    with patch("couchers.i18n.i18n.get_translations", new=lambda: translation_dict):
         return template.render(template_args)
+
+
+def _greeting_dict(value: str) -> dict:
+    return {"en": {"component": {"greeting": value}}}
 
 
 def test_v2translate_no_substitutions() -> None:
     translated = _render_template(
-        template_str='{{ "greeting"|v2translate }}',
-        translation_dict={
-            "en" : {"greeting": "Hello!"}
-        }
+        template_str='{{ "greeting"|v2translate }}', translation_dict=_greeting_dict("Hello!")
     )
     assert translated == "Hello!"
+
 
 def test_v2translate_multiple_languages() -> None:
     translated = _render_template(
         template_str='{{ "greeting"|v2translate }}',
         lang="fr",
-        translation_dict={
-            "en" : {"greeting": "Hello!"},
-            "fr" : {"greeting": "Bonjour!"}
-        }
+        translation_dict={"en": {"component": {"greeting": "Hello!"}}, "fr": {"component": {"greeting": "Bonjour!"}}},
     )
     assert translated == "Bonjour!"
+
 
 def test_v2translate_with_substitutions() -> None:
     translated = _render_template(
         template_str='{{ "greeting"|v2translate(name=user_name) }}',
         template_args={"user_name": "Jack"},
-        translation_dict={
-            "en" : {"greeting": "Hello, {{name}}!"}
-        }
+        translation_dict=_greeting_dict("Hello, {{name}}!"),
     )
     assert translated == "Hello, Jack!"
+
 
 def test_v2translate_escaping() -> None:
     translated = _render_template(
         template_str='{{ "greeting"|v2translate(name=name) }}',
         template_args={"name": "<script />"},
-        translation_dict={
-            "en" : {"greeting": "Hello, {{name}}!"}
-        }
+        translation_dict=_greeting_dict("Hello, {{name}}!"),
     )
     assert translated == "Hello, &lt;script /&gt;!"
 
+
 def test_v2translate_translation_tags() -> None:
     translated = _render_template(
-        template_str='{{ "greeting"|v2translate }}',
-        translation_dict={
-            "en" : {"greeting": "<b>Hello!</b>"}
-        }
+        template_str='{{ "greeting"|v2translate }}', translation_dict=_greeting_dict("<b>Hello!</b>")
     )
     assert translated == "<b>Hello!</b>"
 
+
 def test_v2translate_newlines_br() -> None:
     translated = _render_template(
-        template_str='{{ "greeting"|v2translate }}',
-        translation_dict={
-            "en" : {"greeting": "Hello!\nWelcome!"}
-        }
+        template_str='{{ "greeting"|v2translate }}', translation_dict=_greeting_dict("Hello!\nWelcome!")
     )
     assert translated == "Hello!<br />Welcome!"
 
+
 def test_v2translate_plain_strip_tags() -> None:
     translated = _render_template(
-        template_str='{{ "greeting"|v2translate }}',
-        plain=True,
-        translation_dict={
-            "en" : {"greeting": "<b>Hello!</b>"}
-        }
+        template_str='{{ "greeting"|v2translate }}', plain=True, translation_dict=_greeting_dict("<b>Hello!</b>")
     )
     assert translated == "Hello!"
+
 
 def test_v2translate_plain_strip_links() -> None:
     translated = _render_template(
         template_str='{{ "greeting"|v2translate }}',
         plain=True,
-        translation_dict={
-            "en" : {"greeting": '<a href="#foo">Hello!</a>'}
-        }
+        translation_dict=_greeting_dict('<a href="#foo">Hello!</a>'),
     )
     assert translated == "<Hello!>"

--- a/app/backend/templates/v2/donation_received.mjml
+++ b/app/backend/templates/v2/donation_received.mjml
@@ -1,23 +1,23 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Dear {{ user.name|v2esc }},</mj-text>
-    <mj-text>Thank you so much for your donation of ${{ amount|v2esc }} to Couchers.org.</mj-text>
-    <mj-text>Your contribution will go towards building and sustaining the Couchers.org platform and community, and is vital for our goal of a completely free and non-profit generation of couch surfing.</mj-text>
-    <mj-text>You can download an invoice and receipt for the donation here:</mj-text>
+    <mj-text>{{ "greeting"|v2translate(name=user.name) }}</mj-text>
+    <mj-text>{{ "thanks_donation"|v2translate(amount=amount) }}</mj-text>
+    <mj-text>{{ "donation_purpose"|v2translate }}</mj-text>
+    <mj-text>{{ "invoice_receipt_info"|v2translate }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
     <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ receipt_url|v2url }}">
-      <b>Download invoice</b>
+      <b>{{ "download_invoice"|v2translate }}</b>
     </mj-button>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>If you have any questions about your donation, please email us at <a href="mailto:donations@couchers.org">donations@couchers.org</a>.</mj-text>
-    <mj-text>Your generosity will help deliver the platform for everyone.</mj-text>
-    <mj-text><b>Thank you!</b></mj-text>
-    <mj-text>Aapeli and Itsi,<br />Couchers.org Founders</mj-text>
+    <mj-text>{{ "questions_contact"|v2translate }}</mj-text>
+    <mj-text>{{ "generosity_helps"|v2translate }}</mj-text>
+    <mj-text><b>{{ "thank_you"|v2translate }}</b></mj-text>
+    <mj-text>{{ "signature"|v2translate }}</mj-text>
   </mj-column>
 </mj-section>

--- a/app/backend/templates/v2/donation_received.mjml
+++ b/app/backend/templates/v2/donation_received.mjml
@@ -1,23 +1,23 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>{{ "greeting"|v2translate(name=user.name) }}</mj-text>
-    <mj-text>{{ "thanks_donation"|v2translate(amount=amount) }}</mj-text>
-    <mj-text>{{ "donation_purpose"|v2translate }}</mj-text>
-    <mj-text>{{ "invoice_receipt_info"|v2translate }}</mj-text>
+    <mj-text>{{ "dear_name"|v2translate(name=user.name) }}</mj-text>
+    <mj-text>{{ "donation_received_thanks_amount"|v2translate(amount=amount) }}</mj-text>
+    <mj-text>{{ "donation_received_purpose"|v2translate }}</mj-text>
+    <mj-text>{{ "donation_received_invoice_receipt_info"|v2translate }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
     <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ receipt_url|v2url }}">
-      <b>{{ "download_invoice"|v2translate }}</b>
+      <b>{{ "donation_received_download_invoice"|v2translate }}</b>
     </mj-button>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>{{ "questions_contact"|v2translate }}</mj-text>
-    <mj-text>{{ "generosity_helps"|v2translate }}</mj-text>
+    <mj-text>{{ "donation_received_questions_contact"|v2translate }}</mj-text>
+    <mj-text>{{ "donation_received_generosity_helps"|v2translate }}</mj-text>
     <mj-text><b>{{ "thank_you"|v2translate }}</b></mj-text>
-    <mj-text>{{ "signature"|v2translate }}</mj-text>
+    <mj-text>{{ "founders_signature"|v2translate }}</mj-text>
   </mj-column>
 </mj-section>

--- a/app/backend/templates/v2/donation_received.txt
+++ b/app/backend/templates/v2/donation_received.txt
@@ -1,19 +1,19 @@
-{{ "greeting"|v2translate(name=user.name) }}
+{{ "dear_name"|v2translate(name=user.name) }}
 
-{{ "thanks_donation"|v2translate(amount=amount) }}
+{{ "donation_received_thanks_amount"|v2translate(amount=amount) }}
 
-{{ "donation_purpose"|v2translate }}
+{{ "donation_received_purpose"|v2translate }}
 
 
-{{ "invoice_receipt_info"|v2translate }}
+{{ "donation_received_invoice_receipt_info"|v2translate }}
 
 <{{ receipt_url }}>
 
-{{ "questions_contact"|v2translate }}
+{{ "donation_received_questions_contact"|v2translate }}
 
-{{ "generosity_helps"|v2translate }}
+{{ "donation_received_generosity_helps"|v2translate }}
 
 
 {{ "thank_you"|v2translate }}
 
-{{ "signature"|v2translate }}
+{{ "founders_signature"|v2translate }}

--- a/app/backend/templates/v2/donation_received.txt
+++ b/app/backend/templates/v2/donation_received.txt
@@ -1,20 +1,19 @@
-Dear {{ user.name }},
+{{ "greeting"|v2translate(name=user.name) }}
 
-Thank you so much for your donation of ${{ amount }} to Couchers.org.
+{{ "thanks_donation"|v2translate(amount=amount) }}
 
-Your contribution will go towards building and sustaining the Couchers.org platform and community, and is vital for our goal of a completely free and non-profit generation of couch surfing.
+{{ "donation_purpose"|v2translate }}
 
 
-You can download an invoice and receipt for the donation here:
+{{ "invoice_receipt_info"|v2translate }}
 
 <{{ receipt_url }}>
 
-If you have any questions about your donation, please email us at <donations@couchers.org>.
+{{ "questions_contact"|v2translate }}
 
-Your generosity will help deliver the platform for everyone.
+{{ "generosity_helps"|v2translate }}
 
 
-Thank you!
+{{ "thank_you"|v2translate }}
 
-Aapeli and Itsi,
-Couchers.org Founders
+{{ "signature"|v2translate }}

--- a/app/backend/templates/v2/generated_html/donation_received.html
+++ b/app/backend/templates/v2/generated_html/donation_received.html
@@ -167,22 +167,22 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "greeting"|v2translate(name=user.name) }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "dear_name"|v2translate(name=user.name) }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "thanks_donation"|v2translate(amount=amount) }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "donation_received_thanks_amount"|v2translate(amount=amount) }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "donation_purpose"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "donation_received_purpose"|v2translate }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "invoice_receipt_info"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "donation_received_invoice_receipt_info"|v2translate }}</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -211,7 +211,7 @@
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
                                           <a href="{{ receipt_url|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
-                                            <b>{{ "download_invoice"|v2translate }}</b>
+                                            <b>{{ "donation_received_download_invoice"|v2translate }}</b>
                                           </a>
                                         </td>
                                       </tr>
@@ -240,12 +240,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "questions_contact"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "donation_received_questions_contact"|v2translate }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "generosity_helps"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "donation_received_generosity_helps"|v2translate }}</div>
                                 </td>
                               </tr>
                               <tr>
@@ -255,7 +255,7 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "signature"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "founders_signature"|v2translate }}</div>
                                 </td>
                               </tr>
                             </tbody>

--- a/app/backend/templates/v2/generated_html/donation_received.html
+++ b/app/backend/templates/v2/generated_html/donation_received.html
@@ -167,22 +167,22 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Dear {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "greeting"|v2translate(name=user.name) }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Thank you so much for your donation of ${{ amount|v2esc }} to Couchers.org.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "thanks_donation"|v2translate(amount=amount) }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Your contribution will go towards building and sustaining the Couchers.org platform and community, and is vital for our goal of a completely free and non-profit generation of couch surfing.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "donation_purpose"|v2translate }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">You can download an invoice and receipt for the donation here:</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "invoice_receipt_info"|v2translate }}</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -211,7 +211,7 @@
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
                                           <a href="{{ receipt_url|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
-                                            <b>Download invoice</b>
+                                            <b>{{ "download_invoice"|v2translate }}</b>
                                           </a>
                                         </td>
                                       </tr>
@@ -240,22 +240,22 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">If you have any questions about your donation, please email us at <a href="mailto:donations@couchers.org" style="color: #00a398;">donations@couchers.org</a>.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "questions_contact"|v2translate }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Your generosity will help deliver the platform for everyone.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "generosity_helps"|v2translate }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>Thank you!</b></div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ "thank_you"|v2translate }}</b></div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Aapeli and Itsi,<br>Couchers.org Founders</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "signature"|v2translate }}</div>
                                 </td>
                               </tr>
                             </tbody>


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
Implements translating emails via a new jinja filter "v2translate" taking a string id and optional substitution arguments. This PR only migrates the body of the donation_received email as a proof of concept and to align on the design.

Design decisions:
1. `{{ "string_id"|v2translate(name=user.name) }}` syntax (for a string identified with `string_id` with one `{{name}}` substitution)
2. All substitutions get html-escaped
3. Strings can include basic html tags like \<a> or \<b> (otherwise we have to break it and concatenate, which is not i18n friendly)
4. html and plaintext emails share strings. In the case of plaintext emails, any html tags are stripped or converted into equivalents.

See #7368

**Please give clear steps for how the reviewer can best test this PR**
- Added a unit test for the `v2translate` jinja filter.
- The modified email was already validated by a test: `uv run -m pytest src/tests/test_email.py`

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A, usual Python testing setup.

**Backend checklist**
- [x] Formatted my code by running `make format` in `app/backend`
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)


<!---
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, remember to merge it if you have write access
--->
