### PR TITLE
Fix remaining type errors

### DIFF
--- a/app/backend/Makefile
+++ b/app/backend/Makefile
@@ -26,34 +26,7 @@ format:
 fmt: format
 
 mypy:
-	uv run mypy \
-		src/couchers/config.py \
-		src/couchers/constants.py \
-		src/couchers/context.py \
-		src/couchers/crypto.py \
-		src/couchers/db.py \
-		src/couchers/descriptor_pool.py \
-		src/couchers/interceptors.py \
-		src/couchers/materialized_views.py \
-		src/couchers/metrics.py \
-		src/couchers/reranker.py \
-		src/couchers/resources.py \
-		src/couchers/server.py \
-		src/couchers/sql.py \
-		src/couchers/tasks.py \
-		src/couchers/tracing.py \
-		src/couchers/urls.py \
-		src/couchers/utils.py \
-		src/couchers/migrations/env.py \
-		src/couchers/models \
-		src/couchers/notifications \
-		src/couchers/rate_limits \
-		src/couchers/email \
-		src/couchers/templates \
-		src/couchers/helpers \
-		src/couchers/jobs \
-		src/couchers/i18n \
-		src/couchers/phone
+	uv run mypy src/couchers
 
 # Downgrade the local database to the previous migration. Good if you ran a migration on a branch and will run the backend on another branch after.
 # Usage:

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -102,13 +102,6 @@ exclude = [
 ]
 
 [[tool.mypy.overrides]]
-module = "couchers.models.*"
-# SQLAlchemy hybrid_property intentionally redefines names for instance/class expressions
-disable_error_code = [
-    "no-redef",
-]
-
-[[tool.mypy.overrides]]
 module = ["http_ece", "py_vapid", "luhn", "sqlalchemy_utils.*", "statsig_python_core", "user_agents"]
 # These libraries don't have type stubs or py.typed markers
 ignore_missing_imports = true

--- a/app/backend/src/couchers/context.py
+++ b/app/backend/src/couchers/context.py
@@ -241,3 +241,14 @@ def make_background_user_context(user_id: int) -> CouchersContext:
         token=None,
         ui_language_preference=None,
     )
+
+
+def make_logged_out_context() -> CouchersContext:
+    return CouchersContext(
+        user_id=0,
+        is_interactive=False,
+        is_api_key=None,
+        grpc_context=None,
+        token=None,
+        ui_language_preference=None,
+    )

--- a/app/backend/src/couchers/i18n/i18n.py
+++ b/app/backend/src/couchers/i18n/i18n.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Mapping
 from functools import lru_cache
 from pathlib import Path
 
