### PR TITLE
Switch to new i18next implementation

### DIFF
--- a/app/backend/src/app.py
+++ b/app/backend/src/app.py
@@ -80,7 +80,7 @@ logger.info("Running DB migrations")
 
 apply_migrations()
 
-get_i18next() # Force eager loading of translations
+get_i18next()  # Force eager loading of translations
 
 if config["ADD_DUMMY_DATA"]:
     add_dummy_data()

--- a/app/backend/src/app.py
+++ b/app/backend/src/app.py
@@ -4,7 +4,7 @@ import sys
 from os import environ
 from tempfile import TemporaryDirectory
 
-from couchers.i18n.i18n import get_translations
+from couchers.i18n.i18n import get_i18next
 
 # these two lines need to be at the top of the file before we span child processes
 # this temp dir will be destroyed when prometheus_multiproc_dir is destroyed, aka at the end of the program
@@ -80,7 +80,7 @@ logger.info("Running DB migrations")
 
 apply_migrations()
 
-get_translations()
+get_i18next() # Force eager loading of translations
 
 if config["ADD_DUMMY_DATA"]:
     add_dummy_data()

--- a/app/backend/src/couchers/context.py
+++ b/app/backend/src/couchers/context.py
@@ -133,7 +133,7 @@ class CouchersContext:
         else:
             context = cast(grpc.ServicerContext, self._grpc_context)
             # Get the translated error message using the user's language preference
-            error_message = self.get_localized_string(f"errors.{error_message_id}", substitutions)
+            error_message = self.get_localized_string(f"errors.{error_message_id}", substitutions=substitutions)
             context.abort(status_code, error_message)
 
     def set_cookies(self, cookies: list[str]) -> None:

--- a/app/backend/src/couchers/context.py
+++ b/app/backend/src/couchers/context.py
@@ -2,7 +2,7 @@ from typing import NoReturn, cast
 
 import grpc
 
-from couchers.i18n.i18n import get_raw_translation_string
+from couchers.i18n.i18n import localize_string
 
 
 class NonInteractiveContextException(Exception):
@@ -99,22 +99,21 @@ class CouchersContext:
         return self.__logged_in
 
     def get_localized_string(
-        self, component: str, message_id: str, *, substitutions: dict[str, str | int] | None = None
+        self, key: str, *, substitutions: dict[str, str | int] | None = None
     ) -> str:
         """
         Get a localized string using the user's language preference.
         Falls back to the default language if no preference is set.
 
         Args:
-            component: Component name (e.g., "errors")
-            message_id: The key for the specific string
+            key: The key for the specific string
             substitutions: Dictionary of variable substitutions for the string (optional)
 
         Returns:
             The translated string with substitutions applied
         """
