### PR TITLE
Fix warnings and ignore warnings we can't fix

### DIFF
--- a/app/backend/Makefile
+++ b/app/backend/Makefile
@@ -63,22 +63,4 @@ teardown-db:
 # make test file=test_file.py → runs tests in a specific file
 # make test file=test_file.py::TestClass::test_method → runs a specific test
 test:
-	uv run pytest $(if $(file),src/tests/$(file),src/tests) --disable-warnings
-
-# Run backend tests in Docker
-# Usage:
-# make docker-test                    → runs all tests
-# make docker-test file=test_file.py → runs tests in a specific file
-docker-test:
-	$(eval COMPOSE_FILES := -f ../docker-compose.test.yml $(if $(filter Darwin,$(shell uname -s)),-f ../docker-compose.testmac.yml))
-	docker compose $(COMPOSE_FILES) up -d --wait postgres_tests
-	docker compose $(COMPOSE_FILES) run --rm --build \
-		-v $(ROOT_DIR):/app \
-		-v /app/.venv \
-		-e DATABASE_CONNECTION_STRING=postgresql://postgres:06b3890acd2c235c41be0bbfe22f1b386a04bf02eedf8c977486355616be2aa1@postgres_tests:6544/testdb \
-		--no-deps \
-		backend_test_runner \
-		pytest $(if $(file),src/tests/$(file),src/tests) --disable-warnings
-
-teardown-docker-test:
-	docker compose -f ../docker-compose.test.yml down
+	uv run pytest $(if $(file),src/tests/$(file),src/tests)

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -96,6 +96,18 @@ known-first-party = ["couchers", "proto", "tests", "dummy_data"]
 extra-standard-library = ["zoneinfo"]
 
 
+# Pytest
+[tool.pytest]
+strict = true
+filterwarnings = [
+    "error",  # Treat all warnings as errors by default
+    # Ignore scalar subquery warning from geoalchemy2 library (not fixable in our code)
+    "ignore:implicitly coercing SELECT object to scalar subquery:sqlalchemy.exc.SAWarning:geoalchemy2",
+    # Ignore SQLAlchemy session management warnings (informational, from SQLAlchemy internals)
+    "ignore:Object of type .* not in session:sqlalchemy.exc.SAWarning",
+]
+
+
 # Mypy
 [tool.mypy]
 strict = true

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -170,7 +170,7 @@ def _sanitized_bytes(proto: Message | None) -> bytes | None:
                 submessage = getattr(message, name)
                 if not submessage:
                     continue
-                if descriptor.label == descriptor.LABEL_REPEATED:
+                if descriptor.is_repeated:
                     for msg in submessage:
                         _sanitize_message(msg)
                 else:

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -7,7 +7,7 @@ from os import getpid
 from threading import get_ident
 from time import perf_counter_ns
 from traceback import format_exception
-from typing import Any, Never, NoReturn, cast
+from typing import Any, NoReturn, cast
 
 import grpc
 import sentry_sdk
@@ -135,11 +135,10 @@ def _try_get_and_update_user_details(
             )
 
 
-# We have to lie with R | NoReturn to please mypy. It should be NoReturn.
 def abort_handler[T, R](
     message: str,
     status_code: grpc.StatusCode,
-) -> "grpc.RpcMethodHandler[T, R | NoReturn]":
+) -> "grpc.RpcMethodHandler[T, R]":
     def f(request: Any, context: CouchersContext) -> NoReturn:
         context.abort(status_code, message)
 
@@ -149,7 +148,7 @@ def abort_handler[T, R](
 def unauthenticated_handler[T, R](
     message: str = UNAUTHORIZED_ERROR_MESSAGE,
     status_code: grpc.StatusCode = grpc.StatusCode.UNAUTHENTICATED,
-) -> "grpc.RpcMethodHandler[T, R | NoReturn]":
+) -> "grpc.RpcMethodHandler[T, R]":
     return abort_handler(message, status_code)
 
 
@@ -246,7 +245,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
         self,
         continuation: Cont[T, R],
         handler_call_details: grpc.HandlerCallDetails,
