### PR TITLE
Specify Ruff formatter for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
     "editor.formatOnSave": false,
     "editor.formatOnPaste": false,
     "editor.formatOnType": false,
-    "editor.defaultFormatter": null
+    "editor.defaultFormatter": "charliermarsh.ruff"
   },
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
Instructs VSCode to use the [Ruff extension](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff) when invoking the "Format Document" command, such that the result is consistent with running `make format`. This doesn't activate auto-formatting, just makes sure VSCode won't use a different formatter.

**Please give clear steps for how the reviewer can best test this PR**
Mess with formatting and then use the "Format Document" command.

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A

**Backend checklist**
Do not apply
- [ ] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)