-        return get_raw_translation_string(
-            self.__ui_language_preference, component, message_id, substitutions=substitutions
+        return localize_string(
+            self.__ui_language_preference, key, substitutions=substitutions
         )
 
     def abort(self, status_code: grpc.StatusCode, error_message: str) -> NoReturn:
@@ -138,7 +137,7 @@ class CouchersContext:
         else:
             context = cast(grpc.ServicerContext, self._grpc_context)
             # Get the translated error message using the user's language preference
-            error_message = self.get_localized_string("errors", error_message_id, substitutions=substitutions)
+            error_message = self.get_localized_string(f"errors.{error_message_id}", substitutions)
             context.abort(status_code, error_message)
 
     def set_cookies(self, cookies: list[str]) -> None:

--- a/app/backend/src/couchers/context.py
+++ b/app/backend/src/couchers/context.py
@@ -98,9 +98,7 @@ class CouchersContext:
     def is_logged_in(self) -> bool:
         return self.__logged_in
 
-    def get_localized_string(
-        self, key: str, *, substitutions: dict[str, str | int] | None = None
-    ) -> str:
+    def get_localized_string(self, key: str, *, substitutions: dict[str, str | int] | None = None) -> str:
         """
         Get a localized string using the user's language preference.
         Falls back to the default language if no preference is set.
@@ -112,9 +110,7 @@ class CouchersContext:
         Returns:
             The translated string with substitutions applied
         """
-        return localize_string(
-            self.__ui_language_preference, key, substitutions=substitutions
-        )
+        return localize_string(self.__ui_language_preference, key, substitutions=substitutions)
 
     def abort(self, status_code: grpc.StatusCode, error_message: str) -> NoReturn:
         """

--- a/app/backend/src/couchers/helpers/badges.py
+++ b/app/backend/src/couchers/helpers/badges.py
@@ -21,8 +21,8 @@ def user_add_badge(session: Session, user_id: int, badge_id: str, do_notify: boo
             key=badge_id,
             data=notification_data_pb2.BadgeAdd(
                 badge_id=badge["id"],
-                badge_name=context.get_localized_string("badges", f"{badge_id}_name"),
-                badge_description=context.get_localized_string("badges", f"{badge_id}_description"),
+                badge_name=context.get_localized_string(f"badges.{badge_id}_name"),
+                badge_description=context.get_localized_string(f"badges.{badge_id}_description"),
             ),
         )
     session.commit()
@@ -40,8 +40,8 @@ def user_remove_badge(session: Session, user_id: int, badge_id: str) -> None:
         key=badge_id,
         data=notification_data_pb2.BadgeRemove(
             badge_id=badge["id"],
-            badge_name=context.get_localized_string("badges", f"{badge_id}_name"),
-            badge_description=context.get_localized_string("badges", f"{badge_id}_description"),
+            badge_name=context.get_localized_string(f"badges.{badge_id}_name"),
+            badge_description=context.get_localized_string(f"badges.{badge_id}_description"),
         ),
     )
     session.commit()

--- a/app/backend/src/couchers/i18n/constants.py
+++ b/app/backend/src/couchers/i18n/constants.py
@@ -1,11 +1,10 @@
 # Language fallback hierarchy
-# If a string is not found in the requested language, fall back to these languages in order
-LANGUAGE_FALLBACKS: dict[str, list[str]] = {
-    "pt-BR": ["pt", "en"],
-    "pt-PT": ["pt-BR", "en"],
-    "es-419": ["es", "en"],
-    "fr-CA": ["fr", "en"],
-    "zh": ["zh-Hans", "en"],
-    "en_CORP": ["en"],
+# If a string is not found in the requested language, transitively fall back to these languages.
+# Other languages implicitly fallback to English.
+LANGUAGE_FALLBACKS: dict[str, str] = {
+    "pt-BR": "pt",
+    "pt-PT": "pt-BR",
+    "es-419": "es",
+    "fr-CA": "fr",
+    "zh": "zh-Hans",
 }
-DEFAULT_FALLBACK = ["en"]

--- a/app/backend/src/couchers/i18n/i18n.py
+++ b/app/backend/src/couchers/i18n/i18n.py
@@ -40,7 +40,7 @@ def get_i18next() -> I18Next:
     i18next.fallback_language = en
 
     # Apply other fallbacks
-    for from_lang_code, to_lang_code in LANGUAGE_FALLBACKS:
+    for from_lang_code, to_lang_code in LANGUAGE_FALLBACKS.items():
         from_lang = i18next.languages_by_code.get(from_lang_code)
         to_lang = i18next.languages_by_code.get(to_lang_code)
         if from_lang is not None and to_lang is not None:

--- a/app/backend/src/couchers/i18n/i18n.py
+++ b/app/backend/src/couchers/i18n/i18n.py
@@ -3,132 +3,64 @@ from collections.abc import Mapping
 from functools import lru_cache
 from pathlib import Path
 
-from couchers.i18n.constants import DEFAULT_FALLBACK, LANGUAGE_FALLBACKS
-
-
-class MissingTranslationError(Exception):
-    """Raised when a translation template is not found in any fallback language."""
-
-    def __init__(self, lang: str, component: str, string_name: str):
-        self.lang = lang
-        self.component = component
-        self.string_name = string_name
-        super().__init__(f"Missing translation: {lang}.{component}.{string_name}")
+from couchers.i18n.constants import LANGUAGE_FALLBACKS
+from couchers.i18n.i18next import I18Next
+from couchers.i18n.plurals import PluralRules
 
 
 @lru_cache(maxsize=1)
-def get_translations() -> dict[str, dict[str, dict[str, str]]]:
+def get_i18next() -> I18Next:
     """
     Load all translation files from the locales directory and apply fallbacks.
-    Each locale JSON file contains components as top-level keys that map to
-    dictionaries of string translations. Fallbacks are prebaked so every language
-    has complete coverage using English as the base and applying fallbacks in the
-    correct precedence order.
 
     Returns:
-        Dictionary structure: lang -> component -> (string -> translated string)
+        An I18Next object that can localize the application strings.
 
     The result is cached so that translations are only loaded once per process.
     """
-    all_langs_all_strings: dict[str, dict[str, dict[str, str]]] = {}
 
-    locales_dir = Path(__file__).parent / "locales"
+    i18next = I18Next()
 
     # Load all locale JSON files from the locales directory
+    locales_dir = Path(__file__).parent / "locales"
     for locale_file in locales_dir.glob("*.json"):
-        lang = locale_file.stem  # e.g., "en" from "en.json"
+        lang_code = locale_file.stem  # e.g., "en" from "en.json"
 
         with open(locale_file, "r", encoding="utf-8") as f:
             translations = json.load(f)
 
-        # Initialize the language dictionary if needed
-        if lang not in all_langs_all_strings:
-            all_langs_all_strings[lang] = {}
+        plural_rule = PluralRules.for_language(lang_code) or PluralRules.en
+        language = i18next.add_language(lang_code, plural_rule)
+        language.load_json_dict(translations)
 
-        # Each top-level key in the JSON file is a component
-        for component_name, component_translations in translations.items():
-            if component_name not in all_langs_all_strings[lang]:
-                all_langs_all_strings[lang][component_name] = {}
-
-            # Store the translations for this component
-            all_langs_all_strings[lang][component_name] = component_translations
-
-    # Apply fallbacks: English is our source of truth - must exist
-    if "en" not in all_langs_all_strings:
+    # Apply ultimate fallback: English is our source of truth - must exist
+    en = i18next.languages_by_code.get("en")
+    if en is None:
         raise RuntimeError("English translations must be loaded")
+    i18next.fallback_language = en
 
-    en_strings = all_langs_all_strings["en"]
+    # Apply other fallbacks
+    for from_lang_code, to_lang_code in LANGUAGE_FALLBACKS:
+        from_lang = i18next.languages_by_code.get(from_lang_code)
+        to_lang = i18next.languages_by_code.get(to_lang_code)
+        if from_lang is not None and to_lang is not None:
+            from_lang.fallback = to_lang.fallback
 
-    # Get all languages we need to process (loaded languages + those in fallback config)
-    all_languages = set(all_langs_all_strings.keys()) | set(LANGUAGE_FALLBACKS.keys())
-
-    for lang in all_languages:
-        if lang == "en":
-            continue  # English is already complete
-
-        # Start with a complete copy of English as the base
-        lang_strings = {}
-        for component in en_strings:
-            lang_strings[component] = en_strings[component].copy()
-
-        # Get fallback chain for this language
-        fallback_chain = LANGUAGE_FALLBACKS.get(lang, DEFAULT_FALLBACK)
-
-        # Apply fallbacks in reverse order (so more specific overrides less specific)
-        # For pt-BR with fallbacks ["pt", "en"]: Apply "en" (already done) → then "pt"
-        for fallback_lang in reversed(fallback_chain):
-            if fallback_lang in all_langs_all_strings:
-                for component in all_langs_all_strings[fallback_lang]:
-                    if component not in lang_strings:
-                        lang_strings[component] = {}
-                    lang_strings[component].update(all_langs_all_strings[fallback_lang][component])
-
-        # Finally, apply the language's own translations (highest priority)
-        if lang in all_langs_all_strings:
-            for component in all_langs_all_strings[lang]:
-                if component not in lang_strings:
-                    lang_strings[component] = {}
-                lang_strings[component].update(all_langs_all_strings[lang][component])
-
-        # Replace the language entry with the complete version
-        all_langs_all_strings[lang] = lang_strings
-
-    return all_langs_all_strings
+    return i18next
 
 
-def get_raw_translation_string(
-    lang: str | None, component: str, string_name: str, *, substitutions: Mapping[str, str | int] | None = None
+def localize_string(
+    lang: str | None, key: str, *, substitutions: Mapping[str, str | int] | None = None
 ) -> str:
     """
-    Retrieves a translated string from the all_langs_all_strings dictionary
-    and performs variable substitutions. Fallbacks have been prebaked during
-    module initialization, so this is now a simple lookup.
+    Retrieves a translated string and performs substitutions.
 
     Args:
         lang: Language code (e.g., "en", "pt-BR"). If None, defaults to the default fallback language ("en")
-        component: Component name (e.g., "errors")
-        string_name: The key for the specific string
+        key: The key for the string to be looked up.
         substitutions: Dictionary of variable substitutions for the string (e.g., {"hours": 24})
 
     Returns:
         The translated string with substitutions applied
     """
-    # Get translations (cached)
-    all_langs_all_strings = get_translations()
-
-    # Use default fallback language if lang is None or doesn't exist
-    if lang is None or lang not in all_langs_all_strings:
-        lang = "en"
-
-    # Direct lookup (fallbacks already applied during initialization)
-    try:
-        template = all_langs_all_strings[lang][component][string_name]
-    except KeyError as e:
-        raise MissingTranslationError(lang, component, string_name) from e
-
-    # Perform substitutions by replacing {{key}} with the corresponding value
-    if substitutions:
-        for key, value in substitutions.items():
-            template = template.replace(f"{{{{{key}}}}}", str(value))
-
-    return template
+    return get_i18next().localize(key, lang or "en", substitutions)

--- a/app/backend/src/couchers/i18n/i18n.py
+++ b/app/backend/src/couchers/i18n/i18n.py
@@ -49,9 +49,7 @@ def get_i18next() -> I18Next:
     return i18next
 
 
-def localize_string(
-    lang: str | None, key: str, *, substitutions: Mapping[str, str | int] | None = None
-) -> str:
+def localize_string(lang: str | None, key: str, *, substitutions: Mapping[str, str | int] | None = None) -> str:
     """
     Retrieves a translated string and performs substitutions.
 

--- a/app/backend/src/couchers/i18n/i18n.py
+++ b/app/backend/src/couchers/i18n/i18n.py
@@ -33,18 +33,21 @@ def get_i18next() -> I18Next:
         language = i18next.add_language(lang_code, plural_rule)
         language.load_json_dict(translations)
 
-    # Apply ultimate fallback: English is our source of truth - must exist
+    # English is our default for undefined languages
     en = i18next.languages_by_code.get("en")
     if en is None:
         raise RuntimeError("English translations must be loaded")
-    i18next.fallback_language = en
+    i18next.default_language = en
 
-    # Apply other fallbacks
-    for from_lang_code, to_lang_code in LANGUAGE_FALLBACKS.items():
-        from_lang = i18next.languages_by_code.get(from_lang_code)
-        to_lang = i18next.languages_by_code.get(to_lang_code)
-        if from_lang is not None and to_lang is not None:
-            from_lang.fallback = to_lang.fallback
+    # Apply fallbacks
+    for language in i18next.languages_by_code.values():
+        if language == en:
+            continue  # English has no fallback
+
+        fallback_language = en
+        if fallback_code := LANGUAGE_FALLBACKS.get(language.code):
+            fallback_language = i18next.languages_by_code[fallback_code]
+        language.fallback = fallback_language
 
     return i18next
 

--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -18,7 +18,7 @@ class I18Next:
     """Retrieves translated strings from their keys based on the i18next format."""
 
     languages_by_code: "dict[str, Language]" = field(default_factory=dict)
-    fallback_language: "Language | None" = None
+    default_language: "Language | None" = None
     """The language used to look up strings in unsupported languages."""
 
     def add_language(self, code: str, plural_rule: PluralRule) -> "Language":
@@ -30,17 +30,14 @@ class I18Next:
         self, key: str, language_code: str, substitutions: Mapping[str, str | int] | None = None
     ) -> "String | None":
         """Find the string that will be localized, applying fallbacks and variant selection."""
