### PR TITLE
Update mobile and frontend job ads

### DIFF
--- a/app/web/markdown/volunteer.md
+++ b/app/web/markdown/volunteer.md
@@ -55,8 +55,8 @@ Want to help but don't see anything listed for you? [Fill out this form](/volunt
 #### Development
 
 - [Senior Backend Developer (Python)](./volunteer/senior-backend-developer)
-- [Frontend (web) Developer (React/Typescript)](./volunteer/frontend-developer)
-- [Mobile Development Lead](./volunteer/mobile-development-lead)
+- [Mid-level or Senior Frontend (Web) Developer (React/Typescript)](./volunteer/mid-senior-frontend-developer)
+- [Mobile Developer (React Native/Expo)](./volunteer/mobile-developer)
 
 #### Operations
 

--- a/app/web/markdown/volunteer/mid-senior-frontend-developer.md
+++ b/app/web/markdown/volunteer/mid-senior-frontend-developer.md
@@ -1,0 +1,61 @@
+---
+title: "Mid-level or Senior Frontend Developer"
+description: "Apply to become a Mid-level or Senior Frontend (web) Developer for Couchers.org"
+---
+
+## [Apply Here](/volunteer/form)
+
+## Position Description
+
+**This is a remote volunteer position**
+
+For this role we are specifically seeking experienced mid-level and up frontend (or fullstack) engineers who are able to help review PRs and support junior engineers on the frontend team, in addition to doing feature work.
+
+We currently have a lot of features that have been implemented on the backend, but could use more support getting them done on the frontend!
+
+The Couchers.org codebase is open source under the MIT license and we accept occasional contributions via the [Open Source Developer process](/volunteer/open-source-developer), however, we are looking for some dedicated volunteers who can join the formal web team and make a commitment of roughly 5+ hours per week (you choose when!).
+
+We pride ourselves on good documentation, a fun volunteer experience, ease of contribution, and ability for contributors to make large impacts. You will be working alongside experienced professionals who are motivated to develop their skills, meet other professionals, and develop this critical platform for the couch surfing community. And most of all, have fun and do something we love together!
+
+### Duties
+
+- Developing and expanding features;
+- Helping review frontend PRs
+- Making UI improvements;
+- Addressing bugs reported by our QA team;
+- Helping address tech debt (we're mostly up to date)
+- Debugging, documentation, and testing;
+- Working with the the backend and UX teams to design and implement features;
+
+### Requirements
+
+- Experience with writing tested, production-grade React and TypeScript (you've had at least one job doing frontend formally before);
+- Experience with Git and GitHub;
+
+### Our Stack
+
+- React/Typescript frontend
+- Next.js for server-side rendering and routing
+- Tanstack Query for state management and data fetching
+- GRPC for the API layer
+- Jest and React Testing Library for testing
+
+### Preferred
+
+- Experience with Material UI;
+- (Bonus but not required) Experience with Python for occasional backend implementation;
+
+
+### Expectations/Commitment
+
+- Roughly 5 hours per Week (we won't time you but enough time to get features done in a reasonable time period so they don't get blocked)
+- Plan to stay around at least 6 months
+- Willing to pop into one of our Tuesday dev meetings sometimes to keep on top of what the priorities are
+
+### Apply
+
+1. [Fill out this form](/volunteer/form). Under "Position Applying For", put "Mid-level/Senior Frontend Developer".
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team. Sometimes there might be a bit of a delay as none of us work on the project full-time, someone might be traveling, etc.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.

--- a/app/web/markdown/volunteer/mobile-developer.md
+++ b/app/web/markdown/volunteer/mobile-developer.md
@@ -1,0 +1,49 @@
+---
+title: "Mobile Developer (React Native/Expo)"
+description: "Apply to become a Mobile Developer for Couchers.org"
+---
+
+## [Apply Here](/volunteer/form)
+
+## Position Description
+
+**This is a remote volunteer position**
+
+We are seeking an experienced Mobile Developer for the Couchers.org Mobile Project. We currently have a mobile app about ready to release using React Native with Expo with a WebEmbed around the web app. We'd love to iterate on this as we go to provide a better offline experience for users, and get input from a more mobile-focused developer to improve on our bootstrapped version.
+
+It is important that the mobile developer have some experience for this role, as none of us have formal mobile experience 😅, thus we are unable to provide much mentorship.
+
+The Couchers.org codebase is open source under the MIT license and we accept occasional contributions via the [Open Source Developer process](/volunteer/open-source-developer), however we are looking for a dedicated volunteer who can take a major role in the organization and take on 10+ hours per week.
+
+We pride ourselves on good documentation, a fun volunteer experience, ease of contribution, and ability for contributors to make large impacts. You will be working alongside experienced professionals who are motivated to develop their skills, meet other professionals, and develop this critical platform for the couch surfing community. And most of all, have fun and do something we love together!
+
+### Duties
+
+- Providing strategic vision for mobile development including technical design;
+- Work with our backend, web, and UX teams as part of our software lifecycle;
+- Assist in maintaining our documentation;
+
+### Requirements
+
+- Experience in building mobile projects using React Natve;
+- Experience with cross-platform frameworks (React Native and Expo);
+- Ability to work iteratively and release improvements in manageable chunks;
+- Experience with Git and GitHub;
+
+### Nice to have
+
+- Experience with the rest of our stack — Python/Django for backend, TypeScript/React for web frontend.
+- Assist in our recruitment process for the onboarding of mobile developers;
+
+### Expectations/Commitment
+
+- Roughly 5 hours per Week (we won't time you but enough time to get features done in a reasonable time period so they don't get blocked)
+- 6 months commitment
+
+### Apply
+
+1. [Fill out this form](/volunteer/form). Under "Position Applying For", put "Mobile Developer".
+
+2. We'll review and get back to you as soon as possible — setting up a Zoom call so we can get to know you and you can meet the team.
+
+3. After accepting the position, we'll send you some volunteer agreements and then get you onboarded with the people you're going to directly work with.


### PR DESCRIPTION
Made a new frontend dev job add to be more mid-level/senior-focused, as we really need one more person before we can mentor more juniors.

Created a less senior mobile developer ad. We only had a leader one, this seems more accurate to where we're at now and maybe less intimidating.