### PR TITLE
Run mypy on tests

### DIFF
--- a/app/backend/Makefile
+++ b/app/backend/Makefile
@@ -26,7 +26,7 @@ format:
 fmt: format
 
 mypy:
-	uv run mypy src/couchers
+	uv run mypy src/couchers src/tests
 
 # Downgrade the local database to the previous migration. Good if you ran a migration on a branch and will run the backend on another branch after.
 # Usage:

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -130,6 +130,18 @@ module = ["http_ece", "py_vapid", "luhn", "sqlalchemy_utils.*", "statsig_python_
 # These libraries don't have type stubs or py.typed markers
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ["tests.*"]
+# Test files don't require strict type checking
+disallow_untyped_defs = false
+disallow_untyped_calls = false
+disallow_incomplete_defs = false
+
+[[tool.mypy.overrides]]
+module = ["tests.fixtures.sessions"]
+# Mock gRPC infrastructure intentionally violates type contracts
+disable_error_code = ["arg-type"]
+
 
 # Coverage
 [tool.coverage.run]

--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -154,7 +154,7 @@ def get_parent_node_at_location(session: Session, shape: WKBElement) -> Node | N
     """
     Finds the smallest node containing the shape.
 
-    Shape can be any PostGIS geo object, e.g. output from create_coordinate
+    Shape can be any PostGIS geo object, e.g., output from create_coordinate
     """
 
     # Find the lowest Node (in the Node tree) that contains the shape. By construction of nodes, the area of a sub-node

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -7,7 +7,7 @@ from os import getpid
 from threading import get_ident
 from time import perf_counter_ns
 from traceback import format_exception
-from typing import Any, NoReturn, cast
+from typing import Any, NoReturn, cast, overload
 
 import grpc
 import sentry_sdk
@@ -152,6 +152,10 @@ def unauthenticated_handler[T, R](
     return abort_handler(message, status_code)
 
 
+@overload
+def _sanitized_bytes(proto: Message) -> bytes: ...
+@overload
+def _sanitized_bytes(proto: None) -> None: ...
 def _sanitized_bytes(proto: Message | None) -> bytes | None:
     """
     Remove fields marked sensitive and return serialized bytes

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -316,7 +316,7 @@ class User(Base):
     age = column_property(func.date_part("year", func.age(birthdate)))
 
     # ID of the invite code used to sign up (if any)
-    invite_code_id: Mapped[int | None] = mapped_column(ForeignKey("invite_codes.id"), nullable=True)
+    invite_code_id: Mapped[str | None] = mapped_column(ForeignKey("invite_codes.id"), nullable=True)
     invite_code: Mapped[InviteCode | None] = relationship(foreign_keys=[invite_code_id])
 
     moderation_user_lists: Mapped[list[ModerationUserList]] = relationship(

--- a/app/backend/src/couchers/tasks.py
+++ b/app/backend/src/couchers/tasks.py
@@ -118,7 +118,7 @@ def send_rate_limit_violation_report_email(
     logger.info(
         f"Sending rate limit moderation email for user '{rate_limit_violation.user_id}' ({rate_limit_violation.action})"
     )
-    user = session.get(User, rate_limit_violation.user_id)
+    user = session.get_one(User, rate_limit_violation.user_id)
     email.enqueue_system_email(
         session,
         config["REPORTS_EMAIL_RECIPIENT"],

--- a/app/backend/src/tests/fixtures/db.py
+++ b/app/backend/src/tests/fixtures/db.py
@@ -3,12 +3,13 @@ from collections.abc import Sequence
 from contextlib import contextmanager
 from datetime import date, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from sqlalchemy import Connection, Engine, create_engine, or_, select, text, update
 from sqlalchemy.orm import Session
 
 from couchers.constants import GUIDELINES_VERSION, TOS_VERSION
+from couchers.context import CouchersContext
 from couchers.crypto import random_hex
 from couchers.db import _get_base_engine, session_scope
 from couchers.models import (
@@ -232,7 +233,8 @@ def generate_user(
             session.add(LanguageAbility(user_id=user.id, language_code=lang, fluency=fluency))
 
         # this expires the user, so now it's "dirty"
-        token, _ = create_session(_MockCouchersContext(), session, user, False, set_cookie=False)
+        context = cast(CouchersContext, _MockCouchersContext())
+        token, _ = create_session(context, session, user, False, set_cookie=False)
 
         # deleted user aborts session creation, hence this follows and necessitates a second commit
         if delete_user:
@@ -323,7 +325,7 @@ def make_user_invisible(user_id: int) -> None:
 
 
 # This doubles as get_FriendRequest, since a friend request is just a pending friend relationship
-def get_friend_relationship(user1: User, user2: User) -> FriendRelationship:
+def get_friend_relationship(user1: User, user2: User) -> FriendRelationship | None:
     with session_scope() as session:
         friend_relationship = session.execute(
             select(FriendRelationship).where(
@@ -345,7 +347,7 @@ def add_users_to_new_moderation_list(users: list[User]) -> int:
         session.add(moderation_user_list)
         session.flush()
         for user in users:
-            refreshed_user = session.get(User, user.id)
+            refreshed_user = session.get_one(User, user.id)
             moderation_user_list.users.append(refreshed_user)
         return moderation_user_list.id
 

--- a/app/backend/src/tests/fixtures/misc.py
+++ b/app/backend/src/tests/fixtures/misc.py
@@ -1,6 +1,10 @@
+from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import Mock, patch
+
+from sqlalchemy.orm import Session
 
 from couchers.jobs.worker import process_job
 from couchers.models import User
@@ -9,13 +13,13 @@ from couchers.proto import moderation_pb2
 from tests.fixtures.sessions import real_moderation_session
 
 
-def process_jobs():
+def process_jobs() -> None:
     while process_job():
         pass
 
 
 @contextmanager
-def mock_notification_email():
+def mock_notification_email() -> Generator[Mock]:
     with patch("couchers.email._queue_email") as mock:
         yield mock
         process_jobs()
@@ -33,7 +37,7 @@ class EmailData:
     list_unsubscribe_header: str
 
 
-def email_fields(mock, call_ix=0):
+def email_fields(mock: Mock, call_ix: int = 0) -> EmailData:
     _, kw = mock.call_args_list[call_ix]
     return EmailData(
         sender_name=kw.get("sender_name"),
@@ -63,7 +67,7 @@ class PushCollector:
     def by_user(self, user_id: int) -> list[Push]:
         return [push for uid, push in self.pushes if uid == user_id]
 
-    def push_to_user(self, session, user_id: int, **kwargs) -> None:
+    def push_to_user(self, session: Session, user_id: int, **kwargs: Any) -> None:
         self.pushes.append((user_id, Push(**kwargs)))
 
     def count_for_user(self, user_id: int) -> int:
@@ -80,10 +84,10 @@ class PushCollector:
             return pushes[0]
         return pushes[index]
 
-    def assert_user_has_count(self, user_id, count):
+    def assert_user_has_count(self, user_id: int, count: int) -> None:
         assert len(self.by_user(user_id)) == count
 
-    def assert_user_push_matches_fields(self, user_id, ix=0, **kwargs):
+    def assert_user_push_matches_fields(self, user_id: int, ix: int = 0, **kwargs: Any) -> None:
         push = self.by_user(user_id)[ix]
         for kwarg in kwargs:
             assert hasattr(push, kwarg), f"Push notification {user_id=}, {ix=} missing field '{kwarg}'"
@@ -91,7 +95,7 @@ class PushCollector:
                 f"Push notification {user_id=}, {ix=} mismatch in field '{kwarg}', expected '{kwargs[kwarg]}' but got '{getattr(push, kwarg)}'"
             )
 
-    def assert_user_has_single_matching(self, user_id, **kwargs):
+    def assert_user_has_single_matching(self, user_id: int, **kwargs: Any) -> None:
         self.assert_user_has_count(user_id, 1)
         self.assert_user_push_matches_fields(user_id, ix=0, **kwargs)
 

--- a/app/backend/src/tests/fixtures/sessions.py
+++ b/app/backend/src/tests/fixtures/sessions.py
@@ -1,6 +1,7 @@
 from collections.abc import Generator
 from concurrent import futures
 from contextlib import contextmanager
+from typing import Any
 
 import grpc
 from grpc._server import _validate_generic_rpc_handlers
@@ -113,7 +114,7 @@ class FakeRpcError(grpc.RpcError):
         return self._details
 
 
-def _check_user_perms(method: str, auth_info: UserAuthInfo) -> None:
+def _check_user_perms(method: str, auth_info: UserAuthInfo | None) -> None:
     # method is of the form "/org.couchers.api.core.API/GetUser"
     _, service_name, method_name = method.split("/")
 
@@ -171,10 +172,10 @@ class FakeChannel:
     """
 
     def __init__(self, token: str | None = None):
-        self.handlers = {}
+        self.handlers: dict[str, Any] = {}
         self._token = token
 
-    def add_generic_rpc_handlers(self, generic_rpc_handlers):
+    def add_generic_rpc_handlers(self, generic_rpc_handlers: Any):
         _validate_generic_rpc_handlers(generic_rpc_handlers)
         self.handlers.update(generic_rpc_handlers[0]._method_handlers)
 

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -536,7 +536,9 @@ def test_ChangeEmailV2(db, fast_passwords, push_collector: PushCollector):
         assert user_updated.email == user.email
         assert user_updated.new_email == new_email
         assert user_updated.new_email_token is not None
+        assert user_updated.new_email_token_created
         assert user_updated.new_email_token_created <= now()
+        assert user_updated.new_email_token_expiry
         assert user_updated.new_email_token_expiry >= now()
 
         token = user_updated.new_email_token
@@ -675,10 +677,10 @@ def test_full_delete_account_with_recovery(db, push_collector: PushCollector):
     user_id = user.id
 
     with account_session(token) as account:
-        with pytest.raises(grpc.RpcError) as e:
+        with pytest.raises(grpc.RpcError) as err:
             account.DeleteAccount(account_pb2.DeleteAccountReq())
-        assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
-        assert e.value.details() == "Please confirm your account deletion."
+        assert err.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+        assert err.value.details() == "Please confirm your account deletion."
 
         # Check the right email is sent
         with mock_notification_email() as mock:
@@ -739,6 +741,7 @@ def test_full_delete_account_with_recovery(db, push_collector: PushCollector):
         user_ = session.execute(select(User).where(User.id == user_id)).scalar_one()
         assert user_.is_deleted
         assert user_.undelete_token
+        assert user_.undelete_until
         assert user_.undelete_until > now()
 
         undelete_token = user_.undelete_token
@@ -801,7 +804,7 @@ def test_multiple_delete_tokens(db):
 
     with session_scope() as session:
         assert session.execute(select(func.count()).select_from(AccountDeletionToken)).scalar_one() == 3
-        token = session.execute(select(AccountDeletionToken).limit(1)).scalars().one_or_none().token
+        token = session.execute(select(AccountDeletionToken.token).limit(1)).scalar_one()
 
     with auth_api_session() as (auth_api, metadata_interceptor):
         auth_api.ConfirmDeleteAccount(
@@ -811,7 +814,7 @@ def test_multiple_delete_tokens(db):
         )
 
     with session_scope() as session:
-        assert not session.execute(select(AccountDeletionToken)).scalar_one_or_none()
+        assert not session.execute(select(AccountDeletionToken.token)).scalar_one_or_none()
 
 
 def test_ListActiveSessions_pagination(db, fast_passwords):
@@ -996,7 +999,7 @@ def test_reminders(db, moderator):
     req_user1, req_user_token1 = generate_user(complete_profile=True)
     req_user2, req_user_token2 = generate_user(complete_profile=True)
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
     with account_session(complete_token) as account:
         assert [reminder.WhichOneof("reminder") for reminder in account.GetReminders(empty_pb2.Empty()).reminders] == [
             "complete_verification_reminder"
@@ -1041,7 +1044,7 @@ def test_reminders(db, moderator):
         ).host_request_id
     moderator.approve_host_request(host_request2_id)
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
     with account_session(token) as account:
         reminders = account.GetReminders(empty_pb2.Empty()).reminders
         assert [reminder.WhichOneof("reminder") for reminder in reminders] == [
@@ -1066,7 +1069,7 @@ def test_reminders(db, moderator):
         ).host_request_id
     moderator.approve_host_request(host_request3_id)
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
     with account_session(token) as account:
         reminders = account.GetReminders(empty_pb2.Empty()).reminders
         assert [reminder.WhichOneof("reminder") for reminder in reminders] == [
@@ -1091,7 +1094,7 @@ def test_reminders(db, moderator):
             )
         )
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
     with account_session(token) as account:
         reminders = account.GetReminders(empty_pb2.Empty()).reminders
         assert [reminder.WhichOneof("reminder") for reminder in reminders] == [
@@ -1212,7 +1215,7 @@ def test_volunteer_stuff(db):
         assert res.link_text == "tester@vontester.com.invalid"
         assert res.link_url == "mailto:tester@vontester.com.invalid"
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with public_session() as public:
         res = public.GetVolunteers(empty_pb2.Empty())

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from re import match
 
 import grpc
@@ -17,7 +17,7 @@ from couchers.models import (
     UserSession,
 )
 from couchers.proto import admin_pb2, auth_pb2, events_pb2, references_pb2, reporting_pb2
-from couchers.utils import Timestamp_from_datetime, now, parse_date, timedelta
+from couchers.utils import Timestamp_from_datetime, now, parse_date
 from tests.fixtures.db import add_users_to_new_moderation_list, generate_user, make_friends
 from tests.fixtures.misc import PushCollector, email_fields, mock_notification_email
 from tests.fixtures.sessions import (
@@ -275,7 +275,9 @@ def test_admin_content_reports(db):
         )
 
     with session_scope() as session:
-        id_by_description = dict(session.execute(select(ContentReport.description, ContentReport.id)).all())
+        id_by_description: dict[str, int] = dict(
+            session.execute(select(ContentReport.description, ContentReport.id)).all()  # type: ignore[arg-type]
+        )
 
     with real_admin_session(super_token) as api:
         with pytest.raises(grpc.RpcError) as e:
@@ -478,7 +480,7 @@ def test_DeleteEvent(db):
                     event_id=event_id,
                 )
             )