-        language = self.languages_by_code.get(language_code, self.fallback_language)
+        language = self.languages_by_code.get(language_code, self.default_language)
         while True:
             if language is None:
                 raise LocalizationError(language_code, key)
 
             string = language.find_string(key, substitutions)
             if string is None or not string.template.can_render(substitutions):
-                if language.fallback is None and language != self.fallback_language:
-                    language = self.fallback_language
-                else:
-                    language = language.fallback
+                language = language.fallback
                 continue
 
             return string

--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -3,6 +3,7 @@ Implements localizing strings stored in the i18next json format.
 """
 
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -26,7 +27,7 @@ class I18Next:
         return language
 
     def find_string(
-        self, key: str, language_code: str, substitutions: dict[str, str | int] | None = None
+        self, key: str, language_code: str, substitutions: Mapping[str, str | int] | None = None
     ) -> "String | None":
         """Find the string that will be localized, applying fallbacks and variant selection."""
         language = self.languages_by_code.get(language_code, self.fallback_language)
@@ -44,7 +45,9 @@ class I18Next:
 
             return string
 
-    def localize(self, string_key: str, language_code: str, substitutions: dict[str, str | int] | None = None) -> str:
+    def localize(
+        self, string_key: str, language_code: str, substitutions: Mapping[str, str | int] | None = None
+    ) -> str:
         if string := self.find_string(string_key, language_code, substitutions):
             return string.render(substitutions)
         else:
@@ -62,8 +65,8 @@ class Language:
     strings_by_key: "dict[str, String]" = field(default_factory=dict)
     fallback: "Language | None" = None
 
-    def load_json_dict(self, json_dict: dict[str, Any]) -> None:
-        def add_strings(json_dict: dict[str, Any], key_prefix: str | None) -> None:
+    def load_json_dict(self, json_dict: Mapping[str, Any]) -> None:
+        def add_strings(json_dict: Mapping[str, Any], key_prefix: str | None) -> None:
             for k, v in json_dict.items():
                 full_key = f"{key_prefix}.{k}" if key_prefix else k
                 if isinstance(v, str):
@@ -78,7 +81,7 @@ class Language:
     def add_string(self, key: str, value: str) -> None:
         self.strings_by_key[key] = String(key, StringTemplate.parse(value))
 
-    def find_string(self, key: str, substitutions: dict[str, str | int] | None = None) -> "String | None":
+    def find_string(self, key: str, substitutions: Mapping[str, str | int] | None = None) -> "String | None":
         # if we have a numerical "count" substitution,
         # i18next will first search for a key with a suffix
         # based on the plural category suggested by the count
@@ -92,7 +95,7 @@ class Language:
                         return string
         return self.strings_by_key.get(key)
 
-    def localize(self, string_key: str, substitutions: dict[str, str | int] | None = None) -> str:
+    def localize(self, string_key: str, substitutions: Mapping[str, str | int] | None = None) -> str:
         string = self.find_string(string_key, substitutions)
         if string is None:
             raise LocalizationError(language_code=self.code, string_key=string_key)
@@ -106,7 +109,7 @@ class String:
     key: str
     template: "StringTemplate"
 
-    def render(self, substitutions: dict[str, str | int] | None) -> str:
+    def render(self, substitutions: Mapping[str, str | int] | None) -> str:
         return self.template.render(substitutions)
 
 
@@ -116,14 +119,14 @@ class StringTemplate:
 
     segments: "list[StringSegment]"
 
-    def can_render(self, substitutions: dict[str, str | int] | None) -> bool:
+    def can_render(self, substitutions: Mapping[str, str | int] | None) -> bool:
         for segment in self.segments:
             if segment.is_variable:
                 if not substitutions or substitutions.get(segment.text) is None:
                     return False
         return True
 
-    def render(self, substitutions: dict[str, str | int] | None) -> str:
+    def render(self, substitutions: Mapping[str, str | int] | None) -> str:
         substrings: list[str] = []
         for segment in self.segments:
             if segment.is_variable:

--- a/app/backend/src/couchers/notifications/quick_links.py
+++ b/app/backend/src/couchers/notifications/quick_links.py
@@ -98,7 +98,7 @@ def respond_quick_link(request: auth_pb2.UnsubscribeReq, context: CouchersContex
         user.do_not_email = True
         user.hosting_status = HostingStatus.cant_host
         user.meetup_status = MeetupStatus.does_not_want_to_meetup
-        return context.get_localized_string("quick_links", "do_not_email")
+        return context.get_localized_string("quick_links.do_not_email")
     if payload.HasField("topic_action"):
         logger.info(f"User {user.name} unsubscribing from topic_action")
         topic = payload.topic_action.topic
@@ -106,7 +106,7 @@ def respond_quick_link(request: auth_pb2.UnsubscribeReq, context: CouchersContex
         topic_action = enum_from_topic_action[topic, action]
         # disable emails for this type
         settings.set_preference(session, user.id, topic_action, NotificationDeliveryType.email, False)
-        return context.get_localized_string("quick_links", "topic_action")
+        return context.get_localized_string("quick_links.topic_action")
     if payload.HasField("topic_key"):
         logger.info(f"User {user.name} unsubscribing from topic_key")
         topic = payload.topic_key.topic
@@ -128,7 +128,7 @@ def respond_quick_link(request: auth_pb2.UnsubscribeReq, context: CouchersContex
 
             assert subscription is not None
             subscription.muted_until = DATETIME_INFINITY
-            return context.get_localized_string("quick_links", "chat_unsub")
+            return context.get_localized_string("quick_links.chat_unsub")
         else:
             context.abort_with_error_code(grpc.StatusCode.UNIMPLEMENTED, "cant_unsub_topic")
     if payload.HasField("host_request_quick_decline"):
@@ -140,5 +140,5 @@ def respond_quick_link(request: auth_pb2.UnsubscribeReq, context: CouchersContex
             context=make_one_off_interactive_user_context(couchers_context=context, user_id=payload.user_id),
             session=session,
         )
-        return context.get_localized_string("quick_links", "host_request_quick_decline")
+        return context.get_localized_string("quick_links.host_request_quick_decline")
     raise Exception("Unhandled quick link type")

--- a/app/backend/src/couchers/notifications/render.py
+++ b/app/backend/src/couchers/notifications/render.py
@@ -44,12 +44,8 @@ class RenderedNotification:
 
 
 def render_notification(user: User, notification: Notification) -> RenderedNotification:
-    def get_localized_string(
-        key: str, *, substitutions: dict[str, str | int] | None = None
-    ) -> str:
-        return localize_string(
-            user.ui_language_preference, key, substitutions
-        )
+    def get_localized_string(key: str, *, substitutions: dict[str, str | int] | None = None) -> str:
+        return localize_string(user.ui_language_preference, key, substitutions)
 
     data = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
     if notification.topic == "host_request":

--- a/app/backend/src/couchers/notifications/render.py
+++ b/app/backend/src/couchers/notifications/render.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from couchers import urls
-from couchers.i18n.i18n import get_raw_translation_string
+from couchers.i18n.i18n import localize_string
 from couchers.models import Notification, User
 from couchers.notifications.quick_links import generate_quick_decline_link, generate_unsub_topic_action
 from couchers.proto import notification_data_pb2
@@ -45,10 +45,10 @@ class RenderedNotification:
 
 def render_notification(user: User, notification: Notification) -> RenderedNotification:
     def get_localized_string(
-        component: str, message_id: str, *, substitutions: dict[str, str | int] | None = None
+        key: str, *, substitutions: dict[str, str | int] | None = None
     ) -> str:
-        return get_raw_translation_string(
-            user.ui_language_preference, component, message_id, substitutions=substitutions
+        return localize_string(
+            user.ui_language_preference, key, substitutions
         )
 
     data = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
@@ -367,10 +367,9 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
             email_list_unsubscribe_url=generate_unsub_topic_action(notification),
         )
     elif notification.topic_action.display == "donation:received":
-        title = get_localized_string("notifications", "donation_received_title")
+        title = get_localized_string("notifications.donation_received_title")
         message = get_localized_string(
-            "notifications",
-            "donation_received_thanks_amount",
+            "notifications.donation_received_thanks_amount",
             substitutions={
                 "amount": data.amount,
             },

--- a/app/backend/src/couchers/notifications/render.py
+++ b/app/backend/src/couchers/notifications/render.py
@@ -45,7 +45,7 @@ class RenderedNotification:
 
 def render_notification(user: User, notification: Notification) -> RenderedNotification:
     def get_localized_string(key: str, *, substitutions: dict[str, str | int] | None = None) -> str:
-        return localize_string(user.ui_language_preference, key, substitutions)
+        return localize_string(user.ui_language_preference, key, substitutions=substitutions)
 
     data = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
     if notification.topic == "host_request":

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -966,8 +966,8 @@ def user_model_to_pb(
                 user_id=db_user.id,
                 is_ghost=True,
                 username=GHOST_USERNAME,
-                name=context.get_localized_string("ghost_users", "display_name"),
-                about_me=context.get_localized_string("ghost_users", "about_me"),
+                name=context.get_localized_string("ghost_users.display_name"),
+                about_me=context.get_localized_string("ghost_users.about_me"),
             )
         raise GhostUserSerializationError(
             f"Tried to serialize ghost profile in user_model_to_pb without appropriate flags. "
@@ -1164,7 +1164,7 @@ def lite_user_to_pb(
                 user_id=lite_user.id,
                 is_ghost=True,
                 username=GHOST_USERNAME,
-                name=context.get_localized_string("ghost_users", "display_name"),
+                name=context.get_localized_string("ghost_users.display_name"),
             )
         raise GhostUserSerializationError(
             f"Tried to serialize ghost profile in lite_user_to_pb without appropriate flags. "

--- a/app/backend/src/couchers/servicers/resources.py
+++ b/app/backend/src/couchers/servicers/resources.py
@@ -35,8 +35,8 @@ class Resources(resources_pb2_grpc.ResourcesServicer):
         return resources_pb2.GetCommunityGuidelinesRes(
             community_guidelines=[
                 resources_pb2.CommunityGuideline(
-                    title=context.get_localized_string("community_guidelines", f"{cg['key']}_title"),
-                    guideline=context.get_localized_string("community_guidelines", f"{cg['key']}_guideline"),
+                    title=context.get_localized_string(f"community_guidelines.{cg['key']}_title"),
+                    guideline=context.get_localized_string(f"community_guidelines.{cg['key']}_guideline"),
                     icon_svg=get_icon(cg["icon"]),
                 )
                 for cg in COMMUNITY_GUIDELINES
@@ -68,8 +68,8 @@ class Resources(resources_pb2_grpc.ResourcesServicer):
             badges=[
                 resources_pb2.Badge(
                     id=badge["id"],
-                    name=context.get_localized_string("badges", f"{badge['id']}_name"),
-                    description=context.get_localized_string("badges", f"{badge['id']}_description"),
+                    name=context.get_localized_string(f"badges.{badge['id']}_name"),
+                    description=context.get_localized_string(f"badges.{badge['id']}_description"),
                     color=badge["color"],
                 )
                 for badge in get_badge_dict().values()

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import Session
 from couchers import urls
 from couchers.config import config
 from couchers.email import queue_email
-from couchers.i18n.i18n import get_raw_translation_string
+from couchers.i18n.i18n import localize_string
 from couchers.models import User
 from couchers.utils import get_tz_as_text, now, to_aware_datetime
 
@@ -106,12 +106,11 @@ def v2translate(context: Context, key: str, **kwargs: Any) -> str:
     """
 
     lang: str = context[CONTEXT_TRANSLATION_LANGUAGE_KEY]
