### PR TITLE
Always flush changes when adding a new model to a session

### DIFF
--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -20,6 +20,7 @@ from couchers.config import config
 from couchers.constants import SERVER_THREADS, WORKER_THREADS
 from couchers.context import CouchersContext
 from couchers.models import (
+    Base,
     Cluster,
     ClusterRole,
     ClusterSubscription,
@@ -267,3 +268,8 @@ def timezone_at_coordinate(session: Session, geom: WKBElement) -> str | None:
         select(TimezoneArea.tzid).where(func.ST_Contains(TimezoneArea.geom, geom))
     ).scalar_one_or_none()
     return tzid
+
+
+def add(session: Session, obj: Base) -> None:
+    session.add(obj)
+    session.flush()

--- a/app/backend/src/couchers/helpers/badges.py
+++ b/app/backend/src/couchers/helpers/badges.py
@@ -2,6 +2,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import delete
 
 from couchers.context import make_background_user_context
+from couchers.db import add
 from couchers.models import UserBadge
 from couchers.notifications.notify import notify
 from couchers.proto import notification_data_pb2
@@ -10,8 +11,7 @@ from couchers.resources import get_badge_dict
 
 def user_add_badge(session: Session, user_id: int, badge_id: str, do_notify: bool = True) -> None:
     badge = get_badge_dict()[badge_id]
