### PR TITLE
Fix running backend tests in Docker

### DIFF
--- a/app/backend.test.env
+++ b/app/backend.test.env
@@ -1,1 +1,1 @@
-DATABASE_CONNECTION_STRING=postgresql://postgres:06b3890acd2c235c41be0bbfe22f1b386a04bf02eedf8c977486355616be2aa1@postgres_tests:6544/postgres
+DATABASE_CONNECTION_STRING=postgresql://postgres:06b3890acd2c235c41be0bbfe22f1b386a04bf02eedf8c977486355616be2aa1@postgres_tests:6544/testdb

--- a/app/backend/Makefile
+++ b/app/backend/Makefile
@@ -64,3 +64,21 @@ teardown-db:
 # make test file=test_file.py::TestClass::test_method → runs a specific test
 test:
 	uv run pytest $(if $(file),src/tests/$(file),src/tests) --disable-warnings
+
+# Run backend tests in Docker
+# Usage:
+# make docker-test                    → runs all tests
+# make docker-test file=test_file.py → runs tests in a specific file
+docker-test:
+	$(eval COMPOSE_FILES := -f ../docker-compose.test.yml $(if $(filter Darwin,$(shell uname -s)),-f ../docker-compose.testmac.yml))
+	docker compose $(COMPOSE_FILES) up -d --wait postgres_tests
+	docker compose $(COMPOSE_FILES) run --rm --build \
+		-v $(ROOT_DIR):/app \
+		-v /app/.venv \
+		-e DATABASE_CONNECTION_STRING=postgresql://postgres:06b3890acd2c235c41be0bbfe22f1b386a04bf02eedf8c977486355616be2aa1@postgres_tests:6544/testdb \
+		--no-deps \
+		backend_test_runner \
+		pytest $(if $(file),src/tests/$(file),src/tests) --disable-warnings
+
+teardown-docker-test:
+	docker compose -f ../docker-compose.test.yml down

--- a/app/backend/readme.md
+++ b/app/backend/readme.md
@@ -29,20 +29,9 @@ This will spin up a complete copy of the database, backend, and proxies needed t
 
 This will not currently run the frontend, to do that, please follow the instructions in [app/web/readme.md](../web/readme.md) under *Quick Start*, then *Running against a local backend*.
 
-### Running tests in docker
-
-**Remember** 
-
-If you've made changes to any \*.proto files, you may need to re-compile the protocol buffers (step 2).
-
-You can run all backend tests in docker with the following command, executed in the `app` folder:
-
-```sh
-docker compose -f docker-compose.test.yml up --build
-```
-
 ### Running tests locally
 
+This is the recommended approach. 
 ```sh
 cd app/backend
 
@@ -61,6 +50,29 @@ make test
 ## Or run a single file's tests, add your filename
 make test file=[test_filename.py]
 ```
+
+
+### Running tests in docker
+
+**Remember**
+
+If you've made changes to any \*.proto files, you may need to re-compile the protocol buffers (step 2).
+
+You can run all backend tests in docker with the following commands:
+
+```sh
+cd app/backend
+
+## Run all tests
+make docker-test
+
+## Or run a single file's tests
+make docker-test file=test_filename.py
+
+## Teardown the test database when done
+make teardown-docker-test
+```
+
 
 ## Q/A:
 

--- a/app/docker-compose.test.yml
+++ b/app/docker-compose.test.yml
@@ -18,22 +18,15 @@ services:
       - 6544:6544
     platform: linux/amd64
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      test: [ "CMD-SHELL", "psql -U postgres -c 'SELECT PostGIS_Version();' || exit 1" ]
       interval: 1s
       timeout: 10s
-      start_period: 3s
+      start_period: 5s
       retries: 10
-  backend_tests:
+  backend_test_runner:
     build: backend
     env_file: backend.test.env
-    volumes:
-      - "./backend:/app"
-    command: bash -c "find src -name '**.py' | ENTR_INOTIFY_WORKAROUND=1 entr -nd pytest src"
-    restart: unless-stopped
-    depends_on:
-      - postgres_tests
-    links:
-      - postgres_tests
+    profiles: ["test"]  # This service won't start with 'up', only with 'run'
   media_tests:
     build: media
     env_file: media.test.env


### PR DESCRIPTION
1. Suggest running tests locally as a preferred approach.
2. Suggest running tests in Docker via `make docker-test` command. This command spins up a database container and then runs tests with `docker run ...` command, instead of running them continuously as part of docker compose. IMO this is a more natural way to run tests, especially if you're a frontend developer wanting to make a small change.

I tried running tests via currently recommended docker compose way and found it very confusing. The output is mingled between three containers and it's difficult to understand what's going on.