-    ) -> "grpc.RpcMethodHandler[T, R | Never]":
+    ) -> "grpc.RpcMethodHandler[T, R]":
         start = perf_counter_ns()
 
         method = handler_call_details.method
@@ -426,7 +425,7 @@ class MediaInterceptor(grpc.ServerInterceptor):
         self,
         continuation: Cont[T, R],
         handler_call_details: grpc.HandlerCallDetails,
-    ) -> "grpc.RpcMethodHandler[T, R | Never]":
+    ) -> "grpc.RpcMethodHandler[T, R]":
         handler = continuation(handler_call_details)
         if not handler:
             raise RuntimeError("No handler")
@@ -465,7 +464,7 @@ class OTelInterceptor(grpc.ServerInterceptor):
         self,
         continuation: Cont[T, R],
         handler_call_details: grpc.HandlerCallDetails,
-    ) -> "grpc.RpcMethodHandler[T, R | Never]":
+    ) -> "grpc.RpcMethodHandler[T, R]":
         handler = continuation(handler_call_details)
         if not handler:
             raise RuntimeError("No handler")
@@ -515,7 +514,7 @@ class ErrorSanitizationInterceptor(grpc.ServerInterceptor):
         self,
         continuation: Cont[T, R],
         handler_call_details: grpc.HandlerCallDetails,
-    ) -> "grpc.RpcMethodHandler[T, R | Never]":
+    ) -> "grpc.RpcMethodHandler[T, R]":
         handler = continuation(handler_call_details)
         if not handler:
             raise RuntimeError("No handler")

