### PR TITLE
Remove timeAgo and improve timeAgoI18n testability

### DIFF
--- a/app/web/features/communities/discussions/Comment.tsx
+++ b/app/web/features/communities/discussions/Comment.tsx
@@ -20,7 +20,7 @@ import { useEffect, useRef, useState } from "react";
 import { theme } from "theme";
 import { timestamp2Date } from "utils/date";
 import hasAtLeastOnePage from "utils/hasAtLeastOnePage";
-import { timeAgo } from "utils/timeAgo";
+import { timeAgoI18n } from "utils/timeAgo";
 
 import { useThread } from "../hooks";
 import CommentForm from "./CommentForm";
@@ -126,7 +126,7 @@ export default function Comment({ topLevel = false, comment }: CommentProps) {
   }, [showCommentForm]);
 
   const replyDate = timestamp2Date(comment.createdTime!);
-  const postedTime = timeAgo(replyDate);
+  const postedTime = timeAgoI18n({ input: replyDate, t: t });
 
   return (
     <>

--- a/app/web/features/communities/discussions/DiscussionCard.tsx
+++ b/app/web/features/communities/discussions/DiscussionCard.tsx
@@ -12,7 +12,7 @@ import { useMemo } from "react";
 import { routeToDiscussion } from "routes";
 import { theme } from "theme";
 import { timestamp2Date } from "utils/date";
-import { timeAgo } from "utils/timeAgo";
+import { timeAgoI18n } from "utils/timeAgo";
 
 import getContentSummary from "../getContentSummary";
 
@@ -70,7 +70,7 @@ export default function DiscussionCard({
   const date = discussion.created
     ? timestamp2Date(discussion.created)
     : undefined;
-  const postedTime = date ? timeAgo(date) : null;
+  const postedTime = date ? timeAgoI18n({ input: date, t: t }) : null;
   const truncatedContent = useMemo(
     () =>
       getContentSummary({

--- a/app/web/features/communities/discussions/DiscussionCard.tsx
+++ b/app/web/features/communities/discussions/DiscussionCard.tsx
@@ -5,7 +5,7 @@ import CopyOnClick from "features/mod/CopyOnClick";
 import ModVisibleComponent from "features/mod/ModVisibleComponent";
 import { useLiteUser } from "features/userQueries/useLiteUsers";
 import { useTranslation } from "i18n";
-import { COMMUNITIES } from "i18n/namespaces";
+import { COMMUNITIES, GLOBAL } from "i18n/namespaces";
 import Link from "next/link";
 import { Discussion } from "proto/discussions_pb";
 import { useMemo } from "react";
@@ -64,7 +64,7 @@ export default function DiscussionCard({
   discussion: Discussion.AsObject;
   className?: string;
 }) {
-  const { t } = useTranslation([COMMUNITIES]);
+  const { t } = useTranslation([GLOBAL, COMMUNITIES]);
   const { data: creator } = useLiteUser(discussion.creatorUserId);
 
   const date = discussion.created

--- a/app/web/utils/timeAgo.test.ts
+++ b/app/web/utils/timeAgo.test.ts
@@ -10,7 +10,6 @@ import {
   timeAgoI18n,
   TimeUnit,
   weekMillis,
-  yearMillis,
 } from "./timeAgo";
 
 beforeEach(() => {
@@ -61,7 +60,7 @@ test("timeAgoI18n function, normal case", () => {
   const now = Date.now();
   const before = new Date(now - 8.5 * hourMillis);
   const timeString = timeAgoI18n({ input: before, t: mockT });
-  expect(timeString).toBe("x_hours_ago,8");
+  expect(timeString).toBe("n_hours_ago,8");
 });
 
 test("timeAgoI18n function with fuzzy", () => {

--- a/app/web/utils/timeAgo.test.ts
+++ b/app/web/utils/timeAgo.test.ts
@@ -1,53 +1,80 @@
+import { TFunction, TOptions } from "i18next";
+
 import {
   dayMillis,
+  FriendlyTimeSpan,
   hourMillis,
-  lessThanHour,
   minuteMillis,
   monthMillis,
-  timeAgo,
-  twoDayMillis,
-  twoHourMillis,
-  twoMinuteMillis,
-  twoMonthMillis,
-  twoWeekMillis,
-  twoYearMillis,
+  secondMillis,
+  timeAgoI18n,
+  TimeUnit,
   weekMillis,
   yearMillis,
 } from "./timeAgo";
-
-const timeAgoMap = {
-  [dayMillis]: "1 day ago",
-  [hourMillis]: "1 hour ago",
-  [minuteMillis]: "< 1 minute ago",
-  [monthMillis]: "1 month ago",
-  [twoDayMillis]: "2 days ago",
-  [twoHourMillis]: "2 hours ago",
-  [twoMinuteMillis]: "1 minute ago",
-  [twoMonthMillis]: "2 months ago",
-  [twoWeekMillis]: "2 weeks ago",
-  [twoYearMillis]: "2 years ago",
-  [weekMillis]: "1 week ago",
-  [yearMillis]: "1 year ago",
-};
 
 beforeEach(() => {
   jest.spyOn(Date, "now").mockReturnValue(1614556800000);
 });
 
-test("timeAgo function", () => {
-  Object.keys(timeAgoMap).forEach((key: string) => {
-    const now = Date.now();
-    const millis = parseInt(key);
-    const expectedValue = timeAgoMap[millis];
-    const date = new Date(now - millis);
-    const timeString = timeAgo(date);
-    expect(timeString).toBe(expectedValue);
-  });
+test("FriendlyTimeSpan.fromMillis", () => {
+  expect(FriendlyTimeSpan.fromMillis(5 * secondMillis)).toEqual(
+    new FriendlyTimeSpan(5, TimeUnit.Seconds),
+  );
+  expect(FriendlyTimeSpan.fromMillis(125 * secondMillis)).toEqual(
+    new FriendlyTimeSpan(2, TimeUnit.Minutes),
+  );
+  expect(FriendlyTimeSpan.fromMillis(125 * minuteMillis)).toEqual(
+    new FriendlyTimeSpan(2, TimeUnit.Hours),
+  );
+  expect(FriendlyTimeSpan.fromMillis(48 * hourMillis)).toEqual(
+    new FriendlyTimeSpan(2, TimeUnit.Days),
+  );
+  expect(FriendlyTimeSpan.fromMillis(8 * dayMillis)).toEqual(
+    new FriendlyTimeSpan(1, TimeUnit.Weeks),
+  );
+  expect(FriendlyTimeSpan.fromMillis(6 * weekMillis)).toEqual(
+    new FriendlyTimeSpan(1, TimeUnit.Months),
+  );
+  expect(FriendlyTimeSpan.fromMillis(30 * monthMillis)).toEqual(
+    new FriendlyTimeSpan(2, TimeUnit.Years),
+  );
 });
 
-test("timeAgo function with fuzzy", () => {
+/// Mock translation function, returns "key,count"
+const mockT = ((key: string, options?: TOptions): string => {
+  key = key.replace("relative_time.", "");
+  if (options && options.count) {
+    return `${key},${options.count}`;
+  }
+  return key;
+}) as TFunction;
+
+test("timeAgoI18n function, less than a minute", () => {
   const now = Date.now();
-  const date = new Date(now - twoMinuteMillis);
-  const timeString = timeAgo(date, { millis: hourMillis, text: lessThanHour });
+  const before = new Date(now - 10.5 * secondMillis);
+  const timeString = timeAgoI18n({ input: before, t: mockT });
+  expect(timeString).toBe("less_than_a_minute_ago");
+});
+
+test("timeAgoI18n function, normal case", () => {
+  const now = Date.now();
+  const before = new Date(now - 8.5 * hourMillis);
+  const timeString = timeAgoI18n({ input: before, t: mockT });
+  expect(timeString).toBe("x_hours_ago,8");
+});
+
+test("timeAgoI18n function with fuzzy", () => {
+  const now = Date.now();
+  const date = new Date(now - 2 * minuteMillis);
+  const lessThanHour = "less_than_hour";
+  const timeString = timeAgoI18n({
+    input: date,
+    t: mockT,
+    fuzzy: {
+      millis: hourMillis,
+      translationKey: lessThanHour,
+    },
+  });
   expect(timeString).toBe(lessThanHour);
 });

--- a/app/web/utils/timeAgo.ts
+++ b/app/web/utils/timeAgo.ts
@@ -1,66 +1,96 @@
 import { TFunction } from "i18next";
 
-export const minuteMillis = 60000;
-export const twoMinuteMillis = 120000;
-export const hourMillis = 3600000;
-export const twoHourMillis = 7200000;
-export const dayMillis = 86400000;
-export const twoDayMillis = 172800000;
-export const weekMillis = 604800000;
-export const twoWeekMillis = 1209600000;
-export const monthMillis = weekMillis * 4;
-export const twoMonthMillis = weekMillis * 8;
-export const yearMillis = 31557600000;
-export const twoYearMillis = 31557600000 * 2;
-
-export const lessThanHour = "Less than an hour ago";
-
-interface FuzzySpec {
-  millis: number;
-  text: string;
-}
-
-/**
- * @deprecated Use `timeAgoI18n` instead.
- */
-export function timeAgo(input: Date | string, fuzzy?: FuzzySpec) {
-  if (input === undefined) return "";
-  const date = new Date(input);
-  const diffMillis = Date.now() - date.getTime();
-
-  if (fuzzy && diffMillis < fuzzy.millis) {
-    // if fuzzyMillis and fuzzyText are both set, then for times less than fuzzyMillis, we return fuzzyText
-    return fuzzy.text;
-  }
-
-  if (diffMillis <= minuteMillis) return "< 1 minute ago";
-  if (diffMillis <= twoMinuteMillis) return "1 minute ago";
-  if (diffMillis < hourMillis)
-    return "" + (diffMillis / minuteMillis).toFixed() + " minutes ago";
-
-  if (diffMillis < twoHourMillis) return "1 hour ago";
-  if (diffMillis < dayMillis)
-    return "" + (diffMillis / hourMillis).toFixed() + " hours ago";
-
-  if (diffMillis < twoDayMillis) return "1 day ago";
-  if (diffMillis < weekMillis)
-    return "" + (diffMillis / dayMillis).toFixed() + " days ago";
-
-  if (diffMillis < twoWeekMillis) return "1 week ago";
-  if (diffMillis < monthMillis)
-    return "" + (diffMillis / weekMillis).toFixed() + " weeks ago";
-
-  if (diffMillis < twoMonthMillis) return "1 month ago";
-  if (diffMillis < yearMillis)
-    return "" + (diffMillis / monthMillis).toFixed() + " months ago";
-
-  if (diffMillis < twoYearMillis) return "1 year ago";
-  return "" + (diffMillis / yearMillis).toFixed() + " years ago";
-}
+export const secondMillis = 1000;
+export const minuteMillis = 60 * secondMillis;
+export const hourMillis = 60 * minuteMillis;
+export const dayMillis = 24 * hourMillis;
+export const weekMillis = 7 * dayMillis;
+export const monthMillis = 30 * dayMillis;
+export const yearMillis = 365 * dayMillis + 6 * hourMillis; // 365.25;
 
 interface FuzzySpecT {
   millis: number;
   translationKey: Parameters<TFunction<"global", undefined>>[0];
+}
+
+export enum TimeUnit {
+  Seconds,
+  Minutes,
+  Hours,
+  Days,
+  Weeks,
+  Months,
+  Years,
+}
+
+/// A time span represented in human-friendly units, e.g. "5 days".
+export class FriendlyTimeSpan {
+  constructor(
+    public value: number,
+    public unit: TimeUnit,
+  ) {}
+
+  static fromMillis(value: number): FriendlyTimeSpan {
+    if (value < minuteMillis) {
+      return new FriendlyTimeSpan(Math.floor(value / 1000), TimeUnit.Seconds);
+    }
+    if (value < hourMillis) {
+      return new FriendlyTimeSpan(
+        Math.floor(value / minuteMillis),
+        TimeUnit.Minutes,
+      );
+    }
+    if (value < dayMillis) {
+      return new FriendlyTimeSpan(
+        Math.floor(value / hourMillis),
+        TimeUnit.Hours,
+      );
+    }
+    if (value < weekMillis) {
+      return new FriendlyTimeSpan(Math.floor(value / dayMillis), TimeUnit.Days);
+    }
+    if (value < monthMillis) {
+      return new FriendlyTimeSpan(
+        Math.floor(value / weekMillis),
+        TimeUnit.Weeks,
+      );
+    }
+    if (value < yearMillis) {
+      return new FriendlyTimeSpan(
+        Math.floor(value / monthMillis),
+        TimeUnit.Months,
+      );
+    }
+    return new FriendlyTimeSpan(Math.floor(value / yearMillis), TimeUnit.Years);
+  }
+
+  static between(start: Date, end: Date): FriendlyTimeSpan {
+    const diffMillis = end.getTime() - start.getTime();
+    return FriendlyTimeSpan.fromMillis(diffMillis);
+  }
+
+  static since(date: Date): FriendlyTimeSpan {
+    return this.between(date, new Date());
+  }
+
+  toLocalizedAgoText(t: TFunction<"global", undefined>): string {
+    switch (this.unit) {
+      case TimeUnit.Seconds:
+        return t("relative_time.less_than_a_minute_ago");
+      case TimeUnit.Minutes:
+        return t("relative_time.n_minutes_ago", { count: this.value });
+      case TimeUnit.Hours:
+        return t("relative_time.n_hours_ago", { count: this.value });
+      case TimeUnit.Days:
+        return t("relative_time.n_days_ago", { count: this.value });
+      case TimeUnit.Weeks:
+        return t("relative_time.n_weeks_ago", { count: this.value });
+      case TimeUnit.Months:
+        return t("relative_time.n_months_ago", { count: this.value });
+      case TimeUnit.Years:
+        return t("relative_time.n_years_ago", { count: this.value });
+    }
+  }
 }
 
 export function timeAgoI18n({
@@ -81,34 +111,5 @@ export function timeAgoI18n({
     return t(fuzzy.translationKey) as string;
   }
 
-  if (diffMillis < minuteMillis)
-    return t("relative_time.less_than_a_minute_ago");
-  if (diffMillis < hourMillis)
-    return t("relative_time.n_minutes_ago", {
-      count: Math.floor(diffMillis / minuteMillis),
-    });
-
-  if (diffMillis < dayMillis)
-    return t("relative_time.n_hours_ago", {
-      count: Math.floor(diffMillis / hourMillis),
-    });
-
-  if (diffMillis < weekMillis)
-    return t("relative_time.n_days_ago", {
-      count: Math.floor(diffMillis / dayMillis),
-    });
-
-  if (diffMillis < monthMillis)
-    return t("relative_time.n_weeks_ago", {
-      count: Math.floor(diffMillis / weekMillis),
-    });
-
-  if (diffMillis < yearMillis)
-    return t("relative_time.n_months_ago", {
-      count: Math.floor(diffMillis / monthMillis),
-    });
-
-  return t("relative_time.n_years_ago", {
-    count: Math.floor(diffMillis / yearMillis),
-  });
+  return FriendlyTimeSpan.fromMillis(diffMillis).toLocalizedAgoText(t);
 }


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
- Migrate last usages of the non-localized timeAgo function so that code can be deleted.
- Extract FriendlyTimeSpan from timeAgo logic to make the logic testable in isolation from the string localization. It would also allow for implementing "in x minutes" without code duplication.

**Please give clear steps for how the reviewer can best test this PR**
Run yarn test.

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A

**Web frontend checklist**
- [x] Formatted my code with `yarn format`
- [x] There are no warnings from `yarn lint --fix`
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [ ] All tests pass
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)