### PR TITLE
Donation drive block should always show on donate page

### DIFF
--- a/app/web/features/donations/DonationDriveBlock.tsx
+++ b/app/web/features/donations/DonationDriveBlock.tsx
@@ -10,6 +10,7 @@ import DonationProgressBar from "./DonationProgressBar";
 export interface DonationDriveBlockProps {
   onClose?: () => void;
   action?: React.ReactNode;
+  alwaysShow?: boolean;
 }
 
 const OuterWrapper = styled("div")(({ theme }) => ({
@@ -42,11 +43,12 @@ const Message = styled("span")(({ theme }) => ({
 export default function DonationDriveBlock({
   onClose,
   action,
+  alwaysShow = false,
 }: DonationDriveBlockProps) {
   const { t } = useTranslation(GLOBAL);
   const { data: accountInfo, isLoading } = useAccountInfo();
 
-  if (isLoading || !accountInfo?.shouldShowDonationBanner) {
+  if (!alwaysShow && (isLoading || !accountInfo?.shouldShowDonationBanner)) {
     return null;
   }
 

--- a/app/web/features/donations/Donations.tsx
+++ b/app/web/features/donations/Donations.tsx
@@ -122,7 +122,7 @@ export default function Donations() {
       </StyledBanner>
       <StyledBody>
         <StyledDonationsBoxSection>
-          <DonationDriveBlock />
+          <DonationDriveBlock alwaysShow />
           <DonationsBox />
           <StyledBenefactorText>
             <Typography variant="body2">


### PR DESCRIPTION
DonationBanner gets hidden once a user donates, but we want the progress bar on the donate page to always show.