--- a/app/backend/src/couchers/materialized_views.py
+++ b/app/backend/src/couchers/materialized_views.py
@@ -91,7 +91,7 @@ cluster_subscription_counts = create_materialized_view(
     [
         Index(
             "uq_cluster_subscription_counts_cluster_id",
-            cluster_subscription_counts_selectable.c.cluster_id,
+            cluster_subscription_counts_selectable.subquery().c.cluster_id,
             unique=True,
         )
     ],
@@ -121,7 +121,13 @@ cluster_admin_counts = create_materialized_view(
     "cluster_admin_counts",
     cluster_admin_counts_selectable,
     Base.metadata,
-    [Index("uq_cluster_admin_counts_cluster_id", cluster_admin_counts_selectable.c.cluster_id, unique=True)],
+    [
+        Index(
+            "uq_cluster_admin_counts_cluster_id",
+            cluster_admin_counts_selectable.subquery().c.cluster_id,
+            unique=True,
+        )
+    ],
 )
 
 
@@ -173,25 +179,27 @@ def make_lite_users_selectable(create: bool = False) -> Select[Any]:
 lite_users_selectable_select = make_lite_users_selectable(create=False)
 lite_users_selectable_create = make_lite_users_selectable(create=True)
 
+lite_users_subquery = lite_users_selectable_create.subquery()
+
 lite_users = create_materialized_view_with_different_ddl(
     "lite_users",
     lite_users_selectable_select,
     lite_users_selectable_create,
     Base.metadata,
     [
-        Index("uq_lite_users_id", lite_users_selectable_create.c.id, unique=True),
-        Index("uq_lite_users_username", lite_users_selectable_create.c.username, unique=True),
+        Index("uq_lite_users_id", lite_users_subquery.c.id, unique=True),
+        Index("uq_lite_users_username", lite_users_subquery.c.username, unique=True),
         Index(
             "ix_lite_users_id_visible",
-            lite_users_selectable_create.c.id,
+            lite_users_subquery.c.id,
             postgresql_using="hash",
-            postgresql_where=lite_users_selectable_create.c.is_visible,
+            postgresql_where=lite_users_subquery.c.is_visible,
         ),
         Index(
             "ix_lite_users_username_visible",
-            lite_users_selectable_create.c.username,
+            lite_users_subquery.c.username,
             postgresql_using="hash",
-            postgresql_where=lite_users_selectable_create.c.is_visible,
+            postgresql_where=lite_users_subquery.c.is_visible,
         ),
     ],
 )
@@ -331,7 +339,7 @@ user_response_rates = create_materialized_view(
     "user_response_rates",
     user_response_rates_selectable,
     Base.metadata,
-    [Index("uq_user_response_rates_id", user_response_rates_selectable.c.user_id, unique=True)],
+    [Index("uq_user_response_rates_id", user_response_rates_selectable.subquery().c.user_id, unique=True)],
 )
 
 

--- a/app/backend/src/couchers/migrations/versions/7d04ba82351c_ums_backfill_notifs.py
+++ b/app/backend/src/couchers/migrations/versions/7d04ba82351c_ums_backfill_notifs.py
@@ -124,7 +124,7 @@ def upgrade() -> None:
     # Backfill moderation_state_id for host_request notifications
     # The notification key contains the conversation_id, which is the host_request.id
     # Only process rows where key is non-empty and numeric
-    op.execute("""
+    op.execute(r"""
         UPDATE notifications n
         SET moderation_state_id = hr.moderation_state_id
         FROM host_requests hr
@@ -137,7 +137,7 @@ def upgrade() -> None:
 
     # Backfill moderation_state_id for chat notifications
     # The notification key contains the conversation_id, which is the group_chat.id
-    op.execute("""
+    op.execute(r"""
         UPDATE notifications n
         SET moderation_state_id = gc.moderation_state_id
         FROM group_chats gc

--- a/app/backend/src/couchers/models/clusters.py
+++ b/app/backend/src/couchers/models/clusters.py
@@ -16,7 +16,14 @@ from sqlalchemy import (
     func,
     text,
 )
-from sqlalchemy.orm import DynamicMapped, Mapped, column_property, deferred, mapped_column, relationship
+from sqlalchemy.orm import (
+    DynamicMapped,
+    Mapped,
+    column_property,
+    deferred,
+    mapped_column,
+    relationship,
+)
 from sqlalchemy.sql import expression
 
 from couchers.models.base import Base, Geom, communities_seq
@@ -49,7 +56,16 @@ class Node(Base):
 
     parent_node: Mapped["Node"] = relationship("Node", back_populates="child_nodes", remote_side="Node.id")
     child_nodes: Mapped[list["Node"]] = relationship("Node")
-    official_cluster: Mapped["Cluster"] = relationship("Cluster", uselist=False)
+    child_clusters: Mapped[list["Cluster"]] = relationship(
+        "Cluster", back_populates="parent_node", overlaps="official_cluster"
+    )
+    official_cluster: Mapped["Cluster"] = relationship(
+        "Cluster",
+        primaryjoin="and_(Node.id == Cluster.parent_node_id, Cluster.is_official_cluster)",
+        foreign_keys="[Cluster.parent_node_id]",
+        uselist=False,
+        viewonly=True,
+    )
 
 
 class Cluster(Base):
@@ -84,7 +100,11 @@ class Cluster(Base):
     )
 
     parent_node: Mapped["Node"] = relationship(
-        "Node", backref="child_clusters", remote_side="Node.id", foreign_keys="Cluster.parent_node_id"
+        "Node",
+        back_populates="child_clusters",
+        remote_side="Node.id",
+        foreign_keys="Cluster.parent_node_id",
+        overlaps="official_cluster",
     )
 
     nodes: Mapped[list["Cluster"]] = relationship(

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -145,7 +145,7 @@ def _user_can_message(session: Session, context: CouchersContext, group_chat: Gr
     if not group_chat.is_dm:
         return True
 
-    query = func.exists(
+    query = select(
         where_users_column_visible(
             select(GroupChatSubscription)
             .where(GroupChatSubscription.user_id != context.user_id)
@@ -153,9 +153,9 @@ def _user_can_message(session: Session, context: CouchersContext, group_chat: Gr
             .where(GroupChatSubscription.left == None),
             context=context,
             column=GroupChatSubscription.user_id,
-        )
+        ).exists()
     )
-    return cast(bool, session.execute(query).scalar_one())
+    return session.execute(query).scalar_one()
 
 
 def generate_message_notifications(payload: jobs_pb2.GenerateMessageNotificationsPayload) -> None:

--- a/app/backend/src/pytest.ini
+++ b/app/backend/src/pytest.ini
@@ -1,7 +1,0 @@
-[pytest]
-
-# pytest's normal mechanism for finding the path to prepend
-# to sys.path fails when faced with our PEP 420 namespace
-# package, so we need to add this manually.
-pythonpath = .
-xfail_strict = true

--- a/app/backend/src/tests/test_sanitized_bytes.py
+++ b/app/backend/src/tests/test_sanitized_bytes.py
@@ -1,0 +1,262 @@
+from google.protobuf import empty_pb2
+
+from couchers.interceptors import _sanitized_bytes
+from couchers.proto import api_pb2, auth_pb2, conversations_pb2
+
+
+class TestSanitizedBytes:
+    """Test suite for _sanitized_bytes function."""
+
+    def test_none_input(self):
+        """Test that None input returns None."""
+        result = _sanitized_bytes(None)
+        assert result is None
+
+    def test_empty_message(self):
+        """Test that an empty message is serialized correctly."""
+        proto = empty_pb2.Empty()
+        result = _sanitized_bytes(proto)
+
+        assert isinstance(result, bytes)
+        # Verify we can deserialize it back
+        deserialized = empty_pb2.Empty.FromString(result)
+        assert deserialized == proto
+
+    def test_message_with_no_sensitive_fields(self):
+        """Test that messages without sensitive fields are not modified."""
+        # AuthRes has no sensitive fields
+        proto = auth_pb2.AuthRes(user_id=12345, jailed=False)
+        result = _sanitized_bytes(proto)
+
+        assert result is not None
+        deserialized = auth_pb2.AuthRes.FromString(result)
+        assert deserialized.user_id == 12345
+        assert deserialized.jailed is False
+
+    def test_message_with_sensitive_field(self):
+        """Test that sensitive fields are cleared from messages."""
+        # AuthReq has a sensitive password field
+        proto = auth_pb2.AuthReq(user="testuser", password="supersecret123", remember_device=True)
+        result = _sanitized_bytes(proto)
+
+        assert result is not None
+        deserialized = auth_pb2.AuthReq.FromString(result)
+
+        # Non-sensitive fields should remain
+        assert deserialized.user == "testuser"
+        assert deserialized.remember_device is True
+
+        # Sensitive field should be cleared
+        assert deserialized.password == ""
+
+    def test_message_with_nested_message_non_repeated(self):
+        """Test that nested messages are recursively sanitized (non-repeated case)."""
+        # SignupFlowReq contains a nested SignupAccount message
+        proto = auth_pb2.SignupFlowReq(
+            flow_token="token123",
+            account=auth_pb2.SignupAccount(username="nesteduser", password="nestedsecret", city="Boston"),
+        )
+        result = _sanitized_bytes(proto)
+
+        assert result is not None
+        deserialized = auth_pb2.SignupFlowReq.FromString(result)
+
+        # Top-level fields should remain
+        assert deserialized.flow_token == "token123"
+
+        # Nested message non-sensitive fields should remain
+        assert deserialized.account.username == "nesteduser"
+        assert deserialized.account.city == "Boston"
+
+        # Nested message sensitive field should be cleared
+        assert deserialized.account.password == ""
+
+    def test_message_with_empty_nested_message(self):
+        """Test that empty nested message fields don't cause errors (continue branch)."""
+        # Create a message where nested message field is default/empty
+        # SignupFlowRes with auth_res not set (optional field)
+        proto = auth_pb2.SignupFlowRes(
+            flow_token="token456",
+            need_basic=True,
+            need_account=False,
+            # auth_res is not set
+        )
+        result = _sanitized_bytes(proto)
+
+        assert result is not None
+        deserialized = auth_pb2.SignupFlowRes.FromString(result)
+        assert deserialized.flow_token == "token456"
+        assert deserialized.need_basic is True
+        assert deserialized.need_account is False
+        # auth_res should still be empty/default
+        assert not deserialized.HasField("auth_res")
+
+    def test_message_with_empty_repeated_field(self):
+        """
+        Test that empty repeated message fields trigger the continue branch.
+
+        This covers line 171-172 where submessage evaluates to False (empty list).
+        """
+        # Create a message with a repeated field but don't add any items
+        proto = conversations_pb2.GetGroupChatMessagesRes(
+            last_message_id=999,
+            no_more=True,
+            # messages field is empty (default empty repeated field)
+        )
+        result = _sanitized_bytes(proto)
+
+        assert result is not None
+        deserialized = conversations_pb2.GetGroupChatMessagesRes.FromString(result)
+        assert deserialized.last_message_id == 999
+        assert deserialized.no_more is True
+        # Repeated field should be empty
+        assert len(deserialized.messages) == 0
+
+    def test_message_with_repeated_messages(self):
+        """Test that repeated message fields are recursively sanitized."""
+        # Create a message with repeated nested messages
+        # Using GetGroupChatMessagesRes which has repeated Message fields
+        proto = conversations_pb2.GetGroupChatMessagesRes(last_message_id=100, no_more=False)
+
+        # Add messages to the repeated field
+        msg1 = proto.messages.add()
+        msg1.message_id = 1
+        msg1.author_user_id = 123
+        msg1.text.text = "Hello"
+
+        msg2 = proto.messages.add()
+        msg2.message_id = 2
+        msg2.author_user_id = 456
+        msg2.text.text = "World"
+
+        result = _sanitized_bytes(proto)
+
+        assert result is not None
+        deserialized = conversations_pb2.GetGroupChatMessagesRes.FromString(result)
+
+        # Check that repeated messages are preserved
+        assert len(deserialized.messages) == 2
+        assert deserialized.messages[0].message_id == 1
+        assert deserialized.messages[0].text.text == "Hello"
+        assert deserialized.messages[0].author_user_id == 123
+        assert deserialized.messages[1].message_id == 2
+        assert deserialized.messages[1].text.text == "World"
+        assert deserialized.messages[1].author_user_id == 456
+
+    def test_deeply_nested_messages(self):
+        """Test that deeply nested messages are recursively sanitized."""
+        # SignupFlowRes contains AuthRes which is nested
+        proto = auth_pb2.SignupFlowRes(
+            flow_token="deep_token",
+            auth_res=auth_pb2.AuthRes(user_id=789, jailed=False),
+            need_basic=False,
+            need_account=True,
+        )
+        result = _sanitized_bytes(proto)
+
+        assert result is not None
+        deserialized = auth_pb2.SignupFlowRes.FromString(result)
+
+        # All nested data should be preserved (no sensitive fields in this structure)
+        assert deserialized.flow_token == "deep_token"
+        assert deserialized.auth_res.user_id == 789
+        assert deserialized.auth_res.jailed is False
+        assert deserialized.need_basic is False
+        assert deserialized.need_account is True
+
+    def test_multiple_nested_messages_with_sensitive_fields(self):
+        """
+        Test sanitization when a message has multiple nested messages with sensitive fields.
+
+        This ensures the function properly handles multiple different nested message fields.
+        """
+        # Create a SignupFlowReq with multiple nested messages
+        proto = auth_pb2.SignupFlowReq(
+            flow_token="repeat_token",
+            basic=auth_pb2.SignupBasic(name="Test User", email="test@example.com"),
+            account=auth_pb2.SignupAccount(username="testuser", password="shouldberemoved"),
+        )
+        result = _sanitized_bytes(proto)
+
+        assert result is not None
+        deserialized = auth_pb2.SignupFlowReq.FromString(result)
+
+        # Check basic nested message
+        assert deserialized.basic.name == "Test User"
+        assert deserialized.basic.email == "test@example.com"
+
+        # Check account nested message with sensitive field
+        assert deserialized.account.username == "testuser"
+        assert deserialized.account.password == ""
+
+    def test_message_preserves_original(self):
+        """Test that the original message is not modified (deepcopy is used)."""
+        original = auth_pb2.AuthReq(user="original_user", password="original_password")
+
+        # Store original values
+        original_user = original.user
+        original_password = original.password
+
+        # Call _sanitized_bytes
+        result = _sanitized_bytes(original)
+
+        # Original should not be modified
+        assert original.user == original_user
+        assert original.password == original_password
+
+        # But the result should have password cleared
+        deserialized = auth_pb2.AuthReq.FromString(result)
+        assert deserialized.user == original_user
+        assert deserialized.password == ""
+
+    def test_message_with_non_message_type_fields(self):
+        """Test messages with primitive fields (no message_type)."""
+        # Create a message with only primitive types
+        proto = auth_pb2.AuthRes(user_id=12345, jailed=True)
+        result = _sanitized_bytes(proto)
+
+        assert result is not None
+        deserialized = auth_pb2.AuthRes.FromString(result)
+        assert deserialized.user_id == 12345
+        assert deserialized.jailed is True
+
+    def test_complex_nested_structure(self):
+        """Test a complex nested structure to ensure all branches are covered."""
+        # Create a complex nested message
+        proto = auth_pb2.SignupFlowReq(
+            flow_token="complex_token",
+            basic=auth_pb2.SignupBasic(name="Complex User", email="complex@example.com", invite_code="INVITE123"),
+            account=auth_pb2.SignupAccount(
+                username="complexuser",
+                password="complexsecret",
+                city="Seattle",
+                lat=47.6062,
+                lng=-122.3321,
+                birthdate="1985-05-15",
+                gender="other",
+                hosting_status=api_pb2.HOSTING_STATUS_CAN_HOST,
+                accept_tos=True,
+            ),
+            feedback=auth_pb2.ContributorForm(ideas="Great platform!", contribute=auth_pb2.CONTRIBUTE_OPTION_YES),
+            email_token="email_verification_token",
+        )
+
+        result = _sanitized_bytes(proto)
+
+        assert result is not None
+        deserialized = auth_pb2.SignupFlowReq.FromString(result)
+
+        # Verify all non-sensitive fields are preserved
+        assert deserialized.flow_token == "complex_token"
+        assert deserialized.basic.name == "Complex User"
+        assert deserialized.basic.email == "complex@example.com"
+        assert deserialized.basic.invite_code == "INVITE123"
+        assert deserialized.account.username == "complexuser"
+        assert deserialized.account.city == "Seattle"
+        assert deserialized.account.lat == 47.6062
+        assert deserialized.account.birthdate == "1985-05-15"
+        assert deserialized.feedback.ideas == "Great platform!"
+        assert deserialized.email_token == "email_verification_token"
+
+        # Verify sensitive field is cleared
+        assert deserialized.account.password == ""

--- a/app/backend/uv.lock
+++ b/app/backend/uv.lock
@@ -458,15 +458,15 @@ wheels = [
 
 [[package]]
 name = "geoalchemy2"
-version = "0.18.0"
+version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "sqlalchemy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/15/88398e863a9e044e06957d0f214cc5f7ef3c1dee4c540d828bfa6c7d4535/geoalchemy2-0.18.0.tar.gz", hash = "sha256:9a04690cc33fbc580d15c7c028d9b1b1ea08271489730096c7092e1d486c2b7a", size = 239129, upload-time = "2025-07-21T10:51:47.52Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/df/f6d689120a15a2287794e16696c3bdb4cf2e53038255d288b61a4d59e1fa/geoalchemy2-0.18.1.tar.gz", hash = "sha256:4bdc7daf659e36f6456e2f2c3bcce222b879584921a4f50a803ab05fa2bb3124", size = 239302, upload-time = "2025-11-18T15:12:05.296Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/f5/1e36e49d4380d70d58c777953fd3c465b4fb242309b6bd6b88e45ef11bd7/geoalchemy2-0.18.0-py3-none-any.whl", hash = "sha256:ff0fe7339ba535c50845a2c7e8817a20c164364128991d795733b3c5904b1ee1", size = 81248, upload-time = "2025-07-21T10:51:46.291Z" },
+    { url = "https://files.pythonhosted.org/packages/48/25/b3d6fc757d8d909e0e666ec6fbf1b7914e9ad18d6e1b08994cd9d2e63330/geoalchemy2-0.18.1-py3-none-any.whl", hash = "sha256:a49d9559bf7acbb69129a01c6e1861657c15db420886ad0a09b1871fb0ff4bdb", size = 81261, upload-time = "2025-11-18T15:12:03.985Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Move pytest configuration into pyproject.toml
- Update geoalchemy2 (0.18 -> 0.18.1)
- Fix sqlalchemy warnings
- Ignore warnings originating from geoalchemy2
- Ignore warnings related to use of object outside of session (they seem harmless)
- Fail tests if a new warning is encountered