### PR TITLE
Step 1 to prep for new message tabs with archive (suggestion)

### DIFF
--- a/app/backend/src/couchers/migrations/versions/a0d6686e2ee4_add_conversation_subscriptions_and_type.py
+++ b/app/backend/src/couchers/migrations/versions/a0d6686e2ee4_add_conversation_subscriptions_and_type.py
@@ -1,0 +1,79 @@
+"""add_conversation_subscriptions_and_type
+
+Revision ID: a0d6686e2ee4
+Revises: f8b4ef6e3819
+Create Date: 2026-01-01 19:00:13.067150
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "a0d6686e2ee4"
+down_revision = "f8b4ef6e3819"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Create ConversationType enum
+    conversationtype = postgresql.ENUM("group_chat", "host_request", name="conversationtype")
+    conversationtype.create(op.get_bind())
+
+    # 2. Add type column to conversations table (nullable first)
+    op.add_column("conversations", sa.Column("type", conversationtype, nullable=True))
+
+    # 3. Populate conversation types for existing data
+    op.execute("""
+        UPDATE conversations SET type = 'group_chat'
+        WHERE id IN (SELECT id FROM group_chats)
+    """)
+    op.execute("""
+        UPDATE conversations SET type = 'host_request'
+        WHERE id IN (SELECT id FROM host_requests)
+    """)
+
+    # 4. Make type NOT NULL
+    op.alter_column("conversations", "type", nullable=False)
+
+    # 5. Create conversation_subscriptions table
+    op.execute("""
+        CREATE TABLE conversation_subscriptions (
+            id BIGSERIAL PRIMARY KEY,
+            user_id BIGINT NOT NULL REFERENCES users(id),
+            conversation_id BIGINT NOT NULL REFERENCES conversations(id),
+            is_archived BOOLEAN NOT NULL DEFAULT false,
+            last_seen_message_id BIGINT NOT NULL DEFAULT 0,
+            muted_until TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT TIMESTAMP '-infinity',
+            joined TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            "left" TIMESTAMP WITH TIME ZONE,
+            role groupchatrole,
+            UNIQUE (user_id, conversation_id)
+        )
+    """)
+
+    # 6. Create indexes
+    op.create_index("ix_conversation_subs_user_archived", "conversation_subscriptions", ["user_id", "is_archived"])
+    op.create_index("ix_conversation_subs_user_conv", "conversation_subscriptions", ["user_id", "conversation_id"])
+    op.create_index(
+        op.f("ix_conversation_subscriptions_conversation_id"), "conversation_subscriptions", ["conversation_id"]
+    )
+    op.create_index(op.f("ix_conversation_subscriptions_user_id"), "conversation_subscriptions", ["user_id"])
+
+
+def downgrade() -> None:
+    # 1. Drop conversation_subscriptions table and indexes
+    op.drop_index(op.f("ix_conversation_subscriptions_user_id"), table_name="conversation_subscriptions")
+    op.drop_index(op.f("ix_conversation_subscriptions_conversation_id"), table_name="conversation_subscriptions")
+    op.drop_index("ix_conversation_subs_user_conv", table_name="conversation_subscriptions")
+    op.drop_index("ix_conversation_subs_user_archived", table_name="conversation_subscriptions")
+    op.drop_table("conversation_subscriptions")
+
+    # 2. Drop type column from conversations
+    op.drop_column("conversations", "type")
+
+    # 3. Drop ConversationType enum
+    conversationtype = postgresql.ENUM("group_chat", "host_request", name="conversationtype")
+    conversationtype.drop(op.get_bind())

--- a/app/backend/src/couchers/models/conversations.py
+++ b/app/backend/src/couchers/models/conversations.py
@@ -2,7 +2,7 @@ import enum
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import BigInteger, Boolean, DateTime, Enum, ForeignKey, String, func
+from sqlalchemy import BigInteger, Boolean, DateTime, Enum, ForeignKey, Index, String, UniqueConstraint, func, text
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import DynamicMapped, Mapped, mapped_column, relationship
 
@@ -15,6 +15,11 @@ if TYPE_CHECKING:
     from couchers.models import ModerationState, User
 
 
+class ConversationType(enum.Enum):
+    group_chat = enum.auto()
+    host_request = enum.auto()
+
+
 class Conversation(Base):
     """
     Conversation brings together the different types of message/conversation types
