### PR TITLE
Use an i18next string scope per notification kind

### DIFF
--- a/app/backend/src/couchers/i18n/locales/de.json
+++ b/app/backend/src/couchers/i18n/locales/de.json
@@ -263,15 +263,17 @@
         "no_money_guideline": "Halte es unkommerziell. Tausche kein Geld während des Surfens oder beim Hosten. Couchers.org dreht sich um Lernen, Erfahrungen und das Kennenlernen von Menschen."
     },
     "notifications": {
-        "donation_received_title": "Vielen Dank für deine Spende an Couchers.org!",
         "dear_name": "Hallo {{name}},",
-        "donation_received_thanks_amount": "vielen Dank für deine Spende in höhe von ${{amount}} an Couchers.org.",
-        "donation_received_invoice_receipt_info": "Du kannst eine Rechnung und eine Quittung für die Spende hier herunterladen:",
-        "donation_received_download_invoice": "Rechnung herunterladen",
-        "donation_received_questions_contact": "Wenn du Fragen zu deiner Spende hast, schreib uns bitte eine E-Mail an <a href=\"mailto:donations@couchers.org\">donations@couchers.org</a>.",
-        "donation_received_generosity_helps": "Deine Großzügigkeit wird dazu beitragen, die Plattform für alle bereitzustellen.",
         "thank_you": "Danke!",
         "founders_signature": "Aapeli und Itsi,\nGründer von Couchers.org",
-        "donation_received_purpose": "Dein Beitrag wird für den Aufbau und Erhalt der Couchers.org-Plattform und Community verwendet und ist entscheidend für unser Ziel einer völlig kostenlosen und gemeinnützigen Generation des Couchsurfings."
+        "donation_received": {
+            "title": "Vielen Dank für deine Spende an Couchers.org!",
+            "thanks_amount": "vielen Dank für deine Spende in höhe von ${{amount}} an Couchers.org.",
+            "invoice_receipt_info": "Du kannst eine Rechnung und eine Quittung für die Spende hier herunterladen:",
+            "download_invoice": "Rechnung herunterladen",
+            "questions_contact": "Wenn du Fragen zu deiner Spende hast, schreib uns bitte eine E-Mail an <a href=\"mailto:donations@couchers.org\">donations@couchers.org</a>.",
+            "generosity_helps": "Deine Großzügigkeit wird dazu beitragen, die Plattform für alle bereitzustellen.",
+            "purpose": "Dein Beitrag wird für den Aufbau und Erhalt der Couchers.org-Plattform und Community verwendet und ist entscheidend für unser Ziel einer völlig kostenlosen und gemeinnützigen Generation des Couchsurfings."
+        }
     }
 }

--- a/app/backend/src/couchers/i18n/locales/en.json
+++ b/app/backend/src/couchers/i18n/locales/en.json
@@ -261,15 +261,17 @@
     "no_money_guideline": "Keep things non-transactional. Don't exchange money while staying or hosting. Couchers.org is about learning, experiences, and getting to know people."
   },
   "notifications": {
-    "donation_received_title": "Thank you for your donation to Couchers.org!",
     "dear_name": "Dear {{name}},",
-    "donation_received_thanks_amount": "Thank you so much for your donation of ${{amount}} to Couchers.org.",
-    "donation_received_purpose": "Your contribution will go towards building and sustaining the Couchers.org platform and community, and is vital for our goal of a completely free and non-profit generation of couch surfing.",
-    "donation_received_invoice_receipt_info": "You can download an invoice and receipt for the donation here:",
-    "donation_received_download_invoice": "Download invoice",
-    "donation_received_questions_contact": "If you have any questions about your donation, please email us at <a href=\"mailto:donations@couchers.org\">donations@couchers.org</a>.",
-    "donation_received_generosity_helps": "Your generosity will help deliver the platform for everyone.",
     "thank_you": "Thank you!",
-    "founders_signature": "Aapeli and Itsi,\nCouchers.org Founders"
+    "founders_signature": "Aapeli and Itsi,\nCouchers.org Founders",
+    "donation_received": {
+      "title": "Thank you for your donation to Couchers.org!",
+      "thanks_amount": "Thank you so much for your donation of ${{amount}} to Couchers.org.",
+      "purpose": "Your contribution will go towards building and sustaining the Couchers.org platform and community, and is vital for our goal of a completely free and non-profit generation of couch surfing.",
+      "invoice_receipt_info": "You can download an invoice and receipt for the donation here:",
+      "download_invoice": "Download invoice",
+      "questions_contact": "If you have any questions about your donation, please email us at <a href=\"mailto:donations@couchers.org\">donations@couchers.org</a>.",
+      "generosity_helps": "Your generosity will help deliver the platform for everyone."
+    }
   }
 }

