### PR TITLE
Fix people_range_message var suffix for weblate

### DIFF
--- a/app/web/features/search/locales/en.json
+++ b/app/web/features/search/locales/en.json
@@ -80,8 +80,8 @@
     "no_user_result_message": "No users found. Try removing some filters to see more results.",
     "show_user_button_label": "Show {{name}} on the map",
     "missing_about_description": "{{name}} hasn't said anything about themselves yet",
-    "people_range_message": "{{currentRange}} of {{count}} people",
     "people_range_message_one": "{{currentRange}} of {{count}} person",
+    "people_range_message_other": "{{currentRange}} of {{count}} people",
     "few_results_suggestion": "By default, empty and \"can't host\" profiles are hidden.",
     "include_empty_profiles_button": "Show all profiles"
   },


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
Follow-up to #7501. Although i18next supports having two strings "foo" and "foo_one", weblate expects "foo_other" and "foo_one", so it believe there is no plural defined:

<img width="437" height="418" alt="image" src="https://github.com/user-attachments/assets/4ae7f73e-5b3d-4416-a676-08dac896edb1" />

**Please give clear steps for how the reviewer can best test this PR**
Search for users and check message.

<img width="782" height="131" alt="image" src="https://github.com/user-attachments/assets/2c20cd7a-77bf-49f2-a980-66b994436df8" />

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A

**Web frontend checklist**
- [ ] Formatted my code with `yarn format`
- [ ] There are no warnings from `yarn lint --fix`
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] All tests pass
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)