### PR TITLE
Split email and push notification rendering logic

### DIFF
--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -24,7 +24,8 @@ from couchers.notifications.quick_links import (
     generate_unsub_topic_action,
     generate_unsub_topic_key,
 )
-from couchers.notifications.render import render_notification, render_push_notification
+from couchers.notifications.render import render_email_notification
+from couchers.notifications.render_push import render_push_notification
 from couchers.notifications.settings import get_preference
 from couchers.proto.internal import jobs_pb2
 from couchers.sql import moderation_state_column_visible
@@ -48,7 +49,7 @@ add_filters(env)
 
 
 def _send_email_notification(session: Session, user: User, notification: Notification) -> None:
-    rendered = render_notification(user, notification)
+    rendered = render_email_notification(user, notification)
 
     email_lang = "en"
     if config["ENABLE_NOTIFICATION_TRANSLATIONS"]:
@@ -59,50 +60,50 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         "time": notification.created,
         "footer_email_is_critical": rendered.is_critical,
         "footer_manage_notifications_link": urls.notification_settings_link(),
-        "footer_notification_topic_action": rendered.email_topic_action_unsubscribe_text,
+        "footer_notification_topic_action": rendered.topic_action_unsubscribe_text,
         "footer_notification_topic_action_link": generate_unsub_topic_action(notification),
-        "footer_notification_topic_key": rendered.email_topic_key_unsubscribe_text,
+        "footer_notification_topic_key": rendered.topic_key_unsubscribe_text,
         "footer_notification_topic_key_link": generate_unsub_topic_key(notification),
         "footer_do_not_email_link": generate_do_not_email(user),
         CONTEXT_TRANSLATION_LANGUAGE_KEY: email_lang,
         CONTEXT_YEAR_KEY: now().year,
         CONTEXT_TIMEZONE_DISPLAY_KEY: get_tz_as_text(user.timezone or "Etc/UTC"),
-        **rendered.email_template_args,
+        **rendered.template_args,
     }
 
-    plain_tmplt = (template_folder / f"{rendered.email_template_name}.txt").read_text()
+    plain_tmplt = (template_folder / f"{rendered.template_name}.txt").read_text()
     plain_tmplt_footer = (template_folder / "_footer.txt").read_text()
     plain_template_args = {**template_args, CONTEXT_PLAINTEXT_KEY: True}  # Strip html from translations.
     plain = env.from_string(plain_tmplt + plain_tmplt_footer).render(plain_template_args)
 
-    html_tmplt = (template_folder / "generated_html" / f"{rendered.email_template_name}.html").read_text()
+    html_tmplt = (template_folder / "generated_html" / f"{rendered.template_name}.html").read_text()
     html = env.from_string(html_tmplt).render(template_args)
 
     if user.do_not_email and not rendered.is_critical:
-        logger.info(f"Not emailing {user} based on template {rendered.email_template_name} due to emails turned off")
+        logger.info(f"Not emailing {user} based on template {rendered.template_name} due to emails turned off")
         return
 
     if user.is_banned:
-        logger.info(f"Tried emailing {user} based on template {rendered.email_template_name} but user is banned")
+        logger.info(f"Tried emailing {user} based on template {rendered.template_name} but user is banned")
         return
 
     if user.is_deleted and not rendered.allow_deleted:
-        logger.info(f"Tried emailing {user} based on template {rendered.email_template_name} but user is deleted")
+        logger.info(f"Tried emailing {user} based on template {rendered.template_name} but user is deleted")
         return
 
     list_unsubscribe_header = None
-    if rendered.email_list_unsubscribe_url:
-        list_unsubscribe_header = f"<{rendered.email_list_unsubscribe_url}>"
+    if rendered.list_unsubscribe_url:
+        list_unsubscribe_header = f"<{rendered.list_unsubscribe_url}>"
 
     queue_email(
         session,
         sender_name=config["NOTIFICATION_EMAIL_SENDER"],
         sender_email=config["NOTIFICATION_EMAIL_ADDRESS"],
         recipient=user.email,
-        subject=config["NOTIFICATION_PREFIX"] + rendered.email_subject,
+        subject=config["NOTIFICATION_PREFIX"] + rendered.subject,
         plain=plain,
         html=html,
-        source_data=config["VERSION"] + f"/{rendered.email_template_name}",
+        source_data=config["VERSION"] + f"/{rendered.template_name}",
         list_unsubscribe_header=list_unsubscribe_header,
     )
 

--- a/app/backend/src/couchers/notifications/render.py
+++ b/app/backend/src/couchers/notifications/render.py
@@ -175,7 +175,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
                 "message": message,
             },
         )
-    elif notification.topic_action.display == "address:change":
+    elif notification.topic_action.display == "email_address:change":
         title = "An email change was initiated on your account"
         message = f"An email change to the email <b>{data.new_email}</b> was initiated on your account."
         return RenderedEmailNotification(
@@ -188,7 +188,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
                 "message": message,
             },
         )
-    elif notification.topic_action.display == "address:verify":
+    elif notification.topic_action.display == "email_address:verify":
         title = "Email change completed"
         message = "Your new email address has been verified."
         return RenderedEmailNotification(

--- a/app/backend/src/couchers/notifications/render.py
+++ b/app/backend/src/couchers/notifications/render.py
@@ -10,7 +10,6 @@ from couchers.proto import notification_data_pb2
 from couchers.templates.v2 import v2date, v2esc, v2phone, v2timestamp
 from couchers.utils import now, to_aware_datetime
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/app/backend/src/couchers/notifications/render.py
+++ b/app/backend/src/couchers/notifications/render.py
@@ -5,46 +5,38 @@ from typing import Any
 from couchers import urls
 from couchers.i18n.i18n import localize_string
 from couchers.models import Notification, User
-from couchers.notifications.push import PushNotificationContent
 from couchers.notifications.quick_links import generate_quick_decline_link, generate_unsub_topic_action
 from couchers.proto import notification_data_pb2
-from couchers.templates.v2 import v2avatar, v2date, v2esc, v2phone, v2timestamp
+from couchers.templates.v2 import v2date, v2esc, v2phone, v2timestamp
 from couchers.utils import now, to_aware_datetime
+
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass(kw_only=True)
-class RenderedNotification:
+class RenderedEmailNotification:
     # whether the notification is critical and cannot be turned off
     is_critical: bool = False
     # whether this email can be sent to someone who is deleted
     allow_deleted: bool = False
     # email subject
-    email_subject: str
+    subject: str
     # shows up when listing emails in many clients
-    email_preview: str
+    preview: str
     # corresponds to .mjml + .txt file in templates/v2
-    email_template_name: str
+    template_name: str
     # other template args
-    email_template_args: dict[str, Any]
+    template_args: dict[str, Any]
     # the link label on the topic_action unsubscribe link
-    email_topic_action_unsubscribe_text: str | None = None
+    topic_action_unsubscribe_text: str | None = None
     # the link label on the topic_key unsubscribe link
-    email_topic_key_unsubscribe_text: str | None = None
+    topic_key_unsubscribe_text: str | None = None
     # url to unsubscribe with one click
-    email_list_unsubscribe_url: str | None = None
-    # push notification title
-    push_title: str
-    # push notification content
-    push_body: str
-    # url to an icon for push notifications
-    push_icon: str
-    # url to where clicking on the notification should take you
-    push_url: str
+    list_unsubscribe_url: str | None = None
 
 
-def render_notification(user: User, notification: Notification) -> RenderedNotification:
+def render_email_notification(user: User, notification: Notification) -> RenderedEmailNotification:
     def get_localized_string(key: str, *, substitutions: dict[str, str | int] | None = None) -> str:
         return localize_string(user.ui_language_preference, key, substitutions=substitutions)
 
@@ -56,30 +48,26 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
             other = data.user
             # "declined your host request", or similar
             message = f"{other.name} sent you message(s) in {their_your} host request"
-            return RenderedNotification(
-                email_subject=message,
-                email_preview=message,
-                email_template_name="host_request__plain",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject=message,
+                preview=message,
+                template_name="host_request__plain",
+                template_args={
                     "view_link": view_link,
                     "host_request": data.host_request,
                     "message": message,
                     "other": other,
                 },
-                email_topic_action_unsubscribe_text="missed messages in host requests",
-                push_title=message,
-                push_body="Check the app for more info.",
-                push_icon=v2avatar(other),
-                push_url=view_link,
+                topic_action_unsubscribe_text="missed messages in host requests",
             )
         elif notification.action == "create":
             other = data.surfer
             message = f"{other.name} sent you a host request"
-            return RenderedNotification(
-                email_subject=message,
-                email_preview=message,
-                email_template_name="host_request__new",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject=message,
+                preview=message,
+                template_name="host_request__new",
+                template_args={
                     "view_link": view_link,
                     "quick_decline_link": generate_quick_decline_link(data.host_request),
                     "host_request": data.host_request,
@@ -87,11 +75,7 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
                     "other": other,
                     "text": data.text,
                 },
-                email_topic_action_unsubscribe_text="new host requests",
-                push_title=f"{message}",
-                push_body=f"Dates: {v2date(data.host_request.from_date, user)} to {v2date(data.host_request.to_date, user)}.\n\n{data.text}",
-                push_icon=v2avatar(other),
-                push_url=view_link,
+                topic_action_unsubscribe_text="new host requests",
             )
         elif notification.action == "message":
             other = data.user
@@ -100,22 +84,18 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
             else:
                 message = f"{other.name} sent you a message in your host request"
             topic_action_unsub_text = "messages in host request"
-            return RenderedNotification(
-                email_subject=message,
-                email_preview=message,
-                email_template_name="host_request__message",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject=message,
+                preview=message,
+                template_name="host_request__message",
+                template_args={
                     "view_link": view_link,
                     "host_request": data.host_request,
                     "message": message,
                     "other": other,
                     "text": data.text,
                 },
-                email_topic_action_unsubscribe_text=topic_action_unsub_text,
-                push_title=f"{message}",
-                push_body=f"Dates: {v2date(data.host_request.from_date, user)} to {v2date(data.host_request.to_date, user)}.\n\n{data.text}",
-                push_icon=v2avatar(other),
-                push_url=view_link,
+                topic_action_unsubscribe_text=topic_action_unsub_text,
             )
         elif notification.action in ["accept", "reject", "confirm", "cancel"]:
             if notification.action in ["accept", "reject"]:
@@ -132,178 +112,136 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
             }[notification.action]
             # "declined your host request", or similar
             message = f"{other.name} {actioned} {their_your} host request"
-            return RenderedNotification(
-                email_subject=message,
-                email_preview=message,
-                email_template_name="host_request__plain",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject=message,
+                preview=message,
+                template_name="host_request__plain",
+                template_args={
                     "view_link": view_link,
                     "host_request": data.host_request,
                     "message": message,
                     "other": other,
                 },
-                email_topic_action_unsubscribe_text=f"{actioned} host requests",
-                push_title=message,
-                push_body="Check the app for more info.",
-                push_icon=v2avatar(other),
-                push_url=view_link,
+                topic_action_unsubscribe_text=f"{actioned} host requests",
             )
         elif notification.action == "reminder":
             message = f"You have a pending host request from {data.surfer.name}!"
             description = "Please respond to the request!"
-            return RenderedNotification(
-                email_subject=message,
-                email_preview=description,
-                email_template_name="host_request__plain",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject=message,
+                preview=description,
+                template_name="host_request__plain",
+                template_args={
                     "view_link": view_link,
                     "host_request": data.host_request,
                     "message": description,
                     "other": data.surfer,
                 },
-                email_topic_action_unsubscribe_text="Pending host request reminders",
-                push_title=message,
-                push_body=description,
-                push_icon=v2avatar(data.surfer),
-                push_url=view_link,
+                topic_action_unsubscribe_text="Pending host request reminders",
             )
     elif notification.topic_action.display == "password:change":
         title = "Your password was changed"
         message = "Your login password for Couchers.org was changed."
