### PR TITLE
Enable branch coverage and adjust report

### DIFF
--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -124,7 +124,20 @@ ignore_missing_imports = true
 # Coverage
 [tool.coverage.run]
 omit = ["src/couchers/proto/**", "src/couchers/migrations/versions/**", "src/dummy_data.py"]
+branch = true
 
+[tool.coverage.report]
+exclude_also = [
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "class .*\\bProtocol\\):",
+    "@(abc\\.)?abstractmethod",
+]
+skip_covered = true
+show_missing = true
 
 # Build
 [build-system]

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -6,7 +6,7 @@ prometheus_multiproc_dir = TemporaryDirectory()
 environ["PROMETHEUS_MULTIPROC_DIR"] = prometheus_multiproc_dir.name
 
 # Default for running with a database from docker-compose.test.yml.
-if "DATABASE_CONNECTION_STRING" not in environ:
+if "DATABASE_CONNECTION_STRING" not in environ:  # pragma: no cover
     environ["DATABASE_CONNECTION_STRING"] = (
         "postgresql://postgres:06b3890acd2c235c41be0bbfe22f1b386a04bf02eedf8c977486355616be2aa1@localhost:6544/testdb"
     )

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -579,7 +579,7 @@ def test_ChangeEmailV2(db, fast_passwords, push_collector):
     )
 
     with auth_api_session() as (auth_api, metadata_interceptor):
-        res = auth_api.ConfirmChangeEmailV2(
+        auth_api.ConfirmChangeEmailV2(
             auth_pb2.ConfirmChangeEmailV2Req(
                 change_email_token=token,
             )
@@ -620,8 +620,6 @@ def test_ChangeEmailV2_sends_proper_emails(db, fast_passwords, push_collector):
     with session_scope() as session:
         jobs = session.execute(select(BackgroundJob).where(BackgroundJob.job_type == "send_email")).scalars().all()
         assert len(jobs) == 2
-        payload_for_notification_email = jobs[0].payload
-        payload_for_confirmation_email_new_address = jobs[1].payload
         uq_str1 = b"An email change to the email"
         uq_str2 = (
             b"You requested that your email be changed to this email address on Couchers.org. Your old email address is"
@@ -639,7 +637,7 @@ def test_ChangeEmailV2_sends_proper_emails(db, fast_passwords, push_collector):
 
 def test_ChangeLanguagePreference(db, fast_passwords):
     # user changes from default to ISO 639-1 language code
-    newLanguageCode = "zh"
+    new_lang = "zh"
     user, token = generate_user()
 
     with real_account_session(token) as account:
@@ -648,20 +646,19 @@ def test_ChangeLanguagePreference(db, fast_passwords):
 
         # call will have info about the request
         res, call = account.ChangeLanguagePreference.with_call(
-            account_pb2.ChangeLanguagePreferenceReq(ui_language_preference=newLanguageCode)
+            account_pb2.ChangeLanguagePreferenceReq(ui_language_preference=new_lang)
         )
 
         # cookies are sent via initial metadata, so we check for it there
-        for key, val in call.initial_metadata():
-            if key == "set-cookie":
-                # the value of "set-cookie" will be the full cookie string, pull the key value from the string
-                key_val = val.split(";")[0]
-                if key_val == "NEXT_LOCALE=zh":
-                    # the changed language preference should also be sent to the backend
-                    res = account.GetAccountInfo(empty_pb2.Empty())
-                    assert res.ui_language_preference == "zh"
-                    return
-        raise Exception(f"Didn't find right cookie, got {call.initial_metadata()}")
+        # the value of "set-cookie" will be the full cookie string, pull the key value from the string
+        cookie_values = [v.split(";")[0] for k, v in call.initial_metadata() if k == "set-cookie"]
+        assert any(val == "NEXT_LOCALE=zh" for val in cookie_values), (
+            f"Didn't find the right cookie, got {call.initial_metadata()}"
+        )
+
+        # the changed language preference should also be sent to the backend
+        res = account.GetAccountInfo(empty_pb2.Empty())
+        assert res.ui_language_preference == "zh"
 
 
 def test_contributor_form(db):

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -34,6 +34,7 @@ from couchers.models import (
     BackgroundJob,
     BackgroundJobState,
     Email,
+    HostRequest,
     HostRequestStatus,
     LoginToken,
     Message,
@@ -1370,8 +1371,6 @@ def test_send_host_request_reminders_blocked_users_no_notification(db, moderator
         session.execute(delete(BackgroundJob).execution_options(synchronize_session=False))
 
         # Reset the reminder counter so we can test again
-        from couchers.models import HostRequest
-
         host_request = session.execute(select(HostRequest).where(HostRequest.conversation_id == hr)).scalar_one()
         host_request.host_sent_request_reminders = 0
         host_request.last_sent_request_reminder_time = now() - HOST_REQUEST_REMINDER_INTERVAL

--- a/app/backend/src/tests/test_utils.py
+++ b/app/backend/src/tests/test_utils.py
@@ -1,10 +1,13 @@
+from datetime import UTC, datetime
+from unittest.mock import patch
+
 import pytest
 from sqlalchemy import select, update
 from sqlalchemy.sql import func
 
 from couchers.db import session_scope
 from couchers.models import User
-from couchers.utils import dt_from_page_token, dt_to_page_token, now, wrap_coordinate
+from couchers.utils import dt_from_page_token, dt_to_page_token, http_date, now, wrap_coordinate
 from tests.test_fixtures import db, generate_user, testconfig  # noqa
 
 
@@ -35,6 +38,25 @@ def test_page_token_time_db(db):
         # make sure euqality is still equality
         user = session.execute(select(User).where(User.joined == roundtrip)).scalar_one()
         assert user.joined == roundtrip
+
+
+def test_http_date_with_datetime():
+    """Test http_date with a specific datetime to verify usegmt=True is used"""
+    dt = datetime(2024, 1, 15, 10, 30, 45, tzinfo=UTC)
+
+    result = http_date(dt)
+
+    assert result == "Mon, 15 Jan 2024 10:30:45 GMT"
+
+
+def test_http_date_without_datetime():
+    """Test http_date with dt=None to verify it uses now() and usegmt=True"""
+    mock_now = datetime(2024, 3, 20, 14, 25, 30, tzinfo=UTC)
+
+    with patch("couchers.utils.now", return_value=mock_now):
+        result = http_date()
+
+    assert result == "Wed, 20 Mar 2024 14:25:30 GMT"
 
 
 def test_wrap_coordinate():

--- a/app/backend/src/tests/test_verification.py
+++ b/app/backend/src/tests/test_verification.py
@@ -155,15 +155,13 @@ def test_VerifyPhone(push_collector):
 
 
 def test_VerifyPhone_antibrute():
-    user, token = generate_user()
-    with account_session(token) as account:
-        with session_scope() as session:
-            session.execute(
-                update(User)
-                .where(User.id == user.id)
-                .values(phone_verification_token="111112", phone_verification_sent=now(), phone="+46701740605")
-            )
+    user, token = generate_user(
+        phone_verification_token="111112",
+        phone_verification_sent=now(),
+        phone="+46701740605",
+    )
 
+    with account_session(token) as account:
         for _ in range(10):
             with pytest.raises(grpc.RpcError) as e:
                 account.VerifyPhone(account_pb2.VerifyPhoneReq(token="123455"))


### PR DESCRIPTION
- Enable branch coverage (so a line like `x = 1 if True else 0` is considered covered only if both branches are covered)
- Ignore code that is generally uncovered
- In coverage report, don't show files that are 100% covered, and show the lines that are not covered