@@ -96,7 +97,7 @@ def get_translations() -> dict[str, dict[str, dict[str, str]]]:
 
 
 def get_raw_translation_string(
-    lang: str | None, component: str, string_name: str, *, substitutions: dict[str, str | int] | None = None
+    lang: str | None, component: str, string_name: str, *, substitutions: Mapping[str, str | int] | None = None
 ) -> str:
     """
     Retrieves a translated string from the all_langs_all_strings dictionary

--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -61,8 +61,8 @@ class Language:
     strings_by_key: "dict[str, String]" = field(default_factory=dict)
     fallback: "Language | None" = None
 
-    def load_json_dict(self, json_dict: dict):
-        def add_strings(json_dict: dict, key_prefix: str | None):
+    def load_json_dict(self, json_dict: dict[str, Any]) -> None:
+        def add_strings(json_dict: dict[str, Any], key_prefix: str | None) -> None:
             for k, v in json_dict.items():
                 full_key = f"{key_prefix}.{k}" if key_prefix else k
                 if isinstance(v, str):
@@ -74,7 +74,7 @@ class Language:
 
         add_strings(json_dict, key_prefix=None)
 
-    def add_string(self, key: str, value: str):
+    def add_string(self, key: str, value: str) -> None:
         self.strings_by_key[key] = String(key, StringTemplate.parse(value))
 
     def find_string(self, key: str, substitutions: dict[str, str | int] | None = None) -> "String | None":
@@ -126,7 +126,7 @@ class StringTemplate:
         substrings: list[str] = []
         for segment in self.segments:
             if segment.is_variable:
-                if segment.text in substitutions:
+                if substitutions is not None and segment.text in substitutions:
                     substrings.append(str(substitutions[segment.text]))
                 else:
                     raise ValueError(f"Missing substitution for variable '{segment.text}'")
@@ -135,7 +135,7 @@ class StringTemplate:
         return "".join(substrings)
 
     @staticmethod
-    def parse(value: str) -> "list[StringSegment]":
+    def parse(value: str) -> "StringTemplate":
         last_index = 0
         segments: list[StringSegment] = []
         for match in re.finditer(r"\{\{([^\}]+)\}\}", value):

--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -4,6 +4,7 @@ Implements localizing strings stored in the i18next json format.
 
 import re
 from dataclasses import dataclass, field
+from typing import Any
 
 from couchers.i18n.plurals import PluralRule
 

--- a/app/backend/src/couchers/i18n/plurals.py
+++ b/app/backend/src/couchers/i18n/plurals.py
@@ -37,7 +37,7 @@ class PluralRules:
         lang_family = lang if separator_index == -1 else lang[0:separator_index]
 
         # Resolve one of the methods below
-        return getattr(PluralRules, lang_family, default=None)
+        return getattr(PluralRules, lang_family, None)
 
     @staticmethod
     def de(count: int) -> PluralCategory:

--- a/app/backend/src/couchers/materialized_views.py
+++ b/app/backend/src/couchers/materialized_views.py
@@ -158,10 +158,10 @@ def make_lite_users_selectable(create: bool = False) -> Select[Any]:
             User.age.label("age"),
             geom_column.label("geom"),
             User.geom_radius.label("radius"),
-            User.is_visible.label("is_visible"),  # type: ignore[attr-defined]
+            User.is_visible.label("is_visible"),
             Upload.filename.label("avatar_filename"),
-            User.has_completed_profile.label("has_completed_profile"),  # type: ignore[attr-defined]
-            User.has_completed_my_home.label("has_completed_my_home"),  # type: ignore[attr-defined]
+            User.has_completed_profile.label("has_completed_profile"),
+            User.has_completed_my_home.label("has_completed_my_home"),
             func.coalesce(strong_verification_subquery.c.true, False).label("has_strong_verification"),
         )
         .select_from(User)

--- a/app/backend/src/couchers/models/clusters.py
+++ b/app/backend/src/couchers/models/clusters.py
@@ -44,6 +44,7 @@ class Node(Base):
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     parent_node = relationship("Node", backref="child_nodes", remote_side="Node.id")
+    official_cluster: Mapped["Cluster"] = relationship("Cluster", uselist=False)
 
 
 class Cluster(Base):
@@ -72,7 +73,7 @@ class Cluster(Base):
     official_cluster_for_node = relationship(
         "Node",
         primaryjoin="and_(Cluster.parent_node_id == Node.id, Cluster.is_official_cluster)",
-        backref=backref("official_cluster", uselist=False),
+        back_populates="official_cluster",
         uselist=False,
         viewonly=True,
     )
@@ -250,6 +251,7 @@ class Page(Base):
     )
 
     editors = relationship("User", secondary="page_versions", viewonly=True)
+    versions = relationship("PageVersion", back_populates="page", order_by="PageVersion.id")
 
     __table_args__ = (
         # Only one of owner_user and owner_cluster should be set
@@ -297,7 +299,7 @@ class PageVersion(Base):
 
     slug = column_property(func.slugify(title))
 
-    page = relationship("Page", backref="versions", order_by="PageVersion.id")
+    page = relationship("Page", back_populates="versions", order_by="PageVersion.id")
     editor_user = relationship("User", backref="edited_pages")
     photo = relationship("Upload")
 

--- a/app/backend/src/couchers/models/events.py
+++ b/app/backend/src/couchers/models/events.py
@@ -1,6 +1,6 @@
 import enum
 from datetime import datetime
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from geoalchemy2 import Geometry
 from psycopg2.extras import DateTimeTZRange
@@ -19,12 +19,15 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import TSTZRANGE, ExcludeConstraint
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import Mapped, backref, column_property, mapped_column, relationship
+from sqlalchemy.orm import DynamicMapped, Mapped, backref, column_property, mapped_column, relationship
 from sqlalchemy.sql import expression
 from sqlalchemy.sql.elements import ColumnElement
 
 from couchers.models.base import Base, Geom, communities_seq
 from couchers.utils import get_coordinates
+
+if TYPE_CHECKING:
+    from couchers.models import User
 
 
 class ClusterEventAssociation(Base):
@@ -143,6 +146,10 @@ class EventOccurrence(Base):
     )
 
     photo = relationship("Upload")
+    attendances = relationship("EventOccurrenceAttendee", back_populates="occurrence", lazy="dynamic")
+    community_invite_requests: DynamicMapped["EventCommunityInviteRequest"] = relationship(
+        "EventCommunityInviteRequest", back_populates="occurrence", lazy="dynamic"
+    )
 
     __table_args__ = (
         # Geom and address go together
@@ -241,8 +248,8 @@ class EventOccurrenceAttendee(Base):
     responded: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     attendee_status: Mapped[AttendeeStatus] = mapped_column(Enum(AttendeeStatus))
 
-    user = relationship("User")
-    occurrence = relationship("EventOccurrence", backref=backref("attendances", lazy="dynamic"))
+    user: Mapped["User"] = relationship("User")
+    occurrence: Mapped[EventOccurrence] = relationship("EventOccurrence", back_populates="attendances")
 
     reminder_sent: Mapped[bool] = mapped_column(Boolean, default=False, server_default=expression.false())
 
@@ -265,8 +272,8 @@ class EventCommunityInviteRequest(Base):
     decided_by_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
     approved: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
 
-    occurrence = relationship("EventOccurrence", backref=backref("community_invite_requests", lazy="dynamic"))
-    user = relationship("User", foreign_keys="EventCommunityInviteRequest.user_id")
+    occurrence: Mapped[EventOccurrence] = relationship("EventOccurrence", back_populates="community_invite_requests")
+    user: Mapped["User"] = relationship("User", foreign_keys="EventCommunityInviteRequest.user_id")
 
     __table_args__ = (
         # each user can only request once

--- a/app/backend/src/couchers/models/events.py
+++ b/app/backend/src/couchers/models/events.py
@@ -1,6 +1,6 @@
 import enum
 from datetime import datetime
-from typing import Any
+from typing import cast
 
 from geoalchemy2 import Geometry
 from psycopg2.extras import DateTimeTZRange
@@ -21,6 +21,7 @@ from sqlalchemy.dialects.postgresql import TSTZRANGE, ExcludeConstraint
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, backref, column_property, mapped_column, relationship
 from sqlalchemy.sql import expression
+from sqlalchemy.sql.elements import ColumnElement
 
 from couchers.models.base import Base, Geom, communities_seq
 from couchers.utils import get_coordinates
@@ -166,20 +167,22 @@ class EventOccurrence(Base):
         return get_coordinates(self.geom)
 
     @hybrid_property
-    def start_time(self) -> Any:
-        return self.during.lower
+    def start_time(self) -> datetime:
+        return cast(datetime, self.during.lower)
 
-    @start_time.expression
-    def start_time(cls) -> Any:  # noqa: ARG003,D102
-        return func.lower(cls.during)
+    @start_time.inplace.expression
+    @classmethod
+    def _start_time_expression(cls) -> ColumnElement[datetime]:
+        return cast(ColumnElement[datetime], func.lower(cls.during))
 
     @hybrid_property
-    def end_time(self) -> Any:
-        return self.during.upper
+    def end_time(self) -> datetime:
+        return cast(datetime, self.during.upper)
 
-    @end_time.expression
-    def end_time(cls) -> Any:  # noqa: ARG003,D102
-        return func.upper(cls.during)
+    @end_time.inplace.expression
+    @classmethod
+    def _end_time_expression(cls) -> ColumnElement[datetime]:
+        return cast(ColumnElement[datetime], func.upper(cls.during))
 
 
 class EventSubscription(Base):

--- a/app/backend/src/couchers/models/mod_note.py
+++ b/app/backend/src/couchers/models/mod_note.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import BigInteger, DateTime, ForeignKey, Index, String, func
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import Mapped, backref, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from couchers.models.base import Base
 
@@ -33,9 +33,7 @@ class ModNote(Base):
 
     note_content: Mapped[str] = mapped_column(String)  # CommonMark without images
 
-    user: Mapped["User"] = relationship(
-        "User", foreign_keys="ModNote.user_id", backref=backref("mod_notes", lazy="dynamic")
-    )
+    user: Mapped["User"] = relationship("User", foreign_keys="ModNote.user_id", back_populates="mod_notes")
 
     def __repr__(self) -> str:
         return f"ModeNote(id={self.id}, user={self.user}, created={self.created}, ack'd={self.acknowledged})"

--- a/app/backend/src/couchers/models/postal_verification.py
+++ b/app/backend/src/couchers/models/postal_verification.py
@@ -1,6 +1,6 @@
 import enum
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from sqlalchemy import (
     BigInteger,
@@ -16,6 +16,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql.elements import ColumnElement
 
 from couchers.models.base import Base
 
@@ -85,9 +86,9 @@ class PostalVerificationAttempt(Base):
     def is_valid(self) -> bool:
         return self.status == PostalVerificationStatus.succeeded
 
-    @is_valid.expression
+    @is_valid.inplace.expression
     @classmethod
-    def is_valid(cls) -> Any:
+    def _is_valid_expression(cls) -> ColumnElement[bool]:
         return cls.status == PostalVerificationStatus.succeeded
 
     # Relationships

--- a/app/backend/src/couchers/models/rest.py
+++ b/app/backend/src/couchers/models/rest.py
@@ -50,7 +50,7 @@ class UserBadge(Base):
     # take this with a grain of salt, someone may get then lose a badge for whatever reason
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    user = relationship("User", backref="badges")
+    user = relationship("User", back_populates="badges")
 
 
 class FriendStatus(enum.Enum):

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -26,7 +26,7 @@ from sqlalchemy import (
 from sqlalchemy import LargeBinary as Binary
 from sqlalchemy import select as sa_select
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import Mapped, column_property, mapped_column, relationship
+from sqlalchemy.orm import DynamicMapped, Mapped, column_property, mapped_column, relationship
 from sqlalchemy.sql import expression
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -45,6 +45,7 @@ from couchers.models.uploads import Upload
 from couchers.utils import get_coordinates, last_active_coarsen, now
 
 if TYPE_CHECKING:
+    from couchers.models import UserBadge
     from couchers.models.rest import InviteCode, ModerationUserList
     from couchers.models.uploads import PhotoGallery
 
@@ -329,6 +330,10 @@ class User(Base):
     galleries: Mapped[list["PhotoGallery"]] = relationship(
         "PhotoGallery", foreign_keys="PhotoGallery.owner_user_id", back_populates="owner_user"
     )
+    mod_notes: DynamicMapped["ModNote"] = relationship(
+        "ModNote", foreign_keys="ModNote.user_id", back_populates="user", lazy="dynamic"
+    )
+    badges: Mapped[list["UserBadge"]] = relationship("UserBadge", back_populates="user")
 
     __table_args__ = (
         # Verified phone numbers should be unique
@@ -451,7 +456,7 @@ class User(Base):
     @hybrid_property
     def jailed_pending_mod_notes(self) -> Any:
         # mod_notes come from a backref in ModNote
-        return self.mod_notes.where(ModNote.is_pending).count() > 0  # type: ignore[attr-defined]
+        return self.mod_notes.where(ModNote.is_pending).count() > 0
 
     @hybrid_property
     def jailed_pending_activeness_probe(self) -> Any:

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -28,6 +28,7 @@ from sqlalchemy import select as sa_select
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, column_property, mapped_column, relationship
 from sqlalchemy.sql import expression
+from sqlalchemy.sql.elements import ColumnElement
 
 from couchers.constants import (
     EMAIL_REGEX,
@@ -401,8 +402,9 @@ class User(Base):
     def has_completed_profile(self) -> bool:
         return self.avatar_key is not None and self.about_me is not None and len(self.about_me) >= 150
 
-    @has_completed_profile.expression
-    def has_completed_profile(cls):
+    @has_completed_profile.inplace.expression
+    @classmethod
+    def _has_completed_profile_expression(cls) -> ColumnElement[bool]:
         return (cls.avatar_key != None) & (func.character_length(cls.about_me) >= 150)
 
     @hybrid_property
@@ -423,8 +425,9 @@ class User(Base):
             )
         )
 
-    @has_completed_my_home.expression
-    def has_completed_my_home(cls):
+    @has_completed_my_home.inplace.expression
+    @classmethod
+    def _has_completed_my_home_expression(cls) -> ColumnElement[bool]:
         return and_(
             cls.max_guests != None,
             cls.sleeping_arrangement != None,
@@ -473,8 +476,9 @@ class User(Base):
     def is_visible(self) -> bool:
         return not self.is_banned and not self.is_deleted
 
-    @is_visible.expression
-    def is_visible(cls):
+    @is_visible.inplace.expression
+    @classmethod
+    def _is_visible_expression(cls) -> ColumnElement[bool]:
         return ~(cls.is_banned | cls.is_deleted)
 
     @property
@@ -502,8 +506,9 @@ class User(Base):
             and now() - self.phone_verification_verified < PHONE_VERIFICATION_LIFETIME
         )
 
-    @phone_is_verified.expression
-    def phone_is_verified(cls):
+    @phone_is_verified.inplace.expression
+    @classmethod
+    def _phone_is_verified_expression(cls) -> ColumnElement[bool]:
         return (cls.phone_verification_verified != None) & (
             now() - cls.phone_verification_verified < PHONE_VERIFICATION_LIFETIME
         )

--- a/app/backend/src/couchers/models/verification.py
+++ b/app/backend/src/couchers/models/verification.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
 from sqlalchemy import LargeBinary as Binary
 from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
 from sqlalchemy.orm import Mapped, column_property, mapped_column, relationship
+from sqlalchemy.sql.elements import ColumnElement
 
 from couchers.models.base import Base
 from couchers.utils import date_in_timezone, now
@@ -101,14 +102,15 @@ class StrongVerificationAttempt(Base):
     user: Mapped["User"] = relationship("User")
 
     @hybrid_property
-    def is_valid(self) -> Any:
+    def is_valid(self) -> bool:
         """
         This only checks whether the attempt is a success and the passport is not expired, use `has_strong_verification` for full check
         """
         return (self.status == StrongVerificationAttemptStatus.succeeded) and (self.passport_expiry_datetime >= now())
 
-    @is_valid.expression
-    def is_valid(cls) -> Any:  # noqa: ARG003,D102
+    @is_valid.inplace.expression
+    @classmethod
+    def _is_valid_expression(cls) -> ColumnElement[bool]:
         return (cls.status == StrongVerificationAttemptStatus.succeeded) & (
             func.coalesce(cls.passport_expiry_datetime >= func.now(), False)
         )

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -42,7 +42,7 @@ from couchers.servicers.api import user_model_to_pb
 from couchers.servicers.auth import create_session
 from couchers.servicers.threads import unpack_thread_id
 from couchers.sql import couchers_select as select
-from couchers.utils import Timestamp_from_datetime, date_to_api, now, parse_date, to_aware_datetime
+from couchers.utils import Timestamp_from_datetime, date_to_api, now, parse_date, to_aware_datetime, to_bool
 
 logger = logging.getLogger(__name__)
 
@@ -545,7 +545,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
         user_ids = (
             session.execute(
                 select(User.id)
-                .where(or_(User.id <= next_user_id, next_user_id == 0))
+                .where(or_(User.id <= next_user_id, to_bool(next_user_id == 0)))
                 .where(User.joined >= start_date)
                 .where(User.joined <= end_date)
                 .order_by(User.id.desc())

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -341,7 +341,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
             session.add(user)
             session.flush()
 
-            # Create profile gallery for the user
+            # Create a profile gallery for the user
             profile_gallery = PhotoGallery(owner_user_id=user.id)
             session.add(profile_gallery)
             session.flush()

--- a/app/backend/src/couchers/servicers/communities.py
+++ b/app/backend/src/couchers/servicers/communities.py
@@ -30,7 +30,7 @@ from couchers.servicers.events import event_to_pb
 from couchers.servicers.groups import group_to_pb
 from couchers.servicers.pages import page_to_pb
 from couchers.sql import couchers_select as select
-from couchers.utils import Timestamp_from_datetime, dt_from_millis, millis_from_dt, now
+from couchers.utils import Timestamp_from_datetime, dt_from_millis, millis_from_dt, now, to_bool
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +139,7 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             session.execute(
                 select(Node)
                 .join(Cluster, Cluster.parent_node_id == Node.id)
-                .where(or_(Node.parent_node_id == request.community_id, request.community_id == 0))
+                .where(or_(Node.parent_node_id == request.community_id, to_bool(request.community_id == 0)))
                 .where(Cluster.is_official_cluster)
                 .order_by(Cluster.name)
                 .limit(page_size + 1)
@@ -407,13 +407,11 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         )
 
         if request.past:
-            query = query.where(EventOccurrence.end_time < page_token + timedelta(seconds=1)).order_by(
-                EventOccurrence.start_time.desc()
-            )
+            cutoff = page_token + timedelta(seconds=1)
+            query = query.where(EventOccurrence.end_time < cutoff).order_by(EventOccurrence.start_time.desc())
         else:
-            query = query.where(EventOccurrence.end_time > page_token - timedelta(seconds=1)).order_by(
-                EventOccurrence.start_time.asc()
-            )
+            cutoff = page_token - timedelta(seconds=1)
+            query = query.where(EventOccurrence.end_time > cutoff).order_by(EventOccurrence.start_time.asc())
 
         query = query.limit(page_size + 1)
         occurrences = session.execute(query).scalars().all()
@@ -434,7 +432,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         if not node.official_cluster.discussions_enabled:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "discussions_not_enabled")
         discussions = (
-            node.official_cluster.owned_discussions.where(or_(Discussion.id <= next_page_id, next_page_id == 0))
+            node.official_cluster.owned_discussions.where(
+                or_(Discussion.id <= next_page_id, to_bool(next_page_id == 0))
+            )
             .order_by(Discussion.id.desc())
             .limit(page_size + 1)
             .all()

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -32,7 +32,7 @@ from couchers.rate_limits.check import process_rate_limits_and_check_abort
 from couchers.rate_limits.definitions import RATE_LIMIT_HOURS
 from couchers.servicers.api import user_model_to_pb
 from couchers.sql import couchers_select as select
-from couchers.utils import Timestamp_from_datetime, now
+from couchers.utils import Timestamp_from_datetime, now, to_bool
 
 logger = logging.getLogger(__name__)
 
@@ -361,7 +361,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             .join(GroupChatSubscription, GroupChatSubscription.id == t.c.group_chat_subscriptions_id)
             .join(GroupChat, GroupChat.conversation_id == t.c.group_chat_id)
             .where_moderated_content_visible(context, GroupChat, is_list_operation=True)
-            .where(or_(t.c.message_id < request.last_message_id, request.last_message_id == 0))
+            .where(or_(t.c.message_id < request.last_message_id, to_bool(request.last_message_id == 0)))
             .order_by(t.c.message_id.desc())
             .limit(page_size + 1)
         ).all()
@@ -522,8 +522,8 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
                 .where(GroupChatSubscription.group_chat_id == request.group_chat_id)
                 .where(Message.time >= GroupChatSubscription.joined)
                 .where(or_(Message.time <= GroupChatSubscription.left, GroupChatSubscription.left == None))
-                .where(or_(Message.id < request.last_message_id, request.last_message_id == 0))
-                .where(or_(Message.id > GroupChatSubscription.last_seen_message_id, request.only_unseen == 0))
+                .where(or_(Message.id < request.last_message_id, to_bool(request.last_message_id == 0)))
+                .where(or_(Message.id > GroupChatSubscription.last_seen_message_id, to_bool(request.only_unseen == 0)))
                 .order_by(Message.id.desc())
                 .limit(page_size + 1)
             )
@@ -587,7 +587,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
                 .where(GroupChatSubscription.user_id == context.user_id)
                 .where(Message.time >= GroupChatSubscription.joined)
                 .where(or_(Message.time <= GroupChatSubscription.left, GroupChatSubscription.left == None))
-                .where(or_(Message.id < request.last_message_id, request.last_message_id == 0))
+                .where(or_(Message.id < request.last_message_id, to_bool(request.last_message_id == 0)))
                 .where(Message.text.ilike(f"%{request.query}%"))
                 .order_by(Message.id.desc())
                 .limit(page_size + 1)

--- a/app/backend/src/couchers/servicers/donations.py
+++ b/app/backend/src/couchers/servicers/donations.py
@@ -24,7 +24,7 @@ def _create_stripe_customer(session: Session, user: User) -> None:
     customer = stripe.Customer.create(
         email=user.email,
         # metadata allows us to store arbitrary metadata for ourselves
-        metadata={"user_id": user.id},
+        metadata={"user_id": user.id},  # type: ignore[dict-item]
         api_key=config["STRIPE_API_KEY"],
     )
     user.stripe_customer_id = customer.id

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -607,7 +607,6 @@ class Events(events_pb2_grpc.EventsServicer):
         if request.HasField("title"):
             notify_updated.append("title")
             event.title = request.title.value
-            event.last_edited = now()
 
         if request.HasField("content"):
             notify_updated.append("content")

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -675,20 +675,21 @@ class Events(events_pb2_grpc.EventsServicer):
         # allow editing any event which hasn't ended more than 24 hours before now
         # when editing all future events, we edit all which have not yet ended
 
+        cutoff_time = now() - timedelta(hours=24)
         if request.update_all_future:
             session.execute(
                 update(EventOccurrence)
-                .where(EventOccurrence.end_time >= now() - timedelta(hours=24))
+                .where(EventOccurrence.end_time >= cutoff_time)
                 .where(EventOccurrence.start_time >= occurrence.start_time)
                 .values(occurrence_update)
                 .execution_options(synchronize_session=False)
             )
         else:
-            if occurrence.end_time < now() - timedelta(hours=24):
+            if occurrence.end_time < cutoff_time:
                 context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "event_cant_update_old_event")
             session.execute(
                 update(EventOccurrence)
-                .where(EventOccurrence.end_time >= now() - timedelta(hours=24))
+                .where(EventOccurrence.end_time >= cutoff_time)
                 .where(EventOccurrence.id == occurrence.id)
                 .values(occurrence_update)
                 .execution_options(synchronize_session=False)
@@ -819,13 +820,11 @@ class Events(events_pb2_grpc.EventsServicer):
             query = query.where(~EventOccurrence.is_cancelled)
 
         if not request.past:
-            query = query.where(EventOccurrence.end_time > page_token - timedelta(seconds=1)).order_by(
-                EventOccurrence.start_time.asc()
-            )
+            cutoff = page_token - timedelta(seconds=1)
+            query = query.where(EventOccurrence.end_time > cutoff).order_by(EventOccurrence.start_time.asc())
         else:
-            query = query.where(EventOccurrence.end_time < page_token + timedelta(seconds=1)).order_by(
-                EventOccurrence.start_time.desc()
-            )
+            cutoff = page_token + timedelta(seconds=1)
+            query = query.where(EventOccurrence.end_time < cutoff).order_by(EventOccurrence.start_time.desc())
 
         query = query.limit(page_size + 1)
         occurrences = session.execute(query).scalars().all()
@@ -1093,13 +1092,11 @@ class Events(events_pb2_grpc.EventsServicer):
             query = query.where(~EventOccurrence.is_cancelled)
 
         if not request.past:
-            query = query.where(EventOccurrence.end_time > page_token - timedelta(seconds=1)).order_by(
-                EventOccurrence.start_time.asc()
-            )
+            cutoff = page_token - timedelta(seconds=1)
+            query = query.where(EventOccurrence.end_time > cutoff).order_by(EventOccurrence.start_time.asc())
         else:
-            query = query.where(EventOccurrence.end_time < page_token + timedelta(seconds=1)).order_by(
-                EventOccurrence.start_time.desc()
-            )
+            cutoff = page_token + timedelta(seconds=1)
+            query = query.where(EventOccurrence.end_time < cutoff).order_by(EventOccurrence.start_time.desc())
         # Count the total number of items for pagination
         total_items = session.execute(select(func.count()).select_from(query.subquery())).scalar()
         # Apply pagination by page number
@@ -1127,13 +1124,11 @@ class Events(events_pb2_grpc.EventsServicer):
             query = query.where(~EventOccurrence.is_cancelled)
 
         if not request.past:
-            query = query.where(EventOccurrence.end_time > page_token - timedelta(seconds=1)).order_by(
-                EventOccurrence.start_time.asc()
-            )
+            cutoff = page_token - timedelta(seconds=1)
+            query = query.where(EventOccurrence.end_time > cutoff).order_by(EventOccurrence.start_time.asc())
         else:
-            query = query.where(EventOccurrence.end_time < page_token + timedelta(seconds=1)).order_by(
-                EventOccurrence.start_time.desc()
-            )
+            cutoff = page_token + timedelta(seconds=1)
+            query = query.where(EventOccurrence.end_time < cutoff).order_by(EventOccurrence.start_time.desc())
 
         query = query.limit(page_size + 1)
         occurrences = session.execute(query).scalars().all()

--- a/app/backend/src/couchers/servicers/groups.py
+++ b/app/backend/src/couchers/servicers/groups.py
@@ -241,13 +241,11 @@ class Groups(groups_pb2_grpc.GroupsServicer):
         )
 
         if not request.past:
-            query = query.where(EventOccurrence.end_time > page_token - timedelta(seconds=1)).order_by(
-                EventOccurrence.start_time.asc()
-            )
+            cutoff = page_token - timedelta(seconds=1)
+            query = query.where(EventOccurrence.end_time > cutoff).order_by(EventOccurrence.start_time.asc())
         else:
-            query = query.where(EventOccurrence.end_time < page_token + timedelta(seconds=1)).order_by(
-                EventOccurrence.start_time.desc()
-            )
+            cutoff = page_token + timedelta(seconds=1)
+            query = query.where(EventOccurrence.end_time < cutoff).order_by(EventOccurrence.start_time.desc())
 
         query = query.limit(page_size + 1)
         occurrences = session.execute(query).scalars().all()

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -34,7 +34,7 @@ from couchers.notifications.utils import enum_from_topic_action
 from couchers.notifications.web_push_api import decode_key, get_vapid_public_key_from_private_key
 from couchers.proto import notifications_pb2, notifications_pb2_grpc
 from couchers.sql import couchers_select as select
-from couchers.utils import Timestamp_from_datetime, now
+from couchers.utils import Timestamp_from_datetime, now, to_bool
 
 logger = logging.getLogger(__name__)
 MAX_PAGINATION_LENGTH = 100
@@ -109,7 +109,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
                 select(Notification)
                 .where(Notification.user_id == context.user_id)
                 .where(Notification.id <= next_notification_id)
-                .where(or_(request.only_unread == False, Notification.is_seen == False))
+                .where(or_(to_bool(request.only_unread == False), Notification.is_seen == False))
                 .where(
                     Notification.topic_action.in_(
                         get_topic_actions_by_delivery_type(session, user.id, NotificationDeliveryType.push)

--- a/app/backend/src/couchers/servicers/public.py
+++ b/app/backend/src/couchers/servicers/public.py
@@ -8,7 +8,7 @@ from sqlalchemy.sql import func, union_all
 
 from couchers import urls
 from couchers.constants import DONATION_GOAL_USD, DONATION_OFFSET_USD
-from couchers.context import CouchersContext
+from couchers.context import CouchersContext, make_logged_out_context
 from couchers.materialized_views import LiteUser
 from couchers.models import Cluster, Invoice, InvoiceType, Node, ProfilePublicVisibility, Reference, User, Volunteer
 from couchers.proto import api_pb2, public_pb2, public_pb2_grpc
@@ -17,7 +17,7 @@ from couchers.resources import get_static_badge_dict
 from couchers.servicers.api import fluency2api, hostingstatus2api, meetupstatus2api, user_model_to_pb
 from couchers.servicers.gis import _statement_to_geojson_response
 from couchers.sql import couchers_select as select
-from couchers.utils import Timestamp_from_datetime, make_logged_out_context, not_none, now
+from couchers.utils import Timestamp_from_datetime, not_none, now
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -42,6 +42,7 @@ from couchers.utils import (
     get_coordinates,
     now,
     parse_date,
+    to_bool,
     today_in_timezone,
 )
 
@@ -332,7 +333,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         pagination = min(pagination, MAX_PAGE_SIZE)
 
         # By outer joining messages on itself where the second id is bigger, only the highest IDs will have
-        # none as message_2.id. So just filter for these ones to get highest messages only.
+        # none as message_2.id. So just filter for these to get the highest messages only.
         # See https://stackoverflow.com/a/27802817/6115336
         message_2 = aliased(Message)
         statement = (
@@ -344,9 +345,10 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             .where_users_column_visible(context, HostRequest.host_user_id)
             .where_moderated_content_visible(context, HostRequest, is_list_operation=True)
             .where(message_2.id == None)
-            .where(or_(Message.id < request.last_request_id, request.last_request_id == 0))
         )
 
+        if request.last_request_id != 0:
+            statement = statement.where(Message.id < request.last_request_id)
         if request.only_sent:
             statement = statement.where(HostRequest.surfer_user_id == context.user_id)
         elif request.only_received:
@@ -370,8 +372,8 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             )
 
         # TODO: I considered having the latest control message be the single source of truth for
-        # the HostRequest.status, but decided against it because of this filter.
-        # Another possibility is to filter in the python instead of SQL, but that's slower
+        #  the HostRequest.status, but decided against it because of this filter.
+        #  Another possibility is to filter in the python instead of SQL, but that's slower
         if request.only_active:
             statement = statement.where(
                 or_(
@@ -601,7 +603,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             session.execute(
                 select(Message)
                 .where(Message.conversation_id == host_request.conversation_id)
-                .where(or_(Message.id < request.last_message_id, request.last_message_id == 0))
+                .where(or_(Message.id < request.last_message_id, to_bool(request.last_message_id == 0)))
                 .order_by(Message.id.desc())
                 .limit(pagination + 1)
             )

--- a/app/backend/src/couchers/servicers/search.py
+++ b/app/backend/src/couchers/servicers/search.py
@@ -60,6 +60,7 @@ from couchers.utils import (
     millis_from_dt,
     now,
     to_aware_datetime,
+    to_bool,
 )
 
 # searches are a bit expensive, we'd rather send back a bunch of results at once than lots of small pages
@@ -272,8 +273,8 @@ def _search_pages(
         .join(Page, Page.id == PageVersion.page_id)
         .where(
             or_(
-                (Page.type == PageType.place) if include_places else False,
-                (Page.type == PageType.guide) if include_guides else False,
+                (Page.type == PageType.place) if include_places else to_bool(False),
+                (Page.type == PageType.guide) if include_guides else to_bool(False),
             )
         )
         .group_by(PageVersion.page_id)
@@ -372,8 +373,8 @@ def _search_clusters(
         .join(Page, Page.owner_cluster_id == Cluster.id)
         .join(PageVersion, PageVersion.page_id == Page.id)
         .join(latest_pages, latest_pages.c.id == PageVersion.id)
-        .where(Cluster.is_official_cluster if include_communities and not include_groups else True)
-        .where(~Cluster.is_official_cluster if not include_communities and include_groups else True),
+        .where(Cluster.is_official_cluster if include_communities and not include_groups else to_bool(True))
+        .where(~Cluster.is_official_cluster if not include_communities and include_groups else to_bool(True)),
     )
 
     return [
@@ -843,9 +844,11 @@ class Search(search_pb2_grpc.SearchServicer):
             statement = statement.where(func.ST_Contains(node.geom, EventOccurrence.geom))
 
         if request.HasField("after"):
-            statement = statement.where(EventOccurrence.start_time > to_aware_datetime(request.after))
+            after_time = to_aware_datetime(request.after)
+            statement = statement.where(EventOccurrence.start_time > after_time)
         if request.HasField("before"):
-            statement = statement.where(EventOccurrence.end_time < to_aware_datetime(request.before))
+            before_time = to_aware_datetime(request.before)
+            statement = statement.where(EventOccurrence.end_time < before_time)
 
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         # the page token is a unix timestamp of where we left off
@@ -857,13 +860,11 @@ class Search(search_pb2_grpc.SearchServicer):
         offset = (page_number - 1) * page_size
 
         if not request.past:
-            statement = statement.where(EventOccurrence.end_time > page_token - timedelta(seconds=1)).order_by(
-                EventOccurrence.start_time.asc()
-            )
+            cutoff = page_token - timedelta(seconds=1)
+            statement = statement.where(EventOccurrence.end_time > cutoff).order_by(EventOccurrence.start_time.asc())
         else:
-            statement = statement.where(EventOccurrence.end_time < page_token + timedelta(seconds=1)).order_by(
-                EventOccurrence.start_time.desc()
-            )
+            cutoff = page_token + timedelta(seconds=1)
+            statement = statement.where(EventOccurrence.end_time < cutoff).order_by(EventOccurrence.start_time.desc())
 
         total_items = session.execute(select(func.count()).select_from(statement.subquery())).scalar()
         # Apply pagination by page number

--- a/app/backend/src/couchers/urls.py
+++ b/app/backend/src/couchers/urls.py
@@ -63,15 +63,15 @@ def messages_link() -> str:
     return f"{config['BASE_URL']}/messages/"
 
 
-def chat_link(*, chat_id: str) -> str:
+def chat_link(*, chat_id: int) -> str:
     return f"{config['BASE_URL']}/messages/chats/{chat_id}"
 
 
-def event_link(*, occurrence_id: str, slug: str = "e") -> str:
+def event_link(*, occurrence_id: int, slug: str = "e") -> str:
     return f"{config['BASE_URL']}/event/{occurrence_id}/{slug}"
 
 
-def community_link(*, node_id: str, slug: str = "e") -> str:
+def community_link(*, node_id: int, slug: str = "e") -> str:
     return f"{config['BASE_URL']}/community/{node_id}/{slug}"
 
 

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -14,7 +14,7 @@ from geoalchemy2.shape import from_shape, to_shape
 from google.protobuf.duration_pb2 import Duration
 from google.protobuf.timestamp_pb2 import Timestamp
 from shapely.geometry import Point, Polygon, shape
-from sqlalchemy import Function, cast
+from sqlalchemy import ColumnElement, Function, cast, false, true
 from sqlalchemy.sql import func
 from sqlalchemy.types import DateTime
 
@@ -28,7 +28,8 @@ utc = pytz.UTC
 # When a user logs in, they can basically input one of three things: user id, username, or email
 # These are three non-intersecting sets
 # * user_ids are numeric representations in base 10
-# * usernames are alphanumeric + underscores, at least 2 chars long, and don't start with a number, and don't start or end with underscore
+# * usernames are alphanumeric + underscores, at least 2 chars long, and don't start with a number,
+#   and don't start or end with underscore
 # * emails are just whatever stack overflow says emails are ;)
 
 
@@ -419,3 +420,7 @@ def not_none[T](x: T | None) -> T:
     if x is None:
         raise ValueError("Expected a value but got None")
     return x
+
+
+def to_bool(value: bool) -> ColumnElement[bool]:
+    return true() if value else false()

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -4,7 +4,6 @@ import typing
 from collections.abc import Sequence
 from datetime import date, datetime, timedelta
 from email.utils import formatdate
-from types import SimpleNamespace
 from typing import Any, overload
 from zoneinfo import ZoneInfo
 
@@ -410,10 +409,6 @@ def last_active_coarsen(dt: datetime) -> datetime:
 
 def get_tz_as_text(tz_name: str) -> str:
     return datetime.now(tz=ZoneInfo(tz_name)).strftime("%Z/UTC%z")
-
-
-def make_logged_out_context() -> SimpleNamespace:
-    return SimpleNamespace(user_id=0)
 
 
 def not_none[T](x: T | None) -> T:


### PR DESCRIPTION
This fixes all remaining type errors - `make mypy` now passes. 

Most significant changes:
- change hybrid_property's to use sqlalchemy 2.0 style, understood by mypy
- Migrate from `backref` to `back_populates` for relationship. `backref` is considered legacy and confuses mypy, as it sees no attribute on the referenced model. I only changed `backref`s that were causing errors for now.
- Removed assignment to `Event.last_changed`, since the table has no such column, and it had no effect.