-            occurrence = session.get(EventOccurrence, ident=event_id)
+            occurrence = session.get_one(EventOccurrence, ident=event_id)
             assert occurrence.is_deleted
 
 
@@ -527,7 +529,7 @@ def test_EditReferenceText(db):
 
         modified_reference = session.execute(
             select(Reference).where(Reference.id == reference.reference_id)
-        ).scalar_one_or_none()
+        ).scalar_one()
         assert modified_reference.text == test_new_text
 
 
@@ -557,7 +559,7 @@ def test_DeleteReference(db):
     with session_scope() as session:
         modified_reference = session.execute(
             select(Reference).where(Reference.id == reference.reference_id)
-        ).scalar_one_or_none()
+        ).scalar_one()
         assert modified_reference.is_deleted
 
 
@@ -618,7 +620,7 @@ def test_AddUsersToModerationUserList(db):
             )
             assert res2.moderation_list_id == moderation_list_id
             with session_scope() as session:
-                moderation_user_list = session.get(ModerationUserList, moderation_list_id)
+                moderation_user_list = session.get_one(ModerationUserList, moderation_list_id)
                 assert len(moderation_user_list.users) == 3
                 assert {user1.id, user4.id, user5.id}.issubset({user.id for user in moderation_user_list.users})
 
@@ -665,7 +667,7 @@ def test_RemoveUserFromModerationUserList(db):
             admin_pb2.RemoveUserFromModerationUserListReq(user=user1.username, moderation_list_id=moderation_list_id)
         )
         with session_scope() as session:
-            moderation_user_list = session.get(ModerationUserList, moderation_list_id)
+            moderation_user_list = session.get_one(ModerationUserList, moderation_list_id)
             assert user1.id not in {user.id for user in moderation_user_list.users}
             assert user2.id in {user.id for user in moderation_user_list.users}
 

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -57,7 +57,7 @@ def test_ping(db):
     assert res.user.pronouns == user.pronouns
     assert res.user.age == user.age
 
-    assert (res.user.lat, res.user.lng) == (user.coordinates or (0, 0))
+    assert (res.user.lat, res.user.lng) == user.coordinates
 
     # the joined time is fuzzed
     # but shouldn't be before actual joined time, or more than one hour behind
@@ -90,7 +90,7 @@ def test_coords(db):
     with api_session(token2) as api:
         res = api.Ping(api_pb2.PingReq())
         assert res.user.city == user2.city
-        lat, lng = user2.coordinates or (0, 0)
+        lat, lng = user2.coordinates
         assert res.user.lat == lat
         assert res.user.lng == lng
         assert res.user.radius == user2.geom_radius
@@ -177,7 +177,7 @@ def test_user_model_to_pb_ghost_user(db, flag):
     with session_scope() as session:
         session.execute(update(User).where(User.id == user2.id).values(**{flag: True}))
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token1) as api:
         user_pb = api.GetUser(api_pb2.GetUserReq(user=user2.username))
@@ -243,7 +243,7 @@ def test_user_model_to_pb_ghost_user_blocked(db):
     with blocking_session(token1) as user_blocks:
         user_blocks.BlockUser(blocking_pb2.BlockUserReq(username=user2.username))
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token1) as api:
         user_pb = api.GetUser(api_pb2.GetUserReq(user=user2.username))
@@ -332,12 +332,12 @@ def test_lite_coords(db):
     user1, token1 = generate_user(geom=create_coordinate(0, 0), geom_radius=0, needs_to_update_location=True)
     user2, token2 = generate_user()
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token2) as api:
         res = api.Ping(api_pb2.PingReq())
         assert res.user.city == user2.city
-        lat, lng = user2.coordinates or (0, 0)
+        lat, lng = user2.coordinates
         assert res.user.lat == lat
         assert res.user.lng == lng
         assert res.user.radius == user2.geom_radius
@@ -354,7 +354,7 @@ def test_lite_coords(db):
     user4, token4 = generate_user(geom=create_coordinate(40.0, 20.0))
     user5, token5 = generate_user(geom=create_coordinate(90.5, 20.0))
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token3) as api:
         res = api.GetLiteUser(api_pb2.GetLiteUserReq(user=user3.username))
@@ -393,7 +393,7 @@ def test_lite_coords(db):
         assert not res.jailed
         assert not res.needs_to_update_location
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token2) as api:
         res = api.GetLiteUser(api_pb2.GetLiteUserReq(user=user1.username))
@@ -407,7 +407,7 @@ def test_lite_get_user(db):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token1) as api:
         res = api.GetLiteUser(api_pb2.GetLiteUserReq(user=user2.username))