@@ -25,9 +30,10 @@ class Conversation(Base):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     # timezone should always be UTC
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    type: Mapped[ConversationType] = mapped_column(Enum(ConversationType))
 
     def __repr__(self) -> str:
-        return f"Conversation(id={self.id}, created={self.created})"
+        return f"Conversation(id={self.id}, created={self.created}, type={self.type})"
 
 
 class GroupChat(Base):
@@ -110,6 +116,67 @@ class GroupChatSubscription(Base):
 
     def __repr__(self) -> str:
         return f"GroupChatSubscription(id={self.id}, user={self.user}, joined={self.joined}, left={self.left}, role={self.role}, group_chat={self.group_chat})"
+
+
+class ConversationSubscription(Base):
+    """
+    Unified per-user conversation state for all conversation types (group chats, host requests, etc.).
+    Tracks archiving, last seen messages, mute status, and membership details.
+    """
+
+    __tablename__ = "conversation_subscriptions"
+    __table_args__ = (
+        UniqueConstraint("user_id", "conversation_id"),
+        Index("ix_conversation_subs_user_archived", "user_id", "is_archived"),
+        Index("ix_conversation_subs_user_conv", "user_id", "conversation_id"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    conversation_id: Mapped[int] = mapped_column(ForeignKey("conversations.id"), index=True)
+
+    # Archiving state
+    is_archived: Mapped[bool] = mapped_column(Boolean, server_default=text("false"), nullable=False)
+
+    # Last seen message tracking
+    last_seen_message_id: Mapped[int] = mapped_column(BigInteger, server_default=text("0"), nullable=False)
+
+    # Mute status
+    muted_until: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=text("TIMESTAMP '-infinity'"), nullable=False
+    )
+
+    # Membership timestamps
+    joined: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    left: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # Role (for group chats; NULL for host requests)
+    role: Mapped[GroupChatRole | None] = mapped_column(Enum(GroupChatRole), nullable=True)
+
+    # Relationships
+    user: Mapped["User"] = relationship("User", backref="conversation_subscriptions")
+    conversation: Mapped["Conversation"] = relationship("Conversation", backref="subscriptions")
+
+    def muted_display(self) -> tuple[bool, datetime | None]:
+        """
+        Returns (muted, muted_until) display values:
+        1. If not muted, returns (False, None)
+        2. If muted forever, returns (True, None)
+        3. If muted until a given datetime returns (True, dt)
+        """
+        if self.muted_until < now():
+            return (False, None)
+        elif self.muted_until == DATETIME_INFINITY:
+            return (True, None)
+        else:
+            return (True, self.muted_until)
+
+    @hybrid_property
+    def is_muted(self) -> Any:
+        return self.muted_until > func.now()
+
+    def __repr__(self) -> str:
+        return f"ConversationSubscription(id={self.id}, user_id={self.user_id}, conversation_id={self.conversation_id}, is_archived={self.is_archived}, role={self.role})"
 
 
 class MessageType(enum.Enum):

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -16,6 +16,8 @@ from couchers.jobs.enqueue import queue_job
 from couchers.metrics import sent_messages_counter
 from couchers.models import (
     Conversation,
+    ConversationSubscription,
+    ConversationType,
     GroupChat,
     GroupChatRole,
     GroupChatSubscription,
@@ -249,7 +251,7 @@ def _create_chat(
     title: str | None = None,
     only_admins_invite: bool = True,
 ) -> GroupChat:
-    conversation = Conversation()
+    conversation = Conversation(type=ConversationType.group_chat)
     session.add(conversation)
     session.flush()
 
@@ -279,12 +281,30 @@ def _create_chat(
     )
     session.add(creator_subscription)
 
+    # Create conversation subscription for creator
+    creator_conv_sub = ConversationSubscription(
+        user_id=creator_id,
+        conversation_id=conversation.id,
+        role=GroupChatRole.admin,
+        is_archived=False,
+    )
+    session.add(creator_conv_sub)
+
     for uid in recipient_ids:
         session.add(
             GroupChatSubscription(
                 user_id=uid,
                 group_chat=chat,
                 role=GroupChatRole.participant,
+            )
+        )
+        # Create conversation subscription for each participant
+        session.add(
+            ConversationSubscription(
+                user_id=uid,
+                conversation_id=conversation.id,
+                role=GroupChatRole.participant,
+                is_archived=False,
             )
         )
 
@@ -339,6 +359,16 @@ def _mute_info(subscription: GroupChatSubscription) -> conversations_pb2.MuteInf
         muted=muted,
         muted_until=Timestamp_from_datetime(muted_until) if muted_until else None,
     )
+
+
+def _get_is_archived(session: Session, conversation_id: int, user_id: int) -> bool:
+    """Get archive status from conversation subscription"""
+    subscription = session.execute(
+        select(ConversationSubscription)
+        .where(ConversationSubscription.conversation_id == conversation_id)
+        .where(ConversationSubscription.user_id == user_id)
+    ).scalar_one_or_none()
+    return subscription.is_archived if subscription else False
 
 
 class Conversations(conversations_pb2_grpc.ConversationsServicer):
@@ -396,6 +426,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
                     latest_message=_message_to_pb(result.Message) if result.Message else None,
                     mute_info=_mute_info(result.GroupChatSubscription),
                     can_message=_user_can_message(session, context, result.GroupChat),
+                    is_archived=_get_is_archived(session, result.GroupChat.conversation_id, context.user_id),
                 )
                 for result in results[:page_size]
             ],
