### PR TITLE
Refactor bg job registration to be type-safe

### DIFF
--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -101,11 +101,6 @@ extra-standard-library = ["zoneinfo"]
 strict = true
 
 [[tool.mypy.overrides]]
-module = ["couchers.jobs.handlers"]
-# This file has many type errors that need to be fixed separately
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = ["couchers.proto.*"]
 # Generated protobuf files should not be type-checked
 ignore_errors = true

--- a/app/backend/src/couchers/email/__init__.py
+++ b/app/backend/src/couchers/email/__init__.py
@@ -28,6 +28,9 @@ def _queue_email(
     list_unsubscribe_header: str | None,
     source_data: str | None,
 ) -> None:
+    # Import here to avoid circular dependency
+    from couchers.jobs.handlers import send_email
+
     payload = jobs_pb2.SendEmailPayload(
         sender_name=sender_name,
         sender_email=sender_email,
@@ -40,7 +43,7 @@ def _queue_email(
     )
     queue_job(
         session,
-        job_type="send_email",
+        job=send_email,
         payload=payload,
         priority=5,
     )

--- a/app/backend/src/couchers/jobs/definitions.py
+++ b/app/backend/src/couchers/jobs/definitions.py
@@ -53,64 +53,67 @@ class Job:
     schedule: timedelta | None = None
 
 
-# Job registry - maps job names to job definitions
-JOBS: dict[str, Job] = {
-    "handle_notification": Job(handle_notification, jobs_pb2.HandleNotificationPayload),
-    "send_raw_push_notification_v2": Job(send_raw_push_notification_v2, jobs_pb2.SendRawPushNotificationPayloadV2),
-    "handle_email_digests": Job(handle_email_digests, schedule=timedelta(minutes=15)),
-    "generate_message_notifications": Job(
+# Job registry - first create a list of all jobs
+_JOBS_LIST = [
+    Job(handle_notification, jobs_pb2.HandleNotificationPayload),
+    Job(send_raw_push_notification_v2, jobs_pb2.SendRawPushNotificationPayloadV2),
+    Job(handle_email_digests, schedule=timedelta(minutes=15)),
+    Job(
         generate_message_notifications,
         jobs_pb2.GenerateMessageNotificationsPayload,
     ),
-    "generate_reply_notifications": Job(generate_reply_notifications, jobs_pb2.GenerateReplyNotificationsPayload),
-    "generate_create_discussion_notifications": Job(
+    Job(generate_reply_notifications, jobs_pb2.GenerateReplyNotificationsPayload),
+    Job(
         generate_create_discussion_notifications,
         jobs_pb2.GenerateCreateDiscussionNotificationsPayload,
     ),
-    "generate_event_create_notifications": Job(
+    Job(
         generate_event_create_notifications,
         jobs_pb2.GenerateEventCreateNotificationsPayload,
     ),
-    "generate_event_update_notifications": Job(
+    Job(
         generate_event_update_notifications,
         jobs_pb2.GenerateEventUpdateNotificationsPayload,
     ),
-    "generate_event_cancel_notifications": Job(
+    Job(
         generate_event_cancel_notifications,
         jobs_pb2.GenerateEventCancelNotificationsPayload,
     ),
-    "generate_event_delete_notifications": Job(
+    Job(
         generate_event_delete_notifications,
         jobs_pb2.GenerateEventDeleteNotificationsPayload,
     ),
-    "generate_new_blog_post_notifications": Job(
+    Job(
         generate_new_blog_post_notifications,
         jobs_pb2.GenerateNewBlogPostNotificationsPayload,
     ),
-    "refresh_materialized_views": Job(refresh_materialized_views, schedule=timedelta(minutes=5)),
-    "refresh_materialized_views_rapid": Job(refresh_materialized_views_rapid, schedule=timedelta(seconds=30)),
-    "send_email": Job(send_email, jobs_pb2.SendEmailPayload),
-    "purge_login_tokens": Job(purge_login_tokens, schedule=timedelta(hours=24)),
-    "purge_password_reset_tokens": Job(purge_password_reset_tokens, schedule=timedelta(hours=24)),
-    "purge_account_deletion_tokens": Job(purge_account_deletion_tokens, schedule=timedelta(hours=24)),
-    "send_message_notifications": Job(send_message_notifications, schedule=timedelta(minutes=3)),
-    "send_request_notifications": Job(send_request_notifications, schedule=timedelta(minutes=3)),
-    "send_onboarding_emails": Job(send_onboarding_emails, schedule=timedelta(hours=1)),
-    "send_reference_reminders": Job(send_reference_reminders, schedule=timedelta(hours=1)),
-    "send_host_request_reminders": Job(send_host_request_reminders, schedule=timedelta(minutes=15)),
-    "add_users_to_email_list": Job(add_users_to_email_list, schedule=timedelta(hours=1)),
-    "enforce_community_membership": Job(enforce_community_membership, schedule=timedelta(minutes=15)),
-    "update_recommendation_scores": Job(update_recommendation_scores, schedule=timedelta(hours=24)),
-    "update_badges": Job(update_badges, schedule=timedelta(minutes=15)),
-    "finalize_strong_verification": Job(finalize_strong_verification, jobs_pb2.FinalizeStrongVerificationPayload),
-    "send_activeness_probes": Job(send_activeness_probes, schedule=timedelta(minutes=60)),
-    "update_randomized_locations": Job(update_randomized_locations, schedule=timedelta(hours=1)),
-    "send_event_reminders": Job(send_event_reminders, schedule=timedelta(hours=1)),
-    "check_expo_push_receipts": Job(check_expo_push_receipts, schedule=timedelta(minutes=5)),
-    "send_postal_verification_postcard": Job(
+    Job(refresh_materialized_views, schedule=timedelta(minutes=5)),
+    Job(refresh_materialized_views_rapid, schedule=timedelta(seconds=30)),
+    Job(send_email, jobs_pb2.SendEmailPayload),
+    Job(purge_login_tokens, schedule=timedelta(hours=24)),
+    Job(purge_password_reset_tokens, schedule=timedelta(hours=24)),
+    Job(purge_account_deletion_tokens, schedule=timedelta(hours=24)),
+    Job(send_message_notifications, schedule=timedelta(minutes=3)),
+    Job(send_request_notifications, schedule=timedelta(minutes=3)),
+    Job(send_onboarding_emails, schedule=timedelta(hours=1)),
+    Job(send_reference_reminders, schedule=timedelta(hours=1)),
+    Job(send_host_request_reminders, schedule=timedelta(minutes=15)),
+    Job(add_users_to_email_list, schedule=timedelta(hours=1)),
+    Job(enforce_community_membership, schedule=timedelta(minutes=15)),
+    Job(update_recommendation_scores, schedule=timedelta(hours=24)),
+    Job(update_badges, schedule=timedelta(minutes=15)),
+    Job(finalize_strong_verification, jobs_pb2.FinalizeStrongVerificationPayload),
+    Job(send_activeness_probes, schedule=timedelta(minutes=60)),
+    Job(update_randomized_locations, schedule=timedelta(hours=1)),
+    Job(send_event_reminders, schedule=timedelta(hours=1)),
+    Job(check_expo_push_receipts, schedule=timedelta(minutes=5)),
+    Job(
         send_postal_verification_postcard,
         jobs_pb2.SendPostalVerificationPostcardPayload,
     ),
-    "check_database_consistency": Job(check_database_consistency, schedule=timedelta(hours=24)),
-    "auto_approve_moderation_queue": Job(auto_approve_moderation_queue, schedule=timedelta(seconds=15)),
-}
+    Job(check_database_consistency, schedule=timedelta(hours=24)),
+    Job(auto_approve_moderation_queue, schedule=timedelta(seconds=15)),
+]
+
+# Map job names to job definitions
+JOBS: dict[str, Job] = {job.handler.__name__: job for job in _JOBS_LIST}

--- a/app/backend/src/couchers/jobs/definitions.py
+++ b/app/backend/src/couchers/jobs/definitions.py
@@ -1,9 +1,6 @@
-from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Any
-
-from google.protobuf import empty_pb2
+from typing import Any, Protocol, cast, get_type_hints
 
 from couchers.jobs.handlers import (
     add_users_to_email_list,
@@ -31,7 +28,6 @@ from couchers.jobs.handlers import (
 from couchers.materialized_views import refresh_materialized_views, refresh_materialized_views_rapid
 from couchers.notifications.background import handle_email_digests, handle_notification
 from couchers.notifications.send_raw_push_notification import send_raw_push_notification_v2
-from couchers.proto.internal import jobs_pb2
 from couchers.servicers.conversations import generate_message_notifications
 from couchers.servicers.discussions import generate_create_discussion_notifications
 from couchers.servicers.editor import generate_new_blog_post_notifications
@@ -44,52 +40,46 @@ from couchers.servicers.events import (
 from couchers.servicers.threads import generate_reply_notifications
 
 
+class JobHandler[T](Protocol):
+    def __call__(self, payload: T) -> None: ...
+
+    @property
+    def __name__(self) -> str: ...
+
+
 @dataclass(frozen=True, slots=True)
-class Job:
+class Job[T]:
     """Definition of a background job."""
 
-    handler: Callable[..., Any]
-    payload_type: Any = empty_pb2.Empty
+    handler: JobHandler[T]
     schedule: timedelta | None = None
 
+    @property
+    def name(self) -> str:
+        return self.handler.__name__
 
-# Job registry - first create a list of all jobs
+    @property
+    def payload_type(self) -> type[T]:
+        """Extracts protobuf type from type hints."""
+        return cast(type[T], get_type_hints(self.handler)["payload"])
+
+
+# Job registry - first create a list of all jobs.
 _JOBS_LIST = [
-    Job(handle_notification, jobs_pb2.HandleNotificationPayload),
-    Job(send_raw_push_notification_v2, jobs_pb2.SendRawPushNotificationPayloadV2),
+    Job(handle_notification),
+    Job(send_raw_push_notification_v2),
     Job(handle_email_digests, schedule=timedelta(minutes=15)),
-    Job(
-        generate_message_notifications,
-        jobs_pb2.GenerateMessageNotificationsPayload,
-    ),
-    Job(generate_reply_notifications, jobs_pb2.GenerateReplyNotificationsPayload),
-    Job(
-        generate_create_discussion_notifications,
-        jobs_pb2.GenerateCreateDiscussionNotificationsPayload,
-    ),
-    Job(
-        generate_event_create_notifications,
-        jobs_pb2.GenerateEventCreateNotificationsPayload,
-    ),
-    Job(
-        generate_event_update_notifications,
-        jobs_pb2.GenerateEventUpdateNotificationsPayload,
-    ),
-    Job(
-        generate_event_cancel_notifications,
-        jobs_pb2.GenerateEventCancelNotificationsPayload,
-    ),
-    Job(
-        generate_event_delete_notifications,
-        jobs_pb2.GenerateEventDeleteNotificationsPayload,
-    ),
-    Job(
-        generate_new_blog_post_notifications,
-        jobs_pb2.GenerateNewBlogPostNotificationsPayload,
-    ),
+    Job(generate_message_notifications),
+    Job(generate_reply_notifications),
+    Job(generate_create_discussion_notifications),
+    Job(generate_event_create_notifications),
+    Job(generate_event_update_notifications),
+    Job(generate_event_cancel_notifications),
+    Job(generate_event_delete_notifications),
+    Job(generate_new_blog_post_notifications),
     Job(refresh_materialized_views, schedule=timedelta(minutes=5)),
     Job(refresh_materialized_views_rapid, schedule=timedelta(seconds=30)),
-    Job(send_email, jobs_pb2.SendEmailPayload),
+    Job(send_email),
     Job(purge_login_tokens, schedule=timedelta(hours=24)),
     Job(purge_password_reset_tokens, schedule=timedelta(hours=24)),
     Job(purge_account_deletion_tokens, schedule=timedelta(hours=24)),
@@ -102,18 +92,15 @@ _JOBS_LIST = [
     Job(enforce_community_membership, schedule=timedelta(minutes=15)),
     Job(update_recommendation_scores, schedule=timedelta(hours=24)),
     Job(update_badges, schedule=timedelta(minutes=15)),
-    Job(finalize_strong_verification, jobs_pb2.FinalizeStrongVerificationPayload),
+    Job(finalize_strong_verification),
     Job(send_activeness_probes, schedule=timedelta(minutes=60)),
     Job(update_randomized_locations, schedule=timedelta(hours=1)),
     Job(send_event_reminders, schedule=timedelta(hours=1)),
     Job(check_expo_push_receipts, schedule=timedelta(minutes=5)),
-    Job(
-        send_postal_verification_postcard,
-        jobs_pb2.SendPostalVerificationPostcardPayload,
-    ),
+    Job(send_postal_verification_postcard),
     Job(check_database_consistency, schedule=timedelta(hours=24)),
     Job(auto_approve_moderation_queue, schedule=timedelta(seconds=15)),
 ]
 
 # Map job names to job definitions
-JOBS: dict[str, Job] = {job.handler.__name__: job for job in _JOBS_LIST}
+JOBS: dict[str, Job[Any]] = {job.name: job for job in cast(list[Job[Any]], _JOBS_LIST)}

--- a/app/backend/src/couchers/jobs/definitions.py
+++ b/app/backend/src/couchers/jobs/definitions.py
@@ -1,0 +1,116 @@
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
+
+from google.protobuf import empty_pb2
+
+from couchers.jobs.handlers import (
+    add_users_to_email_list,
+    auto_approve_moderation_queue,
+    check_database_consistency,
+    check_expo_push_receipts,
+    enforce_community_membership,
+    finalize_strong_verification,
+    purge_account_deletion_tokens,
+    purge_login_tokens,
+    purge_password_reset_tokens,
+    send_activeness_probes,
+    send_email,
+    send_event_reminders,
+    send_host_request_reminders,
+    send_message_notifications,
+    send_onboarding_emails,
+    send_postal_verification_postcard,
+    send_reference_reminders,
+    send_request_notifications,
+    update_badges,
+    update_randomized_locations,
+    update_recommendation_scores,
+)
+from couchers.materialized_views import refresh_materialized_views, refresh_materialized_views_rapid
+from couchers.notifications.background import handle_email_digests, handle_notification
+from couchers.notifications.send_raw_push_notification import send_raw_push_notification_v2
+from couchers.proto.internal import jobs_pb2
+from couchers.servicers.conversations import generate_message_notifications
+from couchers.servicers.discussions import generate_create_discussion_notifications
+from couchers.servicers.editor import generate_new_blog_post_notifications
+from couchers.servicers.events import (
+    generate_event_cancel_notifications,
+    generate_event_create_notifications,
+    generate_event_delete_notifications,
+    generate_event_update_notifications,
+)
+from couchers.servicers.threads import generate_reply_notifications
+
+
+@dataclass(frozen=True, slots=True)
+class Job:
+    """Definition of a background job."""
+
+    handler: Callable[..., Any]
+    payload_type: Any = empty_pb2.Empty
+    schedule: timedelta | None = None
+
+
+# Job registry - maps job names to job definitions
+JOBS: dict[str, Job] = {
+    "handle_notification": Job(handle_notification, jobs_pb2.HandleNotificationPayload),
+    "send_raw_push_notification_v2": Job(send_raw_push_notification_v2, jobs_pb2.SendRawPushNotificationPayloadV2),
+    "handle_email_digests": Job(handle_email_digests, schedule=timedelta(minutes=15)),
+    "generate_message_notifications": Job(
+        generate_message_notifications,
+        jobs_pb2.GenerateMessageNotificationsPayload,
+    ),
+    "generate_reply_notifications": Job(generate_reply_notifications, jobs_pb2.GenerateReplyNotificationsPayload),
+    "generate_create_discussion_notifications": Job(
+        generate_create_discussion_notifications,
+        jobs_pb2.GenerateCreateDiscussionNotificationsPayload,
+    ),
+    "generate_event_create_notifications": Job(
+        generate_event_create_notifications,
+        jobs_pb2.GenerateEventCreateNotificationsPayload,
+    ),
+    "generate_event_update_notifications": Job(
+        generate_event_update_notifications,
+        jobs_pb2.GenerateEventUpdateNotificationsPayload,
+    ),
+    "generate_event_cancel_notifications": Job(
+        generate_event_cancel_notifications,
+        jobs_pb2.GenerateEventCancelNotificationsPayload,
+    ),
+    "generate_event_delete_notifications": Job(
+        generate_event_delete_notifications,
+        jobs_pb2.GenerateEventDeleteNotificationsPayload,
+    ),
+    "generate_new_blog_post_notifications": Job(
+        generate_new_blog_post_notifications,
+        jobs_pb2.GenerateNewBlogPostNotificationsPayload,
+    ),
+    "refresh_materialized_views": Job(refresh_materialized_views, schedule=timedelta(minutes=5)),
+    "refresh_materialized_views_rapid": Job(refresh_materialized_views_rapid, schedule=timedelta(seconds=30)),
+    "send_email": Job(send_email, jobs_pb2.SendEmailPayload),
+    "purge_login_tokens": Job(purge_login_tokens, schedule=timedelta(hours=24)),
+    "purge_password_reset_tokens": Job(purge_password_reset_tokens, schedule=timedelta(hours=24)),
+    "purge_account_deletion_tokens": Job(purge_account_deletion_tokens, schedule=timedelta(hours=24)),
+    "send_message_notifications": Job(send_message_notifications, schedule=timedelta(minutes=3)),
+    "send_request_notifications": Job(send_request_notifications, schedule=timedelta(minutes=3)),
+    "send_onboarding_emails": Job(send_onboarding_emails, schedule=timedelta(hours=1)),
+    "send_reference_reminders": Job(send_reference_reminders, schedule=timedelta(hours=1)),
+    "send_host_request_reminders": Job(send_host_request_reminders, schedule=timedelta(minutes=15)),
+    "add_users_to_email_list": Job(add_users_to_email_list, schedule=timedelta(hours=1)),
+    "enforce_community_membership": Job(enforce_community_membership, schedule=timedelta(minutes=15)),
+    "update_recommendation_scores": Job(update_recommendation_scores, schedule=timedelta(hours=24)),
+    "update_badges": Job(update_badges, schedule=timedelta(minutes=15)),
+    "finalize_strong_verification": Job(finalize_strong_verification, jobs_pb2.FinalizeStrongVerificationPayload),
+    "send_activeness_probes": Job(send_activeness_probes, schedule=timedelta(minutes=60)),
+    "update_randomized_locations": Job(update_randomized_locations, schedule=timedelta(hours=1)),
+    "send_event_reminders": Job(send_event_reminders, schedule=timedelta(hours=1)),
+    "check_expo_push_receipts": Job(check_expo_push_receipts, schedule=timedelta(minutes=5)),
+    "send_postal_verification_postcard": Job(
+        send_postal_verification_postcard,
+        jobs_pb2.SendPostalVerificationPostcardPayload,
+    ),
+    "check_database_consistency": Job(check_database_consistency, schedule=timedelta(hours=24)),
+    "auto_approve_moderation_queue": Job(auto_approve_moderation_queue, schedule=timedelta(seconds=15)),
+}

--- a/app/backend/src/couchers/jobs/enqueue.py
+++ b/app/backend/src/couchers/jobs/enqueue.py
@@ -3,8 +3,9 @@ Background jobs
 """
 
 import logging
+from collections.abc import Callable
 
-from google.protobuf.message import Message
+import google.protobuf.message
 from sqlalchemy.orm import Session
 
 from couchers.models import BackgroundJob
@@ -12,16 +13,16 @@ from couchers.models import BackgroundJob
 logger = logging.getLogger(__name__)
 
 
-def queue_job(
+def queue_job[T: google.protobuf.message.Message](
     session: Session,
-    job_type: str,
-    payload: Message,
+    job: Callable[[T], None],
+    payload: T,
     max_tries: int | None = None,
     priority: int | None = None,
 ) -> None:
     session.add(
         BackgroundJob(
-            job_type=job_type,
+            job_type=job.__name__,
             payload=payload.SerializeToString(),
             max_tries=max_tries,
             priority=priority,

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -3,14 +3,16 @@ Background job servicers
 """
 
 import logging
+from collections.abc import Sequence
 from datetime import date, timedelta
 from math import cos, pi, sin, sqrt
 from random import sample
 from typing import Any
+from typing import cast as t_cast
 
 import requests
 from google.protobuf import empty_pb2
-from sqlalchemy import Float, Integer, select
+from sqlalchemy import ColumnElement, Float, Function, Integer, Table, select
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import (
     and_,
@@ -134,41 +136,11 @@ from couchers.utils import (
     Timestamp_from_datetime,
     create_coordinate,
     get_coordinates,
+    not_none,
     now,
 )
 
 logger = logging.getLogger(__name__)
-
-
-# these were straight up imported
-handle_notification.PAYLOAD = jobs_pb2.HandleNotificationPayload
-
-send_raw_push_notification_v2.PAYLOAD = jobs_pb2.SendRawPushNotificationPayloadV2
-
-handle_email_digests.PAYLOAD = empty_pb2.Empty
-handle_email_digests.SCHEDULE = timedelta(minutes=15)
-
-generate_message_notifications.PAYLOAD = jobs_pb2.GenerateMessageNotificationsPayload
-
-generate_reply_notifications.PAYLOAD = jobs_pb2.GenerateReplyNotificationsPayload
-
-generate_create_discussion_notifications.PAYLOAD = jobs_pb2.GenerateCreateDiscussionNotificationsPayload
-
-generate_event_create_notifications.PAYLOAD = jobs_pb2.GenerateEventCreateNotificationsPayload
-
-generate_event_update_notifications.PAYLOAD = jobs_pb2.GenerateEventUpdateNotificationsPayload
-
-generate_event_cancel_notifications.PAYLOAD = jobs_pb2.GenerateEventCancelNotificationsPayload
-
-generate_event_delete_notifications.PAYLOAD = jobs_pb2.GenerateEventDeleteNotificationsPayload
-
-generate_new_blog_post_notifications.PAYLOAD = jobs_pb2.GenerateNewBlogPostNotificationsPayload
-
-refresh_materialized_views.PAYLOAD = empty_pb2.Empty
-refresh_materialized_views.SCHEDULE = timedelta(minutes=5)
-
-refresh_materialized_views_rapid.PAYLOAD = empty_pb2.Empty
-refresh_materialized_views_rapid.SCHEDULE = timedelta(seconds=30)
 
 
 def send_email(payload: jobs_pb2.SendEmailPayload) -> None:
@@ -190,17 +162,10 @@ def send_email(payload: jobs_pb2.SendEmailPayload) -> None:
         session.add(email)
 
 
-send_email.PAYLOAD = jobs_pb2.SendEmailPayload
-
-
 def purge_login_tokens(payload: empty_pb2.Empty) -> None:
     logger.info("Purging login tokens")
     with session_scope() as session:
         session.execute(delete(LoginToken).where(~LoginToken.is_valid).execution_options(synchronize_session=False))
-
-
-purge_login_tokens.PAYLOAD = empty_pb2.Empty
-purge_login_tokens.SCHEDULE = timedelta(hours=24)
 
 
 def purge_password_reset_tokens(payload: empty_pb2.Empty) -> None:
@@ -211,10 +176,6 @@ def purge_password_reset_tokens(payload: empty_pb2.Empty) -> None:
         )
 
 
-purge_password_reset_tokens.PAYLOAD = empty_pb2.Empty
-purge_password_reset_tokens.SCHEDULE = timedelta(hours=24)
-
-
 def purge_account_deletion_tokens(payload: empty_pb2.Empty) -> None:
     logger.info("Purging account deletion tokens")
     with session_scope() as session:
@@ -223,10 +184,6 @@ def purge_account_deletion_tokens(payload: empty_pb2.Empty) -> None:
             .where(~AccountDeletionToken.is_valid)
             .execution_options(synchronize_session=False)
         )
-
-
-purge_account_deletion_tokens.PAYLOAD = empty_pb2.Empty
-purge_account_deletion_tokens.SCHEDULE = timedelta(hours=24)
 
 
 def send_message_notifications(payload: empty_pb2.Empty) -> None:
@@ -310,7 +267,7 @@ def send_message_notifications(payload: empty_pb2.Empty) -> None:
 
             user.last_notified_message_id = max(message.id for _, message, _ in unseen_messages)
 
-            def format_title(message, group_chat, count_unseen):
+            def format_title(message: Message, group_chat: GroupChat, count_unseen: int) -> str:
                 if group_chat.is_dm:
                     return f"You missed {count_unseen} message(s) from {message.author.name}"
                 else:
@@ -338,10 +295,6 @@ def send_message_notifications(payload: empty_pb2.Empty) -> None:
                 ),
             )
             session.commit()
-
-
-send_message_notifications.PAYLOAD = empty_pb2.Empty
-send_message_notifications.SCHEDULE = timedelta(minutes=3)
 
 
 def send_request_notifications(payload: empty_pb2.Empty) -> None:
@@ -408,7 +361,7 @@ def send_request_notifications(payload: empty_pb2.Empty) -> None:
                 .where(Message.id > User.last_notified_request_message_id)
                 .where(Message.time < now() - timedelta(minutes=5))
                 .where(Message.message_type == MessageType.text)
-                .group_by(User, HostRequest)
+                .group_by(User, HostRequest)  # type: ignore[arg-type]
             ).all()
 
             # where this user is hosting
@@ -429,7 +382,7 @@ def send_request_notifications(payload: empty_pb2.Empty) -> None:
                 .where(Message.id > User.last_notified_request_message_id)
                 .where(Message.time < now() - timedelta(minutes=5))
                 .where(Message.message_type == MessageType.text)
-                .group_by(User, HostRequest)
+                .group_by(User, HostRequest)  # type: ignore[arg-type]
             ).all()
 
             for user, host_request, max_message_id in surfing_reqs:
@@ -463,10 +416,6 @@ def send_request_notifications(payload: empty_pb2.Empty) -> None:
                         am_host=True,
                     ),
                 )
-
-
-send_request_notifications.PAYLOAD = empty_pb2.Empty
-send_request_notifications.SCHEDULE = timedelta(minutes=3)
 
 
 def send_onboarding_emails(payload: empty_pb2.Empty) -> None:
@@ -516,10 +465,6 @@ def send_onboarding_emails(payload: empty_pb2.Empty) -> None:
             user.onboarding_emails_sent = 2
             user.last_onboarding_email_sent = now()
             session.commit()
-
-
-send_onboarding_emails.PAYLOAD = empty_pb2.Empty
-send_onboarding_emails.SCHEDULE = timedelta(hours=1)
 
 
 def send_reference_reminders(payload: empty_pb2.Empty) -> None:
@@ -588,13 +533,13 @@ def send_reference_reminders(payload: empty_pb2.Empty) -> None:
             )
 
             union = union_all(q1, q2).subquery()
-            union = select(
+            query = select(
                 union.c[0].label("surfed"),
                 aliased(HostRequest, union),
                 aliased(user, union),
                 aliased(other_user, union),
             )
-            reference_reminders = session.execute(union).all()
+            reference_reminders = session.execute(query).all()
 
             for surfed, host_request, user, other_user in reference_reminders:
                 # visibility and blocking already checked in sql
@@ -616,10 +561,6 @@ def send_reference_reminders(payload: empty_pb2.Empty) -> None:
                 else:
                     host_request.host_sent_reference_reminders = reminder_number
                 session.commit()
-
-
-send_reference_reminders.PAYLOAD = empty_pb2.Empty
-send_reference_reminders.SCHEDULE = timedelta(hours=1)
 
 
 def send_host_request_reminders(payload: empty_pb2.Empty) -> None:
@@ -669,10 +610,6 @@ def send_host_request_reminders(payload: empty_pb2.Empty) -> None:
             session.commit()
 
 
-send_host_request_reminders.PAYLOAD = empty_pb2.Empty
-send_host_request_reminders.SCHEDULE = timedelta(minutes=15)
-
-
 def add_users_to_email_list(payload: empty_pb2.Empty) -> None:
     if not config["LISTMONK_ENABLED"]:
         logger.info("Not adding users to mailing list")
@@ -715,16 +652,8 @@ def add_users_to_email_list(payload: empty_pb2.Empty) -> None:
                 raise Exception("Failed to add users to mailing list")
 
 
-add_users_to_email_list.PAYLOAD = empty_pb2.Empty
-add_users_to_email_list.SCHEDULE = timedelta(hours=1)
-
-
 def enforce_community_membership(payload: empty_pb2.Empty) -> None:
     tasks_enforce_community_memberships()
-
-
-enforce_community_membership.PAYLOAD = empty_pb2.Empty
-enforce_community_membership.SCHEDULE = timedelta(minutes=15)
 
 
 def update_recommendation_scores(payload: empty_pb2.Empty) -> None:
@@ -746,28 +675,28 @@ def update_recommendation_scores(payload: empty_pb2.Empty) -> None:
     ]
     home_fields = [User.about_place, User.other_host_info, User.sleeping_details, User.area, User.house_rules]
 
-    def poor_man_gaussian():
+    def poor_man_gaussian() -> ColumnElement[float] | float:
         """
         Produces an approximatley std normal random variate
         """
         trials = 5
         return (sum([func.random() for _ in range(trials)]) - trials / 2) / sqrt(trials / 12)
 
-    def int_(stmt):
+    def int_(stmt: Any) -> Function[int]:
         return func.coalesce(cast(stmt, Integer), 0)
 
-    def float_(stmt):
+    def float_(stmt: Any) -> Function[float]:
         return func.coalesce(cast(stmt, Float), 0.0)
 
     with session_scope() as session:
         # profile
         profile_text = ""
         for field in text_fields:
-            profile_text += func.coalesce(field, "")
+            profile_text += func.coalesce(field, "")  # type: ignore[assignment]
         text_length = func.length(profile_text)
         home_text = ""
         for field in home_fields:
-            home_text += func.coalesce(field, "")
+            home_text += func.coalesce(field, "")  # type: ignore[assignment]
         home_length = func.length(home_text)
 
         filled_profile = int_(User.has_completed_profile)
@@ -898,20 +827,19 @@ def update_recommendation_scores(payload: empty_pb2.Empty) -> None:
         ).subquery()
 
         session.execute(
-            User.__table__.update().values(recommendation_score=scores.c.score).where(User.id == scores.c.user_id)
+            t_cast(Table, User.__table__)
+            .update()
+            .values(recommendation_score=scores.c.score)
+            .where(User.id == scores.c.user_id)
         )
 
     logger.info("Updated recommendation scores")
 
 
-update_recommendation_scores.PAYLOAD = empty_pb2.Empty
-update_recommendation_scores.SCHEDULE = timedelta(hours=24)
-
-
 def update_badges(payload: empty_pb2.Empty) -> None:
     with session_scope() as session:
 
-        def update_badge(badge_id: str, members: list[int]) -> None:
+        def update_badge(badge_id: str, members: Sequence[int]) -> None:
             badge = get_badge_dict()[badge_id]
             user_ids = session.execute(select(UserBadge.user_id).where(UserBadge.badge_id == badge.id)).scalars().all()
             # in case the user ids don't exist in the db
@@ -955,10 +883,6 @@ def update_badges(payload: empty_pb2.Empty) -> None:
             .scalars()
             .all(),
         )
-
-
-update_badges.PAYLOAD = empty_pb2.Empty
-update_badges.SCHEDULE = timedelta(minutes=15)
 
 
 def finalize_strong_verification(payload: "jobs_pb2.FinalizeStrongVerificationPayload") -> None:
@@ -1069,9 +993,6 @@ def finalize_strong_verification(payload: "jobs_pb2.FinalizeStrongVerificationPa
             )
 
 
-finalize_strong_verification.PAYLOAD = jobs_pb2.FinalizeStrongVerificationPayload
-
-
 def send_activeness_probes(payload: empty_pb2.Empty) -> None:
     with session_scope() as session:
         ## Step 1: create new activeness probes for those who need it and don't have one (if enabled)
@@ -1162,10 +1083,6 @@ def send_activeness_probes(payload: empty_pb2.Empty) -> None:
             session.commit()
 
 
-send_activeness_probes.PAYLOAD = empty_pb2.Empty
-send_activeness_probes.SCHEDULE = timedelta(minutes=60)
-
-
 def update_randomized_locations(payload: empty_pb2.Empty) -> None:
     """
     We generate for each user a randomized location as follows:
@@ -1199,10 +1116,6 @@ def update_randomized_locations(payload: empty_pb2.Empty) -> None:
 
     with session_scope() as session:
         session.execute(update(User), user_updates)
-
-
-update_randomized_locations.PAYLOAD = empty_pb2.Empty
-update_randomized_locations.SCHEDULE = timedelta(hours=1)
 
 
 def send_event_reminders(payload: empty_pb2.Empty) -> None:
@@ -1248,10 +1161,6 @@ def send_event_reminders(payload: empty_pb2.Empty) -> None:
                 session.commit()
 
 
-send_event_reminders.PAYLOAD = empty_pb2.Empty
-send_event_reminders.SCHEDULE = timedelta(hours=1)
-
-
 def check_expo_push_receipts(payload: empty_pb2.Empty) -> None:
     """
     Check Expo push receipts in batch and update delivery attempts.
@@ -1281,10 +1190,10 @@ def check_expo_push_receipts(payload: empty_pb2.Empty) -> None:
 
             logger.info(f"Checking {len(attempts)} Expo push receipts")
 
-            receipts = get_expo_push_receipts([attempt.expo_ticket_id for attempt in attempts])
+            receipts = get_expo_push_receipts([not_none(attempt.expo_ticket_id) for attempt in attempts])
 
             for attempt in attempts:
-                receipt = receipts.get(attempt.expo_ticket_id)
+                receipt = receipts.get(not_none(attempt.expo_ticket_id))
 
                 # Always mark as checked to avoid infinite loops
                 attempt.receipt_checked_at = now()
@@ -1326,10 +1235,6 @@ def check_expo_push_receipts(payload: empty_pb2.Empty) -> None:
     )
 
 
-check_expo_push_receipts.PAYLOAD = empty_pb2.Empty
-check_expo_push_receipts.SCHEDULE = timedelta(minutes=5)
-
-
 def send_postal_verification_postcard(payload: jobs_pb2.SendPostalVerificationPostcardPayload) -> None:
     """
     Sends the postcard via external API and updates attempt status.
@@ -1357,8 +1262,8 @@ def send_postal_verification_postcard(payload: jobs_pb2.SendPostalVerificationPo
             state=attempt.state,
             postal_code=attempt.postal_code,
             country=attempt.country,
-            verification_code=attempt.verification_code,
-            qr_code_url=urls.postal_verification_link(code=attempt.verification_code),
+            verification_code=not_none(attempt.verification_code),
+            qr_code_url=urls.postal_verification_link(code=not_none(attempt.verification_code)),
         )
 
         if result.success:
@@ -1379,9 +1284,6 @@ def send_postal_verification_postcard(payload: jobs_pb2.SendPostalVerificationPo
             # Could retry or fail - for now, fail
             attempt.status = PostalVerificationStatus.failed
             logger.error(f"Postcard send failed: {result.error_message}")
-
-
-send_postal_verification_postcard.PAYLOAD = jobs_pb2.SendPostalVerificationPostcardPayload
 
 
 class DatabaseInconsistencyError(Exception):
@@ -1574,10 +1476,6 @@ def check_database_consistency(payload: empty_pb2.Empty) -> None:
         raise DatabaseInconsistencyError("\n".join(errors))
 
 
-check_database_consistency.PAYLOAD = empty_pb2.Empty
-check_database_consistency.SCHEDULE = timedelta(hours=24)
-
-
 def auto_approve_moderation_queue(payload: empty_pb2.Empty) -> None:
     """
     Dead man's switch: auto-approves unresolved INITIAL_REVIEW items older than the deadline.
@@ -1623,5 +1521,72 @@ def auto_approve_moderation_queue(payload: empty_pb2.Empty) -> None:
         moderation_auto_approved_counter.inc(len(items))
 
 
-auto_approve_moderation_queue.PAYLOAD = empty_pb2.Empty
-auto_approve_moderation_queue.SCHEDULE = timedelta(seconds=15)
+# Job registry - maps job names to (handler_function, payload_type, schedule)
+JOBS: dict[str, tuple[Any, Any, timedelta | None]] = {
+    "handle_notification": (handle_notification, jobs_pb2.HandleNotificationPayload, None),
+    "send_raw_push_notification_v2": (send_raw_push_notification_v2, jobs_pb2.SendRawPushNotificationPayloadV2, None),
+    "handle_email_digests": (handle_email_digests, empty_pb2.Empty, timedelta(minutes=15)),
+    "generate_message_notifications": (
+        generate_message_notifications,
+        jobs_pb2.GenerateMessageNotificationsPayload,
+        None,
+    ),
+    "generate_reply_notifications": (generate_reply_notifications, jobs_pb2.GenerateReplyNotificationsPayload, None),
+    "generate_create_discussion_notifications": (
+        generate_create_discussion_notifications,
+        jobs_pb2.GenerateCreateDiscussionNotificationsPayload,
+        None,
+    ),
+    "generate_event_create_notifications": (
+        generate_event_create_notifications,
+        jobs_pb2.GenerateEventCreateNotificationsPayload,
+        None,
+    ),
+    "generate_event_update_notifications": (
+        generate_event_update_notifications,
+        jobs_pb2.GenerateEventUpdateNotificationsPayload,
+        None,
+    ),
+    "generate_event_cancel_notifications": (
+        generate_event_cancel_notifications,
+        jobs_pb2.GenerateEventCancelNotificationsPayload,
+        None,
+    ),
+    "generate_event_delete_notifications": (
+        generate_event_delete_notifications,
+        jobs_pb2.GenerateEventDeleteNotificationsPayload,
+        None,
+    ),
+    "generate_new_blog_post_notifications": (
+        generate_new_blog_post_notifications,
+        jobs_pb2.GenerateNewBlogPostNotificationsPayload,
+        None,
+    ),
+    "refresh_materialized_views": (refresh_materialized_views, empty_pb2.Empty, timedelta(minutes=5)),
+    "refresh_materialized_views_rapid": (refresh_materialized_views_rapid, empty_pb2.Empty, timedelta(seconds=30)),
+    "send_email": (send_email, jobs_pb2.SendEmailPayload, None),
+    "purge_login_tokens": (purge_login_tokens, empty_pb2.Empty, timedelta(hours=24)),
+    "purge_password_reset_tokens": (purge_password_reset_tokens, empty_pb2.Empty, timedelta(hours=24)),
+    "purge_account_deletion_tokens": (purge_account_deletion_tokens, empty_pb2.Empty, timedelta(hours=24)),
+    "send_message_notifications": (send_message_notifications, empty_pb2.Empty, timedelta(minutes=3)),
+    "send_request_notifications": (send_request_notifications, empty_pb2.Empty, timedelta(minutes=3)),
+    "send_onboarding_emails": (send_onboarding_emails, empty_pb2.Empty, timedelta(hours=1)),
+    "send_reference_reminders": (send_reference_reminders, empty_pb2.Empty, timedelta(hours=1)),
+    "send_host_request_reminders": (send_host_request_reminders, empty_pb2.Empty, timedelta(minutes=15)),
+    "add_users_to_email_list": (add_users_to_email_list, empty_pb2.Empty, timedelta(hours=1)),
+    "enforce_community_membership": (enforce_community_membership, empty_pb2.Empty, timedelta(minutes=15)),
+    "update_recommendation_scores": (update_recommendation_scores, empty_pb2.Empty, timedelta(hours=24)),
+    "update_badges": (update_badges, empty_pb2.Empty, timedelta(minutes=15)),
+    "finalize_strong_verification": (finalize_strong_verification, jobs_pb2.FinalizeStrongVerificationPayload, None),
+    "send_activeness_probes": (send_activeness_probes, empty_pb2.Empty, timedelta(minutes=60)),
+    "update_randomized_locations": (update_randomized_locations, empty_pb2.Empty, timedelta(hours=1)),
+    "send_event_reminders": (send_event_reminders, empty_pb2.Empty, timedelta(hours=1)),
+    "check_expo_push_receipts": (check_expo_push_receipts, empty_pb2.Empty, timedelta(minutes=5)),
+    "send_postal_verification_postcard": (
+        send_postal_verification_postcard,
+        jobs_pb2.SendPostalVerificationPostcardPayload,
+        None,
+    ),
+    "check_database_consistency": (check_database_consistency, empty_pb2.Empty, timedelta(hours=24)),
+    "auto_approve_moderation_queue": (auto_approve_moderation_queue, empty_pb2.Empty, timedelta(seconds=15)),
+}

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -55,8 +55,6 @@ from couchers.email.smtp import send_smtp_email
 from couchers.helpers.badges import user_add_badge, user_remove_badge
 from couchers.materialized_views import (
     UserResponseRate,
-    refresh_materialized_views,
-    refresh_materialized_views_rapid,
 )
 from couchers.metrics import (
     moderation_auto_approved_counter,
@@ -101,28 +99,18 @@ from couchers.models import (
     UserBadge,
     Volunteer,
 )
-from couchers.notifications.background import handle_email_digests, handle_notification
 from couchers.notifications.expo_api import get_expo_push_receipts
 from couchers.notifications.notify import notify
-from couchers.notifications.send_raw_push_notification import send_raw_push_notification_v2
 from couchers.postal.postcard_service import send_postcard
 from couchers.proto import moderation_pb2, notification_data_pb2
 from couchers.proto.internal import jobs_pb2, verification_pb2
 from couchers.resources import get_badge_dict, get_static_badge_dict
 from couchers.servicers.api import user_model_to_pb
-from couchers.servicers.conversations import generate_message_notifications
-from couchers.servicers.discussions import generate_create_discussion_notifications
-from couchers.servicers.editor import generate_new_blog_post_notifications
 from couchers.servicers.events import (
     event_to_pb,
-    generate_event_cancel_notifications,
-    generate_event_create_notifications,
-    generate_event_delete_notifications,
-    generate_event_update_notifications,
 )
 from couchers.servicers.moderation import Moderation
 from couchers.servicers.requests import host_request_to_pb
-from couchers.servicers.threads import generate_reply_notifications
 from couchers.sql import (
     users_visible_to_each_other,
     where_moderated_content_visible,
@@ -1519,74 +1507,3 @@ def auto_approve_moderation_queue(payload: empty_pb2.Empty) -> None:
                 session=session,
             )
         moderation_auto_approved_counter.inc(len(items))
-
-
-# Job registry - maps job names to (handler_function, payload_type, schedule)
-JOBS: dict[str, tuple[Any, Any, timedelta | None]] = {
-    "handle_notification": (handle_notification, jobs_pb2.HandleNotificationPayload, None),
-    "send_raw_push_notification_v2": (send_raw_push_notification_v2, jobs_pb2.SendRawPushNotificationPayloadV2, None),
-    "handle_email_digests": (handle_email_digests, empty_pb2.Empty, timedelta(minutes=15)),
-    "generate_message_notifications": (
-        generate_message_notifications,
-        jobs_pb2.GenerateMessageNotificationsPayload,
-        None,
-    ),
-    "generate_reply_notifications": (generate_reply_notifications, jobs_pb2.GenerateReplyNotificationsPayload, None),
-    "generate_create_discussion_notifications": (
-        generate_create_discussion_notifications,
-        jobs_pb2.GenerateCreateDiscussionNotificationsPayload,
-        None,
-    ),
-    "generate_event_create_notifications": (
-        generate_event_create_notifications,
-        jobs_pb2.GenerateEventCreateNotificationsPayload,
-        None,
-    ),
-    "generate_event_update_notifications": (
-        generate_event_update_notifications,
-        jobs_pb2.GenerateEventUpdateNotificationsPayload,
-        None,
-    ),
-    "generate_event_cancel_notifications": (
-        generate_event_cancel_notifications,
-        jobs_pb2.GenerateEventCancelNotificationsPayload,
-        None,
-    ),
-    "generate_event_delete_notifications": (
-        generate_event_delete_notifications,
-        jobs_pb2.GenerateEventDeleteNotificationsPayload,
-        None,
-    ),
-    "generate_new_blog_post_notifications": (
-        generate_new_blog_post_notifications,
-        jobs_pb2.GenerateNewBlogPostNotificationsPayload,
-        None,
-    ),
-    "refresh_materialized_views": (refresh_materialized_views, empty_pb2.Empty, timedelta(minutes=5)),
-    "refresh_materialized_views_rapid": (refresh_materialized_views_rapid, empty_pb2.Empty, timedelta(seconds=30)),
-    "send_email": (send_email, jobs_pb2.SendEmailPayload, None),
-    "purge_login_tokens": (purge_login_tokens, empty_pb2.Empty, timedelta(hours=24)),
-    "purge_password_reset_tokens": (purge_password_reset_tokens, empty_pb2.Empty, timedelta(hours=24)),
-    "purge_account_deletion_tokens": (purge_account_deletion_tokens, empty_pb2.Empty, timedelta(hours=24)),
-    "send_message_notifications": (send_message_notifications, empty_pb2.Empty, timedelta(minutes=3)),
-    "send_request_notifications": (send_request_notifications, empty_pb2.Empty, timedelta(minutes=3)),
-    "send_onboarding_emails": (send_onboarding_emails, empty_pb2.Empty, timedelta(hours=1)),
-    "send_reference_reminders": (send_reference_reminders, empty_pb2.Empty, timedelta(hours=1)),
-    "send_host_request_reminders": (send_host_request_reminders, empty_pb2.Empty, timedelta(minutes=15)),
-    "add_users_to_email_list": (add_users_to_email_list, empty_pb2.Empty, timedelta(hours=1)),
-    "enforce_community_membership": (enforce_community_membership, empty_pb2.Empty, timedelta(minutes=15)),
-    "update_recommendation_scores": (update_recommendation_scores, empty_pb2.Empty, timedelta(hours=24)),
-    "update_badges": (update_badges, empty_pb2.Empty, timedelta(minutes=15)),
-    "finalize_strong_verification": (finalize_strong_verification, jobs_pb2.FinalizeStrongVerificationPayload, None),
-    "send_activeness_probes": (send_activeness_probes, empty_pb2.Empty, timedelta(minutes=60)),
-    "update_randomized_locations": (update_randomized_locations, empty_pb2.Empty, timedelta(hours=1)),
-    "send_event_reminders": (send_event_reminders, empty_pb2.Empty, timedelta(hours=1)),
-    "check_expo_push_receipts": (check_expo_push_receipts, empty_pb2.Empty, timedelta(minutes=5)),
-    "send_postal_verification_postcard": (
-        send_postal_verification_postcard,
-        jobs_pb2.SendPostalVerificationPostcardPayload,
-        None,
-    ),
-    "check_database_consistency": (check_database_consistency, empty_pb2.Empty, timedelta(hours=24)),
-    "auto_approve_moderation_queue": (auto_approve_moderation_queue, empty_pb2.Empty, timedelta(seconds=15)),
-}

--- a/app/backend/src/couchers/jobs/worker.py
+++ b/app/backend/src/couchers/jobs/worker.py
@@ -6,11 +6,9 @@ import logging
 import traceback
 from collections.abc import Callable
 from datetime import timedelta
-from inspect import getmembers, isfunction
 from multiprocessing import Process
 from sched import scheduler
 from time import monotonic, perf_counter_ns, sleep
-from typing import Any
 
 import sentry_sdk
 import sqlalchemy.exc
@@ -21,8 +19,8 @@ from sqlalchemy import select
 from couchers.config import config
 from couchers.db import db_post_fork, session_scope, worker_repeatable_read_session_scope
 from couchers.experimentation import setup_experimentation
-from couchers.jobs import handlers
 from couchers.jobs.enqueue import queue_job
+from couchers.jobs.handlers import JOBS
 from couchers.metrics import (
     background_jobs_got_job_counter,
     background_jobs_no_jobs_counter,
@@ -36,15 +34,6 @@ from couchers.utils import now
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
-
-JOBS: dict[str, tuple[Any, Callable[[Any], Any]]] = {}
-SCHEDULE: list[tuple[str, timedelta]] = []
-
-for name, func in getmembers(handlers, isfunction):
-    if hasattr(func, "PAYLOAD"):
-        JOBS[name] = (func.PAYLOAD, func)
-        if hasattr(func, "SCHEDULE"):
-            SCHEDULE.append((name, func.SCHEDULE))
 
 
 def process_job() -> bool:
@@ -87,7 +76,7 @@ def process_job() -> bool:
         logger.info(f"Job #{job.id} of type {job.job_type} grabbed")
         job.try_count += 1
 
-        message_type, func = JOBS[job.job_type]
+        func, message_type, _ = JOBS[job.job_type]
 
         jobs_queued_histogram.observe((now() - job.queued).total_seconds())
         try:
@@ -139,18 +128,18 @@ def service_jobs() -> None:
             sleep(1)
 
 
-def _run_job_and_schedule(sched: scheduler, schedule_id: int) -> None:
-    job_type, frequency = SCHEDULE[schedule_id]
+def _run_job_and_schedule(sched: scheduler, job_type: str, frequency: timedelta) -> None:
     logger.info(f"Processing job of type {job_type}")
 
     # wake ourselves up after frequency
     sched.enter(
-        frequency.total_seconds(),
-        1,
-        _run_job_and_schedule,
+        delay=frequency.total_seconds(),
+        priority=1,
+        action=_run_job_and_schedule,
         argument=(
             sched,
-            schedule_id,
+            job_type,
+            frequency,
         ),
     )
 
@@ -161,20 +150,22 @@ def _run_job_and_schedule(sched: scheduler, schedule_id: int) -> None:
 
 def run_scheduler() -> None:
     """
-    Schedules jobs according to schedule in .definitions
+    Schedules jobs according to schedule in JOBS
     """
     sched = scheduler(monotonic, sleep)
 
-    for schedule_id, (job_type, frequency) in enumerate(SCHEDULE):
-        sched.enter(
-            0,
-            1,
-            _run_job_and_schedule,
-            argument=(
-                sched,
-                schedule_id,
-            ),
-        )
+    for job_type, (_, _, frequency) in JOBS.items():
+        if frequency is not None:
+            sched.enter(
+                delay=0,
+                priority=1,
+                action=_run_job_and_schedule,
+                argument=(
+                    sched,
+                    job_type,
+                    frequency,
+                ),
+            )
 
     sched.run()
 

--- a/app/backend/src/couchers/jobs/worker.py
+++ b/app/backend/src/couchers/jobs/worker.py
@@ -19,7 +19,7 @@ from sqlalchemy import select
 from couchers.config import config
 from couchers.db import db_post_fork, session_scope, worker_repeatable_read_session_scope
 from couchers.experimentation import setup_experimentation
-from couchers.jobs.definitions import JOBS
+from couchers.jobs.definitions import JOBS, Job
 from couchers.jobs.enqueue import queue_job
 from couchers.metrics import (
     background_jobs_got_job_counter,
@@ -128,8 +128,8 @@ def service_jobs() -> None:
             sleep(1)
 
 
-def _run_job_and_schedule(sched: scheduler, job_type: str, frequency: timedelta) -> None:
-    logger.info(f"Processing job of type {job_type}")
+def _run_job_and_schedule(sched: scheduler, job_def: Job, frequency: timedelta) -> None:
+    logger.info(f"Processing job of type {job_def.handler.__name__}")
 
     # wake ourselves up after frequency
     sched.enter(
@@ -138,14 +138,14 @@ def _run_job_and_schedule(sched: scheduler, job_type: str, frequency: timedelta)
         action=_run_job_and_schedule,
         argument=(
             sched,
-            job_type,
+            job_def,
             frequency,
         ),
     )
 
     # queue the job
     with session_scope() as session:
-        queue_job(session, job_type, empty_pb2.Empty())
+        queue_job(session, job=job_def.handler, payload=empty_pb2.Empty())
 
 
 def run_scheduler() -> None:
@@ -162,7 +162,7 @@ def run_scheduler() -> None:
                 action=_run_job_and_schedule,
                 argument=(
                     sched,
-                    job_type,
+                    job_def,
                     job_def.schedule,
                 ),
             )

--- a/app/backend/src/couchers/jobs/worker.py
+++ b/app/backend/src/couchers/jobs/worker.py
@@ -19,8 +19,8 @@ from sqlalchemy import select
 from couchers.config import config
 from couchers.db import db_post_fork, session_scope, worker_repeatable_read_session_scope
 from couchers.experimentation import setup_experimentation
+from couchers.jobs.definitions import JOBS
 from couchers.jobs.enqueue import queue_job
-from couchers.jobs.handlers import JOBS
 from couchers.metrics import (
     background_jobs_got_job_counter,
     background_jobs_no_jobs_counter,
@@ -76,13 +76,13 @@ def process_job() -> bool:
         logger.info(f"Job #{job.id} of type {job.job_type} grabbed")
         job.try_count += 1
 
-        func, message_type, _ = JOBS[job.job_type]
+        job_def = JOBS[job.job_type]
 
         jobs_queued_histogram.observe((now() - job.queued).total_seconds())
         try:
             with tracer.start_as_current_span(job.job_type) as rollspan:
                 start = perf_counter_ns()
-                ret = func(message_type.FromString(job.payload))
+                ret = job_def.handler(job_def.payload_type.FromString(job.payload))
                 finished = perf_counter_ns()
             job.state = BackgroundJobState.completed
             observe_in_jobs_duration_histogram(
@@ -154,8 +154,8 @@ def run_scheduler() -> None:
     """
     sched = scheduler(monotonic, sleep)
 
-    for job_type, (_, _, frequency) in JOBS.items():
-        if frequency is not None:
+    for job_type, job_def in JOBS.items():
+        if job_def.schedule is not None:
             sched.enter(
                 delay=0,
                 priority=1,
@@ -163,7 +163,7 @@ def run_scheduler() -> None:
                 argument=(
                     sched,
                     job_type,
-                    frequency,
+                    job_def.schedule,
                 ),
             )
 

--- a/app/backend/src/couchers/jobs/worker.py
+++ b/app/backend/src/couchers/jobs/worker.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from multiprocessing import Process
 from sched import scheduler
 from time import monotonic, perf_counter_ns, sleep
+from typing import Any
 
 import sentry_sdk
 import sqlalchemy.exc
@@ -82,7 +83,7 @@ def process_job() -> bool:
         try:
             with tracer.start_as_current_span(job.job_type) as rollspan:
                 start = perf_counter_ns()
-                ret = job_def.handler(job_def.payload_type.FromString(job.payload))
+                job_def.handler(job_def.payload_type.FromString(job.payload))
                 finished = perf_counter_ns()
             job.state = BackgroundJobState.completed
             observe_in_jobs_duration_histogram(
@@ -128,8 +129,8 @@ def service_jobs() -> None:
             sleep(1)
 
 
-def _run_job_and_schedule(sched: scheduler, job_def: Job, frequency: timedelta) -> None:
-    logger.info(f"Processing job of type {job_def.handler.__name__}")
+def _run_job_and_schedule(sched: scheduler, job_def: Job[Any], frequency: timedelta) -> None:
+    logger.info(f"Processing job of type {job_def.name}")
 
     # wake ourselves up after frequency
     sched.enter(

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -146,7 +146,7 @@ def handle_notification(payload: jobs_pb2.HandleNotificationPayload) -> None:
             ).scalar_one()
 
             if not content_visible:
-                # Content not visible to recipient, leave notification for later processing
+                # Content is not visible to recipient, leave notification for later processing
                 logger.info(
                     f"Deferring notification {notification.id}: content not visible to user {notification.user_id}"
                 )
@@ -155,7 +155,6 @@ def handle_notification(payload: jobs_pb2.HandleNotificationPayload) -> None:
         # ignore this notification if the user hasn't enabled new notifications
         user = session.execute(select(User).where(User.id == notification.user_id)).scalar_one()
 
-        topic, action = notification.topic_action.unpack()
         delivery_types = get_preference(session, notification.user.id, notification.topic_action)
         for delivery_type in delivery_types:
             # Check if delivery already exists for this notification and delivery type

--- a/app/backend/src/couchers/notifications/notify.py
+++ b/app/backend/src/couchers/notifications/notify.py
@@ -42,6 +42,9 @@ def notify(
     (e.g., security notifications like password changes, or aggregated notifications like chat:missed_messages).
     """
     logger.info(f"Generating notification of type {topic_action} for user {user_id}")
+    # Import here to avoid circular dependency
+    from couchers.notifications.background import handle_notification
+
     topic, action = topic_action.split(":")
 
     notification = Notification(
@@ -56,7 +59,7 @@ def notify(
 
     queue_job(
         session,
-        job_type="handle_notification",
+        job=handle_notification,
         payload=jobs_pb2.HandleNotificationPayload(
             notification_id=notification.id,
         ),

--- a/app/backend/src/couchers/notifications/push.py
+++ b/app/backend/src/couchers/notifications/push.py
@@ -6,6 +6,7 @@ from couchers import urls
 from couchers.config import config
 from couchers.jobs.enqueue import queue_job
 from couchers.models import PushNotificationSubscription
+from couchers.notifications.send_raw_push_notification import send_raw_push_notification_v2
 from couchers.proto.internal import jobs_pb2
 
 
@@ -24,7 +25,7 @@ def push_to_subscription(
 ) -> None:
     queue_job(
         session,
-        job_type="send_raw_push_notification_v2",
+        job=send_raw_push_notification_v2,
         payload=jobs_pb2.SendRawPushNotificationPayloadV2(
             push_notification_subscription_id=push_notification_subscription_id,
             ttl=ttl,

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -30,6 +30,7 @@ from couchers.experimentation import check_gate
 from couchers.helpers.geoip import geoip_approximate_location
 from couchers.helpers.strong_verification import get_strong_verification_fields, has_strong_verification
 from couchers.jobs.enqueue import queue_job
+from couchers.jobs.handlers import finalize_strong_verification
 from couchers.materialized_views import LiteUser
 from couchers.metrics import (
     account_deletion_initiations_counter,
@@ -865,7 +866,7 @@ class Iris(iris_pb2_grpc.IrisServicer):
             # background worker will go and sort this one out
             queue_job(
                 session,
-                job_type="finalize_strong_verification",
+                job=finalize_strong_verification,
                 payload=jobs_pb2.FinalizeStrongVerificationPayload(verification_attempt_id=verification_attempt.id),
                 priority=8,
             )

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -41,6 +41,7 @@ from couchers.proto.internal import jobs_pb2
 from couchers.resources import get_badge_dict
 from couchers.servicers.api import user_model_to_pb
 from couchers.servicers.auth import create_session
+from couchers.servicers.events import generate_event_delete_notifications
 from couchers.servicers.threads import unpack_thread_id
 from couchers.sql import to_bool, username_or_email_or_id
 from couchers.utils import Timestamp_from_datetime, date_to_api, now, parse_date, to_aware_datetime
@@ -529,7 +530,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         queue_job(
             session,
-            "generate_event_delete_notifications",
+            job=generate_event_delete_notifications,
             payload=jobs_pb2.GenerateEventDeleteNotificationsPayload(
                 occurrence_id=occurrence.id,
             ),

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -233,7 +233,7 @@ def _add_message_to_subscription(session: Session, subscription: GroupChatSubscr
 
     queue_job(
         session,
-        job_type="generate_message_notifications",
+        job=generate_message_notifications,
         payload=jobs_pb2.GenerateMessageNotificationsPayload(
             message_id=message.id,
         ),

--- a/app/backend/src/couchers/servicers/discussions.py
+++ b/app/backend/src/couchers/servicers/discussions.py
@@ -109,7 +109,7 @@ class Discussions(discussions_pb2_grpc.DiscussionsServicer):
 
         queue_job(
             session,
-            job_type="generate_create_discussion_notifications",
+            job=generate_create_discussion_notifications,
             payload=jobs_pb2.GenerateCreateDiscussionNotificationsPayload(
                 discussion_id=discussion.id,
             ),

--- a/app/backend/src/couchers/servicers/editor.py
+++ b/app/backend/src/couchers/servicers/editor.py
@@ -22,7 +22,7 @@ from couchers.proto import communities_pb2, editor_pb2, editor_pb2_grpc, notific
 from couchers.proto.internal import jobs_pb2
 from couchers.resources import get_static_badge_dict
 from couchers.servicers.communities import community_to_pb
-from couchers.servicers.events import get_users_to_notify_for_new_event
+from couchers.servicers.events import generate_event_create_notifications, get_users_to_notify_for_new_event
 from couchers.servicers.public import format_volunteer_link
 from couchers.utils import date_to_api, now, parse_date
 
@@ -182,7 +182,7 @@ class Editor(editor_pb2_grpc.EditorServicer):
         if request.approve:
             queue_job(
                 session,
-                "generate_event_create_notifications",
+                job=generate_event_create_notifications,
                 payload=jobs_pb2.GenerateEventCreateNotificationsPayload(
                     inviting_user_id=req.user_id,
                     occurrence_id=req.occurrence_id,
@@ -201,7 +201,7 @@ class Editor(editor_pb2_grpc.EditorServicer):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "admin_blog_blurb_too_long")
         queue_job(
             session,
-            "generate_new_blog_post_notifications",
+            job=generate_new_blog_post_notifications,
             payload=jobs_pb2.GenerateNewBlogPostNotificationsPayload(
                 url=request.url,
                 title=request.title,

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -489,7 +489,7 @@ class Events(events_pb2_grpc.EventsServicer):
         if user.has_completed_profile:
             queue_job(
                 session,
-                "generate_event_create_notifications",
+                job=generate_event_create_notifications,
                 payload=jobs_pb2.GenerateEventCreateNotificationsPayload(
                     inviting_user_id=user.id,
                     occurrence_id=occurrence.id,
@@ -708,7 +708,7 @@ class Events(events_pb2_grpc.EventsServicer):
 
                 queue_job(
                     session,
-                    "generate_event_update_notifications",
+                    job=generate_event_update_notifications,
                     payload=jobs_pb2.GenerateEventUpdateNotificationsPayload(
                         updating_user_id=user.id,
                         occurrence_id=occurrence.id,
@@ -754,7 +754,7 @@ class Events(events_pb2_grpc.EventsServicer):
 
         queue_job(
             session,
-            "generate_event_cancel_notifications",
+            job=generate_event_cancel_notifications,
             payload=jobs_pb2.GenerateEventCancelNotificationsPayload(
                 cancelling_user_id=context.user_id,
                 occurrence_id=occurrence.id,

--- a/app/backend/src/couchers/servicers/moderation.py
+++ b/app/backend/src/couchers/servicers/moderation.py
@@ -377,10 +377,13 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
                 .all()
             )
 
+            # Import here to avoid circular dependency
+            from couchers.notifications.background import handle_notification
+
             for notification in pending_notifications:
                 queue_job(
                     session,
-                    job_type="handle_notification",
+                    job=handle_notification,
                     payload=jobs_pb2.HandleNotificationPayload(notification_id=notification.id),
                 )
 

--- a/app/backend/src/couchers/servicers/postal_verification.py
+++ b/app/backend/src/couchers/servicers/postal_verification.py
@@ -15,6 +15,7 @@ from couchers.constants import (
 from couchers.context import CouchersContext
 from couchers.helpers.postal_verification import generate_postal_verification_code, has_postal_verification
 from couchers.jobs.enqueue import queue_job
+from couchers.jobs.handlers import send_postal_verification_postcard
 from couchers.models import User
 from couchers.models.postal_verification import PostalVerificationAttempt, PostalVerificationStatus
 from couchers.notifications.notify import notify
@@ -186,8 +187,8 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
         # Queue background job to send postcard
         queue_job(
             session,
-            "send_postal_verification_postcard",
-            jobs_pb2.SendPostalVerificationPostcardPayload(
+            job=send_postal_verification_postcard,
+            payload=jobs_pb2.SendPostalVerificationPostcardPayload(
                 postal_verification_attempt_id=attempt.id,
             ),
         )

--- a/app/backend/src/couchers/servicers/threads.py
+++ b/app/backend/src/couchers/servicers/threads.py
@@ -301,7 +301,7 @@ class Threads(threads_pb2_grpc.ThreadsServicer):
 
         queue_job(
             session,
-            job_type="generate_reply_notifications",
+            job=generate_reply_notifications,
             payload=jobs_pb2.GenerateReplyNotificationsPayload(
                 thread_id=thread_id,
             ),

--- a/app/backend/src/tests/test_activeness_probes.py
+++ b/app/backend/src/tests/test_activeness_probes.py
@@ -9,6 +9,7 @@ from sqlalchemy import exists, select
 from couchers.config import config
 from couchers.db import session_scope
 from couchers.jobs.enqueue import queue_job
+from couchers.jobs.handlers import send_activeness_probes
 from couchers.models import ActivenessProbe, ActivenessProbeStatus, HostingStatus, MeetupStatus
 from couchers.proto import api_pb2, jail_pb2
 from couchers.utils import now
@@ -37,7 +38,7 @@ def test_activeness_probes_happy_path_inactive(db, push_collector):
     )
 
     with session_scope() as session:
-        queue_job(session, "send_activeness_probes", empty_pb2.Empty())
+        queue_job(session, job=send_activeness_probes, payload=empty_pb2.Empty())
 
     process_jobs()
 
@@ -72,7 +73,7 @@ def test_activeness_probes_happy_path_active(db, push_collector):
     )
 
     with session_scope() as session:
-        queue_job(session, "send_activeness_probes", empty_pb2.Empty())
+        queue_job(session, job=send_activeness_probes, payload=empty_pb2.Empty())
 
     process_jobs()
 
@@ -111,7 +112,7 @@ def test_activeness_probes_disabled(db, push_collector):
         )
 
         with session_scope() as session:
-            queue_job(session, "send_activeness_probes", empty_pb2.Empty())
+            queue_job(session, job=send_activeness_probes, payload=empty_pb2.Empty())
 
         process_jobs()
 
@@ -132,7 +133,7 @@ def test_activeness_probes_expiry(db, push_collector):
     )
 
     with session_scope() as session:
-        queue_job(session, "send_activeness_probes", empty_pb2.Empty())
+        queue_job(session, job=send_activeness_probes, payload=empty_pb2.Empty())
 
     process_jobs()
 
@@ -147,7 +148,7 @@ def test_activeness_probes_expiry(db, push_collector):
         assert probe.notifications_sent == 1
         probe.notifications_sent = 2
 
-        queue_job(session, "send_activeness_probes", empty_pb2.Empty())
+        queue_job(session, job=send_activeness_probes, payload=empty_pb2.Empty())
 
     process_jobs()
 

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -20,6 +20,10 @@ from couchers.jobs.definitions import Job
 from couchers.jobs.enqueue import queue_job
 from couchers.jobs.handlers import (
     add_users_to_email_list,
+    enforce_community_membership,
+    purge_account_deletion_tokens,
+    purge_login_tokens,
+    purge_password_reset_tokens,
     send_host_request_reminders,
     send_message_notifications,
     send_onboarding_emails,
@@ -29,6 +33,7 @@ from couchers.jobs.handlers import (
     update_recommendation_scores,
 )
 from couchers.jobs.worker import _run_job_and_schedule, process_job, run_scheduler, service_jobs
+from couchers.materialized_views import refresh_materialized_views
 from couchers.metrics import create_prometheus_server
 from couchers.models import (
     AccountDeletionToken,
@@ -125,7 +130,7 @@ def test_purge_login_tokens(db):
         session.add(login_token)
         assert session.execute(select(func.count()).select_from(LoginToken)).scalar_one() == 1
 
-        queue_job(session, "purge_login_tokens", empty_pb2.Empty())
+        queue_job(session, job=purge_login_tokens, payload=empty_pb2.Empty())
     process_job()
 
     with session_scope() as session:
@@ -158,7 +163,7 @@ def test_purge_password_reset_tokens(db):
         session.add(password_reset_token)
         assert session.execute(select(func.count()).select_from(PasswordResetToken)).scalar_one() == 1
 
-        queue_job(session, "purge_password_reset_tokens", empty_pb2.Empty())
+        queue_job(session, job=purge_password_reset_tokens, payload=empty_pb2.Empty())
     process_job()
 
     with session_scope() as session:
@@ -204,7 +209,7 @@ def test_purge_account_deletion_tokens(db):
             session.add(token)
         assert session.execute(select(func.count()).select_from(AccountDeletionToken)).scalar_one() == 3
 
-        queue_job(session, "purge_account_deletion_tokens", empty_pb2.Empty())
+        queue_job(session, job=purge_account_deletion_tokens, payload=empty_pb2.Empty())
     process_job()
 
     with session_scope() as session:
@@ -231,7 +236,7 @@ def test_purge_account_deletion_tokens(db):
 
 def test_enforce_community_memberships(db):
     with session_scope() as session:
-        queue_job(session, "enforce_community_membership", empty_pb2.Empty())
+        queue_job(session, job=enforce_community_membership, payload=empty_pb2.Empty())
     process_job()
 
     with session_scope() as session:
@@ -255,7 +260,7 @@ def test_enforce_community_memberships(db):
 
 def test_refresh_materialized_views(db):
     with session_scope() as session:
-        queue_job(session, "refresh_materialized_views", empty_pb2.Empty())
+        queue_job(session, job=refresh_materialized_views, payload=empty_pb2.Empty())
 
     process_job()
 
@@ -315,9 +320,15 @@ def test_service_jobs(db):
 
 
 def test_scheduler(db, monkeypatch):
+    def purge_login_tokens(_):
+        return
+
+    def send_message_notifications(_):
+        return
+
     MOCK_JOBS = {
-        "purge_login_tokens": Job(lambda x: None, empty_pb2.Empty, timedelta(seconds=7)),
-        "send_message_notifications": Job(lambda x: None, empty_pb2.Empty, timedelta(seconds=11)),
+        "purge_login_tokens": Job(purge_login_tokens, empty_pb2.Empty, timedelta(seconds=7)),
+        "send_message_notifications": Job(send_message_notifications, empty_pb2.Empty, timedelta(seconds=11)),
     }
 
     current_time = 0
@@ -327,7 +338,6 @@ def test_scheduler(db, monkeypatch):
         pass
 
     def mock_monotonic():
-        nonlocal current_time
         return current_time
 
     def mock_sleep(seconds):
@@ -338,10 +348,9 @@ def test_scheduler(db, monkeypatch):
 
     realized_schedule = []
 
-    def mock_run_job_and_schedule(sched, job_type, frequency):
-        nonlocal current_time
-        realized_schedule.append((current_time, job_type))
-        _run_job_and_schedule(sched, job_type, frequency)
+    def mock_run_job_and_schedule(sched, job: Job, frequency: timedelta) -> None:
+        realized_schedule.append((current_time, job.handler.__name__))
+        _run_job_and_schedule(sched, job, frequency)
 
     monkeypatch.setattr(couchers.jobs.worker, "_run_job_and_schedule", mock_run_job_and_schedule)
     monkeypatch.setattr(couchers.jobs.worker, "JOBS", MOCK_JOBS)
@@ -353,7 +362,7 @@ def test_scheduler(db, monkeypatch):
 
     # Convert to job indices for comparison (to maintain test compatibility)
     job_order = ["purge_login_tokens", "send_message_notifications"]
-    realized_schedule_indices = [(time, job_order.index(job_type)) for time, job_type in realized_schedule]
+    realized_schedule_indices = [(time, job_order.index(job_name)) for time, job_name in realized_schedule]
 
     assert realized_schedule_indices == [
         (0.0, 0),
@@ -392,15 +401,15 @@ def test_scheduler(db, monkeypatch):
 
 
 def test_job_retry(db):
-    with session_scope() as session:
-        queue_job(session, "mock_job", empty_pb2.Empty())
-
     called_count = 0
 
     def mock_job(payload):
         nonlocal called_count
         called_count += 1
         raise Exception()
+
+    with session_scope() as session:
+        queue_job(session, job=mock_job, payload=empty_pb2.Empty())
 
     MOCK_JOBS = {
         "mock_job": Job(mock_job, empty_pb2.Empty, None),

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -314,10 +314,10 @@ def test_service_jobs(db):
 
 
 def test_scheduler(db, monkeypatch):
-    MOCK_SCHEDULE = [
-        ("purge_login_tokens", timedelta(seconds=7)),
-        ("send_message_notifications", timedelta(seconds=11)),
-    ]
+    MOCK_JOBS = {
+        "purge_login_tokens": (lambda x: None, empty_pb2.Empty, timedelta(seconds=7)),
+        "send_message_notifications": (lambda x: None, empty_pb2.Empty, timedelta(seconds=11)),
+    }
 
     current_time = 0
     end_time = 70
@@ -337,20 +337,24 @@ def test_scheduler(db, monkeypatch):
 
     realized_schedule = []
 
-    def mock_run_job_and_schedule(sched, schedule_id):
+    def mock_run_job_and_schedule(sched, job_type, frequency):
         nonlocal current_time
-        realized_schedule.append((current_time, schedule_id))
-        _run_job_and_schedule(sched, schedule_id)
+        realized_schedule.append((current_time, job_type))
+        _run_job_and_schedule(sched, job_type, frequency)
 
     monkeypatch.setattr(couchers.jobs.worker, "_run_job_and_schedule", mock_run_job_and_schedule)
-    monkeypatch.setattr(couchers.jobs.worker, "SCHEDULE", MOCK_SCHEDULE)
+    monkeypatch.setattr(couchers.jobs.worker, "JOBS", MOCK_JOBS)
     monkeypatch.setattr(couchers.jobs.worker, "monotonic", mock_monotonic)
     monkeypatch.setattr(couchers.jobs.worker, "sleep", mock_sleep)
 
     with pytest.raises(EndOfTime):
         run_scheduler()
 
-    assert realized_schedule == [
+    # Convert to job indices for comparison (to maintain test compatibility)
+    job_order = ["purge_login_tokens", "send_message_notifications"]
+    realized_schedule_indices = [(time, job_order.index(job_type)) for time, job_type in realized_schedule]
+
+    assert realized_schedule_indices == [
         (0.0, 0),
         (0.0, 1),
         (7.0, 0),
@@ -398,7 +402,7 @@ def test_job_retry(db):
         raise Exception()
 
     MOCK_JOBS = {
-        "mock_job": (empty_pb2.Empty, mock_job),
+        "mock_job": (mock_job, empty_pb2.Empty, None),
     }
     create_prometheus_server(port=8000)
 

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -16,6 +16,7 @@ from couchers.db import session_scope
 from couchers.email import queue_email
 from couchers.email.dev import print_dev_email
 from couchers.jobs import handlers
+from couchers.jobs.definitions import Job
 from couchers.jobs.enqueue import queue_job
 from couchers.jobs.handlers import (
     add_users_to_email_list,
@@ -315,8 +316,8 @@ def test_service_jobs(db):
 
 def test_scheduler(db, monkeypatch):
     MOCK_JOBS = {
-        "purge_login_tokens": (lambda x: None, empty_pb2.Empty, timedelta(seconds=7)),
-        "send_message_notifications": (lambda x: None, empty_pb2.Empty, timedelta(seconds=11)),
+        "purge_login_tokens": Job(lambda x: None, empty_pb2.Empty, timedelta(seconds=7)),
+        "send_message_notifications": Job(lambda x: None, empty_pb2.Empty, timedelta(seconds=11)),
     }
 
     current_time = 0
@@ -402,7 +403,7 @@ def test_job_retry(db):
         raise Exception()
 
     MOCK_JOBS = {
-        "mock_job": (mock_job, empty_pb2.Empty, None),
+        "mock_job": Job(mock_job, empty_pb2.Empty, None),
     }
     create_prometheus_server(port=8000)
 

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -320,15 +320,15 @@ def test_service_jobs(db):
 
 
 def test_scheduler(db, monkeypatch):
-    def purge_login_tokens(_):
+    def purge_login_tokens(payload: empty_pb2.Empty):
         return
 
-    def send_message_notifications(_):
+    def send_message_notifications(payload: empty_pb2.Empty):
         return
 
     MOCK_JOBS = {
-        "purge_login_tokens": Job(purge_login_tokens, empty_pb2.Empty, timedelta(seconds=7)),
-        "send_message_notifications": Job(send_message_notifications, empty_pb2.Empty, timedelta(seconds=11)),
+        "purge_login_tokens": Job(purge_login_tokens, timedelta(seconds=7)),
+        "send_message_notifications": Job(send_message_notifications, timedelta(seconds=11)),
     }
 
     current_time = 0
@@ -349,7 +349,7 @@ def test_scheduler(db, monkeypatch):
     realized_schedule = []
 
     def mock_run_job_and_schedule(sched, job: Job, frequency: timedelta) -> None:
-        realized_schedule.append((current_time, job.handler.__name__))
+        realized_schedule.append((current_time, job.name))
         _run_job_and_schedule(sched, job, frequency)
 
     monkeypatch.setattr(couchers.jobs.worker, "_run_job_and_schedule", mock_run_job_and_schedule)
@@ -403,7 +403,7 @@ def test_scheduler(db, monkeypatch):
 def test_job_retry(db):
     called_count = 0
 
-    def mock_job(payload):
+    def mock_job(payload: empty_pb2.Empty) -> empty_pb2.Empty:
         nonlocal called_count
         called_count += 1
         raise Exception()
@@ -412,7 +412,7 @@ def test_job_retry(db):
         queue_job(session, job=mock_job, payload=empty_pb2.Empty())
 
     MOCK_JOBS = {
-        "mock_job": Job(mock_job, empty_pb2.Empty, None),
+        "mock_job": Job(mock_job),
     }
     create_prometheus_server(port=8000)
 

--- a/app/backend/src/tests/test_public.py
+++ b/app/backend/src/tests/test_public.py
@@ -8,6 +8,7 @@ from google.protobuf import empty_pb2
 
 from couchers.db import session_scope
 from couchers.jobs.enqueue import queue_job
+from couchers.jobs.handlers import update_randomized_locations
 from couchers.models import (
     Invoice,
     InvoiceType,
@@ -39,7 +40,7 @@ def test_GetPublicMapLayer(db):
     test_user_coordinates = [-73.9740, 40.7108]
 
     with session_scope() as session:
-        queue_job(session, "update_randomized_locations", empty_pb2.Empty())
+        queue_job(session, job=update_randomized_locations, payload=empty_pb2.Empty())
 
     process_jobs()
 


### PR DESCRIPTION
Create a static dict will background jobs: `name: (function, payload type, schedule)` instead of registering them dynamically and adding attributes to functions.

While the current approach certainly works, it confuses mypy and might be non-obvious to new developers.