@@ -432,7 +432,7 @@ def test_GetLiteUsers(db):
 
     make_user_block(user4, user1)
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token1) as api:
         res = api.GetLiteUsers(
@@ -640,8 +640,8 @@ def test_language_abilities(db):
         assert len(res.language_abilities) == 2
 
         # can't add non-existent languages
-        with pytest.raises(grpc.RpcError) as e:
-            res = api.UpdateProfile(
+        with pytest.raises(grpc.RpcError) as err:
+            api.UpdateProfile(
                 api_pb2.UpdateProfileReq(
                     language_abilities=api_pb2.RepeatedLanguageAbilityValue(
                         value=[
@@ -653,12 +653,12 @@ def test_language_abilities(db):
                     ),
                 )
             )
-        assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
-        assert e.value.details() == "Invalid language."
+        assert err.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+        assert err.value.details() == "Invalid language."
 
         # can't have multiple languages of the same type
-        with pytest.raises(Exception) as e:
-            res = api.UpdateProfile(
+        with pytest.raises(Exception) as err2:
+            api.UpdateProfile(
                 api_pb2.UpdateProfileReq(
                     language_abilities=api_pb2.RepeatedLanguageAbilityValue(
                         value=[
@@ -674,7 +674,7 @@ def test_language_abilities(db):
                     ),
                 )
             )
-        assert "violates unique constraint" in str(e.value)
+        assert "violates unique constraint" in str(err2.value)
 
         # nothing changed
         res = api.GetUser(api_pb2.GetUserReq(user=user.username))
@@ -824,13 +824,11 @@ def test_friend_request_flow(db, push_collector: PushCollector):
     assert "http://localhost:3000/connections/friends/" in e.html
 
     with session_scope() as session:
-        friend_request_id = (
-            session.execute(
-                select(FriendRelationship).where(
-                    FriendRelationship.from_user_id == user1.id and FriendRelationship.to_user_id == user2.id
-                )
-            ).scalar_one_or_none()
-        ).id
+        friend_request_id = session.execute(
+            select(FriendRelationship.id).where(
+                FriendRelationship.from_user_id == user1.id and FriendRelationship.to_user_id == user2.id
+            )
+        ).scalar_one_or_none()
 
     with api_session(token1) as api:
         # check it went through
@@ -898,10 +896,10 @@ def test_friend_request_flow(db, push_collector: PushCollector):
 
     with api_session(token1) as api:
         # we can't unfriend if we aren't friends
-        with pytest.raises(grpc.RpcError) as e:
+        with pytest.raises(grpc.RpcError) as err:
             api.RemoveFriend(api_pb2.RemoveFriendReq(user_id=user3.id))
-        assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
-        assert e.value.details() == "You aren't friends with that user!"
+        assert err.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+        assert err.value.details() == "You aren't friends with that user!"
 
         # we can unfriend
         res = api.RemoveFriend(api_pb2.RemoveFriendReq(user_id=user2.id))
@@ -1521,7 +1519,7 @@ def test_GetLiteUser_ghost_user_by_username(db, flag):
         session.commit()
 
     # Refresh the materialized view
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token1) as api:
         # Query by username
@@ -1553,7 +1551,7 @@ def test_GetLiteUser_ghost_user_by_id(db, flag):
         session.commit()
 
     # Refresh the materialized view
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token1) as api:
         # Query by ID
@@ -1581,7 +1579,7 @@ def test_GetLiteUser_blocked_user(db):
     make_user_block(user1, user2)
 
     # Refresh the materialized view
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token1) as api:
         # Query by username
@@ -1610,7 +1608,7 @@ def test_GetLiteUser_blocking_user(db):
     make_user_block(user2, user1)
 
     # Refresh the materialized view
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token1) as api:
         # Query by username
@@ -1647,7 +1645,7 @@ def test_GetLiteUsers_ghost_users(db, flag):
         session.commit()
 
     # Refresh the materialized view
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token1) as api:
         res = api.GetLiteUsers(
@@ -1708,7 +1706,7 @@ def test_GetLiteUsers_blocked_users(db):
     make_user_block(user4, user1)
 
     # Refresh the materialized view
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token1) as api:
         res = api.GetLiteUsers(

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -1,4 +1,5 @@
 import http.cookies
+from typing import cast
 
 import grpc
 import pytest
@@ -254,7 +255,7 @@ def _quick_signup() -> int:
     sesh, uid = get_session_cookie_tokens(metadata_interceptor)
     assert sesh == token
 
-    return res.auth_res.user_id
+    return cast(int, res.auth_res.user_id)
 
 
 def test_signup(db):
@@ -307,9 +308,9 @@ def test_login_part_signed_up_verified_email(db):
 
     with mock_notification_email() as mock:
         with auth_api_session() as (auth_api, metadata_interceptor):
-            with pytest.raises(grpc.RpcError) as e:
+            with pytest.raises(grpc.RpcError) as err:
                 auth_api.Authenticate(auth_pb2.AuthReq(user="email@couchers.org.invalid", password="wrong pwd"))
-            assert e.value.details() == "Please check your email for a link to continue signing up."
+            assert err.value.details() == "Please check your email for a link to continue signing up."
 
     assert mock.call_count == 1
     e = email_fields(mock)
@@ -343,9 +344,9 @@ def test_login_part_signed_up_not_verified_email(db):
 
     with mock_notification_email() as mock:
         with auth_api_session() as (auth_api, metadata_interceptor):
-            with pytest.raises(grpc.RpcError) as e:
+            with pytest.raises(grpc.RpcError) as err:
                 auth_api.Authenticate(auth_pb2.AuthReq(user="frodo", password="wrong pwd"))
-            assert e.value.details() == "Please check your email for a link to continue signing up."
+            assert err.value.details() == "Please check your email for a link to continue signing up."
 
     with session_scope() as session:
         flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
@@ -354,6 +355,7 @@ def test_login_part_signed_up_not_verified_email(db):
     assert mock.call_count == 1
     e = email_fields(mock)
     assert e.recipient == "email@couchers.org.invalid"
+    assert email_token
     assert email_token in e.plain
     assert email_token in e.html
 
@@ -429,18 +431,18 @@ def test_password_reset_v2(db, push_collector: PushCollector):
     assert push.content.body == "Someone initiated a password change on your account."
     # make sure bad password are caught
     with auth_api_session() as (auth_api, metadata_interceptor):
-        with pytest.raises(grpc.RpcError) as e:
+        with pytest.raises(grpc.RpcError) as err:
             auth_api.CompletePasswordResetV2(
                 auth_pb2.CompletePasswordResetV2Req(password_reset_token=password_reset_token, new_password="password")
             )
-        assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
-        assert e.value.details() == "The password is insecure. Please use one that is not easily guessable."
+        assert err.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+        assert err.value.details() == "The password is insecure. Please use one that is not easily guessable."
 
     # make sure we can set a good password
     with auth_api_session() as (auth_api, metadata_interceptor):
         pwd = random_hex()
         with mock_notification_email() as mock:
-            res = auth_api.CompletePasswordResetV2(
+            auth_api.CompletePasswordResetV2(
                 auth_pb2.CompletePasswordResetV2Req(password_reset_token=password_reset_token, new_password=pwd)
             )
 
@@ -465,14 +467,14 @@ def test_password_reset_v2(db, push_collector: PushCollector):
 
     # make sure we can't set a password again
     with auth_api_session() as (auth_api, metadata_interceptor):
-        with pytest.raises(grpc.RpcError) as e:
+        with pytest.raises(grpc.RpcError) as err:
             auth_api.CompletePasswordResetV2(
                 auth_pb2.CompletePasswordResetV2Req(
                     password_reset_token=password_reset_token, new_password=random_hex()
                 )
             )
-        assert e.value.code() == grpc.StatusCode.NOT_FOUND
-        assert e.value.details() == "Invalid token."
+        assert err.value.code() == grpc.StatusCode.NOT_FOUND
+        assert err.value.details() == "Invalid token."
 
     with session_scope() as session:
         user = session.execute(select(User)).scalar_one()
@@ -490,9 +492,7 @@ def test_password_reset_no_such_user(db):
         )
 
     with session_scope() as session:
-        res = session.execute(select(PasswordResetToken)).scalar_one_or_none()
-
-    assert res is None
+        assert session.execute(select(PasswordResetToken)).scalar_one_or_none() is None
 
 
 def test_password_reset_invalid_token_v2(db):
@@ -762,6 +762,7 @@ def test_signup_resend_email(db):
         assert mock.call_count == 1
         e = email_fields(mock)
         assert e.recipient == "email@couchers.org.invalid"
+        assert email_token
         assert email_token in e.plain
         assert email_token in e.html
 
@@ -1255,5 +1256,7 @@ def test_SignupFlow_invite_code(db):
 
     # Check that invite_code_id is stored in the final User object
     with session_scope() as session:
-        user = session.execute(select(User).where(User.username == "invited_user")).scalar_one()
-        assert user.invite_code_id == invite_code
+        invite_code_id = session.execute(
+            select(User.invite_code_id).where(User.username == "invited_user")
+        ).scalar_one()
+        assert invite_code_id == invite_code

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -1,4 +1,5 @@
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
+from typing import Any
 from unittest.mock import call, patch
 
 import pytest
@@ -59,7 +60,7 @@ from tests.test_references import create_host_reference, create_host_request, cr
 from tests.test_requests import valid_request_text
 
 
-def now_5_min_in_future():
+def now_5_min_in_future() -> datetime:
     return now() + timedelta(minutes=5)
 
 
@@ -339,7 +340,7 @@ def test_scheduler(db, monkeypatch):
 
     realized_schedule = []
 
-    def mock_run_job_and_schedule(sched, job: Job, frequency: timedelta) -> None:
+    def mock_run_job_and_schedule(sched, job: Job[Any], frequency: timedelta) -> None:
         realized_schedule.append((current_time, job.name))
         _run_job_and_schedule(sched, job, frequency)
 
@@ -394,7 +395,7 @@ def test_scheduler(db, monkeypatch):
 def test_job_retry(db):
     called_count = 0
 
-    def mock_job(payload: empty_pb2.Empty) -> empty_pb2.Empty:
+    def mock_job(payload: empty_pb2.Empty) -> None:
         nonlocal called_count
         called_count += 1
         raise Exception()
@@ -402,7 +403,7 @@ def test_job_retry(db):
     with session_scope() as session:
         queue_job(session, job=mock_job, payload=empty_pb2.Empty())
 
-    MOCK_JOBS = {
+    MOCK_JOBS: dict[str, Job[Any]] = {
         "mock_job": Job(mock_job),
     }
     create_prometheus_server(port=8000)
@@ -1210,7 +1211,7 @@ def test_update_badges(db, push_collector: PushCollector):
         (user5.id, "phone_verified"),
     ]
 
-    assert badge_tuples == expected
+    assert badge_tuples == expected  # type: ignore[comparison-overlap]
 
     print(push_collector.pushes)
 

--- a/app/backend/src/tests/test_blocking.py
+++ b/app/backend/src/tests/test_blocking.py
@@ -118,7 +118,7 @@ def test_relationships_userblock_dot_user(db):
     with session_scope() as session:
         block = session.execute(
             select(UserBlock).where((UserBlock.blocking_user_id == user1.id) & (UserBlock.blocked_user_id == user2.id))
-        ).scalar_one_or_none()
+        ).scalar_one()
 
         blocking_user_username = block.blocking_user.username
         blocking_user_name = block.blocking_user.name
@@ -212,22 +212,22 @@ def test_is_not_visible(db):
         assert is_not_visible(session, mutual_blocker2.id, mutual_blocker1.id)
 
         # Test 5: User1 is deleted - should not be visible
-        deleted_user1_db = session.get(User, deleted_user1.id)
+        deleted_user1_db = session.get_one(User, deleted_user1.id)
         deleted_user1_db.is_deleted = True
         session.commit()
         assert is_not_visible(session, deleted_user1.id, visible_for_deleted.id)
         assert is_not_visible(session, visible_for_deleted.id, deleted_user1.id)
 
         # Test 6: User2 is deleted - should not be visible
-        deleted_user2_db = session.get(User, deleted_user2.id)
+        deleted_user2_db = session.get_one(User, deleted_user2.id)
         deleted_user2_db.is_deleted = True
         session.commit()
         assert is_not_visible(session, normal_user1.id, deleted_user2.id)
         assert is_not_visible(session, deleted_user2.id, normal_user1.id)
 
         # Test 7: Both users deleted - should not be visible
-        both_deleted1_db = session.get(User, both_deleted1.id)
-        both_deleted2_db = session.get(User, both_deleted2.id)
+        both_deleted1_db = session.get_one(User, both_deleted1.id)
+        both_deleted2_db = session.get_one(User, both_deleted2.id)
         both_deleted1_db.is_deleted = True
         both_deleted2_db.is_deleted = True
         session.commit()
@@ -235,22 +235,22 @@ def test_is_not_visible(db):
         assert is_not_visible(session, both_deleted2.id, both_deleted1.id)
 
         # Test 8: User1 is banned - should not be visible
-        banned_user1_db = session.get(User, banned_user1.id)
+        banned_user1_db = session.get_one(User, banned_user1.id)
         banned_user1_db.is_banned = True
         session.commit()
         assert is_not_visible(session, banned_user1.id, visible_for_banned.id)
         assert is_not_visible(session, visible_for_banned.id, banned_user1.id)
 
         # Test 9: User2 is banned - should not be visible
-        banned_user2_db = session.get(User, banned_user2.id)
+        banned_user2_db = session.get_one(User, banned_user2.id)
         banned_user2_db.is_banned = True
         session.commit()
         assert is_not_visible(session, normal_user2.id, banned_user2.id)
         assert is_not_visible(session, banned_user2.id, normal_user2.id)
 
         # Test 10: Both users banned - should not be visible
