### PR TITLE
Fix string concatenation in discussions

### DIFF
--- a/app/web/features/communities/discussions/DiscussionPage.test.tsx
+++ b/app/web/features/communities/discussions/DiscussionPage.test.tsx
@@ -137,7 +137,7 @@ describe("Discussion page", () => {
       }),
     ).toBeVisible();
     expect(creatorContainer.getByText("Funny Cat current User")).toBeVisible();
-    expect(creatorContainer.getByText("Created at Jan 01, 2020")).toBeVisible();
+    expect(creatorContainer.getByText("Created on Jan 01, 2020")).toBeVisible();
   });
 
   it("renders a loading skeleton if the user info is still loading", async () => {
@@ -162,7 +162,7 @@ describe("Discussion page", () => {
       screen.queryByText("Funny Cat current User"),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText("Created at Jan 01, 2020"),
+      screen.queryByText("Created on Jan 01, 2020"),
     ).not.toBeInTheDocument();
   });
 

--- a/app/web/features/communities/discussions/DiscussionPage.tsx
+++ b/app/web/features/communities/discussions/DiscussionPage.tsx
@@ -139,10 +139,11 @@ export default function DiscussionPage({
                         <Skeleton width={100} />
                       ) : (
                         <Typography variant="body2">
-                          {t("communities:created_at")}
-                          {dateFormatter(locale).format(
-                            timestamp2Date(discussion.created!),
-                          )}
+                          {t("communities:discussion_creation_date", {
+                            dateOnly: dateFormatter(locale).format(
+                              timestamp2Date(discussion.created!),
+                            ),
+                          })}
                         </Typography>
                       )}
                     </StyledCreatorDetailsContainer>

--- a/app/web/features/communities/locales/en.json
+++ b/app/web/features/communities/locales/en.json
@@ -31,7 +31,7 @@
   "community_moderators": "Community Builders",
   "edit_info_page_success_message": "The community page has been successfully updated.",
   "community_tabs_a11y_label": "Tabs for community sub-pages",
-  "created_at": "Created at ",
+  "discussion_creation_date": "Created on {{dateOnly}}",
   "create_new_discussion_title": "Create new post",
   "discussions_empty_state": "No discussions at the moment.",
   "discussions_label": "Discussions",


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
A string had a trailing space with a concatenated date. Update to using a placeholder, and fix the preposition in the English string.

See translator feedback: https://translate.couchershq.org/translate/couchers/web-app-communities/en/?checksum=10fba54f693c0433

**Please give clear steps for how the reviewer can best test this PR**
Open a community discussion

<img width="201" height="142" alt="image" src="https://github.com/user-attachments/assets/65936cd4-7184-4a89-ade1-10c70166c7b8" />

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A

**Web frontend checklist**
- [x] Formatted my code with `yarn format`
- [ ] There are no warnings from `yarn lint --fix`
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] All tests pass
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)