### PR TITLE
Implement remaining i18n plural rules on the backend

### DIFF
--- a/app/backend/src/couchers/i18n/plurals.py
+++ b/app/backend/src/couchers/i18n/plurals.py
@@ -30,14 +30,26 @@ class PluralRules:
     Implements Unicode CLDR language rules for known languages.
     See https://www.unicode.org/cldr/charts/48/supplemental/language_plural_rules.html
     """
+    _by_lang_family: dict[str, PluralRule] = {} # Populated below
 
     @staticmethod
     def for_language(lang: str) -> PluralRule | None:
         separator_index = lang.find("-")
         lang_family = lang if separator_index == -1 else lang[0:separator_index]
+        return PluralRules._by_lang_family.get(lang_family)
 
-        # Resolve one of the methods below
-        return getattr(PluralRules, lang_family, None)
+    @staticmethod
+    def ca(count: int) -> PluralCategory:
+        return PluralRules.es(count)  # Same as ES
+
+    @staticmethod
+    def cs(count: int) -> PluralCategory:
+        count = abs(count)
+        if count == 1:
+            return PluralCategory.ONE
+        if count >= 2 and count <= 4:
+            return PluralCategory.FEW
+        return PluralCategory.OTHER
 
     @staticmethod
     def de(count: int) -> PluralCategory:
@@ -57,7 +69,6 @@ class PluralRules:
             return PluralCategory.ONE  # 1 manzana
         if count > 0 and count % 1_000_000 == 0:
             return PluralCategory.MANY  # 1000000 de manzanas
-
         return PluralCategory.OTHER  # 2 manzanas
 
     @staticmethod
@@ -69,6 +80,47 @@ class PluralRules:
             return PluralCategory.MANY  # 1000000 de pommes
 
         return PluralCategory.OTHER  # 2 pommes
+
+    @staticmethod
+    def he(count: int) -> PluralCategory:
+        count = abs(count)
+        if count == 1:
+            return PluralCategory.ONE
+        if count == 2:
+            return PluralCategory.TWO
+        return PluralCategory.OTHER
+
+    @staticmethod
+    def hi(count: int) -> PluralCategory:
+        count = abs(count)
+        if count <= 1:
+            return PluralCategory.ONE
+        return PluralCategory.OTHER
+
+    @staticmethod
+    def hu(count: int) -> PluralCategory:
+        return PluralRules.en(count)  # Same as EN
+
+    @staticmethod
+    def it(count: int) -> PluralCategory:
+        return PluralRules.es(count)  # Same as ES
+
+    @staticmethod
+    def ja(count: int) -> PluralCategory:
+        return PluralCategory.OTHER
+
+    @staticmethod
+    def nl(count: int) -> PluralCategory:
+        return PluralRules.en(count)  # Same as EN
+
+    @staticmethod
+    def pl(count: int) -> PluralCategory:
+        count = abs(count)
+        if count == 1:
+            return PluralCategory.ONE
+        if count % 10 in range(2, 5) and count % 100 not in range(12, 15):
+            return PluralCategory.FEW
+        return PluralCategory.MANY  # "Other" is reserved for decimals
 
     @staticmethod
     def pt(count: int) -> PluralCategory:
@@ -84,3 +136,25 @@ class PluralRules:
         elif count % 10 == 0 or count % 10 >= 5 or count % 100 in range(11, 15):
             return PluralCategory.MANY
         return PluralCategory.OTHER
+
+    @staticmethod
+    def sv(count: int) -> PluralCategory:
+        return PluralRules.en(count)  # Same as EN
+
+    @staticmethod
+    def tr(count: int) -> PluralCategory:
+        return PluralRules.en(count)  # Same as EN
+
+    @staticmethod
+    def uk(count: int) -> PluralCategory:
+        return PluralRules.ru(count)  # Same as RU
+
+    @staticmethod
+    def zh(count: int) -> PluralCategory:
+        return PluralCategory.OTHER
+
+# Populate PluralRules lookup table
+for method_name in dir(PluralRules):
+    if len(method_name) == 2:
+        method: PluralRule = getattr(PluralRules, method_name)
+        PluralRules._by_lang_family[method_name] = method

--- a/app/backend/src/couchers/i18n/plurals.py
+++ b/app/backend/src/couchers/i18n/plurals.py
@@ -30,7 +30,8 @@ class PluralRules:
     Implements Unicode CLDR language rules for known languages.
     See https://www.unicode.org/cldr/charts/48/supplemental/language_plural_rules.html
     """
-    _by_lang_family: dict[str, PluralRule] = {} # Populated below
+
+    _by_lang_family: dict[str, PluralRule] = {}  # Populated below
 
     @staticmethod
     def for_language(lang: str) -> PluralRule | None:
@@ -152,6 +153,7 @@ class PluralRules:
     @staticmethod
     def zh(count: int) -> PluralCategory:
         return PluralCategory.OTHER
+
 
 # Populate PluralRules lookup table
 for method_name in dir(PluralRules):