-        both_banned1_db = session.get(User, both_banned1.id)
-        both_banned2_db = session.get(User, both_banned2.id)
+        both_banned1_db = session.get_one(User, both_banned1.id)
+        both_banned2_db = session.get_one(User, both_banned2.id)
         both_banned1_db.is_banned = True
         both_banned2_db.is_banned = True
         session.commit()
@@ -258,8 +258,8 @@ def test_is_not_visible(db):
         assert is_not_visible(session, both_banned2.id, both_banned1.id)
 
         # Test 11: Mixed - one deleted, one banned - should not be visible
-        mixed_deleted_db = session.get(User, mixed_deleted.id)
-        mixed_banned_db = session.get(User, mixed_banned.id)
+        mixed_deleted_db = session.get_one(User, mixed_deleted.id)
+        mixed_banned_db = session.get_one(User, mixed_banned.id)
         mixed_deleted_db.is_deleted = True
         mixed_banned_db.is_banned = True
         session.commit()

--- a/app/backend/src/tests/test_communities.py
+++ b/app/backend/src/tests/test_communities.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 import grpc
 import pytest
 from geoalchemy2 import WKBElement
-from google.protobuf import wrappers_pb2
+from google.protobuf import empty_pb2, wrappers_pb2
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -19,6 +19,7 @@ from couchers.models import (
     PageVersion,
     SignupFlow,
     Thread,
+    User,
 )
 from couchers.proto import api_pb2, auth_pb2, communities_pb2, discussions_pb2, events_pb2, pages_pb2
 from couchers.tasks import enforce_community_memberships
@@ -54,7 +55,15 @@ def create_1d_point(x: int) -> WKBElement:
     return create_coordinate(x, 1)
 
 
