### PR TITLE
fix: add profile gallery for dummy users in dev setup

### DIFF
--- a/app/backend/src/dummy_data.py
+++ b/app/backend/src/dummy_data.py
@@ -32,6 +32,7 @@ from couchers.models import (
     Page,
     PageType,
     PageVersion,
+    PhotoGallery,
     Reference,
     ReferenceType,
     RegionLived,
@@ -91,6 +92,12 @@ def add_dummy_users():
             )
             session.add(new_user)
             session.flush()
+
+            # Create profile gallery for the user (same as in signup flow)
+            profile_gallery = PhotoGallery(owner_user_id=new_user.id)
+            session.add(profile_gallery)
+            session.flush()
+            new_user.profile_gallery_id = profile_gallery.id
 
             for language in user["languages"]:
                 session.add(


### PR DESCRIPTION
The database consistency check expects all non-deleted users to have a profile_gallery_id. When creating dummy users, this field was not being populated, causing the dev backend to show errors when starting fresh.

This mirrors the behavior in the signup flow (auth.py) where a PhotoGallery is created for each new user.

Fixes #7506

Generated with [Claude Code](https://claude.ai/claude-code)