### PR TITLE
Update backend types to support ints in string substitutions

### DIFF
--- a/app/backend/src/couchers/context.py
+++ b/app/backend/src/couchers/context.py
@@ -99,7 +99,7 @@ class CouchersContext:
         return self.__logged_in
 
     def get_localized_string(
-        self, component: str, message_id: str, *, substitutions: dict[str, str] | None = None
+        self, component: str, message_id: str, *, substitutions: dict[str, str | int] | None = None
     ) -> str:
         """
         Get a localized string using the user's language preference.
@@ -128,7 +128,7 @@ class CouchersContext:
             context.abort(status_code, error_message)
 
     def abort_with_error_code(
-        self, status_code: grpc.StatusCode, error_message_id: str, *, substitutions: dict[str, str] | None = None
+        self, status_code: grpc.StatusCode, error_message_id: str, *, substitutions: dict[str, str | int] | None = None
     ) -> NoReturn:
         """
         Raises an error that's returned to the user, but error_message_id should be an entry from translateable errors

--- a/app/backend/src/couchers/i18n/i18n.py
+++ b/app/backend/src/couchers/i18n/i18n.py
@@ -96,7 +96,7 @@ def get_translations() -> dict[str, dict[str, dict[str, str]]]:
 
 
 def get_raw_translation_string(
-    lang: str | None, component: str, string_name: str, *, substitutions: dict[str, str] | None = None
+    lang: str | None, component: str, string_name: str, *, substitutions: dict[str, str | int] | None = None
 ) -> str:
     """
     Retrieves a translated string from the all_langs_all_strings dictionary
@@ -107,7 +107,7 @@ def get_raw_translation_string(
         lang: Language code (e.g., "en", "pt-BR"). If None, defaults to the default fallback language ("en")
         component: Component name (e.g., "errors")
         string_name: The key for the specific string
-        substitutions: Dictionary of variable substitutions for the string (e.g., {"hours": "24"})
+        substitutions: Dictionary of variable substitutions for the string (e.g., {"hours": 24})
 
     Returns:
         The translated string with substitutions applied

--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -4,7 +4,6 @@ Implements localizing strings stored in the i18next json format.
 
 import re
 from dataclasses import dataclass, field
-from typing import Any
 
 from couchers.i18n.plurals import PluralRule
 
@@ -25,7 +24,7 @@ class I18Next:
         self.languages_by_code[code] = language
         return language
 
-    def find_string(self, key: str, language_code: str, substitutions: dict[str, Any] | None = None) -> "String | None":
+    def find_string(self, key: str, language_code: str, substitutions: dict[str, str | int] | None = None) -> "String | None":
         """Find the string that will be localized, applying fallbacks and variant selection."""
         language = self.languages_by_code.get(language_code, self.fallback_language)
         while True:
@@ -42,7 +41,7 @@ class I18Next:
 
             return string
 
-    def localize(self, string_key: str, language_code: str, substitutions: dict[str, Any] | None = None) -> str:
+    def localize(self, string_key: str, language_code: str, substitutions: dict[str, str | int] | None = None) -> str:
         if string := self.find_string(string_key, language_code, substitutions):
             return string.render(substitutions)
         else:
@@ -76,7 +75,7 @@ class Language:
     def add_string(self, key: str, value: str):
         self.strings_by_key[key] = String(key, StringTemplate.parse(value))
 
-    def find_string(self, key: str, substitutions: dict[str, Any] | None = None) -> "String | None":
+    def find_string(self, key: str, substitutions: dict[str, str | int] | None = None) -> "String | None":
         # if we have a numerical "count" substitution,
         # i18next will first search for a key with a suffix
         # based on the plural category suggested by the count
@@ -90,7 +89,7 @@ class Language:
                         return string
         return self.strings_by_key.get(key)
 
-    def localize(self, string_key: str, substitutions: dict[str, Any] | None = None) -> str:
+    def localize(self, string_key: str, substitutions: dict[str, str | int] | None = None) -> str:
         string = self.find_string(string_key, substitutions)
         if string is None:
             raise LocalizationError(language_code=self.code, string_key=string_key)
@@ -104,7 +103,7 @@ class String:
     key: str
     template: "StringTemplate"
 
-    def render(self, substitutions: dict[str, Any] | None) -> str:
+    def render(self, substitutions: dict[str, str | int] | None) -> str:
         return self.template.render(substitutions)
 
 
@@ -114,14 +113,14 @@ class StringTemplate:
 
     segments: "list[StringSegment]"
 
-    def can_render(self, substitutions: dict[str, Any] | None) -> bool:
+    def can_render(self, substitutions: dict[str, str | int] | None) -> bool:
         for segment in self.segments:
             if segment.is_variable:
                 if not substitutions or substitutions.get(segment.text) is None:
                     return False
         return True
 
-    def render(self, substitutions: dict[str, Any] | None) -> str:
+    def render(self, substitutions: dict[str, str | int] | None) -> str:
         substrings: list[str] = []
         for segment in self.segments:
             if segment.is_variable:

--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -24,7 +24,9 @@ class I18Next:
         self.languages_by_code[code] = language
         return language
 
-    def find_string(self, key: str, language_code: str, substitutions: dict[str, str | int] | None = None) -> "String | None":
+    def find_string(
+        self, key: str, language_code: str, substitutions: dict[str, str | int] | None = None
+    ) -> "String | None":
         """Find the string that will be localized, applying fallbacks and variant selection."""
         language = self.languages_by_code.get(language_code, self.fallback_language)
         while True:

--- a/app/backend/src/couchers/notifications/render.py
+++ b/app/backend/src/couchers/notifications/render.py
@@ -44,7 +44,7 @@ class RenderedNotification:
 
 
 def render_notification(user: User, notification: Notification) -> RenderedNotification:
-    def get_localized_string(component: str, message_id: str, *, substitutions: dict[str, str] | None = None) -> str:
+    def get_localized_string(component: str, message_id: str, *, substitutions: dict[str, str | int] | None = None) -> str:
         return get_raw_translation_string(
             user.ui_language_preference, component, message_id, substitutions=substitutions
         )

--- a/app/backend/src/couchers/notifications/render.py
+++ b/app/backend/src/couchers/notifications/render.py
@@ -44,7 +44,9 @@ class RenderedNotification:
 
 
 def render_notification(user: User, notification: Notification) -> RenderedNotification:
-    def get_localized_string(component: str, message_id: str, *, substitutions: dict[str, str | int] | None = None) -> str:
+    def get_localized_string(
+        component: str, message_id: str, *, substitutions: dict[str, str | int] | None = None
+    ) -> str:
         return get_raw_translation_string(
             user.ui_language_preference, component, message_id, substitutions=substitutions
         )


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
String substitution dictionaries were previously typed as `dict[str, str]`, but we need to support int values for pluralization.

Once I integrate i18next.py in the backend, I'll probably define a `SubstitutionDict` type that we can reuse, but for now I'm keeping that code on an island of its own.

**Please give clear steps for how the reviewer can best test this PR**
N/A, non-executable code

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A

**Backend checklist**
- [x] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)