--- a/app/backend/src/couchers/i18n/locales/ru.json
+++ b/app/backend/src/couchers/i18n/locales/ru.json
@@ -260,15 +260,17 @@
         "no_money_guideline": "Сохраняйте отношения некоммерческими. Не платите и не принимайте оплату за проживание или хостинг. Couchers.org - это про обучение, опыт и знакомство с людьми."
     },
     "notifications": {
-        "donation_received_title": "Спасибо за ваш вклад в Couchers.org!",
-        "donation_received_thanks_amount": "Большое спасибо за ваше пожертвование в размере ${{amount}} в пользу Couchers.org.",
-        "donation_received_invoice_receipt_info": "Вы можете скачать счет и квитанцию за пожертвование здесь:",
-        "donation_received_download_invoice": "Скачать счет",
-        "donation_received_generosity_helps": "Ваша щедрость поможет сделать платформу доступной для всех.",
         "thank_you": "Спасибо!",
         "founders_signature": "Аапели и Итси,\nОснователи Couchers.org",
-        "donation_received_questions_contact": "Если у вас есть вопросы о вашем пожертвовании, пожалуйста, напишите нам на <a href=\"mailto:donations@couchers.org\">donations@couchers.org</a>.",
-        "donation_received_purpose": "Ваш вклад поможет в создании и поддержке платформы и сообщества Couchers.org и является жизненно важным для нашей цели - полностью бесплатного и некоммерческого поколения каучсерфинга.",
-        "dear_name": "Привет {{name}},"
+        "dear_name": "Привет {{name}},",
+        "donation_received": {
+            "title": "Спасибо за ваш вклад в Couchers.org!",
+            "thanks_amount": "Большое спасибо за ваше пожертвование в размере ${{amount}} в пользу Couchers.org.",
+            "invoice_receipt_info": "Вы можете скачать счет и квитанцию за пожертвование здесь:",
+            "download_invoice": "Скачать счет",
+            "generosity_helps": "Ваша щедрость поможет сделать платформу доступной для всех.",
+            "questions_contact": "Если у вас есть вопросы о вашем пожертвовании, пожалуйста, напишите нам на <a href=\"mailto:donations@couchers.org\">donations@couchers.org</a>.",
+            "purpose": "Ваш вклад поможет в создании и поддержке платформы и сообщества Couchers.org и является жизненно важным для нашей цели - полностью бесплатного и некоммерческого поколения каучсерфинга."
+        }
     }
 }

--- a/app/backend/src/couchers/notifications/render.py
+++ b/app/backend/src/couchers/notifications/render.py
@@ -363,9 +363,9 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
             email_list_unsubscribe_url=generate_unsub_topic_action(notification),
         )
     elif notification.topic_action.display == "donation:received":