-    component: str = context[CONTEXT_TRANSLATION_COMPONENT_KEY]
 
     # Prevent html injection
     escaped_substitutions = {k: escape(str(v)) for k, v in kwargs.items()}
 
-    translated = get_raw_translation_string(lang, component, key, substitutions=escaped_substitutions)
+    translated = localize_string(lang, key, substitutions=escaped_substitutions)
 
     # Translations may include simple formatting HTML like <b> or <a>,
     # but those should not appear in plain text emails.

--- a/app/backend/src/tests/test_i18n.py
+++ b/app/backend/src/tests/test_i18n.py
@@ -20,3 +20,19 @@ def test_translations_loaded():
 
     # Other languages should also exist
     assert len(i18next.languages_by_code) > 1
+
+
+def test_fallback_chain():
+    """Test that fallbacks are correctly set up"""
+    i18next = get_i18next()
+
+    # Example: fr-CA should fallback to fr, which should fallback to en
+    fr_CA = i18next.languages_by_code["fr-CA"]
+    fr = i18next.languages_by_code["fr"]
+    en = i18next.languages_by_code["en"]
+
+    assert fr_CA.fallback == fr
+    assert fr.fallback == en
+    assert en.fallback is None
+
+    assert i18next.default_language == en

--- a/app/backend/src/tests/test_i18n.py
+++ b/app/backend/src/tests/test_i18n.py
@@ -1,6 +1,6 @@
 import pytest
 