-    session.add(UserBadge(user_id=user_id, badge_id=badge_id))
-    session.flush()
+    add(session, UserBadge(user_id=user_id, badge_id=badge_id))
     if do_notify:
         context = make_background_user_context(user_id=user_id)
         notify(

--- a/app/backend/src/couchers/helpers/clusters.py
+++ b/app/backend/src/couchers/helpers/clusters.py
@@ -4,6 +4,7 @@ from geoalchemy2.shape import from_shape
 from shapely.geometry.base import BaseGeometry
 from sqlalchemy.orm import Session
 
+from couchers.db import add
 from couchers.models import Cluster, ClusterRole, ClusterSubscription, Node, Page, PageType, PageVersion, Thread
 
 DEFAULT_PAGE_CONTENT = "There is nothing here yet..."
@@ -12,8 +13,7 @@ DEFAULT_PAGE_TITLE_TEMPLATE = "Main page for the {name} {type}"
 
 def create_node(session: Session, geom: BaseGeometry, parent_node_id: int | None) -> Node:
     node = Node(geom=from_shape(geom), parent_node_id=parent_node_id)
-    session.add(node)
-    session.flush()
+    add(session, node)
     return node
 
 
@@ -33,8 +33,7 @@ def create_cluster(
         parent_node_id=parent_node_id,
         is_official_cluster=is_community,
     )
-    session.add(cluster)
-    session.flush()
+    add(session, cluster)
     main_page = Page(
         parent_node=cluster.parent_node,
         creator_user_id=creator_user_id,
@@ -42,15 +41,14 @@ def create_cluster(
         type=PageType.main_page,
         thread=Thread(),
     )
-    session.add(main_page)
-    session.flush()
+    add(session, main_page)
     page_version = PageVersion(
         page=main_page,
         editor_user_id=creator_user_id,
         title=DEFAULT_PAGE_TITLE_TEMPLATE.format(name=name, type=cluster_type),
         content=DEFAULT_PAGE_CONTENT,
     )
-    session.add(page_version)
+    add(session, page_version)
     for admin_id in admin_ids:
         cluster.cluster_subscriptions.append(
             ClusterSubscription(

--- a/app/backend/src/couchers/i18n/constants.py
+++ b/app/backend/src/couchers/i18n/constants.py
@@ -1,6 +1,7 @@
 # Language fallback hierarchy
 # If a string is not found in the requested language, transitively fall back to these languages.
 # Other languages implicitly fallback to English.
+
 LANGUAGE_FALLBACKS: dict[str, str] = {
     "pt-BR": "pt",
     "pt-PT": "pt-BR",

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -27,7 +27,7 @@ from couchers.constants import (
     UNKNOWN_ERROR_MESSAGE,
 )
 from couchers.context import CouchersContext, make_interactive_context, make_media_context
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.descriptor_pool import get_descriptor_pool
 from couchers.metrics import observe_in_servicer_duration_histogram
 from couchers.models import APICall, User, UserActivity, UserSession
@@ -113,14 +113,15 @@ def _try_get_and_update_user_details(
             if user_activity:
                 user_activity.api_calls += 1
             else:
-                session.add(
+                add(
+                    session,
                     UserActivity(
                         user_id=user.id,
                         period=_binned_now(),
                         ip_address=ip_address,
                         user_agent=user_agent,
                         api_calls=1,
-                    )
+                    ),
                 )
 
             session.commit()
@@ -202,7 +203,8 @@ def _store_log(
         if res_bytes and len(res_bytes) > truncate_res_bytes_length:
             res_bytes = res_bytes[:truncate_res_bytes_length]
             response_truncated = True
-        session.add(
+        add(
+            session,
             APICall(
                 is_api_key=is_api_key,
                 method=method,
@@ -216,7 +218,7 @@ def _store_log(
                 perf_report=perf_report,
                 ip_address=ip_address,
                 user_agent=user_agent,
-            )
+            ),
         )
     logger.debug(f"{user_id=}, {method=}, {duration=} ms")
 

--- a/app/backend/src/couchers/jobs/enqueue.py
+++ b/app/backend/src/couchers/jobs/enqueue.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 import google.protobuf.message
 from sqlalchemy.orm import Session
 
+from couchers.db import add
 from couchers.models import BackgroundJob
 
 logger = logging.getLogger(__name__)
@@ -20,11 +21,12 @@ def queue_job[T: google.protobuf.message.Message](
     max_tries: int | None = None,
     priority: int | None = None,
 ) -> None:
-    session.add(
+    add(
+        session,
         BackgroundJob(
             job_type=job.__name__,
             payload=payload.SerializeToString(),
             max_tries=max_tries,
             priority=priority,
-        )
+        ),
     )

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -49,7 +49,7 @@ from couchers.crypto import (
     simple_decrypt,
     stable_secure_uniform,
 )
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.email.dev import print_dev_email
 from couchers.email.smtp import send_smtp_email
 from couchers.helpers.badges import user_add_badge, user_remove_badge
@@ -147,7 +147,7 @@ def send_email(payload: jobs_pb2.SendEmailPayload) -> None:
         source_data=payload.source_data,
     )
     with session_scope() as session:
-        session.add(email)
+        add(session, email)
 
 
 def purge_login_tokens(payload: empty_pb2.Empty) -> None:
@@ -1017,7 +1017,7 @@ def send_activeness_probes(payload: empty_pb2.Empty) -> None:
                 new_probe_user_ids = sample(new_probe_user_ids, max_probe_size)
 
             for user_id in new_probe_user_ids:
-                session.add(ActivenessProbe(user_id=user_id))
+                add(session, ActivenessProbe(user_id=user_id))
 
             session.commit()
 

--- a/app/backend/src/couchers/moderation/utils.py
+++ b/app/backend/src/couchers/moderation/utils.py
@@ -4,6 +4,7 @@ Utility functions for the Unified Moderation System (UMS)
 
 from sqlalchemy.orm import Session
 
+from couchers.db import add
 from couchers.metrics import observe_moderation_action, observe_moderation_queue_item_created
 from couchers.models import (
     ModerationAction,
@@ -27,27 +28,27 @@ def create_moderation(
         object_id=object_id,
         visibility=ModerationVisibility.SHADOWED,
     )
-    session.add(moderation_state)
-    session.flush()
+    add(session, moderation_state)
 
-    session.add(
+    add(
+        session,
         ModerationLog(
             moderation_state_id=moderation_state.id,
             action=ModerationAction.CREATE,
             moderator_user_id=creator_user_id,
             new_visibility=ModerationVisibility.SHADOWED,
             reason="Object created.",
-        )
+        ),
     )
 
-    session.add(
+    add(
+        session,
         ModerationQueueItem(
             moderation_state_id=moderation_state.id,
             trigger=ModerationTrigger.INITIAL_REVIEW,
             reason="Object created.",
-        )
+        ),
     )
-    session.flush()
 
     observe_moderation_action(ModerationAction.CREATE, object_type)
     observe_moderation_queue_item_created(ModerationTrigger.INITIAL_REVIEW, object_type)

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -10,7 +10,7 @@ from sqlalchemy.sql import exists, func
 from couchers import urls
 from couchers.config import config
 from couchers.context import make_background_user_context
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.email import queue_email
 from couchers.models import (
     Notification,
@@ -167,31 +167,34 @@ def handle_notification(payload: jobs_pb2.HandleNotificationPayload) -> None:
             logger.info(f"Should notify by {delivery_type}")
             if delivery_type == NotificationDeliveryType.email:
                 # for emails we don't deliver straight up, wait until the email background worker gets around to it and handles deduplication
-                session.add(
+                add(
+                    session,
                     NotificationDelivery(
                         notification_id=notification.id,
                         delivered=func.now(),
                         delivery_type=NotificationDeliveryType.email,
-                    )
+                    ),
                 )
                 _send_email_notification(session, user, notification)
             elif delivery_type == NotificationDeliveryType.digest:
                 # for digest notifications, add to digest queue
-                session.add(
+                add(
+                    session,
                     NotificationDelivery(
                         notification_id=notification.id,
                         delivered=None,
                         delivery_type=NotificationDeliveryType.digest,
-                    )
+                    ),
                 )
             elif delivery_type == NotificationDeliveryType.push:
                 # for push notifications, we send them straight away (web + mobile)
-                session.add(
+                add(
+                    session,
                     NotificationDelivery(
                         notification_id=notification.id,
                         delivered=func.now(),
                         delivery_type=NotificationDeliveryType.push,
-                    )
+                    ),
                 )
                 _send_push_notification(session, user, notification)
 

--- a/app/backend/src/couchers/notifications/notify.py
+++ b/app/backend/src/couchers/notifications/notify.py
@@ -4,6 +4,7 @@ from google.protobuf import empty_pb2
 from google.protobuf.message import Message
 from sqlalchemy.orm import Session
 
+from couchers.db import add
 from couchers.jobs.enqueue import queue_job
 from couchers.models import Notification
 from couchers.notifications.utils import enum_from_topic_action
@@ -54,8 +55,7 @@ def notify(
         data=(data or empty_pb2.Empty()).SerializeToString(),
         moderation_state_id=moderation_state_id,
     )
-    session.add(notification)
-    session.flush()
+    add(session, notification)
 
     queue_job(
         session,

--- a/app/backend/src/couchers/notifications/send_raw_push_notification.py
+++ b/app/backend/src/couchers/notifications/send_raw_push_notification.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.sql import func
 
 from couchers.config import config
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.metrics import push_notification_counter
 from couchers.models import (
     PushNotificationDeliveryAttempt,
@@ -199,14 +199,15 @@ def send_raw_push_notification_v2(payload: jobs_pb2.SendRawPushNotificationPaylo
                 raise ValueError(f"Unknown platform: {sub.platform}")
 
             # Success - receipt will be checked by the batch job check_expo_push_receipts
-            session.add(
+            add(
+                session,
                 PushNotificationDeliveryAttempt(
                     push_notification_subscription_id=sub.id,
                     outcome=PushNotificationDeliveryOutcome.success,
                     status_code=result.status_code,
                     response=result.response,
                     expo_ticket_id=result.expo_ticket_id,
-                )
+                ),
             )
 
             push_notification_counter.labels(platform=sub.platform.name, outcome="success").inc()
@@ -214,39 +215,42 @@ def send_raw_push_notification_v2(payload: jobs_pb2.SendRawPushNotificationPaylo
 
         except PermanentSubscriptionFailure as e:
             logger.info(f"Disabling push sub {sub.id} for user {sub.user_id}: {e}")
-            session.add(
+            add(
+                session,
                 PushNotificationDeliveryAttempt(
                     push_notification_subscription_id=sub.id,
                     outcome=PushNotificationDeliveryOutcome.permanent_subscription_failure,
                     status_code=e.status_code,
                     response=e.response,
-                )
+                ),
             )
             sub.disabled_at = func.now()
             push_notification_counter.labels(platform=sub.platform.name, outcome="permanent_subscription_failure").inc()
 
         except PermanentMessageFailure as e:
             logger.warning(f"Permanent message failure for sub {sub.id}: {e}")
-            session.add(
+            add(
+                session,
                 PushNotificationDeliveryAttempt(
                     push_notification_subscription_id=sub.id,
                     outcome=PushNotificationDeliveryOutcome.permanent_message_failure,
                     status_code=e.status_code,
                     response=e.response,
-                )
+                ),
             )
             push_notification_counter.labels(platform=sub.platform.name, outcome="permanent_message_failure").inc()
 
         except PushNotificationError as e:
             # Transient error - log attempt and re-raise to trigger retry
             logger.warning(f"Transient push failure for sub {sub.id}: {e}")
-            session.add(
+            add(
+                session,
                 PushNotificationDeliveryAttempt(
                     push_notification_subscription_id=sub.id,
                     outcome=PushNotificationDeliveryOutcome.transient_failure,
                     status_code=e.status_code,
                     response=e.response,
-                )
+                ),
             )
             push_notification_counter.labels(platform=sub.platform.name, outcome="transient_failure").inc()
             session.commit()

--- a/app/backend/src/couchers/notifications/settings.py
+++ b/app/backend/src/couchers/notifications/settings.py
@@ -3,7 +3,7 @@ import logging
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.models import (
     NotificationDelivery,
     NotificationDeliveryType,
@@ -94,13 +94,14 @@ def set_preference(
     if current_pref:
         current_pref.deliver = deliver
     else:
-        session.add(
+        add(
+            session,
             NotificationPreference(
                 user_id=user_id,
                 topic_action=topic_action,
                 delivery_type=delivery_type,
                 deliver=deliver,
-            )
+            ),
         )
     session.flush()
 

--- a/app/backend/src/couchers/phone/sms.py
+++ b/app/backend/src/couchers/phone/sms.py
@@ -6,7 +6,7 @@ import luhn
 
 from couchers import crypto
 from couchers.config import config
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.models import SMS
 
 logger = logging.getLogger(__name__)
@@ -51,13 +51,14 @@ def send_sms(number: str, message: str) -> str:
     message_id = response["MessageId"]
 
     with session_scope() as session:
-        session.add(
+        add(
+            session,
             SMS(
                 message_id=message_id,
                 number=number,
                 message=message,
                 sms_sender_id=sender_id,
-            )
+            ),
         )
 
     return "success"

--- a/app/backend/src/couchers/rate_limits/check.py
+++ b/app/backend/src/couchers/rate_limits/check.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from sqlalchemy import RowMapping, exists, select
 from sqlalchemy.orm import Session
 
+from couchers.db import add
 from couchers.models import RateLimitAction, RateLimitViolation
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_INTERVAL
 from couchers.tasks import send_rate_limit_violation_report_email
@@ -31,8 +32,7 @@ def _save_rate_limit_violation(
         action=action,
         is_hard_limit=is_hard_limit,
     )
-    session.add(violation)
-    session.flush()
+    add(session, violation)
     return violation
 
 

--- a/app/backend/src/couchers/resources.py
+++ b/app/backend/src/couchers/resources.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import delete, text
 
 from couchers.config import config
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.models import Language, Region, TimezoneArea
 
 logger = logging.getLogger(__name__)
@@ -142,11 +142,11 @@ def copy_resources_to_database(session: Session) -> None:
 
     session.execute(delete(Region))
     for code, name in regions:
-        session.add(Region(code=code, name=name))
+        add(session, Region(code=code, name=name))
 
     session.execute(delete(Language))
     for code, name in languages:
-        session.add(Language(code=code, name=name))
+        add(session, Language(code=code, name=name))
 
     session.execute(delete(TimezoneArea))
     session.execute(text(tz_sql))

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -26,6 +26,7 @@ from couchers.crypto import (
     verify_password,
     verify_token,
 )
+from couchers.db import add
 from couchers.experimentation import check_gate
 from couchers.helpers.geoip import geoip_approximate_location
 from couchers.helpers.strong_verification import get_strong_verification_fields, has_strong_verification
@@ -294,8 +295,7 @@ class Account(account_pb2_grpc.AccountServicer):
             expertise=form.expertise or None,
         )
 
-        session.add(form)
-        session.flush()
+        add(session, form)
         maybe_send_contributor_form_email(session, form)
 
         user.filled_contributor_form = True
@@ -459,13 +459,14 @@ class Account(account_pb2_grpc.AccountServicer):
 
         iris_session_id = response.json()["id"]
         token = response.json()["token"]
-        session.add(
+        add(
+            session,
             StrongVerificationAttempt(
                 user_id=user.id,
                 verification_attempt_token=verification_attempt_token,
                 iris_session_id=iris_session_id,
                 iris_token=token,
-            )
+            ),
         )
 
         redirect_params = {
@@ -557,8 +558,7 @@ class Account(account_pb2_grpc.AccountServicer):
         reason = request.reason.strip()
         if reason:
             deletion_reason = AccountDeletionReason(user_id=user.id, reason=reason)
-            session.add(deletion_reason)
-            session.flush()
+            add(session, deletion_reason)
             send_account_deletion_report_email(session, deletion_reason)
 
         token = AccountDeletionToken(token=urlsafe_secure_token(), user=user, expiry=now() + timedelta(hours=2))
@@ -572,7 +572,7 @@ class Account(account_pb2_grpc.AccountServicer):
                 deletion_token=token.token,
             ),
         )
-        session.add(token)
+        add(session, token)
 
         account_deletion_initiations_counter.labels(user.gender).inc()
 
@@ -673,7 +673,7 @@ class Account(account_pb2_grpc.AccountServicer):
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session
     ) -> account_pb2.CreateInviteCodeRes:
         code = generate_invite_code()
-        session.add(InviteCode(id=code, creator_user_id=context.user_id))
+        add(session, InviteCode(id=code, creator_user_id=context.user_id))
 
         return account_pb2.CreateInviteCodeRes(
             code=code,
@@ -849,11 +849,12 @@ class Iris(iris_pb2_grpc.IrisServicer):
             .where(StrongVerificationAttempt.iris_session_id == json_data["session_id"])
         ).scalar_one()
         iris_status = json_data["session_state"]
-        session.add(
+        add(
+            session,
             StrongVerificationCallbackEvent(
                 verification_attempt_id=verification_attempt.id,
                 iris_status=iris_status,
-            )
+            ),
         )
         if iris_status == "INITIATED":
             # the user opened the session in the app

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -11,6 +11,7 @@ from user_agents import parse as user_agents_parse
 from couchers import urls
 from couchers.context import CouchersContext
 from couchers.crypto import urlsafe_secure_token
+from couchers.db import add
 from couchers.helpers.badges import user_add_badge, user_remove_badge
 from couchers.helpers.geoip import geoip_approximate_location, geoip_asn
 from couchers.helpers.strong_verification import get_strong_verification_fields
@@ -331,13 +332,14 @@ class Admin(admin_pb2_grpc.AdminServicer):
         user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
-        session.add(
+        add(
+            session,
             ModNote(
                 user_id=user.id,
                 internal_id=request.internal_id,
                 creator_user_id=context.user_id,
                 note_content=request.content,
-            )
+            ),
         )
         session.flush()
 
@@ -641,8 +643,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
         # Create a new moderation user list if no one is provided
         else:
             moderation_user_list = ModerationUserList()
-            session.add(moderation_user_list)
-            session.flush()
+            add(session, moderation_user_list)
 
         # Add users to the moderation list only if not already in it
         for user in users:
@@ -696,7 +697,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         expiry_days = request.expiry_days or 7
         token = AccountDeletionToken(token=urlsafe_secure_token(), user=user, expiry=now() + timedelta(hours=2))
-        session.add(token)
+        add(session, token)
         return admin_pb2.CreateAccountDeletionLinkRes(
             account_deletion_confirm_url=urls.delete_account_link(account_deletion_token=token.token)
         )

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -15,6 +15,7 @@ from couchers.config import config
 from couchers.constants import GHOST_USERNAME
 from couchers.context import CouchersContext
 from couchers.crypto import b64encode, generate_hash_signature, random_hex
+from couchers.db import add
 from couchers.helpers.strong_verification import get_strong_verification_fields
 from couchers.materialized_views import LiteUser, UserResponseRate
 from couchers.models import (
@@ -403,12 +404,13 @@ class API(api_pb2_grpc.APIServicer):
             for language_ability in request.language_abilities.value:
                 if not language_is_allowed(language_ability.code):
                     context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_language")
-                session.add(
+                add(
+                    session,
                     LanguageAbility(
                         user=user,
                         language_code=language_ability.code,
                         fluency=fluency2sql[language_ability.fluency],
-                    )
+                    ),
                 )
 
         if request.HasField("regions_visited"):
@@ -417,11 +419,12 @@ class API(api_pb2_grpc.APIServicer):
             for region in request.regions_visited.value:
                 if not region_is_allowed(region):
                     context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_region")
-                session.add(
+                add(
+                    session,
                     RegionVisited(
                         user_id=user.id,
                         region_code=region,
-                    )
+                    ),
                 )
 
         if request.HasField("regions_lived"):
@@ -430,11 +433,12 @@ class API(api_pb2_grpc.APIServicer):
             for region in request.regions_lived.value:
                 if not region_is_allowed(region):
                     context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_region")
-                session.add(
+                add(
+                    session,
                     RegionLived(
                         user_id=user.id,
                         region_code=region,
-                    )
+                    ),
                 )
 
         if request.HasField("additional_information"):
@@ -727,8 +731,7 @@ class API(api_pb2_grpc.APIServicer):
         # TODO: Race condition where we can create two friend reqs, needs db constraint! See comment in table
 
         friend_relationship = FriendRelationship(from_user=user, to_user=to_user, status=FriendStatus.pending)
-        session.add(friend_relationship)
-        session.flush()
+        add(session, friend_relationship)
 
         notify(
             session,
@@ -851,7 +854,7 @@ class API(api_pb2_grpc.APIServicer):
         expiry = created + timedelta(minutes=20)
 
         upload = InitiatedUpload(key=key, created=created, expiry=expiry, initiator_user_id=context.user_id)
-        session.add(upload)
+        add(session, upload)
         session.commit()
 
         req = media_pb2.UploadRequest(

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -13,6 +13,7 @@ from couchers.config import config
 from couchers.constants import ANTIBOT_FREQ, BANNED_USERNAME_PHRASES, GUIDELINES_VERSION, TOS_VERSION, UNDELETE_DAYS
 from couchers.context import CouchersContext
 from couchers.crypto import cookiesafe_secure_token, hash_password, urlsafe_secure_token, verify_password
+from couchers.db import add
 from couchers.metrics import (
     account_deletion_completions_counter,
     account_recoveries_counter,
@@ -109,7 +110,7 @@ def create_session(
     if duration:
         user_session.expiry = func.now() + duration
 
-    session.add(user_session)
+    add(session, user_session)
     session.commit()
 
     logger.debug(f"Handing out {token=} to {user=}")
@@ -240,8 +241,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                     email=request.basic.email,
                     invite_code_id=invite_id,
                 )
-                session.add(flow)
-                session.flush()
+                add(session, flow)
                 signup_initiations_counter.inc()
             else:
                 # not fresh signup
@@ -340,13 +340,11 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 invite_code_id=flow.invite_code_id,
             )
 
-            session.add(user)
-            session.flush()
+            add(session, user)
 
             # Create a profile gallery for the user
             profile_gallery = PhotoGallery(owner_user_id=user.id)
-            session.add(profile_gallery)
-            session.flush()
+            add(session, profile_gallery)
             user.profile_gallery_id = profile_gallery.id
 
             if flow.filled_feedback:
@@ -360,7 +358,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                     expertise=flow.expertise or None,
                 )
 
-                session.add(form_)
+                add(session, form_)
 
                 user.filled_contributor_form = form_.is_filled
 
@@ -481,8 +479,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
             password_reset_token = PasswordResetToken(
                 token=urlsafe_secure_token(), user=user, expiry=now() + timedelta(hours=2)
             )
-            session.add(password_reset_token)
-            session.flush()
+            add(session, password_reset_token)
 
             notify(
                 session,
@@ -669,9 +666,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
         log.score = resp.json()["riskAnalysis"]["score"]
         log.provider_data = resp.json()
 
-        session.add(log)
-
-        session.flush()
+        add(session, log)
 
         recaptchas_assessed_counter.labels(log.action).inc()
         recaptcha_score_histogram.labels(log.action).observe(log.score)

--- a/app/backend/src/couchers/servicers/blocking.py
+++ b/app/backend/src/couchers/servicers/blocking.py
@@ -6,6 +6,7 @@ from sqlalchemy.sql import not_, or_, union
 
 from couchers import urls
 from couchers.context import CouchersContext
+from couchers.db import add
 from couchers.models import Upload, User, UserBlock
 from couchers.proto import blocking_pb2, blocking_pb2_grpc
 
@@ -64,7 +65,7 @@ class Blocking(blocking_pb2_grpc.BlockingServicer):
                 blocking_user_id=context.user_id,
                 blocked_user_id=blockee.id,
             )
-            session.add(user_block)
+            add(session, user_block)
             session.commit()
 
         return empty_pb2.Empty()

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -11,7 +11,7 @@ from sqlalchemy.sql import func, not_, or_
 
 from couchers.constants import DATETIME_INFINITY, DATETIME_MINUS_INFINITY
 from couchers.context import CouchersContext, make_background_user_context
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.jobs.enqueue import queue_job
 from couchers.metrics import sent_messages_counter
 from couchers.models import (
@@ -226,8 +226,7 @@ def _add_message_to_subscription(session: Session, subscription: GroupChatSubscr
     """
     message = Message(conversation=subscription.group_chat.conversation, author_id=subscription.user_id, **kwargs)
 
-    session.add(message)
-    session.flush()
+    add(session, message)
 
     subscription.last_seen_message_id = message.id
 
@@ -250,8 +249,7 @@ def _create_chat(
     only_admins_invite: bool = True,
 ) -> GroupChat:
     conversation = Conversation()
-    session.add(conversation)
-    session.flush()
+    add(session, conversation)
 
     # Create moderation state for UMS (starts as SHADOWED)
     moderation_state = create_moderation(
@@ -269,23 +267,23 @@ def _create_chat(
         only_admins_invite=only_admins_invite,
         moderation_state_id=moderation_state.id,
     )
-    session.add(chat)
-    session.flush()
+    add(session, chat)
 
     creator_subscription = GroupChatSubscription(
         user_id=creator_id,
         group_chat=chat,
         role=GroupChatRole.admin,
     )
-    session.add(creator_subscription)
+    add(session, creator_subscription)
 
     for uid in recipient_ids:
-        session.add(
+        add(
+            session,
             GroupChatSubscription(
                 user_id=uid,
                 group_chat=chat,
                 role=GroupChatRole.participant,
-            )
+            ),
         )
 
     return chat
@@ -986,7 +984,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             group_chat=your_subscription.group_chat,
             role=GroupChatRole.participant,
         )
-        session.add(subscription)
+        add(session, subscription)
 
         _add_message_to_subscription(
             session, your_subscription, message_type=MessageType.user_invited, target_id=request.user_id

--- a/app/backend/src/couchers/servicers/discussions.py
+++ b/app/backend/src/couchers/servicers/discussions.py
@@ -5,7 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from couchers.context import CouchersContext, make_background_user_context
-from couchers.db import can_moderate_node, session_scope
+from couchers.db import add, can_moderate_node, session_scope
 from couchers.jobs.enqueue import queue_job
 from couchers.models import Cluster, Discussion, Thread, User
 from couchers.notifications.notify import notify
@@ -104,8 +104,7 @@ class Discussions(discussions_pb2_grpc.DiscussionsServicer):
             owner_cluster=cluster,
             thread=Thread(),
         )
-        session.add(discussion)
-        session.flush()
+        add(session, discussion)
 
         queue_job(
             session,

--- a/app/backend/src/couchers/servicers/donations.py
+++ b/app/backend/src/couchers/servicers/donations.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from couchers import urls
 from couchers.config import config
 from couchers.context import CouchersContext
+from couchers.db import add
 from couchers.helpers.badges import user_add_badge
 from couchers.models import DonationInitiation, DonationType, Invoice, InvoiceType, User
 from couchers.notifications.notify import notify
@@ -80,14 +81,15 @@ class Donations(donations_pb2_grpc.DonationsServicer):
             api_key=config["STRIPE_API_KEY"],
         )
 
-        session.add(
+        add(
+            session,
             DonationInitiation(
                 user_id=user.id,
                 amount=request.amount,
                 stripe_checkout_session_id=checkout_session.id,
                 donation_type=DonationType.recurring if request.recurring else DonationType.one_time,
                 source=request.source if request.source else None,
-            )
+            ),
         )
 
         return donations_pb2.InitiateDonationRes(
@@ -159,8 +161,7 @@ class Stripe(stripe_pb2_grpc.StripeServicer):
                     stripe_receipt_url=receipt_url,
                     invoice_type=InvoiceType.on_platform,
                 )
-                session.add(invoice)
-                session.flush()
+                add(session, invoice)
                 user.last_donated = invoice.created
 
                 notify(

--- a/app/backend/src/couchers/servicers/editor.py
+++ b/app/backend/src/couchers/servicers/editor.py
@@ -12,7 +12,7 @@ from sqlalchemy.sql import exists, update
 
 from couchers import urls
 from couchers.context import CouchersContext
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.helpers.clusters import create_cluster, create_node
 from couchers.jobs.enqueue import queue_job
 from couchers.materialized_views import LiteUser
@@ -235,8 +235,7 @@ class Editor(editor_pb2_grpc.EditorServicer):
             started_volunteering=started_volunteering,
             show_on_team_page=not request.hide_on_team_page,
         )
-        session.add(volunteer)
-        session.flush()
+        add(session, volunteer)
 
         return volunteer_to_pb(session, volunteer)
 

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import and_, func, or_, update
 
 from couchers.context import CouchersContext, make_background_user_context
-from couchers.db import can_moderate_node, get_parent_node_at_location, session_scope
+from couchers.db import add, can_moderate_node, get_parent_node_at_location, session_scope
 from couchers.jobs.enqueue import queue_job
 from couchers.models import (
     AttendeeStatus,
@@ -447,7 +447,7 @@ class Events(events_pb2_grpc.EventsServicer):
             thread=Thread(),
             creator_user_id=context.user_id,
         )
-        session.add(event)
+        add(session, event)
 
         occurrence = EventOccurrence(
             event=event,
@@ -460,28 +460,31 @@ class Events(events_pb2_grpc.EventsServicer):
             during=DateTimeTZRange(start_time, end_time),
             creator_user_id=context.user_id,
         )
-        session.add(occurrence)
+        add(session, occurrence)
 
-        session.add(
+        add(
+            session,
             EventOrganizer(
                 user_id=context.user_id,
                 event=event,
-            )
+            ),
         )
 
-        session.add(
+        add(
+            session,
             EventSubscription(
                 user_id=context.user_id,
                 event=event,
-            )
+            ),
         )
 
-        session.add(
+        add(
+            session,
             EventOccurrenceAttendee(
                 user_id=context.user_id,
                 occurrence=occurrence,
                 attendee_status=AttendeeStatus.going,
-            )
+            ),
         )
 
         session.commit()
@@ -573,14 +576,15 @@ class Events(events_pb2_grpc.EventsServicer):
             during=during,
             creator_user_id=context.user_id,
         )
-        session.add(occurrence)
+        add(session, occurrence)
 
-        session.add(
+        add(
+            session,
             EventOccurrenceAttendee(
                 user_id=context.user_id,
                 occurrence=occurrence,
                 attendee_status=AttendeeStatus.going,
-            )
+            ),
         )
 
         session.flush()
@@ -800,8 +804,7 @@ class Events(events_pb2_grpc.EventsServicer):
             occurrence_id=request.event_id,
             user_id=context.user_id,
         )
-        session.add(req)
-        session.flush()
+        add(session, req)
 
         send_event_community_invite_request_email(session, req)
 
@@ -988,7 +991,7 @@ class Events(events_pb2_grpc.EventsServicer):
 
         # if not subscribed, subscribe
         if request.subscribe and not current_subscription:
-            session.add(EventSubscription(user_id=context.user_id, event_id=event.id))
+            add(session, EventSubscription(user_id=context.user_id, event_id=event.id))
 
         # if subscribed but unsubbing, remove subscription
         if not request.subscribe and current_subscription:
@@ -1034,7 +1037,7 @@ class Events(events_pb2_grpc.EventsServicer):
                     occurrence_id=occurrence.id,
                     attendee_status=attendancestate2sql[request.attendance_state],
                 )
-                session.add(attendance)
+                add(session, attendance)
 
         session.flush()
 
@@ -1176,11 +1179,12 @@ class Events(events_pb2_grpc.EventsServicer):
         ).scalar_one_or_none():
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
-        session.add(
+        add(
+            session,
             EventOrganizer(
                 user_id=request.user_id,
                 event=event,
-            )
+            ),
         )
         session.flush()
 

--- a/app/backend/src/couchers/servicers/galleries.py
+++ b/app/backend/src/couchers/servicers/galleries.py
@@ -7,6 +7,7 @@ from sqlalchemy.sql import func
 
 from couchers.constants import GALLERY_MAX_PHOTOS_NOT_VERIFIED, GALLERY_MAX_PHOTOS_VERIFIED
 from couchers.context import CouchersContext
+from couchers.db import add
 from couchers.helpers.strong_verification import has_strong_verification
 from couchers.models import PhotoGallery, PhotoGalleryItem, Upload, User
 from couchers.proto import galleries_pb2, galleries_pb2_grpc
@@ -97,8 +98,7 @@ class Galleries(galleries_pb2_grpc.GalleriesServicer):
             position=0.0 if max_position is None else max_position + 1.0,
             caption=request.caption or None,
         )
-        session.add(item)
-        session.flush()
+        add(session, item)
         session.refresh(gallery)
 
         return _gallery_to_pb(gallery, context)

--- a/app/backend/src/couchers/servicers/media.py
+++ b/app/backend/src/couchers/servicers/media.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from couchers.context import CouchersContext
 from couchers.crypto import secure_compare
+from couchers.db import add
 from couchers.interceptors import MediaInterceptor
 from couchers.models import InitiatedUpload, Upload
 from couchers.proto import media_pb2, media_pb2_grpc
@@ -38,7 +39,7 @@ class Media(media_pb2_grpc.MediaServicer):
             filename=request.filename,
             creator_user_id=initiated_upload.initiator_user_id,
         )
-        session.add(upload)
+        add(session, upload)
 
         # delete the old upload
         session.delete(initiated_upload)

--- a/app/backend/src/couchers/servicers/moderation.py
+++ b/app/backend/src/couchers/servicers/moderation.py
@@ -5,6 +5,7 @@ from sqlalchemy import and_, exists, not_, or_, select
 from sqlalchemy.orm import Session
 
 from couchers.context import CouchersContext
+from couchers.db import add
 from couchers.jobs.enqueue import queue_job
 from couchers.metrics import (
     observe_moderation_action,
@@ -340,7 +341,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
             new_visibility=new_visibility,
             reason=reason,
         )
-        session.add(log_entry)
+        add(session, log_entry)
         session.flush()
 
         # Resolve any pending queue items
@@ -411,7 +412,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
             trigger=trigger,
             reason=reason,
         )
-        session.add(queue_item)
+        add(session, queue_item)
         session.flush()
 
         observe_moderation_action(ModerationAction.FLAG, moderation_state.object_type)
@@ -454,7 +455,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
             new_visibility=None,
             reason=reason,
         )
-        session.add(log_entry)
+        add(session, log_entry)
         session.flush()
 
         # Resolve any pending queue items (inline resolve_queue_item logic)

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -12,6 +12,7 @@ from sqlalchemy.sql import or_
 from couchers.config import config
 from couchers.constants import DATETIME_INFINITY
 from couchers.context import CouchersContext
+from couchers.db import add
 from couchers.models import (
     DeviceType,
     HostingStatus,
@@ -183,8 +184,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             full_subscription_info=request.full_subscription_json,
             user_agent=request.user_agent,
         )
-        session.add(subscription)
-        session.flush()
+        add(session, subscription)
         push_to_subscription(
             session,
             push_notification_subscription_id=subscription.id,
@@ -249,8 +249,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             device_name=request.device_name if request.device_name else None,
             device_type=device_type,
         )
-        session.add(subscription)
-        session.flush()
+        add(session, subscription)
 
         push_to_subscription(
             session,

--- a/app/backend/src/couchers/servicers/pages.py
+++ b/app/backend/src/couchers/servicers/pages.py
@@ -3,7 +3,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from couchers.context import CouchersContext
-from couchers.db import can_moderate_at, can_moderate_node, get_parent_node_at_location
+from couchers.db import add, can_moderate_at, can_moderate_node, get_parent_node_at_location
 from couchers.models import Cluster, Node, Page, PageType, PageVersion, Thread, Upload, User
 from couchers.proto import pages_pb2, pages_pb2_grpc
 from couchers.servicers.threads import thread_to_pb
@@ -127,8 +127,7 @@ class Pages(pages_pb2_grpc.PagesServicer):
             owner_user_id=context.user_id,
             thread=Thread(),
         )
-        session.add(page)
-        session.flush()
+        add(session, page)
         page_version = PageVersion(
             page=page,
             editor_user_id=context.user_id,
@@ -138,7 +137,7 @@ class Pages(pages_pb2_grpc.PagesServicer):
             address=request.address,
             geom=geom,
         )
-        session.add(page_version)
+        add(session, page_version)
         session.commit()
         return page_to_pb(session, page, context)
 
@@ -182,8 +181,7 @@ class Pages(pages_pb2_grpc.PagesServicer):
             owner_user_id=context.user_id,
             thread=Thread(),
         )
-        session.add(page)
-        session.flush()
+        add(session, page)
         page_version = PageVersion(
             page=page,
             editor_user_id=context.user_id,
@@ -193,7 +191,7 @@ class Pages(pages_pb2_grpc.PagesServicer):
             address=address,
             geom=geom,
         )
-        session.add(page_version)
+        add(session, page_version)
         session.commit()
         return page_to_pb(session, page, context)
 
@@ -254,7 +252,7 @@ class Pages(pages_pb2_grpc.PagesServicer):
         if request.HasField("location"):
             page_version.geom = create_coordinate(request.location.lat, request.location.lng)
 
-        session.add(page_version)
+        add(session, page_version)
         session.commit()
         return page_to_pb(session, page, context)
 

--- a/app/backend/src/couchers/servicers/postal_verification.py
+++ b/app/backend/src/couchers/servicers/postal_verification.py
@@ -13,6 +13,7 @@ from couchers.constants import (
     POSTAL_VERIFICATION_RATE_LIMIT,
 )
 from couchers.context import CouchersContext
+from couchers.db import add
 from couchers.helpers.postal_verification import generate_postal_verification_code, has_postal_verification
 from couchers.jobs.enqueue import queue_job
 from couchers.jobs.handlers import send_postal_verification_postcard
@@ -143,8 +144,7 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
                 }
             ),
         )
-        session.add(attempt)
-        session.flush()
+        add(session, attempt)
 
         return postal_verification_pb2.InitiatePostalVerificationRes(
             postal_verification_attempt_id=attempt.id,

--- a/app/backend/src/couchers/servicers/references.py
+++ b/app/backend/src/couchers/servicers/references.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session, aliased
 from sqlalchemy.sql import and_, func, literal, or_, union_all
 
 from couchers.context import CouchersContext, make_background_user_context
-from couchers.db import are_friends
+from couchers.db import add, are_friends
 from couchers.materialized_views import LiteUser
 from couchers.models import HostRequest, Reference, ReferenceType, User
 from couchers.notifications.notify import notify
@@ -274,7 +274,7 @@ class References(references_pb2_grpc.ReferencesServicer):
             rating=request.rating,
             was_appropriate=request.was_appropriate,
         )
-        session.add(reference)
+        add(session, reference)
         session.commit()
 
         # send the recipient of the reference a reminder
@@ -325,7 +325,7 @@ class References(references_pb2_grpc.ReferencesServicer):
             reference.to_user_id = host_request.surfer_user_id
             assert context.user_id == host_request.host_user_id
 
-        session.add(reference)
+        add(session, reference)
         session.commit()
 
         other_reference = session.execute(

--- a/app/backend/src/couchers/servicers/reporting.py
+++ b/app/backend/src/couchers/servicers/reporting.py
@@ -4,6 +4,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from couchers.context import CouchersContext
+from couchers.db import add
 from couchers.models import ContentReport, User
 from couchers.proto import reporting_pb2, reporting_pb2_grpc
 from couchers.sql import username_or_id
@@ -28,8 +29,7 @@ class Reporting(reporting_pb2_grpc.ReportingServicer):
             page=request.page,
         )
 
-        session.add(content_report)
-        session.flush()
+        add(session, content_report)
 
         send_content_report_email(session, content_report)
 

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -9,6 +9,7 @@ from sqlalchemy.sql import and_, func, or_
 
 from couchers.constants import HOST_REQUEST_MIN_LENGTH_UTF16
 from couchers.context import CouchersContext
+from couchers.db import add
 from couchers.materialized_views import UserResponseRate
 from couchers.metrics import (
     account_age_on_host_request_create_histogram,
@@ -238,15 +239,15 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             )
 
         conversation = Conversation()
-        session.add(conversation)
-        session.flush()
+        add(session, conversation)
 
-        session.add(
+        add(
+            session,
             Message(
                 conversation_id=conversation.id,
                 author_id=context.user_id,
                 message_type=MessageType.chat_created,
-            )
+            ),
         )
 
         message = Message(
@@ -255,8 +256,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             text=request.text,
             message_type=MessageType.text,
         )
-        session.add(message)
-        session.flush()
+        add(session, message)
 
         # Create moderation state for UMS (starts as SHADOWED)
         moderation_state = create_moderation(
@@ -281,8 +281,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             hosting_location=host.geom,
             hosting_radius=host.geom_radius,
         )
-        session.add(host_request)
-        session.flush()
+        add(session, host_request)
 
         notify(
             session,
@@ -586,7 +585,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         control_message.message_type = MessageType.host_request_status_changed
         control_message.conversation_id = host_request.conversation_id
         control_message.author_id = context.user_id
-        session.add(control_message)
+        add(session, control_message)
 
         if request.text:
             latest_message = Message()
@@ -594,7 +593,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             latest_message.text = request.text
             latest_message.author_id = context.user_id
             latest_message.message_type = MessageType.text
-            session.add(latest_message)
+            add(session, latest_message)
         else:
             latest_message = control_message
 
@@ -673,8 +672,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         message.author_id = context.user_id
         message.message_type = MessageType.text
         message.text = request.text
-        session.add(message)
-        session.flush()
+        add(session, message)
 
         if host_request.surfer_user_id == context.user_id:
             host_request.surfer_last_seen_message_id = message.id
@@ -860,14 +858,15 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         if feedback:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "already_left_host_request_feedback")
 
-        session.add(
+        add(
+            session,
             HostRequestFeedback(
                 host_request_id=host_request.conversation_id,
                 from_user_id=host_request.host_user_id,
                 to_user_id=host_request.surfer_user_id,
                 request_quality=hostrequestquality2sql.get(request.host_request_quality),
                 decline_reason=request.decline_reason,
-            )
+            ),
         )
 
         return empty_pb2.Empty()

--- a/app/backend/src/couchers/servicers/threads.py
+++ b/app/backend/src/couchers/servicers/threads.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
 
 from couchers.context import CouchersContext, make_background_user_context
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.jobs.enqueue import queue_job
 from couchers.models import Comment, Discussion, Event, EventOccurrence, Reply, Thread, User
 from couchers.notifications.notify import notify
@@ -291,9 +291,9 @@ class Threads(threads_pb2_grpc.ThreadsServicer):
             object_to_add = Reply(comment_id=database_id, author_user_id=context.user_id, content=content)
         else:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "thread_not_found")
-        session.add(object_to_add)
+
         try:
-            session.flush()
+            add(session, object_to_add)
         except sqlalchemy.exc.IntegrityError:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "thread_not_found")
 

--- a/app/backend/src/couchers/tasks.py
+++ b/app/backend/src/couchers/tasks.py
@@ -9,7 +9,7 @@ from couchers import email, urls
 from couchers.config import config
 from couchers.constants import SIGNUP_EMAIL_TOKEN_VALIDITY
 from couchers.crypto import urlsafe_secure_token
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.models import (
     AccountDeletionReason,
     Cluster,
@@ -233,11 +233,12 @@ def enforce_community_memberships_for_user(session: Session, user: User) -> None
     )
 
     for cluster_id in cluster_ids:
-        session.add(
+        add(
+            session,
             ClusterSubscription(
                 user=user,
                 cluster_id=cluster_id,
                 role=ClusterRole.member,
-            )
+            ),
         )
     session.commit()

--- a/app/backend/src/couchers/urls.py
+++ b/app/backend/src/couchers/urls.py
@@ -2,8 +2,6 @@
 # //docs/urls.md
 # Please make sure this file stays in sync with that file as well as
 # //app/web/src/routes.ts
-
-
 from couchers.config import config
 
 

--- a/app/backend/src/dummy_data.py
+++ b/app/backend/src/dummy_data.py
@@ -9,7 +9,7 @@ from sqlalchemy.sql import func
 
 from couchers.constants import GUIDELINES_VERSION, TOS_VERSION
 from couchers.crypto import hash_password
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.models import (
     Cluster,
     ClusterRole,
@@ -90,25 +90,24 @@ def add_dummy_users():
                 is_superuser=user.get("is_superuser", False),
                 is_editor=user.get("is_editor", user.get("is_superuser", False)),
             )
-            session.add(new_user)
-            session.flush()
+            add(session, new_user)
 
             # Create profile gallery for the user (same as in signup flow)
             profile_gallery = PhotoGallery(owner_user_id=new_user.id)
-            session.add(profile_gallery)
-            session.flush()
+            add(session, profile_gallery)
             new_user.profile_gallery_id = profile_gallery.id
 
             for language in user["languages"]:
-                session.add(
+                add(
+                    session,
                     LanguageAbility(
                         user_id=new_user.id, language_code=language[0], fluency=LanguageFluency[language[1]]
-                    )
+                    ),
                 )
             for region in user["regions_visited"]:
-                session.add(RegionVisited(user_id=new_user.id, region_code=region))
+                add(session, RegionVisited(user_id=new_user.id, region_code=region))
             for region in user["regions_lived"]:
-                session.add(RegionLived(user_id=new_user.id, region_code=region))
+                add(session, RegionLived(user_id=new_user.id, region_code=region))
 
             class _MockCouchersContext:
                 @property
@@ -139,7 +138,7 @@ def add_dummy_users():
                 to_user_id=session.execute(select(User).where(User.username == username2)).scalar_one().id,
                 status=FriendStatus.accepted,
             )
-            session.add(friend_relationship)
+            add(session, friend_relationship)
 
         session.commit()
 
@@ -157,7 +156,7 @@ def add_dummy_users():
                 rating=reference["rating"],
                 was_appropriate=reference["was_appropriate"],
             )
-            session.add(new_reference)
+            add(session, new_reference)
 
         session.commit()
 
@@ -167,8 +166,7 @@ def add_dummy_users():
             creator_id = session.execute(select(User).where(User.username == creator)).scalar_one().id
 
             conversation = Conversation()
-            session.add(conversation)
-            session.flush()
+            add(session, conversation)
 
             # Create moderation state for UMS (set as VISIBLE since this is dummy data)
             moderation_state = ModerationState(
@@ -176,17 +174,17 @@ def add_dummy_users():
                 object_id=conversation.id,
                 visibility=ModerationVisibility.VISIBLE,
             )
-            session.add(moderation_state)
-            session.flush()
+            add(session, moderation_state)
 
-            session.add(
+            add(
+                session,
                 ModerationLog(
                     moderation_state_id=moderation_state.id,
                     action=ModerationAction.CREATE,
                     moderator_user_id=creator_id,
                     new_visibility=ModerationVisibility.VISIBLE,
                     reason="Dummy data: group chat created.",
-                )
+                ),
             )
 
             chat = GroupChat(
@@ -196,7 +194,7 @@ def add_dummy_users():
                 is_dm=group_chat["is_dm"],
                 moderation_state_id=moderation_state.id,
             )
-            session.add(chat)
+            add(session, chat)
 
             for participant in group_chat["participants"]:
                 subscription = GroupChatSubscription(
@@ -207,10 +205,11 @@ def add_dummy_users():
                     role=GroupChatRole.admin if participant["username"] == creator else GroupChatRole.participant,
                     joined=parser.isoparse(participant["joined"]),
                 )
-                session.add(subscription)
+                add(session, subscription)
 
             for message in group_chat["messages"]:
-                session.add(
+                add(
+                    session,
                     Message(
                         message_type=MessageType.text,
                         conversation=chat.conversation,
@@ -219,7 +218,7 @@ def add_dummy_users():
                         .id,
                         time=parser.isoparse(message["time"]),
                         text=message["message"],
-                    )
+                    ),
                 )
 
         session.commit()
@@ -235,7 +234,7 @@ def add_dummy_users():
                 link_url=volunteer["link_url"],
             )
 
-            session.add(new_volunteer)
+            add(session, new_volunteer)
 
         session.commit()
 
@@ -284,7 +283,7 @@ def add_dummy_communities():
                 parent_node=parent_node if parent_name else None,
             )
 
-            session.add(node)
+            add(session, node)
 
             cluster = Cluster(
                 name=f"{name}",
@@ -293,7 +292,7 @@ def add_dummy_communities():
                 is_official_cluster=True,
             )
 
-            session.add(cluster)
+            add(session, cluster)
 
             main_page = Page(
                 parent_node=node,
@@ -303,7 +302,7 @@ def add_dummy_communities():
                 thread=Thread(),
             )
 
-            session.add(main_page)
+            add(session, main_page)
 
             page_version = PageVersion(
                 page=main_page,
@@ -312,7 +311,7 @@ def add_dummy_communities():
                 content="There is nothing here yet...",
             )
 
-            session.add(page_version)
+            add(session, page_version)
 
             for admin in admins:
                 cluster.cluster_subscriptions.append(
@@ -349,7 +348,7 @@ def add_dummy_communities():
                 parent_node=parent_node,
             )
 
-            session.add(cluster)
+            add(session, cluster)
 
             main_page = Page(
                 parent_node=cluster.parent_node,
@@ -359,7 +358,7 @@ def add_dummy_communities():
                 thread=Thread(),
             )
 
-            session.add(main_page)
+            add(session, main_page)
 
             page_version = PageVersion(
                 page=main_page,
@@ -368,7 +367,7 @@ def add_dummy_communities():
                 content="There is nothing here yet...",
             )
 
-            session.add(page_version)
+            add(session, page_version)
 
             for admin in admins:
                 cluster.cluster_subscriptions.append(
@@ -398,7 +397,7 @@ def add_dummy_communities():
                 thread=Thread(),
             )
 
-            session.add(page)
+            add(session, page)
 
             page_version = PageVersion(
                 page=page,
@@ -409,7 +408,7 @@ def add_dummy_communities():
                 geom=create_coordinate(place["coordinate"][1], place["coordinate"][0]),
             )
 
-            session.add(page_version)
+            add(session, page_version)
 
         for guide in data["guides"]:
             owner_cluster = session.execute(select(Cluster).where(Cluster.name == guide["owner"])).scalar_one()
@@ -423,7 +422,7 @@ def add_dummy_communities():
                 thread=Thread(),
             )
 
-            session.add(page)
+            add(session, page)
 
             page_version = PageVersion(
                 page=page,
@@ -435,7 +434,7 @@ def add_dummy_communities():
                 ),
             )
 
-            session.add(page_version)
+            add(session, page_version)
 
 
 def add_dummy_data():

--- a/app/backend/src/tests/fixtures/db.py
+++ b/app/backend/src/tests/fixtures/db.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 
 from couchers.constants import GUIDELINES_VERSION, TOS_VERSION
 from couchers.crypto import random_hex
-from couchers.db import _get_base_engine, session_scope
+from couchers.db import _get_base_engine, add, session_scope
 from couchers.models import (
     Base,
     FriendRelationship,
@@ -213,23 +213,23 @@ def generate_user(
         } | kwargs
 
         user = User(**user_opts)
-        session.add(user)
+        add(session, user)
         session.flush()
 
         # Create a profile gallery for the user and link it
         profile_gallery = PhotoGallery(owner_user_id=user.id)
-        session.add(profile_gallery)
+        add(session, profile_gallery)
         session.flush()
         user.profile_gallery_id = profile_gallery.id
 
         for region in regions_visited:
-            session.add(RegionVisited(user_id=user.id, region_code=region))
+            add(session, RegionVisited(user_id=user.id, region_code=region))
 
         for region in regions_lived:
-            session.add(RegionLived(user_id=user.id, region_code=region))
+            add(session, RegionLived(user_id=user.id, region_code=region))
 
         for lang, fluency in language_abilities:
-            session.add(LanguageAbility(user_id=user.id, language_code=lang, fluency=fluency))
+            add(session, LanguageAbility(user_id=user.id, language_code=lang, fluency=fluency))
 
         # this expires the user, so now it's "dirty"
         token, _ = create_session(_MockCouchersContext(), session, user, False, set_cookie=False)
@@ -243,12 +243,13 @@ def generate_user(
         if complete_profile:
             key = random_hex(32)
             filename = random_hex(32) + ".jpg"
-            session.add(
+            add(
+                session,
                 Upload(
                     key=key,
                     filename=filename,
                     creator_user_id=user.id,
-                )
+                ),
             )
             session.flush()
             user.avatar_key = key
@@ -272,7 +273,7 @@ def generate_user(
                 iris_token=f"iris_token_{user.id}",
                 iris_session_id=user.id,
             )
-            session.add(attempt)
+            add(session, attempt)
             session.flush()
             assert attempt.has_strong_verification(user)
 
@@ -305,7 +306,7 @@ def make_friends(user1: User, user2: User) -> None:
             to_user_id=user2.id,
             status=FriendStatus.accepted,
         )
-        session.add(friend_relationship)
+        add(session, friend_relationship)
 
 
 def make_user_block(user1: User, user2: User) -> None:
@@ -314,7 +315,7 @@ def make_user_block(user1: User, user2: User) -> None:
             blocking_user_id=user1.id,
             blocked_user_id=user2.id,
         )
-        session.add(user_block)
+        add(session, user_block)
 
 
 def make_user_invisible(user_id: int) -> None:
@@ -342,7 +343,7 @@ def add_users_to_new_moderation_list(users: list[User]) -> int:
     """Group users as duplicated accounts"""
     with session_scope() as session:
         moderation_user_list = ModerationUserList()
-        session.add(moderation_user_list)
+        add(session, moderation_user_list)
         session.flush()
         for user in users:
             refreshed_user = session.get(User, user.id)

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -9,7 +9,7 @@ from sqlalchemy.sql import func
 
 from couchers import urls
 from couchers.crypto import hash_password, random_hex
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.materialized_views import refresh_materialized_views_rapid
 from couchers.models import (
     AccountDeletionReason,
@@ -136,12 +136,13 @@ def test_GetAccountInfo_regression(db):
     with session_scope() as session:
         key = random_hex(32)
         filename = random_hex(32) + ".jpg"
-        session.add(
+        add(
+            session,
             Upload(
                 key=key,
                 filename=filename,
                 creator_user_id=uploader_user.id,
-            )
+            ),
         )
 
     user, token = generate_user(about_me=None, avatar_key=key)
@@ -960,7 +961,7 @@ def test_DisableInviteCode(db):
     user, token = generate_user()
     code = "TEST1234"
     with session_scope() as session:
-        session.add(InviteCode(id=code, creator_user_id=user.id))
+        add(session, InviteCode(id=code, creator_user_id=user.id))
 
     with account_session(token) as account:
         account.DisableInviteCode(account_pb2.DisableInviteCodeReq(code=code))
@@ -976,7 +977,7 @@ def test_ListInviteCodes(db):
 
     code = "LIST1234"
     with session_scope() as session:
-        session.add(InviteCode(id=code, creator_user_id=user.id))
+        add(session, InviteCode(id=code, creator_user_id=user.id))
         session.execute(update(User).where(User.id == another_user.id).values(invite_code_id=code))
 
     with account_session(token) as account:
@@ -1132,7 +1133,8 @@ def test_volunteer_stuff(db):
         )
 
     with session_scope() as session:
-        session.add(
+        add(
+            session,
             Volunteer(
                 user_id=user.id,
                 display_name="Great Volunteer",
@@ -1140,7 +1142,7 @@ def test_volunteer_stuff(db):
                 role="Lead Tester",
                 started_volunteering=date(2020, 6, 1),
                 show_on_team_page=True,
-            )
+            ),
         )
 
     with account_session(token) as account:

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -5,7 +5,7 @@ import pytest
 from google.protobuf import empty_pb2, wrappers_pb2
 from sqlalchemy import select, update
 
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.jobs.handlers import update_badges
 from couchers.materialized_views import refresh_materialized_views_rapid
 from couchers.models import FriendRelationship, FriendStatus, LanguageFluency, RateLimitAction, User
@@ -1226,7 +1226,7 @@ def test_accept_friend_request(db):
 
     with session_scope() as session:
         friend_request = FriendRelationship(from_user_id=user1.id, to_user_id=user2.id, status=FriendStatus.pending)
-        session.add(friend_request)
+        add(session, friend_request)
         session.commit()
         friend_request_id = friend_request.id
 

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -8,7 +8,7 @@ from sqlalchemy.sql import delete, func
 
 from couchers import urls
 from couchers.crypto import hash_password, random_hex
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.models import (
     ContributeOption,
     ContributorForm,
@@ -1158,13 +1158,12 @@ def test_GetInviteCodeInfo(db):
             filename="test_avatar.jpg",
             creator_user_id=user.id,
         )
-        session.add(avatar)
-        session.flush()
+        add(session, avatar)
 
         session.execute(update(User).where(User.id == user.id).values(avatar_key=avatar.key))
 
         code = InviteCode(id=code_id, creator_user_id=user.id)
-        session.add(code)
+        add(session, code)
 
     with auth_api_session() as (auth, _):
         res = auth.GetInviteCodeInfo(auth_pb2.GetInviteCodeInfoReq(code=code_id))
@@ -1182,7 +1181,7 @@ def test_GetInviteCodeInfo_no_avatar(db):
         session.execute(update(User).where(User.id == user.id).values(avatar_key=None))
 
         code = InviteCode(id="NOAVTR1", creator_user_id=user.id)
-        session.add(code)
+        add(session, code)
 
     with auth_api_session() as (auth, _):
         res = auth.GetInviteCodeInfo(auth_pb2.GetInviteCodeInfoReq(code=code_id))
@@ -1208,7 +1207,7 @@ def test_SignupFlow_invite_code(db):
     with session_scope() as session:
         session.flush()
         invite = InviteCode(id=invite_code, creator_user_id=user.id)
-        session.add(invite)
+        add(session, invite)
 
     with auth_api_session() as (auth_api, _):
         # Signup basic step with invite code

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -12,7 +12,7 @@ import couchers.jobs.worker
 from couchers.config import config
 from couchers.constants import HOST_REQUEST_MAX_REMINDERS, HOST_REQUEST_REMINDER_INTERVAL
 from couchers.crypto import urlsafe_secure_token
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.email import queue_email
 from couchers.email.dev import print_dev_email
 from couchers.jobs import handlers
@@ -118,7 +118,7 @@ def test_purge_login_tokens(db):
 
     with session_scope() as session:
         login_token = LoginToken(token=urlsafe_secure_token(), user=user, expiry=now())
-        session.add(login_token)
+        add(session, login_token)
         assert session.execute(select(func.count()).select_from(LoginToken)).scalar_one() == 1
 
         queue_job(session, job=purge_login_tokens, payload=empty_pb2.Empty())
@@ -151,7 +151,7 @@ def test_purge_password_reset_tokens(db):
 
     with session_scope() as session:
         password_reset_token = PasswordResetToken(token=urlsafe_secure_token(), user=user, expiry=now())
-        session.add(password_reset_token)
+        add(session, password_reset_token)
         assert session.execute(select(func.count()).select_from(PasswordResetToken)).scalar_one() == 1
 
         queue_job(session, job=purge_password_reset_tokens, payload=empty_pb2.Empty())
@@ -197,7 +197,7 @@ def test_purge_account_deletion_tokens(db):
             AccountDeletionToken(token=urlsafe_secure_token(), user=user3, expiry=now() + timedelta(hours=5)),
         ]
         for token in account_deletion_tokens:
-            session.add(token)
+            add(session, token)
         assert session.execute(select(func.count()).select_from(AccountDeletionToken)).scalar_one() == 3
 
         queue_job(session, job=purge_account_deletion_tokens, payload=empty_pb2.Empty())
@@ -1065,14 +1065,15 @@ def test_send_host_request_reminders(db, moderator):
             last_sent_request_reminder_time=now() - HOST_REQUEST_REMINDER_INTERVAL,
         )
 
-        session.add(
+        add(
+            session,
             Message(
                 time=now(),
                 conversation_id=hr7,
                 author_id=user14.id,
                 text="Looking forward to hosting you!",
                 message_type=MessageType.text,
-            )
+            ),
         )
 
     # Approve host requests so they're visible for notifications
@@ -1191,7 +1192,7 @@ def test_update_badges(db, push_collector: PushCollector):
     user6, _ = generate_user(last_donated=None)
 
     with session_scope() as session:
-        session.add(UserBadge(user_id=user5.id, badge_id="board_member"))
+        add(session, UserBadge(user_id=user5.id, badge_id="board_member"))
 
     update_badges(empty_pb2.Empty())
     process_jobs()
@@ -1455,30 +1456,32 @@ def test_update_badges_volunteers(db, push_collector: PushCollector):
 
     with session_scope() as session:
         # user3: active volunteer (stopped_volunteering is null)
-        session.add(
+        add(
+            session,
             Volunteer(
                 user_id=user3.id,
                 role="Developer",
                 started_volunteering=date(2020, 1, 1),
                 stopped_volunteering=None,
-            )
+            ),
         )
 
         # user4: past volunteer (stopped_volunteering is set)
-        session.add(
+        add(
+            session,
             Volunteer(
                 user_id=user4.id,
                 role="Designer",
                 started_volunteering=date(2020, 1, 1),
                 stopped_volunteering=date(2023, 6, 1),
-            )
+            ),
         )
 
         # user5: has old volunteer badge that should be removed (not a volunteer anymore)
-        session.add(UserBadge(user_id=user5.id, badge_id="volunteer"))
+        add(session, UserBadge(user_id=user5.id, badge_id="volunteer"))
 
         # user6: has old past_volunteer badge that should be removed
-        session.add(UserBadge(user_id=user6.id, badge_id="past_volunteer"))
+        add(session, UserBadge(user_id=user6.id, badge_id="past_volunteer"))
 
     update_badges(empty_pb2.Empty())
     process_jobs()
@@ -1529,13 +1532,14 @@ def test_update_badges_volunteer_status_change(db, push_collector: PushCollector
 
     with session_scope() as session:
         # user3: start as active volunteer
-        session.add(
+        add(
+            session,
             Volunteer(
                 user_id=user3.id,
                 role="Developer",
                 started_volunteering=date(2020, 1, 1),
                 stopped_volunteering=None,
-            )
+            ),
         )
 
     update_badges(empty_pb2.Empty())

--- a/app/backend/src/tests/test_communities.py
+++ b/app/backend/src/tests/test_communities.py
@@ -7,7 +7,7 @@ from google.protobuf import wrappers_pb2
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from couchers.db import is_user_in_node_geography, session_scope
+from couchers.db import add, is_user_in_node_geography, session_scope
 from couchers.materialized_views import refresh_materialized_views
 from couchers.models import (
     Cluster,
@@ -59,14 +59,14 @@ def create_community(session, interval_lb, interval_ub, name, admins, extra_memb
         geom=to_multi(create_1d_polygon(interval_lb, interval_ub)),
         parent_node=parent,
     )
-    session.add(node)
+    add(session, node)
     cluster = Cluster(
         name=f"{name}",
         description=f"Description for {name}",
         parent_node=node,
         is_official_cluster=True,
     )
-    session.add(cluster)
+    add(session, cluster)
     main_page = Page(
         parent_node=cluster.parent_node,
         creator_user_id=admins[0].id,
@@ -74,14 +74,14 @@ def create_community(session, interval_lb, interval_ub, name, admins, extra_memb
         type=PageType.main_page,
         thread=Thread(),
     )
-    session.add(main_page)
+    add(session, main_page)
     page_version = PageVersion(
         page=main_page,
         editor_user_id=admins[0].id,
         title=f"Main page for the {name} community",
         content="There is nothing here yet...",
     )
-    session.add(page_version)
+    add(session, page_version)
     for admin in admins:
         cluster.cluster_subscriptions.append(
             ClusterSubscription(
@@ -107,7 +107,7 @@ def create_group(session, name, admins, members, parent_community):
         description=f"Description for {name}",
         parent_node=parent_community,
     )
-    session.add(cluster)
+    add(session, cluster)
     main_page = Page(
         parent_node=cluster.parent_node,
         creator_user=admins[0],
@@ -115,14 +115,14 @@ def create_group(session, name, admins, members, parent_community):
         type=PageType.main_page,
         thread=Thread(),
     )
-    session.add(main_page)
+    add(session, main_page)
     page_version = PageVersion(
         page=main_page,
         editor_user=admins[0],
         title=f"Main page for the {name} community",
         content="There is nothing here yet...",
     )
-    session.add(page_version)
+    add(session, page_version)
     for admin in admins:
         cluster.cluster_subscriptions.append(
             ClusterSubscription(

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -7,7 +7,7 @@ import couchers.email
 import couchers.jobs.handlers
 from couchers.config import config
 from couchers.crypto import random_hex, urlsafe_secure_token
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.models import (
     ContentReport,
     Email,
@@ -94,8 +94,7 @@ def test_reference_report_email_not_sent(db):
         to_user, api_token_reported = generate_user()
 
         friend_relationship = FriendRelationship(from_user=from_user, to_user=to_user, status=FriendStatus.accepted)
-        session.add(friend_relationship)
-        session.flush()
+        add(session, friend_relationship)
 
         reference = Reference(
             from_user=from_user,
@@ -120,8 +119,7 @@ def test_reference_report_email(db):
         to_user, api_token_reported = generate_user()
 
         friend_relationship = FriendRelationship(from_user=from_user, to_user=to_user, status=FriendStatus.accepted)
-        session.add(friend_relationship)
-        session.flush()
+        add(session, friend_relationship)
 
         reference = Reference(
             from_user=from_user,

--- a/app/backend/src/tests/test_galleries.py
+++ b/app/backend/src/tests/test_galleries.py
@@ -3,7 +3,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.models import PhotoGallery, PhotoGalleryItem, Upload, User
 from couchers.proto import galleries_pb2
 from tests.fixtures.db import generate_user
@@ -22,7 +22,7 @@ def create_upload(session, user_id, filename="test.jpg"):
         filename=filename,
         creator_user_id=user_id,
     )
-    session.add(upload)
+    add(session, upload)
     session.commit()
     return upload.key
 
@@ -697,7 +697,7 @@ def test_database_constraints_upload_uniqueness(db):
         user = session.execute(select(User).where(User.id == user1.id)).scalar_one()
 
         upload = Upload(key="key1", filename="test.jpg", creator_user_id=user.id)
-        session.add(upload)
+        add(session, upload)
         session.flush()
 
         item1 = PhotoGalleryItem(gallery_id=user.profile_gallery_id, upload_key="key1", position=0.0)

--- a/app/backend/src/tests/test_magic.py
+++ b/app/backend/src/tests/test_magic.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from typing import Any
+
+from couchers.models import PhotoGallery, PhotoGalleryItem, Upload
+
+
+def make_photogalleryitem(
+    *,
+    gallery: int | PhotoGallery,
+    upload: str | Upload,
+    position: float,
+    caption: str | None = None,
+    created: datetime | None = None,
+) -> PhotoGalleryItem:
+    kwargs: dict[str, Any] = {}
+    if isinstance(gallery, PhotoGallery):
+        kwargs["gallery_id"] = gallery.id
+    else:
+        kwargs["gallery_id"] = gallery
+    if isinstance(upload, Upload):
+        kwargs["upload_key"] = upload.key
+    else:
+        kwargs["upload_key"] = upload
+    kwargs["position"] = position
+    if caption is not None:
+        kwargs["caption"] = caption
+    if created is not None:
+        kwargs["created"] = created
+
+    return PhotoGalleryItem(**kwargs)
+
+
+def test_x():
+    make_photogalleryitem(gallery=1, upload="dog", position=1.0, created=datetime(2020, 6, 1))

--- a/app/backend/src/tests/test_model_constraints.py
+++ b/app/backend/src/tests/test_model_constraints.py
@@ -2,7 +2,7 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql import func
 
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.models import ActivenessProbe, ActivenessProbeStatus, Cluster, Node, Page, PageType, PageVersion, Thread
 from couchers.utils import create_polygon_lat_lng, to_multi
 from tests.fixtures.db import generate_user
@@ -19,21 +19,21 @@ def test_node_constraints(db):
     with pytest.raises(IntegrityError) as e:
         with session_scope() as session:
             node = Node(geom=to_multi(create_1d_polygon(0, 2)))
-            session.add(node)
+            add(session, node)
             cluster1 = Cluster(
                 name="Testing community, cluster 1",
                 description="Testing community description",
                 parent_node=node,
                 is_official_cluster=True,
             )
-            session.add(cluster1)
+            add(session, cluster1)
             cluster2 = Cluster(
                 name="Testing community, cluster 2",
                 description="Testing community description",
                 parent_node=node,
                 is_official_cluster=True,
             )
-            session.add(cluster2)
+            add(session, cluster2)
     assert "violates unique constraint" in str(e.value)
     assert "ix_clusters_owner_parent_node_id_is_official_cluster" in str(e.value)
 
@@ -54,28 +54,28 @@ def test_page_constraints(db):
                 type=PageType.guide,
                 thread=Thread(),
             )
-            session.add(page)
-            session.add(
+            add(session, page)
+            add(
+                session,
                 PageVersion(
                     page=page,
                     editor_user_id=user.id,
                     title="Title",
                     content="Content",
-                )
+                ),
             )
     assert "violates check constraint" in str(e.value)
     assert "one_owner" in str(e.value)
 
     with session_scope() as session:
         node = Node(geom=to_multi(create_polygon_lat_lng([[0, 0], [0, 2], [2, 2], [2, 0], [0, 0]])))
-        session.add(node)
+        add(session, node)
         cluster = Cluster(
             name="Testing Community",
             description="Description for testing community",
             parent_node=node,
         )
-        session.add(cluster)
-        session.flush()
+        add(session, cluster)
         cluster_parent_id = cluster.parent_node_id
         cluster_id = cluster.id
 
@@ -90,14 +90,15 @@ def test_page_constraints(db):
                 type=PageType.guide,
                 thread=Thread(),
             )
-            session.add(page)
-            session.add(
+            add(session, page)
+            add(
+                session,
                 PageVersion(
                     page=page,
                     editor_user_id=user.id,
                     title="Title",
                     content="Content",
-                )
+                ),
             )
     assert "violates check constraint" in str(e.value)
     assert "one_owner" in str(e.value)
@@ -113,14 +114,15 @@ def test_page_constraints(db):
                 type=PageType.main_page,
                 thread=Thread(),
             )
-            session.add(main_page)
-            session.add(
+            add(session, main_page)
+            add(
+                session,
                 PageVersion(
                     page=main_page,
                     editor_user_id=user.id,
                     title="Main page for the testing community",
                     content="Empty.",
-                )
+                ),
             )
     assert "violates check constraint" in str(e.value)
     assert "main_page_owned_by_cluster" in str(e.value)
@@ -135,14 +137,15 @@ def test_page_constraints(db):
                 type=PageType.main_page,
                 thread=Thread(),
             )
-            session.add(main_page1)
-            session.add(
+            add(session, main_page1)
+            add(
+                session,
                 PageVersion(
                     page=main_page1,
                     editor_user_id=user.id,
                     title="Main page 1 for the testing community",
                     content="Empty.",
-                )
+                ),
             )
             main_page2 = Page(
                 parent_node_id=cluster_parent_id,
@@ -151,14 +154,15 @@ def test_page_constraints(db):
                 type=PageType.main_page,
                 thread=Thread(),
             )
-            session.add(main_page2)
-            session.add(
+            add(session, main_page2)
+            add(
+                session,
                 PageVersion(
                     page=main_page2,
                     editor_user_id=user.id,
                     title="Main page 2 for the testing community",
                     content="Empty.",
-                )
+                ),
             )
     assert "violates unique constraint" in str(e.value)
     assert "ix_pages_owner_cluster_id_type" in str(e.value)
@@ -171,7 +175,7 @@ def test_activeness_probes_cant_have_multiple(db):
     with session_scope() as session:
         # we can create one
         first_probe = ActivenessProbe(user_id=user.id)
-        session.add(first_probe)
+        add(session, first_probe)
         session.commit()
 
         # change it to expired
@@ -180,11 +184,11 @@ def test_activeness_probes_cant_have_multiple(db):
         session.commit()
 
         # can create another one
-        session.add(ActivenessProbe(user_id=user.id))
+        add(session, ActivenessProbe(user_id=user.id))
         session.commit()
 
     # can't create one more
     with pytest.raises(IntegrityError) as e:
         with session_scope() as session:
-            session.add(ActivenessProbe(user_id=user.id))
+            add(session, ActivenessProbe(user_id=user.id))
     assert "violates unique constraint" in str(e.value)

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -11,7 +11,7 @@ from couchers.config import config
 from couchers.constants import DATETIME_INFINITY
 from couchers.context import make_background_user_context
 from couchers.crypto import b64decode
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.jobs.worker import process_job
 from couchers.models import (
     DeviceType,
@@ -702,8 +702,7 @@ def test_RegisterMobilePushNotificationSubscription_re_enable(db):
             device_type=DeviceType.ios,
             disabled_at=now(),
         )
-        session.add(sub)
-        session.flush()
+        add(session, sub)
         sub_id = sub.id
 
     # Re-register with the same token
@@ -738,7 +737,7 @@ def test_RegisterMobilePushNotificationSubscription_already_exists(db):
             device_name="Existing Device",
             device_type=DeviceType.ios,
         )
-        session.add(sub)
+        add(session, sub)
 
     # Try to register with the same token - should just return without error
     with notifications_session(token) as notifications:
@@ -826,8 +825,7 @@ def test_check_expo_push_receipts_success(db):
             device_name="Test Device",
             device_type=DeviceType.ios,
         )
-        session.add(sub)
-        session.flush()
+        add(session, sub)
 
         attempt = PushNotificationDeliveryAttempt(
             push_notification_subscription_id=sub.id,
@@ -835,8 +833,7 @@ def test_check_expo_push_receipts_success(db):
             status_code=200,
             expo_ticket_id="test-ticket-id",
         )
-        session.add(attempt)
-        session.flush()
+        add(session, attempt)
         # Make the attempt old enough to be checked (>15 min)
         attempt.time = now() - timedelta(minutes=20)
         attempt_id = attempt.id
@@ -886,8 +883,7 @@ def test_check_expo_push_receipts_device_not_registered(db):
             device_name="Test Device",
             device_type=DeviceType.android,
         )
-        session.add(sub)
-        session.flush()
+        add(session, sub)
 
         attempt = PushNotificationDeliveryAttempt(
             push_notification_subscription_id=sub.id,
@@ -895,8 +891,7 @@ def test_check_expo_push_receipts_device_not_registered(db):
             status_code=200,
             expo_ticket_id="ticket-device-gone",
         )
-        session.add(attempt)
-        session.flush()
+        add(session, attempt)
         # Make the attempt old enough to be checked
         attempt.time = now() - timedelta(minutes=15)
         attempt_id = attempt.id
@@ -950,8 +945,7 @@ def test_check_expo_push_receipts_not_found(db):
             platform=PushNotificationPlatform.expo,
             token="ExponentPushToken[notfound]",
         )
-        session.add(sub)
-        session.flush()
+        add(session, sub)
 
         attempt = PushNotificationDeliveryAttempt(
             push_notification_subscription_id=sub.id,
@@ -959,8 +953,7 @@ def test_check_expo_push_receipts_not_found(db):
             status_code=200,
             expo_ticket_id="unknown-ticket",
         )
-        session.add(attempt)
-        session.flush()
+        add(session, attempt)
         # Make the attempt old enough to be checked
         attempt.time = now() - timedelta(minutes=15)
         attempt_id = attempt.id
@@ -1006,8 +999,7 @@ def test_check_expo_push_receipts_skips_already_checked(db):
             platform=PushNotificationPlatform.expo,
             token="ExponentPushToken[alreadychecked]",
         )
-        session.add(sub)
-        session.flush()
+        add(session, sub)
 
         attempt = PushNotificationDeliveryAttempt(
             push_notification_subscription_id=sub.id,
@@ -1017,8 +1009,7 @@ def test_check_expo_push_receipts_skips_already_checked(db):
             receipt_checked_at=now(),
             receipt_status="ok",
         )
-        session.add(attempt)
-        session.flush()
+        add(session, attempt)
         # Make the attempt old enough
         attempt.time = now() - timedelta(minutes=15)
 
@@ -1138,8 +1129,7 @@ def test_check_expo_push_receipts_skips_too_recent(db):
             platform=PushNotificationPlatform.expo,
             token="ExponentPushToken[recent]",
         )
-        session.add(sub)
-        session.flush()
+        add(session, sub)
 
         attempt = PushNotificationDeliveryAttempt(
             push_notification_subscription_id=sub.id,
@@ -1147,8 +1137,7 @@ def test_check_expo_push_receipts_skips_too_recent(db):
             status_code=200,
             expo_ticket_id="recent-ticket",
         )
-        session.add(attempt)
-        session.flush()
+        add(session, attempt)
         # Make the attempt only 5 minutes old (too recent)
         attempt.time = now() - timedelta(minutes=5)
 
@@ -1178,8 +1167,7 @@ def test_check_expo_push_receipts_batch(db):
             platform=PushNotificationPlatform.expo,
             token="ExponentPushToken[batch]",
         )
-        session.add(sub)
-        session.flush()
+        add(session, sub)
 
         for i in range(3):
             attempt = PushNotificationDeliveryAttempt(
@@ -1188,7 +1176,7 @@ def test_check_expo_push_receipts_batch(db):
                 status_code=200,
                 expo_ticket_id=f"batch-ticket-{i}",
             )
-            session.add(attempt)
+            add(session, attempt)
             session.flush()
             attempt.time = now() - timedelta(minutes=20)
             attempt_ids.append(attempt.id)

--- a/app/backend/src/tests/test_pages.py
+++ b/app/backend/src/tests/test_pages.py
@@ -3,7 +3,7 @@ import pytest
 from google.protobuf import wrappers_pb2
 
 from couchers.crypto import random_hex
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.models import Cluster, ClusterRole, ClusterSubscription, Node, Page, PageType, PageVersion, Thread, Upload
 from couchers.proto import pages_pb2
 from couchers.utils import create_polygon_lat_lng, now, to_aware_datetime, to_multi
@@ -572,14 +572,14 @@ def test_page_transfer(db):
     with session_scope() as session:
         # create a community
         node = Node(geom=to_multi(create_polygon_lat_lng([[0, 0], [0, 2], [2, 2], [2, 0], [0, 0]])))
-        session.add(node)
+        add(session, node)
         community_cluster = Cluster(
             name="Testing Community",
             description="Description for testing community",
             parent_node=node,
             is_official_cluster=True,
         )
-        session.add(community_cluster)
+        add(session, community_cluster)
         main_page = Page(
             parent_node=community_cluster.parent_node,
             creator_user_id=user2.id,
@@ -587,14 +587,15 @@ def test_page_transfer(db):
             type=PageType.main_page,
             thread=Thread(),
         )
-        session.add(main_page)
-        session.add(
+        add(session, main_page)
+        add(
+            session,
             PageVersion(
                 page=main_page,
                 editor_user_id=user2.id,
                 title="Main page for the testing community",
                 content="Empty.",
-            )
+            ),
         )
         community_cluster.cluster_subscriptions.append(
             ClusterSubscription(
@@ -615,7 +616,7 @@ def test_page_transfer(db):
             description="Description for testing group",
             parent_node=node,
         )
-        session.add(group_cluster)
+        add(session, group_cluster)
         main_page = Page(
             parent_node=group_cluster.parent_node,
             creator_user_id=user2.id,
@@ -623,14 +624,15 @@ def test_page_transfer(db):
             type=PageType.main_page,
             thread=Thread(),
         )
-        session.add(main_page)
-        session.add(
+        add(session, main_page)
+        add(
+            session,
             PageVersion(
                 page=main_page,
                 editor_user_id=user2.id,
                 title="Main page for the testing community",
                 content="Empty.",
-            )
+            ),
         )
         group_cluster.cluster_subscriptions.append(
             ClusterSubscription(
@@ -815,12 +817,13 @@ def test_page_photo(db):
         filename1 = random_hex(32)
 
         with session_scope() as session:
-            session.add(
+            add(
+                session,
                 Upload(
                     key=key1,
                     filename=filename1,
                     creator_user_id=user.id,
-                )
+                ),
             )
 
         res = api.CreatePlace(
@@ -887,12 +890,13 @@ def test_page_photo(db):
         filename2 = random_hex(32)
 
         with session_scope() as session:
-            session.add(
+            add(
+                session,
                 Upload(
                     key=key2,
                     filename=filename2,
                     creator_user_id=user.id,
-                )
+                ),
             )
 
         res = api.UpdatePage(

--- a/app/backend/src/tests/test_public.py
+++ b/app/backend/src/tests/test_public.py
@@ -7,7 +7,7 @@ import grpc
 import pytest
 from google.protobuf import empty_pb2
 
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.jobs.enqueue import queue_job
 from couchers.jobs.handlers import update_randomized_locations
 from couchers.materialized_views import refresh_materialized_views_rapid
@@ -110,32 +110,35 @@ def test_GetDonationStats_with_donations(db):
 
     with session_scope() as session:
         # Add some on_platform donations (should be counted)
-        session.add(
+        add(
+            session,
             Invoice(
                 user_id=user.id,
                 amount=100,
                 stripe_payment_intent_id="pi_test_1",
                 stripe_receipt_url="https://example.com/receipt/1",
                 invoice_type=InvoiceType.on_platform,
-            )
+            ),
         )
-        session.add(
+        add(
+            session,
             Invoice(
                 user_id=user.id,
                 amount=250,
                 stripe_payment_intent_id="pi_test_2",
                 stripe_receipt_url="https://example.com/receipt/2",
                 invoice_type=InvoiceType.on_platform,
-            )
+            ),
         )
-        session.add(
+        add(
+            session,
             Invoice(
                 user_id=user.id,
                 amount=500,
                 stripe_payment_intent_id="pi_test_3",
                 stripe_receipt_url="https://example.com/receipt/3",
                 invoice_type=InvoiceType.on_platform,
-            )
+            ),
         )
 
     with (
@@ -155,24 +158,26 @@ def test_GetDonationStats_excludes_merch(db):
 
     with session_scope() as session:
         # Add on_platform donation (should be counted)
-        session.add(
+        add(
+            session,
             Invoice(
                 user_id=user.id,
                 amount=200,
                 stripe_payment_intent_id="pi_test_donation",
                 stripe_receipt_url="https://example.com/receipt/donation",
                 invoice_type=InvoiceType.on_platform,
-            )
+            ),
         )
         # Add external_shop/merch purchase (should NOT be counted)
-        session.add(
+        add(
+            session,
             Invoice(
                 user_id=user.id,
                 amount=50,
                 stripe_payment_intent_id="pi_test_merch",
                 stripe_receipt_url="https://example.com/receipt/merch",
                 invoice_type=InvoiceType.external_shop,
-            )
+            ),
         )
 
     with (
@@ -193,14 +198,15 @@ def test_GetDonationStats_excludes_previous_years(db):
 
     with session_scope() as session:
         # Add donation from this year (should be counted)
-        session.add(
+        add(
+            session,
             Invoice(
                 user_id=user.id,
                 amount=300,
                 stripe_payment_intent_id="pi_test_this_year",
                 stripe_receipt_url="https://example.com/receipt/this_year",
                 invoice_type=InvoiceType.on_platform,
-            )
+            ),
         )
         # Add donation from last year (should NOT be counted)
         last_year = datetime(datetime.now(UTC).year - 1, 6, 15, tzinfo=UTC)
@@ -211,8 +217,7 @@ def test_GetDonationStats_excludes_previous_years(db):
             stripe_receipt_url="https://example.com/receipt/last_year",
             invoice_type=InvoiceType.on_platform,
         )
-        session.add(invoice)
-        session.flush()
+        add(session, invoice)
         # Manually set the created date to last year
         invoice.created = last_year
 
@@ -238,39 +243,43 @@ def test_GetVolunteers_mixed_current_and_past(db):
     past2, _ = generate_user(username="past2")
 
     with session_scope() as session:
-        session.add(
+        add(
+            session,
             Volunteer(
                 user_id=current1.id,
                 role="Current Role 1",
                 started_volunteering=datetime(2023, 1, 1).date(),
                 show_on_team_page=True,
-            )
+            ),
         )
-        session.add(
+        add(
+            session,
             Volunteer(
                 user_id=current2.id,
                 role="Current Role 2",
                 started_volunteering=datetime(2024, 1, 1).date(),
                 show_on_team_page=True,
-            )
+            ),
         )
-        session.add(
+        add(
+            session,
             Volunteer(
                 user_id=past1.id,
                 role="Past Role 1",
                 started_volunteering=datetime(2020, 1, 1).date(),
                 stopped_volunteering=datetime(2022, 6, 1).date(),
                 show_on_team_page=True,
-            )
+            ),
         )
-        session.add(
+        add(
+            session,
             Volunteer(
                 user_id=past2.id,
                 role="Past Role 2",
                 started_volunteering=datetime(2021, 1, 1).date(),
                 stopped_volunteering=datetime(2023, 12, 31).date(),
                 show_on_team_page=True,
-            )
+            ),
         )
 
     refresh_materialized_views_rapid(None)
@@ -296,33 +305,36 @@ def test_GetVolunteers_custom_sort_key(db):
 
     with session_scope() as session:
         # user2 should be first (lowest sort_key)
-        session.add(
+        add(
+            session,
             Volunteer(
                 user_id=user2.id,
                 role="Role 2",
                 started_volunteering=datetime(2023, 3, 1).date(),
                 sort_key=1.0,
                 show_on_team_page=True,
-            )
+            ),
         )
         # user3 should be second
-        session.add(
+        add(
+            session,
             Volunteer(
                 user_id=user3.id,
                 role="Role 3",
                 started_volunteering=datetime(2023, 1, 1).date(),
                 sort_key=2.0,
                 show_on_team_page=True,
-            )
+            ),
         )
         # user1 should be last (no sort_key, falls back to started_volunteering)
-        session.add(
+        add(
+            session,
             Volunteer(
                 user_id=user1.id,
                 role="Role 1",
                 started_volunteering=datetime(2023, 2, 1).date(),
                 show_on_team_page=True,
-            )
+            ),
         )
 
     refresh_materialized_views_rapid(None)
@@ -344,21 +356,23 @@ def test_GetVolunteers_excludes_hidden(db):
     user2, _ = generate_user(username="hidden")
 
     with session_scope() as session:
-        session.add(
+        add(
+            session,
             Volunteer(
                 user_id=user1.id,
                 role="Visible Role",
                 started_volunteering=datetime(2023, 1, 1).date(),
                 show_on_team_page=True,
-            )
+            ),
         )
-        session.add(
+        add(
+            session,
             Volunteer(
                 user_id=user2.id,
                 role="Hidden Role",
                 started_volunteering=datetime(2023, 1, 1).date(),
                 show_on_team_page=False,
-            )
+            ),
         )
 
     refresh_materialized_views_rapid(None)
@@ -379,16 +393,18 @@ def test_GetVolunteers_link_types(db):
 
     with session_scope() as session:
         # Volunteer with default couchers link
-        session.add(
+        add(
+            session,
             Volunteer(
                 user_id=user_default.id,
                 role="Default Link",
                 started_volunteering=datetime(2023, 1, 1).date(),
                 show_on_team_page=True,
-            )
+            ),
         )
         # Volunteer with custom link
-        session.add(
+        add(
+            session,
             Volunteer(
                 user_id=user_custom.id,
                 role="Custom Link",
@@ -397,7 +413,7 @@ def test_GetVolunteers_link_types(db):
                 link_text="contact@example.com",
                 link_url="mailto:contact@example.com",
                 show_on_team_page=True,
-            )
+            ),
         )
 
     refresh_materialized_views_rapid(None)
@@ -428,21 +444,23 @@ def test_GetVolunteers_board_member_flag(db):
     regular_volunteer, _ = generate_user(username="regular")
 
     with session_scope() as session:
-        session.add(
+        add(
+            session,
             Volunteer(
                 user_id=board_member.id,
                 role="Board Member Role",
                 started_volunteering=datetime(2023, 1, 1).date(),
                 show_on_team_page=True,
-            )
+            ),
         )
-        session.add(
+        add(
+            session,
             Volunteer(
                 user_id=regular_volunteer.id,
                 role="Regular Role",
                 started_volunteering=datetime(2023, 1, 1).date(),
                 show_on_team_page=True,
-            )
+            ),
         )
 
     refresh_materialized_views_rapid(None)
@@ -522,7 +540,8 @@ def test_GetPublicUser_limited_visibility(db):
     # Add a reference to test reference counting
     referrer, _ = generate_user(username="referrer")
     with session_scope() as session:
-        session.add(
+        add(
+            session,
             Reference(
                 from_user_id=referrer.id,
                 to_user_id=user.id,
@@ -530,7 +549,7 @@ def test_GetPublicUser_limited_visibility(db):
                 text="Great host!",
                 rating=0.8,
                 was_appropriate=True,
-            )
+            ),
         )
 
     with public_session() as public:

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -7,7 +7,7 @@ from google.protobuf import empty_pb2
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.materialized_views import refresh_materialized_views_rapid
 from couchers.models import (
     Conversation,
@@ -52,15 +52,15 @@ def create_host_request(
     to_date = today() - host_request_age
     fake_created = now() - host_request_age - timedelta(days=3)
     conversation = Conversation()
-    session.add(conversation)
-    session.flush()
-    session.add(
+    add(session, conversation)
+    add(
+        session,
         Message(
             time=fake_created + timedelta(seconds=1),
             conversation_id=conversation.id,
             author_id=surfer_user_id,
             message_type=MessageType.chat_created,
-        )
+        ),
     )
     message = Message(
         time=fake_created + timedelta(seconds=2),
@@ -69,8 +69,7 @@ def create_host_request(
         text="Hi, I'm requesting to be hosted.",
         message_type=MessageType.text,
     )
-    session.add(message)
-    session.flush()
+    add(session, message)
 
     moderation_state = create_moderation(
         session,
@@ -94,7 +93,7 @@ def create_host_request(
         hosting_radius=10,
         moderation_state_id=moderation_state.id,
     )
-    session.add(host_request)
+    add(session, host_request)
     session.commit()
     return host_request.conversation_id
 
@@ -110,16 +109,16 @@ def create_host_request_by_date(
     last_sent_request_reminder_time,
 ):
     conversation = Conversation()
-    session.add(conversation)
-    session.flush()
+    add(session, conversation)
 
-    session.add(
+    add(
+        session,
         Message(
             time=from_date + timedelta(seconds=1),
             conversation_id=conversation.id,
             author_id=surfer_user_id,
             message_type=MessageType.chat_created,
-        )
+        ),
     )
 
     # Unused for now, but every host request must have a message.
@@ -130,8 +129,7 @@ def create_host_request_by_date(
         text="Hi, I'm requesting to be hosted.",
         message_type=MessageType.text,
     )
-    session.add(message)
-    session.flush()
+    add(session, message)
 
     moderation_state = create_moderation(
         session,
@@ -155,7 +153,7 @@ def create_host_request_by_date(
         moderation_state_id=moderation_state.id,
     )
 
-    session.add(host_request)
+    add(session, host_request)
     session.commit()
     return host_request.conversation_id
 
@@ -195,7 +193,7 @@ def create_host_reference(session, from_user_id, to_user_id, reference_age, *, s
         reference.to_user_id = host_request.surfer_user_id
         assert from_user_id == host_request.host_user_id
 
-    session.add(reference)
+    add(session, reference)
     session.commit()
     return reference.id, actual_host_request_id
 
@@ -210,7 +208,7 @@ def create_friend_reference(session: Session, from_user_id: int, to_user_id: int
         rating=0.4,
         was_appropriate=True,
     )
-    session.add(reference)
+    add(session, reference)
     session.commit()
     return reference.id
 

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 
 from couchers.constants import HOST_REQUEST_MIN_LENGTH_UTF16
 from couchers.crypto import b64decode
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.materialized_views import refresh_materialized_view
 from couchers.models import (
     Message,
@@ -276,7 +276,7 @@ def add_message(db, text, author_id, conversation_id):
             conversation_id=conversation_id, author_id=author_id, text=text, message_type=MessageType.text
         )
 
-        session.add(message)
+        add(session, message)
 
 
 def test_GetHostRequest(db):

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 import pytest
 from google.protobuf import wrappers_pb2
 
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.materialized_views import refresh_materialized_views, refresh_materialized_views_rapid
 from couchers.models import EventOccurrence, HostingStatus, LanguageAbility, LanguageFluency, MeetupStatus
 from couchers.proto import api_pb2, communities_pb2, events_pb2, search_pb2
@@ -220,20 +220,23 @@ def test_user_filter_language(db):
     user_with_german_fluent, token13 = generate_user(hosting_status=HostingStatus.can_host)
 
     with session_scope() as session:
-        session.add(
+        add(
+            session,
             LanguageAbility(
                 user_id=user_with_german_beginner.id, language_code="deu", fluency=LanguageFluency.beginner
             ),
         )
-        session.add(
+        add(
+            session,
             LanguageAbility(
                 user_id=user_with_japanese_conversational.id,
                 language_code="jpn",
                 fluency=LanguageFluency.fluent,
-            )
+            ),
         )
-        session.add(
-            LanguageAbility(user_id=user_with_german_fluent.id, language_code="deu", fluency=LanguageFluency.fluent)
+        add(
+            session,
+            LanguageAbility(user_id=user_with_german_fluent.id, language_code="deu", fluency=LanguageFluency.fluent),
         )
 
     refresh_materialized_views_rapid(None)

--- a/app/backend/src/tests/test_templates.py
+++ b/app/backend/src/tests/test_templates.py
@@ -1,5 +1,4 @@
 # Tests jinja template rendering
-
 from typing import Any
 from unittest.mock import patch
 

--- a/app/backend/src/tests/test_threads.py
+++ b/app/backend/src/tests/test_threads.py
@@ -4,7 +4,7 @@ import textwrap
 import grpc
 import pytest
 
-from couchers.db import session_scope
+from couchers.db import add, session_scope
 from couchers.models import Thread
 from couchers.proto import threads_pb2
 from couchers.servicers.threads import pack_thread_id
@@ -23,8 +23,7 @@ def test_threads_basic(db):
     # Create a dummy Thread (should be replaced by pages later on)
     with session_scope() as session:
         dummy_thread = Thread()
-        session.add(dummy_thread)
-        session.flush()
+        add(session, dummy_thread)
         PARENT_THREAD_ID = pack_thread_id(database_id=dummy_thread.id, depth=0)
 
     with threads_session(token1) as api:
@@ -138,7 +137,7 @@ def test_threads_pagination(db):
 
     # Create a dummy Thread (should be replaced by pages later on)
     with session_scope() as session:
-        session.add(Thread(id=1))
+        add(session, Thread(id=1))
 
     with threads_session(token1) as api:
         comment_id = pagination_test(api, PARENT_THREAD_ID)


### PR DESCRIPTION
This prevents cases when we created an instance, added it to a session, but haven't flushed it, and then try to use it's databased-generated properties (like id)

## Why we need it 

This is a part of migration to `MappedAsDataclass` for sqlalchemy models.  `MappedAsDataclass`  gives us a type-safe `__init__`; we can no longer forget to pass a required field. But this also means that for relationships we have to pass both foreign key column and the related object, e.g.:

```python
class PhotoGalleryItem(Base):
    __tablename__ = "photo_gallery_items"
    
    gallery_id: Mapped[int] = mapped_column(ForeignKey("photo_galleries.id"), index=True)
    gallery: Mapped[PhotoGallery] = relationship(back_populates="photos")

PhotoGalleryItem(gallery=gallery)  # type error, gallery_id not passed
PhotoGalleryItem(gallery_id=1)  # type error, gallery not passed
```

This is annoying, and I propose we standardise on always passing only the foreign key column, since it's always available. Then it will look like this (note the `init=False` for `gallery`)

```python
class PhotoGalleryItem(Base):
    __tablename__ = "photo_gallery_items"
    
    gallery_id: Mapped[int] = mapped_column(ForeignKey("photo_galleries.id"), index=True)
    gallery: Mapped[PhotoGallery] = relationship(init=False, back_populates="photos")

PhotoGalleryItem(gallery=gallery)  # type error, no such argument
PhotoGalleryItem(gallery_id=1)  # good!
```

The only problem with this approach is that we have to remember to flush the gallery object. Consider:

```python
gallery = PhotoGallery(...)
session.add(gallery)
item = PhotoGalleryItem(gallery_id=gallery.id)  # whooops, gallery.id is None!
```

This is where this PR comes in: by using our own `add` instead of `session.add` we can never forget to flush. 

Ideally, I think that we should use our own wrapper around `Session` everywhere:

```python
class DB:
    _session: Session
    def add(self, obj):
        self._session.add(obj)
        self._session.flush()
        return obj
    
     # Provided so that we don't have to directly access session
     def execute(self, stmt):
         return self._session.execute(stmt)
         
def AddUser(
    self, request: AddUserReq, context: CouchersContext, db: DB
) -> empty_pb2.Empty:
    
    user = db.add(User(...))
```