@@ -441,6 +472,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             latest_message=_message_to_pb(result.Message) if result.Message else None,
             mute_info=_mute_info(result.GroupChatSubscription),
             can_message=_user_can_message(session, context, result.GroupChat),
+            is_archived=_get_is_archived(session, result.GroupChat.conversation_id, context.user_id),
         )
 
     def GetDirectMessage(
@@ -496,6 +528,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             latest_message=_message_to_pb(result.Message) if result.Message else None,
             mute_info=_mute_info(result.GroupChatSubscription),
             can_message=_user_can_message(session, context, result.GroupChat),
+            is_archived=_get_is_archived(session, result.GroupChat.conversation_id, context.user_id),
         )
 
     def GetUpdates(
@@ -736,6 +769,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             created=Timestamp_from_datetime(group_chat.conversation.created),
             mute_info=_mute_info(your_subscription),
             can_message=True,
+            is_archived=False,  # New chats are never archived
         )
 
     def SendMessage(
@@ -1062,5 +1096,23 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         _add_message_to_subscription(session, subscription, message_type=MessageType.user_left)
 
         subscription.left = func.now()
+
+        return empty_pb2.Empty()
+
+    def SetConversationArchiveStatus(
+        self, request: conversations_pb2.SetConversationArchiveStatusReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
+        # Get the conversation subscription for this user
+        subscription = session.execute(
+            select(ConversationSubscription)
+            .where(ConversationSubscription.conversation_id == request.conversation_id)
+            .where(ConversationSubscription.user_id == context.user_id)
+        ).scalar_one_or_none()
+
+        if not subscription:
+            context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "conversation_not_found")
+
+        subscription.is_archived = request.is_archived
+        session.commit()
 
         return empty_pb2.Empty()

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -19,6 +19,8 @@ from couchers.metrics import (
 )
 from couchers.models import (
     Conversation,
+    ConversationSubscription,
+    ConversationType,
     HostRequest,
     HostRequestFeedback,
     HostRequestQuality,
@@ -127,6 +129,12 @@ def host_request_to_pb(
             )
         ).scalar_one()
 
+    # @TODO(NA): Use old fields for now (migration to ConversationSubscription will happen in next PR)
+    if context.user_id == host_request.surfer_user_id:
+        is_archived = host_request.is_surfer_archived
+    else:
+        is_archived = host_request.is_host_archived
+
     return requests_pb2.HostRequest(
         host_request_id=host_request.conversation_id,
         surfer_user_id=host_request.surfer_user_id,
@@ -146,6 +154,7 @@ def host_request_to_pb(
         hosting_lng=lng,
         hosting_radius=host_request.hosting_radius,
         need_host_request_feedback=need_feedback,
+        is_archived=is_archived,
     )
 
 
@@ -237,7 +246,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
                 substitutions={"hours": str(RATE_LIMIT_HOURS)},
             )
 
-        conversation = Conversation()
+        conversation = Conversation(type=ConversationType.host_request)
         session.add(conversation)
         session.flush()
 
@@ -283,6 +292,22 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         )
         session.add(host_request)
         session.flush()
