### PR TITLE
Let relationship targets be inferred from type annotations

### DIFF
--- a/app/backend/src/couchers/models/activeness_probe.py
+++ b/app/backend/src/couchers/models/activeness_probe.py
@@ -54,7 +54,7 @@ class ActivenessProbe(Base):
     def is_pending(self) -> bool:
         return self.responded == None
 
-    user: Mapped[User] = relationship("User", back_populates="pending_activeness_probe")
+    user: Mapped[User] = relationship(back_populates="pending_activeness_probe")
 
     __table_args__ = (
         # a user can have at most one pending activeness probe at a time

--- a/app/backend/src/couchers/models/auth.py
+++ b/app/backend/src/couchers/models/auth.py
@@ -65,7 +65,7 @@ class UserSession(Base):
     ip_address: Mapped[str | None] = mapped_column(String, default=None)
     user_agent: Mapped[str | None] = mapped_column(String, default=None)
 
-    user: Mapped[User] = relationship("User", backref="sessions")
+    user: Mapped[User] = relationship(backref="sessions")
 
     @hybrid_property
     def is_valid(self) -> Any:
@@ -106,7 +106,7 @@ class LoginToken(Base):
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     expiry: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
-    user: Mapped[User] = relationship("User", backref="login_tokens")
+    user: Mapped[User] = relationship(backref="login_tokens")
 
     @hybrid_property
     def is_valid(self) -> Any:
@@ -125,7 +125,7 @@ class PasswordResetToken(Base):
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     expiry: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
-    user: Mapped[User] = relationship("User", backref="password_reset_tokens")
+    user: Mapped[User] = relationship(backref="password_reset_tokens")
 
     @hybrid_property
     def is_valid(self) -> Any:

--- a/app/backend/src/couchers/models/clusters.py
+++ b/app/backend/src/couchers/models/clusters.py
@@ -54,13 +54,10 @@ class Node(Base):
     geom: Mapped[Geom] = deferred(mapped_column(Geometry(geometry_type="MULTIPOLYGON", srid=4326), nullable=False))
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    parent_node: Mapped[Node] = relationship("Node", back_populates="child_nodes", remote_side="Node.id")
-    child_nodes: Mapped[list[Node]] = relationship("Node")
-    child_clusters: Mapped[list[Cluster]] = relationship(
-        "Cluster", back_populates="parent_node", overlaps="official_cluster"
-    )
+    parent_node: Mapped[Node] = relationship(back_populates="child_nodes", remote_side="Node.id")
+    child_nodes: Mapped[list[Node]] = relationship()
+    child_clusters: Mapped[list[Cluster]] = relationship(back_populates="parent_node", overlaps="official_cluster")
     official_cluster: Mapped[Cluster] = relationship(
-        "Cluster",
         primaryjoin="and_(Node.id == Cluster.parent_node_id, Cluster.is_official_cluster)",
         foreign_keys="[Cluster.parent_node_id]",
         uselist=False,
@@ -92,7 +89,6 @@ class Cluster(Base):
     slug: Mapped[str] = column_property(func.slugify(name))
 
     official_cluster_for_node: Mapped[Node] = relationship(
-        "Node",
         primaryjoin="and_(Cluster.parent_node_id == Node.id, Cluster.is_official_cluster)",
         back_populates="official_cluster",
         uselist=False,
@@ -100,7 +96,6 @@ class Cluster(Base):
     )
 
     parent_node: Mapped[Node] = relationship(
-        "Node",
         back_populates="child_clusters",
         remote_side="Node.id",
         foreign_keys="Cluster.parent_node_id",
@@ -108,22 +103,19 @@ class Cluster(Base):
     )
 
     nodes: Mapped[list[Cluster]] = relationship(
-        "Cluster", backref="clusters", secondary="node_cluster_associations", viewonly=True
+        backref="clusters", secondary="node_cluster_associations", viewonly=True
     )
     # all pages
     pages: DynamicMapped[Page] = relationship(
-        "Page", backref="clusters", secondary="cluster_page_associations", lazy="dynamic", viewonly=True
+        backref="clusters", secondary="cluster_page_associations", lazy="dynamic", viewonly=True
     )
-    events: Mapped[Event] = relationship(
-        "Event", backref="clusters", secondary="cluster_event_associations", viewonly=True
-    )
+    events: Mapped[Event] = relationship(backref="clusters", secondary="cluster_event_associations", viewonly=True)
     discussions: Mapped[Discussion] = relationship(
-        "Discussion", backref="clusters", secondary="cluster_discussion_associations", viewonly=True
+        backref="clusters", secondary="cluster_discussion_associations", viewonly=True
     )
 
     # includes also admins
     members: DynamicMapped[User] = relationship(
-        "User",
         lazy="dynamic",
         backref="cluster_memberships",
         secondary="cluster_subscriptions",
@@ -133,7 +125,6 @@ class Cluster(Base):
     )
 
     admins: DynamicMapped[User] = relationship(
-        "User",
         lazy="dynamic",
         backref="cluster_adminships",
         secondary="cluster_subscriptions",
@@ -142,12 +133,11 @@ class Cluster(Base):
         viewonly=True,
     )
 
-    cluster_subscriptions: Mapped[list[ClusterSubscription]] = relationship("ClusterSubscription")
-    owned_pages: DynamicMapped[Page] = relationship("Page", lazy="dynamic")
-    owned_discussions: DynamicMapped[Discussion] = relationship("Discussion", lazy="dynamic")
+    cluster_subscriptions: Mapped[list[ClusterSubscription]] = relationship()
+    owned_pages: DynamicMapped[Page] = relationship(lazy="dynamic")
+    owned_discussions: DynamicMapped[Discussion] = relationship(lazy="dynamic")
 
     main_page: Mapped[Page] = relationship(
-        "Page",
         primaryjoin="and_(Cluster.id == Page.owner_cluster_id, Page.type == 'main_page')",
         viewonly=True,
         uselist=False,
@@ -190,8 +180,8 @@ class NodeClusterAssociation(Base):
     node_id: Mapped[int] = mapped_column(ForeignKey("nodes.id"), index=True)
     cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
 
-    node: Mapped[Node] = relationship("Node", backref="node_cluster_associations")
-    cluster: Mapped[Cluster] = relationship("Cluster", backref="node_cluster_associations")
+    node: Mapped[Node] = relationship(backref="node_cluster_associations")
+    cluster: Mapped[Cluster] = relationship(backref="node_cluster_associations")
 
 
 class ClusterRole(enum.Enum):
@@ -212,8 +202,8 @@ class ClusterSubscription(Base):
     cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
     role: Mapped[ClusterRole] = mapped_column(Enum(ClusterRole))
 
-    user: Mapped[User] = relationship("User", backref="cluster_subscriptions")
-    cluster: Mapped[Cluster] = relationship("Cluster", back_populates="cluster_subscriptions")
+    user: Mapped[User] = relationship(backref="cluster_subscriptions")
+    cluster: Mapped[Cluster] = relationship(back_populates="cluster_subscriptions")
 
     __table_args__ = (
         UniqueConstraint("user_id", "cluster_id"),
@@ -245,8 +235,8 @@ class ClusterPageAssociation(Base):
     page_id: Mapped[int] = mapped_column(ForeignKey("pages.id"), index=True)
     cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
 
-    page: Mapped[Page] = relationship("Page", backref="cluster_page_associations")
-    cluster: Mapped[Cluster] = relationship("Cluster", backref="cluster_page_associations")
+    page: Mapped[Page] = relationship(backref="cluster_page_associations")
+    cluster: Mapped[Cluster] = relationship(backref="cluster_page_associations")
 
 
 class PageType(enum.Enum):
@@ -275,18 +265,18 @@ class Page(Base):
     thread_id: Mapped[int] = mapped_column(ForeignKey("threads.id"), unique=True)
 
     parent_node: Mapped[Node] = relationship(
-        "Node", backref="child_pages", remote_side="Node.id", foreign_keys="Page.parent_node_id"
+        backref="child_pages", remote_side="Node.id", foreign_keys="Page.parent_node_id"
     )
 
-    thread: Mapped[Thread] = relationship("Thread", backref="page", uselist=False)
-    creator_user: Mapped[User] = relationship("User", backref="created_pages", foreign_keys="Page.creator_user_id")
-    owner_user: Mapped[User | None] = relationship("User", backref="owned_pages", foreign_keys="Page.owner_user_id")
+    thread: Mapped[Thread] = relationship(backref="page", uselist=False)
+    creator_user: Mapped[User] = relationship(backref="created_pages", foreign_keys="Page.creator_user_id")
+    owner_user: Mapped[User | None] = relationship(backref="owned_pages", foreign_keys="Page.owner_user_id")
     owner_cluster: Mapped[Cluster | None] = relationship(
-        "Cluster", back_populates="owned_pages", uselist=False, foreign_keys="Page.owner_cluster_id"
+        back_populates="owned_pages", uselist=False, foreign_keys="Page.owner_cluster_id"
     )
 
-    editors: Mapped[list[User]] = relationship("User", secondary="page_versions", viewonly=True)
-    versions: Mapped[list[PageVersion]] = relationship("PageVersion", back_populates="page", order_by="PageVersion.id")
+    editors: Mapped[list[User]] = relationship(secondary="page_versions", viewonly=True)
+    versions: Mapped[list[PageVersion]] = relationship(back_populates="page", order_by="PageVersion.id")
 
     __table_args__ = (
         # Only one of owner_user and owner_cluster should be set
@@ -334,9 +324,9 @@ class PageVersion(Base):
 
     slug: Mapped[str] = column_property(func.slugify(title))
 
-    page: Mapped[Page] = relationship("Page", back_populates="versions")
-    editor_user: Mapped[User] = relationship("User", backref="edited_pages")
-    photo: Mapped[Upload] = relationship("Upload")
+    page: Mapped[Page] = relationship(back_populates="versions")
+    editor_user: Mapped[User] = relationship(backref="edited_pages")
+    photo: Mapped[Upload] = relationship()
 
     __table_args__ = (
         # Geom and address must either both be null or both be set

--- a/app/backend/src/couchers/models/conversations.py
+++ b/app/backend/src/couchers/models/conversations.py
@@ -48,10 +48,10 @@ class GroupChat(Base):
     # Unified Moderation System
     moderation_state_id: Mapped[int] = mapped_column(ForeignKey("moderation_states.id"), index=True)
 
-    conversation: Mapped[Conversation] = relationship("Conversation", backref="group_chat")
-    creator: Mapped[User] = relationship("User", backref="created_group_chats")
-    moderation_state: Mapped[ModerationState] = relationship("ModerationState")
-    subscriptions: DynamicMapped[GroupChatSubscription] = relationship("GroupChatSubscription", lazy="dynamic")
+    conversation: Mapped[Conversation] = relationship(backref="group_chat")
+    creator: Mapped[User] = relationship(backref="created_group_chats")
+    moderation_state: Mapped[ModerationState] = relationship()
+    subscriptions: DynamicMapped[GroupChatSubscription] = relationship(lazy="dynamic")
 
     def __repr__(self) -> str:
         return f"GroupChat(conversation={self.conversation}, title={self.title or 'None'}, only_admins_invite={self.only_admins_invite}, creator={self.creator}, is_dm={self.is_dm})"
@@ -87,8 +87,8 @@ class GroupChatSubscription(Base):
         DateTime(timezone=True), server_default=DATETIME_MINUS_INFINITY.isoformat()
     )
 
-    user: Mapped[User] = relationship("User", backref="group_chat_subscriptions")
-    group_chat: Mapped[GroupChat] = relationship("GroupChat", back_populates="subscriptions")
+    user: Mapped[User] = relationship(backref="group_chat_subscriptions")
+    group_chat: Mapped[GroupChat] = relationship(back_populates="subscriptions")
 
     def muted_display(self) -> tuple[bool, datetime | None]:
         """
@@ -160,11 +160,9 @@ class Message(Base):
     # the new host request status if the message type is host_request_status_changed
     host_request_status_target: Mapped[HostRequestStatus | None] = mapped_column(Enum(HostRequestStatus), nullable=True)
 
-    conversation: Mapped[Conversation] = relationship(
-        "Conversation", backref="messages", order_by="Message.time.desc()"
-    )
-    author: Mapped[User] = relationship("User", foreign_keys="Message.author_id")
-    target: Mapped[User | None] = relationship("User", foreign_keys="Message.target_id")
+    conversation: Mapped[Conversation] = relationship(backref="messages", order_by="Message.time.desc()")
+    author: Mapped[User] = relationship(foreign_keys="Message.author_id")
+    target: Mapped[User | None] = relationship(foreign_keys="Message.target_id")
 
     @property
     def is_normal_message(self) -> bool:

--- a/app/backend/src/couchers/models/discussions.py
+++ b/app/backend/src/couchers/models/discussions.py
@@ -31,16 +31,14 @@ class Discussion(Base):
 
     slug: Mapped[str] = column_property(func.slugify(title))
 
-    thread: Mapped[Thread] = relationship("Thread", backref="discussion", uselist=False)
+    thread: Mapped[Thread] = relationship(backref="discussion", uselist=False)
 
     subscribers: Mapped[list[User]] = relationship(
-        "User", backref="discussions", secondary="discussion_subscriptions", viewonly=True
+        backref="discussions", secondary="discussion_subscriptions", viewonly=True
     )
 
-    creator_user: Mapped[User] = relationship(
-        "User", backref="created_discussions", foreign_keys="Discussion.creator_user_id"
-    )
-    owner_cluster: Mapped[Cluster] = relationship("Cluster", back_populates="owned_discussions", uselist=False)
+    creator_user: Mapped[User] = relationship(backref="created_discussions", foreign_keys="Discussion.creator_user_id")
+    owner_cluster: Mapped[Cluster] = relationship(back_populates="owned_discussions", uselist=False)
 
 
 class DiscussionSubscription(Base):
@@ -58,8 +56,8 @@ class DiscussionSubscription(Base):
     joined: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     left: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
-    user: Mapped[User] = relationship("User", backref="discussion_subscriptions")
-    discussion: Mapped[Discussion] = relationship("Discussion", backref="discussion_subscriptions")
+    user: Mapped[User] = relationship(backref="discussion_subscriptions")
+    discussion: Mapped[Discussion] = relationship(backref="discussion_subscriptions")
 
 
 class Thread(Base):
@@ -90,7 +88,7 @@ class Comment(Base):
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     deleted: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
-    thread: Mapped[Thread] = relationship("Thread", backref="comments")
+    thread: Mapped[Thread] = relationship(backref="comments")
 
 
 class Reply(Base):
@@ -108,7 +106,7 @@ class Reply(Base):
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     deleted: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
-    comment: Mapped[Comment] = relationship("Comment", backref="replies")
+    comment: Mapped[Comment] = relationship(backref="replies")
 
 
 class ClusterDiscussionAssociation(Base):
@@ -124,5 +122,5 @@ class ClusterDiscussionAssociation(Base):
     discussion_id: Mapped[int] = mapped_column(ForeignKey("discussions.id"), index=True)
     cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
 
-    discussion: Mapped[Discussion] = relationship("Discussion", backref="cluster_discussion_associations")
-    cluster: Mapped[Cluster] = relationship("Cluster", backref="cluster_discussion_associations")
+    discussion: Mapped[Discussion] = relationship(backref="cluster_discussion_associations")
+    cluster: Mapped[Cluster] = relationship(backref="cluster_discussion_associations")

--- a/app/backend/src/couchers/models/donations.py
+++ b/app/backend/src/couchers/models/donations.py
@@ -38,7 +38,7 @@ class DonationInitiation(Base):
     donation_type: Mapped[DonationType] = mapped_column(Enum(DonationType))
     source: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    user: Mapped[User] = relationship("User", backref="donation_initiations")
+    user: Mapped[User] = relationship(backref="donation_initiations")
 
 
 class Invoice(Base):
@@ -61,4 +61,4 @@ class Invoice(Base):
 
     invoice_type: Mapped[InvoiceType] = mapped_column(Enum(InvoiceType))
 
-    user: Mapped[User] = relationship("User", backref="invoices")
+    user: Mapped[User] = relationship(backref="invoices")

--- a/app/backend/src/couchers/models/events.py
+++ b/app/backend/src/couchers/models/events.py
@@ -43,8 +43,8 @@ class ClusterEventAssociation(Base):
     event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), index=True)
     cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
 
-    event: Mapped[Event] = relationship("Event", backref="cluster_event_associations")
-    cluster: Mapped[Cluster] = relationship("Cluster", backref="cluster_event_associations")
+    event: Mapped[Event] = relationship(backref="cluster_event_associations")
+    cluster: Mapped[Cluster] = relationship(backref="cluster_event_associations")
 
 
 class Event(Base):
@@ -76,24 +76,23 @@ class Event(Base):
     thread_id: Mapped[int] = mapped_column(ForeignKey("threads.id"), unique=True)
 
     parent_node: Mapped[Node] = relationship(
-        "Node", backref="child_events", remote_side="Node.id", foreign_keys="Event.parent_node_id"
+        backref="child_events", remote_side="Node.id", foreign_keys="Event.parent_node_id"
     )
-    thread: Mapped[Thread] = relationship("Thread", backref="event", uselist=False)
+    thread: Mapped[Thread] = relationship(backref="event", uselist=False)
     subscribers: DynamicMapped[User] = relationship(
-        "User", backref="subscribed_events", secondary="event_subscriptions", lazy="dynamic", viewonly=True
+        backref="subscribed_events", secondary="event_subscriptions", lazy="dynamic", viewonly=True
     )
     organizers: DynamicMapped[User] = relationship(
-        "User", backref="organized_events", secondary="event_organizers", lazy="dynamic", viewonly=True
+        backref="organized_events", secondary="event_organizers", lazy="dynamic", viewonly=True
     )
-    creator_user: Mapped[User] = relationship("User", backref="created_events", foreign_keys="Event.creator_user_id")
-    owner_user: Mapped[User | None] = relationship("User", backref="owned_events", foreign_keys="Event.owner_user_id")
+    creator_user: Mapped[User] = relationship(backref="created_events", foreign_keys="Event.creator_user_id")
+    owner_user: Mapped[User | None] = relationship(backref="owned_events", foreign_keys="Event.owner_user_id")
     owner_cluster: Mapped[Cluster | None] = relationship(
-        "Cluster",
         backref=backref("owned_events", lazy="dynamic"),
         uselist=False,
         foreign_keys="Event.owner_cluster_id",
     )
-    occurrences: DynamicMapped[EventOccurrence] = relationship("EventOccurrence", lazy="dynamic")
+    occurrences: DynamicMapped[EventOccurrence] = relationship(lazy="dynamic")
 
     __table_args__ = (
         # Only one of owner_user and owner_cluster should be set
@@ -137,21 +136,18 @@ class EventOccurrence(Base):
     last_edited: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     creator_user: Mapped[User] = relationship(
-        "User", backref="created_event_occurrences", foreign_keys="EventOccurrence.creator_user_id"
+        backref="created_event_occurrences", foreign_keys="EventOccurrence.creator_user_id"
     )
     event: Mapped[Event] = relationship(
-        "Event",
         back_populates="occurrences",
         remote_side="Event.id",
         foreign_keys="EventOccurrence.event_id",
     )
 
-    photo: Mapped[Upload | None] = relationship("Upload")
-    attendances: DynamicMapped[EventOccurrenceAttendee] = relationship(
-        "EventOccurrenceAttendee", back_populates="occurrence", lazy="dynamic"
-    )
+    photo: Mapped[Upload | None] = relationship()
+    attendances: DynamicMapped[EventOccurrenceAttendee] = relationship(back_populates="occurrence", lazy="dynamic")
     community_invite_requests: DynamicMapped[EventCommunityInviteRequest] = relationship(
-        "EventCommunityInviteRequest", back_populates="occurrence", lazy="dynamic"
+        back_populates="occurrence", lazy="dynamic"
     )
 
     __table_args__ = (
@@ -168,7 +164,7 @@ class EventOccurrence(Base):
             name="link_or_geom",
         ),
         # Can't have overlapping occurrences in the same Event
-        ExcludeConstraint(("event_id", "="), ("during", "&&"), name="event_occurrences_event_id_during_excl"),  # type: ignore[no-untyped-call]
+        ExcludeConstraint(("event_id", "="), ("during", "&&"), name="event_occurrences_event_id_during_excl"),
     )
 
     @property
@@ -209,8 +205,8 @@ class EventSubscription(Base):
     event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), index=True)
     joined: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    user: Mapped[User] = relationship("User")
-    event: Mapped[Event] = relationship("Event")
+    user: Mapped[User] = relationship()
+    event: Mapped[Event] = relationship()
 
 
 class EventOrganizer(Base):
@@ -227,8 +223,8 @@ class EventOrganizer(Base):
     event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), index=True)
     joined: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    user: Mapped[User] = relationship("User")
-    event: Mapped[Event] = relationship("Event")
+    user: Mapped[User] = relationship()
+    event: Mapped[Event] = relationship()
 
 
 class AttendeeStatus(enum.Enum):
@@ -251,8 +247,8 @@ class EventOccurrenceAttendee(Base):
     responded: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     attendee_status: Mapped[AttendeeStatus] = mapped_column(Enum(AttendeeStatus))
 
-    user: Mapped[User] = relationship("User")
-    occurrence: Mapped[EventOccurrence] = relationship("EventOccurrence", back_populates="attendances")
+    user: Mapped[User] = relationship()
+    occurrence: Mapped[EventOccurrence] = relationship(back_populates="attendances")
 
     reminder_sent: Mapped[bool] = mapped_column(Boolean, default=False, server_default=expression.false())
 
@@ -275,8 +271,8 @@ class EventCommunityInviteRequest(Base):
     decided_by_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"))
     approved: Mapped[bool | None] = mapped_column(Boolean)
 
-    occurrence: Mapped[EventOccurrence] = relationship("EventOccurrence", back_populates="community_invite_requests")
-    user: Mapped[User] = relationship("User", foreign_keys="EventCommunityInviteRequest.user_id")
+    occurrence: Mapped[EventOccurrence] = relationship(back_populates="community_invite_requests")
+    user: Mapped[User] = relationship(foreign_keys="EventCommunityInviteRequest.user_id")
 
     __table_args__ = (
         # each user can only request once

--- a/app/backend/src/couchers/models/host_requests.py
+++ b/app/backend/src/couchers/models/host_requests.py
@@ -84,10 +84,10 @@ class HostRequest(Base):
     host_reason_didnt_meetup: Mapped[str | None] = mapped_column(String, nullable=True)
     surfer_reason_didnt_meetup: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    surfer: Mapped[User] = relationship("User", backref="host_requests_sent", foreign_keys="HostRequest.surfer_user_id")
-    host: Mapped[User] = relationship("User", backref="host_requests_received", foreign_keys="HostRequest.host_user_id")
-    conversation: Mapped[Conversation] = relationship("Conversation")
-    moderation_state: Mapped[ModerationState] = relationship("ModerationState")
+    surfer: Mapped[User] = relationship(backref="host_requests_sent", foreign_keys="HostRequest.surfer_user_id")
+    host: Mapped[User] = relationship(backref="host_requests_received", foreign_keys="HostRequest.host_user_id")
+    conversation: Mapped[Conversation] = relationship()
+    moderation_state: Mapped[ModerationState] = relationship()
 
     __table_args__ = (
         # allows fast lookup as to whether they didn't meet up
@@ -146,7 +146,7 @@ class HostRequestFeedback(Base):
     request_quality: Mapped[HostRequestQuality | None] = mapped_column(Enum(HostRequestQuality), nullable=True)
     decline_reason: Mapped[str | None] = mapped_column(String, nullable=True)  # plain text
 
-    host_request: Mapped[HostRequest] = relationship("HostRequest")
+    host_request: Mapped[HostRequest] = relationship()
 
     __table_args__ = (
         # Each user can leave at most one friend reference to another user

--- a/app/backend/src/couchers/models/mod_note.py
+++ b/app/backend/src/couchers/models/mod_note.py
@@ -33,7 +33,7 @@ class ModNote(Base):
 
     note_content: Mapped[str] = mapped_column(String)  # CommonMark without images
 
-    user: Mapped[User] = relationship("User", foreign_keys="ModNote.user_id", back_populates="mod_notes")
+    user: Mapped[User] = relationship(foreign_keys="ModNote.user_id", back_populates="mod_notes")
 
     def __repr__(self) -> str:
         return f"ModeNote(id={self.id}, user={self.user}, created={self.created}, ack'd={self.acknowledged})"

--- a/app/backend/src/couchers/models/moderation.py
+++ b/app/backend/src/couchers/models/moderation.py
@@ -121,7 +121,7 @@ class ModerationQueueItem(Base):
     resolved_by_log_id: Mapped[int | None] = mapped_column(ForeignKey("moderation_log.id"), index=True)
 
     # Relationships
-    moderation_state: Mapped[ModerationState] = relationship("ModerationState")
+    moderation_state: Mapped[ModerationState] = relationship()
 
     __table_args__ = (
         # Fast lookup of unresolved items
@@ -165,8 +165,8 @@ class ModerationLog(Base):
     reason: Mapped[str] = mapped_column(String)
 
     # Relationships
-    moderation_state: Mapped[ModerationState] = relationship("ModerationState")
-    moderator: Mapped[User] = relationship("User")
+    moderation_state: Mapped[ModerationState] = relationship()
+    moderator: Mapped[User] = relationship()
 
     __table_args__ = (
         # Fast lookup of log entries for a given state, ordered by time

--- a/app/backend/src/couchers/models/notifications.py
+++ b/app/backend/src/couchers/models/notifications.py
@@ -177,7 +177,7 @@ class NotificationPreference(Base):
     delivery_type: Mapped[NotificationDeliveryType] = mapped_column(Enum(NotificationDeliveryType))
     deliver: Mapped[bool] = mapped_column(Boolean)
 
-    user: Mapped[User] = relationship("User", foreign_keys="NotificationPreference.user_id")
+    user: Mapped[User] = relationship(foreign_keys="NotificationPreference.user_id")
 
     __table_args__ = (UniqueConstraint("user_id", "topic_action", "delivery_type"),)
 
@@ -209,10 +209,8 @@ class Notification(Base):
         ForeignKey("moderation_states.id"), nullable=True, index=True
     )
 
-    user: Mapped[User] = relationship("User", foreign_keys="Notification.user_id")
-    moderation_state: Mapped[ModerationState] = relationship(
-        "ModerationState", foreign_keys="Notification.moderation_state_id"
-    )
+    user: Mapped[User] = relationship(foreign_keys="Notification.user_id")
+    moderation_state: Mapped[ModerationState] = relationship(foreign_keys="Notification.moderation_state_id")
 
     __table_args__ = (
         # used in looking up which notifications need delivery
@@ -257,9 +255,7 @@ class NotificationDelivery(Base):
     delivery_type: Mapped[NotificationDeliveryType] = mapped_column(Enum(NotificationDeliveryType))
     # todo: device id
     # todo: receipt id, etc
-    notification: Mapped[Notification] = relationship(
-        "Notification", foreign_keys="NotificationDelivery.notification_id"
-    )
+    notification: Mapped[Notification] = relationship(foreign_keys="NotificationDelivery.notification_id")
 
     __table_args__ = (
         UniqueConstraint("notification_id", "delivery_type"),
@@ -331,7 +327,7 @@ class PushNotificationSubscription(Base):
     # when it was disabled
     disabled_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=DATETIME_INFINITY.isoformat())
 
-    user: Mapped[User] = relationship("User")
+    user: Mapped[User] = relationship()
 
     __table_args__ = (
         # web_push platform requires: endpoint, auth_key, p256dh_key, full_subscription_info
@@ -372,4 +368,4 @@ class PushNotificationDeliveryAttempt(Base):
     receipt_status: Mapped[str | None] = mapped_column(String)  # "ok" or "error"
     receipt_error_code: Mapped[str | None] = mapped_column(String)  # e.g., "DeviceNotRegistered"
 
-    push_notification_subscription: Mapped[PushNotificationSubscription] = relationship("PushNotificationSubscription")
+    push_notification_subscription: Mapped[PushNotificationSubscription] = relationship()

--- a/app/backend/src/couchers/models/postal_verification.py
+++ b/app/backend/src/couchers/models/postal_verification.py
@@ -92,7 +92,7 @@ class PostalVerificationAttempt(Base):
         return cls.status == PostalVerificationStatus.succeeded
 
     # Relationships
-    user: Mapped[User] = relationship("User")
+    user: Mapped[User] = relationship()
 
     # Constraints
     __table_args__ = (

--- a/app/backend/src/couchers/models/rest.py
+++ b/app/backend/src/couchers/models/rest.py
@@ -53,7 +53,7 @@ class UserBadge(Base):
     # take this with a grain of salt, someone may get then lose a badge for whatever reason
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    user: Mapped[User] = relationship("User", back_populates="badges")
+    user: Mapped[User] = relationship(back_populates="badges")
 
 
 class FriendStatus(enum.Enum):
@@ -84,10 +84,8 @@ class FriendRelationship(Base):
     time_sent: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     time_responded: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
-    from_user: Mapped[User] = relationship(
-        "User", backref="friends_from", foreign_keys="FriendRelationship.from_user_id"
-    )
-    to_user: Mapped[User] = relationship("User", backref="friends_to", foreign_keys="FriendRelationship.to_user_id")
+    from_user: Mapped[User] = relationship(backref="friends_from", foreign_keys="FriendRelationship.from_user_id")
+    to_user: Mapped[User] = relationship(backref="friends_to", foreign_keys="FriendRelationship.to_user_id")
 
     __table_args__ = (
         # Ping looks up pending friend reqs, this speeds that up
@@ -125,7 +123,7 @@ class ContributorForm(Base):
     contribute_ways: Mapped[list[str]] = mapped_column(ARRAY(String))
     expertise: Mapped[str | None] = mapped_column(String)
 
-    user: Mapped[User] = relationship("User", backref="contributor_forms")
+    user: Mapped[User] = relationship(backref="contributor_forms")
 
     @hybrid_property
     def is_filled(self) -> Any:
@@ -236,7 +234,7 @@ class AccountDeletionToken(Base):
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     expiry: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
-    user: Mapped[User] = relationship("User", backref="account_deletion_tokens")
+    user: Mapped[User] = relationship(backref="account_deletion_tokens")
 
     @hybrid_property
     def is_valid(self) -> Any:
@@ -289,7 +287,7 @@ class InviteCode(Base):
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=func.now())
     disabled: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
-    creator: Mapped[User] = relationship("User", foreign_keys=[creator_user_id])
+    creator: Mapped[User] = relationship(foreign_keys=[creator_user_id])
 
 
 class ContentReport(Base):
@@ -322,8 +320,8 @@ class ContentReport(Base):
     page: Mapped[str] = mapped_column(String)
 
     # see comments above for reporting vs author
-    reporting_user: Mapped[User] = relationship("User", foreign_keys="ContentReport.reporting_user_id")
-    author_user: Mapped[User] = relationship("User", foreign_keys="ContentReport.author_user_id")
+    reporting_user: Mapped[User] = relationship(foreign_keys="ContentReport.reporting_user_id")
+    author_user: Mapped[User] = relationship(foreign_keys="ContentReport.author_user_id")
 
 
 class Email(Base):
@@ -404,10 +402,10 @@ class Reference(Base):
 
     is_deleted: Mapped[bool] = mapped_column(Boolean, default=False, server_default=expression.false())
 
-    from_user: Mapped[User] = relationship("User", backref="references_from", foreign_keys="Reference.from_user_id")
-    to_user: Mapped[User] = relationship("User", backref="references_to", foreign_keys="Reference.to_user_id")
+    from_user: Mapped[User] = relationship(backref="references_from", foreign_keys="Reference.from_user_id")
+    to_user: Mapped[User] = relationship(backref="references_to", foreign_keys="Reference.to_user_id")
 
-    host_request: Mapped[HostRequest | None] = relationship("HostRequest", backref="references")
+    host_request: Mapped[HostRequest | None] = relationship(backref="references")
 
     __table_args__ = (
         # Rating must be between 0 and 1, inclusive
@@ -461,8 +459,8 @@ class UserBlock(Base):
     blocked_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     time_blocked: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    blocking_user: Mapped[User] = relationship("User", foreign_keys="UserBlock.blocking_user_id")
-    blocked_user: Mapped[User] = relationship("User", foreign_keys="UserBlock.blocked_user_id")
+    blocking_user: Mapped[User] = relationship(foreign_keys="UserBlock.blocking_user_id")
+    blocked_user: Mapped[User] = relationship(foreign_keys="UserBlock.blocked_user_id")
 
     __table_args__ = (
         UniqueConstraint("blocking_user_id", "blocked_user_id"),
@@ -479,7 +477,7 @@ class AccountDeletionReason(Base):
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     reason: Mapped[str | None] = mapped_column(String)
 
-    user: Mapped[User] = relationship("User")
+    user: Mapped[User] = relationship()
 
 
 class ModerationUserList(Base):
@@ -493,7 +491,7 @@ class ModerationUserList(Base):
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     users: Mapped[list[User]] = relationship(
-        "User", secondary="moderation_user_list_members", back_populates="moderation_user_lists"
+        secondary="moderation_user_list_members", back_populates="moderation_user_lists"
     )
 
 
@@ -542,7 +540,7 @@ class RateLimitViolation(Base):
     action: Mapped[RateLimitAction] = mapped_column(Enum(RateLimitAction))
     is_hard_limit: Mapped[bool] = mapped_column(Boolean)
 
-    user: Mapped[User] = relationship("User")
+    user: Mapped[User] = relationship()
 
     __table_args__ = (
         # Fast lookup for rate limits in interval

--- a/app/backend/src/couchers/models/uploads.py
+++ b/app/backend/src/couchers/models/uploads.py
@@ -27,7 +27,7 @@ class InitiatedUpload(Base):
 
     initiator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    initiator_user: Mapped[User] = relationship("User")
+    initiator_user: Mapped[User] = relationship()
 
     @hybrid_property
     def is_valid(self) -> Any:
@@ -50,7 +50,7 @@ class Upload(Base):
     # photo credit, etc
     credit: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    creator_user: Mapped[User] = relationship("User", backref="uploads", foreign_keys="Upload.creator_user_id")
+    creator_user: Mapped[User] = relationship(backref="uploads", foreign_keys="Upload.creator_user_id")
 
     def _url(self, size: str) -> str:
         return urls.media_url(filename=self.filename, size=size)
@@ -79,9 +79,8 @@ class PhotoGallery(Base):
 
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    owner_user: Mapped[User] = relationship("User", foreign_keys=[owner_user_id], back_populates="galleries")
+    owner_user: Mapped[User] = relationship(foreign_keys=[owner_user_id], back_populates="galleries")
     photos: Mapped[list[PhotoGalleryItem]] = relationship(
-        "PhotoGalleryItem",
         back_populates="gallery",
         order_by="PhotoGalleryItem.position",
     )
@@ -106,8 +105,8 @@ class PhotoGalleryItem(Base):
 
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    gallery: Mapped[PhotoGallery] = relationship("PhotoGallery", back_populates="photos")
-    upload: Mapped[Upload] = relationship("Upload")
+    gallery: Mapped[PhotoGallery] = relationship(back_populates="photos")
+    upload: Mapped[Upload] = relationship()
 
     __table_args__ = (
         # Ensure each upload is only in a gallery once

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -127,8 +127,8 @@ class User(Base):
     # "Grew up in" on profile
     hometown: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    regions_visited: Mapped[list[Region]] = relationship("Region", secondary="regions_visited", order_by="Region.name")
-    regions_lived: Mapped[list[Region]] = relationship("Region", secondary="regions_lived", order_by="Region.name")
+    regions_visited: Mapped[list[Region]] = relationship(secondary="regions_visited", order_by="Region.name")
+    regions_lived: Mapped[list[Region]] = relationship(secondary="regions_lived", order_by="Region.name")
 
     timezone = column_property(
         sa_select(TimezoneArea.tzid).where(func.ST_Contains(TimezoneArea.geom, geom)).limit(1).scalar_subquery(),
@@ -303,8 +303,8 @@ class User(Base):
     # whether this user has all emails turned off
     do_not_email: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
 
-    avatar: Mapped[Upload | None] = relationship("Upload", foreign_keys="User.avatar_key")
-    profile_gallery: Mapped[PhotoGallery | None] = relationship("PhotoGallery", foreign_keys="User.profile_gallery_id")
+    avatar: Mapped[Upload | None] = relationship(foreign_keys="User.avatar_key")
+    profile_gallery: Mapped[PhotoGallery | None] = relationship(foreign_keys="User.profile_gallery_id")
 
     admin_note: Mapped[str] = mapped_column(String, server_default=text("''"))
 
@@ -317,20 +317,27 @@ class User(Base):
 
     # ID of the invite code used to sign up (if any)
     invite_code_id: Mapped[int | None] = mapped_column(ForeignKey("invite_codes.id"), nullable=True)
-    invite_code: Mapped[InviteCode | None] = relationship("InviteCode", foreign_keys=[invite_code_id])
+    invite_code: Mapped[InviteCode | None] = relationship(foreign_keys=[invite_code_id])
 
     moderation_user_lists: Mapped[list[ModerationUserList]] = relationship(
-        "ModerationUserList", secondary="moderation_user_list_members", back_populates="users"
+        secondary="moderation_user_list_members", back_populates="users"
     )
-    language_abilities: Mapped[list[LanguageAbility]] = relationship("LanguageAbility", back_populates="user")
+    language_abilities: Mapped[list[LanguageAbility]] = relationship(back_populates="user")
     galleries: Mapped[list[PhotoGallery]] = relationship(
-        "PhotoGallery", foreign_keys="PhotoGallery.owner_user_id", back_populates="owner_user"
+        foreign_keys="PhotoGallery.owner_user_id", back_populates="owner_user"
     )
     mod_notes: DynamicMapped[ModNote] = relationship(
-        "ModNote", foreign_keys="ModNote.user_id", back_populates="user", lazy="dynamic"
+        foreign_keys="ModNote.user_id", back_populates="user", lazy="dynamic"
     )
 
-    badges: Mapped[list[UserBadge]] = relationship("UserBadge", back_populates="user")
+    badges: Mapped[list[UserBadge]] = relationship(back_populates="user")
+
+    pending_activeness_probe: Mapped[ActivenessProbe | None] = relationship(
+        primaryjoin="and_(ActivenessProbe.user_id == User.id, ActivenessProbe.is_pending)",
+        uselist=False,
+        back_populates="user",
+    )
+
     __table_args__ = (
         # Verified phone numbers should be unique
         Index(
@@ -457,7 +464,7 @@ class User(Base):
     @hybrid_property
     def jailed_pending_activeness_probe(self) -> Any:
         # search for User.pending_activeness_probe
-        return self.pending_activeness_probe != None  # type: ignore[attr-defined]
+        return self.pending_activeness_probe != None
 
     @hybrid_property
     def is_jailed(self) -> Any:
@@ -522,14 +529,6 @@ class User(Base):
         return f"User(id={self.id}, email={self.email}, username={self.username})"
 
 
-User.pending_activeness_probe = relationship(
-    ActivenessProbe,
-    primaryjoin="and_(ActivenessProbe.user_id == User.id, ActivenessProbe.is_pending)",
-    uselist=False,
-    back_populates="user",
-)
-
-
 class LanguageFluency(enum.Enum):
     # note that the numbering is important here, these are ordinal
     beginner = 1
@@ -549,8 +548,8 @@ class LanguageAbility(Base):
     language_code: Mapped[str] = mapped_column(ForeignKey("languages.code", deferrable=True))
     fluency: Mapped[LanguageFluency] = mapped_column(Enum(LanguageFluency))
 
-    user: Mapped[User] = relationship("User", back_populates="language_abilities")
-    language: Mapped[Language] = relationship("Language")
+    user: Mapped[User] = relationship(back_populates="language_abilities")
+    language: Mapped[Language] = relationship()
 
 
 class RegionVisited(Base):

--- a/app/backend/src/couchers/models/verification.py
+++ b/app/backend/src/couchers/models/verification.py
@@ -99,7 +99,7 @@ class StrongVerificationAttempt(Base):
 
     passport_expiry_datetime = column_property(date_in_timezone(passport_expiry_date, "Etc/UTC"))  # type: ignore[arg-type]
 
-    user: Mapped[User] = relationship("User")
+    user: Mapped[User] = relationship()
 
     @hybrid_property
     def is_valid(self) -> bool:

--- a/app/backend/uv.lock
+++ b/app/backend/uv.lock
@@ -538,6 +538,29 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/e5/40dbda2736893e3e53d25838e0f19a2b417dfc122b9989c91918db30b5d3/greenlet-3.3.0.tar.gz", hash = "sha256:a82bb225a4e9e4d653dd2fb7b8b2d36e4fb25bc0165422a11e48b88e9e6f78fb", size = 190651, upload-time = "2025-12-04T14:49:44.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/7c/f0a6d0ede2c7bf092d00bc83ad5bafb7e6ec9b4aab2fbdfa6f134dc73327/greenlet-3.3.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:60c2ef0f578afb3c8d92ea07ad327f9a062547137afe91f38408f08aacab667f", size = 275671, upload-time = "2025-12-04T14:23:05.267Z" },
+    { url = "https://files.pythonhosted.org/packages/44/06/dac639ae1a50f5969d82d2e3dd9767d30d6dbdbab0e1a54010c8fe90263c/greenlet-3.3.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a5d554d0712ba1de0a6c94c640f7aeba3f85b3a6e1f2899c11c2c0428da9365", size = 646360, upload-time = "2025-12-04T14:50:10.026Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/94/0fb76fe6c5369fba9bf98529ada6f4c3a1adf19e406a47332245ef0eb357/greenlet-3.3.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3a898b1e9c5f7307ebbde4102908e6cbfcb9ea16284a3abe15cab996bee8b9b3", size = 658160, upload-time = "2025-12-04T14:57:45.41Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/d2c70cae6e823fac36c3bbc9077962105052b7ef81db2f01ec3b9bf17e2b/greenlet-3.3.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dcd2bdbd444ff340e8d6bdf54d2f206ccddbb3ccfdcd3c25bf4afaa7b8f0cf45", size = 671388, upload-time = "2025-12-04T15:07:15.789Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/14/bab308fc2c1b5228c3224ec2bf928ce2e4d21d8046c161e44a2012b5203e/greenlet-3.3.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5773edda4dc00e173820722711d043799d3adb4f01731f40619e07ea2750b955", size = 660166, upload-time = "2025-12-04T14:26:05.099Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d2/91465d39164eaa0085177f61983d80ffe746c5a1860f009811d498e7259c/greenlet-3.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ac0549373982b36d5fd5d30beb8a7a33ee541ff98d2b502714a09f1169f31b55", size = 1615193, upload-time = "2025-12-04T15:04:27.041Z" },
+    { url = "https://files.pythonhosted.org/packages/42/1b/83d110a37044b92423084d52d5d5a3b3a73cafb51b547e6d7366ff62eff1/greenlet-3.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d198d2d977460358c3b3a4dc844f875d1adb33817f0613f663a656f463764ccc", size = 1683653, upload-time = "2025-12-04T14:27:32.366Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/9030e6f9aa8fd7808e9c31ba4c38f87c4f8ec324ee67431d181fe396d705/greenlet-3.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:73f51dd0e0bdb596fb0417e475fa3c5e32d4c83638296e560086b8d7da7c4170", size = 305387, upload-time = "2025-12-04T14:26:51.063Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/66/bd6317bc5932accf351fc19f177ffba53712a202f9df10587da8df257c7e/greenlet-3.3.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d6ed6f85fae6cdfdb9ce04c9bf7a08d666cfcfb914e7d006f44f840b46741931", size = 282638, upload-time = "2025-12-04T14:25:20.941Z" },
+    { url = "https://files.pythonhosted.org/packages/30/cf/cc81cb030b40e738d6e69502ccbd0dd1bced0588e958f9e757945de24404/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9125050fcf24554e69c4cacb086b87b3b55dc395a8b3ebe6487b045b2614388", size = 651145, upload-time = "2025-12-04T14:50:11.039Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ea/1020037b5ecfe95ca7df8d8549959baceb8186031da83d5ecceff8b08cd2/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:87e63ccfa13c0a0f6234ed0add552af24cc67dd886731f2261e46e241608bee3", size = 654236, upload-time = "2025-12-04T14:57:47.007Z" },
+    { url = "https://files.pythonhosted.org/packages/69/cc/1e4bae2e45ca2fa55299f4e85854606a78ecc37fead20d69322f96000504/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2662433acbca297c9153a4023fe2161c8dcfdcc91f10433171cf7e7d94ba2221", size = 662506, upload-time = "2025-12-04T15:07:16.906Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b9/f8025d71a6085c441a7eaff0fd928bbb275a6633773667023d19179fe815/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3c6e9b9c1527a78520357de498b0e709fb9e2f49c3a513afd5a249007261911b", size = 653783, upload-time = "2025-12-04T14:26:06.225Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c7/876a8c7a7485d5d6b5c6821201d542ef28be645aa024cfe1145b35c120c1/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:286d093f95ec98fdd92fcb955003b8a3d054b4e2cab3e2707a5039e7b50520fd", size = 1614857, upload-time = "2025-12-04T15:04:28.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/dc/041be1dff9f23dac5f48a43323cd0789cb798342011c19a248d9c9335536/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c10513330af5b8ae16f023e8ddbfb486ab355d04467c4679c5cfe4659975dd9", size = 1676034, upload-time = "2025-12-04T14:27:33.531Z" },
+]
+
+[[package]]
 name = "grpcio"
 version = "1.76.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1417,14 +1440,23 @@ wheels = [
 
 [[package]]
 name = "sqlalchemy"
-version = "2.0.43"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/bc/d59b5d97d27229b0e009bd9098cd81af71c2fa5549c580a0a67b9bed0496/sqlalchemy-2.0.43.tar.gz", hash = "sha256:788bfcef6787a7764169cfe9859fe425bf44559619e1d9f56f5bddf2ebf6f417", size = 9762949, upload-time = "2025-08-11T14:24:58.438Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/f9/5e4491e5ccf42f5d9cfc663741d261b3e6e1683ae7812114e7636409fcc6/sqlalchemy-2.0.45.tar.gz", hash = "sha256:1632a4bda8d2d25703fdad6363058d882541bdaaee0e5e3ddfa0cd3229efce88", size = 9869912, upload-time = "2025-12-09T21:05:16.737Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/d9/13bdde6521f322861fab67473cec4b1cc8999f3871953531cf61945fad92/sqlalchemy-2.0.43-py3-none-any.whl", hash = "sha256:1681c21dd2ccee222c2fe0bef671d1aef7c504087c9c4e800371cfcc8ac966fc", size = 1924759, upload-time = "2025-08-11T15:39:53.024Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/64/4e1913772646b060b025d3fc52ce91a58967fe58957df32b455de5a12b4f/sqlalchemy-2.0.45-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7f46ec744e7f51275582e6a24326e10c49fbdd3fc99103e01376841213028774", size = 3272404, upload-time = "2025-12-09T22:11:09.662Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/27/caf606ee924282fe4747ee4fd454b335a72a6e018f97eab5ff7f28199e16/sqlalchemy-2.0.45-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:883c600c345123c033c2f6caca18def08f1f7f4c3ebeb591a63b6fceffc95cce", size = 3277057, upload-time = "2025-12-09T22:13:56.213Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d0/3d64218c9724e91f3d1574d12eb7ff8f19f937643815d8daf792046d88ab/sqlalchemy-2.0.45-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2c0b74aa79e2deade948fe8593654c8ef4228c44ba862bb7c9585c8e0db90f33", size = 3222279, upload-time = "2025-12-09T22:11:11.1Z" },
+    { url = "https://files.pythonhosted.org/packages/24/10/dd7688a81c5bc7690c2a3764d55a238c524cd1a5a19487928844cb247695/sqlalchemy-2.0.45-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a420169cef179d4c9064365f42d779f1e5895ad26ca0c8b4c0233920973db74", size = 3244508, upload-time = "2025-12-09T22:13:57.932Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/41/db75756ca49f777e029968d9c9fee338c7907c563267740c6d310a8e3f60/sqlalchemy-2.0.45-cp314-cp314-win32.whl", hash = "sha256:e50dcb81a5dfe4b7b4a4aa8f338116d127cb209559124f3694c70d6cd072b68f", size = 2113204, upload-time = "2025-12-09T21:39:38.365Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a2/0e1590e9adb292b1d576dbcf67ff7df8cf55e56e78d2c927686d01080f4b/sqlalchemy-2.0.45-cp314-cp314-win_amd64.whl", hash = "sha256:4748601c8ea959e37e03d13dcda4a44837afcd1b21338e637f7c935b8da06177", size = 2138785, upload-time = "2025-12-09T21:39:39.503Z" },
+    { url = "https://files.pythonhosted.org/packages/42/39/f05f0ed54d451156bbed0e23eb0516bcad7cbb9f18b3bf219c786371b3f0/sqlalchemy-2.0.45-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd337d3526ec5298f67d6a30bbbe4ed7e5e68862f0bf6dd21d289f8d37b7d60b", size = 3522029, upload-time = "2025-12-09T22:13:32.09Z" },
+    { url = "https://files.pythonhosted.org/packages/54/0f/d15398b98b65c2bce288d5ee3f7d0a81f77ab89d9456994d5c7cc8b2a9db/sqlalchemy-2.0.45-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9a62b446b7d86a3909abbcd1cd3cc550a832f99c2bc37c5b22e1925438b9367b", size = 3475142, upload-time = "2025-12-09T22:13:33.739Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e1/3ccb13c643399d22289c6a9786c1a91e3dcbb68bce4beb44926ac2c557bf/sqlalchemy-2.0.45-py3-none-any.whl", hash = "sha256:5225a288e4c8cc2308dbdd874edad6e7d0fd38eac1e9e5f23503425c8eee20d0", size = 1936672, upload-time = "2025-12-09T21:54:52.608Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Let relationship targets be inferred from type annotations
- Update slqalchemy 2.0.43 -> 2.0.45
- Remove unnecessary workaround for User.pending_activeness_probe