-        return RenderedNotification(
+        return RenderedEmailNotification(
             is_critical=True,
-            email_subject=title,
-            email_preview=message,
-            email_template_name="security",
-            email_template_args={
+            subject=title,
+            preview=message,
+            template_name="security",
+            template_args={
                 "title": title,
                 "message": message,
             },
-            push_title=title,
-            push_body=message,
-            push_icon=urls.icon_url(),
-            push_url=urls.account_settings_link(),
         )
     elif notification.topic_action.display == "password_reset:start":
         message = "Someone initiated a password change on your account."
-        return RenderedNotification(
+        return RenderedEmailNotification(
             is_critical=True,
-            email_subject="Reset your Couchers.org password",
-            email_preview=message,
-            email_template_name="password_reset",
-            email_template_args={
+            subject="Reset your Couchers.org password",
+            preview=message,
+            template_name="password_reset",
+            template_args={
                 "password_reset_link": urls.password_reset_link(password_reset_token=data.password_reset_token)
             },
-            push_title="A password reset was initiated on your account",
-            push_body=message,
-            push_icon=urls.icon_url(),
-            push_url=urls.account_settings_link(),
         )
     elif notification.topic_action.display == "password_reset:complete":
         title = "Your password was successfully reset"
         message = "Your password on Couchers.org was changed. If that was you, then no further action is needed."
-        return RenderedNotification(
+        return RenderedEmailNotification(
             is_critical=True,
-            email_subject=title,
-            email_preview=title,
-            email_template_name="security",
-            email_template_args={
+            subject=title,
+            preview=title,
+            template_name="security",
+            template_args={
                 "title": title,
                 "message": message,
             },
-            push_title=title,
-            push_body=message,
-            push_icon=urls.icon_url(),
-            push_url=urls.account_settings_link(),
         )
-    elif notification.topic_action.display == "email_address:change":
+    elif notification.topic_action.display == "address:change":
         title = "An email change was initiated on your account"
         message = f"An email change to the email <b>{data.new_email}</b> was initiated on your account."
-        message_plain = f"An email change to the email {data.new_email} was initiated on your account."
-        return RenderedNotification(
+        return RenderedEmailNotification(
             is_critical=True,
-            email_subject=title,
-            email_preview=title,
-            email_template_name="security",
-            email_template_args={
+            subject=title,
+            preview=title,
+            template_name="security",
+            template_args={
                 "title": title,
                 "message": message,
             },
-            push_title=title,
-            push_body=message_plain,
-            push_icon=urls.icon_url(),
-            push_url=urls.account_settings_link(),
         )
-    elif notification.topic_action.display == "email_address:verify":
+    elif notification.topic_action.display == "address:verify":
         title = "Email change completed"
         message = "Your new email address has been verified."
-        return RenderedNotification(
+        return RenderedEmailNotification(
             is_critical=True,
-            email_subject=title,
-            email_preview=message,
-            email_template_name="security",
-            email_template_args={
+            subject=title,
+            preview=message,
+            template_name="security",
+            template_args={
                 "title": title,
                 "message": message,
             },
-            push_title=title,
-            push_body=message,
-            push_icon=urls.icon_url(),
-            push_url=urls.account_settings_link(),
         )
     elif notification.topic_action.display == "phone_number:change":
         title = "Phone verification started"
         message = f"You started phone number verification with the number <b>{v2phone(data.phone)}</b>."
-        message_plain = f"You started phone number verification with the number {v2phone(data.phone)}."
-        return RenderedNotification(
+        return RenderedEmailNotification(
             is_critical=True,
-            email_subject=title,
-            email_preview=message,
-            email_template_name="security",
-            email_template_args={
+            subject=title,
+            preview=message,
+            template_name="security",
+            template_args={
                 "title": title,
                 "message": message,
             },
-            push_title=title,
-            push_body=message_plain,
-            push_icon=urls.icon_url(),
-            push_url=urls.feature_preview_link(),
         )
     elif notification.topic_action.display == "phone_number:verify":
         title = "Phone successfully verified"
         message = f"Your phone was successfully verified as <b>{v2phone(data.phone)}</b> on Couchers.org."
         message_plain = f"Your phone was successfully verified as {v2phone(data.phone)} on Couchers.org."
-        return RenderedNotification(
+        return RenderedEmailNotification(
             is_critical=True,
-            email_subject=title,
-            email_preview=message_plain,
-            email_template_name="security",
-            email_template_args={
+            subject=title,
+            preview=message_plain,
+            template_name="security",
+            template_args={
                 "title": title,
                 "message": message,
             },
-            push_title=title,
-            push_body=message_plain,
-            push_icon=urls.icon_url(),
-            push_url=urls.feature_preview_link(),
         )
     elif notification.topic_action.display == "gender:change":
         title = "Your gender was changed"
         message = f"Your gender on Couchers.org was changed to <b>{data.gender}</b> by an admin."
         message_plain = f"Your gender on Couchers.org was changed to {data.gender} by an admin."
-        return RenderedNotification(
+        return RenderedEmailNotification(
             is_critical=True,
-            email_subject=title,
-            email_preview=message_plain,
-            email_template_name="security",
-            email_template_args={
+            subject=title,
+            preview=message_plain,
+            template_name="security",
+            template_args={
                 "title": title,
                 "message": message,
             },
-            push_title=title,
-            push_body=message_plain,
-            push_icon=urls.icon_url(),
-            push_url=urls.account_settings_link(),
         )
     elif notification.topic_action.display == "birthdate:change":
         title = "Your date of birth was changed"
@@ -311,57 +249,41 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
             f"Your date of birth on Couchers.org was changed to <b>{v2date(data.birthdate, user)}</b> by an admin."
         )
         message_plain = f"Your date of birth on Couchers.org was changed to {v2date(data.birthdate, user)} by an admin."
-        return RenderedNotification(
+        return RenderedEmailNotification(
             is_critical=True,
-            email_subject=title,
-            email_preview=message_plain,
-            email_template_name="security",
-            email_template_args={
+            subject=title,
+            preview=message_plain,
+            template_name="security",
+            template_args={
                 "title": title,
                 "message": message,
             },
-            push_title=title,
-            push_body=message_plain,
-            push_icon=urls.icon_url(),
-            push_url=urls.account_settings_link(),
         )
     elif notification.topic_action.display == "api_key:create":
-        return RenderedNotification(
+        return RenderedEmailNotification(
             is_critical=True,
-            email_subject="Your API key for Couchers.org",
-            email_preview="We have issued you an API key as per your request.",
-            email_template_name="api_key",
-            email_template_args={
+            subject="Your API key for Couchers.org",
+            preview="We have issued you an API key as per your request.",
+            template_name="api_key",
+            template_args={
                 "api_key": data.api_key,
                 "expiry": data.expiry,
             },
-            push_title="An API key was created for your account",
-            push_body="Details were sent to you via email.",
-            push_icon=urls.icon_url(),
-            push_url=urls.app_link(),
         )
     elif notification.topic_action.display in ["badge:add", "badge:remove"]:
         actioned = "added to" if notification.action == "add" else "removed from"
         title = f"The {data.badge_name} badge was {actioned} your profile"
-        return RenderedNotification(
-            email_subject=title,
-            email_preview=title,
-            email_template_name="badge",
-            email_template_args={
+        return RenderedEmailNotification(
+            subject=title,
+            preview=title,
+            template_name="badge",
+            template_args={
                 "badge_name": data.badge_name,
                 "actioned": actioned,
                 "unsub_type": "badge additions" if notification.action == "add" else "badge removals",
             },
-            email_topic_action_unsubscribe_text="badge additions" if notification.action == "add" else "badge removals",
-            push_title=title,
-            push_body=(
-                "Check out your profile to see the new badge!"
-                if notification.action == "add"
-                else "You can see all your badges on your profile."
-            ),
-            push_icon=urls.icon_url(),
-            push_url=urls.profile_link(),
-            email_list_unsubscribe_url=generate_unsub_topic_action(notification),
+            topic_action_unsubscribe_text="badge additions" if notification.action == "add" else "badge removals",
+            list_unsubscribe_url=generate_unsub_topic_action(notification),
         )
     elif notification.topic_action.display == "donation:received":
         title = get_localized_string("notifications.donation_received.title")
@@ -371,128 +293,100 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
                 "amount": data.amount,
             },
         )
-        return RenderedNotification(
+        return RenderedEmailNotification(
             is_critical=True,
-            email_subject=title,
-            email_preview=message,
-            email_template_name="donation_received",
-            email_template_args={
+            subject=title,
+            preview=message,
+            template_name="donation_received",
+            template_args={
                 "amount": data.amount,
                 "receipt_url": data.receipt_url,
             },
-            push_title=title,
-            push_body=message,
-            push_icon=urls.icon_url(),
-            push_url=data.receipt_url,
         )
     elif notification.topic_action.display == "friend_request:create":
         other = data.other_user
         preview = f"You've received a friend request from {other.name}"
-        return RenderedNotification(
-            email_subject=f"{other.name} wants to be your friend on Couchers.org!",
-            email_preview=preview,
-            email_template_name="friend_request",
-            email_template_args={
+        return RenderedEmailNotification(
+            subject=f"{other.name} wants to be your friend on Couchers.org!",
+            preview=preview,
+            template_name="friend_request",
+            template_args={
                 "friend_requests_link": urls.friend_requests_link(),
                 "other": other,
             },
-            email_topic_action_unsubscribe_text="new friend requests",
-            push_title=f"{other.name} wants to be your friend",
-            push_body=preview,
-            push_icon=v2avatar(other),
-            push_url=urls.friend_requests_link(),
+            topic_action_unsubscribe_text="new friend requests",
         )
     elif notification.topic_action.display == "friend_request:accept":
         other = data.other_user
         title = f"{other.name} accepted your friend request!"
         preview = f"{v2esc(other.name)} has accepted your friend request"
-        return RenderedNotification(
-            email_subject=title,
-            email_preview=preview,
-            email_template_name="friend_request_accepted",
-            email_template_args={
+        return RenderedEmailNotification(
+            subject=title,
+            preview=preview,
+            template_name="friend_request_accepted",
+            template_args={
                 "other_user_link": urls.user_link(username=other.username),
                 "other": other,
             },
-            email_topic_action_unsubscribe_text="accepted friend requests",
-            push_title=title,
-            push_body=preview,
-            push_icon=v2avatar(other),
-            push_url=urls.user_link(username=other.username),
+            topic_action_unsubscribe_text="accepted friend requests",
         )
     elif notification.topic_action.display == "account_deletion:start":
-        return RenderedNotification(
+        return RenderedEmailNotification(
             is_critical=True,
             allow_deleted=True,
-            email_subject="Confirm your Couchers.org account deletion",
-            email_preview="Please confirm that you want to delete your Couchers.org account.",
-            email_template_name="account_deletion_start",
-            email_template_args={
+            subject="Confirm your Couchers.org account deletion",
+            preview="Please confirm that you want to delete your Couchers.org account.",
+            template_name="account_deletion_start",
+            template_args={
                 "deletion_link": urls.delete_account_link(account_deletion_token=data.deletion_token),
             },
-            push_title="Account deletion initiated",
-            push_body="Someone initiated the deletion of your Couchers.org account. To delete your account, please follow the link in the email we sent you.",
-            push_icon=urls.icon_url(),
-            push_url=urls.app_link(),
         )
     elif notification.topic_action.display == "account_deletion:complete":
         title = "Your Couchers.org account has been deleted"
-        return RenderedNotification(
+        return RenderedEmailNotification(
             is_critical=True,
             allow_deleted=True,
-            email_subject=title,
-            email_preview="We have deleted your Couchers.org account, to undo, follow the link in this email.",
-            email_template_name="account_deletion_complete",
-            email_template_args={
+            subject=title,
+            preview="We have deleted your Couchers.org account, to undo, follow the link in this email.",
+            template_name="account_deletion_complete",
+            template_args={
                 "undelete_link": urls.recover_account_link(account_undelete_token=data.undelete_token),
                 "days": data.undelete_days,
             },
-            push_title=title,
-            push_body=f"You can still undo this by following the link we emailed to you within {data.undelete_days} days.",
-            push_icon=urls.icon_url(),
-            push_url=urls.app_link(),
         )
     elif notification.topic_action.display == "account_deletion:recovered":
         title = "Your Couchers.org account has been recovered!"
         subtitle = "We have recovered your Couchers.org account as per your request! Welcome back!"
-        return RenderedNotification(
+        return RenderedEmailNotification(
             is_critical=True,
             allow_deleted=True,
-            email_subject=title,
-            email_preview=subtitle,
-            email_template_name="account_deletion_recovered",
-            email_template_args={
+            subject=title,
+            preview=subtitle,
+            template_name="account_deletion_recovered",
+            template_args={
                 "app_link": urls.app_link(),
             },
-            push_title=title,
-            push_body=subtitle,
-            push_icon=urls.icon_url(),
-            push_url=urls.app_link(),
         )
     elif notification.topic_action.display == "chat:message":
-        return RenderedNotification(
-            email_subject=data.message,
-            email_preview="You received a message on Couchers.org!",
-            email_template_name="chat_message",
-            email_template_args={
+        return RenderedEmailNotification(
+            subject=data.message,
+            preview="You received a message on Couchers.org!",
+            template_name="chat_message",
+            template_args={
                 "author": data.author,
                 "message": data.message,
                 "text": data.text,
                 "view_link": urls.chat_link(chat_id=data.group_chat_id),
             },
-            email_topic_action_unsubscribe_text="new chat messages",
-            email_topic_key_unsubscribe_text="this chat (mute)",
-            push_title=data.message,
-            push_body=data.text,
-            push_icon=v2avatar(data.author),
-            push_url=urls.chat_link(chat_id=data.group_chat_id),
+            topic_action_unsubscribe_text="new chat messages",
+            topic_key_unsubscribe_text="this chat (mute)",
         )
     elif notification.topic_action.display == "chat:missed_messages":
-        return RenderedNotification(
-            email_subject="You have unseen messages on Couchers.org!",
-            email_preview="You missed some messages on the platform.",
-            email_template_name="chat_unseen_messages",
-            email_template_args={
+        return RenderedEmailNotification(
+            subject="You have unseen messages on Couchers.org!",
+            preview="You missed some messages on the platform.",
+            template_name="chat_unseen_messages",
+            template_args={
                 "items": [
                     {
                         "author": item.author,
@@ -503,11 +397,7 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
                     for item in data.messages
                 ]
             },
-            email_topic_action_unsubscribe_text="unseen chat messages",
-            push_title="You have unseen messages on Couchers.org",
-            push_body="Please check out any messages you missed.",
-            push_icon=urls.icon_url(),
-            push_url=urls.messages_link(),
+            topic_action_unsubscribe_text="unseen chat messages",
         )
     elif notification.topic == "event":
         event = data.event
@@ -520,22 +410,19 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
             if notification.action == "create_approved":
                 subject = f'{data.inviting_user.name} invited you to "{event.title}"'
                 start_text = "You've been invited to a new event"
-                body += f"Invited by {data.inviting_user.name}\n\n"
             elif notification.action == "create_any":
                 subject = f'{data.inviting_user.name} created an event called "{event.title}"'
                 start_text = "A new event was created"
-                body += f"Created by {data.inviting_user.name}\n\n"
-            body += event.content
             community_link = (
                 urls.community_link(node_id=data.in_community.community_id, slug=data.in_community.slug)
                 if data.in_community
                 else None
             )
-            return RenderedNotification(
-                email_subject=subject,
-                email_preview=f"{start_text} on Couchers.org!",
-                email_template_name="event_create",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject=subject,
+                preview=f"{start_text} on Couchers.org!",
+                template_name="event_create",
+                template_args={
                     "inviting_user": data.inviting_user,
                     "time_display": time_display,
                     "start_text": start_text,
@@ -545,172 +432,117 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
                     "event": event,
                     "view_link": event_link,
                 },
-                email_topic_action_unsubscribe_text=(
+                topic_action_unsubscribe_text=(
                     "new events by community members"
                     if notification.action == "create_any"
                     else "invitations to events (approved by moderators)"
                 ),
-                push_title=subject,
-                push_body=body,
-                push_icon=v2avatar(data.inviting_user),
-                push_url=event_link,
             )
         elif notification.action == "update":
             updated_text = ", ".join(data.updated_items)
-            body = f"{time_display}\n"
-            body += f"{data.updating_user.name} updated: {updated_text}\n\n"
-            body += event.content
-            return RenderedNotification(
-                email_subject=f'{data.updating_user.name} updated "{event.title}"',
-                email_preview="An event you are subscribed to was updated.",
-                email_template_name="event_update",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject=f'{data.updating_user.name} updated "{event.title}"',
+                preview="An event you are subscribed to was updated.",
+                template_name="event_update",
+                template_args={
                     "updating_user": data.updating_user,
                     "time_display": time_display,
                     "event": event,
                     "updated_text": updated_text,
                     "view_link": event_link,
                 },
-                email_topic_action_unsubscribe_text="event updates",
-                push_title=f'{data.updating_user.name} updated "{event.title}"',
-                push_body=body,
-                push_icon=v2avatar(data.updating_user),
-                push_url=event_link,
+                topic_action_unsubscribe_text="event updates",
             )
         elif notification.action == "cancel":
-            body = f"{time_display}\n"
-            body += f"The event has been cancelled by {data.cancelling_user.name}.\n\n"
-            body += event.content
-            return RenderedNotification(
-                email_subject=f'{data.cancelling_user.name} cancelled "{event.title}"',
-                email_preview="An event you are subscribed to has been cancelled.",
-                email_template_name="event_cancel",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject=f'{data.cancelling_user.name} cancelled "{event.title}"',
+                preview="An event you are subscribed to has been cancelled.",
+                template_name="event_cancel",
+                template_args={
                     "cancelling_user": data.cancelling_user,
                     "time_display": time_display,
                     "event": event,
                     "view_link": event_link,
                 },
-                email_topic_action_unsubscribe_text="event cancellations",
-                push_title=f'{data.cancelling_user.name} cancelled "{event.title}"',
-                push_body=body,
-                push_icon=v2avatar(data.cancelling_user),
-                push_url=event_link,
+                topic_action_unsubscribe_text="event cancellations",
             )
         elif notification.action == "delete":
-            return RenderedNotification(
-                email_subject=f'A moderator deleted "{event.title}"',
-                email_preview="An event you are subscribed to has been deleted.",
-                email_template_name="event_delete",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject=f'A moderator deleted "{event.title}"',
+                preview="An event you are subscribed to has been deleted.",
+                template_name="event_delete",
+                template_args={
                     "time_display": time_display,
                     "event": event,
                 },
-                email_topic_action_unsubscribe_text="event deletions",
-                push_title=f'A moderator deleted "{event.title}"',
-                push_body=f"{time_display}\nThe event has been deleted by the moderators.",
-                push_icon=urls.icon_url(),
-                push_url=urls.app_link(),
+                topic_action_unsubscribe_text="event deletions",
             )
         elif notification.action == "invite_organizer":
-            body = f"{time_display}\n"
-            body += f"Invited to co-organize by {data.inviting_user.name}\n\n"
-            body += event.content
-            return RenderedNotification(
-                email_subject=f'{data.inviting_user.name} invited you to co-organize "{event.title}"',
-                email_preview="You were invited to co-organize an event on Couchers.org.",
-                email_template_name="event_invite_organizer",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject=f'{data.inviting_user.name} invited you to co-organize "{event.title}"',
+                preview="You were invited to co-organize an event on Couchers.org.",
+                template_name="event_invite_organizer",
+                template_args={
                     "inviting_user": data.inviting_user,
                     "time_display": time_display,
                     "event": event,
                     "view_link": event_link,
                 },
-                email_topic_action_unsubscribe_text="invitations to co-organize events",
-                push_title=f'{data.inviting_user.name} invited you to co-organize "{event.title}"',
-                push_body=body,
-                push_icon=v2avatar(data.inviting_user),
-                push_url=event_link,
+                topic_action_unsubscribe_text="invitations to co-organize events",
             )
         elif notification.action == "comment":
-            body = f"{time_display}\n"
-            body += f"{data.author.name} commented:\n\n"
-            body += data.reply.content
-            return RenderedNotification(
-                email_subject=f'{data.author.name} commented on "{event.title}"',
-                email_preview="Someone commented on an event you are attending.",
-                email_template_name="event_comment",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject=f'{data.author.name} commented on "{event.title}"',
+                preview="Someone commented on an event you are attending.",
+                template_name="event_comment",
+                template_args={
                     "author": data.author,
                     "time_display": time_display,
                     "event": event,
                     "content": data.reply.content,
                     "view_link": event_link,
                 },
-                email_topic_action_unsubscribe_text="event comments",
-                push_title=f'{data.author.name} commented on "{event.title}"',
-                push_body=body,
-                push_icon=v2avatar(data.author),
-                push_url=event_link,
+                topic_action_unsubscribe_text="event comments",
             )
         elif notification.action == "reminder":
-            body = "Don't forget your upcoming event on Couchers.org\n"
-            body += f"{time_display}\n"
-            body += data.event.content
-            return RenderedNotification(
-                email_subject=f'Reminder: "{data.event.title}" starts soon',
-                email_preview="Don't forget your upcoming event on Couchers.org",
-                email_template_name="event_reminder",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject=f'Reminder: "{data.event.title}" starts soon',
+                preview="Don't forget your upcoming event on Couchers.org",
+                template_name="event_reminder",
+                template_args={
                     "time_display": time_display,
                     "event": event,
                     "view_link": event_link,
                 },
-                email_topic_action_unsubscribe_text="event reminders",
-                push_title=f'"{data.event.title}" starts soon',
-                push_body=body,
-                push_icon=urls.icon_url(),
-                push_url=event_link,
+                topic_action_unsubscribe_text="event reminders",
             )
     elif notification.topic == "discussion":
         discussion = data.discussion
         discussion_link = urls.discussion_link(discussion_id=discussion.discussion_id, slug=discussion.slug)
         if notification.action == "create":
-            body = f"{data.author.name} created a discussion in {discussion.owner_title}: {discussion.title}\n\n"
-            body += discussion.content
-            return RenderedNotification(
-                email_subject=f'{data.author.name} created a discussion: "{discussion.title}"',
-                email_preview="Someone created a discussion in a community or group you are subscribed to.",
-                email_template_name="discussion_create",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject=f'{data.author.name} created a discussion: "{discussion.title}"',
+                preview="Someone created a discussion in a community or group you are subscribed to.",
+                template_name="discussion_create",
+                template_args={
                     "author": data.author,
                     "discussion": discussion,
                     "view_link": discussion_link,
                 },
-                email_topic_action_unsubscribe_text="new discussions",
-                push_title=discussion.title,
-                push_body=body,
-                push_icon=v2avatar(data.author),
-                push_url=discussion_link,
+                topic_action_unsubscribe_text="new discussions",
             )
         elif notification.action == "comment":
-            body = f"{data.author.name} commented:\n\n"
-            body += data.reply.content
-            return RenderedNotification(
-                email_subject=f'{data.author.name} commented on "{discussion.title}"',
-                email_preview="Someone commented on your discussion.",
-                email_template_name="discussion_comment",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject=f'{data.author.name} commented on "{discussion.title}"',
+                preview="Someone commented on your discussion.",
+                template_name="discussion_comment",
+                template_args={
                     "author": data.author,
                     "discussion": discussion,
                     "reply": data.reply,
                     "view_link": discussion_link,
                 },
-                email_topic_action_unsubscribe_text="discussion comments",
-                push_title=discussion.title,
-                push_body=body,
-                push_icon=v2avatar(data.author),
-                push_url=discussion_link,
+                topic_action_unsubscribe_text="discussion comments",
             )
     elif notification.topic_action.display == "thread:reply":
         parent = data.WhichOneof("reply_parent")
@@ -723,41 +555,31 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
         else:
             raise Exception("Can only do replies to events and discussions")
 
-        body = f"{data.author.name} replied:\n\n"
-        body += data.reply.content
-        return RenderedNotification(
-            email_subject=f'{data.author.name} replied in "{title}"',
-            email_preview="Someone replied in a comment thread you have participated in.",
-            email_template_name="comment_reply",
-            email_template_args={
+        return RenderedEmailNotification(
+            subject=f'{data.author.name} replied in "{title}"',
+            preview="Someone replied in a comment thread you have participated in.",
+            template_name="comment_reply",
+            template_args={
                 "author": data.author,
                 "title": title,
                 "reply": data.reply,
                 "view_link": view_link,
             },
-            email_topic_action_unsubscribe_text="comment replies",
-            push_title=title,
-            push_body=body,
-            push_icon=v2avatar(data.author),
-            push_url=view_link,
+            topic_action_unsubscribe_text="comment replies",
         )
     elif notification.topic == "reference":
         if notification.action == "receive_friend":
             title = f"You've received a friend reference from {data.from_user.name}!"
-            return RenderedNotification(
-                email_subject=title,
-                email_preview=v2esc(data.text),
-                email_template_name="friend_reference",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject=title,
+                preview=v2esc(data.text),
+                template_name="friend_reference",
+                template_args={
                     "from_user": data.from_user,
                     "profile_references_link": urls.profile_references_link(),
                     "text": data.text,
                 },
-                email_topic_action_unsubscribe_text="new references from friends",
-                push_title=title,
-                push_body=data.text,
-                push_icon=v2avatar(data.from_user),
-                push_url=urls.profile_references_link(),
+                topic_action_unsubscribe_text="new references from friends",
             )
         elif notification.action in ["receive_hosted", "receive_surfed"]:
             title = f"You've received a reference from {data.from_user.name}!"
@@ -771,15 +593,13 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
             profile_references_link = urls.profile_references_link()
             if data.text:
                 body = v2esc(data.text)
-                push_url = profile_references_link
             else:
                 body = "Please go and write a reference for them too. It's a nice gesture and helps us build a community together!"
-                push_url = leave_reference_link
-            return RenderedNotification(
-                email_subject=title,
-                email_preview=body,
-                email_template_name="host_reference",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject=title,
+                preview=body,
+                template_name="host_reference",
+                template_args={
                     "from_user": data.from_user,
                     "leave_reference_link": leave_reference_link,
                     "profile_references_link": profile_references_link,
@@ -787,11 +607,7 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
                     "both_written": True if data.text else False,
                     "surfed": surfed,
                 },
-                email_topic_action_unsubscribe_text="new references from " + ("hosts" if surfed else "surfers"),
-                push_title=title,
-                push_body=body,
-                push_icon=v2avatar(data.from_user),
-                push_url=push_url,
+                topic_action_unsubscribe_text="new references from " + ("hosts" if surfed else "surfers"),
             )
         elif notification.action in ["reminder_hosted", "reminder_surfed"]:
             # what was my type? i surfed with them if i get a surfed reminder
@@ -803,81 +619,61 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
             )
             title = f"You have {data.days_left} days to write a reference for {data.other_user.name}!"
             preview = "It's a nice gesture to write references and helps us build a community together! References will become visible 2 weeks after the stay, or when you've both written a reference for each other, whichever happens first."
-            return RenderedNotification(
-                email_subject=title,
-                email_preview=preview,
-                email_template_name="reference_reminder",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject=title,
+                preview=preview,
+                template_name="reference_reminder",
+                template_args={
                     "other_user": data.other_user,
                     "leave_reference_link": leave_reference_link,
                     "days_left": str(data.days_left),
                     "surfed": surfed,
                 },
-                email_topic_action_unsubscribe_text=("surfed" if surfed else "hosted") + " reference reminders",
-                push_title=title,
-                push_body=preview,
-                push_icon=v2avatar(data.other_user),
-                push_url=leave_reference_link,
+                topic_action_unsubscribe_text=("surfed" if surfed else "hosted") + " reference reminders",
             )
     elif notification.topic_action.display == "onboarding:reminder":
         if notification.key == "1":
-            return RenderedNotification(
-                email_subject="Welcome to Couchers.org and the future of couch surfing",
-                email_preview="We are so excited to have you join our community!",
-                email_template_name="onboarding1",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject="Welcome to Couchers.org and the future of couch surfing",
+                preview="We are so excited to have you join our community!",
+                template_name="onboarding1",
+                template_args={
                     "app_link": urls.app_link(),
                     "edit_profile_link": urls.edit_profile_link(),
                 },
-                email_topic_action_unsubscribe_text="onboarding emails",
-                push_title="Welcome to Couchers.org and the future of couch surfing",
-                push_body=f"Hi {v2esc(user.name)}! We are excited that you have joined us! Please take a moment to complete your profile with a picture and a bit of text about yourself!",
-                push_icon=urls.icon_url(),
-                push_url=urls.edit_profile_link(),
+                topic_action_unsubscribe_text="onboarding emails",
             )
         elif notification.key == "2":
-            return RenderedNotification(
-                email_subject="Complete your profile on Couchers.org",
-                email_preview="We would ask one big favour of you: please fill out your profile by adding a photo and some text.",
-                email_template_name="onboarding2",
-                email_template_args={
+            return RenderedEmailNotification(
+                subject="Complete your profile on Couchers.org",
+                preview="We would ask one big favour of you: please fill out your profile by adding a photo and some text.",
+                template_name="onboarding2",
+                template_args={
                     "edit_profile_link": urls.edit_profile_link(),
                 },
-                email_topic_action_unsubscribe_text="onboarding emails",
-                push_title="Please complete your profile on Couchers.org!",
-                push_body=f"Hi {v2esc(user.name)}! We would ask one big favour of you: please fill out your profile by adding a photo and some text.",
-                push_icon=urls.icon_url(),
-                push_url=urls.edit_profile_link(),
+                topic_action_unsubscribe_text="onboarding emails",
             )
     elif notification.topic_action.display == "modnote:create":
         title = "You have received a mod note"
         message = "You have received an important note from the moderators. You must read and acknowledge it before continuing to use the platform."
-        return RenderedNotification(
+        return RenderedEmailNotification(
             is_critical=True,
-            email_subject=title,
-            email_preview=message,
-            email_template_name="mod_note",
-            email_template_args={"title": title},
-            push_title="You received a mod note",
-            push_body="You need to read and acknowledge the note before continuing to use the platform.",
-            push_icon=urls.icon_url(),
-            push_url=urls.app_link(),
+            subject=title,
+            preview=message,
+            template_name="mod_note",
+            template_args={"title": title},
         )
     elif notification.topic_action.display == "verification:sv_success":
         title = "Strong Verification succeeded"
         message = "You have been verified with Strong Verification! You will now see a tick next to your name on the platform."
-        return RenderedNotification(
+        return RenderedEmailNotification(
             is_critical=True,
-            email_subject=title,
-            email_preview=message,
-            email_template_name="strong_verification_success",
-            email_template_args={
+            subject=title,
+            preview=message,
+            template_name="strong_verification_success",
+            template_args={
                 "message": message,
             },
-            push_title=title,
-            push_body=message,
-            push_icon=urls.icon_url(),
-            push_url=urls.account_settings_link(),
         )
     elif notification.topic_action.display == "verification:sv_fail":
         title = "Strong Verification failed"
@@ -889,54 +685,42 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
             reason_message = "You tried to verify with a passport that has already been used for verification. Please use another passport."
         else:
             raise Exception("Shouldn't get here")
-        return RenderedNotification(
+        return RenderedEmailNotification(
             is_critical=True,
-            email_subject=title,
-            email_preview=title,
-            email_template_name="security",
-            email_template_args={
+            subject=title,
+            preview=title,
+            template_name="security",
+            template_args={
                 "title": title,
                 "message": reason_message,
             },
-            push_title=title,
-            push_body=reason_message,
-            push_icon=urls.icon_url(),
-            push_url=urls.account_settings_link(),
         )
     elif notification.topic == "postal_verification":
         if notification.action == "postcard_sent":
             title = "Your verification postcard is on its way"
             message = f"We've sent a postcard with your verification code to {data.city}, {data.country}. It should arrive within 1-3 weeks depending on your location. Once it arrives, enter the code on the platform to complete verification."
-            return RenderedNotification(
+            return RenderedEmailNotification(
                 is_critical=True,
-                email_subject=title,
-                email_preview=message,
-                email_template_name="security",
-                email_template_args={
+                subject=title,
+                preview=message,
+                template_name="security",
+                template_args={
                     "title": title,
                     "message": message,
                 },
-                push_title=title,
-                push_body=f"Postcard sent to {data.city}, {data.country}. Expect it within 1-3 weeks.",
-                push_icon=urls.icon_url(),
-                push_url=urls.account_settings_link(),
             )
         elif notification.action == "success":
             title = "Postal Verification succeeded"
             message = "You have been verified with Postal Verification! Your address has been confirmed."
-            return RenderedNotification(
+            return RenderedEmailNotification(
                 is_critical=True,
-                email_subject=title,
-                email_preview=message,
-                email_template_name="security",
-                email_template_args={
+                subject=title,
+                preview=message,
+                template_name="security",
+                template_args={
                     "title": title,
                     "message": message,
                 },
-                push_title=title,
-                push_body=message,
-                push_icon=urls.icon_url(),
-                push_url=urls.account_settings_link(),
             )
         elif notification.action == "failed":
             title = "Postal Verification failed"
@@ -948,64 +732,39 @@ def render_notification(user: User, notification: Notification) -> RenderedNotif
                 reason_message = (
                     "Your postal verification attempt has failed. You can start a new verification attempt."
                 )
-            return RenderedNotification(
+            return RenderedEmailNotification(
                 is_critical=True,
-                email_subject=title,
-                email_preview=title,
-                email_template_name="security",
-                email_template_args={
+                subject=title,
+                preview=title,
+                template_name="security",
+                template_args={
                     "title": title,
                     "message": reason_message,
                 },
-                push_title=title,
-                push_body=reason_message,
-                push_icon=urls.icon_url(),
-                push_url=urls.account_settings_link(),
             )
     elif notification.topic_action.display == "activeness:probe":
         title = "Are you still open to hosting on Couchers.org?"
-        return RenderedNotification(
-            email_subject=title,
-            email_preview=title,
-            email_template_name="activeness_probe",
-            email_template_args={
+        return RenderedEmailNotification(
+            subject=title,
+            preview=title,
+            template_name="activeness_probe",
+            template_args={
                 "app_link": urls.app_link(),
                 "days_left": (to_aware_datetime(data.deadline) - now()).days,
             },
-            push_title=title,
-            push_body="Please log in to confirm your hosting status.",
-            push_icon=urls.icon_url(),
-            push_url=urls.app_link(),
         )
     elif notification.topic_action.display == "general:new_blog_post":
         title = f"New blog post: {data.title}"
-        return RenderedNotification(
-            email_subject=title,
-            email_preview=data.blurb,
-            email_template_name="new_blog_post",
-            email_template_args={
+        return RenderedEmailNotification(
+            subject=title,
+            preview=data.blurb,
+            template_name="new_blog_post",
+            template_args={
                 "title": data.title,
                 "blurb": data.blurb,
                 "url": data.url,
             },
-            email_topic_action_unsubscribe_text="new blog post alerts",
-            push_title=title,
-            push_body=data.blurb,
-            push_icon=urls.icon_url(),
-            push_url=data.url,
+            topic_action_unsubscribe_text="new blog post alerts",
         )
 
     raise NotImplementedError(f"Unknown topic-action: {notification.topic}:{notification.action}")
-
-
-def render_push_notification(user: User, notification: Notification) -> PushNotificationContent:
-    email_notification = render_notification(user, notification)
-    if email_notification.push_title is None:  # type: ignore[comparison-overlap]
-        raise NotImplementedError(f"topic-action {notification.topic}:{notification.action} does not have push info")
-
-    return PushNotificationContent(
-        title=email_notification.push_title,
-        body=email_notification.push_body,
-        action_url=email_notification.push_url,
-        icon_url=email_notification.push_icon,
-    )

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -577,7 +577,7 @@ def _verification_sv_fail(data: notification_data_pb2.VerificationSVFail) -> Pus
 def render_push_notification(user: User, notification: Notification) -> PushNotificationContent:
     data: empty_pb2.Empty = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
     # Keep topics sorted (action can follow logical ordering)
-    match notification.topic_action:
+    match notification.topic_action.display:
         case "account_deletion:start":
             return _account_deletion_start(data)
         case "account_deletion:complete":
@@ -685,4 +685,4 @@ def render_push_notification(user: User, notification: Notification) -> PushNoti
         case "verification:sv_fail":
             return _verification_sv_fail(data)
         case _:
-            raise NotImplementedError(f"Unknown topic-action: {notification.topic}:{notification.action}")
+            raise NotImplementedError(f"Unknown topic-action: {notification.topic_action.display}")

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -29,152 +29,152 @@ def render_push_notification(user: User, notification: Notification) -> PushNoti
     # Any-typed so it implicitly converts when calling the methods below
     data: Any = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
     match notification.topic_action:
+        # Using a match statement enable mypy's exhaustiveness checking.
+        # Every case is has its own function so that they can declare different types for "data",
+        # as mypy wouldn't allow that in a single function.
         # Keep topics sorted (actions can follow logical ordering)
         case NotificationTopicAction.account_deletion__start:
-            return _account_deletion_start(data)
+            return _account_deletion__start(data)
         case NotificationTopicAction.account_deletion__complete:
-            return _account_deletion_complete(data)
+            return _account_deletion__complete(data)
         case NotificationTopicAction.account_deletion__recovered:
-            return _account_deletion_recovered(data)
+            return _account_deletion__recovered(data)
         case NotificationTopicAction.activeness__probe:
-            return _activeness_probe(data)
+            return _activeness__probe(data)
         case NotificationTopicAction.api_key__create:
-            return _api_key_create(data)
+            return _api_key__create(data)
         case NotificationTopicAction.badge__add:
-            return _badge_add(data)
+            return _badge__add(data)
         case NotificationTopicAction.badge__remove:
-            return _badge_remove(data)
+            return _badge__remove(data)
         case NotificationTopicAction.birthdate__change:
-            return _birthdate_change(data, user)
+            return _birthdate__change(data, user)
         case NotificationTopicAction.chat__message:
-            return _chat_message(data)
+            return _chat__message(data)
         case NotificationTopicAction.chat__missed_messages:
-            return _chat_missed_messages(data)
+            return _chat__missed_messages(data)
         case NotificationTopicAction.donation__received:
-            return _donation_received(data)
+            return _donation__received(data)
         case NotificationTopicAction.discussion__create:
-            return _discussion_create(data)
+            return _discussion__create(data)
         case NotificationTopicAction.discussion__comment:
-            return _discussion_comment(data)
+            return _discussion__comment(data)
         case NotificationTopicAction.email_address__change:
-            return _email_address_change(data)
+            return _email_address__change(data)
         case NotificationTopicAction.email_address__verify:
-            return _email_address_verify(data)
+            return _email_address__verify(data)
         case NotificationTopicAction.event__create_any:
-            return _event_create_any(data, user)
+            return _event__create_any(data, user)
         case NotificationTopicAction.event__create_approved:
-            return _event_create_approved(data, user)
+            return _event__create_approved(data, user)
         case NotificationTopicAction.event__update:
-            return _event_update(data, user)
+            return _event__update(data, user)
         case NotificationTopicAction.event__invite_organizer:
-            return _event_invite_organizer(data, user)
+            return _event__invite_organizer(data, user)
         case NotificationTopicAction.event__comment:
-            return _event_comment(data, user)
+            return _event__comment(data, user)
         case NotificationTopicAction.event__reminder:
-            return _event_reminder(data, user)
+            return _event__reminder(data, user)
         case NotificationTopicAction.event__cancel:
-            return _event_cancel(data, user)
+            return _event__cancel(data, user)
         case NotificationTopicAction.event__delete:
-            return _event_delete(data, user)
+            return _event__delete(data, user)
         case NotificationTopicAction.friend_request__create:
-            return _friend_request_create(data)
+            return _friend_request__create(data)
         case NotificationTopicAction.friend_request__accept:
-            return _friend_request_accept(data)
+            return _friend_request__accept(data)
         case NotificationTopicAction.gender__change:
-            return _gender_change(data)
+            return _gender__change(data)
         case NotificationTopicAction.general__new_blog_post:
-            return _general_new_blog_post(data)
+            return _general__new_blog_post(data)
         case NotificationTopicAction.host_request__create:
-            return _host_request_create(data, user)
+            return _host_request__create(data, user)
         case NotificationTopicAction.host_request__message:
-            return _host_request_message(data, user)
+            return _host_request__message(data, user)
         case NotificationTopicAction.host_request__missed_messages:
-            return _host_request_missed_messages(data)
+            return _host_request__missed_messages(data)
         case NotificationTopicAction.host_request__reminder:
-            return _host_request_reminder(data)
+            return _host_request__reminder(data)
         case NotificationTopicAction.host_request__accept:
-            return _host_request_accept(data)
+            return _host_request__accept(data)
         case NotificationTopicAction.host_request__reject:
-            return _host_request_reject(data)
+            return _host_request__reject(data)
         case NotificationTopicAction.host_request__cancel:
-            return _host_request_cancel(data)
+            return _host_request__cancel(data)
         case NotificationTopicAction.host_request__confirm:
-            return _host_request_confirm(data)
+            return _host_request__confirm(data)
         case NotificationTopicAction.modnote__create:
-            return _modnote_create(data)
+            return _modnote__create(data)
         case NotificationTopicAction.onboarding__reminder:
-            return _onboarding_reminder(data, notification.key, user)
+            return _onboarding__reminder(data, notification.key, user)
         case NotificationTopicAction.password__change:
-            return _password_change(data)
+            return _password__change(data)
         case NotificationTopicAction.password_reset__start:
-            return _password_reset_start(data)
+            return _password_reset__start(data)
         case NotificationTopicAction.password_reset__complete:
-            return _password_reset_complete(data)
+            return _password_reset__complete(data)
         case NotificationTopicAction.phone_number__change:
-            return _phone_number_change(data)
+            return _phone_number__change(data)
         case NotificationTopicAction.phone_number__verify:
-            return _phone_number_verify(data)
+            return _phone_number__verify(data)
         case NotificationTopicAction.postal_verification__postcard_sent:
-            return _postal_verification_postcard_sent(data)
+            return _postal_verification__postcard_sent(data)
         case NotificationTopicAction.postal_verification__success:
-            return _postal_verification_success(data)
+            return _postal_verification__success(data)
         case NotificationTopicAction.postal_verification__failed:
-            return _postal_verification_failed(data)
+            return _postal_verification__failed(data)
         case NotificationTopicAction.reference__receive_friend:
-            return _reference_receive_friend(data)
+            return _reference__receive_friend(data)
         case NotificationTopicAction.reference__receive_hosted:
-            return _reference_receive(data, action=notification.action)
+            return _reference__receive_hosted(data)
         case NotificationTopicAction.reference__receive_surfed:
-            return _reference_receive(data, action=notification.action)
+            return _reference__receive_surfed(data)
         case NotificationTopicAction.reference__reminder_hosted:
-            return _reference_reminder(data, action=notification.action)
+            return _reference__reminder_hosted(data)
         case NotificationTopicAction.reference__reminder_surfed:
-            return _reference_reminder(data, action=notification.action)
+            return _reference__reminder_surfed(data)
         case NotificationTopicAction.thread__reply:
-            return _thread_reply(data)
+            return _thread__reply(data)
         case NotificationTopicAction.verification__sv_success:
-            return _verification_sv_success(data)
+            return _verification__sv_success(data)
         case NotificationTopicAction.verification__sv_fail:
-            return _verification_sv_fail(data)
+            return _verification__sv_fail(data)
         case _:
             # Enables mypy's exhaustiveness checking for the cases above.
             assert_never(notification.topic_action)
 
+    raise NotImplementedError(f"Unknown topic-action: {notification.topic}:{notification.action}")
 
-# account_deletion:start
-def _account_deletion_start(data: empty_pb2.Empty) -> PushNotificationContent:
+
+def _account_deletion__start(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
         title="Account deletion initiated",
         body="Someone initiated the deletion of your Couchers.org account. To delete your account, please follow the link in the email we sent you.",
     )
 
 
-# account_deletion:complete
-def _account_deletion_complete(data: notification_data_pb2.AccountDeletionComplete) -> PushNotificationContent:
+def _account_deletion__complete(data: notification_data_pb2.AccountDeletionComplete) -> PushNotificationContent:
     return PushNotificationContent(
         title="Your Couchers.org account has been deleted",
         body=f"You can still undo this by following the link we emailed to you within {data.undelete_days} days.",
     )
 
 
-# account_deletion:recovered
-def _account_deletion_recovered(data: empty_pb2.Empty) -> PushNotificationContent:
+def _account_deletion__recovered(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
         title="Your Couchers.org account has been recovered!",
         body="We have recovered your Couchers.org account as per your request! Welcome back!",
     )
 
 
-# activeness:probe
-def _activeness_probe(data: notification_data_pb2.ActivenessProbe) -> PushNotificationContent:
+def _activeness__probe(data: notification_data_pb2.ActivenessProbe) -> PushNotificationContent:
     return PushNotificationContent(
         title="Are you still open to hosting on Couchers.org?",
         body="Please log in to confirm your hosting status.",
     )
 
 
-# api_key:create
-def _api_key_create(data: empty_pb2.Empty) -> PushNotificationContent:
+def _api_key__create(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
         title="An API key was created for your account",
         body="Details were sent to you via email.",
@@ -182,8 +182,7 @@ def _api_key_create(data: empty_pb2.Empty) -> PushNotificationContent:
     )
 
 
-# badge:add
-def _badge_add(data: notification_data_pb2.BadgeAdd) -> PushNotificationContent:
+def _badge__add(data: notification_data_pb2.BadgeAdd) -> PushNotificationContent:
     return PushNotificationContent(
         title=f"The {data.badge_name} badge was added to your profile",
         body="Check out your profile to see the new badge!",
@@ -191,8 +190,7 @@ def _badge_add(data: notification_data_pb2.BadgeAdd) -> PushNotificationContent:
     )
 
 
-# badge:remove
-def _badge_remove(data: notification_data_pb2.BadgeRemove) -> PushNotificationContent:
+def _badge__remove(data: notification_data_pb2.BadgeRemove) -> PushNotificationContent:
     return PushNotificationContent(
         title=f"The {data.badge_name} badge was removed from your profile",
         body="You can see all your badges on your profile.",
@@ -200,8 +198,7 @@ def _badge_remove(data: notification_data_pb2.BadgeRemove) -> PushNotificationCo
     )
 
 
-# birthdate:change
-def _birthdate_change(data: notification_data_pb2.BirthdateChange, user: User) -> PushNotificationContent:
+def _birthdate__change(data: notification_data_pb2.BirthdateChange, user: User) -> PushNotificationContent:
     return PushNotificationContent(
         title="Your date of birth was changed",
         body=f"Your date of birth on Couchers.org was changed to {v2date(data.birthdate, user)} by an admin.",
@@ -209,8 +206,7 @@ def _birthdate_change(data: notification_data_pb2.BirthdateChange, user: User) -
     )
 
 
-# chat:message
-def _chat_message(data: notification_data_pb2.ChatMessage) -> PushNotificationContent:
+def _chat__message(data: notification_data_pb2.ChatMessage) -> PushNotificationContent:
     return PushNotificationContent(
         title=data.message,
         body=data.text,
@@ -219,8 +215,7 @@ def _chat_message(data: notification_data_pb2.ChatMessage) -> PushNotificationCo
     )
 
 
-# chat:missed_messages
-def _chat_missed_messages(data: empty_pb2.Empty) -> PushNotificationContent:
+def _chat__missed_messages(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
         title="You have unseen messages on Couchers.org",
         body="Please check out any messages you missed.",
@@ -228,8 +223,7 @@ def _chat_missed_messages(data: empty_pb2.Empty) -> PushNotificationContent:
     )
 
 
-# donation:received
-def _donation_received(data: notification_data_pb2.DonationReceived) -> PushNotificationContent:
+def _donation__received(data: notification_data_pb2.DonationReceived) -> PushNotificationContent:
     return PushNotificationContent(
         title="Thank you for your donation to Couchers.org!",
         body=f"Thank you so much for your donation of ${data.amount} to Couchers.org.",
@@ -237,8 +231,7 @@ def _donation_received(data: notification_data_pb2.DonationReceived) -> PushNoti
     )
 
 
-# discussion:create
-def _discussion_create(data: notification_data_pb2.DiscussionCreate) -> PushNotificationContent:
+def _discussion__create(data: notification_data_pb2.DiscussionCreate) -> PushNotificationContent:
     return PushNotificationContent(
         title=data.discussion.title,
         body=f"{data.author.name} created a discussion in {data.discussion.owner_title}: {data.discussion.title}\n\n{data.discussion.content}",
@@ -247,8 +240,7 @@ def _discussion_create(data: notification_data_pb2.DiscussionCreate) -> PushNoti
     )
 
 
-# discussion:comment
-def _discussion_comment(data: notification_data_pb2.DiscussionComment) -> PushNotificationContent:
+def _discussion__comment(data: notification_data_pb2.DiscussionComment) -> PushNotificationContent:
     return PushNotificationContent(
         title=data.discussion.title,
         body=f"{data.author.name} commented:\n\n{data.reply.content}",
@@ -257,8 +249,7 @@ def _discussion_comment(data: notification_data_pb2.DiscussionComment) -> PushNo
     )
 
 
-# email_address:change
-def _email_address_change(data: notification_data_pb2.EmailAddressChange) -> PushNotificationContent:
+def _email_address__change(data: notification_data_pb2.EmailAddressChange) -> PushNotificationContent:
     return PushNotificationContent(
         title="An email change was initiated on your account",
         body=f"An email change to the email {data.new_email} was initiated on your account.",
@@ -266,8 +257,7 @@ def _email_address_change(data: notification_data_pb2.EmailAddressChange) -> Pus
     )
 
 
-# email_address:verify
-def _email_address_verify(data: empty_pb2.Empty) -> PushNotificationContent:
+def _email_address__verify(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
         title="Email change completed",
         body="Your new email address has been verified.",
@@ -279,8 +269,7 @@ def _get_event_time_display(event: events_pb2.Event, user: User) -> str:
     return f"{v2timestamp(event.start_time, user)} - {v2timestamp(event.end_time, user)}"
 
 
-# event:create_any
-def _event_create_any(data: notification_data_pb2.EventCreate, user: User) -> PushNotificationContent:
+def _event__create_any(data: notification_data_pb2.EventCreate, user: User) -> PushNotificationContent:
     time_display = _get_event_time_display(data.event, user)
     return PushNotificationContent(
         title=f'{data.inviting_user.name} created an event called "{data.event.title}"',
@@ -290,8 +279,7 @@ def _event_create_any(data: notification_data_pb2.EventCreate, user: User) -> Pu
     )
 
 
-# event:create_approved
-def _event_create_approved(data: notification_data_pb2.EventCreate, user: User) -> PushNotificationContent:
+def _event__create_approved(data: notification_data_pb2.EventCreate, user: User) -> PushNotificationContent:
     time_display = _get_event_time_display(data.event, user)
     return PushNotificationContent(
         title=f'{data.inviting_user.name} invited you to "{data.event.title}"',
@@ -301,8 +289,7 @@ def _event_create_approved(data: notification_data_pb2.EventCreate, user: User) 
     )
 
 
-# event:update
-def _event_update(data: notification_data_pb2.EventUpdate, user: User) -> PushNotificationContent:
+def _event__update(data: notification_data_pb2.EventUpdate, user: User) -> PushNotificationContent:
     time_display = _get_event_time_display(data.event, user)
     updated_text = ", ".join(data.updated_items)
     return PushNotificationContent(
@@ -313,8 +300,7 @@ def _event_update(data: notification_data_pb2.EventUpdate, user: User) -> PushNo
     )
 
 
-# event:invite_organizer
-def _event_invite_organizer(data: notification_data_pb2.EventInviteOrganizer, user: User) -> PushNotificationContent:
+def _event__invite_organizer(data: notification_data_pb2.EventInviteOrganizer, user: User) -> PushNotificationContent:
     time_display = _get_event_time_display(data.event, user)
     return PushNotificationContent(
         title=f'{data.inviting_user.name} invited you to co-organize "{data.event.title}"',
@@ -324,8 +310,7 @@ def _event_invite_organizer(data: notification_data_pb2.EventInviteOrganizer, us
     )
 
 
-# event:comment
-def _event_comment(data: notification_data_pb2.EventComment, user: User) -> PushNotificationContent:
+def _event__comment(data: notification_data_pb2.EventComment, user: User) -> PushNotificationContent:
     time_display = _get_event_time_display(data.event, user)
     return PushNotificationContent(
         title=f'{data.author.name} commented on "{data.event.title}"',
@@ -335,8 +320,7 @@ def _event_comment(data: notification_data_pb2.EventComment, user: User) -> Push
     )
 
 
-# event:reminder
-def _event_reminder(data: notification_data_pb2.EventReminder, user: User) -> PushNotificationContent:
+def _event__reminder(data: notification_data_pb2.EventReminder, user: User) -> PushNotificationContent:
     time_display = _get_event_time_display(data.event, user)
     return PushNotificationContent(
         title=f'"{data.event.title}" starts soon',
@@ -345,8 +329,7 @@ def _event_reminder(data: notification_data_pb2.EventReminder, user: User) -> Pu
     )
 
 
-# event:cancel
-def _event_cancel(data: notification_data_pb2.EventCancel, user: User) -> PushNotificationContent:
+def _event__cancel(data: notification_data_pb2.EventCancel, user: User) -> PushNotificationContent:
     time_display = _get_event_time_display(data.event, user)
     return PushNotificationContent(
         title=f'{data.cancelling_user.name} cancelled "{data.event.title}"',
@@ -356,8 +339,7 @@ def _event_cancel(data: notification_data_pb2.EventCancel, user: User) -> PushNo
     )
 
 
-# event:delete
-def _event_delete(data: notification_data_pb2.EventDelete, user: User) -> PushNotificationContent:
+def _event__delete(data: notification_data_pb2.EventDelete, user: User) -> PushNotificationContent:
     time_display = _get_event_time_display(data.event, user)
     return PushNotificationContent(
         title=f'A moderator deleted "{data.event.title}"',
@@ -365,8 +347,7 @@ def _event_delete(data: notification_data_pb2.EventDelete, user: User) -> PushNo
     )
 
 
-# friend_request:create
-def _friend_request_create(data: notification_data_pb2.FriendRequestCreate) -> PushNotificationContent:
+def _friend_request__create(data: notification_data_pb2.FriendRequestCreate) -> PushNotificationContent:
     return PushNotificationContent(
         title=f"{data.other_user.name} wants to be your friend",
         body=f"You've received a friend request from {data.other_user.name}",
@@ -375,8 +356,7 @@ def _friend_request_create(data: notification_data_pb2.FriendRequestCreate) -> P
     )
 
 
-# friend_request:accept
-def _friend_request_accept(data: notification_data_pb2.FriendRequestAccept) -> PushNotificationContent:
+def _friend_request__accept(data: notification_data_pb2.FriendRequestAccept) -> PushNotificationContent:
     return PushNotificationContent(
         title=f"{data.other_user.name} accepted your friend request!",
         body=f"{v2esc(data.other_user.name)} has accepted your friend request",
@@ -385,8 +365,7 @@ def _friend_request_accept(data: notification_data_pb2.FriendRequestAccept) -> P
     )
 
 
-# gender:change
-def _gender_change(data: notification_data_pb2.GenderChange) -> PushNotificationContent:
+def _gender__change(data: notification_data_pb2.GenderChange) -> PushNotificationContent:
     return PushNotificationContent(
         title="Your gender was changed",
         body=f"Your gender on Couchers.org was changed to {data.gender} by an admin.",
@@ -394,8 +373,7 @@ def _gender_change(data: notification_data_pb2.GenderChange) -> PushNotification
     )
 
 
-# general:new_blog_post
-def _general_new_blog_post(data: notification_data_pb2.GeneralNewBlogPost) -> PushNotificationContent:
+def _general__new_blog_post(data: notification_data_pb2.GeneralNewBlogPost) -> PushNotificationContent:
     return PushNotificationContent(
         title=f"New blog post: {data.title}",
         body=data.blurb,
@@ -403,8 +381,7 @@ def _general_new_blog_post(data: notification_data_pb2.GeneralNewBlogPost) -> Pu
     )
 
 
-# host_request:create
-def _host_request_create(data: notification_data_pb2.HostRequestCreate, user: User) -> PushNotificationContent:
+def _host_request__create(data: notification_data_pb2.HostRequestCreate, user: User) -> PushNotificationContent:
     return PushNotificationContent(
         title=f"{data.surfer.name} sent you a host request",
         body=f"Dates: {v2date(data.host_request.from_date, user)} to {v2date(data.host_request.to_date, user)}.\n\n{data.text}",
@@ -413,8 +390,7 @@ def _host_request_create(data: notification_data_pb2.HostRequestCreate, user: Us
     )
 
 
-# host_request:message
-def _host_request_message(data: notification_data_pb2.HostRequestMessage, user: User) -> PushNotificationContent:
+def _host_request__message(data: notification_data_pb2.HostRequestMessage, user: User) -> PushNotificationContent:
     if data.am_host:
         title = f"{data.user.name} sent you a message in their host request"
     else:
@@ -427,8 +403,7 @@ def _host_request_message(data: notification_data_pb2.HostRequestMessage, user: 
     )
 
 
-# host_request:missed_messages
-def _host_request_missed_messages(data: notification_data_pb2.HostRequestMissedMessages) -> PushNotificationContent:
+def _host_request__missed_messages(data: notification_data_pb2.HostRequestMissedMessages) -> PushNotificationContent:
     their_your = "their" if data.am_host else "your"
     return PushNotificationContent(
         title=f"{data.user.name} sent you message(s) in {their_your} host request",
@@ -438,8 +413,7 @@ def _host_request_missed_messages(data: notification_data_pb2.HostRequestMissedM
     )
 
 
-# host_request:reminder
-def _host_request_reminder(data: notification_data_pb2.HostRequestReminder) -> PushNotificationContent:
+def _host_request__reminder(data: notification_data_pb2.HostRequestReminder) -> PushNotificationContent:
     return PushNotificationContent(
         title=f"You have a pending host request from {data.surfer.name}!",
         body="Please respond to the request!",
@@ -448,8 +422,7 @@ def _host_request_reminder(data: notification_data_pb2.HostRequestReminder) -> P
     )
 
 
-# host_request:accept
-def _host_request_accept(data: notification_data_pb2.HostRequestAccept) -> PushNotificationContent:
+def _host_request__accept(data: notification_data_pb2.HostRequestAccept) -> PushNotificationContent:
     return PushNotificationContent(
         title=f"{data.host.name} accepted your host request",
         body="Check the app for more info.",
@@ -458,8 +431,7 @@ def _host_request_accept(data: notification_data_pb2.HostRequestAccept) -> PushN
     )
 
 
-# host_request:reject
-def _host_request_reject(data: notification_data_pb2.HostRequestReject) -> PushNotificationContent:
+def _host_request__reject(data: notification_data_pb2.HostRequestReject) -> PushNotificationContent:
     return PushNotificationContent(
         title=f"{data.host.name} rejected your host request",
         body="Check the app for more info.",
@@ -468,8 +440,7 @@ def _host_request_reject(data: notification_data_pb2.HostRequestReject) -> PushN
     )
 
 
-# host_request:cancel
-def _host_request_cancel(data: notification_data_pb2.HostRequestCancel) -> PushNotificationContent:
+def _host_request__cancel(data: notification_data_pb2.HostRequestCancel) -> PushNotificationContent:
     return PushNotificationContent(
         title=f"{data.surfer.name} cancelled their host request",
         body="Check the app for more info.",
@@ -478,8 +449,7 @@ def _host_request_cancel(data: notification_data_pb2.HostRequestCancel) -> PushN
     )
 
 
-# host_request:confirm
-def _host_request_confirm(data: notification_data_pb2.HostRequestConfirm) -> PushNotificationContent:
+def _host_request__confirm(data: notification_data_pb2.HostRequestConfirm) -> PushNotificationContent:
     return PushNotificationContent(
         title=f"{data.surfer.name} confirmed their host request",
         body="Check the app for more info.",
@@ -488,16 +458,14 @@ def _host_request_confirm(data: notification_data_pb2.HostRequestConfirm) -> Pus
     )
 
 
-# modnote:create
-def _modnote_create(data: empty_pb2.Empty) -> PushNotificationContent:
+def _modnote__create(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
         title="You received a mod note",
         body="You need to read and acknowledge the note before continuing to use the platform.",
     )
 
 
-# onboarding:reminder
-def _onboarding_reminder(data: empty_pb2.Empty, key: str, user: User) -> PushNotificationContent:
+def _onboarding__reminder(data: empty_pb2.Empty, key: str, user: User) -> PushNotificationContent:
     if key == "1":
         return PushNotificationContent(
             title="Welcome to Couchers.org and the future of couch surfing",
@@ -514,8 +482,7 @@ def _onboarding_reminder(data: empty_pb2.Empty, key: str, user: User) -> PushNot
         raise NotImplementedError(f"Unknown onboarding reminder key: {key}")
 
 
-# password:change
-def _password_change(data: empty_pb2.Empty) -> PushNotificationContent:
+def _password__change(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
         title="Your password was changed",
         body="Your login password for Couchers.org was changed.",
@@ -523,8 +490,7 @@ def _password_change(data: empty_pb2.Empty) -> PushNotificationContent:
     )
 
 
-# password_reset:start
-def _password_reset_start(data: empty_pb2.Empty) -> PushNotificationContent:
+def _password_reset__start(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
         title="A password reset was initiated on your account",
         body="Someone initiated a password change on your account.",
@@ -532,8 +498,7 @@ def _password_reset_start(data: empty_pb2.Empty) -> PushNotificationContent:
     )
 
 
-# password_reset:complete
-def _password_reset_complete(data: empty_pb2.Empty) -> PushNotificationContent:
+def _password_reset__complete(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
         title="Your password was successfully reset",
         body="Your password on Couchers.org was changed. If that was you, then no further action is needed.",
@@ -541,8 +506,7 @@ def _password_reset_complete(data: empty_pb2.Empty) -> PushNotificationContent:
     )
 
 
-# phone_number:change
-def _phone_number_change(data: notification_data_pb2.PhoneNumberChange) -> PushNotificationContent:
+def _phone_number__change(data: notification_data_pb2.PhoneNumberChange) -> PushNotificationContent:
     return PushNotificationContent(
         title="Phone verification started",
         body=f"You started phone number verification with the number {v2phone(data.phone)}.",
@@ -550,8 +514,7 @@ def _phone_number_change(data: notification_data_pb2.PhoneNumberChange) -> PushN
     )
 
 
-# phone_number:verify
-def _phone_number_verify(data: notification_data_pb2.PhoneNumberVerify) -> PushNotificationContent:
+def _phone_number__verify(data: notification_data_pb2.PhoneNumberVerify) -> PushNotificationContent:
     return PushNotificationContent(
         title="Phone successfully verified",
         body=f"Your phone was successfully verified as {v2phone(data.phone)} on Couchers.org.",
@@ -559,8 +522,7 @@ def _phone_number_verify(data: notification_data_pb2.PhoneNumberVerify) -> PushN
     )
 
 
-# postal_verification:postcard_sent
-def _postal_verification_postcard_sent(
+def _postal_verification__postcard_sent(
     data: notification_data_pb2.PostalVerificationPostcardSent,
 ) -> PushNotificationContent:
     return PushNotificationContent(
@@ -570,8 +532,7 @@ def _postal_verification_postcard_sent(
     )
 
 
-# postal_verification:success
-def _postal_verification_success(data: empty_pb2.Empty) -> PushNotificationContent:
+def _postal_verification__success(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
         title="Postal Verification succeeded",
         body="You have been verified with Postal Verification! Your address has been confirmed.",
@@ -579,8 +540,7 @@ def _postal_verification_success(data: empty_pb2.Empty) -> PushNotificationConte
     )
 
 
-# postal_verification:failed
-def _postal_verification_failed(data: notification_data_pb2.PostalVerificationFailed) -> PushNotificationContent:
+def _postal_verification__failed(data: notification_data_pb2.PostalVerificationFailed) -> PushNotificationContent:
     if data.reason == notification_data_pb2.POSTAL_VERIFICATION_FAIL_REASON_CODE_EXPIRED:
         reason_message = "Your verification code has expired. Codes are valid for 90 days after the postcard is sent. You can start a new verification attempt."
     elif data.reason == notification_data_pb2.POSTAL_VERIFICATION_FAIL_REASON_TOO_MANY_ATTEMPTS:
@@ -594,8 +554,7 @@ def _postal_verification_failed(data: notification_data_pb2.PostalVerificationFa
     )
 
 
-# reference:receive_friend
-def _reference_receive_friend(data: notification_data_pb2.ReferenceReceiveFriend) -> PushNotificationContent:
+def _reference__receive_friend(data: notification_data_pb2.ReferenceReceiveFriend) -> PushNotificationContent:
     return PushNotificationContent(
         title=f"You've received a friend reference from {data.from_user.name}!",
         body=data.text,
@@ -604,8 +563,9 @@ def _reference_receive_friend(data: notification_data_pb2.ReferenceReceiveFriend
     )
 
 
-# reference:receive_hosted, reference:receive_surfed
-def _reference_receive(data: notification_data_pb2.ReferenceReceiveHostRequest, action: str) -> PushNotificationContent:
+def _reference__receive(
+    data: notification_data_pb2.ReferenceReceiveHostRequest, reference_type: str
+) -> PushNotificationContent:
     if data.text:
         body = v2esc(data.text)
         action_url = urls.profile_references_link()
@@ -613,10 +573,8 @@ def _reference_receive(data: notification_data_pb2.ReferenceReceiveHostRequest, 
         body = (
             "Please go and write a reference for them too. It's a nice gesture and helps us build a community together!"
         )
-        # what was my type? i surfed with them if i received a "hosted" request
-        surfed = action == "receive_hosted"
         action_url = urls.leave_reference_link(
-            reference_type="surfed" if surfed else "hosted",
+            reference_type=reference_type,
             to_user_id=data.from_user.user_id,
             host_request_id=str(data.host_request_id),
         )
@@ -628,12 +586,18 @@ def _reference_receive(data: notification_data_pb2.ReferenceReceiveHostRequest, 
     )
 
 
-# reference:reminder_hosted, reference:reminder_surfed
-def _reference_reminder(data: notification_data_pb2.ReferenceReminder, action: str) -> PushNotificationContent:
-    # what was my type? i surfed with them if i get a surfed reminder
-    surfed = action == "reminder_surfed"
+def _reference__receive_hosted(data: notification_data_pb2.ReferenceReceiveHostRequest) -> PushNotificationContent:
+    # I surfed with them if I received a "hosted" request
+    return _reference__receive(data, reference_type="surfed")
+
+
+def _reference__receive_surfed(data: notification_data_pb2.ReferenceReceiveHostRequest) -> PushNotificationContent:
+    return _reference__receive(data, reference_type="hosted")
+
+
+def _reference__reminder(data: notification_data_pb2.ReferenceReminder, reference_type=str) -> PushNotificationContent:
     leave_reference_link = urls.leave_reference_link(
-        reference_type="surfed" if surfed else "hosted",
+        reference_type=reference_type,
         to_user_id=data.other_user.user_id,
         host_request_id=str(data.host_request_id),
     )
@@ -645,8 +609,16 @@ def _reference_reminder(data: notification_data_pb2.ReferenceReminder, action: s
     )
 
 
-# thread:reply
-def _thread_reply(data: notification_data_pb2.ThreadReply) -> PushNotificationContent:
+def _reference__reminder_surfed(data: notification_data_pb2.ReferenceReminder) -> PushNotificationContent:
+    # I surfed with them if I get a surfed reminder
+    return _reference__reminder(data, reference_type="surfed")
+
+
+def _reference__reminder_hosted(data: notification_data_pb2.ReferenceReminder) -> PushNotificationContent:
+    return _reference__reminder(data, reference_type="hosted")
+
+
+def _thread__reply(data: notification_data_pb2.ThreadReply) -> PushNotificationContent:
     parent = data.WhichOneof("reply_parent")
     if parent == "event":
         title = data.event.title
@@ -665,8 +637,7 @@ def _thread_reply(data: notification_data_pb2.ThreadReply) -> PushNotificationCo
     )
 
 
-# verification:sv_success
-def _verification_sv_success(data: empty_pb2.Empty) -> PushNotificationContent:
+def _verification__sv_success(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
         title="Strong Verification succeeded",
         body="You have been verified with Strong Verification! You will now see a tick next to your name on the platform.",
@@ -674,8 +645,7 @@ def _verification_sv_success(data: empty_pb2.Empty) -> PushNotificationContent:
     )
 
 
-# verification:sv_fail
-def _verification_sv_fail(data: notification_data_pb2.VerificationSVFail) -> PushNotificationContent:
+def _verification__sv_fail(data: notification_data_pb2.VerificationSVFail) -> PushNotificationContent:
     if data.reason == notification_data_pb2.SV_FAIL_REASON_WRONG_BIRTHDATE_OR_GENDER:
         reason_message = "The date of birth or gender on your profile does not match the date of birth or sex on your passport. Please contact the support team to update your date of birth or gender, or if your passport sex does not match your gender identity."
     elif data.reason == notification_data_pb2.SV_FAIL_REASON_NOT_A_PASSPORT:

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -3,15 +3,14 @@ Renders a Notification model into a localized push notification.
 """
 
 import logging
-from typing import Any
+
+from google.protobuf import empty_pb2
 
 from couchers import urls
 from couchers.models import Notification, User
 from couchers.notifications.push import PushNotificationContent
 from couchers.proto import events_pb2, notification_data_pb2
 from couchers.templates.v2 import v2avatar, v2date, v2esc, v2phone, v2timestamp
-
-from google.protobuf import empty_pb2
 
 logger = logging.getLogger(__name__)
 
@@ -24,12 +23,14 @@ logger = logging.getLogger(__name__)
 #   <= 80 chars (Android), first 40 visible when collapsed
 #   Sentence-style capitalization with punctuation
 
+
 # account_deletion:start
 def _account_deletion_start(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
         title="Account deletion initiated",
         body="Someone initiated the deletion of your Couchers.org account. To delete your account, please follow the link in the email we sent you.",
     )
+
 
 # account_deletion:complete
 def _account_deletion_complete(data: notification_data_pb2.AccountDeletionComplete) -> PushNotificationContent:
@@ -38,6 +39,7 @@ def _account_deletion_complete(data: notification_data_pb2.AccountDeletionComple
         body=f"You can still undo this by following the link we emailed to you within {data.undelete_days} days.",
     )
 
+
 # account_deletion:recovered
 def _account_deletion_recovered(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
@@ -45,12 +47,14 @@ def _account_deletion_recovered(data: empty_pb2.Empty) -> PushNotificationConten
         body="We have recovered your Couchers.org account as per your request! Welcome back!",
     )
 
+
 # activeness:probe
 def _activeness_probe(data: notification_data_pb2.ActivenessProbe) -> PushNotificationContent:
     return PushNotificationContent(
         title="Are you still open to hosting on Couchers.org?",
         body="Please log in to confirm your hosting status.",
     )
+
 
 # address:change
 def _address_change(data: notification_data_pb2.EmailAddressChange) -> PushNotificationContent:
@@ -60,6 +64,7 @@ def _address_change(data: notification_data_pb2.EmailAddressChange) -> PushNotif
         action_url=urls.account_settings_link(),
     )
 
+
 # address:verify
 def _address_verify(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
@@ -67,6 +72,7 @@ def _address_verify(data: empty_pb2.Empty) -> PushNotificationContent:
         body="Your new email address has been verified.",
         action_url=urls.account_settings_link(),
     )
+
 
 # api_key:create
 def _api_key_create(data: empty_pb2.Empty) -> PushNotificationContent:
@@ -76,6 +82,7 @@ def _api_key_create(data: empty_pb2.Empty) -> PushNotificationContent:
         action_url=urls.app_link(),
     )
 
+
 # badge:add
 def _badge_add(data: notification_data_pb2.BadgeAdd) -> PushNotificationContent:
     return PushNotificationContent(
@@ -83,6 +90,7 @@ def _badge_add(data: notification_data_pb2.BadgeAdd) -> PushNotificationContent:
         body="Check out your profile to see the new badge!",
         action_url=urls.profile_link(),
     )
+
 
 # badge:remove
 def _badge_remove(data: notification_data_pb2.BadgeRemove) -> PushNotificationContent:
@@ -92,6 +100,7 @@ def _badge_remove(data: notification_data_pb2.BadgeRemove) -> PushNotificationCo
         action_url=urls.profile_link(),
     )
 
+
 # birthdate:change
 def _birthdate_change(data: notification_data_pb2.BirthdateChange, user: User) -> PushNotificationContent:
     return PushNotificationContent(
@@ -99,6 +108,7 @@ def _birthdate_change(data: notification_data_pb2.BirthdateChange, user: User) -
         body=f"Your date of birth on Couchers.org was changed to {v2date(data.birthdate, user)} by an admin.",
         action_url=urls.account_settings_link(),
     )
+
 
 # chat:message
 def _chat_message(data: notification_data_pb2.ChatMessage) -> PushNotificationContent:
@@ -109,6 +119,7 @@ def _chat_message(data: notification_data_pb2.ChatMessage) -> PushNotificationCo
         action_url=urls.chat_link(chat_id=data.group_chat_id),
     )
 
+
 # chat:missed_messages
 def _chat_missed_messages(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
@@ -117,6 +128,7 @@ def _chat_missed_messages(data: empty_pb2.Empty) -> PushNotificationContent:
         action_url=urls.messages_link(),
     )
 
+
 # donation:received
 def _donation_received(data: notification_data_pb2.DonationReceived) -> PushNotificationContent:
     return PushNotificationContent(
@@ -124,6 +136,7 @@ def _donation_received(data: notification_data_pb2.DonationReceived) -> PushNoti
         body=f"Thank you so much for your donation of ${data.amount} to Couchers.org.",
         action_url=data.receipt_url,
     )
+
 
 # discussion:create
 def _discussion_create(data: notification_data_pb2.DiscussionCreate) -> PushNotificationContent:
@@ -134,6 +147,7 @@ def _discussion_create(data: notification_data_pb2.DiscussionCreate) -> PushNoti
         action_url=urls.discussion_link(discussion_id=data.discussion.discussion_id, slug=data.discussion.slug),
     )
 
+
 # discussion:comment
 def _discussion_comment(data: notification_data_pb2.DiscussionComment) -> PushNotificationContent:
     return PushNotificationContent(
@@ -143,8 +157,10 @@ def _discussion_comment(data: notification_data_pb2.DiscussionComment) -> PushNo
         action_url=urls.discussion_link(discussion_id=data.discussion.discussion_id, slug=data.discussion.slug),
     )
 
+
 def _get_event_time_display(event: events_pb2.Event, user: User) -> str:
     return f"{v2timestamp(event.start_time, user)} - {v2timestamp(event.end_time, user)}"
+
 
 # event:create_any
 def _event_create_any(data: notification_data_pb2.EventCreate, user: User) -> PushNotificationContent:
@@ -156,6 +172,7 @@ def _event_create_any(data: notification_data_pb2.EventCreate, user: User) -> Pu
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
 
+
 # event:create_approved
 def _event_create_approved(data: notification_data_pb2.EventCreate, user: User) -> PushNotificationContent:
     time_display = _get_event_time_display(data.event, user)
@@ -165,6 +182,7 @@ def _event_create_approved(data: notification_data_pb2.EventCreate, user: User) 
         icon_url=v2avatar(data.inviting_user),
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
+
 
 # event:update
 def _event_update(data: notification_data_pb2.EventUpdate, user: User) -> PushNotificationContent:
@@ -177,6 +195,7 @@ def _event_update(data: notification_data_pb2.EventUpdate, user: User) -> PushNo
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
 
+
 # event:invite_organizer
 def _event_invite_organizer(data: notification_data_pb2.EventInviteOrganizer, user: User) -> PushNotificationContent:
     time_display = _get_event_time_display(data.event, user)
@@ -186,6 +205,7 @@ def _event_invite_organizer(data: notification_data_pb2.EventInviteOrganizer, us
         icon_url=v2avatar(data.inviting_user),
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
+
 
 # event:action
 def _event_action(data: notification_data_pb2.EventComment, user: User) -> PushNotificationContent:
@@ -197,6 +217,7 @@ def _event_action(data: notification_data_pb2.EventComment, user: User) -> PushN
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
 
+
 # event:reminder
 def _event_reminder(data: notification_data_pb2.EventReminder, user: User) -> PushNotificationContent:
     time_display = _get_event_time_display(data.event, user)
@@ -205,6 +226,7 @@ def _event_reminder(data: notification_data_pb2.EventReminder, user: User) -> Pu
         body=f"Don't forget your upcoming event on Couchers.org\n{time_display}\n{data.event.content}",
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
+
 
 # event:cancel
 def _event_cancel(data: notification_data_pb2.EventCancel, user: User) -> PushNotificationContent:
@@ -216,6 +238,7 @@ def _event_cancel(data: notification_data_pb2.EventCancel, user: User) -> PushNo
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
 
+
 # event:delete
 def _event_delete(data: notification_data_pb2.EventDelete, user: User) -> PushNotificationContent:
     time_display = _get_event_time_display(data.event, user)
@@ -223,6 +246,7 @@ def _event_delete(data: notification_data_pb2.EventDelete, user: User) -> PushNo
         title=f'A moderator deleted "{data.event.title}"',
         body=f"{time_display}\nThe event has been deleted by the moderators.",
     )
+
 
 # friend_request:create
 def _friend_request_create(data: notification_data_pb2.FriendRequestCreate) -> PushNotificationContent:
@@ -233,6 +257,7 @@ def _friend_request_create(data: notification_data_pb2.FriendRequestCreate) -> P
         action_url=urls.friend_requests_link(),
     )
 
+
 # friend_request:accept
 def _friend_request_accept(data: notification_data_pb2.FriendRequestAccept) -> PushNotificationContent:
     return PushNotificationContent(
@@ -242,6 +267,7 @@ def _friend_request_accept(data: notification_data_pb2.FriendRequestAccept) -> P
         action_url=urls.user_link(username=data.other_user.username),
     )
 
+
 # gender:change
 def _gender_change(data: notification_data_pb2.GenderChange) -> PushNotificationContent:
     return PushNotificationContent(
@@ -249,6 +275,7 @@ def _gender_change(data: notification_data_pb2.GenderChange) -> PushNotification
         body=f"Your gender on Couchers.org was changed to {data.gender} by an admin.",
         action_url=urls.account_settings_link(),
     )
+
 
 # general:new_blog_post
 def _general_new_blog_post(data: notification_data_pb2.GeneralNewBlogPost) -> PushNotificationContent:
@@ -258,14 +285,16 @@ def _general_new_blog_post(data: notification_data_pb2.GeneralNewBlogPost) -> Pu
         action_url=data.url,
     )
 
+
 # host_request:create
 def _host_request_create(data: notification_data_pb2.HostRequestCreate, user: User) -> PushNotificationContent:
     return PushNotificationContent(
         title=f"{data.surfer.name} sent you a host request",
         body=f"Dates: {v2date(data.host_request.from_date, user)} to {v2date(data.host_request.to_date, user)}.\n\n{data.text}",
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
-        icon_url=v2avatar(data.surfer)
+        icon_url=v2avatar(data.surfer),
     )
+
 
 # host_request:message
 def _host_request_message(data: notification_data_pb2.HostRequestMessage, user: User) -> PushNotificationContent:
@@ -277,8 +306,9 @@ def _host_request_message(data: notification_data_pb2.HostRequestMessage, user: 
         title=title,
         body=f"Dates: {v2date(data.host_request.from_date, user)} to {v2date(data.host_request.to_date, user)}.\n\n{data.text}",
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
-        icon_url=v2avatar(data.user)
+        icon_url=v2avatar(data.user),
     )
+
 
 # host_request:missed_messages
 def _host_request_missed_messages(data: notification_data_pb2.HostRequestMissedMessages) -> PushNotificationContent:
@@ -287,8 +317,9 @@ def _host_request_missed_messages(data: notification_data_pb2.HostRequestMissedM
         title=f"{data.user.name} sent you message(s) in {their_your} host request",
         body="Check the app for more info.",
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
-        icon_url=v2avatar(data.user)
+        icon_url=v2avatar(data.user),
     )
+
 
 # host_request:reminder
 def _host_request_reminder(data: notification_data_pb2.HostRequestReminder) -> PushNotificationContent:
@@ -299,6 +330,7 @@ def _host_request_reminder(data: notification_data_pb2.HostRequestReminder) -> P
         icon_url=v2avatar(data.surfer),
     )
 
+
 # host_request:accept
 def _host_request_accept(data: notification_data_pb2.HostRequestAccept) -> PushNotificationContent:
     return PushNotificationContent(
@@ -307,6 +339,7 @@ def _host_request_accept(data: notification_data_pb2.HostRequestAccept) -> PushN
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
         icon_url=v2avatar(data.host),
     )
+
 
 # host_request:reject
 def _host_request_reject(data: notification_data_pb2.HostRequestReject) -> PushNotificationContent:
@@ -317,6 +350,7 @@ def _host_request_reject(data: notification_data_pb2.HostRequestReject) -> PushN
         icon_url=v2avatar(data.host),
     )
 
+
 # host_request:cancel
 def _host_request_cancel(data: notification_data_pb2.HostRequestCancel) -> PushNotificationContent:
     return PushNotificationContent(
@@ -325,6 +359,7 @@ def _host_request_cancel(data: notification_data_pb2.HostRequestCancel) -> PushN
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
         icon_url=v2avatar(data.surfer),
     )
+
 
 # host_request:confirm
 def _host_request_confirm(data: notification_data_pb2.HostRequestConfirm) -> PushNotificationContent:
@@ -335,12 +370,14 @@ def _host_request_confirm(data: notification_data_pb2.HostRequestConfirm) -> Pus
         icon_url=v2avatar(data.surfer),
     )
 
+
 # modnote:create
 def _modnote_create(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
         title="You received a mod note",
         body="You need to read and acknowledge the note before continuing to use the platform.",
     )
+
 
 # onboarding:reminder
 def _onboarding_reminder(data: empty_pb2.Empty, key: str, user: User) -> PushNotificationContent:
@@ -359,6 +396,7 @@ def _onboarding_reminder(data: empty_pb2.Empty, key: str, user: User) -> PushNot
     else:
         raise NotImplementedError(f"Unknown onboarding reminder key: {key}")
 
+
 # password:change
 def _password_change(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
@@ -366,6 +404,7 @@ def _password_change(data: empty_pb2.Empty) -> PushNotificationContent:
         body="Your login password for Couchers.org was changed.",
         action_url=urls.account_settings_link(),
     )
+
 
 # password_reset:start
 def _password_reset_start(data: empty_pb2.Empty) -> PushNotificationContent:
@@ -375,6 +414,7 @@ def _password_reset_start(data: empty_pb2.Empty) -> PushNotificationContent:
         action_url=urls.account_settings_link(),
     )
 
+
 # password_reset:complete
 def _password_reset_complete(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
@@ -382,6 +422,7 @@ def _password_reset_complete(data: empty_pb2.Empty) -> PushNotificationContent:
         body="Your password on Couchers.org was changed. If that was you, then no further action is needed.",
         action_url=urls.account_settings_link(),
     )
+
 
 # phone_number:change
 def _phone_number_change(data: notification_data_pb2.PhoneNumberChange) -> PushNotificationContent:
@@ -391,6 +432,7 @@ def _phone_number_change(data: notification_data_pb2.PhoneNumberChange) -> PushN
         action_url=urls.feature_preview_link(),
     )
 
+
 # phone_number:verify
 def _phone_number_verify(data: notification_data_pb2.PhoneNumberVerify) -> PushNotificationContent:
     return PushNotificationContent(
@@ -399,13 +441,17 @@ def _phone_number_verify(data: notification_data_pb2.PhoneNumberVerify) -> PushN
         action_url=urls.feature_preview_link(),
     )
 
+
 # postal_verification:postcard_sent
-def _postal_verification_postcard_sent(data: notification_data_pb2.PostalVerificationPostcardSent) -> PushNotificationContent:
+def _postal_verification_postcard_sent(
+    data: notification_data_pb2.PostalVerificationPostcardSent,
+) -> PushNotificationContent:
     return PushNotificationContent(
         title="Your verification postcard is on its way",
         body=f"Postcard sent to {data.city}, {data.country}. Expect it within 1-3 weeks.",
         action_url=urls.account_settings_link(),
     )
+
 
 # postal_verification:success
 def _postal_verification_success(data: empty_pb2.Empty) -> PushNotificationContent:
@@ -415,6 +461,7 @@ def _postal_verification_success(data: empty_pb2.Empty) -> PushNotificationConte
         action_url=urls.account_settings_link(),
     )
 
+
 # postal_verification:failed
 def _postal_verification_failed(data: notification_data_pb2.PostalVerificationFailed) -> PushNotificationContent:
     if data.reason == notification_data_pb2.POSTAL_VERIFICATION_FAIL_REASON_CODE_EXPIRED:
@@ -422,14 +469,13 @@ def _postal_verification_failed(data: notification_data_pb2.PostalVerificationFa
     elif data.reason == notification_data_pb2.POSTAL_VERIFICATION_FAIL_REASON_TOO_MANY_ATTEMPTS:
         reason_message = "Too many incorrect code attempts. You can start a new verification attempt."
     else:
-        reason_message = (
-            "Your postal verification attempt has failed. You can start a new verification attempt."
-        )
+        reason_message = "Your postal verification attempt has failed. You can start a new verification attempt."
     return PushNotificationContent(
         title="Postal Verification failed",
         body=reason_message,
         action_url=urls.account_settings_link(),
     )
+
 
 # reference:receive_friend
 def _reference_receive_friend(data: notification_data_pb2.ReferenceReceiveFriend) -> PushNotificationContent:
@@ -440,13 +486,16 @@ def _reference_receive_friend(data: notification_data_pb2.ReferenceReceiveFriend
         action_url=urls.profile_references_link(),
     )
 
+
 # reference:receive_hosted, reference:receive_surfed
 def _reference_receive(data: notification_data_pb2.ReferenceReceiveHostRequest, action: str) -> PushNotificationContent:
     if data.text:
         body = v2esc(data.text)
         action_url = urls.profile_references_link()
     else:
-        body = "Please go and write a reference for them too. It's a nice gesture and helps us build a community together!"
+        body = (
+            "Please go and write a reference for them too. It's a nice gesture and helps us build a community together!"
+        )
         # what was my type? i surfed with them if i received a "hosted" request
         surfed = action == "receive_hosted"
         action_url = urls.leave_reference_link(
@@ -460,6 +509,7 @@ def _reference_receive(data: notification_data_pb2.ReferenceReceiveHostRequest, 
         icon_url=v2avatar(data.from_user),
         action_url=action_url,
     )
+
 
 # reference:reminder_hosted, reference:reminder_surfed
 def _reference_reminder(data: notification_data_pb2.ReferenceReminder, action: str) -> PushNotificationContent:
@@ -476,6 +526,7 @@ def _reference_reminder(data: notification_data_pb2.ReferenceReminder, action: s
         icon_url=v2avatar(data.other_user),
         action_url=leave_reference_link,
     )
+
 
 # thread:reply
 def _thread_reply(data: notification_data_pb2.ThreadReply) -> PushNotificationContent:
@@ -496,6 +547,7 @@ def _thread_reply(data: notification_data_pb2.ThreadReply) -> PushNotificationCo
         action_url=view_link,
     )
 
+
 # verification:sv_success
 def _verification_sv_success(data: empty_pb2.Empty) -> PushNotificationContent:
     return PushNotificationContent(
@@ -503,6 +555,7 @@ def _verification_sv_success(data: empty_pb2.Empty) -> PushNotificationContent:
         body="You have been verified with Strong Verification! You will now see a tick next to your name on the platform.",
         action_url=urls.account_settings_link(),
     )
+
 
 # verification:sv_fail
 def _verification_sv_fail(data: notification_data_pb2.VerificationSVFail) -> PushNotificationContent:
@@ -520,8 +573,9 @@ def _verification_sv_fail(data: notification_data_pb2.VerificationSVFail) -> Pus
         action_url=urls.account_settings_link(),
     )
 
+
 def render_push_notification(user: User, notification: Notification) -> PushNotificationContent:
-    data: empty_pb2.Empty = notification.topic_action.data_type.FromString(notification.data) # type: ignore[attr-defined]
+    data: empty_pb2.Empty = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
     # Keep topics sorted (action can follow logical ordering)
     match notification.topic_action:
         case "account_deletion:start":
@@ -632,4 +686,3 @@ def render_push_notification(user: User, notification: Notification) -> PushNoti
             return _verification_sv_fail(data)
         case _:
             raise NotImplementedError(f"Unknown topic-action: {notification.topic}:{notification.action}")
-

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -3,12 +3,12 @@ Renders a Notification model into a localized push notification.
 """
 
 import logging
-from typing import Any
+from typing import Any, assert_never
 
 from google.protobuf import empty_pb2
 
 from couchers import urls
-from couchers.models import Notification, User
+from couchers.models import Notification, NotificationTopicAction, User
 from couchers.notifications.push import PushNotificationContent
 from couchers.proto import events_pb2, notification_data_pb2
 from couchers.templates.v2 import v2avatar, v2date, v2esc, v2phone, v2timestamp
@@ -26,117 +26,119 @@ logger = logging.getLogger(__name__)
 
 
 def render_push_notification(user: User, notification: Notification) -> PushNotificationContent:
+    # Any-typed so it implicitly converts when calling the methods below
     data: Any = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
-    # Keep topics sorted (action can follow logical ordering)
-    match notification.topic_action.display:
-        case "account_deletion:start":
+    match notification.topic_action:
+        # Keep topics sorted (actions can follow logical ordering)
+        case NotificationTopicAction.account_deletion__start:
             return _account_deletion_start(data)
-        case "account_deletion:complete":
+        case NotificationTopicAction.account_deletion__complete:
             return _account_deletion_complete(data)
-        case "account_deletion:recovered":
+        case NotificationTopicAction.account_deletion__recovered:
             return _account_deletion_recovered(data)
-        case "activeness:probe":
+        case NotificationTopicAction.activeness__probe:
             return _activeness_probe(data)
-        case "api_key:create":
+        case NotificationTopicAction.api_key__create:
             return _api_key_create(data)
-        case "badge:add":
+        case NotificationTopicAction.badge__add:
             return _badge_add(data)
-        case "badge:remove":
+        case NotificationTopicAction.badge__remove:
             return _badge_remove(data)
-        case "birthdate:change":
+        case NotificationTopicAction.birthdate__change:
             return _birthdate_change(data, user)
-        case "chat:message":
+        case NotificationTopicAction.chat__message:
             return _chat_message(data)
-        case "chat:missed_messages":
+        case NotificationTopicAction.chat__missed_messages:
             return _chat_missed_messages(data)
-        case "donation:received":
+        case NotificationTopicAction.donation__received:
             return _donation_received(data)
-        case "discussion:create":
+        case NotificationTopicAction.discussion__create:
             return _discussion_create(data)
-        case "discussion:comment":
+        case NotificationTopicAction.discussion__comment:
             return _discussion_comment(data)
-        case "email_address:change":
+        case NotificationTopicAction.email_address__change:
             return _email_address_change(data)
-        case "email_address:verify":
+        case NotificationTopicAction.email_address__verify:
             return _email_address_verify(data)
-        case "event:create_any":
+        case NotificationTopicAction.event__create_any:
             return _event_create_any(data, user)
-        case "event:create_approved":
+        case NotificationTopicAction.event__create_approved:
             return _event_create_approved(data, user)
-        case "event:update":
+        case NotificationTopicAction.event__update:
             return _event_update(data, user)
-        case "event:invite_organizer":
+        case NotificationTopicAction.event__invite_organizer:
             return _event_invite_organizer(data, user)
-        case "event:comment":
+        case NotificationTopicAction.event__comment:
             return _event_comment(data, user)
-        case "event:reminder":
+        case NotificationTopicAction.event__reminder:
             return _event_reminder(data, user)
-        case "event:cancel":
+        case NotificationTopicAction.event__cancel:
             return _event_cancel(data, user)
-        case "event:delete":
+        case NotificationTopicAction.event__delete:
             return _event_delete(data, user)
-        case "friend_request:create":
+        case NotificationTopicAction.friend_request__create:
             return _friend_request_create(data)
-        case "friend_request:accept":
+        case NotificationTopicAction.friend_request__accept:
             return _friend_request_accept(data)
-        case "gender:change":
+        case NotificationTopicAction.gender__change:
             return _gender_change(data)
-        case "general:new_blog_post":
+        case NotificationTopicAction.general__new_blog_post:
             return _general_new_blog_post(data)
-        case "host_request:create":
+        case NotificationTopicAction.host_request__create:
             return _host_request_create(data, user)
-        case "host_request:message":
+        case NotificationTopicAction.host_request__message:
             return _host_request_message(data, user)
-        case "host_request:missed_messages":
+        case NotificationTopicAction.host_request__missed_messages:
             return _host_request_missed_messages(data)
-        case "host_request:reminder":
+        case NotificationTopicAction.host_request__reminder:
             return _host_request_reminder(data)
-        case "host_request:accept":
+        case NotificationTopicAction.host_request__accept:
             return _host_request_accept(data)
-        case "host_request:reject":
+        case NotificationTopicAction.host_request__reject:
             return _host_request_reject(data)
-        case "host_request:cancel":
+        case NotificationTopicAction.host_request__cancel:
             return _host_request_cancel(data)
-        case "host_request:confirm":
+        case NotificationTopicAction.host_request__confirm:
             return _host_request_confirm(data)
-        case "modnote:create":
+        case NotificationTopicAction.modnote__create:
             return _modnote_create(data)
-        case "onboarding:reminder":
+        case NotificationTopicAction.onboarding__reminder:
             return _onboarding_reminder(data, notification.key, user)
-        case "password:change":
+        case NotificationTopicAction.password__change:
             return _password_change(data)
-        case "password_reset:start":
+        case NotificationTopicAction.password_reset__start:
             return _password_reset_start(data)
-        case "password_reset:complete":
+        case NotificationTopicAction.password_reset__complete:
             return _password_reset_complete(data)
-        case "phone_number:change":
+        case NotificationTopicAction.phone_number__change:
             return _phone_number_change(data)
-        case "phone_number:verify":
+        case NotificationTopicAction.phone_number__verify:
             return _phone_number_verify(data)
-        case "postal_verification:postcard_sent":
+        case NotificationTopicAction.postal_verification__postcard_sent:
             return _postal_verification_postcard_sent(data)
-        case "postal_verification:success":
+        case NotificationTopicAction.postal_verification__success:
             return _postal_verification_success(data)
-        case "postal_verification:failed":
+        case NotificationTopicAction.postal_verification__failed:
             return _postal_verification_failed(data)
-        case "reference:receive_friend":
+        case NotificationTopicAction.reference__receive_friend:
             return _reference_receive_friend(data)
-        case "reference:receive_hosted":
+        case NotificationTopicAction.reference__receive_hosted:
             return _reference_receive(data, action=notification.action)
-        case "reference:receive_surfed":
+        case NotificationTopicAction.reference__receive_surfed:
             return _reference_receive(data, action=notification.action)
-        case "reference:reminder_hosted":
+        case NotificationTopicAction.reference__reminder_hosted:
             return _reference_reminder(data, action=notification.action)
-        case "reference:reminder_surfed":
+        case NotificationTopicAction.reference__reminder_surfed:
             return _reference_reminder(data, action=notification.action)
-        case "thread:reply":
+        case NotificationTopicAction.thread__reply:
             return _thread_reply(data)
-        case "verification:sv_success":
+        case NotificationTopicAction.verification__sv_success:
             return _verification_sv_success(data)
-        case "verification:sv_fail":
+        case NotificationTopicAction.verification__sv_fail:
             return _verification_sv_fail(data)
         case _:
-            raise NotImplementedError(f"Unknown topic-action: {notification.topic_action.display}")
+            # Enables mypy's exhaustiveness checking for the cases above.
+            assert_never(notification.topic_action)
 
 
 # account_deletion:start

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -3,6 +3,7 @@ Renders a Notification model into a localized push notification.
 """
 
 import logging
+from typing import Any
 
 from google.protobuf import empty_pb2
 
@@ -53,24 +54,6 @@ def _activeness_probe(data: notification_data_pb2.ActivenessProbe) -> PushNotifi
     return PushNotificationContent(
         title="Are you still open to hosting on Couchers.org?",
         body="Please log in to confirm your hosting status.",
-    )
-
-
-# address:change
-def _address_change(data: notification_data_pb2.EmailAddressChange) -> PushNotificationContent:
-    return PushNotificationContent(
-        title="An email change was initiated on your account",
-        body=f"An email change to the email {data.new_email} was initiated on your account.",
-        action_url=urls.account_settings_link(),
-    )
-
-
-# address:verify
-def _address_verify(data: empty_pb2.Empty) -> PushNotificationContent:
-    return PushNotificationContent(
-        title="Email change completed",
-        body="Your new email address has been verified.",
-        action_url=urls.account_settings_link(),
     )
 
 
@@ -158,6 +141,24 @@ def _discussion_comment(data: notification_data_pb2.DiscussionComment) -> PushNo
     )
 
 
+# email_address:change
+def _email_address_change(data: notification_data_pb2.EmailAddressChange) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="An email change was initiated on your account",
+        body=f"An email change to the email {data.new_email} was initiated on your account.",
+        action_url=urls.account_settings_link(),
+    )
+
+
+# email_address:verify
+def _email_address_verify(data: empty_pb2.Empty) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="Email change completed",
+        body="Your new email address has been verified.",
+        action_url=urls.account_settings_link(),
+    )
+
+
 def _get_event_time_display(event: events_pb2.Event, user: User) -> str:
     return f"{v2timestamp(event.start_time, user)} - {v2timestamp(event.end_time, user)}"
 
@@ -207,8 +208,8 @@ def _event_invite_organizer(data: notification_data_pb2.EventInviteOrganizer, us
     )
 
 
-# event:action
-def _event_action(data: notification_data_pb2.EventComment, user: User) -> PushNotificationContent:
+# event:comment
+def _event_comment(data: notification_data_pb2.EventComment, user: User) -> PushNotificationContent:
     time_display = _get_event_time_display(data.event, user)
     return PushNotificationContent(
         title=f'{data.author.name} commented on "{data.event.title}"',
@@ -575,7 +576,7 @@ def _verification_sv_fail(data: notification_data_pb2.VerificationSVFail) -> Pus
 
 
 def render_push_notification(user: User, notification: Notification) -> PushNotificationContent:
-    data: empty_pb2.Empty = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
+    data: Any = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
     # Keep topics sorted (action can follow logical ordering)
     match notification.topic_action.display:
         case "account_deletion:start":
@@ -586,10 +587,6 @@ def render_push_notification(user: User, notification: Notification) -> PushNoti
             return _account_deletion_recovered(data)
         case "activeness:probe":
             return _activeness_probe(data)
-        case "address:change":
-            return _address_change(data)
-        case "address:verify":
-            return _address_verify(data)
         case "api_key:create":
             return _api_key_create(data)
         case "badge:add":
@@ -599,30 +596,34 @@ def render_push_notification(user: User, notification: Notification) -> PushNoti
         case "birthdate:change":
             return _birthdate_change(data, user)
         case "chat:message":
-            return _chat_message(data, user)
+            return _chat_message(data)
         case "chat:missed_messages":
-            return _chat_missed_messages(data, user)
+            return _chat_missed_messages(data)
         case "donation:received":
             return _donation_received(data)
         case "discussion:create":
             return _discussion_create(data)
         case "discussion:comment":
             return _discussion_comment(data)
+        case "email_address:change":
+            return _email_address_change(data)
+        case "email_address:verify":
+            return _email_address_verify(data)
         case "event:create_any":
             return _event_create_any(data, user)
         case "event:create_approved":
             return _event_create_approved(data, user)
-        case "event:create_update":
+        case "event:update":
             return _event_update(data, user)
-        case "event:create_invite_organizer":
+        case "event:invite_organizer":
             return _event_invite_organizer(data, user)
-        case "event:create_action":
-            return _event_action(data, user)
-        case "event:create_reminder":
+        case "event:comment":
+            return _event_comment(data, user)
+        case "event:reminder":
             return _event_reminder(data, user)
-        case "event:create_cancel":
+        case "event:cancel":
             return _event_cancel(data, user)
-        case "event:create_delete":
+        case "event:delete":
             return _event_delete(data, user)
         case "friend_request:create":
             return _friend_request_create(data)
@@ -651,7 +652,7 @@ def render_push_notification(user: User, notification: Notification) -> PushNoti
         case "modnote:create":
             return _modnote_create(data)
         case "onboarding:reminder":
-            return _onboarding_reminder(data)
+            return _onboarding_reminder(data, notification.key, user)
         case "password:change":
             return _password_change(data)
         case "password_reset:start":

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -595,7 +595,7 @@ def _reference__receive_surfed(data: notification_data_pb2.ReferenceReceiveHostR
     return _reference__receive(data, reference_type="hosted")
 
 
-def _reference__reminder(data: notification_data_pb2.ReferenceReminder, reference_type=str) -> PushNotificationContent:
+def _reference__reminder(data: notification_data_pb2.ReferenceReminder, reference_type: str) -> PushNotificationContent:
     leave_reference_link = urls.leave_reference_link(
         reference_type=reference_type,
         to_user_id=data.other_user.user_id,

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -5,8 +5,6 @@ Renders a Notification model into a localized push notification.
 import logging
 from typing import Any, assert_never
 
-from google.protobuf import empty_pb2
-
 from couchers import urls
 from couchers.models import Notification, NotificationTopicAction, User
 from couchers.notifications.push import PushNotificationContent

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -1,0 +1,635 @@
+"""
+Renders a Notification model into a localized push notification.
+"""
+
+import logging
+from typing import Any
+
+from couchers import urls
+from couchers.models import Notification, User
+from couchers.notifications.push import PushNotificationContent
+from couchers.proto import events_pb2, notification_data_pb2
+from couchers.templates.v2 import v2avatar, v2date, v2esc, v2phone, v2timestamp
+
+from google.protobuf import empty_pb2
+
+logger = logging.getLogger(__name__)
+
+# Best practices for push notification strings (Android/iOS lowest common denominator):
+# Title:
+#   Describe the event, e.g. "Payment Successful"
+#   <= 30 chars (Android), most important info in first 20 chars
+#   Title-style capitalization, no ending punctuation
+# Body:
+#   <= 80 chars (Android), first 40 visible when collapsed
+#   Sentence-style capitalization with punctuation
+
+# account_deletion:start
+def _account_deletion_start(data: empty_pb2.Empty) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="Account deletion initiated",
+        body="Someone initiated the deletion of your Couchers.org account. To delete your account, please follow the link in the email we sent you.",
+    )
+
+# account_deletion:complete
+def _account_deletion_complete(data: notification_data_pb2.AccountDeletionComplete) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="Your Couchers.org account has been deleted",
+        body=f"You can still undo this by following the link we emailed to you within {data.undelete_days} days.",
+    )
+
+# account_deletion:recovered
+def _account_deletion_recovered(data: empty_pb2.Empty) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="Your Couchers.org account has been recovered!",
+        body="We have recovered your Couchers.org account as per your request! Welcome back!",
+    )
+
+# activeness:probe
+def _activeness_probe(data: notification_data_pb2.ActivenessProbe) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="Are you still open to hosting on Couchers.org?",
+        body="Please log in to confirm your hosting status.",
+    )
+
+# address:change
+def _address_change(data: notification_data_pb2.EmailAddressChange) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="An email change was initiated on your account",
+        body=f"An email change to the email {data.new_email} was initiated on your account.",
+        action_url=urls.account_settings_link(),
+    )
+
+# address:verify
+def _address_verify(data: empty_pb2.Empty) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="Email change completed",
+        body="Your new email address has been verified.",
+        action_url=urls.account_settings_link(),
+    )
+
+# api_key:create
+def _api_key_create(data: empty_pb2.Empty) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="An API key was created for your account",
+        body="Details were sent to you via email.",
+        action_url=urls.app_link(),
+    )
+
+# badge:add
+def _badge_add(data: notification_data_pb2.BadgeAdd) -> PushNotificationContent:
+    return PushNotificationContent(
+        title=f"The {data.badge_name} badge was added to your profile",
+        body="Check out your profile to see the new badge!",
+        action_url=urls.profile_link(),
+    )
+
+# badge:remove
+def _badge_remove(data: notification_data_pb2.BadgeRemove) -> PushNotificationContent:
+    return PushNotificationContent(
+        title=f"The {data.badge_name} badge was removed from your profile",
+        body="You can see all your badges on your profile.",
+        action_url=urls.profile_link(),
+    )
+
+# birthdate:change
+def _birthdate_change(data: notification_data_pb2.BirthdateChange, user: User) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="Your date of birth was changed",
+        body=f"Your date of birth on Couchers.org was changed to {v2date(data.birthdate, user)} by an admin.",
+        action_url=urls.account_settings_link(),
+    )
+
+# chat:message
+def _chat_message(data: notification_data_pb2.ChatMessage) -> PushNotificationContent:
+    return PushNotificationContent(
+        title=data.message,
+        body=data.text,
+        icon_url=v2avatar(data.author),
+        action_url=urls.chat_link(chat_id=data.group_chat_id),
+    )
+
+# chat:missed_messages
+def _chat_missed_messages(data: empty_pb2.Empty) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="You have unseen messages on Couchers.org",
+        body="Please check out any messages you missed.",
+        action_url=urls.messages_link(),
+    )
+
+# donation:received
+def _donation_received(data: notification_data_pb2.DonationReceived) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="Thank you for your donation to Couchers.org!",
+        body=f"Thank you so much for your donation of ${data.amount} to Couchers.org.",
+        action_url=data.receipt_url,
+    )
+
+# discussion:create
+def _discussion_create(data: notification_data_pb2.DiscussionCreate) -> PushNotificationContent:
+    return PushNotificationContent(
+        title=data.discussion.title,
+        body=f"{data.author.name} created a discussion in {data.discussion.owner_title}: {data.discussion.title}\n\n{data.discussion.content}",
+        icon_url=v2avatar(data.author),
+        action_url=urls.discussion_link(discussion_id=data.discussion.discussion_id, slug=data.discussion.slug),
+    )
+
+# discussion:comment
+def _discussion_comment(data: notification_data_pb2.DiscussionComment) -> PushNotificationContent:
+    return PushNotificationContent(
+        title=data.discussion.title,
+        body=f"{data.author.name} commented:\n\n{data.reply.content}",
+        icon_url=v2avatar(data.author),
+        action_url=urls.discussion_link(discussion_id=data.discussion.discussion_id, slug=data.discussion.slug),
+    )
+
+def _get_event_time_display(event: events_pb2.Event, user: User) -> str:
+    return f"{v2timestamp(event.start_time, user)} - {v2timestamp(event.end_time, user)}"
+
+# event:create_any
+def _event_create_any(data: notification_data_pb2.EventCreate, user: User) -> PushNotificationContent:
+    time_display = _get_event_time_display(data.event, user)
+    return PushNotificationContent(
+        title=f'{data.inviting_user.name} created an event called "{data.event.title}"',
+        body=f"{time_display}\nCreated by {data.inviting_user.name}\n\n{data.event.content}",
+        icon_url=v2avatar(data.inviting_user),
+        action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
+    )
+
+# event:create_approved
+def _event_create_approved(data: notification_data_pb2.EventCreate, user: User) -> PushNotificationContent:
+    time_display = _get_event_time_display(data.event, user)
+    return PushNotificationContent(
+        title=f'{data.inviting_user.name} invited you to "{data.event.title}"',
+        body=f"{time_display}\nInvited by {data.inviting_user.name}\n\n{data.event.content}",
+        icon_url=v2avatar(data.inviting_user),
+        action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
+    )
+
+# event:update
+def _event_update(data: notification_data_pb2.EventUpdate, user: User) -> PushNotificationContent:
+    time_display = _get_event_time_display(data.event, user)
+    updated_text = ", ".join(data.updated_items)
+    return PushNotificationContent(
+        title=f'{data.updating_user.name} updated "{data.event.title}"',
+        body=f"{time_display}\n{data.updating_user.name} updated: {updated_text}\n\n{data.event.content}",
+        icon_url=v2avatar(data.updating_user),
+        action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
+    )
+
+# event:invite_organizer
+def _event_invite_organizer(data: notification_data_pb2.EventInviteOrganizer, user: User) -> PushNotificationContent:
+    time_display = _get_event_time_display(data.event, user)
+    return PushNotificationContent(
+        title=f'{data.inviting_user.name} invited you to co-organize "{data.event.title}"',
+        body=f"{time_display}\nInvited to co-organize by {data.inviting_user.name}\n\n{data.event.content}",
+        icon_url=v2avatar(data.inviting_user),
+        action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
+    )
+
+# event:action
+def _event_action(data: notification_data_pb2.EventComment, user: User) -> PushNotificationContent:
+    time_display = _get_event_time_display(data.event, user)
+    return PushNotificationContent(
+        title=f'{data.author.name} commented on "{data.event.title}"',
+        body=f"{time_display}\n{data.author.name} commented:\n\n{data.reply.content}",
+        icon_url=v2avatar(data.author),
+        action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
+    )
+
+# event:reminder
+def _event_reminder(data: notification_data_pb2.EventReminder, user: User) -> PushNotificationContent:
+    time_display = _get_event_time_display(data.event, user)
+    return PushNotificationContent(
+        title=f'"{data.event.title}" starts soon',
+        body=f"Don't forget your upcoming event on Couchers.org\n{time_display}\n{data.event.content}",
+        action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
+    )
+
+# event:cancel
+def _event_cancel(data: notification_data_pb2.EventCancel, user: User) -> PushNotificationContent:
+    time_display = _get_event_time_display(data.event, user)
+    return PushNotificationContent(
+        title=f'{data.cancelling_user.name} cancelled "{data.event.title}"',
+        body=f"{time_display}\nThe event has been cancelled by {data.cancelling_user.name}.\n\n{data.event.content}",
+        icon_url=v2avatar(data.cancelling_user),
+        action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
+    )
+
+# event:delete
+def _event_delete(data: notification_data_pb2.EventDelete, user: User) -> PushNotificationContent:
+    time_display = _get_event_time_display(data.event, user)
+    return PushNotificationContent(
+        title=f'A moderator deleted "{data.event.title}"',
+        body=f"{time_display}\nThe event has been deleted by the moderators.",
+    )
+
+# friend_request:create
+def _friend_request_create(data: notification_data_pb2.FriendRequestCreate) -> PushNotificationContent:
+    return PushNotificationContent(
+        title=f"{data.other_user.name} wants to be your friend",
+        body=f"You've received a friend request from {data.other_user.name}",
+        icon_url=v2avatar(data.other_user),
+        action_url=urls.friend_requests_link(),
+    )
+
+# friend_request:accept
+def _friend_request_accept(data: notification_data_pb2.FriendRequestAccept) -> PushNotificationContent:
+    return PushNotificationContent(
+        title=f"{data.other_user.name} accepted your friend request!",
+        body=f"{v2esc(data.other_user.name)} has accepted your friend request",
+        icon_url=v2avatar(data.other_user),
+        action_url=urls.user_link(username=data.other_user.username),
+    )
+
+# gender:change
+def _gender_change(data: notification_data_pb2.GenderChange) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="Your gender was changed",
+        body=f"Your gender on Couchers.org was changed to {data.gender} by an admin.",
+        action_url=urls.account_settings_link(),
+    )
+
+# general:new_blog_post
+def _general_new_blog_post(data: notification_data_pb2.GeneralNewBlogPost) -> PushNotificationContent:
+    return PushNotificationContent(
+        title=f"New blog post: {data.title}",
+        body=data.blurb,
+        action_url=data.url,
+    )
+
+# host_request:create
+def _host_request_create(data: notification_data_pb2.HostRequestCreate, user: User) -> PushNotificationContent:
+    return PushNotificationContent(
+        title=f"{data.surfer.name} sent you a host request",
+        body=f"Dates: {v2date(data.host_request.from_date, user)} to {v2date(data.host_request.to_date, user)}.\n\n{data.text}",
+        action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
+        icon_url=v2avatar(data.surfer)
+    )
+
+# host_request:message
+def _host_request_message(data: notification_data_pb2.HostRequestMessage, user: User) -> PushNotificationContent:
+    if data.am_host:
+        title = f"{data.user.name} sent you a message in their host request"
+    else:
+        title = f"{data.user.name} sent you a message in your host request"
+    return PushNotificationContent(
+        title=title,
+        body=f"Dates: {v2date(data.host_request.from_date, user)} to {v2date(data.host_request.to_date, user)}.\n\n{data.text}",
+        action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
+        icon_url=v2avatar(data.user)
+    )
+
+# host_request:missed_messages
+def _host_request_missed_messages(data: notification_data_pb2.HostRequestMissedMessages) -> PushNotificationContent:
+    their_your = "their" if data.am_host else "your"
+    return PushNotificationContent(
+        title=f"{data.user.name} sent you message(s) in {their_your} host request",
+        body="Check the app for more info.",
+        action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
+        icon_url=v2avatar(data.user)
+    )
+
+# host_request:reminder
+def _host_request_reminder(data: notification_data_pb2.HostRequestReminder) -> PushNotificationContent:
+    return PushNotificationContent(
+        title=f"You have a pending host request from {data.surfer.name}!",
+        body="Please respond to the request!",
+        action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
+        icon_url=v2avatar(data.surfer),
+    )
+
+# host_request:accept
+def _host_request_accept(data: notification_data_pb2.HostRequestAccept) -> PushNotificationContent:
+    return PushNotificationContent(
+        title=f"{data.host.name} accepted your host request",
+        body="Check the app for more info.",
+        action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
+        icon_url=v2avatar(data.host),
+    )
+
+# host_request:reject
+def _host_request_reject(data: notification_data_pb2.HostRequestReject) -> PushNotificationContent:
+    return PushNotificationContent(
+        title=f"{data.host.name} rejected your host request",
+        body="Check the app for more info.",
+        action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
+        icon_url=v2avatar(data.host),
+    )
+
+# host_request:cancel
+def _host_request_cancel(data: notification_data_pb2.HostRequestCancel) -> PushNotificationContent:
+    return PushNotificationContent(
+        title=f"{data.surfer.name} cancelled their host request",
+        body="Check the app for more info.",
+        action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
+        icon_url=v2avatar(data.surfer),
+    )
+
+# host_request:confirm
+def _host_request_confirm(data: notification_data_pb2.HostRequestConfirm) -> PushNotificationContent:
+    return PushNotificationContent(
+        title=f"{data.surfer.name} confirmed their host request",
+        body="Check the app for more info.",
+        action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
+        icon_url=v2avatar(data.surfer),
+    )
+
+# modnote:create
+def _modnote_create(data: empty_pb2.Empty) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="You received a mod note",
+        body="You need to read and acknowledge the note before continuing to use the platform.",
+    )
+
+# onboarding:reminder
+def _onboarding_reminder(data: empty_pb2.Empty, key: str, user: User) -> PushNotificationContent:
+    if key == "1":
+        return PushNotificationContent(
+            title="Welcome to Couchers.org and the future of couch surfing",
+            body=f"Hi {v2esc(user.name)}! We are excited that you have joined us! Please take a moment to complete your profile with a picture and a bit of text about yourself!",
+            action_url=urls.edit_profile_link(),
+        )
+    elif key == "2":
+        return PushNotificationContent(
+            title="Please complete your profile on Couchers.org!",
+            body=f"Hi {v2esc(user.name)}! We would ask one big favour of you: please fill out your profile by adding a photo and some text.",
+            action_url=urls.edit_profile_link(),
+        )
+    else:
+        raise NotImplementedError(f"Unknown onboarding reminder key: {key}")
+
+# password:change
+def _password_change(data: empty_pb2.Empty) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="Your password was changed",
+        body="Your login password for Couchers.org was changed.",
+        action_url=urls.account_settings_link(),
+    )
+
+# password_reset:start
+def _password_reset_start(data: empty_pb2.Empty) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="A password reset was initiated on your account",
+        body="Someone initiated a password change on your account.",
+        action_url=urls.account_settings_link(),
+    )
+
+# password_reset:complete
+def _password_reset_complete(data: empty_pb2.Empty) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="Your password was successfully reset",
+        body="Your password on Couchers.org was changed. If that was you, then no further action is needed.",
+        action_url=urls.account_settings_link(),
+    )
+
+# phone_number:change
+def _phone_number_change(data: notification_data_pb2.PhoneNumberChange) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="Phone verification started",
+        body=f"You started phone number verification with the number {v2phone(data.phone)}.",
+        action_url=urls.feature_preview_link(),
+    )
+
+# phone_number:verify
+def _phone_number_verify(data: notification_data_pb2.PhoneNumberVerify) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="Phone successfully verified",
+        body=f"Your phone was successfully verified as {v2phone(data.phone)} on Couchers.org.",
+        action_url=urls.feature_preview_link(),
+    )
+
+# postal_verification:postcard_sent
+def _postal_verification_postcard_sent(data: notification_data_pb2.PostalVerificationPostcardSent) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="Your verification postcard is on its way",
+        body=f"Postcard sent to {data.city}, {data.country}. Expect it within 1-3 weeks.",
+        action_url=urls.account_settings_link(),
+    )
+
+# postal_verification:success
+def _postal_verification_success(data: empty_pb2.Empty) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="Postal Verification succeeded",
+        body="You have been verified with Postal Verification! Your address has been confirmed.",
+        action_url=urls.account_settings_link(),
+    )
+
+# postal_verification:failed
+def _postal_verification_failed(data: notification_data_pb2.PostalVerificationFailed) -> PushNotificationContent:
+    if data.reason == notification_data_pb2.POSTAL_VERIFICATION_FAIL_REASON_CODE_EXPIRED:
+        reason_message = "Your verification code has expired. Codes are valid for 90 days after the postcard is sent. You can start a new verification attempt."
+    elif data.reason == notification_data_pb2.POSTAL_VERIFICATION_FAIL_REASON_TOO_MANY_ATTEMPTS:
+        reason_message = "Too many incorrect code attempts. You can start a new verification attempt."
+    else:
+        reason_message = (
+            "Your postal verification attempt has failed. You can start a new verification attempt."
+        )
+    return PushNotificationContent(
+        title="Postal Verification failed",
+        body=reason_message,
+        action_url=urls.account_settings_link(),
+    )
+
+# reference:receive_friend
+def _reference_receive_friend(data: notification_data_pb2.ReferenceReceiveFriend) -> PushNotificationContent:
+    return PushNotificationContent(
+        title=f"You've received a friend reference from {data.from_user.name}!",
+        body=data.text,
+        icon_url=v2avatar(data.from_user),
+        action_url=urls.profile_references_link(),
+    )
+
+# reference:receive_hosted, reference:receive_surfed
+def _reference_receive(data: notification_data_pb2.ReferenceReceiveHostRequest, action: str) -> PushNotificationContent:
+    if data.text:
+        body = v2esc(data.text)
+        action_url = urls.profile_references_link()
+    else:
+        body = "Please go and write a reference for them too. It's a nice gesture and helps us build a community together!"
+        # what was my type? i surfed with them if i received a "hosted" request
+        surfed = action == "receive_hosted"
+        action_url = urls.leave_reference_link(
+            reference_type="surfed" if surfed else "hosted",
+            to_user_id=data.from_user.user_id,
+            host_request_id=str(data.host_request_id),
+        )
+    return PushNotificationContent(
+        title=f"You've received a reference from {data.from_user.name}!",
+        body=body,
+        icon_url=v2avatar(data.from_user),
+        action_url=action_url,
+    )
+
+# reference:reminder_hosted, reference:reminder_surfed
+def _reference_reminder(data: notification_data_pb2.ReferenceReminder, action: str) -> PushNotificationContent:
+    # what was my type? i surfed with them if i get a surfed reminder
+    surfed = action == "reminder_surfed"
+    leave_reference_link = urls.leave_reference_link(
+        reference_type="surfed" if surfed else "hosted",
+        to_user_id=data.other_user.user_id,
+        host_request_id=str(data.host_request_id),
+    )
+    return PushNotificationContent(
+        title=f"You have {data.days_left} days to write a reference for {data.other_user.name}!",
+        body="It's a nice gesture to write references and helps us build a community together! References will become visible 2 weeks after the stay, or when you've both written a reference for each other, whichever happens first.",
+        icon_url=v2avatar(data.other_user),
+        action_url=leave_reference_link,
+    )
+
+# thread:reply
+def _thread_reply(data: notification_data_pb2.ThreadReply) -> PushNotificationContent:
+    parent = data.WhichOneof("reply_parent")
+    if parent == "event":
+        title = data.event.title
+        view_link = urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug)
+    elif parent == "discussion":
+        title = data.discussion.title
+        view_link = urls.discussion_link(discussion_id=data.discussion.discussion_id, slug=data.discussion.slug)
+    else:
+        raise Exception("Can only do replies to events and discussions")
+
+    return PushNotificationContent(
+        title=title,
+        body=f"{data.author.name} replied:\n\n{data.reply.content}",
+        icon_url=v2avatar(data.author),
+        action_url=view_link,
+    )
+
+# verification:sv_success
+def _verification_sv_success(data: empty_pb2.Empty) -> PushNotificationContent:
+    return PushNotificationContent(
+        title="Strong Verification succeeded",
+        body="You have been verified with Strong Verification! You will now see a tick next to your name on the platform.",
+        action_url=urls.account_settings_link(),
+    )
+
+# verification:sv_fail
+def _verification_sv_fail(data: notification_data_pb2.VerificationSVFail) -> PushNotificationContent:
+    if data.reason == notification_data_pb2.SV_FAIL_REASON_WRONG_BIRTHDATE_OR_GENDER:
+        reason_message = "The date of birth or gender on your profile does not match the date of birth or sex on your passport. Please contact the support team to update your date of birth or gender, or if your passport sex does not match your gender identity."
+    elif data.reason == notification_data_pb2.SV_FAIL_REASON_NOT_A_PASSPORT:
+        reason_message = "You tried to verify with a document that is not a passport. You can only use a passport for Strong Verification."
+    elif data.reason == notification_data_pb2.SV_FAIL_REASON_DUPLICATE:
+        reason_message = "You tried to verify with a passport that has already been used for verification. Please use another passport."
+    else:
+        raise Exception("Shouldn't get here")
+    return PushNotificationContent(
+        title="Strong Verification failed",
+        body=reason_message,
+        action_url=urls.account_settings_link(),
+    )
+
+def render_push_notification(user: User, notification: Notification) -> PushNotificationContent:
+    data: empty_pb2.Empty = notification.topic_action.data_type.FromString(notification.data) # type: ignore[attr-defined]
+    # Keep topics sorted (action can follow logical ordering)
+    match notification.topic_action:
+        case "account_deletion:start":
+            return _account_deletion_start(data)
+        case "account_deletion:complete":
+            return _account_deletion_complete(data)
+        case "account_deletion:recovered":
+            return _account_deletion_recovered(data)
+        case "activeness:probe":
+            return _activeness_probe(data)
+        case "address:change":
+            return _address_change(data)
+        case "address:verify":
+            return _address_verify(data)
+        case "api_key:create":
+            return _api_key_create(data)
+        case "badge:add":
+            return _badge_add(data)
+        case "badge:remove":
+            return _badge_remove(data)
+        case "birthdate:change":
+            return _birthdate_change(data, user)
+        case "chat:message":
+            return _chat_message(data, user)
+        case "chat:missed_messages":
+            return _chat_missed_messages(data, user)
+        case "donation:received":
+            return _donation_received(data)
+        case "discussion:create":
+            return _discussion_create(data)
+        case "discussion:comment":
+            return _discussion_comment(data)
+        case "event:create_any":
+            return _event_create_any(data, user)
+        case "event:create_approved":
+            return _event_create_approved(data, user)
+        case "event:create_update":
+            return _event_update(data, user)
+        case "event:create_invite_organizer":
+            return _event_invite_organizer(data, user)
+        case "event:create_action":
+            return _event_action(data, user)
+        case "event:create_reminder":
+            return _event_reminder(data, user)
+        case "event:create_cancel":
+            return _event_cancel(data, user)
+        case "event:create_delete":
+            return _event_delete(data, user)
+        case "friend_request:create":
+            return _friend_request_create(data)
+        case "friend_request:accept":
+            return _friend_request_accept(data)
+        case "gender:change":
+            return _gender_change(data)
+        case "general:new_blog_post":
+            return _general_new_blog_post(data)
+        case "host_request:create":
+            return _host_request_create(data, user)
+        case "host_request:message":
+            return _host_request_message(data, user)
+        case "host_request:missed_messages":
+            return _host_request_missed_messages(data)
+        case "host_request:reminder":
+            return _host_request_reminder(data)
+        case "host_request:accept":
+            return _host_request_accept(data)
+        case "host_request:reject":
+            return _host_request_reject(data)
+        case "host_request:cancel":
+            return _host_request_cancel(data)
+        case "host_request:confirm":
+            return _host_request_confirm(data)
+        case "modnote:create":
+            return _modnote_create(data)
+        case "onboarding:reminder":
+            return _onboarding_reminder(data)
+        case "password:change":
+            return _password_change(data)
+        case "password_reset:start":
+            return _password_reset_start(data)
+        case "password_reset:complete":
+            return _password_reset_complete(data)
+        case "phone_number:change":
+            return _phone_number_change(data)
+        case "phone_number:verify":
+            return _phone_number_verify(data)
+        case "postal_verification:postcard_sent":
+            return _postal_verification_postcard_sent(data)
+        case "postal_verification:success":
+            return _postal_verification_success(data)
+        case "postal_verification:failed":
+            return _postal_verification_failed(data)
+        case "reference:receive_friend":
+            return _reference_receive_friend(data)
+        case "reference:receive_hosted":
+            return _reference_receive(data, action=notification.action)
+        case "reference:receive_surfed":
+            return _reference_receive(data, action=notification.action)
+        case "reference:reminder_hosted":
+            return _reference_reminder(data, action=notification.action)
+        case "reference:reminder_surfed":
+            return _reference_reminder(data, action=notification.action)
+        case "thread:reply":
+            return _thread_reply(data)
+        case "verification:sv_success":
+            return _verification_sv_success(data)
+        case "verification:sv_fail":
+            return _verification_sv_fail(data)
+        case _:
+            raise NotImplementedError(f"Unknown topic-action: {notification.topic}:{notification.action}")
+

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -38,7 +38,7 @@ def render_push_notification(user: User, notification: Notification) -> PushNoti
         case NotificationTopicAction.account_deletion__complete:
             return _account_deletion__complete(data)
         case NotificationTopicAction.account_deletion__recovered:
-            return _account_deletion__recovered(data)
+            return _account_deletion__recovered()
         case NotificationTopicAction.activeness__probe:
             return _activeness__probe(data)
         case NotificationTopicAction.api_key__create:
@@ -52,7 +52,7 @@ def render_push_notification(user: User, notification: Notification) -> PushNoti
         case NotificationTopicAction.chat__message:
             return _chat__message(data)
         case NotificationTopicAction.chat__missed_messages:
-            return _chat__missed_messages(data)
+            return _chat__missed_messages()
         case NotificationTopicAction.donation__received:
             return _donation__received(data)
         case NotificationTopicAction.discussion__create:
@@ -62,7 +62,7 @@ def render_push_notification(user: User, notification: Notification) -> PushNoti
         case NotificationTopicAction.email_address__change:
             return _email_address__change(data)
         case NotificationTopicAction.email_address__verify:
-            return _email_address__verify(data)
+            return _email_address__verify()
         case NotificationTopicAction.event__create_any:
             return _event__create_any(data, user)
         case NotificationTopicAction.event__create_approved:
@@ -104,15 +104,15 @@ def render_push_notification(user: User, notification: Notification) -> PushNoti
         case NotificationTopicAction.host_request__confirm:
             return _host_request__confirm(data)
         case NotificationTopicAction.modnote__create:
-            return _modnote__create(data)
+            return _modnote__create()
         case NotificationTopicAction.onboarding__reminder:
-            return _onboarding__reminder(data, notification.key, user)
+            return _onboarding__reminder(notification.key, user)
         case NotificationTopicAction.password__change:
-            return _password__change(data)
+            return _password__change()
         case NotificationTopicAction.password_reset__start:
             return _password_reset__start(data)
         case NotificationTopicAction.password_reset__complete:
-            return _password_reset__complete(data)
+            return _password_reset__complete()
         case NotificationTopicAction.phone_number__change:
             return _phone_number__change(data)
         case NotificationTopicAction.phone_number__verify:
@@ -120,7 +120,7 @@ def render_push_notification(user: User, notification: Notification) -> PushNoti
         case NotificationTopicAction.postal_verification__postcard_sent:
             return _postal_verification__postcard_sent(data)
         case NotificationTopicAction.postal_verification__success:
-            return _postal_verification__success(data)
+            return _postal_verification__success()
         case NotificationTopicAction.postal_verification__failed:
             return _postal_verification__failed(data)
         case NotificationTopicAction.reference__receive_friend:
@@ -136,7 +136,7 @@ def render_push_notification(user: User, notification: Notification) -> PushNoti
         case NotificationTopicAction.thread__reply:
             return _thread__reply(data)
         case NotificationTopicAction.verification__sv_success:
-            return _verification__sv_success(data)
+            return _verification__sv_success()
         case NotificationTopicAction.verification__sv_fail:
             return _verification__sv_fail(data)
         case _:
@@ -158,7 +158,7 @@ def _account_deletion__complete(data: notification_data_pb2.AccountDeletionCompl
     )
 
 
-def _account_deletion__recovered(data: empty_pb2.Empty) -> PushNotificationContent:
+def _account_deletion__recovered() -> PushNotificationContent:
     return PushNotificationContent(
         title="Your Couchers.org account has been recovered!",
         body="We have recovered your Couchers.org account as per your request! Welcome back!",
@@ -213,7 +213,7 @@ def _chat__message(data: notification_data_pb2.ChatMessage) -> PushNotificationC
     )
 
 
-def _chat__missed_messages(data: empty_pb2.Empty) -> PushNotificationContent:
+def _chat__missed_messages() -> PushNotificationContent:
     return PushNotificationContent(
         title="You have unseen messages on Couchers.org",
         body="Please check out any messages you missed.",
@@ -255,7 +255,7 @@ def _email_address__change(data: notification_data_pb2.EmailAddressChange) -> Pu
     )
 
 
-def _email_address__verify(data: empty_pb2.Empty) -> PushNotificationContent:
+def _email_address__verify() -> PushNotificationContent:
     return PushNotificationContent(
         title="Email change completed",
         body="Your new email address has been verified.",
@@ -456,14 +456,14 @@ def _host_request__confirm(data: notification_data_pb2.HostRequestConfirm) -> Pu
     )
 
 
-def _modnote__create(data: empty_pb2.Empty) -> PushNotificationContent:
+def _modnote__create() -> PushNotificationContent:
     return PushNotificationContent(
         title="You received a mod note",
         body="You need to read and acknowledge the note before continuing to use the platform.",
     )
 
 
-def _onboarding__reminder(data: empty_pb2.Empty, key: str, user: User) -> PushNotificationContent:
+def _onboarding__reminder(key: str, user: User) -> PushNotificationContent:
     if key == "1":
         return PushNotificationContent(
             title="Welcome to Couchers.org and the future of couch surfing",
@@ -480,7 +480,7 @@ def _onboarding__reminder(data: empty_pb2.Empty, key: str, user: User) -> PushNo
         raise NotImplementedError(f"Unknown onboarding reminder key: {key}")
 
 
-def _password__change(data: empty_pb2.Empty) -> PushNotificationContent:
+def _password__change() -> PushNotificationContent:
     return PushNotificationContent(
         title="Your password was changed",
         body="Your login password for Couchers.org was changed.",
@@ -496,7 +496,7 @@ def _password_reset__start(data: notification_data_pb2.PasswordResetStart) -> Pu
     )
 
 
-def _password_reset__complete(data: empty_pb2.Empty) -> PushNotificationContent:
+def _password_reset__complete() -> PushNotificationContent:
     return PushNotificationContent(
         title="Your password was successfully reset",
         body="Your password on Couchers.org was changed. If that was you, then no further action is needed.",
@@ -530,7 +530,7 @@ def _postal_verification__postcard_sent(
     )
 
 
-def _postal_verification__success(data: empty_pb2.Empty) -> PushNotificationContent:
+def _postal_verification__success() -> PushNotificationContent:
     return PushNotificationContent(
         title="Postal Verification succeeded",
         body="You have been verified with Postal Verification! Your address has been confirmed.",
@@ -635,7 +635,7 @@ def _thread__reply(data: notification_data_pb2.ThreadReply) -> PushNotificationC
     )
 
 
-def _verification__sv_success(data: empty_pb2.Empty) -> PushNotificationContent:
+def _verification__sv_success() -> PushNotificationContent:
     return PushNotificationContent(
         title="Strong Verification succeeded",
         body="You have been verified with Strong Verification! You will now see a tick next to your name on the platform.",

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -17,12 +17,126 @@ logger = logging.getLogger(__name__)
 
 # Best practices for push notification strings (Android/iOS lowest common denominator):
 # Title:
-#   Describe the event, e.g. "Payment Successful"
-#   <= 30 chars (Android), most important info in first 20 chars
-#   Title-style capitalization, no ending punctuation
+#   - Describe the event, e.g. "Payment Successful"
+#   - <= 30 chars (Android), most important info in first 20 chars
+#   - Title-style capitalization, no ending punctuation
 # Body:
-#   <= 80 chars (Android), first 40 visible when collapsed
-#   Sentence-style capitalization with punctuation
+#   - <= 80 chars (Android), first 40 visible when collapsed
+#   - Sentence-style capitalization with punctuation
+
+
+def render_push_notification(user: User, notification: Notification) -> PushNotificationContent:
+    data: Any = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
+    # Keep topics sorted (action can follow logical ordering)
+    match notification.topic_action.display:
+        case "account_deletion:start":
+            return _account_deletion_start(data)
+        case "account_deletion:complete":
+            return _account_deletion_complete(data)
+        case "account_deletion:recovered":
+            return _account_deletion_recovered(data)
+        case "activeness:probe":
+            return _activeness_probe(data)
+        case "api_key:create":
+            return _api_key_create(data)
+        case "badge:add":
+            return _badge_add(data)
+        case "badge:remove":
+            return _badge_remove(data)
+        case "birthdate:change":
+            return _birthdate_change(data, user)
+        case "chat:message":
+            return _chat_message(data)
+        case "chat:missed_messages":
+            return _chat_missed_messages(data)
+        case "donation:received":
+            return _donation_received(data)
+        case "discussion:create":
+            return _discussion_create(data)
+        case "discussion:comment":
+            return _discussion_comment(data)
+        case "email_address:change":
+            return _email_address_change(data)
+        case "email_address:verify":
+            return _email_address_verify(data)
+        case "event:create_any":
+            return _event_create_any(data, user)
+        case "event:create_approved":
+            return _event_create_approved(data, user)
+        case "event:update":
+            return _event_update(data, user)
+        case "event:invite_organizer":
+            return _event_invite_organizer(data, user)
+        case "event:comment":
+            return _event_comment(data, user)
+        case "event:reminder":
+            return _event_reminder(data, user)
+        case "event:cancel":
+            return _event_cancel(data, user)
+        case "event:delete":
+            return _event_delete(data, user)
+        case "friend_request:create":
+            return _friend_request_create(data)
+        case "friend_request:accept":
+            return _friend_request_accept(data)
+        case "gender:change":
+            return _gender_change(data)
+        case "general:new_blog_post":
+            return _general_new_blog_post(data)
+        case "host_request:create":
+            return _host_request_create(data, user)
+        case "host_request:message":
+            return _host_request_message(data, user)
+        case "host_request:missed_messages":
+            return _host_request_missed_messages(data)
+        case "host_request:reminder":
+            return _host_request_reminder(data)
+        case "host_request:accept":
+            return _host_request_accept(data)
+        case "host_request:reject":
+            return _host_request_reject(data)
+        case "host_request:cancel":
+            return _host_request_cancel(data)
+        case "host_request:confirm":
+            return _host_request_confirm(data)
+        case "modnote:create":
+            return _modnote_create(data)
+        case "onboarding:reminder":
+            return _onboarding_reminder(data, notification.key, user)
+        case "password:change":
+            return _password_change(data)
+        case "password_reset:start":
+            return _password_reset_start(data)
+        case "password_reset:complete":
+            return _password_reset_complete(data)
+        case "phone_number:change":
+            return _phone_number_change(data)
+        case "phone_number:verify":
+            return _phone_number_verify(data)
+        case "postal_verification:postcard_sent":
+            return _postal_verification_postcard_sent(data)
+        case "postal_verification:success":
+            return _postal_verification_success(data)
+        case "postal_verification:failed":
+            return _postal_verification_failed(data)
+        case "reference:receive_friend":
+            return _reference_receive_friend(data)
+        case "reference:receive_hosted":
+            return _reference_receive(data, action=notification.action)
+        case "reference:receive_surfed":
+            return _reference_receive(data, action=notification.action)
+        case "reference:reminder_hosted":
+            return _reference_reminder(data, action=notification.action)
+        case "reference:reminder_surfed":
+            return _reference_reminder(data, action=notification.action)
+        case "thread:reply":
+            return _thread_reply(data)
+        case "verification:sv_success":
+            return _verification_sv_success(data)
+        case "verification:sv_fail":
+            return _verification_sv_fail(data)
+        case _:
+            raise NotImplementedError(f"Unknown topic-action: {notification.topic_action.display}")
 
 
 # account_deletion:start
@@ -573,117 +687,3 @@ def _verification_sv_fail(data: notification_data_pb2.VerificationSVFail) -> Pus
         body=reason_message,
         action_url=urls.account_settings_link(),
     )
-
-
-def render_push_notification(user: User, notification: Notification) -> PushNotificationContent:
-    data: Any = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
-    # Keep topics sorted (action can follow logical ordering)
-    match notification.topic_action.display:
-        case "account_deletion:start":
-            return _account_deletion_start(data)
-        case "account_deletion:complete":
-            return _account_deletion_complete(data)
-        case "account_deletion:recovered":
-            return _account_deletion_recovered(data)
-        case "activeness:probe":
-            return _activeness_probe(data)
-        case "api_key:create":
-            return _api_key_create(data)
-        case "badge:add":
-            return _badge_add(data)
-        case "badge:remove":
-            return _badge_remove(data)
-        case "birthdate:change":
-            return _birthdate_change(data, user)
-        case "chat:message":
-            return _chat_message(data)
-        case "chat:missed_messages":
-            return _chat_missed_messages(data)
-        case "donation:received":
-            return _donation_received(data)
-        case "discussion:create":
-            return _discussion_create(data)
-        case "discussion:comment":
-            return _discussion_comment(data)
-        case "email_address:change":
-            return _email_address_change(data)
-        case "email_address:verify":
-            return _email_address_verify(data)
-        case "event:create_any":
-            return _event_create_any(data, user)
-        case "event:create_approved":
-            return _event_create_approved(data, user)
-        case "event:update":
-            return _event_update(data, user)
-        case "event:invite_organizer":
-            return _event_invite_organizer(data, user)
-        case "event:comment":
-            return _event_comment(data, user)
-        case "event:reminder":
-            return _event_reminder(data, user)
-        case "event:cancel":
-            return _event_cancel(data, user)
-        case "event:delete":
-            return _event_delete(data, user)
-        case "friend_request:create":
-            return _friend_request_create(data)
-        case "friend_request:accept":
-            return _friend_request_accept(data)
-        case "gender:change":
-            return _gender_change(data)
-        case "general:new_blog_post":
-            return _general_new_blog_post(data)
-        case "host_request:create":
-            return _host_request_create(data, user)
-        case "host_request:message":
-            return _host_request_message(data, user)
-        case "host_request:missed_messages":
-            return _host_request_missed_messages(data)
-        case "host_request:reminder":
-            return _host_request_reminder(data)
-        case "host_request:accept":
-            return _host_request_accept(data)
-        case "host_request:reject":
-            return _host_request_reject(data)
-        case "host_request:cancel":
-            return _host_request_cancel(data)
-        case "host_request:confirm":
-            return _host_request_confirm(data)
-        case "modnote:create":
-            return _modnote_create(data)
-        case "onboarding:reminder":
-            return _onboarding_reminder(data, notification.key, user)
-        case "password:change":
-            return _password_change(data)
-        case "password_reset:start":
-            return _password_reset_start(data)
-        case "password_reset:complete":
-            return _password_reset_complete(data)
-        case "phone_number:change":
-            return _phone_number_change(data)
-        case "phone_number:verify":
-            return _phone_number_verify(data)
-        case "postal_verification:postcard_sent":
-            return _postal_verification_postcard_sent(data)
-        case "postal_verification:success":
-            return _postal_verification_success(data)
-        case "postal_verification:failed":
-            return _postal_verification_failed(data)
-        case "reference:receive_friend":
-            return _reference_receive_friend(data)
-        case "reference:receive_hosted":
-            return _reference_receive(data, action=notification.action)
-        case "reference:receive_surfed":
-            return _reference_receive(data, action=notification.action)
-        case "reference:reminder_hosted":
-            return _reference_reminder(data, action=notification.action)
-        case "reference:reminder_surfed":
-            return _reference_reminder(data, action=notification.action)
-        case "thread:reply":
-            return _thread_reply(data)
-        case "verification:sv_success":
-            return _verification_sv_success(data)
-        case "verification:sv_fail":
-            return _verification_sv_fail(data)
-        case _:
-            raise NotImplementedError(f"Unknown topic-action: {notification.topic_action.display}")

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -143,10 +143,8 @@ def render_push_notification(user: User, notification: Notification) -> PushNoti
             # Enables mypy's exhaustiveness checking for the cases above.
             assert_never(notification.topic_action)
 
-    raise NotImplementedError(f"Unknown topic-action: {notification.topic}:{notification.action}")
 
-
-def _account_deletion__start(data: empty_pb2.Empty) -> PushNotificationContent:
+def _account_deletion__start(data: notification_data_pb2.AccountDeletionStart) -> PushNotificationContent:
     return PushNotificationContent(
         title="Account deletion initiated",
         body="Someone initiated the deletion of your Couchers.org account. To delete your account, please follow the link in the email we sent you.",
@@ -174,7 +172,7 @@ def _activeness__probe(data: notification_data_pb2.ActivenessProbe) -> PushNotif
     )
 
 
-def _api_key__create(data: empty_pb2.Empty) -> PushNotificationContent:
+def _api_key__create(data: notification_data_pb2.ApiKeyCreate) -> PushNotificationContent:
     return PushNotificationContent(
         title="An API key was created for your account",
         body="Details were sent to you via email.",
@@ -490,7 +488,7 @@ def _password__change(data: empty_pb2.Empty) -> PushNotificationContent:
     )
 
 
-def _password_reset__start(data: empty_pb2.Empty) -> PushNotificationContent:
+def _password_reset__start(data: notification_data_pb2.PasswordResetStart) -> PushNotificationContent:
     return PushNotificationContent(
         title="A password reset was initiated on your account",
         body="Someone initiated a password change on your account.",

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -23,7 +23,7 @@ from couchers.models import (
     User,
 )
 from couchers.notifications.push import PushNotificationContent, push_to_subscription, push_to_user
-from couchers.notifications.render import render_push_notification
+from couchers.notifications.render_push import render_push_notification
 from couchers.notifications.settings import (
     PreferenceNotUserEditableError,
     get_topic_actions_by_delivery_type,


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
Building upon #7559, splits the logic for email and push notification rendering. The combined logic currently somewhat benefits from sharing strings, but it is because our notification strings are designed to be email titles. We are far from the iOS/Android best practices (which I've summarized in a comment). I will rewrite all push notification strings in a subsequent PR before extracting them for localization.

I chose to have one function per notification kind because it allows strongly typing the `data` variable and getting mypy validation. In a few places I shared the implementation between two types of notifications, but I suspect this will go away when I rewrite the strings.

I also renamed `RenderedNotification` to `RenderedEmailNotification` and changed property names since this type is now email-specific. I didn't rename `render.py` for diffability in this PR, but might change it to `render_email.py` later.

The size of the changes means this PR has some risk, though there are no functional changes and test coverage is pretty good.

**Please give clear steps for how the reviewer can best test this PR**
There is no functionality change, but you can trigger any notification to validate (e.g. receive a message).

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A

**Backend checklist**
- [x] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)