-from couchers.i18n.i18n import MissingTranslationError, get_raw_translation_string, get_translations
+from couchers.i18n.i18n import get_i18next
 from tests.test_fixtures import testconfig  # noqa
 
 
@@ -11,83 +11,12 @@ def _(testconfig):
 
 def test_translations_loaded():
     """Test that translations are loaded from JSON files"""
+    i18next = get_i18next()
+
     # Should have at least English errors loaded
-    assert "en" in get_translations()
-    assert "errors" in get_translations()["en"]
-    assert len(get_translations()["en"]["errors"]) > 0
+    en_lang = i18next.languages_by_code.get("en")
+    assert en_lang is not None
+    assert en_lang.strings_by_key.get("errors.account_not_found") is not None
 
-
-def test_get_string_simple():
-    """Test simple string retrieval without substitutions"""
-    result = get_raw_translation_string("en", "errors", "cant_write_reference_indicated_didnt_meetup")
-    expected = "You can't write a reference for that host request because you indicated that you didn't meet up."
-    assert result == expected
-
-
-def test_get_string_with_substitution():
-    """Test string retrieval with variable substitutions"""
-    result = get_raw_translation_string("en", "errors", "chat_initiation_rate_limit", substitutions={"hours": 24})
-    expected = "You have messaged a lot of users in the past 24 hours. To avoid spam, you can't contact any more users for now."
-    assert result == expected
-
-
-def test_get_string_fallback_to_english():
-    """Test that non-existent languages fall back to English"""
-    # Request in pt-BR which doesn't exist, should fall back to pt, then to en
-    result = get_raw_translation_string("pt-BR", "errors", "cant_write_reference_indicated_didnt_meetup")
-    expected = "You can't write a reference for that host request because you indicated that you didn't meet up."
-    assert result == expected
-
-
-def test_get_string_fallback_chain():
-    """Test language fallback chain works correctly"""
-    # Test pt-PT -> pt-BR -> en fallback chain
-    result = get_raw_translation_string("pt-PT", "errors", "user_not_found")
-    expected = "Couldn't find that user."
-    assert result == expected
-
-
-def test_get_string_missing():
-    """Test that missing strings raise MissingTranslationError"""
-    with pytest.raises(MissingTranslationError) as exc_info:
-        get_raw_translation_string("en", "errors", "nonexistent_string_key_12345")
-
-    assert exc_info.value.lang == "en"
-    assert exc_info.value.component == "errors"
-    assert exc_info.value.string_name == "nonexistent_string_key_12345"
-    assert "en.errors.nonexistent_string_key_12345" in str(exc_info.value)
-
-
-def test_get_string_missing_component():
-    """Test that missing components raise MissingTranslationError"""
-    with pytest.raises(MissingTranslationError) as exc_info:
-        get_raw_translation_string("en", "nonexistent_component", "some_string")
-
-    assert exc_info.value.lang == "en"
-    assert exc_info.value.component == "nonexistent_component"
-    assert exc_info.value.string_name == "some_string"
-    assert "en.nonexistent_component.some_string" in str(exc_info.value)
-
-
-def test_get_string_multiple_substitutions():
-    """Test string with multiple variable substitutions"""
-    # Using a string that exists, even though this particular one has only one substitution
-    result = get_raw_translation_string("en", "errors", "chat_initiation_rate_limit", substitutions={"hours": 48})
-    assert "48 hours" in result
-    assert "messaged a lot of users" in result
-
-
-def test_fallbacks():
-    """Test that en_CORP uses its custom translation"""
-    result = get_raw_translation_string("en_CORP", "errors", "account_not_found")
-    expected = "The requested account could not be located."
-    assert result == expected
-
-    # Verify it's different from the English version
-    result_en = get_raw_translation_string("en", "errors", "account_not_found")
-    assert result != result_en
-
-    # user_not_found is not translated in en_CORP, so it should fall back to en
-    result = get_raw_translation_string("en_CORP", "errors", "user_not_found")
-    expected = "Couldn't find that user."
-    assert result == expected
+    # Other languages should also exist
+    assert len(i18next.languages_by_code) > 1