+
+        # Create conversation subscriptions for both surfer and host
+        surfer_subscription = ConversationSubscription(
+            user_id=context.user_id,
+            conversation_id=conversation.id,
+            last_seen_message_id=message.id,
+            is_archived=False,
+        )
+        host_subscription = ConversationSubscription(
+            user_id=host.id,
+            conversation_id=conversation.id,
+            last_seen_message_id=0,
+            is_archived=False,
+        )
+        session.add(surfer_subscription)
+        session.add(host_subscription)
 
         notify(
             session,

--- a/app/backend/src/dummy_data.py
+++ b/app/backend/src/dummy_data.py
@@ -15,6 +15,7 @@ from couchers.models import (
     ClusterRole,
     ClusterSubscription,
     Conversation,
+    ConversationType,
     FriendRelationship,
     FriendStatus,
     GroupChat,
@@ -166,7 +167,7 @@ def add_dummy_users():
             creator = group_chat["creator"]
             creator_id = session.execute(select(User).where(User.username == creator)).scalar_one().id
 
-            conversation = Conversation()
+            conversation = Conversation(type=ConversationType.group_chat)
             session.add(conversation)
             session.flush()
 

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -1676,3 +1676,64 @@ def test_incomplete_profile(db):
             c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user3.id]))
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
         assert e.value.details() == "You have to complete your profile before you can send a message."