-def create_community(session, interval_lb, interval_ub, name, admins, extra_members, parent):
+def create_community(
+    session: Session,
+    interval_lb: int,
+    interval_ub: int,
+    name: str,
+    admins: list[User],
+    extra_members: list[User],
+    parent: Node | None,
+) -> Node:
     node = Node(
         geom=to_multi(create_1d_polygon(interval_lb, interval_ub)),
         parent_node=parent,
@@ -101,7 +110,9 @@ def create_community(session, interval_lb, interval_ub, name, admins, extra_memb
     return node
 
 
-def create_group(session, name, admins, members, parent_community):
+def create_group(
+    session: Session, name: str, admins: list[User], members: list[User], parent_community: Node | None
+) -> Cluster:
     cluster = Cluster(
         name=f"{name}",
         description=f"Description for {name}",
@@ -141,9 +152,9 @@ def create_group(session, name, admins, members, parent_community):
     return cluster
 
 
-def create_place(token, title, content, address, x):
+def create_place(token: str, title: str, content: str, address: str, x: float) -> None:
     with pages_session(token) as api:
-        res = api.CreatePlace(
+        api.CreatePlace(
             pages_pb2.CreatePlaceReq(
                 title=title,
                 content=content,
@@ -156,10 +167,10 @@ def create_place(token, title, content, address, x):
         )
 
 
-def create_discussion(token, community_id, group_id, title, content):
+def create_discussion(token: str, community_id: int | None, group_id: int | None, title: str, content: str) -> None:
     # set group_id or community_id to None
     with discussions_session(token) as api:
-        res = api.CreateDiscussion(
+        api.CreateDiscussion(
             discussions_pb2.CreateDiscussionReq(
                 title=title,
                 content=content,
@@ -169,7 +180,9 @@ def create_discussion(token, community_id, group_id, title, content):
         )
 
 
-def create_event(token, community_id, group_id, title, content, start_td):
+def create_event(
+    token: str, community_id: int | None, group_id: int | None, title: str, content: str, start_td: timedelta
+) -> None:
     with events_session(token) as api:
         res = api.CreateEvent(
             events_pb2.CreateEventReq(
@@ -276,7 +289,7 @@ def testing_communities(db_class, testconfig):
     create_place(token8, "Global, Attraction", "Place content", "Somewhere in w", 51.5)
     create_place(token6, "Country 2, Region 1, Attraction", "Place content", "Somewhere in c2r1", 59)
 
-    refresh_materialized_views(None)
+    refresh_materialized_views(empty_pb2.Empty())
 
     yield
 

--- a/app/backend/src/tests/test_crypto.py
+++ b/app/backend/src/tests/test_crypto.py
@@ -1,3 +1,4 @@
+import nacl.utils
 import pytest
 
 from couchers import crypto
@@ -42,7 +43,7 @@ def test_stable_secure_uniform():
 
     # make sure it's rand unif
     for _ in range(1000):
-        u = crypto.stable_secure_uniform(key=b"test", seed=crypto.random_bytes(32))
+        u = crypto.stable_secure_uniform(key=b"test", seed=nacl.utils.random(32))
         assert u > 0 and u < 1
         print(u)
 

--- a/app/backend/src/tests/test_db.py
+++ b/app/backend/src/tests/test_db.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import pytest
 from google.protobuf import empty_pb2
@@ -24,13 +25,13 @@ from tests.fixtures.db import create_schema_from_models, drop_database, generate
 from tests.test_communities import create_1d_point, get_community_id, testing_communities  # noqa
 
 
-def test_is_valid_user_id():
+def test_is_valid_user_id() -> None:
     assert is_valid_user_id("10")
     assert not is_valid_user_id("1a")
     assert not is_valid_user_id("01")
 
 
-def test_is_valid_email():
+def test_is_valid_email() -> None:
     assert is_valid_email("a@b.cc")
     assert is_valid_email("te.st+email.valid@a.org.au.xx.yy")
     assert is_valid_email("invalid@yahoo.co.uk")
@@ -41,7 +42,7 @@ def test_is_valid_email():
     assert not is_valid_email("b@xxb....blabla")
 
 
-def test_is_valid_username():
+def test_is_valid_username() -> None:
     assert is_valid_username("user")
     assert is_valid_username("us")
     assert is_valid_username("us_er")
@@ -52,7 +53,7 @@ def test_is_valid_username():
     assert not is_valid_username("User")
 
 
-def test_is_valid_name():
+def test_is_valid_name() -> None:
     assert is_valid_name("a")
     assert is_valid_name("a b")
     assert is_valid_name("1")
@@ -62,7 +63,7 @@ def test_is_valid_name():
     assert not is_valid_name(" ")
 
 
-def test_parse_date():
+def test_parse_date() -> None:
     assert parse_date("2020-01-01") is not None
     assert parse_date("1900-01-01") is not None
     assert parse_date("2099-01-01") is not None
@@ -87,21 +88,21 @@ def test_get_parent_node_at_location(testing_communities):
         c2r1_id = get_community_id(session, "Country 2, Region 1")  # 52 to 71
         c2r1c1_id = get_community_id(session, "Country 2, Region 1, City 1")  # 53 to 70
 
-        assert get_parent_node_at_location(session, create_1d_point(1)).id == c1r1c1_id
-        assert get_parent_node_at_location(session, create_1d_point(3)).id == c1r1c1_id
-        assert get_parent_node_at_location(session, create_1d_point(6)).id == c1r1_id
-        assert get_parent_node_at_location(session, create_1d_point(8)).id == c1r1c2_id
-        assert get_parent_node_at_location(session, create_1d_point(15)).id == c1_id
-        assert get_parent_node_at_location(session, create_1d_point(51)).id == w_id
+        assert get_parent_node_at_location(session, create_1d_point(1)).id == c1r1c1_id  # type: ignore[union-attr]
+        assert get_parent_node_at_location(session, create_1d_point(3)).id == c1r1c1_id  # type: ignore[union-attr]
+        assert get_parent_node_at_location(session, create_1d_point(6)).id == c1r1_id  # type: ignore[union-attr]
+        assert get_parent_node_at_location(session, create_1d_point(8)).id == c1r1c2_id  # type: ignore[union-attr]
+        assert get_parent_node_at_location(session, create_1d_point(15)).id == c1_id  # type: ignore[union-attr]
+        assert get_parent_node_at_location(session, create_1d_point(51)).id == w_id  # type: ignore[union-attr]
 
 
-def pg_dump():
+def pg_dump() -> str:
     return subprocess.run(
         ["pg_dump", "-s", config["DATABASE_CONNECTION_STRING"]], stdout=subprocess.PIPE, encoding="ascii", check=True
     ).stdout
 
 
-def sort_pg_dump_output(output):
+def sort_pg_dump_output(output: str) -> str:
     """Sorts the tables, functions and indices dumped by pg_dump in
     alphabetic order. Also sorts all lists enclosed with parentheses
     in alphabetic order.
@@ -123,16 +124,16 @@ def sort_pg_dump_output(output):
     return s.replace("§", "\n")
 
 
-def test_sort_pg_dump_output():
+def test_sort_pg_dump_output() -> None:
     assert sort_pg_dump_output(" (\nb,\nc,\na\n);\n") == " (\na,\nb,\nc\n);\n"
 
 
-def strip_leading_whitespace(lines):
+def strip_leading_whitespace(lines: list[str]) -> list[str]:
     return [s.lstrip() for s in lines]
 
 
 @pytest.mark.skipif(not run_migration_test(), reason="Migration test disabled")
-def test_migrations(db, testconfig):
+def test_migrations(db, testconfig: dict[str, Any]) -> None:
     """
     This test will only run successfully if you have `pg_dump` installed and everything set up, which only happens if the
     test is being run within Gitlab CI where we do all that setup. So we disable it unless explicitly marked to run.
@@ -164,7 +165,7 @@ def test_migrations(db, testconfig):
         (output_path / "schema_from_migrations.sql").write_text(with_migrations)
         (output_path / "schema_from_models.sql").write_text(from_scratch)
 
-    def message(s):
+    def message(s: str) -> list[str]:
         s = sort_pg_dump_output(s)
 
         # filter out alembic tables
@@ -213,7 +214,7 @@ def test_slugify(db):
         )
 
 
-def test_database_consistency_check(db, testconfig):
+def test_database_consistency_check(db, testconfig: dict[str, Any]) -> None:
     """The database consistency check should pass with valid user/gallery setup"""
     # Create a few users (which auto-creates their profile galleries)
     generate_user()

--- a/app/backend/src/tests/test_editor.py
+++ b/app/backend/src/tests/test_editor.py
@@ -1,5 +1,6 @@
 import grpc
 import pytest
+from google.protobuf import empty_pb2
 from google.protobuf.wrappers_pb2 import BoolValue, DoubleValue, StringValue
 from sqlalchemy import select
 
@@ -288,7 +289,7 @@ def test_MakeUserVolunteer(db):
     editor_user, editor_token = generate_user(is_editor=True)
     normal_user, normal_token = generate_user()
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
     with session_scope() as session:
         with real_editor_session(editor_token) as api:
             res = api.MakeUserVolunteer(
@@ -319,7 +320,7 @@ def test_MakeUserVolunteer_default_values(db):
     editor_user, editor_token = generate_user(is_editor=True)
     normal_user, normal_token = generate_user()
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
     with session_scope() as session:
         with real_editor_session(editor_token) as api:
             api.MakeUserVolunteer(
@@ -331,7 +332,7 @@ def test_MakeUserVolunteer_default_values(db):
 
             volunteer = session.execute(select(Volunteer).where(Volunteer.user_id == normal_user.id)).scalar_one()
             assert volunteer.role == "Test Volunteer"
-            assert volunteer.started_volunteering is not None  # defaults to today
+            assert volunteer.started_volunteering  # defaults to today
             assert volunteer.show_on_team_page is True  # hide_on_team_page defaults to False
 
 
@@ -340,7 +341,7 @@ def test_MakeUserVolunteer_hide_on_team_page(db):
     editor_user, editor_token = generate_user(is_editor=True)
     normal_user, normal_token = generate_user()
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
     with session_scope() as session:
         with real_editor_session(editor_token) as api:
             api.MakeUserVolunteer(
@@ -377,7 +378,7 @@ def test_MakeUserVolunteer_already_volunteer(db):
     editor_user, editor_token = generate_user(is_editor=True)
     normal_user, normal_token = generate_user()
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
     with real_editor_session(editor_token) as api:
         # Create volunteer first time
         api.MakeUserVolunteer(
@@ -422,7 +423,7 @@ def test_UpdateVolunteer(db):
     editor_user, editor_token = generate_user(is_editor=True)
     normal_user, normal_token = generate_user()
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
     with session_scope() as session:
         with real_editor_session(editor_token) as api:
             # Create volunteer first
@@ -458,6 +459,7 @@ def test_UpdateVolunteer(db):
             assert volunteer.role == "Updated Volunteer"
             assert volunteer.sort_key == 10.5
             assert volunteer.started_volunteering.isoformat() == "2023-06-01"
+            assert volunteer.stopped_volunteering
             assert volunteer.stopped_volunteering.isoformat() == "2024-12-31"
             assert volunteer.show_on_team_page is False
 
@@ -467,7 +469,7 @@ def test_UpdateVolunteer_partial_update(db):
     editor_user, editor_token = generate_user(is_editor=True)
     normal_user, normal_token = generate_user()
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
     with session_scope() as session:
         with real_editor_session(editor_token) as api:
             # Create volunteer first
@@ -515,7 +517,7 @@ def test_UpdateVolunteer_invalid_started_date(db):
     editor_user, editor_token = generate_user(is_editor=True)
     normal_user, normal_token = generate_user()
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
     with real_editor_session(editor_token) as api:
         # Create volunteer first
         api.MakeUserVolunteer(
@@ -542,7 +544,7 @@ def test_UpdateVolunteer_invalid_stopped_date(db):
     editor_user, editor_token = generate_user(is_editor=True)
     normal_user, normal_token = generate_user()
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
     with real_editor_session(editor_token) as api:
         # Create volunteer first
         api.MakeUserVolunteer(
@@ -571,7 +573,7 @@ def test_ListVolunteers(db):
     user2, _ = generate_user()
     user3, _ = generate_user()
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
     with session_scope() as session:
         with real_editor_session(editor_token) as api:
             # Create three volunteers
@@ -620,7 +622,7 @@ def test_ListVolunteers_with_past(db):
     user1, _ = generate_user()
     user2, _ = generate_user()
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
     with session_scope() as session:
         with real_editor_session(editor_token) as api:
             # Create current volunteer
@@ -669,7 +671,7 @@ def test_ListVolunteers_ordering(db):
     user2, _ = generate_user()
     user3, _ = generate_user()
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
     with session_scope() as session:
         with real_editor_session(editor_token) as api:
             # Create volunteers with different sort keys
@@ -694,7 +696,7 @@ def test_ListVolunteers_empty(db):
     """ListVolunteers should return empty list when no volunteers exist"""
     editor_user, editor_token = generate_user(is_editor=True)
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
     with real_editor_session(editor_token) as api:
         res = api.ListVolunteers(editor_pb2.ListVolunteersReq(include_past=False))
         assert len(res.volunteers) == 0

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
@@ -27,7 +28,7 @@ from couchers.tasks import (
     send_email_changed_confirmation_to_new_email,
     send_signup_email,
 )
-from couchers.utils import Timestamp_from_datetime, now, timedelta
+from couchers.utils import Timestamp_from_datetime, now
 from tests.fixtures.db import generate_user
 from tests.fixtures.misc import email_fields, mock_notification_email, process_jobs
 from tests.fixtures.sessions import api_session, events_session, notifications_session, real_editor_session
@@ -51,7 +52,8 @@ def test_signup_verification_email(db):
     assert mock.call_count == 1
     e = email_fields(mock)
     assert e.recipient == request_email
-    assert flow.email_token in e.plain
+    assert flow.email_token
+    assert flow.email_token in e.html
     assert flow.email_token in e.html
 
 
@@ -149,6 +151,7 @@ def test_reference_report_email(db):
         assert reference.to_user.email in e.plain
         assert reference.text in e.plain
         assert "friend" in e.plain.lower()
+        assert reference.private_text
         assert reference.private_text in e.plain
 
 

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -1792,7 +1792,7 @@ def test_ListMyEvents(db):
 
     start = now()
 
-    def new_event(hours_from_now, community_id, online=True):
+    def new_event(hours_from_now: int, community_id: int, online: bool = True) -> events_pb2.CreateEventReq:
         if online:
             return events_pb2.CreateEventReq(
                 title="Dummy Online Title",
@@ -2368,10 +2368,10 @@ def test_community_invite_requests(db):
         assert event_url in e.plain
 
         # can't send another req
-        with pytest.raises(grpc.RpcError) as e:
+        with pytest.raises(grpc.RpcError) as err:
             api.RequestCommunityInvite(events_pb2.RequestCommunityInviteReq(event_id=event_id))
-        assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
-        assert e.value.details() == "You have already requested a community invite for this event."
+        assert err.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+        assert err.value.details() == "You have already requested a community invite for this event."
 
     # another user can send one though
     with events_session(token3) as api:
@@ -2379,10 +2379,10 @@ def test_community_invite_requests(db):
 
     # but not a non-admin
     with events_session(token2) as api:
-        with pytest.raises(grpc.RpcError) as e:
+        with pytest.raises(grpc.RpcError) as err:
             api.RequestCommunityInvite(events_pb2.RequestCommunityInviteReq(event_id=event_id))
-        assert e.value.code() == grpc.StatusCode.PERMISSION_DENIED
-        assert e.value.details() == "You're not allowed to edit that event."
+        assert err.value.code() == grpc.StatusCode.PERMISSION_DENIED
+        assert err.value.details() == "You're not allowed to edit that event."
 
     with real_editor_session(token5) as editor:
         res = editor.ListEventCommunityInviteRequests(editor_pb2.ListEventCommunityInviteRequestsReq())
@@ -2408,10 +2408,10 @@ def test_community_invite_requests(db):
 
     # not after approve
     with events_session(token4) as api:
-        with pytest.raises(grpc.RpcError) as e:
+        with pytest.raises(grpc.RpcError) as err:
             api.RequestCommunityInvite(events_pb2.RequestCommunityInviteReq(event_id=event_id))
-        assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
-        assert e.value.details() == "A community invite has already been sent out for this event."
+        assert err.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+        assert err.value.details() == "A community invite has already been sent out for this event."
 
 
 def test_update_event_should_notify_queues_job():

--- a/app/backend/src/tests/test_gis.py
+++ b/app/backend/src/tests/test_gis.py
@@ -19,7 +19,7 @@ class TestGIS:
     def test_GetUsers(testing_communities):
         _, token = generate_user()
 
-        refresh_materialized_views_rapid(None)
+        refresh_materialized_views_rapid(empty_pb2.Empty())
 
         with gis_session(token) as gis:
             http_body = gis.GetUsers(empty_pb2.Empty())
@@ -33,7 +33,7 @@ class TestGIS:
     def test_GetClusteredUsers(testing_communities):
         _, token = generate_user()
 
-        refresh_materialized_views(None)
+        refresh_materialized_views(empty_pb2.Empty())
 
         with gis_session(token) as gis:
             http_body = gis.GetClusteredUsers(empty_pb2.Empty())

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -185,7 +185,9 @@ def test_tracing_interceptor_ok_open(db):
         assert trace.method == "/org.couchers.auth.Auth/SignupFlow"
         assert not trace.status_code
         assert not trace.user_id
+        assert trace.request is not None
         assert len(trace.request) == 0
+        assert trace.response is not None
         assert len(trace.response) == 0
         assert not trace.traceback
 
@@ -214,9 +216,11 @@ def test_tracing_interceptor_sensitive(db):
         assert not trace.status_code
         assert not trace.user_id
         assert not trace.traceback
+        assert trace.request is not None
         req = auth_pb2.SignupFlowReq.FromString(trace.request)
         assert not req.account.password
         assert req.account.username == "not removed"
+        assert trace.response
         res = auth_pb2.AuthReq.FromString(trace.response)
         assert res.user == "this is not secret"
         assert not res.password
@@ -258,7 +262,9 @@ def test_tracing_interceptor_exception(db):
         assert trace.method == "/org.couchers.auth.Auth/SignupFlow"
         assert not trace.status_code
         assert not trace.user_id
+        assert trace.traceback
         assert "Some error message" in trace.traceback
+        assert trace.request is not None
         req = auth_pb2.SignupAccount.FromString(trace.request)
         assert not req.password
         assert req.username == "not removed"
@@ -287,7 +293,9 @@ def test_tracing_interceptor_abort(db):
         assert trace.method == "/org.couchers.auth.Auth/SignupFlow"
         assert trace.status_code == "FAILED_PRECONDITION"
         assert not trace.user_id
+        assert trace.traceback
         assert "now a grpc abort" in trace.traceback
+        assert trace.request is not None
         req = auth_pb2.SignupAccount.FromString(trace.request)
         assert not req.password
         assert req.username == "not removed"
@@ -406,6 +414,7 @@ def test_tracing_interceptor_auth_cookies(db):
         assert not trace.status_code
         assert trace.user_id == user.id
         assert not trace.is_api_key
+        assert trace.request is not None
         assert len(trace.request) == 0
         assert not trace.traceback
 
@@ -445,6 +454,7 @@ def test_tracing_interceptor_auth_api_key(db):
         assert not trace.status_code
         assert trace.user_id == user.id
         assert trace.is_api_key
+        assert trace.request is not None
         assert len(trace.request) == 0
         assert not trace.traceback
 
@@ -523,25 +533,25 @@ def test_auth_levels(db):
             if should_work:
                 call_rpc(empty_pb2.Empty(), metadata=metadata)
             else:
-                with pytest.raises(grpc.RpcError) as e:
+                with pytest.raises(grpc.RpcError) as err:
                     call_rpc(empty_pb2.Empty(), metadata=metadata)
-                assert e.value.code() == code
-                assert e.value.details() == message
+                assert err.value.code() == code
+                assert err.value.details() == message
 
     # a non-existent RPC
     nonexistent = gen_args("org.couchers.nonexistent.NA", "GetNothing")
 
     with interceptor_dummy_api(**nonexistent) as call_rpc:
-        with pytest.raises(Exception) as e:
+        with pytest.raises(grpc.RpcError) as err:
             call_rpc(empty_pb2.Empty())
-        assert e.value.code() == grpc.StatusCode.UNIMPLEMENTED
-        assert e.value.details() == "API call does not exist. Please refresh and try again."
+        assert err.value.code() == grpc.StatusCode.UNIMPLEMENTED
+        assert err.value.details() == "API call does not exist. Please refresh and try again."
 
     # an RPC without a service level
     invalid_args = gen_args("org.couchers.media.Media", "UploadConfirmation")
 
     with interceptor_dummy_api(**invalid_args) as call_rpc:
-        with pytest.raises(Exception) as e:
+        with pytest.raises(grpc.RpcError) as err:
             call_rpc(empty_pb2.Empty())
-        assert e.value.code() == grpc.StatusCode.INTERNAL
-        assert e.value.details() == "Internal authentication error."
+        assert err.value.code() == grpc.StatusCode.INTERNAL
+        assert err.value.details() == "Internal authentication error."

--- a/app/backend/src/tests/test_jail.py
+++ b/app/backend/src/tests/test_jail.py
@@ -287,9 +287,9 @@ def test_modnotes(db, push_collector: PushCollector):
                 )
             )
         mock.assert_called_once()
-        e = email_fields(mock)
+        fields = email_fields(mock)
 
-        assert e.subject == "[TEST] You have received a mod note"
+        assert fields.subject == "[TEST] You have received a mod note"
         push = push_collector.get_for_user(user.id)
         assert push.content.title == "You received a mod note"
         assert push.content.body == "You need to read and acknowledge the note before continuing to use the platform."

--- a/app/backend/src/tests/test_media.py
+++ b/app/backend/src/tests/test_media.py
@@ -52,7 +52,7 @@ def test_media_upload(db):
                 .where(Upload.key == key)
                 .where(Upload.filename == filename)
                 .where(Upload.creator_user_id == user.id)
-            ).scalar_one()
+            ).scalar_one_or_none()
             is not None
         )
 

--- a/app/backend/src/tests/test_moderation.py
+++ b/app/backend/src/tests/test_moderation.py
@@ -80,7 +80,6 @@ def test_create_moderation(db):
             creator_user_id=user.id,
         )
 
-        assert moderation_state.id is not None
         assert moderation_state.object_type == ModerationObjectType.HOST_REQUEST
         assert moderation_state.object_id == 123
         assert moderation_state.visibility == ModerationVisibility.SHADOWED
@@ -183,7 +182,7 @@ def test_moderate_content(db):
 
     # Check that state was updated in database
     with session_scope() as session:
-        updated_state = session.get(ModerationState, state_id)
+        updated_state = session.get_one(ModerationState, state_id)
         assert updated_state.visibility == ModerationVisibility.VISIBLE
 
         # Check that log entry was created
@@ -302,7 +301,7 @@ def test_approve_content_via_api(db):
 
     # Check that state was updated to VISIBLE
     with session_scope() as session:
-        updated_state = session.get(ModerationState, state_id)
+        updated_state = session.get_one(ModerationState, state_id)
         assert updated_state.visibility == ModerationVisibility.VISIBLE
 
         # Check log entry
@@ -344,8 +343,6 @@ def test_create_host_request_creates_moderation_state(db):
         host_request = session.execute(
             select(HostRequest).where(HostRequest.conversation_id == host_request_id)
         ).scalar_one()
-
-        assert host_request.moderation_state_id is not None
 
         # Check moderation state properties
         moderation_state = session.execute(
@@ -875,7 +872,7 @@ def test_moderation_queue_workflow(db):
         assert queue_item_id not in [item.id for item in unresolved_items]
 
         # Verify the queue item was linked to a log entry
-        queue_item = session.get(ModerationQueueItem, queue_item_id)
+        queue_item = session.get_one(ModerationQueueItem, queue_item_id)
         assert queue_item.resolved_by_log_id is not None
 
 
@@ -1464,7 +1461,7 @@ def test_ModerateContent_approve(db):
 
     # Verify state was updated in database
     with session_scope() as session:
-        state = session.get(ModerationState, state_id)
+        state = session.get_one(ModerationState, state_id)
         assert state.visibility == ModerationVisibility.VISIBLE
 
 
@@ -1509,7 +1506,7 @@ def test_ModerateContent_hide(db):
 
     # Verify state was updated in database
     with session_scope() as session:
-        state = session.get(ModerationState, state_id)
+        state = session.get_one(ModerationState, state_id)
         assert state.visibility == ModerationVisibility.HIDDEN
 
 
@@ -1536,7 +1533,7 @@ def test_ModerateContent_shadow(db):
 
     # Verify state was updated in database
     with session_scope() as session:
-        state = session.get(ModerationState, state_id)
+        state = session.get_one(ModerationState, state_id)
         assert state.visibility == ModerationVisibility.SHADOWED
 
 
@@ -1591,6 +1588,7 @@ def test_FlagContentForReview(db):
             .scalars()
             .first()
         )
+        assert queue_item
         assert queue_item.trigger == ModerationTrigger.MODERATOR_REVIEW
         assert queue_item.resolved_by_log_id is None
 
@@ -1614,8 +1612,6 @@ def test_group_chat_created_with_moderation_state(db):
     with session_scope() as session:
         group_chat = session.execute(select(GroupChat).where(GroupChat.conversation_id == group_chat_id)).scalar_one()
 
-        assert group_chat.moderation_state_id is not None
-        assert group_chat.moderation_state is not None
         assert group_chat.moderation_state.object_type == ModerationObjectType.GROUP_CHAT
         assert group_chat.moderation_state.object_id == group_chat_id
         # Group chats start as SHADOWED

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -39,7 +39,7 @@ from couchers.proto import (
 from couchers.proto.internal import unsubscribe_pb2
 from couchers.servicers.api import user_model_to_pb
 from couchers.templates.v2 import v2timestamp
-from couchers.utils import now
+from couchers.utils import not_none, now
 from tests.fixtures.db import generate_user
 from tests.fixtures.misc import PushCollector, email_fields, mock_notification_email, process_jobs
 from tests.fixtures.sessions import (
@@ -600,7 +600,7 @@ def test_event_reminder_email_sent(db):
 
     with mock_notification_email() as mock:
         with session_scope() as session:
-            user_in_session = session.get(User, user.id)
+            user_in_session = session.get_one(User, user.id)
 
             notify(
                 session,
@@ -1093,7 +1093,7 @@ def test_SendDevPushNotification_disabled(db, push_collector: PushCollector):
                 )
             )
         assert e.value.code() == grpc.StatusCode.UNAVAILABLE
-        assert "Development APIs are not enabled" in e.value.details()
+        assert "Development APIs are not enabled" in not_none(e.value.details())
 
     assert push_collector.count_for_user(user.id) == 0
 
@@ -1114,7 +1114,7 @@ def test_SendDevPushNotification_push_notifications_disabled(db, push_collector:
                 )
             )
         assert e.value.code() == grpc.StatusCode.UNAVAILABLE
-        assert "Push notifications are currently disabled" in e.value.details()
+        assert "Push notifications are currently disabled" in not_none(e.value.details())
 
     assert push_collector.count_for_user(user.id) == 0
 

--- a/app/backend/src/tests/test_postal_verification.py
+++ b/app/backend/src/tests/test_postal_verification.py
@@ -572,6 +572,7 @@ def test_postal_verification_code_case_insensitive(db, monkeypatch):
             select(PostalVerificationAttempt).where(PostalVerificationAttempt.id == attempt_id)
         ).scalar_one()
         verification_code = attempt.verification_code
+        assert verification_code
 
     # Verify with lowercase code
     with postal_verification_session(token) as pv:

--- a/app/backend/src/tests/test_public.py
+++ b/app/backend/src/tests/test_public.py
@@ -91,7 +91,7 @@ def test_GetPublicMapLayer(db):
 
 def test_GetDonationStats_empty(db):
     """Test GetDonationStats with no donations returns zero and goal"""
-    _get_donation_stats.cache.clear()
+    _get_donation_stats.cache_clear()
 
     with (
         patch("couchers.servicers.public.DONATION_GOAL_USD", 2500),
@@ -105,7 +105,7 @@ def test_GetDonationStats_empty(db):
 
 def test_GetDonationStats_with_donations(db):
     """Test GetDonationStats sums on_platform donations correctly"""
-    _get_donation_stats.cache.clear()
+    _get_donation_stats.cache_clear()
     user, _ = generate_user()
 
     with session_scope() as session:
@@ -150,7 +150,7 @@ def test_GetDonationStats_with_donations(db):
 
 def test_GetDonationStats_excludes_merch(db):
     """Test GetDonationStats excludes external_shop (merch) invoices"""
-    _get_donation_stats.cache.clear()
+    _get_donation_stats.cache_clear()
     user, _ = generate_user()
 
     with session_scope() as session:
@@ -188,7 +188,7 @@ def test_GetDonationStats_excludes_merch(db):
 
 def test_GetDonationStats_excludes_previous_years(db):
     """Test GetDonationStats only counts current year donations"""
-    _get_donation_stats.cache.clear()
+    _get_donation_stats.cache_clear()
     user, _ = generate_user()
 
     with session_scope() as session:
@@ -273,7 +273,7 @@ def test_GetVolunteers_mixed_current_and_past(db):
             )
         )
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with public_session() as public:
         res = public.GetVolunteers(empty_pb2.Empty())
@@ -288,7 +288,7 @@ def test_GetVolunteers_mixed_current_and_past(db):
 def test_GetVolunteers_custom_sort_key(db):
     """Test GetVolunteers respects custom sort_key"""
 
-    _get_volunteers.cache.clear()
+    _get_volunteers.cache_clear()
 
     user1, _ = generate_user(username="user1")
     user2, _ = generate_user(username="user2")
@@ -325,7 +325,7 @@ def test_GetVolunteers_custom_sort_key(db):
             )
         )
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with public_session() as public:
         res = public.GetVolunteers(empty_pb2.Empty())
@@ -338,7 +338,7 @@ def test_GetVolunteers_custom_sort_key(db):
 def test_GetVolunteers_excludes_hidden(db):
     """Test GetVolunteers excludes volunteers with show_on_team_page=False"""
 
-    _get_volunteers.cache.clear()
+    _get_volunteers.cache_clear()
 
     user1, _ = generate_user(username="visible")
     user2, _ = generate_user(username="hidden")
@@ -361,7 +361,7 @@ def test_GetVolunteers_excludes_hidden(db):
             )
         )
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with public_session() as public:
         res = public.GetVolunteers(empty_pb2.Empty())
@@ -400,7 +400,7 @@ def test_GetVolunteers_link_types(db):
             )
         )
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with public_session() as public:
         res = public.GetVolunteers(empty_pb2.Empty())
@@ -445,7 +445,7 @@ def test_GetVolunteers_board_member_flag(db):
             )
         )
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     # Mock the static badge dict to include board_member
     with patch("couchers.servicers.public.get_static_badge_dict", return_value={"board_member": [board_member.id]}):