--- a/app/backend/src/tests/test_i18next.py
+++ b/app/backend/src/tests/test_i18next.py
@@ -80,7 +80,7 @@ def test_fallback_locale():
     i18next = I18Next()
     en = i18next.add_language("en", PluralRules.en)
     en.add_string("greeting", "hello")
-    i18next.fallback_language = en
+    i18next.default_language = en
     assert i18next.localize("greeting", "fr") == "hello"
 
 

--- a/app/backend/src/tests/test_templates.py
+++ b/app/backend/src/tests/test_templates.py
@@ -21,24 +21,22 @@ def _render_template(
     translation_dict: dict,
     template_args: dict[str, Any] | None = None,
     plain: bool = False,
-    component: str = "component",
     lang: str = "en",
 ) -> str:
     template = _env.from_string(template_str)
     template_args = {
         **(template_args or {}),
         CONTEXT_TRANSLATION_LANGUAGE_KEY: lang,
-        CONTEXT_TRANSLATION_COMPONENT_KEY: component,
     }
     if plain:
         template_args[CONTEXT_PLAINTEXT_KEY] = True
 
-    with patch("couchers.i18n.i18n.get_translations", new=lambda: translation_dict):
+    with patch("couchers.i18n.i18n.get_i18next", new=lambda: translation_dict):
         return template.render(template_args)
 
 
 def _greeting_dict(value: str) -> dict:
-    return {"en": {"component": {"greeting": value}}}
+    return {"en": {"greeting": value}}
 
 
 def test_v2translate_no_substitutions() -> None:
@@ -52,7 +50,7 @@ def test_v2translate_multiple_languages() -> None:
     translated = _render_template(
         template_str='{{ "greeting"|v2translate }}',
         lang="fr",
-        translation_dict={"en": {"component": {"greeting": "Hello!"}}, "fr": {"component": {"greeting": "Bonjour!"}}},
+        translation_dict={"en": {"greeting": "Hello!"}, "fr": {"greeting": "Bonjour!"}},
     )
     assert translated == "Bonjour!"
 

--- a/app/backend/src/tests/test_templates.py
+++ b/app/backend/src/tests/test_templates.py
@@ -7,7 +7,6 @@ from jinja2 import Environment
 
 from couchers.templates.v2 import (
     CONTEXT_PLAINTEXT_KEY,
-    CONTEXT_TRANSLATION_COMPONENT_KEY,
     CONTEXT_TRANSLATION_LANGUAGE_KEY,
     add_filters,
 )

--- a/app/backend/src/tests/test_templates.py
+++ b/app/backend/src/tests/test_templates.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 
 from jinja2 import Environment
 
+from couchers.i18n.i18next import I18Next
+from couchers.i18n.plurals import PluralRules
 from couchers.templates.v2 import (
     CONTEXT_PLAINTEXT_KEY,
     CONTEXT_TRANSLATION_LANGUAGE_KEY,
@@ -30,7 +32,12 @@ def _render_template(
     if plain:
         template_args[CONTEXT_PLAINTEXT_KEY] = True
 
-    with patch("couchers.i18n.i18n.get_i18next", new=lambda: translation_dict):
+    mock_i18next = I18Next()
+    for lang_code, strings in translation_dict.items():
+        language = mock_i18next.add_language(lang_code, PluralRules.en)
+        language.load_json_dict(strings)
+
+    with patch("couchers.i18n.i18n.get_i18next", new=lambda: mock_i18next):
         return template.render(template_args)
 
 

--- a/app/backend/templates/v2/donation_received.mjml
+++ b/app/backend/templates/v2/donation_received.mjml
@@ -1,23 +1,23 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>{{ "dear_name"|v2translate(name=user.name) }}</mj-text>
-    <mj-text>{{ "donation_received_thanks_amount"|v2translate(amount=amount) }}</mj-text>
-    <mj-text>{{ "donation_received_purpose"|v2translate }}</mj-text>
-    <mj-text>{{ "donation_received_invoice_receipt_info"|v2translate }}</mj-text>
+    <mj-text>{{ "notifications.dear_name"|v2translate(name=user.name) }}</mj-text>
+    <mj-text>{{ "notifications.donation_received_thanks_amount"|v2translate(amount=amount) }}</mj-text>
+    <mj-text>{{ "notifications.donation_received_purpose"|v2translate }}</mj-text>
+    <mj-text>{{ "notifications.donation_received_invoice_receipt_info"|v2translate }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
     <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ receipt_url|v2url }}">
-      <b>{{ "donation_received_download_invoice"|v2translate }}</b>
+      <b>{{ "notifications.donation_received_download_invoice"|v2translate }}</b>
     </mj-button>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>{{ "donation_received_questions_contact"|v2translate }}</mj-text>
-    <mj-text>{{ "donation_received_generosity_helps"|v2translate }}</mj-text>
-    <mj-text><b>{{ "thank_you"|v2translate }}</b></mj-text>
-    <mj-text>{{ "founders_signature"|v2translate }}</mj-text>
+    <mj-text>{{ "notifications.donation_received_questions_contact"|v2translate }}</mj-text>
+    <mj-text>{{ "notifications.donation_received_generosity_helps"|v2translate }}</mj-text>
+    <mj-text><b>{{ "notifications.thank_you"|v2translate }}</b></mj-text>
+    <mj-text>{{ "notifications.founders_signature"|v2translate }}</mj-text>
   </mj-column>
 </mj-section>

--- a/app/backend/templates/v2/donation_received.txt
+++ b/app/backend/templates/v2/donation_received.txt
@@ -1,19 +1,19 @@
-{{ "dear_name"|v2translate(name=user.name) }}
+{{ "notifications.dear_name"|v2translate(name=user.name) }}
 
-{{ "donation_received_thanks_amount"|v2translate(amount=amount) }}
+{{ "notifications.donation_received_thanks_amount"|v2translate(amount=amount) }}
 
-{{ "donation_received_purpose"|v2translate }}
+{{ "notifications.donation_received_purpose"|v2translate }}
 
 
-{{ "donation_received_invoice_receipt_info"|v2translate }}
+{{ "notifications.donation_received_invoice_receipt_info"|v2translate }}
 
 <{{ receipt_url }}>
 
-{{ "donation_received_questions_contact"|v2translate }}
+{{ "notifications.donation_received_questions_contact"|v2translate }}
 
-{{ "donation_received_generosity_helps"|v2translate }}
+{{ "notifications.donation_received_generosity_helps"|v2translate }}
 
 
-{{ "thank_you"|v2translate }}
+{{ "notifications.thank_you"|v2translate }}
 
-{{ "founders_signature"|v2translate }}
+{{ "notifications.founders_signature"|v2translate }}

--- a/app/backend/templates/v2/generated_html/donation_received.html
+++ b/app/backend/templates/v2/generated_html/donation_received.html
@@ -167,22 +167,22 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "dear_name"|v2translate(name=user.name) }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.dear_name"|v2translate(name=user.name) }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "donation_received_thanks_amount"|v2translate(amount=amount) }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received_thanks_amount"|v2translate(amount=amount) }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "donation_received_purpose"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received_purpose"|v2translate }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "donation_received_invoice_receipt_info"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received_invoice_receipt_info"|v2translate }}</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -211,7 +211,7 @@
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
                                           <a href="{{ receipt_url|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