-        title = get_localized_string("notifications.donation_received_title")
+        title = get_localized_string("notifications.donation_received.title")
         message = get_localized_string(
-            "notifications.donation_received_thanks_amount",
+            "notifications.donation_received.thanks_amount",
             substitutions={
                 "amount": data.amount,
             },

--- a/app/backend/templates/v2/donation_received.mjml
+++ b/app/backend/templates/v2/donation_received.mjml
@@ -1,22 +1,22 @@
 <mj-section padding="0px">
   <mj-column>
     <mj-text>{{ "notifications.dear_name"|v2translate(name=user.name) }}</mj-text>
-    <mj-text>{{ "notifications.donation_received_thanks_amount"|v2translate(amount=amount) }}</mj-text>
-    <mj-text>{{ "notifications.donation_received_purpose"|v2translate }}</mj-text>
-    <mj-text>{{ "notifications.donation_received_invoice_receipt_info"|v2translate }}</mj-text>
+    <mj-text>{{ "notifications.donation_received.thanks_amount"|v2translate(amount=amount) }}</mj-text>
+    <mj-text>{{ "notifications.donation_received.purpose"|v2translate }}</mj-text>
+    <mj-text>{{ "notifications.donation_received.invoice_receipt_info"|v2translate }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
     <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ receipt_url|v2url }}">
-      <b>{{ "notifications.donation_received_download_invoice"|v2translate }}</b>
+      <b>{{ "notifications.donation_received.download_invoice"|v2translate }}</b>
     </mj-button>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>{{ "notifications.donation_received_questions_contact"|v2translate }}</mj-text>
-    <mj-text>{{ "notifications.donation_received_generosity_helps"|v2translate }}</mj-text>
+    <mj-text>{{ "notifications.donation_received.questions_contact"|v2translate }}</mj-text>
+    <mj-text>{{ "notifications.donation_received.generosity_helps"|v2translate }}</mj-text>
     <mj-text><b>{{ "notifications.thank_you"|v2translate }}</b></mj-text>
     <mj-text>{{ "notifications.founders_signature"|v2translate }}</mj-text>
   </mj-column>

--- a/app/backend/templates/v2/donation_received.txt
+++ b/app/backend/templates/v2/donation_received.txt
@@ -1,17 +1,17 @@
 {{ "notifications.dear_name"|v2translate(name=user.name) }}
 
-{{ "notifications.donation_received_thanks_amount"|v2translate(amount=amount) }}
+{{ "notifications.donation_received.thanks_amount"|v2translate(amount=amount) }}
 
-{{ "notifications.donation_received_purpose"|v2translate }}
+{{ "notifications.donation_received.purpose"|v2translate }}
 
 
-{{ "notifications.donation_received_invoice_receipt_info"|v2translate }}
+{{ "notifications.donation_received.invoice_receipt_info"|v2translate }}
 
 <{{ receipt_url }}>
 
-{{ "notifications.donation_received_questions_contact"|v2translate }}
+{{ "notifications.donation_received.questions_contact"|v2translate }}
 
-{{ "notifications.donation_received_generosity_helps"|v2translate }}
+{{ "notifications.donation_received.generosity_helps"|v2translate }}
 
 
 {{ "notifications.thank_you"|v2translate }}

--- a/app/backend/templates/v2/generated_html/donation_received.html
+++ b/app/backend/templates/v2/generated_html/donation_received.html
@@ -172,17 +172,17 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received_thanks_amount"|v2translate(amount=amount) }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received.thanks_amount"|v2translate(amount=amount) }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received_purpose"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received.purpose"|v2translate }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received_invoice_receipt_info"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received.invoice_receipt_info"|v2translate }}</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -211,7 +211,7 @@
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
                                           <a href="{{ receipt_url|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
-                                            <b>{{ "notifications.donation_received_download_invoice"|v2translate }}</b>
+                                            <b>{{ "notifications.donation_received.download_invoice"|v2translate }}</b>
                                           </a>
                                         </td>
                                       </tr>
@@ -240,12 +240,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received_questions_contact"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received.questions_contact"|v2translate }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received_generosity_helps"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received.generosity_helps"|v2translate }}</div>
                                 </td>
                               </tr>
                               <tr>


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
Moves the existing `donation_received` email strings to a subscope, `notifications.donation_received`. This sets the pattern for localizing other emails.

Note: This updates translated strings so I might have to solve integration conflicts with weblate.

**Please give clear steps for how the reviewer can best test this PR**
Run the test_email.py test, since it formats and asserts on the `donation_received` email.

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A

**Backend checklist**
- [x] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)