@@ -469,7 +469,7 @@ def test_GetSignupPageInfo(db):
     user2, _ = generate_user(username="user2")
     user3, _ = generate_user(username="user3")
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with public_session() as public:
         res = public.GetSignupPageInfo(empty_pb2.Empty())

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import date, datetime, timedelta
 from unittest.mock import patch
 
 import grpc
@@ -37,14 +37,14 @@ def _(testconfig):
 
 
 def create_host_request(
-    session,
-    surfer_user_id,
-    host_user_id,
-    host_request_age=timedelta(days=15),
-    status=HostRequestStatus.confirmed,
-    host_reason_didnt_meetup=None,
-    surfer_reason_didnt_meetup=None,
-):
+    session: Session,
+    surfer_user_id: int,
+    host_user_id: int,
+    host_request_age: timedelta = timedelta(days=15),
+    status: HostRequestStatus = HostRequestStatus.confirmed,
+    host_reason_didnt_meetup: str | None = None,
+    surfer_reason_didnt_meetup: str | None = None,
+) -> int:
     """
     Create a host request that's `host_request_age` old
     """
@@ -100,15 +100,15 @@ def create_host_request(
 
 
 def create_host_request_by_date(
-    session,
-    surfer_user_id,
-    host_user_id,
-    from_date,
-    to_date,
-    status,
-    host_sent_request_reminders,
-    last_sent_request_reminder_time,
-):
+    session: Session,
+    surfer_user_id: int,
+    host_user_id: int,
+    from_date: date,
+    to_date: date,
+    status: HostRequestStatus,
+    host_sent_request_reminders: int,
+    last_sent_request_reminder_time: datetime,
+) -> int:
     conversation = Conversation()
     session.add(conversation)
     session.flush()