+
+
+def test_archive_group_chat(db, moderator):
+    """Test archiving and unarchiving group chats using SetConversationArchiveStatus."""
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    make_friends(user1, user2)
+
+    # User 1 creates a group chat with user 2
+    with conversations_session(token1) as api:
+        group_chat_id = api.CreateGroupChat(
+            conversations_pb2.CreateGroupChatReq(
+                recipient_user_ids=[user2.id],
+            )
+        ).group_chat_id
+
+        # Send a message so there's definitely a message in the chat
+        api.SendMessage(
+            conversations_pb2.SendMessageReq(
+                group_chat_id=group_chat_id,
+                text="Test message",
+            )
+        )
+
+    # Approve the group chat so it's visible to all users
+    moderator.approve_group_chat(group_chat_id)
+
+    with conversations_session(token1) as api:
+        # Initially not archived for user 1
+        group_chat = api.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=group_chat_id))
+        assert not group_chat.is_archived
+
+        # Archive the group chat for user 1
+        api.SetConversationArchiveStatus(
+            conversations_pb2.SetConversationArchiveStatusReq(
+                conversation_id=group_chat_id,
+                is_archived=True,
+            )
+        )
+
+        # Verify it's archived for user 1
+        group_chat = api.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=group_chat_id))
+        assert group_chat.is_archived
+
+    # Verify user 2 doesn't see it as archived (archive is per-user)
+    with conversations_session(token2) as api:
+        group_chat = api.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=group_chat_id))
+        assert not group_chat.is_archived
+
+    # User 1 unarchives it
+    with conversations_session(token1) as api:
+        api.SetConversationArchiveStatus(
+            conversations_pb2.SetConversationArchiveStatusReq(
+                conversation_id=group_chat_id,
+                is_archived=False,
+            )
+        )
+
+        # Verify it's no longer archived
+        group_chat = api.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=group_chat_id))
+        assert not group_chat.is_archived

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -11,6 +11,7 @@ from couchers.db import session_scope
 from couchers.materialized_views import refresh_materialized_views_rapid
 from couchers.models import (
     Conversation,
+    ConversationType,
     FriendRelationship,
     FriendStatus,
     HostRequest,
@@ -51,7 +52,7 @@ def create_host_request(
     from_date = today() - host_request_age - timedelta(days=2)
     to_date = today() - host_request_age
     fake_created = now() - host_request_age - timedelta(days=3)
-    conversation = Conversation()
+    conversation = Conversation(type=ConversationType.host_request)
     session.add(conversation)
     session.flush()
     session.add(
@@ -109,7 +110,7 @@ def create_host_request_by_date(
     host_sent_request_reminders,
     last_sent_request_reminder_time,
 ):
-    conversation = Conversation()
+    conversation = Conversation(type=ConversationType.host_request)
     session.add(conversation)
     session.flush()
 

--- a/app/proto/conversations.proto
+++ b/app/proto/conversations.proto
@@ -80,6 +80,10 @@ service Conversations {
     // Leave a group chat
   }
 
+  rpc SetConversationArchiveStatus(SetConversationArchiveStatusReq) returns (google.protobuf.Empty) {
+    // Archive or unarchive a conversation (group chat or host request)
+  }
+
   rpc SearchMessages(SearchMessagesReq) returns (SearchMessagesRes) {
     // Search messages by string
   }
@@ -162,6 +166,7 @@ message GroupChat {
   Message latest_message = 10;
   MuteInfo mute_info = 11;
   bool can_message = 12;
+  bool is_archived = 13; // whether this group chat is archived for the current user
 }
 
 message GetGroupChatReq {
@@ -272,6 +277,11 @@ message SendDirectMessageRes {
 
 message LeaveGroupChatReq {
   uint64 group_chat_id = 1;
+}
+
+message SetConversationArchiveStatusReq {
+  uint64 conversation_id = 1;
+  bool is_archived = 2;
 }
 
 message SearchMessagesReq {

--- a/app/proto/requests.proto
+++ b/app/proto/requests.proto
@@ -76,6 +76,7 @@ message HostRequest {
   double hosting_lng = 12;
   double hosting_radius = 13;
   bool need_host_request_feedback = 14;
+  bool is_archived = 15; // whether this host request is archived for the current user
 }
 
 message GetHostRequestReq {


### PR DESCRIPTION
Part of #6528 

Goals:

- we want to introduce ability to archive messages and host requests
- we want to introduce an "all", "requests" and "archived" tabs to the messages screen so need to query for that eventually
- group chats also need ability to be archived (right now only host req do on backend)
- host requests have `is_host_archived` and `is_surfer_archived` hardcoded into HostRequest, doesn't follow existing pattern we have e.g. `GroupChatSubscription `

My suggestion:
- make `conversation_subscriptions` table with per-user state (step 1, in this PR)
- add to this table when new group chats or host requests are created (step 1, in this PR)
- replace `group_chat_subscriptions` with `conversation_subscriptions` and migrate existing convos there
- migrate existing host requests so all have `conversation_subscriptions` rows
- frontend can then easily query for the different views, all with `conversation_subscriptions` with different filters

Let me know if y'all are happy with this plan!

**TO TEST:**
- Run backend locally, should run without error
- Change `NEXT_PUBLIC_API_URL` in web `.env.development` to the value from `.env.localdev`
- in `app/web`, yarn install then yarn start the frontend
- Create a group chat
- Check the `conversation_subscriptions` table it should have 1 row for each user in the chat
- Existing chats should still work fine