-                                            <b>{{ "donation_received_download_invoice"|v2translate }}</b>
+                                            <b>{{ "notifications.donation_received_download_invoice"|v2translate }}</b>
                                           </a>
                                         </td>
                                       </tr>
@@ -240,22 +240,22 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "donation_received_questions_contact"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received_questions_contact"|v2translate }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "donation_received_generosity_helps"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received_generosity_helps"|v2translate }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ "thank_you"|v2translate }}</b></div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ "notifications.thank_you"|v2translate }}</b></div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "founders_signature"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.founders_signature"|v2translate }}</div>
                                 </td>
                               </tr>
                             </tbody>


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
- Switches to the i18next implementation for https://github.com/Couchers-org/couchers/pull/7475 which supports nested keys and pluralization.
- Removes the "component" argument in favor of '.'-delimited composite keys.
- Rename `get_raw_translation_string` to `localize_string` since "raw" seems to imply that substitutions aren't applied, and it standardizes terminology on "localize" instead of "translation" (both are fine, just for consistency)
- Removes most `get_raw_translation_string` tests since those are now covered at a more unit level in `test_i18next.py`, keeping only one test that validates the strings are loaded correctly.
- Update email template translation to specify the full key.

This is a prerequisite for translating emails, which will make use of nested string keys.

Fixes #7465

**Please give clear steps for how the reviewer can best test this PR**
Validate any translated string coming from the backend, for example badge descriptions or running test_email.py.

<img width="721" height="444" alt="image" src="https://github.com/user-attachments/assets/3a692775-3647-4f8f-b978-814168fcdfbb" />

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A

**Backend checklist**
- [x] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)