@@ -160,7 +160,15 @@ def create_host_request_by_date(
     return host_request.conversation_id
 
 
-def create_host_reference(session, from_user_id, to_user_id, reference_age, *, surfing=True, host_request_id=None):
+def create_host_reference(
+    session: Session,
+    from_user_id: int,
+    to_user_id: int,
+    reference_age: timedelta,
+    *,
+    surfing: bool = True,
+    host_request_id: int | None = None,
+) -> tuple[int, int]:
     if host_request_id:
         actual_host_request_id = host_request_id
     else:
@@ -1032,7 +1040,7 @@ def test_AvailableWriteReferences_and_ListPendingReferencesToWrite(db, moderator
     moderator.approve_host_request(hr6)
     moderator.approve_host_request(hr7)
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with references_session(token1) as api:
         # can't write reference for invisible user
@@ -1193,7 +1201,7 @@ def test_regression_disappearing_refs(db, hs, moderator):
             )
         )
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with references_session(token1) as api:
         res = api.ListPendingReferencesToWrite(empty_pb2.Empty())

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -5,11 +5,11 @@ from urllib.parse import parse_qs, urlparse
 import grpc
 import pytest
 from sqlalchemy import select
+from sqlalchemy_utils import refresh_materialized_view
 
 from couchers.constants import HOST_REQUEST_MIN_LENGTH_UTF16
 from couchers.crypto import b64decode
 from couchers.db import session_scope
-from couchers.materialized_views import refresh_materialized_view
 from couchers.models import (
     Message,
     MessageType,

--- a/app/backend/src/tests/test_sanitized_bytes.py
+++ b/app/backend/src/tests/test_sanitized_bytes.py
@@ -28,7 +28,6 @@ class TestSanitizedBytes:
         proto = auth_pb2.AuthRes(user_id=12345, jailed=False)
         result = _sanitized_bytes(proto)
 
-        assert result is not None
         deserialized = auth_pb2.AuthRes.FromString(result)
         assert deserialized.user_id == 12345
         assert deserialized.jailed is False
@@ -39,7 +38,6 @@ class TestSanitizedBytes:
         proto = auth_pb2.AuthReq(user="testuser", password="supersecret123", remember_device=True)
         result = _sanitized_bytes(proto)
 
-        assert result is not None
         deserialized = auth_pb2.AuthReq.FromString(result)
 
         # Non-sensitive fields should remain
@@ -58,7 +56,6 @@ class TestSanitizedBytes:
         )
         result = _sanitized_bytes(proto)
 
-        assert result is not None
         deserialized = auth_pb2.SignupFlowReq.FromString(result)
 
         # Top-level fields should remain
@@ -83,7 +80,6 @@ class TestSanitizedBytes:
         )
         result = _sanitized_bytes(proto)
 
-        assert result is not None
         deserialized = auth_pb2.SignupFlowRes.FromString(result)
         assert deserialized.flow_token == "token456"
         assert deserialized.need_basic is True
@@ -105,7 +101,6 @@ class TestSanitizedBytes:
         )
         result = _sanitized_bytes(proto)
 
-        assert result is not None
         deserialized = conversations_pb2.GetGroupChatMessagesRes.FromString(result)
         assert deserialized.last_message_id == 999
         assert deserialized.no_more is True
@@ -131,7 +126,6 @@ class TestSanitizedBytes:
 
         result = _sanitized_bytes(proto)
 
-        assert result is not None
         deserialized = conversations_pb2.GetGroupChatMessagesRes.FromString(result)
 
         # Check that repeated messages are preserved
@@ -154,7 +148,6 @@ class TestSanitizedBytes:
         )
         result = _sanitized_bytes(proto)
 
-        assert result is not None
         deserialized = auth_pb2.SignupFlowRes.FromString(result)
 
         # All nested data should be preserved (no sensitive fields in this structure)
@@ -178,7 +171,6 @@ class TestSanitizedBytes:
         )
         result = _sanitized_bytes(proto)
 
-        assert result is not None
         deserialized = auth_pb2.SignupFlowReq.FromString(result)
 
         # Check basic nested message
@@ -215,7 +207,6 @@ class TestSanitizedBytes:
         proto = auth_pb2.AuthRes(user_id=12345, jailed=True)
         result = _sanitized_bytes(proto)
 
-        assert result is not None
         deserialized = auth_pb2.AuthRes.FromString(result)
         assert deserialized.user_id == 12345
         assert deserialized.jailed is True
@@ -243,7 +234,6 @@ class TestSanitizedBytes:
 
         result = _sanitized_bytes(proto)
 
-        assert result is not None
         deserialized = auth_pb2.SignupFlowReq.FromString(result)
 
         # Verify all non-sensitive fields are preserved

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -1,7 +1,8 @@
 from datetime import timedelta
+from typing import Any
 
 import pytest
-from google.protobuf import wrappers_pb2
+from google.protobuf import empty_pb2, wrappers_pb2
 
 from couchers.db import session_scope
 from couchers.materialized_views import refresh_materialized_views, refresh_materialized_views_rapid
@@ -49,8 +50,8 @@ def test_UserSearch(testing_communities):
     """Test that UserSearch returns all users if no filter is set."""
     user, token = generate_user()
 
