### PR TITLE
fix: use NEXT_LOCALE cookie for unauthenticated requests

### DIFF
--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -331,7 +331,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                 user_id=auth_info.user_id if auth_info else None,
                 is_api_key=is_api_key,
                 token=token,
-                ui_language_preference=auth_info.ui_language_preference if auth_info else None,
+                ui_language_preference=auth_info.ui_language_preference if auth_info else parse_ui_lang_cookie(headers),
             )
             with session_scope() as session:
                 try:


### PR DESCRIPTION
When users are not authenticated, fall back to the NEXT_LOCALE cookie to determine the UI language preference. This ensures that Community Guidelines and other localized content is served in the user's selected language during signup, before they are authenticated.

Fixes #6860

Generated with [Claude Code](https://claude.ai/code)