### PR TITLE
Extract push notification content to its own type

### DIFF
--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -107,19 +107,12 @@ def _send_email_notification(session: Session, user: User, notification: Notific
 def _send_push_notification(session: Session, user: User, notification: Notification) -> None:
     logger.debug(f"Formatting push notification for {user}")
 
-    rendered = render_push_notification(user, notification)
-
-    if not rendered.push_title:
-        raise Exception(f"Tried to send push notification to {user} but didn't have push info")
-
+    content = render_push_notification(user, notification)
     push_to_user(
         session,
         user_id=user.id,
-        title=rendered.push_title,
-        body=rendered.push_body,
-        icon=rendered.push_icon,
-        url=rendered.push_url,
         topic_action=notification.topic_action.display,
+        content=content,
         key=notification.key,
         # keep on server for at most an hour if the client is not around
         ttl=3600,

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -24,7 +24,7 @@ from couchers.notifications.quick_links import (
     generate_unsub_topic_action,
     generate_unsub_topic_key,
 )
-from couchers.notifications.render import render_notification
+from couchers.notifications.render import render_notification, render_push_notification
 from couchers.notifications.settings import get_preference
 from couchers.proto.internal import jobs_pb2
 from couchers.sql import moderation_state_column_visible
@@ -107,7 +107,7 @@ def _send_email_notification(session: Session, user: User, notification: Notific
 def _send_push_notification(session: Session, user: User, notification: Notification) -> None:
     logger.debug(f"Formatting push notification for {user}")
 
-    rendered = render_notification(user, notification)
+    rendered = render_push_notification(user, notification)
 
     if not rendered.push_title:
         raise Exception(f"Tried to send push notification to {user} but didn't have push info")

--- a/app/backend/src/couchers/notifications/push.py
+++ b/app/backend/src/couchers/notifications/push.py
@@ -43,8 +43,8 @@ def push_to_subscription(
     key: str | None = None,
     ttl: int = 0,
 ) -> None:
-    title = config["NOTIFICATION_PREFIX"] + content[: PushNotificationSubscription.MAX_TITLE_LENGTH]
-    body = content.body[: PushNotificationSubscription.MAX_BODY_LENGTH]
+    title = config["NOTIFICATION_PREFIX"] + content.title[: PushNotificationContent.MAX_TITLE_LENGTH]
+    body = content.body[: PushNotificationContent.MAX_BODY_LENGTH]
     icon_url = content.icon_url or urls.icon_url()
     action_url = content.action_url or ""
     queue_job(

--- a/app/backend/src/couchers/notifications/push.py
+++ b/app/backend/src/couchers/notifications/push.py
@@ -12,9 +12,11 @@ from couchers.models import PushNotificationSubscription
 from couchers.notifications.send_raw_push_notification import send_raw_push_notification_v2
 from couchers.proto.internal import jobs_pb2
 
+
 @dataclass(frozen=True, slots=True)
 class PushNotificationContent:
     """Defines the user-visible content of a push notification."""
+
     # Android reference: https://developer.android.com/develop/ui/views/notifications
     # iOS reference: https://developer.apple.com/documentation/usernotifications/unnotificationcontent
 
@@ -24,11 +26,11 @@ class PushNotificationContent:
     title: str
     """A localized title for the notification, this should be a very short string (2-4 words)."""
     body: str
-    """The main text of the notification."""
-    icon_url: str | None = None
-    """A URL to the icon to show in the notification. If None, will use the default app icon."""
+    """The localized text of the notification body."""
     action_url: str | None = None
     """The URL to open when the notification is clicked. If None, will open the app's main URL."""
+    icon_url: str | None = None
+    """A URL to the icon to show in the notification. If None, will use the default app icon."""
 
 
 def push_to_subscription(
@@ -41,8 +43,8 @@ def push_to_subscription(
     key: str | None = None,
     ttl: int = 0,
 ) -> None:
-    title = config["NOTIFICATION_PREFIX"] + content[:PushNotificationSubscription.MAX_TITLE_LENGTH]
-    body = content.body[:PushNotificationSubscription.MAX_BODY_LENGTH]
+    title = config["NOTIFICATION_PREFIX"] + content[: PushNotificationSubscription.MAX_TITLE_LENGTH]
+    body = content.body[: PushNotificationSubscription.MAX_BODY_LENGTH]
     icon_url = content.icon_url or urls.icon_url()
     action_url = content.action_url or ""
     queue_job(

--- a/app/backend/src/couchers/notifications/push.py
+++ b/app/backend/src/couchers/notifications/push.py
@@ -1,3 +1,6 @@
+from dataclasses import dataclass
+from typing import ClassVar
+
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
@@ -9,6 +12,24 @@ from couchers.models import PushNotificationSubscription
 from couchers.notifications.send_raw_push_notification import send_raw_push_notification_v2
 from couchers.proto.internal import jobs_pb2
 
+@dataclass(frozen=True, slots=True)
+class PushNotificationContent:
+    """Defines the user-visible content of a push notification."""
+    # Android reference: https://developer.android.com/develop/ui/views/notifications
+    # iOS reference: https://developer.apple.com/documentation/usernotifications/unnotificationcontent
+
+    MAX_TITLE_LENGTH: ClassVar[int] = 500
+    MAX_BODY_LENGTH: ClassVar[int] = 2000
+
+    title: str
+    """A localized title for the notification, this should be a very short string (2-4 words)."""
+    body: str
+    """The main text of the notification."""
+    icon_url: str | None = None
+    """A URL to the icon to show in the notification. If None, will use the default app icon."""
+    action_url: str | None = None
+    """The URL to open when the notification is clicked. If None, will open the app's main URL."""
+
 
 def push_to_subscription(
     session: Session,
@@ -16,23 +37,24 @@ def push_to_subscription(
     push_notification_subscription_id: int,
     user_id: int,
     topic_action: str,
+    content: PushNotificationContent,
     key: str | None = None,
-    title: str = "",
-    body: str = "",
-    icon: str | None = None,
-    url: str | None = None,
     ttl: int = 0,
 ) -> None:
+    title = config["NOTIFICATION_PREFIX"] + content[:PushNotificationSubscription.MAX_TITLE_LENGTH]
+    body = content.body[:PushNotificationSubscription.MAX_BODY_LENGTH]
+    icon_url = content.icon_url or urls.icon_url()
+    action_url = content.action_url or ""
     queue_job(
         session,
         job=send_raw_push_notification_v2,
         payload=jobs_pb2.SendRawPushNotificationPayloadV2(
             push_notification_subscription_id=push_notification_subscription_id,
             ttl=ttl,
-            title=config["NOTIFICATION_PREFIX"] + title[:500],
-            body=body[:2000],
-            icon=icon or urls.icon_url(),
-            url=url or "",
+            title=title,
+            body=body,
+            icon=icon_url,
+            url=action_url,
             user_id=user_id,
             topic_action=topic_action,
             key=key or "",
@@ -45,11 +67,8 @@ def _push_to_user(
     session: Session,
     user_id: int,
     topic_action: str,
+    content: PushNotificationContent,
     key: str | None,
-    title: str,
-    body: str,
-    icon: str | None,
-    url: str | None,
     ttl: int,
 ) -> None:
     """
@@ -70,11 +89,8 @@ def _push_to_user(
             push_notification_subscription_id=sub_id,
             user_id=user_id,
             topic_action=topic_action,
+            content=content,
             key=key,
-            title=title,
-            body=body,
-            icon=icon,
-            url=url,
             ttl=ttl,
         )
 
@@ -84,11 +100,8 @@ def push_to_user(
     *,
     user_id: int,
     topic_action: str,
+    content: PushNotificationContent,
     key: str | None = None,
-    title: str = "",
-    body: str = "",
-    icon: str | None = None,
-    url: str | None = None,
     ttl: int = 0,
 ) -> None:
     """
@@ -98,10 +111,7 @@ def push_to_user(
         session,
         user_id=user_id,
         topic_action=topic_action,
+        content=content,
         key=key,
-        title=title,
-        body=body,
-        icon=icon,
-        url=url,
         ttl=ttl,
     )

--- a/app/backend/src/couchers/notifications/render.py
+++ b/app/backend/src/couchers/notifications/render.py
@@ -1000,6 +1000,9 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
 
 def render_push_notification(user: User, notification: Notification) -> PushNotificationContent:
     email_notification = render_notification(user, notification)
+    if email_notification.push_title is None:
+        raise NotImplementedError(f"topic-action {notification.topic}:{notification.action} does not have push info")
+
     return PushNotificationContent(
         title=email_notification.push_title,
         body=email_notification.push_body,

--- a/app/backend/src/couchers/notifications/render.py
+++ b/app/backend/src/couchers/notifications/render.py
@@ -5,6 +5,7 @@ from typing import Any
 from couchers import urls
 from couchers.i18n.i18n import localize_string
 from couchers.models import Notification, User
+from couchers.notifications.push import PushNotificationContent
 from couchers.notifications.quick_links import generate_quick_decline_link, generate_unsub_topic_action
 from couchers.proto import notification_data_pb2
 from couchers.templates.v2 import v2avatar, v2date, v2esc, v2phone, v2timestamp
@@ -995,3 +996,13 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
         )
 
     raise NotImplementedError(f"Unknown topic-action: {notification.topic}:{notification.action}")
+
+
+def render_push_notification(user: User, notification: Notification) -> PushNotificationContent:
+    email_notification = render_notification(user, notification)
+    return PushNotificationContent(
+        title=email_notification.push_title,
+        body=email_notification.push_body,
+        action_url=email_notification.push_url,
+        icon_url=email_notification.push_icon,
+    )

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -22,8 +22,8 @@ from couchers.models import (
     PushNotificationSubscription,
     User,
 )
-from couchers.notifications.push import push_to_subscription, push_to_user, PushNotificationContent
-from couchers.notifications.render import render_notification
+from couchers.notifications.push import PushNotificationContent, push_to_subscription, push_to_user
+from couchers.notifications.render import render_push_notification
 from couchers.notifications.settings import (
     PreferenceNotUserEditableError,
     get_topic_actions_by_delivery_type,
@@ -46,7 +46,7 @@ def get_vapid_public_key() -> str:
 
 
 def notification_to_pb(user: User, notification: Notification) -> notifications_pb2.Notification:
-    rendered = render_notification(user, notification)
+    rendered = render_push_notification(user, notification)
     return notifications_pb2.Notification(
         notification_id=notification.id,
         created=Timestamp_from_datetime(notification.created),
@@ -209,7 +209,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             content=PushNotificationContent(
                 title="Checking push notifications work!",
                 body="If you see this, then it's working :)",
-            )
+            ),
         )
 
         return empty_pb2.Empty()
@@ -296,8 +296,8 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             content=PushNotificationContent(
                 title=request.title,
                 body=request.body,
-                icon_url=request.icon or None,
                 action_url=request.url or None,
+                icon_url=request.icon or None,
             ),
             key=request.key or None,
             ttl=request.ttl,

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -46,17 +46,17 @@ def get_vapid_public_key() -> str:
 
 
 def notification_to_pb(user: User, notification: Notification) -> notifications_pb2.Notification:
-    rendered = render_push_notification(user, notification)
+    content = render_push_notification(user, notification)
     return notifications_pb2.Notification(
         notification_id=notification.id,
         created=Timestamp_from_datetime(notification.created),
         topic=notification.topic_action.topic,
         action=notification.topic_action.action,
         key=notification.key,
-        title=rendered.push_title,
-        body=rendered.push_body,
-        icon=rendered.push_icon,
-        url=rendered.push_url,
+        title=content.title,
+        body=content.body,
+        icon=content.icon_url,
+        url=content.action_url,
         is_seen=notification.is_seen,
     )
 
@@ -190,8 +190,9 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             push_notification_subscription_id=subscription.id,
             user_id=context.user_id,
             topic_action="adhoc:setup",
-            title="Checking push notifications work!",
-            body="Hi, thanks for enabling push notifications!",
+            content=PushNotificationContent(
+                title="Checking push notifications work!", body="Hi, thanks for enabling push notifications!"
+            ),
         )
 
         return empty_pb2.Empty()
@@ -256,8 +257,10 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             push_notification_subscription_id=subscription.id,
             user_id=context.user_id,
             topic_action="adhoc:setup",
-            title="Push notifications enabled!",
-            body="You'll now receive notifications on this device.",
+            content=PushNotificationContent(
+                title="Push notifications enabled!",
+                body="You'll now receive notifications on this device.",
+            ),
         )
 
         return empty_pb2.Empty()

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -22,7 +22,7 @@ from couchers.models import (
     PushNotificationSubscription,
     User,
 )
-from couchers.notifications.push import push_to_subscription, push_to_user
+from couchers.notifications.push import push_to_subscription, push_to_user, PushNotificationContent
 from couchers.notifications.render import render_notification
 from couchers.notifications.settings import (
     PreferenceNotUserEditableError,
@@ -206,8 +206,10 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             session,
             user_id=context.user_id,
             topic_action="adhoc:testing",
-            title="Checking push notifications work!",
-            body="If you see this, then it's working :)",
+            content=PushNotificationContent(
+                title="Checking push notifications work!",
+                body="If you see this, then it's working :)",
+            )
         )
 
         return empty_pb2.Empty()
@@ -270,8 +272,10 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             session,
             user_id=context.user_id,
             topic_action="adhoc:testing",
-            title="Checking mobile push notifications work!",
-            body="If you see this on your phone, everything is wired up correctly 🎉",
+            content=PushNotificationContent(
+                title="Checking mobile push notifications work!",
+                body="If you see this on your phone, everything is wired up correctly 🎉",
+            ),
         )
 
         return empty_pb2.Empty()
@@ -289,11 +293,13 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             session,
             user_id=context.user_id,
             topic_action="adhoc:testing",
+            content=PushNotificationContent(
+                title=request.title,
+                body=request.body,
+                icon_url=request.icon or None,
+                action_url=request.url or None,
+            ),
             key=request.key or None,
-            title=request.title,
-            body=request.body,
-            icon=request.icon or None,
-            url=request.url or None,
             ttl=request.ttl,
         )
 

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -23,6 +23,7 @@ from couchers.models import (
 from couchers.proto import account_pb2, api_pb2, auth_pb2, conversations_pb2, requests_pb2
 from couchers.utils import now, today
 from tests.test_fixtures import (  # noqa
+    PushCollector,
     account_session,
     auth_api_session,
     email_fields,
@@ -33,7 +34,6 @@ from tests.test_fixtures import (  # noqa
     public_session,
     real_account_session,
     requests_session,
-    PushCollector,
 )
 from tests.test_requests import valid_request_text
 
@@ -629,6 +629,7 @@ def test_ChangeEmailV2_sends_proper_emails(db, fast_passwords, push_collector: P
     assert push.content.title == "An email change was initiated on your account"
     assert push.content.body == f"An email change to the email {new_email} was initiated on your account."
 
+
 def test_ChangeLanguagePreference(db, fast_passwords):
     # user changes from default to ISO 639-1 language code
     newLanguageCode = "zh"
@@ -718,7 +719,10 @@ def test_full_delete_account_with_recovery(db, push_collector: PushCollector):
 
     push = push_collector.get_for_user(user_id, index=0)
     assert push.content.title == "Account deletion initiated"
-    assert push.content.body == "Someone initiated the deletion of your Couchers.org account. To delete your account, please follow the link in the email we sent you."
+    assert (
+        push.content.body
+        == "Someone initiated the deletion of your Couchers.org account. To delete your account, please follow the link in the email we sent you."
+    )
 
     mock.assert_called_once()
     e = email_fields(mock)

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -33,6 +33,7 @@ from tests.test_fixtures import (  # noqa
     public_session,
     real_account_session,
     requests_session,
+    PushCollector,
 )
 from tests.test_requests import valid_request_text
 
@@ -179,7 +180,7 @@ def test_GetAccountInfo_regression(db):
         res = account.GetAccountInfo(empty_pb2.Empty())
 
 
-def test_ChangePasswordV2_normal(db, fast_passwords, push_collector):
+def test_ChangePasswordV2_normal(db, fast_passwords, push_collector: PushCollector):
     # user has old password and is changing to new password
     old_password = random_hex()
     new_password = random_hex()
@@ -197,9 +198,9 @@ def test_ChangePasswordV2_normal(db, fast_passwords, push_collector):
     mock.assert_called_once()
     assert email_fields(mock).subject == "[TEST] Your password was changed"
 
-    push_collector.assert_user_has_single_matching(
-        user.id, title="Your password was changed", body="Your login password for Couchers.org was changed."
-    )
+    push = push_collector.get_for_user(user.id)
+    assert push.content.title == "Your password was changed"
+    assert push.content.body == "Your login password for Couchers.org was changed."
 
     with session_scope() as session:
         updated_user = session.execute(select(User).where(User.id == user.id)).scalar_one()
@@ -546,7 +547,7 @@ def test_ChangeEmailV2_tokens_two_hour_window(db):
             assert e.value.details() == "Invalid token."
 
 
-def test_ChangeEmailV2(db, fast_passwords, push_collector):
+def test_ChangeEmailV2(db, fast_passwords, push_collector: PushCollector):
     password = random_hex()
     new_email = f"{random_hex()}@couchers.org.invalid"
     user, token = generate_user(hashed_password=hash_password(password))
@@ -571,12 +572,9 @@ def test_ChangeEmailV2(db, fast_passwords, push_collector):
         token = user_updated.new_email_token
 
     process_jobs()
-    push_collector.assert_user_push_matches_fields(
-        user_id,
-        ix=0,
-        title="An email change was initiated on your account",
-        body=f"An email change to the email {new_email} was initiated on your account.",
-    )
+    push = push_collector.get_for_user(user_id, index=0)
+    assert push.content.title == "An email change was initiated on your account"
+    assert push.content.body == f"An email change to the email {new_email} was initiated on your account."
 
     with auth_api_session() as (auth_api, metadata_interceptor):
         res = auth_api.ConfirmChangeEmailV2(
@@ -594,15 +592,12 @@ def test_ChangeEmailV2(db, fast_passwords, push_collector):
         assert user.new_email_token_expiry is None
 
     process_jobs()
-    push_collector.assert_user_push_matches_fields(
-        user_id,
-        ix=1,
-        title="Email change completed",
-        body="Your new email address has been verified.",
-    )
+    push = push_collector.get_for_user(user_id, index=1)
+    assert push.content.title == "Email change completed"
+    assert push.content.body == "Your new email address has been verified."
 
 
-def test_ChangeEmailV2_sends_proper_emails(db, fast_passwords, push_collector):
+def test_ChangeEmailV2_sends_proper_emails(db, fast_passwords, push_collector: PushCollector):
     password = random_hex()
     new_email = f"{random_hex()}@couchers.org.invalid"
     user, token = generate_user(hashed_password=hash_password(password))
@@ -630,12 +625,9 @@ def test_ChangeEmailV2_sends_proper_emails(db, fast_passwords, push_collector):
             uq_str2 in jobs[0].payload and uq_str1 in jobs[1].payload
         )
 
-    push_collector.assert_user_has_single_matching(
-        user.id,
-        title="An email change was initiated on your account",
-        body=f"An email change to the email {new_email} was initiated on your account.",
-    )
-
+    push = push_collector.get_for_user(user.id)
+    assert push.content.title == "An email change was initiated on your account"
+    assert push.content.body == f"An email change to the email {new_email} was initiated on your account."
 
 def test_ChangeLanguagePreference(db, fast_passwords):
     # user changes from default to ISO 639-1 language code
@@ -710,7 +702,7 @@ def test_DeleteAccount_message_storage(db):
         assert session.execute(select(func.count()).select_from(AccountDeletionReason)).scalar_one() == 3
 
 
-def test_full_delete_account_with_recovery(db, push_collector):
+def test_full_delete_account_with_recovery(db, push_collector: PushCollector):
     user, token = generate_user()
     user_id = user.id
 
@@ -724,12 +716,9 @@ def test_full_delete_account_with_recovery(db, push_collector):
         with mock_notification_email() as mock:
             account.DeleteAccount(account_pb2.DeleteAccountReq(confirm=True))
 
-    push_collector.assert_user_push_matches_fields(
-        user_id,
-        ix=0,
-        title="Account deletion initiated",
-        body="Someone initiated the deletion of your Couchers.org account. To delete your account, please follow the link in the email we sent you.",
-    )
+    push = push_collector.get_for_user(user_id, index=0)
+    assert push.content.title == "Account deletion initiated"
+    assert push.content.body == "Someone initiated the deletion of your Couchers.org account. To delete your account, please follow the link in the email we sent you."
 
     mock.assert_called_once()
     e = email_fields(mock)
@@ -766,12 +755,9 @@ def test_full_delete_account_with_recovery(db, push_collector):
                 )
             )
 
-    push_collector.assert_user_push_matches_fields(
-        user_id,
-        ix=1,
-        title="Your Couchers.org account has been deleted",
-        body="You can still undo this by following the link we emailed to you within 7 days.",
-    )
+    push = push_collector.get_for_user(user_id, index=1)
+    assert push.content.title == "Your Couchers.org account has been deleted"
+    assert push.content.body == "You can still undo this by following the link we emailed to you within 7 days."
 
     mock.assert_called_once()
     e = email_fields(mock)
@@ -807,12 +793,9 @@ def test_full_delete_account_with_recovery(db, push_collector):
                 )
             )
 
-    push_collector.assert_user_push_matches_fields(
-        user_id,
-        ix=2,
-        title="Your Couchers.org account has been recovered!",
-        body="We have recovered your Couchers.org account as per your request! Welcome back!",
-    )
+    push = push_collector.get_for_user(user_id, index=2)
+    assert push.content.title == "Your Couchers.org account has been recovered!"
+    assert push.content.body == "We have recovered your Couchers.org account as per your request! Welcome back!"
 
     mock.assert_called_once()
     e = email_fields(mock)

--- a/app/backend/src/tests/test_activeness_probes.py
+++ b/app/backend/src/tests/test_activeness_probes.py
@@ -14,6 +14,7 @@ from couchers.models import ActivenessProbe, ActivenessProbeStatus, HostingStatu
 from couchers.proto import api_pb2, jail_pb2
 from couchers.utils import now
 from tests.test_fixtures import (  # noqa
+    PushCollector,
     api_session,
     db,
     email_fields,
@@ -22,7 +23,6 @@ from tests.test_fixtures import (  # noqa
     push_collector,
     real_jail_session,
     testconfig,
-    PushCollector
 )
 
 
@@ -63,6 +63,7 @@ def test_activeness_probes_happy_path_inactive(db, push_collector: PushCollector
     assert push.content.title == "Are you still open to hosting on Couchers.org?"
     assert push.content.body == "Please log in to confirm your hosting status."
 
+
 def test_activeness_probes_happy_path_active(db, push_collector: PushCollector):
     user, token = generate_user(
         hosting_status=HostingStatus.can_host,
@@ -94,6 +95,7 @@ def test_activeness_probes_happy_path_active(db, push_collector: PushCollector):
     push = push_collector.get_for_user(user.id)
     assert push.content.title == "Are you still open to hosting on Couchers.org?"
     assert push.content.body == "Please log in to confirm your hosting status."
+
 
 def test_activeness_probes_disabled(db, push_collector: PushCollector):
     new_config = config.copy()

--- a/app/backend/src/tests/test_activeness_probes.py
+++ b/app/backend/src/tests/test_activeness_probes.py
@@ -22,6 +22,7 @@ from tests.test_fixtures import (  # noqa
     push_collector,
     real_jail_session,
     testconfig,
+    PushCollector
 )
 
 
@@ -30,7 +31,7 @@ def _(testconfig):
     pass
 
 
-def test_activeness_probes_happy_path_inactive(db, push_collector):
+def test_activeness_probes_happy_path_inactive(db, push_collector: PushCollector):
     user, token = generate_user(
         hosting_status=HostingStatus.can_host,
         meetup_status=MeetupStatus.wants_to_meetup,
@@ -58,14 +59,11 @@ def test_activeness_probes_happy_path_inactive(db, push_collector):
         assert res.hosting_status == api_pb2.HOSTING_STATUS_CANT_HOST
         assert res.meetup_status == api_pb2.MEETUP_STATUS_WANTS_TO_MEETUP
 
-    push_collector.assert_user_has_single_matching(
-        user.id,
-        title="Are you still open to hosting on Couchers.org?",
-        body="Please log in to confirm your hosting status.",
-    )
+    push = push_collector.get_for_user(user.id)
+    assert push.content.title == "Are you still open to hosting on Couchers.org?"
+    assert push.content.body == "Please log in to confirm your hosting status."
 
-
-def test_activeness_probes_happy_path_active(db, push_collector):
+def test_activeness_probes_happy_path_active(db, push_collector: PushCollector):
     user, token = generate_user(
         hosting_status=HostingStatus.can_host,
         meetup_status=MeetupStatus.wants_to_meetup,
@@ -93,14 +91,11 @@ def test_activeness_probes_happy_path_active(db, push_collector):
         assert res.hosting_status == api_pb2.HOSTING_STATUS_CAN_HOST
         assert res.meetup_status == api_pb2.MEETUP_STATUS_WANTS_TO_MEETUP
 
-    push_collector.assert_user_has_single_matching(
-        user.id,
-        title="Are you still open to hosting on Couchers.org?",
-        body="Please log in to confirm your hosting status.",
-    )
+    push = push_collector.get_for_user(user.id)
+    assert push.content.title == "Are you still open to hosting on Couchers.org?"
+    assert push.content.body == "Please log in to confirm your hosting status."
 
-
-def test_activeness_probes_disabled(db, push_collector):
+def test_activeness_probes_disabled(db, push_collector: PushCollector):
     new_config = config.copy()
     new_config["ACTIVENESS_PROBES_ENABLED"] = False
 
@@ -125,7 +120,7 @@ def test_activeness_probes_disabled(db, push_collector):
             assert not session.execute(select(exists(ActivenessProbe))).scalar_one()
 
 
-def test_activeness_probes_expiry(db, push_collector):
+def test_activeness_probes_expiry(db, push_collector: PushCollector):
     user, token = generate_user(
         hosting_status=HostingStatus.can_host,
         meetup_status=MeetupStatus.wants_to_meetup,

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -20,6 +20,7 @@ from couchers.proto import admin_pb2, auth_pb2, events_pb2, references_pb2, repo
 from couchers.utils import Timestamp_from_datetime, now, parse_date, timedelta
 from tests.test_communities import create_community
 from tests.test_fixtures import (  # noqa
+    PushCollector,
     add_users_to_new_moderation_list,
     auth_api_session,
     db,
@@ -35,7 +36,6 @@ from tests.test_fixtures import (  # noqa
     reporting_session,
     requests_session,
     testconfig,
-    PushCollector
 )
 
 
@@ -137,6 +137,7 @@ def test_ChangeUserGender(db, push_collector: PushCollector):
     assert push.content.title == "Your gender was changed"
     assert push.content.body == "Your gender on Couchers.org was changed to Machine by an admin."
 
+
 def test_ChangeUserBirthdate(db, push_collector: PushCollector):
     super_user, super_token = generate_user(is_superuser=True)
     normal_user, normal_token = generate_user(birthdate=date(year=2000, month=1, day=1))
@@ -168,6 +169,7 @@ def test_ChangeUserBirthdate(db, push_collector: PushCollector):
     push = push_collector.get_for_user(normal_user.id)
     assert push.content.title == "Your date of birth was changed"
     assert push.content.body == "Your date of birth on Couchers.org was changed to Friday 25 May 1990 by an admin."
+
 
 def test_BanUser(db):
     super_user, super_token = generate_user(is_superuser=True)

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -35,6 +35,7 @@ from tests.test_fixtures import (  # noqa
     reporting_session,
     requests_session,
     testconfig,
+    PushCollector
 )
 
 
@@ -110,7 +111,7 @@ def test_GetUserDetails(db):
     assert not res.deleted
 
 
-def test_ChangeUserGender(db, push_collector):
+def test_ChangeUserGender(db, push_collector: PushCollector):
     super_user, super_token = generate_user(is_superuser=True)
     normal_user, normal_token = generate_user()
 
@@ -132,14 +133,11 @@ def test_ChangeUserGender(db, push_collector):
     assert "Machine" in e.plain
     assert "Machine" in e.html
 
-    push_collector.assert_user_has_single_matching(
-        normal_user.id,
-        title="Your gender was changed",
-        body="Your gender on Couchers.org was changed to Machine by an admin.",
-    )
+    push = push_collector.get_for_user(normal_user.id)
+    assert push.content.title == "Your gender was changed"
+    assert push.content.body == "Your gender on Couchers.org was changed to Machine by an admin."
 
-
-def test_ChangeUserBirthdate(db, push_collector):
+def test_ChangeUserBirthdate(db, push_collector: PushCollector):
     super_user, super_token = generate_user(is_superuser=True)
     normal_user, normal_token = generate_user(birthdate=date(year=2000, month=1, day=1))
 
@@ -167,12 +165,9 @@ def test_ChangeUserBirthdate(db, push_collector):
     assert "1990" in e.plain
     assert "1990" in e.html
 
-    push_collector.assert_user_has_single_matching(
-        normal_user.id,
-        title="Your date of birth was changed",
-        body="Your date of birth on Couchers.org was changed to Friday 25 May 1990 by an admin.",
-    )
-
+    push = push_collector.get_for_user(normal_user.id)
+    assert push.content.title == "Your date of birth was changed"
+    assert push.content.body == "Your date of birth on Couchers.org was changed to Friday 25 May 1990 by an admin."
 
 def test_BanUser(db):
     super_user, super_token = generate_user(is_superuser=True)
@@ -336,7 +331,7 @@ def test_DeleteUser(db):
     assert not res.deleted
 
 
-def test_CreateApiKey(db, push_collector):
+def test_CreateApiKey(db, push_collector: PushCollector):
     with session_scope() as session:
         super_user, super_token = generate_user(is_superuser=True)
         normal_user, normal_token = generate_user()
@@ -378,9 +373,9 @@ def test_CreateApiKey(db, push_collector):
     assert "support@couchers.org" in e.plain
     assert "support@couchers.org" in e.html
 
-    push_collector.assert_user_has_single_matching(
-        normal_user.id, title="An API key was created for your account", body="Details were sent to you via email."
-    )
+    push = push_collector.get_for_user(normal_user.id)
+    assert push.content.title == "An API key was created for your account"
+    assert push.content.body == "Details were sent to you via email."
 
 
 def test_GetChats(db):
@@ -399,7 +394,7 @@ def test_GetChats(db):
     assert len(res.group_chats) == 0
 
 
-def test_badges(db, push_collector):
+def test_badges(db, push_collector: PushCollector):
     super_user, super_token = generate_user(is_superuser=True)
     normal_user, normal_token = generate_user()
 
@@ -413,11 +408,9 @@ def test_badges(db, push_collector):
         # badge emails are disabled by default
         mock.assert_not_called()
 
-        push_collector.assert_user_has_single_matching(
-            normal_user.id,
-            title="The Swagster badge was added to your profile",
-            body="Check out your profile to see the new badge!",
-        )
+        push = push_collector.get_for_user(normal_user.id)
+        assert push.content.title == "The Swagster badge was added to your profile"
+        assert push.content.body == "Check out your profile to see the new badge!"
 
         # can't add/edit special tags
         with pytest.raises(grpc.RpcError) as e:
@@ -440,12 +433,9 @@ def test_badges(db, push_collector):
         # badge emails are disabled by default
         mock.assert_not_called()
 
-        push_collector.assert_user_push_matches_fields(
-            normal_user.id,
-            ix=1,
-            title="The Swagster badge was removed from your profile",
-            body="You can see all your badges on your profile.",
-        )
+        push = push_collector.get_for_user(normal_user.id, index=1)
+        assert push.content.title == "The Swagster badge was removed from your profile"
+        assert push.content.body == "You can see all your badges on your profile."
 
         # not found on user
         with pytest.raises(grpc.RpcError) as e:
@@ -700,7 +690,7 @@ def test_RemoveUserFromModerationUserList(db):
             assert session.get(ModerationUserList, moderation_list_id) is None
 
 
-def test_admin_delete_account_url(db, push_collector):
+def test_admin_delete_account_url(db, push_collector: PushCollector):
     super_user, super_token = generate_user(is_superuser=True)
 
     user, token = generate_user()
@@ -711,7 +701,7 @@ def test_admin_delete_account_url(db, push_collector):
             admin_pb2.CreateAccountDeletionLinkReq(user=user.username)
         ).account_deletion_confirm_url
 
-    push_collector.assert_user_has_count(user_id, 0)
+    assert push_collector.count_for_user(user_id) == 0
 
     with session_scope() as session:
         token_o = session.execute(select(AccountDeletionToken)).scalar_one()
@@ -727,13 +717,9 @@ def test_admin_delete_account_url(db, push_collector):
                 )
             )
 
-    push_collector.assert_user_push_matches_fields(
-        user_id,
-        ix=0,
-        title="Your Couchers.org account has been deleted",
-        body="You can still undo this by following the link we emailed to you within 7 days.",
-    )
-
+    push = push_collector.get_for_user(user_id, index=0)
+    assert push.content.title == "Your Couchers.org account has been deleted"
+    assert push.content.body == "You can still undo this by following the link we emailed to you within 7 days."
     mock.assert_called_once()
     e = email_fields(mock)
 

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -28,6 +28,7 @@ from tests.test_fixtures import (  # noqa
     real_api_session,
     real_jail_session,
     testconfig,
+    PushCollector
 )
 from tests.test_fixtures import real_admin_session as admin_session
 
@@ -801,7 +802,7 @@ def test_pending_friend_request_count(db):
         assert res.pending_friend_request_count == 0
 
 
-def test_friend_request_flow(db, push_collector):
+def test_friend_request_flow(db, push_collector: PushCollector):
     user1, token1 = generate_user(complete_profile=True)
     user2, token2 = generate_user(complete_profile=True)
     user3, token3 = generate_user()
@@ -811,11 +812,9 @@ def test_friend_request_flow(db, push_collector):
         with api_session(token1) as api:
             api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user2.id))
 
-    push_collector.assert_user_has_single_matching(
-        user2.id,
-        title=f"{user1.name} wants to be your friend",
-        body=f"You've received a friend request from {user1.name}",
-    )
+    push = push_collector.get_for_user(user2.id)
+    assert push.content.title == f"{user1.name} wants to be your friend"
+    assert push.content.body == f"You've received a friend request from {user1.name}"
 
     mock.assert_called_once()
     e = email_fields(mock)
@@ -874,12 +873,10 @@ def test_friend_request_flow(db, push_collector):
         assert len(res.user_ids) == 1
         assert res.user_ids[0] == user1.id
 
-    push_collector.assert_user_has_count(user2.id, 1)
-    push_collector.assert_user_push_matches_fields(
-        user1.id,
-        title=f"{user2.name} accepted your friend request!",
-        body=f"{user2.name} has accepted your friend request",
-    )
+    assert push_collector.count_for_user(user2.id) == 1
+    push = push_collector.get_for_user(user1.id, index=0)
+    assert push.content.title == f"{user2.name} accepted your friend request!"
+    assert push.content.body == f"{user2.name} has accepted your friend request"
 
     mock.assert_called_once()
     e = email_fields(mock)
@@ -919,7 +916,7 @@ def test_friend_request_flow(db, push_collector):
         assert len(res.user_ids) == 0
 
 
-def test_RemoveFriend_regression(db, push_collector):
+def test_RemoveFriend_regression(db, push_collector: PushCollector):
     user1, token1 = generate_user(complete_profile=True)
     user2, token2 = generate_user(complete_profile=True)
     user3, token3 = generate_user()

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -14,6 +14,7 @@ from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_
 from couchers.resources import get_badge_dict
 from couchers.utils import create_coordinate, to_aware_datetime
 from tests.test_fixtures import (  # noqa
+    PushCollector,
     api_session,
     blocking_session,
     db,
@@ -28,7 +29,6 @@ from tests.test_fixtures import (  # noqa
     real_api_session,
     real_jail_session,
     testconfig,
-    PushCollector
 )
 from tests.test_fixtures import real_admin_session as admin_session
 

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -32,6 +32,7 @@ from tests.test_fixtures import (  # noqa
     push_collector,
     real_api_session,
     testconfig,
+    PushCollector
 )
 
 
@@ -406,7 +407,7 @@ def test_invalid_token(db):
     assert e.value.details() == "Unauthorized"
 
 
-def test_password_reset_v2(db, push_collector):
+def test_password_reset_v2(db, push_collector: PushCollector):
     user, token = generate_user(hashed_password=hash_password("mypassword"))
 
     with auth_api_session() as (auth_api, metadata_interceptor):
@@ -430,12 +431,9 @@ def test_password_reset_v2(db, push_collector):
     assert "support@couchers.org" in e.plain
     assert "support@couchers.org" in e.html
 
-    push_collector.assert_user_push_matches_fields(
-        user.id,
-        title="A password reset was initiated on your account",
-        body="Someone initiated a password change on your account.",
-    )
-
+    push = push_collector.get_for_user(user.id, index=0,)
+    assert push.content.title == "A password reset was initiated on your account"
+    assert push.content.body == "Someone initiated a password change on your account."
     # make sure bad password are caught
     with auth_api_session() as (auth_api, metadata_interceptor):
         with pytest.raises(grpc.RpcError) as e:
@@ -453,12 +451,9 @@ def test_password_reset_v2(db, push_collector):
                 auth_pb2.CompletePasswordResetV2Req(password_reset_token=password_reset_token, new_password=pwd)
             )
 
-    push_collector.assert_user_push_matches_fields(
-        user.id,
-        ix=1,
-        title="Your password was successfully reset",
-        body="Your password on Couchers.org was changed. If that was you, then no further action is needed.",
-    )
+    push = push_collector.get_for_user(user.id, index=1)
+    assert push.content.title == "Your password was successfully reset"
+    assert push.content.body == "Your password on Couchers.org was changed. If that was you, then no further action is needed."
 
     session_token, _ = get_session_cookie_tokens(metadata_interceptor)
 

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -22,6 +22,7 @@ from couchers.models import (
 )
 from couchers.proto import api_pb2, auth_pb2
 from tests.test_fixtures import (  # noqa
+    PushCollector,
     api_session,
     auth_api_session,
     db,
@@ -32,7 +33,6 @@ from tests.test_fixtures import (  # noqa
     push_collector,
     real_api_session,
     testconfig,
-    PushCollector
 )
 
 
@@ -431,7 +431,10 @@ def test_password_reset_v2(db, push_collector: PushCollector):
     assert "support@couchers.org" in e.plain
     assert "support@couchers.org" in e.html
 
-    push = push_collector.get_for_user(user.id, index=0,)
+    push = push_collector.get_for_user(
+        user.id,
+        index=0,
+    )
     assert push.content.title == "A password reset was initiated on your account"
     assert push.content.body == "Someone initiated a password change on your account."
     # make sure bad password are caught
@@ -453,7 +456,10 @@ def test_password_reset_v2(db, push_collector: PushCollector):
 
     push = push_collector.get_for_user(user.id, index=1)
     assert push.content.title == "Your password was successfully reset"
-    assert push.content.body == "Your password on Couchers.org was changed. If that was you, then no further action is needed."
+    assert (
+        push.content.body
+        == "Your password on Couchers.org was changed. If that was you, then no further action is needed."
+    )
 
     session_token, _ = get_session_cookie_tokens(metadata_interceptor)
 

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -52,6 +52,7 @@ from couchers.models import (
 from couchers.proto import conversations_pb2, requests_pb2
 from couchers.utils import now, today
 from tests.test_fixtures import (  # noqa
+    PushCollector,
     auth_api_session,
     conversations_session,
     db,
@@ -63,7 +64,6 @@ from tests.test_fixtures import (  # noqa
     push_collector,
     requests_session,
     testconfig,
-    PushCollector
 )
 from tests.test_references import create_host_reference, create_host_request, create_host_request_by_date
 from tests.test_requests import valid_request_text

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -63,6 +63,7 @@ from tests.test_fixtures import (  # noqa
     push_collector,
     requests_session,
     testconfig,
+    PushCollector
 )
 from tests.test_references import create_host_reference, create_host_request, create_host_request_by_date
 from tests.test_requests import valid_request_text
@@ -1191,7 +1192,7 @@ def test_update_recommendation_scores(db):
     update_recommendation_scores(empty_pb2.Empty())
 
 
-def test_update_badges(db, push_collector):
+def test_update_badges(db, push_collector: PushCollector):
     user1, _ = generate_user(last_donated=None)
     user2, _ = generate_user(last_donated=None)
     user3, _ = generate_user(last_donated=None)
@@ -1223,48 +1224,33 @@ def test_update_badges(db, push_collector):
 
     print(push_collector.pushes)
 
-    push_collector.assert_user_push_matches_fields(
-        user1.id,
-        ix=0,
-        title="The Founder badge was added to your profile",
-        body="Check out your profile to see the new badge!",
-    )
-    push_collector.assert_user_push_matches_fields(
-        user1.id,
-        ix=1,
-        title="The Board Member badge was added to your profile",
-        body="Check out your profile to see the new badge!",
-    )
-    push_collector.assert_user_push_matches_fields(
-        user2.id,
-        ix=0,
-        title="The Founder badge was added to your profile",
-        body="Check out your profile to see the new badge!",
-    )
-    push_collector.assert_user_push_matches_fields(
-        user2.id,
-        ix=1,
-        title="The Board Member badge was added to your profile",
-        body="Check out your profile to see the new badge!",
-    )
-    push_collector.assert_user_push_matches_fields(
-        user4.id,
-        ix=0,
-        title="The Verified Phone badge was added to your profile",
-        body="Check out your profile to see the new badge!",
-    )
-    push_collector.assert_user_push_matches_fields(
-        user5.id,
-        ix=0,
-        title="The Board Member badge was removed from your profile",
-        body="You can see all your badges on your profile.",
-    )
-    push_collector.assert_user_push_matches_fields(
-        user5.id,
-        ix=1,
-        title="The Verified Phone badge was added to your profile",
-        body="Check out your profile to see the new badge!",
-    )
+    push = push_collector.get_for_user(user1.id, index=0)
+    assert push.content.title == "The Founder badge was added to your profile"
+    assert push.content.body == "Check out your profile to see the new badge!"
+
+    push = push_collector.get_for_user(user1.id, index=1)
+    assert push.content.title == "The Board Member badge was added to your profile"
+    assert push.content.body == "Check out your profile to see the new badge!"
+
+    push = push_collector.get_for_user(user2.id, index=0)
+    assert push.content.title == "The Founder badge was added to your profile"
+    assert push.content.body == "Check out your profile to see the new badge!"
+
+    push = push_collector.get_for_user(user2.id, index=1)
+    assert push.content.title == "The Board Member badge was added to your profile"
+    assert push.content.body == "Check out your profile to see the new badge!"
+
+    push = push_collector.get_for_user(user4.id, index=0)
+    assert push.content.title == "The Verified Phone badge was added to your profile"
+    assert push.content.body == "Check out your profile to see the new badge!"
+
+    push = push_collector.get_for_user(user5.id, index=0)
+    assert push.content.title == "The Board Member badge was removed from your profile"
+    assert push.content.body == "You can see all your badges on your profile."
+
+    push = push_collector.get_for_user(user5.id, index=1)
+    assert push.content.title == "The Verified Phone badge was added to your profile"
+    assert push.content.body == "Check out your profile to see the new badge!"
 
 
 def test_send_request_notifications_blocked_users_no_notification(db, moderator):
@@ -1469,7 +1455,7 @@ def test_send_message_notifications_blocked_users_no_notification(db, moderator)
         assert email_job_count == 0, "No notification email should be sent when recipient has blocked sender"
 
 
-def test_update_badges_volunteers(db, push_collector):
+def test_update_badges_volunteers(db, push_collector: PushCollector):
     """Test that volunteer and past_volunteer badges are automatically granted based on Volunteer model."""
     # Create 6 users - users 1 and 2 get founder/board_member badges from static_badges
     user1, _ = generate_user(last_donated=None)
@@ -1529,29 +1515,24 @@ def test_update_badges_volunteers(db, push_collector):
         assert "past_volunteer" not in user6_badges
 
     # Check notifications for volunteer badge users
-    push_collector.assert_user_has_single_matching(
-        user3.id,
-        title="The Active Volunteer badge was added to your profile",
-        body="Check out your profile to see the new badge!",
-    )
-    push_collector.assert_user_has_single_matching(
-        user4.id,
-        title="The Past Volunteer badge was added to your profile",
-        body="Check out your profile to see the new badge!",
-    )
-    push_collector.assert_user_has_single_matching(
-        user5.id,
-        title="The Active Volunteer badge was removed from your profile",
-        body="You can see all your badges on your profile.",
-    )
-    push_collector.assert_user_has_single_matching(
-        user6.id,
-        title="The Past Volunteer badge was removed from your profile",
-        body="You can see all your badges on your profile.",
-    )
+    push = push_collector.get_for_user(user3.id)
+    assert push.content.title == "The Active Volunteer badge was added to your profile"
+    assert push.content.body == "Check out your profile to see the new badge!"
+
+    push = push_collector.get_for_user(user4.id)
+    assert push.content.title == "The Past Volunteer badge was added to your profile"
+    assert push.content.body == "Check out your profile to see the new badge!"
+
+    push = push_collector.get_for_user(user5.id)
+    assert push.content.title == "The Active Volunteer badge was removed from your profile"
+    assert push.content.body == "You can see all your badges on your profile."
+
+    push = push_collector.get_for_user(user6.id)
+    assert push.content.title == "The Past Volunteer badge was removed from your profile"
+    assert push.content.body == "You can see all your badges on your profile."
 
 
-def test_update_badges_volunteer_status_change(db, push_collector):
+def test_update_badges_volunteer_status_change(db, push_collector: PushCollector):
     """Test that badge is updated when volunteer status changes from active to past."""
     # Create users - users 1 and 2 get founder/board_member badges from static_badges
     user1, _ = generate_user(last_donated=None)
@@ -1577,11 +1558,9 @@ def test_update_badges_volunteer_status_change(db, push_collector):
         assert "volunteer" in user3_badges
         assert "past_volunteer" not in user3_badges
 
-    push_collector.assert_user_has_single_matching(
-        user3.id,
-        title="The Active Volunteer badge was added to your profile",
-        body="Check out your profile to see the new badge!",
-    )
+    push = push_collector.get_for_user(user3.id)
+    assert push.content.title == "The Active Volunteer badge was added to your profile"
+    assert push.content.body == "Check out your profile to see the new badge!"
 
     # Now change the volunteer to past volunteer
     with session_scope() as session:
@@ -1597,18 +1576,13 @@ def test_update_badges_volunteer_status_change(db, push_collector):
         assert "past_volunteer" in user3_badges
 
     # Check both badges were updated
-    push_collector.assert_user_push_matches_fields(
-        user3.id,
-        ix=1,
-        title="The Active Volunteer badge was removed from your profile",
-        body="You can see all your badges on your profile.",
-    )
-    push_collector.assert_user_push_matches_fields(
-        user3.id,
-        ix=2,
-        title="The Past Volunteer badge was added to your profile",
-        body="Check out your profile to see the new badge!",
-    )
+    push = push_collector.get_for_user(user3.id, index=1)
+    assert push.content.title == "The Active Volunteer badge was removed from your profile"
+    assert push.content.body == "You can see all your badges on your profile."
+
+    push = push_collector.get_for_user(user3.id, index=2)
+    assert push.content.title == "The Past Volunteer badge was added to your profile"
+    assert push.content.body == "Check out your profile to see the new badge!"
 
 
 def test_send_message_notifications_empty_unseen_simple(monkeypatch):

--- a/app/backend/src/tests/test_discussions.py
+++ b/app/backend/src/tests/test_discussions.py
@@ -14,6 +14,7 @@ from tests.test_fixtures import (  # noqa
     push_collector,
     testconfig,
     threads_session,
+    PushCollector
 )
 
 
@@ -47,7 +48,7 @@ def test_create_discussion_errors(db):
         assert e.value.details() == "Missing discussion content."
 
 
-def test_create_and_get_discussion(db, push_collector):
+def test_create_and_get_discussion(db, push_collector: PushCollector):
     generate_user()
     user, token = generate_user()
     user2, token2 = generate_user()
@@ -96,11 +97,9 @@ def test_create_and_get_discussion(db, push_collector):
 
     process_jobs()
 
-    push_collector.assert_user_has_single_matching(
-        user2_id,
-        title="dummy title",
-        body=f"{user.name} created a discussion in Testing Community: dummy title\n\ndummy content",
-    )
+    push = push_collector.get_for_user(user2_id)
+    assert push.content.title == "dummy title"
+    assert push.content.body == f"{user.name} created a discussion in Testing Community: dummy title\n\ndummy content"
 
     with discussions_session(token) as api:
         res = api.GetDiscussion(
@@ -151,7 +150,7 @@ def test_create_and_get_discussion(db, push_collector):
         assert res.owner_group_id == group_id
 
 
-def test_discussion_notifications_regression(db, push_collector):
+def test_discussion_notifications_regression(db, push_collector: PushCollector):
     generate_user()
     user, token = generate_user()
     user2, token2 = generate_user()
@@ -198,16 +197,12 @@ def test_discussion_notifications_regression(db, push_collector):
     process_jobs()
 
     # User2 should get 2 notifications about 2 replies to their comment, User3 should get 1 notification about 1 reply
-    push_collector.assert_user_has_count(user2_id, 2)
+    assert push_collector.count_for_user(user2_id) == 2
     for i in range(2):
-        push_collector.assert_user_push_matches_fields(
-            user2_id,
-            ix=i,
-            title="dummy title",
-            topic_action="thread:reply",
-        )
-    push_collector.assert_user_has_single_matching(
-        user3.id,
-        title="dummy title",
-        topic_action="thread:reply",
-    )
+        push = push_collector.get_for_user(user2_id, index=i)
+        assert push.content.title == "dummy title"
+        assert push.topic_action == "thread:reply"
+
+    push = push_collector.get_for_user(user3.id)
+    assert push.content.title == "dummy title"
+    assert push.topic_action == "thread:reply"

--- a/app/backend/src/tests/test_discussions.py
+++ b/app/backend/src/tests/test_discussions.py
@@ -6,6 +6,7 @@ from couchers.proto import discussions_pb2, notifications_pb2, threads_pb2
 from couchers.utils import now, to_aware_datetime
 from tests.test_communities import create_community, create_group
 from tests.test_fixtures import (  # noqa
+    PushCollector,
     db,
     discussions_session,
     generate_user,
@@ -14,7 +15,6 @@ from tests.test_fixtures import (  # noqa
     push_collector,
     testconfig,
     threads_session,
-    PushCollector
 )
 
 

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -24,6 +24,7 @@ from tests.test_fixtures import (  # noqa
     real_editor_session,
     testconfig,
     threads_session,
+    PushCollector
 )
 
 
@@ -32,7 +33,7 @@ def _(testconfig):
     pass
 
 
-def test_CreateEvent(db, push_collector):
+def test_CreateEvent(db, push_collector: PushCollector):
     # test cases:
     # can create event
     # cannot create event with missing details
@@ -2095,7 +2096,7 @@ def test_ListEventAttendees_regression(db):
         assert res.attendee_user_ids[0] == user1.id
 
 
-def test_event_threads(db, push_collector):
+def test_event_threads(db, push_collector: PushCollector):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
     user3, token3 = generate_user()
@@ -2144,9 +2145,9 @@ def test_event_threads(db, push_collector):
 
     process_jobs()
 
-    push_collector.assert_user_has_single_matching(user1.id, title=f'{user2.name} commented on "Dummy Title"')
-    push_collector.assert_user_has_single_matching(user2.id, title="Dummy Title")
-    push_collector.assert_user_has_count(user4_id, 0)
+    assert push_collector.get_for_user(user1.id).title == f'{user2.name} commented on "Dummy Title"'
+    assert push_collector.get_for_user(user2.id).title == "Dummy Title"
+    assert push_collector.count_for_user(user4_id) == 0
 
 
 def test_can_overlap_other_events_schedule_regression(db):

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -2145,8 +2145,8 @@ def test_event_threads(db, push_collector: PushCollector):
 
     process_jobs()
 
-    assert push_collector.get_for_user(user1.id).title == f'{user2.name} commented on "Dummy Title"'
-    assert push_collector.get_for_user(user2.id).title == "Dummy Title"
+    assert push_collector.get_for_user(user1.id).content.title == f'{user2.name} commented on "Dummy Title"'
+    assert push_collector.get_for_user(user2.id).content.title == "Dummy Title"
     assert push_collector.count_for_user(user4_id) == 0
 
 

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -13,6 +13,7 @@ from couchers.tasks import enforce_community_memberships
 from couchers.utils import Timestamp_from_datetime, now, to_aware_datetime
 from tests.test_communities import create_community, create_group
 from tests.test_fixtures import (  # noqa
+    PushCollector,
     db,
     email_fields,
     events_session,
@@ -24,7 +25,6 @@ from tests.test_fixtures import (  # noqa
     real_editor_session,
     testconfig,
     threads_session,
-    PushCollector
 )
 
 

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -1199,72 +1199,38 @@ def email_fields(mock, call_ix=0):
     )
 
 
+@dataclass(frozen=True, slots=True, kw_only=True)
 class Push:
-    """
-    This allows nice access to the push info via e.g. push.title instead of push["title"]
-    """
-
-    def __init__(self, kwargs):
-        self.kwargs = kwargs
-
-    def __getattr__(self, attr):
-        try:
-            return self.kwargs[attr]
-        except KeyError:
-            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{attr}'") from None
-
-    def __repr__(self):
-        kwargs_disp = ", ".join(f"'{key}'='{val}'" for key, val in self.kwargs.items())
-        return f"Push({kwargs_disp})"
+    topic_action: str
+    content: PushNotificationContent
+    key: str | None = None
+    ttl: int | None = None
 
 
 class PushCollector:
     def __init__(self):
         # pairs of (user_id, push)
-        self.pushes = []
+        self.pushes: list[tuple[int, Push]] = []
 
-    def by_user(self, user_id: int):
-        return [kwargs for uid, kwargs in self.pushes if uid == user_id]
+    def by_user(self, user_id: int) -> list[Push]:
+        return [push for uid, push in self.pushes if uid == user_id]
 
-    def push_to_user(self, session, user_id: int, **kwargs):
-        self.pushes.append((user_id, Push(kwargs=kwargs)))
+    def push_to_user(self, session, user_id: int, **kwargs) -> None:
+        self.pushes.append((user_id, Push(**kwargs)))
 
-    def assert_user_has_count(self, user_id: int, count: int) -> None:
-        assert len(self.by_user(user_id)) == count
+    def count_for_user(self, user_id: int) -> int:
+        return len(self.by_user(user_id))
 
-    def assert_user_push_matches_fields(
+    def get_for_user(
         self,
         user_id: int,
-        ix=0,
-        title: str | None = None,
-        body: str | None = None,
-        action_url: str | None = None,
-        **kwargs: Any,
-    ) -> None:
-        push = self.by_user(user_id)[ix]
-        content: PushNotificationContent = push.kwargs["content"]
-        if title is not None:
-            assert content.title == title, f"Push notification {user_id=}, {ix=} title mismatch"
-        if body is not None:
-            assert content.body == body, f"Push notification {user_id=}, {ix=} body mismatch"
-        if action_url is not None:
-            assert content.action_url == action_url, f"Push notification {user_id=}, {ix=} action_url mismatch"
-        for kwarg in kwargs:
-            assert kwarg in push.kwargs or kwargs, f"Push notification {user_id=}, {ix=} missing field '{kwarg}'"
-            assert push.kwargs[kwarg] == kwargs[kwarg], (
-                f"Push notification {user_id=}, {ix=} mismatch in field '{kwarg}', expected '{kwargs[kwarg]}' but got '{push.kwargs[kwarg]}'"
-            )
-
-    def assert_user_has_single_matching(
-        self,
-        user_id: int,
-        title: str | None = None,
-        body: str | None = None,
-        action_url: str | None = None,
-        **kwargs: Any,
-    ) -> None:
-        self.assert_user_has_count(user_id, 1)
-        self.assert_user_push_matches_fields(user_id, ix=0, title=title, body=body, action_url=action_url, **kwargs)
+        index: int | None = None,
+    ) -> Push:
+        pushes = self.by_user(user_id)
+        if index is None:
+            assert len(pushes) == 1, "Expected a single user notification"
+            return pushes[0].content
+        return pushes[index]
 
 
 @pytest.fixture

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -1229,7 +1229,7 @@ class PushCollector:
         pushes = self.by_user(user_id)
         if index is None:
             assert len(pushes) == 1, "Expected a single user notification"
-            return pushes[0].content
+            return pushes[0]
         return pushes[index]
 
 

--- a/app/backend/src/tests/test_fixtures.py
+++ b/app/backend/src/tests/test_fixtures.py
@@ -48,6 +48,7 @@ from couchers.models import (
     UserBlock,
     UserSession,
 )
+from couchers.notifications.push import PushNotificationContent
 from couchers.proto import (
     account_pb2_grpc,
     admin_pb2_grpc,
@@ -1222,26 +1223,48 @@ class PushCollector:
         # pairs of (user_id, push)
         self.pushes = []
 
-    def by_user(self, user_id):
+    def by_user(self, user_id: int):
         return [kwargs for uid, kwargs in self.pushes if uid == user_id]
 
-    def push_to_user(self, session, user_id, **kwargs):
+    def push_to_user(self, session, user_id: int, **kwargs):
         self.pushes.append((user_id, Push(kwargs=kwargs)))
 
-    def assert_user_has_count(self, user_id, count):
+    def assert_user_has_count(self, user_id: int, count: int) -> None:
         assert len(self.by_user(user_id)) == count
 
-    def assert_user_push_matches_fields(self, user_id, ix=0, **kwargs):
+    def assert_user_push_matches_fields(
+        self,
+        user_id: int,
+        ix=0,
+        title: str | None = None,
+        body: str | None = None,
+        action_url: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         push = self.by_user(user_id)[ix]
+        content: PushNotificationContent = push.kwargs["content"]
+        if title is not None:
+            assert content.title == title, f"Push notification {user_id=}, {ix=} title mismatch"
+        if body is not None:
+            assert content.body == body, f"Push notification {user_id=}, {ix=} body mismatch"
+        if action_url is not None:
+            assert content.action_url == action_url, f"Push notification {user_id=}, {ix=} action_url mismatch"
         for kwarg in kwargs:
-            assert kwarg in push.kwargs, f"Push notification {user_id=}, {ix=} missing field '{kwarg}'"
+            assert kwarg in push.kwargs or kwargs, f"Push notification {user_id=}, {ix=} missing field '{kwarg}'"
             assert push.kwargs[kwarg] == kwargs[kwarg], (
                 f"Push notification {user_id=}, {ix=} mismatch in field '{kwarg}', expected '{kwargs[kwarg]}' but got '{push.kwargs[kwarg]}'"
             )
 
-    def assert_user_has_single_matching(self, user_id, **kwargs):
+    def assert_user_has_single_matching(
+        self,
+        user_id: int,
+        title: str | None = None,
+        body: str | None = None,
+        action_url: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         self.assert_user_has_count(user_id, 1)
-        self.assert_user_push_matches_fields(user_id, ix=0, **kwargs)
+        self.assert_user_push_matches_fields(user_id, ix=0, title=title, body=body, action_url=action_url, **kwargs)
 
 
 @pytest.fixture

--- a/app/backend/src/tests/test_jail.py
+++ b/app/backend/src/tests/test_jail.py
@@ -8,6 +8,7 @@ from couchers.proto import admin_pb2, api_pb2, jail_pb2
 from couchers.servicers import jail as servicers_jail
 from couchers.utils import create_coordinate, to_aware_datetime
 from tests.test_fixtures import (  # noqa
+    PushCollector,
     db,
     email_fields,
     fast_passwords,
@@ -19,7 +20,6 @@ from tests.test_fixtures import (  # noqa
     real_api_session,
     real_jail_session,
     testconfig,
-    PushCollector
 )
 
 

--- a/app/backend/src/tests/test_jail.py
+++ b/app/backend/src/tests/test_jail.py
@@ -19,6 +19,7 @@ from tests.test_fixtures import (  # noqa
     real_api_session,
     real_jail_session,
     testconfig,
+    PushCollector
 )
 
 
@@ -273,7 +274,7 @@ def test_AcceptCommunityGuidelines(db):
         assert not res.has_not_accepted_community_guidelines
 
 
-def test_modnotes(db, push_collector):
+def test_modnotes(db, push_collector: PushCollector):
     user, token = generate_user()
     super_user, super_token = generate_user(is_superuser=True)
 
@@ -300,11 +301,9 @@ def test_modnotes(db, push_collector):
         e = email_fields(mock)
 
         assert e.subject == "[TEST] You have received a mod note"
-        push_collector.assert_user_has_single_matching(
-            user.id,
-            title="You received a mod note",
-            body="You need to read and acknowledge the note before continuing to use the platform.",
-        )
+        push = push_collector.get_for_user(user.id)
+        assert push.content.title == "You received a mod note"
+        assert push.content.body == "You need to read and acknowledge the note before continuing to use the platform."
 
     with real_jail_session(token) as jail:
         res = jail.JailInfo(empty_pb2.Empty())
@@ -362,7 +361,7 @@ def test_modnotes(db, push_collector):
         assert to_aware_datetime(note.acknowledged) > to_aware_datetime(note.created)
 
 
-def test_modnotes_no_notify(db, push_collector):
+def test_modnotes_no_notify(db, push_collector: PushCollector):
     user, token = generate_user()
     super_user, super_token = generate_user(is_superuser=True)
 

--- a/app/backend/src/tests/test_moderation.py
+++ b/app/backend/src/tests/test_moderation.py
@@ -26,6 +26,7 @@ from couchers.moderation.utils import create_moderation
 from couchers.proto import conversations_pb2, moderation_pb2, notifications_pb2, requests_pb2
 from couchers.utils import Timestamp_from_datetime, now, today
 from tests.test_fixtures import (  # noqa
+    PushCollector,
     conversations_session,
     db,
     email_fields,
@@ -38,7 +39,6 @@ from tests.test_fixtures import (  # noqa
     real_moderation_session,
     requests_session,
     testconfig,
-    PushCollector
 )
 from tests.test_requests import valid_request_text
 
@@ -2326,6 +2326,7 @@ def test_host_request_notifications_sent_after_approval(db, push_collector, mode
     assert push_collector.count_for_user(host.id) == 2
     push = push_collector.get_for_user(host.id, index=1)
     assert push.content.title == f"{surfer.name} confirmed their host request"
+
 
 def test_group_chat_message_notifications_suppressed_before_approval(db, push_collector, moderator):
     """

--- a/app/backend/src/tests/test_moderation.py
+++ b/app/backend/src/tests/test_moderation.py
@@ -38,6 +38,7 @@ from tests.test_fixtures import (  # noqa
     real_moderation_session,
     requests_session,
     testconfig,
+    PushCollector
 )
 from tests.test_requests import valid_request_text
 
@@ -377,7 +378,7 @@ def test_create_host_request_creates_moderation_state(db):
         # item_author_user_id is no longer stored in the model, it's dynamically retrieved
 
 
-def test_host_request_no_notification_before_approval(db, push_collector):
+def test_host_request_no_notification_before_approval(db, push_collector: PushCollector):
     """Test that host requests don't send notifications until approved"""
     user1, token1 = generate_user()
     user2, token2 = generate_user()
@@ -399,7 +400,7 @@ def test_host_request_no_notification_before_approval(db, push_collector):
     process_jobs()
 
     # No push notification should be sent yet (host requests are shadowed initially)
-    push_collector.assert_user_has_count(user2.id, 0)
+    assert push_collector.count_for_user(user2.id) == 0
 
 
 def test_shadowed_notification_not_in_list_notifications(db):
@@ -538,7 +539,7 @@ def test_unlisted_host_request_not_in_lists(db):
         assert len(res.host_requests) == 0
 
 
-def test_approved_host_request_in_lists_and_notifications(db, push_collector):
+def test_approved_host_request_in_lists_and_notifications(db, push_collector: PushCollector):
     """Test that approved host requests appear in lists and send notifications"""
     user1, token1 = generate_user()
     user2, token2 = generate_user()
@@ -559,7 +560,7 @@ def test_approved_host_request_in_lists_and_notifications(db, push_collector):
 
     # Process the initial notification job - should be deferred (no notification sent)
     process_jobs()
-    push_collector.assert_user_has_count(user2.id, 0)
+    assert push_collector.count_for_user(user2.id) == 0
 
     # Get the moderation state ID
     state_id = None
@@ -596,7 +597,7 @@ def test_approved_host_request_in_lists_and_notifications(db, push_collector):
         assert res.host_requests[0].host_request_id == host_request_id
 
     # After approval, the host should have received a push notification
-    push_collector.assert_user_has_single_matching(user2.id, topic_action="host_request:create")
+    assert push_collector.get_for_user(user2.id).topic_action == "host_request:create"
 
 
 def test_hidden_host_request_invisible_to_all(db):
@@ -1864,7 +1865,7 @@ def test_auto_approve_moderation_queue_disabled_when_zero(db):
         assert state_res.moderation_state.visibility == moderation_pb2.MODERATION_VISIBILITY_SHADOWED
 
 
-def test_auto_approve_moderation_queue_approves_old_items(db, push_collector):
+def test_auto_approve_moderation_queue_approves_old_items(db, push_collector: PushCollector):
     """Test that auto-approval approves items older than the deadline"""
     moderator, mod_token = generate_user(is_superuser=True)
     user1, token1 = generate_user()
@@ -2191,7 +2192,7 @@ def test_host_request_message_notifications_suppressed_before_approval(db, push_
         ).host_request_id
 
     # No notifications should have been sent to the host (request is SHADOWED)
-    push_collector.assert_user_has_count(host.id, 0)
+    assert push_collector.count_for_user(host.id) == 0
 
     # Send additional messages BEFORE approval - should NOT generate notifications
     with requests_session(surfer_token) as api:
@@ -2209,7 +2210,7 @@ def test_host_request_message_notifications_suppressed_before_approval(db, push_
         )
 
     # Host should STILL have no notifications (messages sent while SHADOWED)
-    push_collector.assert_user_has_count(host.id, 0)
+    assert push_collector.count_for_user(host.id) == 0
 
     # Now approve the request
     with mock_notification_email():
@@ -2219,12 +2220,9 @@ def test_host_request_message_notifications_suppressed_before_approval(db, push_
     # 1. host_request:create (the initial request)
     # 2. host_request:message (Follow-up message 1)
     # 3. host_request:message (Follow-up message 2)
-    push_collector.assert_user_has_count(host.id, 3)
-    push_collector.assert_user_push_matches_fields(
-        host.id,
-        ix=0,
-        title=f"{surfer.name} sent you a host request",
-    )
+    assert push_collector.count_for_user(host.id) == 3
+    push = push_collector.get_for_user(host.id, index=0)
+    assert push.content.title == f"{surfer.name} sent you a host request"
 
 
 def test_host_request_status_notifications_suppressed_before_approval(db, push_collector, moderator):
@@ -2253,7 +2251,7 @@ def test_host_request_status_notifications_suppressed_before_approval(db, push_c
         ).host_request_id
 
     # No notifications should have been sent to the host (request is SHADOWED)
-    push_collector.assert_user_has_count(host.id, 0)
+    assert push_collector.count_for_user(host.id) == 0
 
     # The surfer can cancel their own request even when SHADOWED
     # But this should NOT notify the host since the request isn't approved
@@ -2267,7 +2265,7 @@ def test_host_request_status_notifications_suppressed_before_approval(db, push_c
         )
 
     # Host should STILL have no notifications (cancel notification suppressed)
-    push_collector.assert_user_has_count(host.id, 0)
+    assert push_collector.count_for_user(host.id) == 0
 
 
 def test_host_request_notifications_sent_after_approval(db, push_collector, moderator):
@@ -2295,7 +2293,7 @@ def test_host_request_notifications_sent_after_approval(db, push_collector, mode
         moderator.approve_host_request(hr_id)
 
     # Host should have received 1 notification (the approval notification)
-    push_collector.assert_user_has_count(host.id, 1)
+    assert push_collector.count_for_user(host.id) == 1
 
     # Host accepts the request - surfer should be notified
     with requests_session(host_token) as api:
@@ -2309,12 +2307,9 @@ def test_host_request_notifications_sent_after_approval(db, push_collector, mode
             )
 
     # Surfer should have 1 notification (the accept notification)
-    push_collector.assert_user_has_count(surfer.id, 1)
-    push_collector.assert_user_push_matches_fields(
-        surfer.id,
-        ix=0,
-        title=f"{host.name} accepted your host request",
-    )
+    assert push_collector.count_for_user(surfer.id) == 1
+    push = push_collector.get_for_user(surfer.id, index=0)
+    assert push.content.title == f"{host.name} accepted your host request"
 
     # Surfer confirms - host should be notified
     with requests_session(surfer_token) as api:
@@ -2328,13 +2323,9 @@ def test_host_request_notifications_sent_after_approval(db, push_collector, mode
             )
 
     # Host should now have 2 notifications (approval + confirm)
-    push_collector.assert_user_has_count(host.id, 2)
-    push_collector.assert_user_push_matches_fields(
-        host.id,
-        ix=1,
-        title=f"{surfer.name} confirmed their host request",
-    )
-
+    assert push_collector.count_for_user(host.id) == 2
+    push = push_collector.get_for_user(host.id, index=1)
+    assert push.content.title == f"{surfer.name} confirmed their host request"
 
 def test_group_chat_message_notifications_suppressed_before_approval(db, push_collector, moderator):
     """
@@ -2362,7 +2353,7 @@ def test_group_chat_message_notifications_suppressed_before_approval(db, push_co
         assert gc.moderation_state.visibility == ModerationVisibility.SHADOWED
 
     # No notifications should have been sent yet (chat is SHADOWED)
-    push_collector.assert_user_has_count(user2.id, 0)
+    assert push_collector.count_for_user(user2.id) == 0
 
     # Send messages BEFORE approval
     with conversations_session(token1) as api:
@@ -2378,7 +2369,7 @@ def test_group_chat_message_notifications_suppressed_before_approval(db, push_co
         pass
 
     # User2 should STILL have no notifications (chat is SHADOWED)
-    push_collector.assert_user_has_count(user2.id, 0)
+    assert push_collector.count_for_user(user2.id) == 0
 
     # Now approve the group chat
     moderator.approve_group_chat(gc_id)
@@ -2393,11 +2384,9 @@ def test_group_chat_message_notifications_suppressed_before_approval(db, push_co
         assert gc.moderation_state.visibility == ModerationVisibility.VISIBLE
 
     # User2 should now have 1 notification for the first message sent before approval
-    push_collector.assert_user_has_single_matching(
-        user2.id,
-        title=f"{user1.name} sent you a message",
-        body="Hello before approval",
-    )
+    push = push_collector.get_for_user(user2.id)
+    assert push.content.title == f"{user1.name} sent you a message"
+    assert push.content.body == "Hello before approval"
 
     # Send a message AFTER approval
     with conversations_session(token1) as api:
@@ -2413,4 +2402,4 @@ def test_group_chat_message_notifications_suppressed_before_approval(db, push_co
         pass
 
     # User2 SHOULD now have 2 notifications total
-    push_collector.assert_user_has_count(user2.id, 2)
+    assert push_collector.count_for_user(user2.id) == 2

--- a/app/backend/src/tests/test_moderation.py
+++ b/app/backend/src/tests/test_moderation.py
@@ -2169,7 +2169,7 @@ def test_auto_approve_does_not_approve_moderator_shadowed_items(db):
 # ============================================================================
 
 
-def test_host_request_message_notifications_suppressed_before_approval(db, push_collector, moderator):
+def test_host_request_message_notifications_suppressed_before_approval(db, push_collector: PushCollector, moderator):
     """
     Test that notifications are NOT sent for messages in host requests
     that haven't been approved yet.
@@ -2225,7 +2225,7 @@ def test_host_request_message_notifications_suppressed_before_approval(db, push_
     assert push.content.title == f"{surfer.name} sent you a host request"
 
 
-def test_host_request_status_notifications_suppressed_before_approval(db, push_collector, moderator):
+def test_host_request_status_notifications_suppressed_before_approval(db, push_collector: PushCollector, moderator):
     """
     Test that status change notifications (accept/reject/etc.) are NOT sent
     for host requests that haven't been approved yet.
@@ -2268,7 +2268,7 @@ def test_host_request_status_notifications_suppressed_before_approval(db, push_c
     assert push_collector.count_for_user(host.id) == 0
 
 
-def test_host_request_notifications_sent_after_approval(db, push_collector, moderator):
+def test_host_request_notifications_sent_after_approval(db, push_collector: PushCollector, moderator):
     """
     Test that after a host request is approved, all notifications work normally.
     """
@@ -2328,7 +2328,7 @@ def test_host_request_notifications_sent_after_approval(db, push_collector, mode
     assert push.content.title == f"{surfer.name} confirmed their host request"
 
 
-def test_group_chat_message_notifications_suppressed_before_approval(db, push_collector, moderator):
+def test_group_chat_message_notifications_suppressed_before_approval(db, push_collector: PushCollector, moderator):
     """
     Test that notifications are NOT sent for messages in group chats
     that haven't been approved yet.

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -55,6 +55,7 @@ from tests.test_fixtures import (  # noqa
     real_editor_session,
     session_scope,
     testconfig,
+    PushCollector
 )
 
 
@@ -380,7 +381,7 @@ def test_list_notifications(db, push_collector, moderator):
     assert bodys == [n.body for n in all_notifs]
 
 
-def test_notifications_seen(db, push_collector):
+def test_notifications_seen(db, push_collector: PushCollector):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
     user3, token3 = generate_user()
@@ -469,29 +470,23 @@ def test_RegisterPushNotificationSubscription(db):
         )
 
 
-def test_SendTestPushNotification(db, push_collector):
+def test_SendTestPushNotification(db, push_collector: PushCollector):
     user, token = generate_user()
 
     with notifications_session(token) as notifications:
         notifications.SendTestPushNotification(empty_pb2.Empty())
 
-    push_collector.assert_user_has_count(user.id, 1)
-    push_collector.assert_user_push_matches_fields(
-        user.id,
-        title="Checking push notifications work!",
-        body="If you see this, then it's working :)",
-    )
-
+    assert push_collector.count_for_user(user.id) == 1
+    push = push_collector.get_for_user(user.id, index=0)
+    assert push.content.title == "Checking push notifications work!"
+    assert push.content.body == "If you see this, then it's working :)"
     # the above two are equivalent to this
 
-    push_collector.assert_user_has_single_matching(
-        user.id,
-        title="Checking push notifications work!",
-        body="If you see this, then it's working :)",
-    )
+    push = push_collector.get_for_user(user.id, index=0)
+    assert push.content.title == "Checking push notifications work!"
+    assert push.content.body == "If you see this, then it's working :)"
 
-
-def test_SendBlogPostNotification(db, push_collector):
+def test_SendBlogPostNotification(db, push_collector: PushCollector):
     super_user, super_token = generate_user(is_superuser=True)
 
     user1, user1_token = generate_user()
@@ -551,23 +546,17 @@ def test_SendBlogPostNotification(db, push_collector):
     assert "https://couchers.org/blog/2025/05/11/v0.9.9-release" in email_fields(mock).html
     assert "https://couchers.org/blog/2025/05/11/v0.9.9-release" in email_fields(mock).plain
 
-    push_collector.assert_user_has_count(user1.id, 1)
-    push_collector.assert_user_push_matches_fields(
-        user1.id,
-        title="New blog post: Couchers.org v0.9.9 Release Notes",
-        body="Read about last major updates before v1!",
-        action_url="https://couchers.org/blog/2025/05/11/v0.9.9-release",
-    )
+    push = push_collector.get_for_user(user1.id)
+    assert push.content.title == "New blog post: Couchers.org v0.9.9 Release Notes"
+    assert push.content.body == "Read about last major updates before v1!"
+    assert push.action_url == "https://couchers.org/blog/2025/05/11/v0.9.9-release"
 
-    push_collector.assert_user_has_count(user2.id, 1)
-    push_collector.assert_user_push_matches_fields(
-        user2.id,
-        title="New blog post: Couchers.org v0.9.9 Release Notes",
-        body="Read about last major updates before v1!",
-        action_url="https://couchers.org/blog/2025/05/11/v0.9.9-release",
-    )
+    push = push_collector.get_for_user(user2.id)
+    assert push.content.title == "New blog post: Couchers.org v0.9.9 Release Notes"
+    assert push.content.body == "Read about last major updates before v1!"
+    assert push.action_url == "https://couchers.org/blog/2025/05/11/v0.9.9-release"
 
-    push_collector.assert_user_has_count(user3.id, 0)
+    assert push_collector.count_for_user(user3.id) == 0
 
 
 def test_get_topic_actions_by_delivery_type(db):
@@ -777,18 +766,15 @@ def test_RegisterMobilePushNotificationSubscription_already_exists(db):
         assert sub.device_name == "Existing Device"  # unchanged
 
 
-def test_SendTestMobilePushNotification(db, push_collector):
+def test_SendTestMobilePushNotification(db, push_collector: PushCollector):
     user, token = generate_user()
 
     with notifications_session(token) as notifications:
         notifications.SendTestMobilePushNotification(empty_pb2.Empty())
 
-    push_collector.assert_user_has_single_matching(
-        user.id,
-        title="Checking mobile push notifications work!",
-        body="If you see this on your phone, everything is wired up correctly 🎉",
-    )
-
+    push = push_collector.get_for_user(user.id)
+    assert push.content.title == "Checking mobile push notifications work!"
+    assert push.content.body == "If you see this on your phone, everything is wired up correctly 🎉"
 
 def test_get_expo_push_receipts(db):
     from unittest.mock import Mock, patch
@@ -1048,7 +1034,7 @@ def test_check_expo_push_receipts_skips_already_checked(db):
         mock_post.assert_not_called()
 
 
-def test_SendDevPushNotification_success(db, push_collector):
+def test_SendDevPushNotification_success(db, push_collector: PushCollector):
     """Test SendDevPushNotification sends push with all specified parameters."""
     user, token = generate_user()
 
@@ -1067,19 +1053,17 @@ def test_SendDevPushNotification_success(db, push_collector):
             )
         )
 
-    push_collector.assert_user_has_single_matching(
-        user.id,
-        title="Test Dev Title",
-        body="Test dev notification body",
-        icon="https://example.com/icon.png",
-        action_url="https://example.com/action",
-        topic_action="adhoc:testing",
-        key="test-key",
-        ttl=3600,
-    )
+    push = push_collector.get_for_user(user.id)
+    assert push.content.title == "Test Dev Title"
+    assert push.content.body == "Test dev notification body"
+    assert push.action_url == "https://example.com/action"
+    assert push.icon_url == "https://example.com/icon.png"
+    assert push.topic_action == "adhoc:testing"
+    assert push.key == "test-key"
+    assert push.ttl == 3600
 
 
-def test_SendDevPushNotification_minimal(db, push_collector):
+def test_SendDevPushNotification_minimal(db, push_collector: PushCollector):
     """Test SendDevPushNotification with minimal parameters."""
     user, token = generate_user()
 
@@ -1093,15 +1077,13 @@ def test_SendDevPushNotification_minimal(db, push_collector):
             )
         )
 
-    push_collector.assert_user_has_single_matching(
-        user.id,
-        title="Minimal Title",
-        body="Minimal body",
-        topic_action="adhoc:testing",
-    )
+    push = push_collector.get_for_user(user.id)
+    assert push.content.title == "Minimal Title"
+    assert push.content.body == "Minimal body"
+    assert push.topic_action == "adhoc:testing"
 
 
-def test_SendDevPushNotification_disabled(db, push_collector):
+def test_SendDevPushNotification_disabled(db, push_collector: PushCollector):
     """Test SendDevPushNotification fails when ENABLE_DEV_APIS is disabled."""
     user, token = generate_user()
 
@@ -1119,10 +1101,10 @@ def test_SendDevPushNotification_disabled(db, push_collector):
         assert e.value.code() == grpc.StatusCode.UNAVAILABLE
         assert "Development APIs are not enabled" in e.value.details()
 
-    push_collector.assert_user_has_count(user.id, 0)
+    assert push_collector.count_for_user(user.id) == 0
 
 
-def test_SendDevPushNotification_push_notifications_disabled(db, push_collector):
+def test_SendDevPushNotification_push_notifications_disabled(db, push_collector: PushCollector):
     """Test SendDevPushNotification fails when push notifications are disabled."""
     user, token = generate_user()
 
@@ -1140,7 +1122,7 @@ def test_SendDevPushNotification_push_notifications_disabled(db, push_collector)
         assert e.value.code() == grpc.StatusCode.UNAVAILABLE
         assert "Push notifications are currently disabled" in e.value.details()
 
-    push_collector.assert_user_has_count(user.id, 0)
+    assert push_collector.count_for_user(user.id) == 0
 
 
 def test_check_expo_push_receipts_skips_too_recent(db):

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -40,6 +40,7 @@ from couchers.servicers.api import user_model_to_pb
 from couchers.templates.v2 import v2timestamp
 from couchers.utils import now
 from tests.test_fixtures import (  # noqa
+    PushCollector,
     api_session,
     auth_api_session,
     conversations_session,
@@ -55,7 +56,6 @@ from tests.test_fixtures import (  # noqa
     real_editor_session,
     session_scope,
     testconfig,
-    PushCollector
 )
 
 
@@ -486,6 +486,7 @@ def test_SendTestPushNotification(db, push_collector: PushCollector):
     assert push.content.title == "Checking push notifications work!"
     assert push.content.body == "If you see this, then it's working :)"
 
+
 def test_SendBlogPostNotification(db, push_collector: PushCollector):
     super_user, super_token = generate_user(is_superuser=True)
 
@@ -775,6 +776,7 @@ def test_SendTestMobilePushNotification(db, push_collector: PushCollector):
     push = push_collector.get_for_user(user.id)
     assert push.content.title == "Checking mobile push notifications work!"
     assert push.content.body == "If you see this on your phone, everything is wired up correctly 🎉"
+
 
 def test_get_expo_push_receipts(db):
     from unittest.mock import Mock, patch

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -550,12 +550,12 @@ def test_SendBlogPostNotification(db, push_collector: PushCollector):
     push = push_collector.get_for_user(user1.id)
     assert push.content.title == "New blog post: Couchers.org v0.9.9 Release Notes"
     assert push.content.body == "Read about last major updates before v1!"
-    assert push.action_url == "https://couchers.org/blog/2025/05/11/v0.9.9-release"
+    assert push.content.action_url == "https://couchers.org/blog/2025/05/11/v0.9.9-release"
 
     push = push_collector.get_for_user(user2.id)
     assert push.content.title == "New blog post: Couchers.org v0.9.9 Release Notes"
     assert push.content.body == "Read about last major updates before v1!"
-    assert push.action_url == "https://couchers.org/blog/2025/05/11/v0.9.9-release"
+    assert push.content.action_url == "https://couchers.org/blog/2025/05/11/v0.9.9-release"
 
     assert push_collector.count_for_user(user3.id) == 0
 
@@ -1058,8 +1058,8 @@ def test_SendDevPushNotification_success(db, push_collector: PushCollector):
     push = push_collector.get_for_user(user.id)
     assert push.content.title == "Test Dev Title"
     assert push.content.body == "Test dev notification body"
-    assert push.action_url == "https://example.com/action"
-    assert push.icon_url == "https://example.com/icon.png"
+    assert push.content.action_url == "https://example.com/action"
+    assert push.content.icon_url == "https://example.com/icon.png"
     assert push.topic_action == "adhoc:testing"
     assert push.key == "test-key"
     assert push.ttl == 3600

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -556,7 +556,7 @@ def test_SendBlogPostNotification(db, push_collector):
         user1.id,
         title="New blog post: Couchers.org v0.9.9 Release Notes",
         body="Read about last major updates before v1!",
-        url="https://couchers.org/blog/2025/05/11/v0.9.9-release",
+        action_url="https://couchers.org/blog/2025/05/11/v0.9.9-release",
     )
 
     push_collector.assert_user_has_count(user2.id, 1)
@@ -564,7 +564,7 @@ def test_SendBlogPostNotification(db, push_collector):
         user2.id,
         title="New blog post: Couchers.org v0.9.9 Release Notes",
         body="Read about last major updates before v1!",
-        url="https://couchers.org/blog/2025/05/11/v0.9.9-release",
+        action_url="https://couchers.org/blog/2025/05/11/v0.9.9-release",
     )
 
     push_collector.assert_user_has_count(user3.id, 0)
@@ -1072,7 +1072,7 @@ def test_SendDevPushNotification_success(db, push_collector):
         title="Test Dev Title",
         body="Test dev notification body",
         icon="https://example.com/icon.png",
-        url="https://example.com/action",
+        action_url="https://example.com/action",
         topic_action="adhoc:testing",
         key="test-key",
         ttl=3600,

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -331,7 +331,7 @@ def test_set_do_not_email(db):
         assert not user.do_not_email
 
 
-def test_list_notifications(db, push_collector, moderator):
+def test_list_notifications(db, push_collector: PushCollector, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
 

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -38,6 +38,7 @@ from tests.test_fixtures import (  # noqa
     references_session,
     requests_session,
     testconfig,
+    PushCollector
 )
 from tests.test_requests import valid_request_text
 
@@ -512,7 +513,7 @@ def test_WriteFriendReference_with_empty_text(db):
     assert e.value.details() == "The text of a reference must not be empty"
 
 
-def test_WriteFriendReference_with_private_text(db, push_collector):
+def test_WriteFriendReference_with_private_text(db, push_collector: PushCollector):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
 
@@ -539,12 +540,9 @@ def test_WriteFriendReference_with_private_text(db, push_collector):
     assert e.subject == f"[TEST] You've received a friend reference from {user1.name}!"
     assert e.recipient == user2.email
 
-    push_collector.assert_user_has_single_matching(
-        user2.id,
-        title=f"You've received a friend reference from {user1.name}!",
-        body="They were nice!",
-    )
-
+    push = push_collector.get_for_user(user2.id)
+    assert push.content.title == f"You've received a friend reference from {user1.name}!"
+    assert push.content.body == "They were nice!"
 
 def test_WriteFriendReference_requires_friendship(db):
     """Test that users must be friends to write friend references"""
@@ -840,7 +838,7 @@ def test_WriteHostRequestReference(db, moderator):
         )
 
 
-def test_WriteHostRequestReference_private_text(db, push_collector):
+def test_WriteHostRequestReference_private_text(db, push_collector: PushCollector):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
 
@@ -868,12 +866,9 @@ def test_WriteHostRequestReference_private_text(db, push_collector):
     assert e.subject == f"[TEST] You've received a reference from {user1.name}!"
     assert e.recipient == user2.email
 
-    push_collector.assert_user_has_single_matching(
-        user2.id,
-        title=f"You've received a reference from {user1.name}!",
-        body="Please go and write a reference for them too. It's a nice gesture and helps us build a community together!",
-    )
-
+    push = push_collector.get_for_user(user2.id)
+    assert push.content.title == f"You've received a reference from {user1.name}!"
+    assert push.content.body == "Please go and write a reference for them too. It's a nice gesture and helps us build a community together!"
 
 def test_GetHostRequestReferenceStatus(db, moderator):
     user1, token1 = generate_user()

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -26,6 +26,7 @@ from couchers.moderation.utils import create_moderation
 from couchers.proto import conversations_pb2, references_pb2, requests_pb2
 from couchers.utils import create_coordinate, now, to_aware_datetime, today
 from tests.test_fixtures import (  # noqa
+    PushCollector,
     account_session,
     db,
     email_fields,
@@ -38,7 +39,6 @@ from tests.test_fixtures import (  # noqa
     references_session,
     requests_session,
     testconfig,
-    PushCollector
 )
 from tests.test_requests import valid_request_text
 
@@ -544,6 +544,7 @@ def test_WriteFriendReference_with_private_text(db, push_collector: PushCollecto
     assert push.content.title == f"You've received a friend reference from {user1.name}!"
     assert push.content.body == "They were nice!"
 
+
 def test_WriteFriendReference_requires_friendship(db):
     """Test that users must be friends to write friend references"""
     user1, token1 = generate_user()
@@ -868,7 +869,11 @@ def test_WriteHostRequestReference_private_text(db, push_collector: PushCollecto
 
     push = push_collector.get_for_user(user2.id)
     assert push.content.title == f"You've received a reference from {user1.name}!"
-    assert push.content.body == "Please go and write a reference for them too. It's a nice gesture and helps us build a community together!"
+    assert (
+        push.content.body
+        == "Please go and write a reference for them too. It's a nice gesture and helps us build a community together!"
+    )
+
 
 def test_GetHostRequestReferenceStatus(db, moderator):
     user1, token1 = generate_user()

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -26,6 +26,7 @@ from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_
 from couchers.templates.v2 import v2date
 from couchers.utils import create_coordinate, now, today
 from tests.test_fixtures import (  # noqa
+    PushCollector,
     api_session,
     auth_api_session,
     db,
@@ -36,7 +37,6 @@ from tests.test_fixtures import (  # noqa
     push_collector,
     requests_session,
     testconfig,
-    PushCollector
 )
 
 

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -1283,7 +1283,7 @@ def test_response_rate(db, moderator):
         assert res.almost_all.response_time_p66.ToTimedelta() == timedelta(hours=35)
 
 
-def test_request_notifications(db, push_collector, moderator):
+def test_request_notifications(db, push_collector: PushCollector, moderator):
     host, host_token = generate_user(complete_profile=True)
     surfer, surfer_token = generate_user(complete_profile=True)
 
@@ -1322,7 +1322,7 @@ def test_request_notifications(db, push_collector, moderator):
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.plain
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.html
 
-    assert push_collector.get_for_user(host.id).title == f"{surfer.name} sent you a host request"
+    assert push_collector.get_for_user(host.id).content.title == f"{surfer.name} sent you a host request"
 
     with requests_session(host_token) as api:
         with mock_notification_email() as mock:
@@ -1350,10 +1350,10 @@ def test_request_notifications(db, push_collector, moderator):
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.plain
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.html
 
-    assert push_collector.get_for_user(surfer.id).title == f"{host.name} accepted your host request"
+    assert push_collector.get_for_user(surfer.id).content.title == f"{host.name} accepted your host request"
 
 
-def test_quick_decline(db, push_collector, moderator):
+def test_quick_decline(db, push_collector: PushCollector, moderator):
     host, host_token = generate_user(complete_profile=True)
     surfer, surfer_token = generate_user(complete_profile=True)
 
@@ -1392,7 +1392,7 @@ def test_quick_decline(db, push_collector, moderator):
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.plain
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.html
 
-    assert push_collector.get_for_user(host.id).title == f"{surfer.name} sent you a host request"
+    assert push_collector.get_for_user(host.id).content.title == f"{surfer.name} sent you a host request"
 
     # very ugly
     # http://localhost:3000/quick-link?payload=CAEiGAoOZnJpZW5kX3JlcXVlc3QSBmFjY2VwdA==&sig=BQdk024NTATm8zlR0krSXTBhP5U9TlFv7VhJeIHZtUg=

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -36,6 +36,7 @@ from tests.test_fixtures import (  # noqa
     push_collector,
     requests_session,
     testconfig,
+    PushCollector
 )
 
 
@@ -1321,10 +1322,7 @@ def test_request_notifications(db, push_collector, moderator):
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.plain
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.html
 
-    push_collector.assert_user_has_single_matching(
-        host.id,
-        title=f"{surfer.name} sent you a host request",
-    )
+    assert push_collector.get_for_user(host.id).title == f"{surfer.name} sent you a host request"
 
     with requests_session(host_token) as api:
         with mock_notification_email() as mock:
@@ -1352,10 +1350,7 @@ def test_request_notifications(db, push_collector, moderator):
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.plain
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.html
 
-    push_collector.assert_user_has_single_matching(
-        surfer.id,
-        title=f"{host.name} accepted your host request",
-    )
+    assert push_collector.get_for_user(surfer.id).title == f"{host.name} accepted your host request"
 
 
 def test_quick_decline(db, push_collector, moderator):
@@ -1397,10 +1392,7 @@ def test_quick_decline(db, push_collector, moderator):
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.plain
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.html
 
-    push_collector.assert_user_has_single_matching(
-        host.id,
-        title=f"{surfer.name} sent you a host request",
-    )
+    assert push_collector.get_for_user(host.id).title == f"{surfer.name} sent you a host request"
 
     # very ugly
     # http://localhost:3000/quick-link?payload=CAEiGAoOZnJpZW5kX3JlcXVlc3QSBmFjY2VwdA==&sig=BQdk024NTATm8zlR0krSXTBhP5U9TlFv7VhJeIHZtUg=

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -27,6 +27,7 @@ from couchers.models import (
 from couchers.proto import account_pb2, admin_pb2, api_pb2
 from couchers.proto.google.api import httpbody_pb2
 from tests.test_fixtures import (  # noqa
+    PushCollector,
     account_session,
     api_session,
     db,
@@ -35,7 +36,6 @@ from tests.test_fixtures import (  # noqa
     real_admin_session,
     real_iris_session,
     testconfig,
-    PushCollector
 )
 
 
@@ -801,7 +801,10 @@ def test_strong_verification_delete_data_cant_reverify(db, monkeypatch, push_col
 
     push = push_collector.get_for_user(user.id, index=1)
     assert push.content.title == "Strong Verification failed"
-    assert push.content.body == "You tried to verify with a passport that has already been used for verification. Please use another passport."
+    assert (
+        push.content.body
+        == "You tried to verify with a passport that has already been used for verification. Please use another passport."
+    )
 
     refresh_materialized_views_rapid(None)
 
@@ -949,7 +952,11 @@ def test_strong_verification_duplicate_other_user(db, monkeypatch, push_collecto
 
     push = push_collector.get_for_user(user2.id, index=0)
     assert push.content.title == "Strong Verification failed"
-    assert push.content.body == "You tried to verify with a passport that has already been used for verification. Please use another passport."
+    assert (
+        push.content.body
+        == "You tried to verify with a passport that has already been used for verification. Please use another passport."
+    )
+
 
 def test_strong_verification_non_passport(db, monkeypatch, push_collector: PushCollector):
     monkeypatch_sv_config(monkeypatch)
@@ -1020,4 +1027,7 @@ def test_strong_verification_non_passport(db, monkeypatch, push_collector: PushC
 
     push = push_collector.get_for_user(user.id, index=0)
     assert push.content.title == "Strong Verification failed"
-    assert push.content.body == "You tried to verify with a document that is not a passport. You can only use a passport for Strong Verification."
+    assert (
+        push.content.body
+        == "You tried to verify with a document that is not a passport. You can only use a passport for Strong Verification."
+    )

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -35,6 +35,7 @@ from tests.test_fixtures import (  # noqa
     real_admin_session,
     real_iris_session,
     testconfig,
+    PushCollector
 )
 
 
@@ -669,7 +670,7 @@ def test_strong_verification_disabled(db):
         assert e.value.details() == "Strong verification is currently disabled."
 
 
-def test_strong_verification_delete_data_cant_reverify(db, monkeypatch, push_collector):
+def test_strong_verification_delete_data_cant_reverify(db, monkeypatch, push_collector: PushCollector):
     monkeypatch_sv_config(monkeypatch)
 
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
@@ -798,12 +799,9 @@ def test_strong_verification_delete_data_cant_reverify(db, monkeypatch, push_col
         assert verification_attempt.user_id == user.id
         assert verification_attempt.status == StrongVerificationAttemptStatus.duplicate
 
-    push_collector.assert_user_push_matches_fields(
-        user.id,
-        ix=1,
-        title="Strong Verification failed",
-        body="You tried to verify with a passport that has already been used for verification. Please use another passport.",
-    )
+    push = push_collector.get_for_user(user.id, index=1)
+    assert push.content.title == "Strong Verification failed"
+    assert push.content.body == "You tried to verify with a passport that has already been used for verification. Please use another passport."
 
     refresh_materialized_views_rapid(None)
 
@@ -815,7 +813,7 @@ def test_strong_verification_delete_data_cant_reverify(db, monkeypatch, push_col
         )
 
 
-def test_strong_verification_duplicate_other_user(db, monkeypatch, push_collector):
+def test_strong_verification_duplicate_other_user(db, monkeypatch, push_collector: PushCollector):
     monkeypatch_sv_config(monkeypatch)
 
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
@@ -949,14 +947,11 @@ def test_strong_verification_duplicate_other_user(db, monkeypatch, push_collecto
         assert verification_attempt.user_id == user2.id
         assert verification_attempt.status == StrongVerificationAttemptStatus.duplicate
 
-    push_collector.assert_user_push_matches_fields(
-        user2.id,
-        title="Strong Verification failed",
-        body="You tried to verify with a passport that has already been used for verification. Please use another passport.",
-    )
+    push = push_collector.get_for_user(user2.id, index=0)
+    assert push.content.title == "Strong Verification failed"
+    assert push.content.body == "You tried to verify with a passport that has already been used for verification. Please use another passport."
 
-
-def test_strong_verification_non_passport(db, monkeypatch, push_collector):
+def test_strong_verification_non_passport(db, monkeypatch, push_collector: PushCollector):
     monkeypatch_sv_config(monkeypatch)
 
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
@@ -1023,8 +1018,6 @@ def test_strong_verification_non_passport(db, monkeypatch, push_collector):
         assert verification_attempt.user_id == user.id
         assert verification_attempt.status == StrongVerificationAttemptStatus.failed
 
-    push_collector.assert_user_push_matches_fields(
-        user.id,
-        title="Strong Verification failed",
-        body="You tried to verify with a document that is not a passport. You can only use a passport for Strong Verification.",
-    )
+    push = push_collector.get_for_user(user.id, index=0)
+    assert push.content.title == "Strong Verification failed"
+    assert push.content.body == "You tried to verify with a document that is not a passport. You can only use a passport for Strong Verification."

--- a/app/backend/src/tests/test_verification.py
+++ b/app/backend/src/tests/test_verification.py
@@ -21,6 +21,7 @@ from tests.test_fixtures import (  # noqa
     process_jobs,
     push_collector,
     testconfig,
+    PushCollector
 )
 
 
@@ -29,7 +30,7 @@ def _(testconfig):
     pass
 
 
-def test_ChangePhone(db, monkeypatch, push_collector):
+def test_ChangePhone(db, monkeypatch, push_collector: PushCollector):
     user, token = generate_user()
     user_id = user.id
 
@@ -65,7 +66,7 @@ def test_ChangePhone(db, monkeypatch, push_collector):
             assert phone == "+46701740605"
             return "success"
 
-        push_collector.assert_user_has_count(user_id, 0)
+        assert push_collector.count_for_user(user_id) == 0
 
         monkeypatch.setattr(couchers.phone.sms, "send_sms", succeed)
 
@@ -77,11 +78,9 @@ def test_ChangePhone(db, monkeypatch, push_collector):
             assert len(user.phone_verification_token) == 6
 
         process_jobs()
-        push_collector.assert_user_has_single_matching(
-            user_id,
-            title="Phone verification started",
-            body="You started phone number verification with the number +46 70 174 06 05.",
-        )
+        push = push_collector.get_for_user(user_id)
+        assert push.content.title == "Phone verification started"
+        assert push.content.body == "You started phone number verification with the number +46 70 174 06 05."
 
         # Phone number should show up but not be verified in your profile settings
         res = account.GetAccountInfo(empty_pb2.Empty())
@@ -120,7 +119,7 @@ def test_ChangePhone_ratelimit(db, monkeypatch):
             assert len(user.phone_verification_token) == 6
 
 
-def test_VerifyPhone(push_collector):
+def test_VerifyPhone(push_collector: PushCollector):
     user, token = generate_user()
     with account_session(token) as account, api_session(token) as api:
         with pytest.raises(grpc.RpcError) as e:
@@ -140,11 +139,9 @@ def test_VerifyPhone(push_collector):
         account.VerifyPhone(account_pb2.VerifyPhoneReq(token="111112"))
 
         process_jobs()
-        push_collector.assert_user_has_single_matching(
-            user.id,
-            title="Phone successfully verified",
-            body="Your phone was successfully verified as +46 70 174 06 05 on Couchers.org.",
-        )
+        push = push_collector.get_for_user(user.id)
+        assert push.content.title == "Phone successfully verified"
+        assert push.content.body == "Your phone was successfully verified as +46 70 174 06 05 on Couchers.org."
 
         res = api.GetUser(api_pb2.GetUserReq(user=str(user.id)))
         assert res.verification == 1.0

--- a/app/backend/src/tests/test_verification.py
+++ b/app/backend/src/tests/test_verification.py
@@ -13,6 +13,7 @@ from couchers.models import SMS, User
 from couchers.proto import account_pb2, api_pb2
 from couchers.utils import now
 from tests.test_fixtures import (  # noqa
+    PushCollector,
     account_session,
     api_session,
     db,
@@ -21,7 +22,6 @@ from tests.test_fixtures import (  # noqa
     process_jobs,
     push_collector,
     testconfig,
-    PushCollector
 )
 
 


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
Adds a `PushNotificationContent` type with everything defining the content of the notification (maps to Android and iOS concepts).

This is a first step towards splitting off email and push notification rendering, since they are used by non-overlapping code paths and shouldn't share strings (push notifications should be much more succint).

I added `render_push_notification` to demonstrate the code shape I'm going towards. Currently it still delegates to `render_notification`. I'll extract the implementation from the latter in a follow-up PR.

This impacted tests which expected a flat argument list to the `_push_to_user` function, so I refactored the tests to store a strongly-typed representation of the pushed notifications.

**Please give clear steps for how the reviewer can best test this PR**
No functional changes, just run tests.

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A

**Backend checklist**
- [x] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)