-    refresh_materialized_views_rapid(None)
-    refresh_materialized_views(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+    refresh_materialized_views(empty_pb2.Empty())
 
     with search_session(token) as api:
         res = api.UserSearch(search_pb2.UserSearchReq())
@@ -79,8 +80,8 @@ def test_regression_search_in_area(db):
     # outside
     user5, token5 = generate_user(geom=create_coordinate(10, 10), geom_radius=100)
 
-    refresh_materialized_views_rapid(None)
-    refresh_materialized_views(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+    refresh_materialized_views(empty_pb2.Empty())
 
     with search_session(token5) as api:
         res = api.UserSearch(
@@ -126,8 +127,8 @@ def test_user_search_in_rectangle(db):
     # outside
     user7, token7 = generate_user(geom=create_coordinate(10, 10), geom_radius=100)
 
-    refresh_materialized_views_rapid(None)
-    refresh_materialized_views(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+    refresh_materialized_views(empty_pb2.Empty())
 
     with search_session(token5) as api:
         res = api.UserSearch(
@@ -163,8 +164,8 @@ def test_user_filter_complete_profile(db):
 
     user_incomplete_profile, token7 = generate_user(complete_profile=False)
 
-    refresh_materialized_views_rapid(None)
-    refresh_materialized_views(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+    refresh_materialized_views(empty_pb2.Empty())
 
     with search_session(token7) as api:
         res = api.UserSearch(search_pb2.UserSearchReq(profile_completed=wrappers_pb2.BoolValue(value=False)))
@@ -189,8 +190,8 @@ def test_user_filter_meetup_status(db):
 
     user_does_not_want_to_meet, token9 = generate_user(meetup_status=MeetupStatus.does_not_want_to_meetup)
 
-    refresh_materialized_views_rapid(None)
-    refresh_materialized_views(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+    refresh_materialized_views(empty_pb2.Empty())
 
     with search_session(token8) as api:
         res = api.UserSearch(search_pb2.UserSearchReq(meetup_status_filter=[api_pb2.MEETUP_STATUS_WANTS_TO_MEETUP]))
@@ -236,8 +237,8 @@ def test_user_filter_language(db):
             LanguageAbility(user_id=user_with_german_fluent.id, language_code="deu", fluency=LanguageFluency.fluent)
         )
 
-    refresh_materialized_views_rapid(None)
-    refresh_materialized_views(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+    refresh_materialized_views(empty_pb2.Empty())
 
     with search_session(token11) as api:
         res = api.UserSearch(
@@ -296,8 +297,8 @@ def test_user_filter_strong_verification(db):
     user4, _ = generate_user(strong_verification=True)
     user5, _ = generate_user(strong_verification=True)
 
-    refresh_materialized_views_rapid(None)
-    refresh_materialized_views(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+    refresh_materialized_views(empty_pb2.Empty())
 
     with search_session(token1) as api:
         res = api.UserSearch(search_pb2.UserSearchReq(only_with_strong_verification=False))
@@ -319,8 +320,8 @@ def test_regression_search_only_with_references(db):
     user3, _ = generate_user()
     user4, _ = generate_user(delete_user=True)
 
-    refresh_materialized_views_rapid(None)
-    refresh_materialized_views(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+    refresh_materialized_views(empty_pb2.Empty())
 
     with session_scope() as session:
         # user 2 has references
@@ -356,8 +357,8 @@ def test_user_search_exactly_user_ids(db):
     user4, _ = generate_user(meetup_status=MeetupStatus.wants_to_meetup)
     user5, _ = generate_user(delete_user=True)  # Deleted user
 
-    refresh_materialized_views_rapid(None)
-    refresh_materialized_views(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+    refresh_materialized_views(empty_pb2.Empty())
 
     with search_session(token1) as api:
         # Test that exactly_user_ids returns only the specified users
@@ -400,7 +401,7 @@ def test_user_search_exactly_user_ids(db):
 
 
 @pytest.fixture
-def sample_event_data() -> dict:
+def sample_event_data() -> dict[str, Any]:
     """Dummy data for creating events."""
     start_time = now() + timedelta(hours=2)
     end_time = start_time + timedelta(hours=3)
@@ -421,7 +422,7 @@ def create_event(sample_event_data):
 
     def _create_event(event_api, **kwargs) -> EventOccurrence:
         """Create an event with default values, unless overridden by kwargs."""
-        return event_api.CreateEvent(events_pb2.CreateEventReq(**{**sample_event_data, **kwargs}))
+        return event_api.CreateEvent(events_pb2.CreateEventReq(**{**sample_event_data, **kwargs}))  # type: ignore
 
     return _create_event
 
@@ -750,8 +751,8 @@ def test_regression_search_multiple_pages(db):
         other_user, _ = generate_user()
         user_ids.append(other_user.id)
 
-    refresh_materialized_views_rapid(None)
-    refresh_materialized_views(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+    refresh_materialized_views(empty_pb2.Empty())
 
     with search_session(token) as api:
         res = api.UserSearchV2(search_pb2.UserSearchReq(page_size=5))
@@ -766,8 +767,8 @@ def test_regression_search_no_results(db):
     # put us far away
     user, token = generate_user()
 
-    refresh_materialized_views_rapid(None)
-    refresh_materialized_views(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+    refresh_materialized_views(empty_pb2.Empty())
 
     with search_session(token) as api:
         res = api.UserSearchV2(search_pb2.UserSearchReq(only_with_references=True))
@@ -783,8 +784,8 @@ def test_user_filter_same_gender_only(db):
     man_without_sv, _ = generate_user(strong_verification=False, gender="Man")
     other_woman_with_sv, _ = generate_user(strong_verification=True, gender="Woman")
 
-    refresh_materialized_views_rapid(None)
-    refresh_materialized_views(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+    refresh_materialized_views(empty_pb2.Empty())
 
     # Test 1: Woman with strong verification should see only women when same_gender_only=True
     with search_session(token_woman_with_sv) as api:
@@ -860,8 +861,8 @@ def test_user_filter_same_gender_only_with_other_filters(db):
     woman_cant_host, _ = generate_user(strong_verification=True, gender="Woman", hosting_status=HostingStatus.cant_host)
     man_host, _ = generate_user(strong_verification=True, gender="Man", hosting_status=HostingStatus.can_host)
 
-    refresh_materialized_views_rapid(None)
-    refresh_materialized_views(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+    refresh_materialized_views(empty_pb2.Empty())
 
     # Test: Combine same_gender_only with hosting_status filter
     with search_session(token_woman) as api:

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -258,7 +258,7 @@ def test_strong_verification_happy_path(db, monkeypatch):
     _, superuser_token = generate_user(is_superuser=True)
 
     update_badges(empty_pb2.Empty())
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=user.username))
@@ -295,7 +295,7 @@ def test_strong_verification_happy_path(db, monkeypatch):
         assert verification_attempt.passport_last_three_document_chars == "855"
 
     update_badges(empty_pb2.Empty())
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     # the user should now have strong verification
     with api_session(token) as api:
@@ -314,7 +314,7 @@ def test_strong_verification_happy_path(db, monkeypatch):
         session.execute(update(User).where(User.id == user.id).values(birthdate=date(1988, 1, 2)))
 
     update_badges(empty_pb2.Empty())
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=user.username))
@@ -332,7 +332,7 @@ def test_strong_verification_happy_path(db, monkeypatch):
         session.execute(update(User).where(User.id == user.id).values(birthdate=date(1988, 1, 1), gender="Woman"))
 
     update_badges(empty_pb2.Empty())
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=user.username))
@@ -356,7 +356,7 @@ def test_strong_verification_happy_path(db, monkeypatch):
         session.execute(update(User).where(User.id == user.id).values(gender="Man"))
 
     update_badges(empty_pb2.Empty())
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=user.username))
@@ -388,7 +388,7 @@ def test_strong_verification_happy_path(db, monkeypatch):
         admin.ChangeUserGender(admin_pb2.ChangeUserGenderReq(user=user.username, gender="Woman"))
 
     update_badges(empty_pb2.Empty())
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=user.username))
@@ -419,7 +419,7 @@ def test_strong_verification_happy_path(db, monkeypatch):
         )
 
     update_badges(empty_pb2.Empty())
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=user.username))
@@ -451,7 +451,7 @@ def test_strong_verification_delete_data(db, monkeypatch):
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
     _, superuser_token = generate_user(is_superuser=True)
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token) as api:
         assert not api.GetUser(api_pb2.GetUserReq(user=user.username)).has_strong_verification
@@ -476,7 +476,7 @@ def test_strong_verification_delete_data(db, monkeypatch):
         nationality="US",
     )
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     # the user should now have strong verification
     with api_session(token) as api:
@@ -490,7 +490,7 @@ def test_strong_verification_delete_data(db, monkeypatch):
     with account_session(token) as account:
         account.DeleteStrongVerificationData(empty_pb2.Empty())
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token) as api:
         assert not api.GetUser(api_pb2.GetUserReq(user=user.username)).has_strong_verification
@@ -524,7 +524,7 @@ def test_strong_verification_expiry(db, monkeypatch):
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
     _, superuser_token = generate_user(is_superuser=True)
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token) as api:
         assert not api.GetUser(api_pb2.GetUserReq(user=user.username)).has_strong_verification
@@ -580,7 +580,7 @@ def test_strong_verification_expiry(db, monkeypatch):
         nationality="AU",
     )
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token) as api:
         assert api.GetUser(api_pb2.GetUserReq(user=user.username)).has_strong_verification
@@ -642,7 +642,7 @@ def test_strong_verification_regression2(db, monkeypatch):
         nationality="AU",
     )
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token) as api:
         assert api.GetUser(api_pb2.GetUserReq(user=user.username)).has_strong_verification
@@ -668,7 +668,7 @@ def test_strong_verification_delete_data_cant_reverify(db, monkeypatch, push_col
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
     _, superuser_token = generate_user(is_superuser=True)
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token) as api:
         assert not api.GetUser(api_pb2.GetUserReq(user=user.username)).has_strong_verification
@@ -689,7 +689,7 @@ def test_strong_verification_delete_data_cant_reverify(db, monkeypatch, push_col
         nationality="US",
     )
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     # the user should now have strong verification
     with api_session(token) as api:
@@ -703,7 +703,7 @@ def test_strong_verification_delete_data_cant_reverify(db, monkeypatch, push_col
     with account_session(token) as account:
         account.DeleteStrongVerificationData(empty_pb2.Empty())
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token) as api:
         assert not api.GetUser(api_pb2.GetUserReq(user=user.username)).has_strong_verification
@@ -798,7 +798,7 @@ def test_strong_verification_delete_data_cant_reverify(db, monkeypatch, push_col
         == "You tried to verify with a passport that has already been used for verification. Please use another passport."
     )
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token) as api:
         assert not api.GetUser(api_pb2.GetUserReq(user=user.username)).has_strong_verification
@@ -815,7 +815,7 @@ def test_strong_verification_duplicate_other_user(db, monkeypatch, push_collecto
     user2, token2 = generate_user(birthdate=date(1988, 1, 1), gender="Man")
     _, superuser_token = generate_user(is_superuser=True)
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token) as api:
         assert not api.GetUser(api_pb2.GetUserReq(user=user.username)).has_strong_verification
@@ -840,7 +840,7 @@ def test_strong_verification_duplicate_other_user(db, monkeypatch, push_collecto
         nationality="US",
     )
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     # the user should now have strong verification
     with api_session(token) as api:
@@ -854,7 +854,7 @@ def test_strong_verification_duplicate_other_user(db, monkeypatch, push_collecto
     with account_session(token) as account:
         account.DeleteStrongVerificationData(empty_pb2.Empty())
 
-    refresh_materialized_views_rapid(None)
+    refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token) as api:
         assert not api.GetUser(api_pb2.GetUserReq(user=user.username)).has_strong_verification

--- a/app/backend/src/tests/test_templates.py
+++ b/app/backend/src/tests/test_templates.py
@@ -19,7 +19,7 @@ add_filters(_env)
 
 def _render_template(
     template_str: str,
-    translation_dict: dict,
+    translation_dict: dict[str, dict[str, str]],
     template_args: dict[str, Any] | None = None,
     plain: bool = False,
     lang: str = "en",
@@ -41,7 +41,7 @@ def _render_template(
         return template.render(template_args)
 
 
-def _greeting_dict(value: str) -> dict:
+def _greeting_dict(value: str) -> dict[str, dict[str, str]]:
     return {"en": {"greeting": value}}
 
 

--- a/app/backend/src/tests/test_verification.py
+++ b/app/backend/src/tests/test_verification.py
@@ -67,6 +67,7 @@ def test_ChangePhone(db, monkeypatch, push_collector: PushCollector):
         with session_scope() as session:
             user = session.execute(select(User).where(User.id == user_id)).scalar_one()
             assert user.phone == "+46701740605"
+            assert user.phone_verification_token
             assert len(user.phone_verification_token) == 6
 
         process_jobs()
@@ -108,6 +109,7 @@ def test_ChangePhone_ratelimit(db, monkeypatch):
         with session_scope() as session:
             user = session.execute(select(User).where(User.id == user_id)).scalar_one()
             assert user.phone == "+46701740605"
+            assert user.phone_verification_token
             assert len(user.phone_verification_token) == 6
 
 

--- a/app/backend/src/tests/test_visible_users.py
+++ b/app/backend/src/tests/test_visible_users.py
@@ -1,6 +1,9 @@
+from typing import cast
+
 from sqlalchemy import select, update
 from sqlalchemy.sql import func
 
+from couchers.context import CouchersContext
 from couchers.db import session_scope
 from couchers.models import FriendRelationship, User
 from couchers.sql import users_visible, where_users_column_visible
@@ -39,7 +42,7 @@ def test_select_dot_where_users_visible(db):
     make_user_block(user1, user3)
     make_user_block(user4, user1)
 
-    context = _FakeContext(user1.id)
+    context = cast(CouchersContext, _FakeContext(user1.id))
     with session_scope() as session:
         assert session.execute(select(func.count()).select_from(User).where(users_visible(context))).scalar_one() == 1
 
@@ -60,7 +63,7 @@ def test_select_dot_where_users_column_visible(db):
     make_user_block(user1, user4)
     make_user_block(user5, user1)
 
-    context = _FakeContext(user1.id)
+    context = cast(CouchersContext, _FakeContext(user1.id))
     with session_scope() as session:
         assert (
             session.execute(


### PR DESCRIPTION
Run mypy on `src/tests`. The main benefit is safer refactoring: e.g., you change something, run mypy and see type errors in tests, instead of waiting them to run (or worse, fail in CI). I disabled the most annoying errors (so that type annotating all tests functions is NOT requried), so this doesn't add much work to writing tests. 