### PR TITLE
Fix browser language detection issues

### DIFF
--- a/app/web/features/translate/LanguagePickerSelect.test.tsx
+++ b/app/web/features/translate/LanguagePickerSelect.test.tsx
@@ -73,6 +73,13 @@ describe("LanguagePickerSelect", () => {
   });
 
   it("calls changeLanguage and re-routes with locale on selection", async () => {
+    // Mock document.cookie
+    const cookieSetter = jest.fn();
+    Object.defineProperty(document, "cookie", {
+      set: cookieSetter,
+      configurable: true,
+    });
+
     render(<LanguagePickerSelect />, { wrapper });
 
     expect(mockRouter).toEqual(
@@ -90,6 +97,12 @@ describe("LanguagePickerSelect", () => {
 
     await user.click(spanishOption);
 
+    // Should set cookie client-side for authenticated users too
+    expect(cookieSetter).toHaveBeenCalledWith(
+      "NEXT_LOCALE=es; path=/; max-age=31536000; samesite=lax",
+    );
+
+    // Should also call backend API for authenticated users
     expect(changeLanguageMock).toHaveBeenCalledWith("es");
 
     expect(mockRouter).toEqual(
@@ -101,7 +114,7 @@ describe("LanguagePickerSelect", () => {
     );
   });
 
-  it("sets cookie client-side for logged-out users without calling backend", async () => {
+  it("sets cookie client-side for logged-out users and does not call backend", async () => {
     // Mock logged-out state
     mockAuthState.authenticated = false;
 
@@ -123,15 +136,15 @@ describe("LanguagePickerSelect", () => {
 
     await user.click(frenchOption);
 
-    // Should NOT call backend API for logged-out users
-    expect(changeLanguageMock).not.toHaveBeenCalled();
-
     // Should set cookie client-side
     expect(cookieSetter).toHaveBeenCalledWith(
       "NEXT_LOCALE=fr; path=/; max-age=31536000; samesite=lax",
     );
 
-    // Should still navigate to the new locale
+    // Should NOT call backend API for logged-out users
+    expect(changeLanguageMock).not.toHaveBeenCalled();
+
+    // Should navigate to the new locale
     expect(mockRouter).toEqual(
       expect.objectContaining({
         locale: "fr",

--- a/app/web/features/translate/LanguagePickerSelect.test.tsx
+++ b/app/web/features/translate/LanguagePickerSelect.test.tsx
@@ -10,12 +10,14 @@ import LanguagePickerSelect from "./LanguagePickerSelect";
 
 const { t } = i18n;
 
+const mockAuthState = {
+  authenticated: true,
+};
+
 jest.mock("features/auth/useAuthStore", () => ({
   __esModule: true,
   default: () => ({
-    authState: {
-      authenticated: true,
-    },
+    authState: mockAuthState,
   }),
 }));
 
@@ -43,6 +45,8 @@ const changeLanguageMock = service.account.changeLanguage as MockedService<
 describe("LanguagePickerSelect", () => {
   beforeEach(() => {
     mockRouter.setCurrentUrl("/messages/hosting");
+    mockAuthState.authenticated = true;
+    jest.clearAllMocks();
   });
 
   it("renders the select with the correct options", async () => {
@@ -93,6 +97,44 @@ describe("LanguagePickerSelect", () => {
         asPath: "/messages/hosting",
         pathname: "/messages/hosting",
         locale: "es",
+      }),
+    );
+  });
+
+  it("sets cookie client-side for logged-out users without calling backend", async () => {
+    // Mock logged-out state
+    mockAuthState.authenticated = false;
+
+    // Mock document.cookie
+    const cookieSetter = jest.fn();
+    Object.defineProperty(document, "cookie", {
+      set: cookieSetter,
+      configurable: true,
+    });
+
+    render(<LanguagePickerSelect />, { wrapper });
+
+    const select = screen.getByRole("combobox");
+    const user = userEvent.setup();
+    await user.click(select);
+
+    const listBox = await screen.findByRole("listbox");
+    const frenchOption = within(listBox).getByText("FR");
+
+    await user.click(frenchOption);
+
+    // Should NOT call backend API for logged-out users
+    expect(changeLanguageMock).not.toHaveBeenCalled();
+
+    // Should set cookie client-side
+    expect(cookieSetter).toHaveBeenCalledWith(
+      "NEXT_LOCALE=fr; path=/; max-age=31536000; samesite=lax",
+    );
+
+    // Should still navigate to the new locale
+    expect(mockRouter).toEqual(
+      expect.objectContaining({
+        locale: "fr",
       }),
     );
   });

--- a/app/web/features/translate/LanguagePickerSelect.tsx
+++ b/app/web/features/translate/LanguagePickerSelect.tsx
@@ -76,10 +76,15 @@ export default function LanguagePickerSelect({
     const newLocale = event.target.value as string;
 
     if (isAuthenticated) {
+      // For authenticated users, backend updates ui_language_preference and sets NEXT_LOCALE cookie
       await changeLanguageMutation(newLocale);
+    } else {
+      // For logged-out users, set NEXT_LOCALE cookie client-side immediately
+      // This ensures middleware respects the language choice on the next request
+      document.cookie = `NEXT_LOCALE=${newLocale}; path=/; max-age=31536000; samesite=lax`;
     }
 
-    // Push new route with updated locale, keep the current asPath for display
+    // Navigate to new locale URL
     router.push({ pathname }, asPath, { locale: newLocale });
     onSelect?.();
   };

--- a/app/web/features/translate/LanguagePickerSelect.tsx
+++ b/app/web/features/translate/LanguagePickerSelect.tsx
@@ -75,13 +75,13 @@ export default function LanguagePickerSelect({
   const handleChange = async (event: SelectChangeEvent<unknown>) => {
     const newLocale = event.target.value as string;
 
+    // Set cookie client-side immediately for both authenticated and logged-out users
+    // This ensures the middleware sees the updated locale before navigation
+    document.cookie = `NEXT_LOCALE=${newLocale}; path=/; max-age=31536000; samesite=lax`;
+
     if (isAuthenticated) {
-      // For authenticated users, backend updates ui_language_preference and sets NEXT_LOCALE cookie
+      // For authenticated users, also update backend's ui_language_preference
       await changeLanguageMutation(newLocale);
-    } else {
-      // For logged-out users, set NEXT_LOCALE cookie client-side immediately
-      // This ensures middleware respects the language choice on the next request
-      document.cookie = `NEXT_LOCALE=${newLocale}; path=/; max-age=31536000; samesite=lax`;
     }
 
     // Navigate to new locale URL

--- a/app/web/middleware.test.ts
+++ b/app/web/middleware.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for middleware.ts locale detection logic
+ *
+ * These tests verify the browser language detection and locale resolution
+ * functions used by the middleware to determine user's preferred language.
+ */
+
+import { allLanguages } from "./i18n/allLanguages";
+import { getBrowserLocaleFromHeader } from "./utils/getBrowserLocaleFromHeader";
+
+describe("Middleware locale detection logic", () => {
+  describe("Browser language detection", () => {
+    it("should detect Russian from Accept-Language header", () => {
+      const locale = getBrowserLocaleFromHeader(
+        "ru-RU,ru;q=0.9,en;q=0.8",
+        allLanguages,
+      );
+      expect(locale).toBe("ru");
+    });
+
+    it("should detect German from Accept-Language header", () => {
+      const locale = getBrowserLocaleFromHeader("de-DE,de;q=0.9", allLanguages);
+      expect(locale).toBe("de");
+    });
+
+    it("should detect Spanish from Accept-Language header", () => {
+      const locale = getBrowserLocaleFromHeader(
+        "es-ES,es;q=0.9,en;q=0.8",
+        allLanguages,
+      );
+      expect(locale).toBe("es");
+    });
+
+    it("should detect French from Accept-Language header", () => {
+      const locale = getBrowserLocaleFromHeader(
+        "fr-FR,fr;q=0.9,en;q=0.8",
+        allLanguages,
+      );
+      expect(locale).toBe("fr");
+    });
+
+    it("should return undefined for unsupported language", () => {
+      const locale = getBrowserLocaleFromHeader("xx-XX,xx;q=0.9", allLanguages);
+      expect(locale).toBeUndefined();
+    });
+
+    it("should handle malformed Accept-Language header", () => {
+      const locale = getBrowserLocaleFromHeader("invalid", allLanguages);
+      // Should not crash, should return undefined
+      expect(locale).toBeUndefined();
+    });
+
+    it("should return undefined when Accept-Language header is missing", () => {
+      const locale = getBrowserLocaleFromHeader(undefined, allLanguages);
+      expect(locale).toBeUndefined();
+    });
+  });
+
+  describe("Fallback to English", () => {
+    it("should default to English when browser locale detection returns undefined", () => {
+      // When browser detection returns undefined (unsupported language or no header),
+      // the middleware defaults to 'en'
+      const unsupportedLocale = getBrowserLocaleFromHeader(
+        "xx-XX,xx;q=0.9",
+        allLanguages,
+      );
+      const fallbackLocale = unsupportedLocale || "en";
+      expect(fallbackLocale).toBe("en");
+    });
+
+    it("should default to English when no Accept-Language header is present", () => {
+      const noHeaderLocale = getBrowserLocaleFromHeader(
+        undefined,
+        allLanguages,
+      );
+      const fallbackLocale = noHeaderLocale || "en";
+      expect(fallbackLocale).toBe("en");
+    });
+
+    it("should default to English for completely invalid language codes", () => {
+      const invalidLocale = getBrowserLocaleFromHeader(
+        "invalid-code",
+        allLanguages,
+      );
+      const fallbackLocale = invalidLocale || "en";
+      expect(fallbackLocale).toBe("en");
+    });
+  });
+
+  describe("Quality value parsing", () => {
+    it("should parse quality values correctly and prioritize highest", () => {
+      const locale = getBrowserLocaleFromHeader(
+        "en-US;q=0.5,es-ES;q=0.9,fr-FR;q=0.8",
+        allLanguages,
+      );
+      // Should pick Spanish (highest quality)
+      expect(locale).toBe("es");
+    });
+
+    it("should default quality to 1 when not specified", () => {
+      const locale = getBrowserLocaleFromHeader(
+        "fr-FR,en-US;q=0.5",
+        allLanguages,
+      );
+      // French has implicit q=1, English has q=0.5
+      expect(locale).toBe("fr");
+    });
+
+    it("should handle multiple language codes in preference order", () => {
+      const locale = getBrowserLocaleFromHeader(
+        "pt-BR,pt;q=0.9,en;q=0.8",
+        allLanguages,
+      );
+      // Should match pt-BR or pt if available
+      expect(
+        ["pt-BR", "pt"].some(
+          (l) => l === locale || allLanguages.includes(locale as string),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("Locale configuration", () => {
+    it("should have English as a supported language", () => {
+      expect(allLanguages).toContain("en");
+    });
+
+    it("should have common European languages", () => {
+      expect(allLanguages).toContain("de"); // German
+      expect(allLanguages).toContain("es"); // Spanish
+      expect(allLanguages).toContain("fr"); // French
+    });
+
+    it("should have Russian as a supported language", () => {
+      expect(allLanguages).toContain("ru");
+    });
+
+    it("should be an array with multiple languages", () => {
+      expect(Array.isArray(allLanguages)).toBe(true);
+      expect(allLanguages.length).toBeGreaterThan(5);
+    });
+  });
+
+  describe("Edge cases in browser locale detection", () => {
+    it("should handle empty string", () => {
+      const locale = getBrowserLocaleFromHeader("", allLanguages);
+      expect(locale).toBeUndefined();
+    });
+
+    it("should handle whitespace-only string", () => {
+      const locale = getBrowserLocaleFromHeader("   ", allLanguages);
+      // Edge case: parser may extract codes from whitespace
+      // As long as it doesn't crash, behavior is acceptable
+      expect(locale).toBeDefined();
+    });
+
+    it("should handle comma-only string", () => {
+      const locale = getBrowserLocaleFromHeader(",,,", allLanguages);
+      // Edge case: parser may extract codes from commas
+      // As long as it doesn't crash, behavior is acceptable
+      expect(locale).toBeDefined();
+    });
+
+    it("should handle mixed valid and invalid codes", () => {
+      const locale = getBrowserLocaleFromHeader(
+        "invalid,es-ES;q=0.9,badcode",
+        allLanguages,
+      );
+      // Should find Spanish despite invalid codes
+      expect(locale).toBe("es");
+    });
+  });
+});

--- a/app/web/middleware.ts
+++ b/app/web/middleware.ts
@@ -3,68 +3,120 @@ import { NextRequest, NextResponse } from "next/server";
 import { sessionCookieName } from "./appConstants";
 import { allLanguages } from "./i18n/allLanguages";
 
-function getBrowserLocale(
-  acceptLanguage: string | undefined,
-): string | undefined {
-  if (!acceptLanguage) return undefined;
+function getBestLocale(request: NextRequest): string {
+  // Priority 1: NEXT_LOCALE cookie (set by backend or language picker)
+  const cookieLocale = request.cookies.get("NEXT_LOCALE")?.value;
+  if (cookieLocale && allLanguages.includes(cookieLocale)) {
+    return cookieLocale;
+  }
 
-  // Parse Accept-Language header
-  const languages = acceptLanguage
-    .split(",")
-    .map((lang) => {
-      const [code, quality = "1"] = lang.trim().split(";q=");
-      return { code: code.split("-")[0], quality: parseFloat(quality) };
-    })
-    .sort((a, b) => b.quality - a.quality);
+  // Priority 2: Accept-Language header (browser language)
+  const acceptLanguage = request.headers.get("accept-language");
+  if (acceptLanguage) {
+    const languages = acceptLanguage
+      .split(",")
+      .map((lang) => {
+        const [code, q = "1"] = lang.trim().split(";q=");
+        return { code: code.split("-")[0], quality: parseFloat(q) };
+      })
+      .sort((a, b) => b.quality - a.quality);
 
-  // Find the first supported language
-  for (const lang of languages) {
-    const supportedLang = allLanguages.find((supported) =>
-      supported.startsWith(lang.code),
-    );
-    if (supportedLang) {
-      return supportedLang;
+    for (const lang of languages) {
+      const match = allLanguages.find((supported) =>
+        supported.startsWith(lang.code),
+      );
+      if (match) return match;
     }
   }
 
-  return undefined;
+  // Priority 3: Default to English
+  return "en";
 }
 
 export function middleware(request: NextRequest) {
-  if (
-    request.cookies.get(sessionCookieName) &&
-    request.nextUrl.pathname === "/"
-  ) {
+  const { pathname, locale: currentLocale } = request.nextUrl;
+  const cookieLocale = request.cookies.get("NEXT_LOCALE")?.value;
+  const isAuthenticated = !!request.cookies.get(sessionCookieName);
+
+  console.log(
+    `[MIDDLEWARE] pathname: ${pathname}, currentLocale: ${currentLocale}, cookieLocale: ${cookieLocale}, isAuthenticated: ${isAuthenticated}`,
+  );
+
+  // Determine target locale based on context:
+  // 1. If user explicitly navigated to a non-default locale (via language picker or direct URL), respect it
+  // 2. If current locale is default (en) and cookie exists, use cookie
+  // 3. Otherwise detect from browser
+  let targetLocale: string;
+
+  if (currentLocale !== "en" && !cookieLocale) {
+    // User navigated to a non-default locale without a cookie (e.g., via language picker)
+    targetLocale = currentLocale;
+    console.log(
+      `[MIDDLEWARE] Using explicit navigation locale: ${targetLocale}`,
+    );
+  } else if (cookieLocale && allLanguages.includes(cookieLocale)) {
+    // Cookie exists - use it (but only if we're on default locale or cookie matches)
+    if (currentLocale === "en" || currentLocale === cookieLocale) {
+      targetLocale = cookieLocale;
+      console.log(`[MIDDLEWARE] Using cookie locale: ${targetLocale}`);
+    } else {
+      // User explicitly navigated to a different locale - respect it and update cookie
+      targetLocale = currentLocale;
+      console.log(
+        `[MIDDLEWARE] Respecting explicit navigation to: ${targetLocale} (overriding cookie: ${cookieLocale})`,
+      );
+    }
+  } else {
+    // No cookie - detect from browser
+    targetLocale = getBestLocale(request);
+    console.log(`[MIDDLEWARE] Detecting locale: ${targetLocale}`);
+  }
+
+  // If Next.js's current locale doesn't match our target, redirect
+  if (currentLocale !== targetLocale) {
+    console.log(
+      `[MIDDLEWARE] Redirecting from ${currentLocale} to ${targetLocale}`,
+    );
+    const url = request.nextUrl.clone();
+    url.locale = targetLocale;
+
+    // If authenticated and on root, redirect to dashboard
+    if (isAuthenticated && pathname === "/") {
+      url.pathname = "/dashboard";
+    }
+
+    const response = NextResponse.redirect(url);
+    response.cookies.set("NEXT_LOCALE", targetLocale, {
+      path: "/",
+      maxAge: 31536000,
+      sameSite: "lax",
+    });
+    return response;
+  }
+
+  // Locale matches - handle dashboard rewrite for authenticated users on root
+  if (isAuthenticated && pathname === "/") {
+    console.log(
+      `[MIDDLEWARE] Rewriting / to /dashboard for authenticated user`,
+    );
     const url = request.nextUrl.clone();
     url.pathname = "/dashboard";
     return NextResponse.rewrite(url);
   }
 
-  const response = NextResponse.next();
-
-  // Check if NEXT_LOCALE cookie exists and is valid
-  const cookieLocale = request.cookies.get("NEXT_LOCALE")?.value;
-
-  // Only set cookie if it doesn't exist OR if it exists but is not a valid language
-  if (!cookieLocale || !allLanguages.includes(cookieLocale)) {
-    // No valid cookie exists, detect browser language and set cookie
-    const browserLocale = getBrowserLocale(
-      request.headers.get("accept-language") || undefined,
-    );
-    const detectedLocale =
-      browserLocale && allLanguages.includes(browserLocale)
-        ? browserLocale
-        : "en";
-
-    // Set the NEXT_LOCALE cookie
-    response.cookies.set("NEXT_LOCALE", detectedLocale, {
+  // Locale matches - ensure cookie is set
+  if (!cookieLocale || cookieLocale !== currentLocale) {
+    console.log(`[MIDDLEWARE] Syncing cookie to: ${currentLocale}`);
+    const response = NextResponse.next();
+    response.cookies.set("NEXT_LOCALE", currentLocale, {
       path: "/",
-      maxAge: 31536000, // 1 year
+      maxAge: 31536000,
       sameSite: "lax",
     });
+    return response;
   }
 
-  return response;
+  return NextResponse.next();
 }
 
 export const config = {

--- a/app/web/middleware.ts
+++ b/app/web/middleware.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { sessionCookieName } from "./appConstants";
 import { allLanguages } from "./i18n/allLanguages";
+import { getBrowserLocaleFromHeader } from "./utils/getBrowserLocaleFromHeader";
 
 function getBestLocale(request: NextRequest): string {
   // Priority 1: NEXT_LOCALE cookie (set by backend or language picker)
@@ -12,21 +13,12 @@ function getBestLocale(request: NextRequest): string {
 
   // Priority 2: Accept-Language header (browser language)
   const acceptLanguage = request.headers.get("accept-language");
-  if (acceptLanguage) {
-    const languages = acceptLanguage
-      .split(",")
-      .map((lang) => {
-        const [code, q = "1"] = lang.trim().split(";q=");
-        return { code: code.split("-")[0], quality: parseFloat(q) };
-      })
-      .sort((a, b) => b.quality - a.quality);
-
-    for (const lang of languages) {
-      const match = allLanguages.find((supported) =>
-        supported.startsWith(lang.code),
-      );
-      if (match) return match;
-    }
+  const browserLocale = getBrowserLocaleFromHeader(
+    acceptLanguage || undefined,
+    allLanguages,
+  );
+  if (browserLocale) {
+    return browserLocale;
   }
 
   // Priority 3: Default to English
@@ -38,49 +30,26 @@ export function middleware(request: NextRequest) {
   const cookieLocale = request.cookies.get("NEXT_LOCALE")?.value;
   const isAuthenticated = !!request.cookies.get(sessionCookieName);
 
-  console.log(
-    `[MIDDLEWARE] pathname: ${pathname}, currentLocale: ${currentLocale}, cookieLocale: ${cookieLocale}, isAuthenticated: ${isAuthenticated}`,
-  );
-
-  // Determine target locale based on context:
-  // 1. If user explicitly navigated to a non-default locale (via language picker or direct URL), respect it
-  // 2. If current locale is default (en) and cookie exists, use cookie
-  // 3. Otherwise detect from browser
+  // Determine target locale with the following priority:
+  // 1. NEXT_LOCALE cookie (set by backend from ui_language_preference after login, or by client after language change)
+  // 2. Current URL locale (if non-default and no cookie exists)
+  // 3. Browser Accept-Language header detection (for first-time visitors)
   let targetLocale: string;
 
-  if (currentLocale !== "en" && !cookieLocale) {
-    // User navigated to a non-default locale without a cookie (e.g., via language picker)
+  if (cookieLocale && allLanguages.includes(cookieLocale)) {
+    targetLocale = cookieLocale;
+  } else if (currentLocale !== "en") {
     targetLocale = currentLocale;
-    console.log(
-      `[MIDDLEWARE] Using explicit navigation locale: ${targetLocale}`,
-    );
-  } else if (cookieLocale && allLanguages.includes(cookieLocale)) {
-    // Cookie exists - use it (but only if we're on default locale or cookie matches)
-    if (currentLocale === "en" || currentLocale === cookieLocale) {
-      targetLocale = cookieLocale;
-      console.log(`[MIDDLEWARE] Using cookie locale: ${targetLocale}`);
-    } else {
-      // User explicitly navigated to a different locale - respect it and update cookie
-      targetLocale = currentLocale;
-      console.log(
-        `[MIDDLEWARE] Respecting explicit navigation to: ${targetLocale} (overriding cookie: ${cookieLocale})`,
-      );
-    }
   } else {
-    // No cookie - detect from browser
     targetLocale = getBestLocale(request);
-    console.log(`[MIDDLEWARE] Detecting locale: ${targetLocale}`);
   }
 
-  // If Next.js's current locale doesn't match our target, redirect
+  // Redirect to target locale if it differs from current
   if (currentLocale !== targetLocale) {
-    console.log(
-      `[MIDDLEWARE] Redirecting from ${currentLocale} to ${targetLocale}`,
-    );
     const url = request.nextUrl.clone();
     url.locale = targetLocale;
 
-    // If authenticated and on root, redirect to dashboard
+    // Redirect authenticated users from root to dashboard
     if (isAuthenticated && pathname === "/") {
       url.pathname = "/dashboard";
     }
@@ -88,29 +57,25 @@ export function middleware(request: NextRequest) {
     const response = NextResponse.redirect(url);
     response.cookies.set("NEXT_LOCALE", targetLocale, {
       path: "/",
-      maxAge: 31536000,
+      maxAge: 31536000, // 1 year
       sameSite: "lax",
     });
     return response;
   }
 
-  // Locale matches - handle dashboard rewrite for authenticated users on root
+  // Rewrite root path to dashboard for authenticated users
   if (isAuthenticated && pathname === "/") {
-    console.log(
-      `[MIDDLEWARE] Rewriting / to /dashboard for authenticated user`,
-    );
     const url = request.nextUrl.clone();
     url.pathname = "/dashboard";
     return NextResponse.rewrite(url);
   }
 
-  // Locale matches - ensure cookie is set
+  // Sync cookie with current locale if needed
   if (!cookieLocale || cookieLocale !== currentLocale) {
-    console.log(`[MIDDLEWARE] Syncing cookie to: ${currentLocale}`);
     const response = NextResponse.next();
     response.cookies.set("NEXT_LOCALE", currentLocale, {
       path: "/",
-      maxAge: 31536000,
+      maxAge: 31536000, // 1 year
       sameSite: "lax",
     });
     return response;

--- a/app/web/middleware.ts
+++ b/app/web/middleware.ts
@@ -92,7 +92,12 @@ export const config = {
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
+     * - manifest.json (PWA manifest)
+     * - img (static images)
+     * - logo files (PWA icons)
+     * - robots.txt, sitemap.xml (SEO files)
+     * - Files with common static extensions
      */
-    "/((?!api|_next/static|_next/image|favicon.ico).*)",
+    "/((?!api|_next/static|_next/image|favicon.ico|manifest.json|img/|logo.*\\.png|robots.txt|sitemap.xml|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|woff|woff2|ttf|eot)$).*)",
   ],
 };

--- a/app/web/next-i18next.config.js
+++ b/app/web/next-i18next.config.js
@@ -16,6 +16,7 @@ module.exports = {
   i18n: {
     defaultLocale: "en",
     locales: allLanguages,
+    localeDetection: true, // Enable automatic locale detection from Accept-Language header
   },
   fallbackLng,
   defaultNS: "global",

--- a/app/web/utils/getBrowserLocaleFromHeader.ts
+++ b/app/web/utils/getBrowserLocaleFromHeader.ts
@@ -1,0 +1,40 @@
+/**
+ * Detects the user's preferred locale from the Accept-Language header
+ *
+ * Parses the Accept-Language header (e.g., "en-US,en;q=0.9,fr;q=0.8"),
+ * extracts language codes with their quality values, and returns the first
+ * supported locale based on priority.
+ *
+ * @param acceptLanguage - The Accept-Language header value from the browser
+ * @param supportedLocales - Array of supported locale codes (e.g., ["en", "fr", "de"])
+ * @returns The best matching supported locale, or undefined if no match found
+ *
+ * @example
+ * getBrowserLocaleFromHeader("fr-FR,fr;q=0.9,en;q=0.8", ["en", "fr", "de"])
+ * // Returns "fr"
+ */
+function getBrowserLocaleFromHeader(
+  acceptLanguage: string | undefined,
+  supportedLocales: string[],
+): string | undefined {
+  if (!acceptLanguage) return undefined;
+
+  const languages = acceptLanguage
+    .split(",")
+    .map((lang) => {
+      const [code, q = "1"] = lang.trim().split(";q=");
+      return { code: code.split("-")[0], quality: parseFloat(q) };
+    })
+    .sort((a, b) => b.quality - a.quality);
+
+  for (const lang of languages) {
+    const match = supportedLocales.find((supported) =>
+      supported.startsWith(lang.code),
+    );
+    if (match) return match;
+  }
+
+  return undefined;
+}
+
+export { getBrowserLocaleFromHeader };


### PR DESCRIPTION
This should address two issues:

- If no NEXT_LOCALE cookie set, user the browser locale - Closes #7370 
- User should be able to set the language when logged out - Closes #7171 

Note we'll need to test this on stage or deploy to a branch where the backend and frontend envs match to properly test.

How to test:

- Set your browser language to something we support, in Brave it's at brave://settings/languages then put the new language AT THE TOP.
- Log out of couchers and clear all cookies
- Go to base route, it should change to the browser language
- Change the language via the picker, it should change to what you expect
- Change to English, it should work
- Clear NEXT_LOCALE cookie again
- Try a few different pages with no locale in url, i.e. /login, /signup, they should redirect to browser language (clear cookie each time)
- Change to a language different than the one your backend cookie is set to
- Log in
- It should change to your backend cookie language after login