--- a/app/backend/src/couchers/i18n/plurals.py
+++ b/app/backend/src/couchers/i18n/plurals.py
@@ -31,20 +31,21 @@ class PluralRules:
     See https://www.unicode.org/cldr/charts/48/supplemental/language_plural_rules.html
     """
 
-    _by_lang_family: dict[str, PluralRule] = {}  # Populated below
-
     @staticmethod
     def for_language(lang: str) -> PluralRule | None:
         separator_index = lang.find("-")
         lang_family = lang if separator_index == -1 else lang[0:separator_index]
-        return PluralRules._by_lang_family.get(lang_family)
+        # Look up one of the plural rule functions defined below
+        return getattr(PluralRules, lang_family, None)
 
     @staticmethod
     def ca(count: int) -> PluralCategory:
+        """Gets the Catalan plural category for a given count."""
         return PluralRules.es(count)  # Same as ES
 
     @staticmethod
     def cs(count: int) -> PluralCategory:
+        """Gets the Czech plural category for a given count."""
         count = abs(count)
         if count == 1:
             return PluralCategory.ONE
@@ -54,10 +55,12 @@ class PluralRules:
 
     @staticmethod
     def de(count: int) -> PluralCategory:
+        """Gets the German plural category for a given count."""
         return PluralRules.en(count)  # Same as EN
 
     @staticmethod
     def en(count: int) -> PluralCategory:
+        """Gets the English plural category for a given count."""
         count = abs(count)
         if count == 1:
             return PluralCategory.ONE  # 1 apple
@@ -65,6 +68,7 @@ class PluralRules:
 
     @staticmethod
     def es(count: int) -> PluralCategory:
+        """Gets the Spanish plural category for a given count."""
         count = abs(count)
         if count == 1:
             return PluralCategory.ONE  # 1 manzana
@@ -74,6 +78,7 @@ class PluralRules:
 
     @staticmethod
     def fr(count: int) -> PluralCategory:
+        """Gets the French plural category for a given count."""
         count = abs(count)
         if count == 0 or count == 1:
             return PluralCategory.ONE  # 0 pomme, 1 pomme
@@ -84,6 +89,7 @@ class PluralRules:
 
     @staticmethod
     def he(count: int) -> PluralCategory:
+        """Gets the Hebrew plural category for a given count."""
         count = abs(count)
         if count == 1:
             return PluralCategory.ONE
@@ -93,6 +99,7 @@ class PluralRules:
 
     @staticmethod
     def hi(count: int) -> PluralCategory:
+        """Gets the Hindi plural category for a given count."""
         count = abs(count)
         if count <= 1:
             return PluralCategory.ONE
@@ -100,22 +107,27 @@ class PluralRules:
 
     @staticmethod
     def hu(count: int) -> PluralCategory:
+        """Gets the Hungarian plural category for a given count."""
         return PluralRules.en(count)  # Same as EN
 
     @staticmethod
     def it(count: int) -> PluralCategory:
+        """Gets the Italian plural category for a given count."""
         return PluralRules.es(count)  # Same as ES
 
     @staticmethod
     def ja(count: int) -> PluralCategory:
+        """Gets the Japanese plural category for a given count."""
         return PluralCategory.OTHER
 
     @staticmethod
     def nl(count: int) -> PluralCategory:
+        """Gets the Dutch plural category for a given count."""
         return PluralRules.en(count)  # Same as EN
 
     @staticmethod
     def pl(count: int) -> PluralCategory:
+        """Gets the Polish plural category for a given count."""
         count = abs(count)
         if count == 1:
             return PluralCategory.ONE
@@ -125,10 +137,12 @@ class PluralRules:
 
     @staticmethod
     def pt(count: int) -> PluralCategory:
+        """Gets the Portuguese plural category for a given count."""
         return PluralRules.fr(count)  # Same as FR
 
     @staticmethod
     def ru(count: int) -> PluralCategory:
+        """Gets the Russian plural category for a given count."""
         count = abs(count)
         if count % 10 == 1 and count % 100 != 11:
             return PluralCategory.ONE
@@ -140,23 +154,20 @@ class PluralRules:
 
     @staticmethod
     def sv(count: int) -> PluralCategory:
+        """Gets the Swedish plural category for a given count."""
         return PluralRules.en(count)  # Same as EN
 
     @staticmethod
     def tr(count: int) -> PluralCategory:
+        """Gets the Turkish plural category for a given count."""
         return PluralRules.en(count)  # Same as EN
 
     @staticmethod
     def uk(count: int) -> PluralCategory:
+        """Gets the Ukrainian plural category for a given count."""
         return PluralRules.ru(count)  # Same as RU
 
     @staticmethod
     def zh(count: int) -> PluralCategory:
+        """Gets the Chinese plural category for a given count."""
         return PluralCategory.OTHER
-
-
-# Populate PluralRules lookup table
-for method_name in dir(PluralRules):
-    if len(method_name) == 2:
-        method: PluralRule = getattr(PluralRules, method_name)
-        PluralRules._by_lang_family[method_name] = method


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
Adds plural rules for remaining supported languages, for string pluralization support, based on [Unicode rules](https://www.unicode.org/cldr/charts/48/supplemental/language_plural_rules.html). See also #7475

**Please give clear steps for how the reviewer can best test this PR**
Compare with reference implementations on https://www.unicode.org/cldr/charts/48/supplemental/language_plural_rules.html

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A

**Backend checklist**
- [x] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)