### PR TITLE
Add helper text to username field during signup

### DIFF
--- a/app/web/features/auth/locales/en.json
+++ b/app/web/features/auth/locales/en.json
@@ -67,6 +67,7 @@
     "header": "Your account details",
     "username": {
       "field_label": "Username",
+      "helper_text": "This is your unique login ID, not your display name.",
       "required_error": "Enter your username",
       "username_taken_error": "This username is taken.",
       "validation_error": "Username can only have numbers or _, and should start with a letter."

--- a/app/web/features/auth/signup/AccountForm.tsx
+++ b/app/web/features/auth/signup/AccountForm.tsx
@@ -216,7 +216,10 @@ export default function AccountForm() {
             if (!usernameInputRef.current) el?.focus();
             if (el) usernameInputRef.current = el;
           }}
-          helperText={errors?.username?.message ?? " "}
+          helperText={
+            errors?.username?.message ??
+            t("auth:account_form.username.helper_text")
+          }
           error={!!errors?.username?.message}
           autoComplete="username"
         />


### PR DESCRIPTION
Added helper text below the username text field to clarify that the username is a unique login ID, not the display name. This addresses user confusion reported in issue #4145.

Only the English locale was updated. Other languages can be translated separately.

Closes #4145