### PR TITLE
Start using MappedAsDataclass for sqlalchemy models

### DIFF
--- a/app/backend/Makefile
+++ b/app/backend/Makefile
@@ -26,7 +26,7 @@ format:
 fmt: format
 
 mypy:
-	uv run mypy src/couchers src/tests
+	uv run mypy src
 
 # Downgrade the local database to the previous migration. Good if you ran a migration on a branch and will run the backend on another branch after.
 # Usage:

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
     "types-boto3>=1.40.69",
     "types-cachetools",
     "types-psycopg2",
+    "types-python-dateutil>=2.9.0.20251115",
 ]
 
 

--- a/app/backend/src/app.py
+++ b/app/backend/src/app.py
@@ -3,6 +3,7 @@ import signal
 import sys
 from os import environ
 from tempfile import TemporaryDirectory
+from types import TracebackType
 
 # these two lines need to be at the top of the file before we span child processes
 # this temp dir will be destroyed when prometheus_multiproc_dir is destroyed, aka at the end of the program
@@ -33,7 +34,11 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-def log_unhandled_exception(exc_type, exc_value, exc_traceback):
+def log_unhandled_exception(
+    exc_type: type[BaseException],
+    exc_value: BaseException,
+    exc_traceback: TracebackType | None,
+) -> None:
     """Make sure that any unhandled exceptions will write to the logs"""
     if issubclass(exc_type, KeyboardInterrupt):
         # call the default excepthook saved at __excepthook__

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -8,11 +8,10 @@ from datetime import date, timedelta
 from math import cos, pi, sin, sqrt
 from random import sample
 from typing import Any
-from typing import cast as t_cast
 
 import requests
 from google.protobuf import empty_pb2
-from sqlalchemy import ColumnElement, Float, Function, Integer, Table, select
+from sqlalchemy import ColumnElement, Float, Function, Integer, select
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import (
     and_,
@@ -814,12 +813,7 @@ def update_recommendation_scores(payload: empty_pb2.Empty) -> None:
             .outerjoin(hr_subquery, hr_subquery.c.user_id == User.id)
         ).subquery()
 
-        session.execute(
-            t_cast(Table, User.__table__)
-            .update()
-            .values(recommendation_score=scores.c.score)
-            .where(User.id == scores.c.user_id)
-        )
+        session.execute(update(User).values(recommendation_score=scores.c.score).where(User.id == scores.c.user_id))
 
     logger.info("Updated recommendation scores")
 

--- a/app/backend/src/couchers/materialized_views.py
+++ b/app/backend/src/couchers/materialized_views.py
@@ -35,6 +35,7 @@ from couchers.models import (
     ClusterSubscription,
     Geom,
     HostRequest,
+    MatViewBase,
     Message,
     MessageType,
     StrongVerificationAttempt,
@@ -98,7 +99,7 @@ cluster_subscription_counts = create_materialized_view(
 )
 
 
-class ClusterSubscriptionCount(Base):
+class ClusterSubscriptionCount(MatViewBase):
     __table__ = cluster_subscription_counts
 
     cluster_id: Mapped[int]
@@ -131,7 +132,7 @@ cluster_admin_counts = create_materialized_view(
 )
 
 
-class ClusterAdminCount(Base):
+class ClusterAdminCount(MatViewBase):
     __table__ = cluster_admin_counts
 
     cluster_id: Mapped[int]
@@ -205,7 +206,7 @@ lite_users = create_materialized_view_with_different_ddl(
 )
 
 
-class LiteUser(Base):
+class LiteUser(MatViewBase):
     __table__ = lite_users
 
     # A subset enough to make mypy happy. Taken from "make_lite_users_selectable".
@@ -275,7 +276,7 @@ clustered_users = create_materialized_view_with_different_ddl(
 )
 
 
-class ClusteredUser(Base):
+class ClusteredUser(MatViewBase):
     __table__ = clustered_users
 
     geom: Mapped[Geom]
@@ -343,7 +344,7 @@ user_response_rates = create_materialized_view(
 )
 
 
-class UserResponseRate(Base):
+class UserResponseRate(MatViewBase):
     __table__ = user_response_rates
 
     user_id: Mapped[int]

--- a/app/backend/src/couchers/models/activeness_probe.py
+++ b/app/backend/src/couchers/models/activeness_probe.py
@@ -54,7 +54,7 @@ class ActivenessProbe(Base, init=False, kw_only=True):
     def is_pending(self) -> bool:
         return self.responded == None
 
-    user: Mapped[User] = relationship(back_populates="pending_activeness_probe")
+    user: Mapped[User] = relationship(init=False, back_populates="pending_activeness_probe")
 
     __table_args__ = (
         # a user can have at most one pending activeness probe at a time

--- a/app/backend/src/couchers/models/activeness_probe.py
+++ b/app/backend/src/couchers/models/activeness_probe.py
@@ -26,7 +26,7 @@ class ActivenessProbeStatus(enum.Enum):
     no_longer_active = enum.auto()
 
 
-class ActivenessProbe(Base):
+class ActivenessProbe(Base, init=False, kw_only=True):
     """
     Activeness probes are used to gauge if users are still active: we send them a notification and ask them to respond,
     we use this data both to help indicate response rate, as well as to make sure only those who are actively hosting
@@ -35,7 +35,7 @@ class ActivenessProbe(Base):
 
     __tablename__ = "activeness_probes"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
     # the time this probe was initiated

--- a/app/backend/src/couchers/models/auth.py
+++ b/app/backend/src/couchers/models/auth.py
@@ -44,7 +44,7 @@ class UserSession(Base, init=False, kw_only=True):
     long_lived: Mapped[bool] = mapped_column(Boolean)
 
     # the time at which the session was created
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     # the expiry of the session: the session *cannot* be refreshed past this
     expiry: Mapped[datetime] = mapped_column(
@@ -103,7 +103,7 @@ class LoginToken(Base, init=False, kw_only=True):
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
     # timezones should always be UTC
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     expiry: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
     user: Mapped[User] = relationship(init=False, backref="login_tokens")
@@ -122,7 +122,7 @@ class PasswordResetToken(Base, init=False, kw_only=True):
     token: Mapped[str] = mapped_column(String, primary_key=True)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     expiry: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
     user: Mapped[User] = relationship(init=False, backref="password_reset_tokens")

--- a/app/backend/src/couchers/models/auth.py
+++ b/app/backend/src/couchers/models/auth.py
@@ -65,7 +65,7 @@ class UserSession(Base, init=False, kw_only=True):
     ip_address: Mapped[str | None] = mapped_column(String, default=None)
     user_agent: Mapped[str | None] = mapped_column(String, default=None)
 
-    user: Mapped[User] = relationship(backref="sessions")
+    user: Mapped[User] = relationship(init=False, backref="sessions")
 
     @hybrid_property
     def is_valid(self) -> Any:
@@ -106,7 +106,7 @@ class LoginToken(Base, init=False, kw_only=True):
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     expiry: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
-    user: Mapped[User] = relationship(backref="login_tokens")
+    user: Mapped[User] = relationship(init=False, backref="login_tokens")
 
     @hybrid_property
     def is_valid(self) -> Any:
@@ -125,7 +125,7 @@ class PasswordResetToken(Base, init=False, kw_only=True):
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     expiry: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
-    user: Mapped[User] = relationship(backref="password_reset_tokens")
+    user: Mapped[User] = relationship(init=False, backref="password_reset_tokens")
 
     @hybrid_property
     def is_valid(self) -> Any:

--- a/app/backend/src/couchers/models/auth.py
+++ b/app/backend/src/couchers/models/auth.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from couchers.models.users import User
 
 
-class UserSession(Base):
+class UserSession(Base, init=False, kw_only=True):
     """
     API keys/session cookies for the app
 
@@ -92,7 +92,7 @@ class UserSession(Base):
     )
 
 
-class LoginToken(Base):
+class LoginToken(Base, init=False, kw_only=True):
     """
     A login token sent in an email to a user, allows them to sign in between the times defined by created and expiry
     """
@@ -116,7 +116,7 @@ class LoginToken(Base):
         return f"LoginToken(token={self.token}, user={self.user}, created={self.created}, expiry={self.expiry})"
 
 
-class PasswordResetToken(Base):
+class PasswordResetToken(Base, init=False, kw_only=True):
     __tablename__ = "password_reset_tokens"
 
     token: Mapped[str] = mapped_column(String, primary_key=True)

--- a/app/backend/src/couchers/models/background_jobs.py
+++ b/app/backend/src/couchers/models/background_jobs.py
@@ -21,14 +21,14 @@ class BackgroundJobState(enum.Enum):
     failed = enum.auto()
 
 
-class BackgroundJob(Base):
+class BackgroundJob(Base, init=False, kw_only=True):
     """
     This table implements a queue of background jobs.
     """
 
     __tablename__ = "background_jobs"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     # used to discern which function should be triggered to service it
     job_type: Mapped[str] = mapped_column(String)

--- a/app/backend/src/couchers/models/base.py
+++ b/app/backend/src/couchers/models/base.py
@@ -1,6 +1,9 @@
 from geoalchemy2 import WKBElement, WKTElement
 from sqlalchemy import MetaData, Sequence
-from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    MappedAsDataclass,
+)
 
 meta = MetaData(
     naming_convention={
@@ -13,7 +16,11 @@ meta = MetaData(
 )
 
 
-class Base(DeclarativeBase):
+class MatViewBase(DeclarativeBase):
+    metadata = meta
+
+
+class Base(MappedAsDataclass, DeclarativeBase):
     metadata = meta
 
 

--- a/app/backend/src/couchers/models/clusters.py
+++ b/app/backend/src/couchers/models/clusters.py
@@ -52,7 +52,7 @@ class Node(Base, init=False, kw_only=True):
     # name and description come from the official cluster
     parent_node_id: Mapped[int | None] = mapped_column(ForeignKey("nodes.id"), nullable=True, index=True)
     geom: Mapped[Geom] = deferred(mapped_column(Geometry(geometry_type="MULTIPOLYGON", srid=4326), nullable=False))
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     parent_node: Mapped[Node] = relationship(init=False, back_populates="child_nodes", remote_side="Node.id")
     child_nodes: Mapped[list[Node]] = relationship(init=False)
@@ -82,7 +82,7 @@ class Cluster(Base, init=False, kw_only=True):
     name: Mapped[str] = mapped_column(String)
     # short description
     description: Mapped[str] = mapped_column(String)
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     is_official_cluster: Mapped[bool] = mapped_column(Boolean, default=False)
 
@@ -330,7 +330,7 @@ class PageVersion(Base, init=False, kw_only=True):
     geom: Mapped[Geom | None] = mapped_column(Geometry(geometry_type="POINT", srid=4326), nullable=True)
     # the human-readable address
     address: Mapped[str | None] = mapped_column(String, nullable=True)
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     slug: Mapped[str] = column_property(func.slugify(title))
 

--- a/app/backend/src/couchers/models/clusters.py
+++ b/app/backend/src/couchers/models/clusters.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from couchers.models import Discussion, Event, Thread, Upload, User
 
 
-class Node(Base):
+class Node(Base, init=False, kw_only=True):
     """
     Node, i.e., geographical subdivision of the world
 
@@ -65,7 +65,7 @@ class Node(Base):
     )
 
 
-class Cluster(Base):
+class Cluster(Base, init=False, kw_only=True):
     """
     Cluster, administered grouping of content
     """
@@ -167,7 +167,7 @@ class Cluster(Base):
     )
 
 
-class NodeClusterAssociation(Base):
+class NodeClusterAssociation(Base, init=False, kw_only=True):
     """
     NodeClusterAssociation, grouping of nodes
     """
@@ -175,7 +175,7 @@ class NodeClusterAssociation(Base):
     __tablename__ = "node_cluster_associations"
     __table_args__ = (UniqueConstraint("node_id", "cluster_id"),)
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     node_id: Mapped[int] = mapped_column(ForeignKey("nodes.id"), index=True)
     cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
@@ -189,14 +189,14 @@ class ClusterRole(enum.Enum):
     admin = enum.auto()
 
 
-class ClusterSubscription(Base):
+class ClusterSubscription(Base, init=False, kw_only=True):
     """
     ClusterSubscription of a user
     """
 
     __tablename__ = "cluster_subscriptions"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
     cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
@@ -222,7 +222,7 @@ class ClusterSubscription(Base):
     )
 
 
-class ClusterPageAssociation(Base):
+class ClusterPageAssociation(Base, init=False, kw_only=True):
     """
     pages related to clusters
     """
@@ -230,7 +230,7 @@ class ClusterPageAssociation(Base):
     __tablename__ = "cluster_page_associations"
     __table_args__ = (UniqueConstraint("page_id", "cluster_id"),)
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     page_id: Mapped[int] = mapped_column(ForeignKey("pages.id"), index=True)
     cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
@@ -245,7 +245,7 @@ class PageType(enum.Enum):
     guide = enum.auto()
 
 
-class Page(Base):
+class Page(Base, init=False, kw_only=True):
     """
     similar to a wiki page about a community, POI or guide
     """
@@ -303,14 +303,14 @@ class Page(Base):
         return f"Page({self.id=})"
 
 
-class PageVersion(Base):
+class PageVersion(Base, init=False, kw_only=True):
     """
     version of page content
     """
 
     __tablename__ = "page_versions"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     page_id: Mapped[int] = mapped_column(ForeignKey("pages.id"), index=True)
     editor_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)

--- a/app/backend/src/couchers/models/clusters.py
+++ b/app/backend/src/couchers/models/clusters.py
@@ -54,10 +54,13 @@ class Node(Base, init=False, kw_only=True):
     geom: Mapped[Geom] = deferred(mapped_column(Geometry(geometry_type="MULTIPOLYGON", srid=4326), nullable=False))
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    parent_node: Mapped[Node] = relationship(back_populates="child_nodes", remote_side="Node.id")
-    child_nodes: Mapped[list[Node]] = relationship()
-    child_clusters: Mapped[list[Cluster]] = relationship(back_populates="parent_node", overlaps="official_cluster")
+    parent_node: Mapped[Node] = relationship(init=False, back_populates="child_nodes", remote_side="Node.id")
+    child_nodes: Mapped[list[Node]] = relationship(init=False)
+    child_clusters: Mapped[list[Cluster]] = relationship(
+        init=False, back_populates="parent_node", overlaps="official_cluster"
+    )
     official_cluster: Mapped[Cluster] = relationship(
+        init=False,
         primaryjoin="and_(Node.id == Cluster.parent_node_id, Cluster.is_official_cluster)",
         foreign_keys="[Cluster.parent_node_id]",
         uselist=False,
@@ -89,6 +92,7 @@ class Cluster(Base, init=False, kw_only=True):
     slug: Mapped[str] = column_property(func.slugify(name))
 
     official_cluster_for_node: Mapped[Node] = relationship(
+        init=False,
         primaryjoin="and_(Cluster.parent_node_id == Node.id, Cluster.is_official_cluster)",
         back_populates="official_cluster",
         uselist=False,
@@ -96,6 +100,7 @@ class Cluster(Base, init=False, kw_only=True):
     )
 
     parent_node: Mapped[Node] = relationship(
+        init=False,
         back_populates="child_clusters",
         remote_side="Node.id",
         foreign_keys="Cluster.parent_node_id",
@@ -103,19 +108,22 @@ class Cluster(Base, init=False, kw_only=True):
     )
 
     nodes: Mapped[list[Cluster]] = relationship(
-        backref="clusters", secondary="node_cluster_associations", viewonly=True
+        init=False, backref="clusters", secondary="node_cluster_associations", viewonly=True
     )
     # all pages
     pages: DynamicMapped[Page] = relationship(
-        backref="clusters", secondary="cluster_page_associations", lazy="dynamic", viewonly=True
+        init=False, backref="clusters", secondary="cluster_page_associations", lazy="dynamic", viewonly=True
     )
-    events: Mapped[Event] = relationship(backref="clusters", secondary="cluster_event_associations", viewonly=True)
+    events: Mapped[Event] = relationship(
+        init=False, backref="clusters", secondary="cluster_event_associations", viewonly=True
+    )
     discussions: Mapped[Discussion] = relationship(
-        backref="clusters", secondary="cluster_discussion_associations", viewonly=True
+        init=False, backref="clusters", secondary="cluster_discussion_associations", viewonly=True
     )
 
     # includes also admins
     members: DynamicMapped[User] = relationship(
+        init=False,
         lazy="dynamic",
         backref="cluster_memberships",
         secondary="cluster_subscriptions",
@@ -125,6 +133,7 @@ class Cluster(Base, init=False, kw_only=True):
     )
 
     admins: DynamicMapped[User] = relationship(
+        init=False,
         lazy="dynamic",
         backref="cluster_adminships",
         secondary="cluster_subscriptions",
@@ -133,11 +142,12 @@ class Cluster(Base, init=False, kw_only=True):
         viewonly=True,
     )
 
-    cluster_subscriptions: Mapped[list[ClusterSubscription]] = relationship()
+    cluster_subscriptions: Mapped[list[ClusterSubscription]] = relationship(init=False)
     owned_pages: DynamicMapped[Page] = relationship(lazy="dynamic")
     owned_discussions: DynamicMapped[Discussion] = relationship(lazy="dynamic")
 
     main_page: Mapped[Page] = relationship(
+        init=False,
         primaryjoin="and_(Cluster.id == Page.owner_cluster_id, Page.type == 'main_page')",
         viewonly=True,
         uselist=False,
@@ -180,8 +190,8 @@ class NodeClusterAssociation(Base, init=False, kw_only=True):
     node_id: Mapped[int] = mapped_column(ForeignKey("nodes.id"), index=True)
     cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
 
-    node: Mapped[Node] = relationship(backref="node_cluster_associations")
-    cluster: Mapped[Cluster] = relationship(backref="node_cluster_associations")
+    node: Mapped[Node] = relationship(init=False, backref="node_cluster_associations")
+    cluster: Mapped[Cluster] = relationship(init=False, backref="node_cluster_associations")
 
 
 class ClusterRole(enum.Enum):
@@ -202,8 +212,8 @@ class ClusterSubscription(Base, init=False, kw_only=True):
     cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
     role: Mapped[ClusterRole] = mapped_column(Enum(ClusterRole))
 
-    user: Mapped[User] = relationship(backref="cluster_subscriptions")
-    cluster: Mapped[Cluster] = relationship(back_populates="cluster_subscriptions")
+    user: Mapped[User] = relationship(init=False, backref="cluster_subscriptions")
+    cluster: Mapped[Cluster] = relationship(init=False, back_populates="cluster_subscriptions")
 
     __table_args__ = (
         UniqueConstraint("user_id", "cluster_id"),
@@ -235,8 +245,8 @@ class ClusterPageAssociation(Base, init=False, kw_only=True):
     page_id: Mapped[int] = mapped_column(ForeignKey("pages.id"), index=True)
     cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
 
-    page: Mapped[Page] = relationship(backref="cluster_page_associations")
-    cluster: Mapped[Cluster] = relationship(backref="cluster_page_associations")
+    page: Mapped[Page] = relationship(init=False, backref="cluster_page_associations")
+    cluster: Mapped[Cluster] = relationship(init=False, backref="cluster_page_associations")
 
 
 class PageType(enum.Enum):
@@ -265,18 +275,18 @@ class Page(Base, init=False, kw_only=True):
     thread_id: Mapped[int] = mapped_column(ForeignKey("threads.id"), unique=True)
 
     parent_node: Mapped[Node] = relationship(
-        backref="child_pages", remote_side="Node.id", foreign_keys="Page.parent_node_id"
+        init=False, backref="child_pages", remote_side="Node.id", foreign_keys="Page.parent_node_id"
     )
 
-    thread: Mapped[Thread] = relationship(backref="page", uselist=False)
-    creator_user: Mapped[User] = relationship(backref="created_pages", foreign_keys="Page.creator_user_id")
-    owner_user: Mapped[User | None] = relationship(backref="owned_pages", foreign_keys="Page.owner_user_id")
+    thread: Mapped[Thread] = relationship(init=False, backref="page", uselist=False)
+    creator_user: Mapped[User] = relationship(init=False, backref="created_pages", foreign_keys="Page.creator_user_id")
+    owner_user: Mapped[User | None] = relationship(init=False, backref="owned_pages", foreign_keys="Page.owner_user_id")
     owner_cluster: Mapped[Cluster | None] = relationship(
-        back_populates="owned_pages", uselist=False, foreign_keys="Page.owner_cluster_id"
+        init=False, back_populates="owned_pages", uselist=False, foreign_keys="Page.owner_cluster_id"
     )
 
     editors: Mapped[list[User]] = relationship(secondary="page_versions", viewonly=True)
-    versions: Mapped[list[PageVersion]] = relationship(back_populates="page", order_by="PageVersion.id")
+    versions: Mapped[list[PageVersion]] = relationship(init=False, back_populates="page", order_by="PageVersion.id")
 
     __table_args__ = (
         # Only one of owner_user and owner_cluster should be set
@@ -324,9 +334,9 @@ class PageVersion(Base, init=False, kw_only=True):
 
     slug: Mapped[str] = column_property(func.slugify(title))
 
-    page: Mapped[Page] = relationship(back_populates="versions")
-    editor_user: Mapped[User] = relationship(backref="edited_pages")
-    photo: Mapped[Upload] = relationship()
+    page: Mapped[Page] = relationship(init=False, back_populates="versions")
+    editor_user: Mapped[User] = relationship(init=False, backref="edited_pages")
+    photo: Mapped[Upload] = relationship(init=False)
 
     __table_args__ = (
         # Geom and address must either both be null or both be set

--- a/app/backend/src/couchers/models/conversations.py
+++ b/app/backend/src/couchers/models/conversations.py
@@ -24,7 +24,7 @@ class Conversation(Base, init=False, kw_only=True):
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     # timezone should always be UTC
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     def __repr__(self) -> str:
         return f"Conversation(id={self.id}, created={self.created})"

--- a/app/backend/src/couchers/models/conversations.py
+++ b/app/backend/src/couchers/models/conversations.py
@@ -48,9 +48,9 @@ class GroupChat(Base, init=False, kw_only=True):
     # Unified Moderation System
     moderation_state_id: Mapped[int] = mapped_column(ForeignKey("moderation_states.id"), index=True)
 
-    conversation: Mapped[Conversation] = relationship(backref="group_chat")
-    creator: Mapped[User] = relationship(backref="created_group_chats")
-    moderation_state: Mapped[ModerationState] = relationship()
+    conversation: Mapped[Conversation] = relationship(init=False, backref="group_chat")
+    creator: Mapped[User] = relationship(init=False, backref="created_group_chats")
+    moderation_state: Mapped[ModerationState] = relationship(init=False)
     subscriptions: DynamicMapped[GroupChatSubscription] = relationship(lazy="dynamic")
 
     def __repr__(self) -> str:
@@ -87,8 +87,8 @@ class GroupChatSubscription(Base, init=False, kw_only=True):
         DateTime(timezone=True), server_default=DATETIME_MINUS_INFINITY.isoformat()
     )
 
-    user: Mapped[User] = relationship(backref="group_chat_subscriptions")
-    group_chat: Mapped[GroupChat] = relationship(back_populates="subscriptions")
+    user: Mapped[User] = relationship(init=False, backref="group_chat_subscriptions")
+    group_chat: Mapped[GroupChat] = relationship(init=False, back_populates="subscriptions")
 
     def muted_display(self) -> tuple[bool, datetime | None]:
         """
@@ -160,7 +160,7 @@ class Message(Base, init=False, kw_only=True):
     # the new host request status if the message type is host_request_status_changed
     host_request_status_target: Mapped[HostRequestStatus | None] = mapped_column(Enum(HostRequestStatus), nullable=True)
 
-    conversation: Mapped[Conversation] = relationship(backref="messages", order_by="Message.time.desc()")
+    conversation: Mapped[Conversation] = relationship(init=False, backref="messages", order_by="Message.time.desc()")
     author: Mapped[User] = relationship(foreign_keys="Message.author_id")
     target: Mapped[User | None] = relationship(foreign_keys="Message.target_id")
 

--- a/app/backend/src/couchers/models/conversations.py
+++ b/app/backend/src/couchers/models/conversations.py
@@ -15,14 +15,14 @@ if TYPE_CHECKING:
     from couchers.models import ModerationState, User
 
 
-class Conversation(Base):
+class Conversation(Base, init=False, kw_only=True):
     """
     Conversation brings together the different types of message/conversation types
     """
 
     __tablename__ = "conversations"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     # timezone should always be UTC
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
@@ -30,7 +30,7 @@ class Conversation(Base):
         return f"Conversation(id={self.id}, created={self.created})"
 
 
-class GroupChat(Base):
+class GroupChat(Base, init=False, kw_only=True):
     """
     Group chat
     """
@@ -62,13 +62,13 @@ class GroupChatRole(enum.Enum):
     participant = enum.auto()
 
 
-class GroupChatSubscription(Base):
+class GroupChatSubscription(Base, init=False, kw_only=True):
     """
     The recipient of a thread and information about when they joined/left/etc.
     """
 
     __tablename__ = "group_chat_subscriptions"
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     # TODO: DB constraint on only one user+group_chat combo at a given time
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
@@ -128,7 +128,7 @@ class MessageType(enum.Enum):
     user_removed = enum.auto()  # user is removed from group chat by amdin RemoveGroupChatUser
 
 
-class Message(Base):
+class Message(Base, init=False, kw_only=True):
     """
     A message.
 
@@ -137,7 +137,7 @@ class Message(Base):
 
     __tablename__ = "messages"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     # which conversation the message belongs in
     conversation_id: Mapped[int] = mapped_column(ForeignKey("conversations.id"), index=True)

--- a/app/backend/src/couchers/models/discussions.py
+++ b/app/backend/src/couchers/models/discussions.py
@@ -24,7 +24,7 @@ class Discussion(Base, init=False, kw_only=True):
     title: Mapped[str] = mapped_column(String)
     content: Mapped[str] = mapped_column(String)
     thread_id: Mapped[int] = mapped_column(ForeignKey("threads.id"), unique=True)
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     creator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
     owner_cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
@@ -71,7 +71,7 @@ class Thread(Base, init=False, kw_only=True):
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     deleted: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
 
@@ -87,7 +87,7 @@ class Comment(Base, init=False, kw_only=True):
     thread_id: Mapped[int] = mapped_column(ForeignKey("threads.id"), index=True)
     author_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     content: Mapped[str] = mapped_column(String)  # CommonMark without images
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     deleted: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     thread: Mapped[Thread] = relationship(init=False, backref="comments")
@@ -105,7 +105,7 @@ class Reply(Base, init=False, kw_only=True):
     comment_id: Mapped[int] = mapped_column(ForeignKey("comments.id"), index=True)
     author_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     content: Mapped[str] = mapped_column(String)  # CommonMark without images
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     deleted: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     comment: Mapped[Comment] = relationship(init=False, backref="replies")

--- a/app/backend/src/couchers/models/discussions.py
+++ b/app/backend/src/couchers/models/discussions.py
@@ -31,14 +31,16 @@ class Discussion(Base, init=False, kw_only=True):
 
     slug: Mapped[str] = column_property(func.slugify(title))
 
-    thread: Mapped[Thread] = relationship(backref="discussion", uselist=False)
+    thread: Mapped[Thread] = relationship(init=False, backref="discussion", uselist=False)
 
     subscribers: Mapped[list[User]] = relationship(
-        backref="discussions", secondary="discussion_subscriptions", viewonly=True
+        init=False, backref="discussions", secondary="discussion_subscriptions", viewonly=True
     )
 
-    creator_user: Mapped[User] = relationship(backref="created_discussions", foreign_keys="Discussion.creator_user_id")
-    owner_cluster: Mapped[Cluster] = relationship(back_populates="owned_discussions", uselist=False)
+    creator_user: Mapped[User] = relationship(
+        init=False, backref="created_discussions", foreign_keys="Discussion.creator_user_id"
+    )
+    owner_cluster: Mapped[Cluster] = relationship(init=False, back_populates="owned_discussions", uselist=False)
 
 
 class DiscussionSubscription(Base, init=False, kw_only=True):
@@ -56,8 +58,8 @@ class DiscussionSubscription(Base, init=False, kw_only=True):
     joined: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     left: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
-    user: Mapped[User] = relationship(backref="discussion_subscriptions")
-    discussion: Mapped[Discussion] = relationship(backref="discussion_subscriptions")
+    user: Mapped[User] = relationship(init=False, backref="discussion_subscriptions")
+    discussion: Mapped[Discussion] = relationship(init=False, backref="discussion_subscriptions")
 
 
 class Thread(Base, init=False, kw_only=True):
@@ -88,7 +90,7 @@ class Comment(Base, init=False, kw_only=True):
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     deleted: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
-    thread: Mapped[Thread] = relationship(backref="comments")
+    thread: Mapped[Thread] = relationship(init=False, backref="comments")
 
 
 class Reply(Base, init=False, kw_only=True):
@@ -106,7 +108,7 @@ class Reply(Base, init=False, kw_only=True):
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     deleted: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
-    comment: Mapped[Comment] = relationship(backref="replies")
+    comment: Mapped[Comment] = relationship(init=False, backref="replies")
 
 
 class ClusterDiscussionAssociation(Base, init=False, kw_only=True):
@@ -122,5 +124,5 @@ class ClusterDiscussionAssociation(Base, init=False, kw_only=True):
     discussion_id: Mapped[int] = mapped_column(ForeignKey("discussions.id"), index=True)
     cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
 
-    discussion: Mapped[Discussion] = relationship(backref="cluster_discussion_associations")
-    cluster: Mapped[Cluster] = relationship(backref="cluster_discussion_associations")
+    discussion: Mapped[Discussion] = relationship(init=False, backref="cluster_discussion_associations")
+    cluster: Mapped[Cluster] = relationship(init=False, backref="cluster_discussion_associations")

--- a/app/backend/src/couchers/models/discussions.py
+++ b/app/backend/src/couchers/models/discussions.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from couchers.models import Cluster, User
 
 
-class Discussion(Base):
+class Discussion(Base, init=False, kw_only=True):
     """
     forum board
     """
@@ -41,7 +41,7 @@ class Discussion(Base):
     owner_cluster: Mapped[Cluster] = relationship(back_populates="owned_discussions", uselist=False)
 
 
-class DiscussionSubscription(Base):
+class DiscussionSubscription(Base, init=False, kw_only=True):
     """
     users subscriptions to discussions
     """
@@ -49,7 +49,7 @@ class DiscussionSubscription(Base):
     __tablename__ = "discussion_subscriptions"
     __table_args__ = (UniqueConstraint("discussion_id", "user_id"),)
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
     discussion_id: Mapped[int] = mapped_column(ForeignKey("discussions.id"), index=True)
@@ -60,27 +60,27 @@ class DiscussionSubscription(Base):
     discussion: Mapped[Discussion] = relationship(backref="discussion_subscriptions")
 
 
-class Thread(Base):
+class Thread(Base, init=False, kw_only=True):
     """
     Thread
     """
 
     __tablename__ = "threads"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     deleted: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
 
-class Comment(Base):
+class Comment(Base, init=False, kw_only=True):
     """
     Comment
     """
 
     __tablename__ = "comments"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     thread_id: Mapped[int] = mapped_column(ForeignKey("threads.id"), index=True)
     author_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
@@ -91,14 +91,14 @@ class Comment(Base):
     thread: Mapped[Thread] = relationship(backref="comments")
 
 
-class Reply(Base):
+class Reply(Base, init=False, kw_only=True):
     """
     Reply
     """
 
     __tablename__ = "replies"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     comment_id: Mapped[int] = mapped_column(ForeignKey("comments.id"), index=True)
     author_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
@@ -109,7 +109,7 @@ class Reply(Base):
     comment: Mapped[Comment] = relationship(backref="replies")
 
 
-class ClusterDiscussionAssociation(Base):
+class ClusterDiscussionAssociation(Base, init=False, kw_only=True):
     """
     discussions related to clusters
     """
@@ -117,7 +117,7 @@ class ClusterDiscussionAssociation(Base):
     __tablename__ = "cluster_discussion_associations"
     __table_args__ = (UniqueConstraint("discussion_id", "cluster_id"),)
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     discussion_id: Mapped[int] = mapped_column(ForeignKey("discussions.id"), index=True)
     cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)

--- a/app/backend/src/couchers/models/donations.py
+++ b/app/backend/src/couchers/models/donations.py
@@ -21,14 +21,14 @@ class InvoiceType(enum.Enum):
     external_shop = enum.auto()
 
 
-class DonationInitiation(Base):
+class DonationInitiation(Base, init=False, kw_only=True):
     """
     Whenever someone initiates a donation through the platform
     """
 
     __tablename__ = "donation_initiations"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
@@ -41,7 +41,7 @@ class DonationInitiation(Base):
     user: Mapped[User] = relationship(backref="donation_initiations")
 
 
-class Invoice(Base):
+class Invoice(Base, init=False, kw_only=True):
     """
     Successful donations, both one-off and recurring
 
@@ -50,7 +50,7 @@ class Invoice(Base):
 
     __tablename__ = "invoices"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
 

--- a/app/backend/src/couchers/models/donations.py
+++ b/app/backend/src/couchers/models/donations.py
@@ -38,7 +38,7 @@ class DonationInitiation(Base, init=False, kw_only=True):
     donation_type: Mapped[DonationType] = mapped_column(Enum(DonationType))
     source: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    user: Mapped[User] = relationship(backref="donation_initiations")
+    user: Mapped[User] = relationship(init=False, backref="donation_initiations")
 
 
 class Invoice(Base, init=False, kw_only=True):
@@ -61,4 +61,4 @@ class Invoice(Base, init=False, kw_only=True):
 
     invoice_type: Mapped[InvoiceType] = mapped_column(Enum(InvoiceType))
 
-    user: Mapped[User] = relationship(backref="invoices")
+    user: Mapped[User] = relationship(init=False, backref="invoices")

--- a/app/backend/src/couchers/models/donations.py
+++ b/app/backend/src/couchers/models/donations.py
@@ -29,7 +29,7 @@ class DonationInitiation(Base, init=False, kw_only=True):
     __tablename__ = "donation_initiations"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
     amount: Mapped[int] = mapped_column(Integer)
@@ -51,7 +51,7 @@ class Invoice(Base, init=False, kw_only=True):
     __tablename__ = "invoices"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
 
     amount: Mapped[float] = mapped_column(Float)

--- a/app/backend/src/couchers/models/events.py
+++ b/app/backend/src/couchers/models/events.py
@@ -70,7 +70,7 @@ class Event(Base, init=False, kw_only=True):
     slug: Mapped[str] = column_property(func.slugify(title))
 
     creator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     owner_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), index=True)
     owner_cluster_id: Mapped[int | None] = mapped_column(ForeignKey("clusters.id"), index=True)
     thread_id: Mapped[int] = mapped_column(ForeignKey("threads.id"), unique=True)
@@ -137,7 +137,7 @@ class EventOccurrence(Base, init=False, kw_only=True):
     # simplifies database constraints, etc
     during: Mapped[DateTimeTZRange] = mapped_column(TSTZRANGE)
 
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     last_edited: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     creator_user: Mapped[User] = relationship(
@@ -273,7 +273,7 @@ class EventCommunityInviteRequest(Base, init=False, kw_only=True):
     occurrence_id: Mapped[int] = mapped_column(ForeignKey("event_occurrences.id"), index=True)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     decided: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     decided_by_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"))

--- a/app/backend/src/couchers/models/events.py
+++ b/app/backend/src/couchers/models/events.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from couchers.models import Cluster, Node, Thread, Upload, User
 
 
-class ClusterEventAssociation(Base):
+class ClusterEventAssociation(Base, init=False, kw_only=True):
     """
     events related to clusters
     """
@@ -38,7 +38,7 @@ class ClusterEventAssociation(Base):
     __tablename__ = "cluster_event_associations"
     __table_args__ = (UniqueConstraint("event_id", "cluster_id"),)
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), index=True)
     cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
@@ -47,7 +47,7 @@ class ClusterEventAssociation(Base):
     cluster: Mapped[Cluster] = relationship(backref="cluster_event_associations")
 
 
-class Event(Base):
+class Event(Base, init=False, kw_only=True):
     """
     An event is composed of two parts:
 
@@ -103,7 +103,7 @@ class Event(Base):
     )
 
 
-class EventOccurrence(Base):
+class EventOccurrence(Base, init=False, kw_only=True):
     __tablename__ = "event_occurrences"
 
     id: Mapped[int] = mapped_column(
@@ -191,7 +191,7 @@ class EventOccurrence(Base):
         return cast(ColumnElement[datetime], func.upper(cls.during))
 
 
-class EventSubscription(Base):
+class EventSubscription(Base, init=False, kw_only=True):
     """
     Users' subscriptions to events
     """
@@ -199,7 +199,7 @@ class EventSubscription(Base):
     __tablename__ = "event_subscriptions"
     __table_args__ = (UniqueConstraint("event_id", "user_id"),)
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
     event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), index=True)
@@ -209,7 +209,7 @@ class EventSubscription(Base):
     event: Mapped[Event] = relationship()
 
 
-class EventOrganizer(Base):
+class EventOrganizer(Base, init=False, kw_only=True):
     """
     Organizers for events
     """
@@ -217,7 +217,7 @@ class EventOrganizer(Base):
     __tablename__ = "event_organizers"
     __table_args__ = (UniqueConstraint("event_id", "user_id"),)
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
     event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), index=True)
@@ -232,7 +232,7 @@ class AttendeeStatus(enum.Enum):
     maybe = enum.auto()
 
 
-class EventOccurrenceAttendee(Base):
+class EventOccurrenceAttendee(Base, init=False, kw_only=True):
     """
     Attendees for events
     """
@@ -240,7 +240,7 @@ class EventOccurrenceAttendee(Base):
     __tablename__ = "event_occurrence_attendees"
     __table_args__ = (UniqueConstraint("occurrence_id", "user_id"),)
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
     occurrence_id: Mapped[int] = mapped_column(ForeignKey("event_occurrences.id"), index=True)
@@ -253,14 +253,14 @@ class EventOccurrenceAttendee(Base):
     reminder_sent: Mapped[bool] = mapped_column(Boolean, default=False, server_default=expression.false())
 
 
-class EventCommunityInviteRequest(Base):
+class EventCommunityInviteRequest(Base, init=False, kw_only=True):
     """
     Requests to send out invitation notifications/emails to the community for a given event occurrence
     """
 
     __tablename__ = "event_community_invite_requests"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     occurrence_id: Mapped[int] = mapped_column(ForeignKey("event_occurrences.id"), index=True)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)

--- a/app/backend/src/couchers/models/events.py
+++ b/app/backend/src/couchers/models/events.py
@@ -43,8 +43,8 @@ class ClusterEventAssociation(Base, init=False, kw_only=True):
     event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), index=True)
     cluster_id: Mapped[int] = mapped_column(ForeignKey("clusters.id"), index=True)
 
-    event: Mapped[Event] = relationship(backref="cluster_event_associations")
-    cluster: Mapped[Cluster] = relationship(backref="cluster_event_associations")
+    event: Mapped[Event] = relationship(init=False, backref="cluster_event_associations")
+    cluster: Mapped[Cluster] = relationship(init=False, backref="cluster_event_associations")
 
 
 class Event(Base, init=False, kw_only=True):
@@ -76,18 +76,23 @@ class Event(Base, init=False, kw_only=True):
     thread_id: Mapped[int] = mapped_column(ForeignKey("threads.id"), unique=True)
 
     parent_node: Mapped[Node] = relationship(
-        backref="child_events", remote_side="Node.id", foreign_keys="Event.parent_node_id"
+        init=False, backref="child_events", remote_side="Node.id", foreign_keys="Event.parent_node_id"
     )
-    thread: Mapped[Thread] = relationship(backref="event", uselist=False)
+    thread: Mapped[Thread] = relationship(init=False, backref="event", uselist=False)
     subscribers: DynamicMapped[User] = relationship(
-        backref="subscribed_events", secondary="event_subscriptions", lazy="dynamic", viewonly=True
+        init=False, backref="subscribed_events", secondary="event_subscriptions", lazy="dynamic", viewonly=True
     )
     organizers: DynamicMapped[User] = relationship(
-        backref="organized_events", secondary="event_organizers", lazy="dynamic", viewonly=True
+        init=False, backref="organized_events", secondary="event_organizers", lazy="dynamic", viewonly=True
     )
-    creator_user: Mapped[User] = relationship(backref="created_events", foreign_keys="Event.creator_user_id")
-    owner_user: Mapped[User | None] = relationship(backref="owned_events", foreign_keys="Event.owner_user_id")
+    creator_user: Mapped[User] = relationship(
+        init=False, backref="created_events", foreign_keys="Event.creator_user_id"
+    )
+    owner_user: Mapped[User | None] = relationship(
+        init=False, backref="owned_events", foreign_keys="Event.owner_user_id"
+    )
     owner_cluster: Mapped[Cluster | None] = relationship(
+        init=False,
         backref=backref("owned_events", lazy="dynamic"),
         uselist=False,
         foreign_keys="Event.owner_cluster_id",
@@ -136,18 +141,21 @@ class EventOccurrence(Base, init=False, kw_only=True):
     last_edited: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     creator_user: Mapped[User] = relationship(
-        backref="created_event_occurrences", foreign_keys="EventOccurrence.creator_user_id"
+        init=False, backref="created_event_occurrences", foreign_keys="EventOccurrence.creator_user_id"
     )
     event: Mapped[Event] = relationship(
+        init=False,
         back_populates="occurrences",
         remote_side="Event.id",
         foreign_keys="EventOccurrence.event_id",
     )
 
-    photo: Mapped[Upload | None] = relationship()
-    attendances: DynamicMapped[EventOccurrenceAttendee] = relationship(back_populates="occurrence", lazy="dynamic")
+    photo: Mapped[Upload | None] = relationship(init=False)
+    attendances: DynamicMapped[EventOccurrenceAttendee] = relationship(
+        init=False, back_populates="occurrence", lazy="dynamic"
+    )
     community_invite_requests: DynamicMapped[EventCommunityInviteRequest] = relationship(
-        back_populates="occurrence", lazy="dynamic"
+        init=False, back_populates="occurrence", lazy="dynamic"
     )
 
     __table_args__ = (
@@ -205,8 +213,8 @@ class EventSubscription(Base, init=False, kw_only=True):
     event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), index=True)
     joined: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    user: Mapped[User] = relationship()
-    event: Mapped[Event] = relationship()
+    user: Mapped[User] = relationship(init=False)
+    event: Mapped[Event] = relationship(init=False)
 
 
 class EventOrganizer(Base, init=False, kw_only=True):
@@ -223,8 +231,8 @@ class EventOrganizer(Base, init=False, kw_only=True):
     event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), index=True)
     joined: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    user: Mapped[User] = relationship()
-    event: Mapped[Event] = relationship()
+    user: Mapped[User] = relationship(init=False)
+    event: Mapped[Event] = relationship(init=False)
 
 
 class AttendeeStatus(enum.Enum):
@@ -247,8 +255,8 @@ class EventOccurrenceAttendee(Base, init=False, kw_only=True):
     responded: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     attendee_status: Mapped[AttendeeStatus] = mapped_column(Enum(AttendeeStatus))
 
-    user: Mapped[User] = relationship()
-    occurrence: Mapped[EventOccurrence] = relationship(back_populates="attendances")
+    user: Mapped[User] = relationship(init=False)
+    occurrence: Mapped[EventOccurrence] = relationship(init=False, back_populates="attendances")
 
     reminder_sent: Mapped[bool] = mapped_column(Boolean, default=False, server_default=expression.false())
 
@@ -271,7 +279,7 @@ class EventCommunityInviteRequest(Base, init=False, kw_only=True):
     decided_by_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"))
     approved: Mapped[bool | None] = mapped_column(Boolean)
 
-    occurrence: Mapped[EventOccurrence] = relationship(back_populates="community_invite_requests")
+    occurrence: Mapped[EventOccurrence] = relationship(init=False, back_populates="community_invite_requests")
     user: Mapped[User] = relationship(foreign_keys="EventCommunityInviteRequest.user_id")
 
     __table_args__ = (

--- a/app/backend/src/couchers/models/host_requests.py
+++ b/app/backend/src/couchers/models/host_requests.py
@@ -84,10 +84,14 @@ class HostRequest(Base, init=False, kw_only=True):
     host_reason_didnt_meetup: Mapped[str | None] = mapped_column(String, nullable=True)
     surfer_reason_didnt_meetup: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    surfer: Mapped[User] = relationship(backref="host_requests_sent", foreign_keys="HostRequest.surfer_user_id")
-    host: Mapped[User] = relationship(backref="host_requests_received", foreign_keys="HostRequest.host_user_id")
-    conversation: Mapped[Conversation] = relationship()
-    moderation_state: Mapped[ModerationState] = relationship()
+    surfer: Mapped[User] = relationship(
+        init=False, backref="host_requests_sent", foreign_keys="HostRequest.surfer_user_id"
+    )
+    host: Mapped[User] = relationship(
+        init=False, backref="host_requests_received", foreign_keys="HostRequest.host_user_id"
+    )
+    conversation: Mapped[Conversation] = relationship(init=False)
+    moderation_state: Mapped[ModerationState] = relationship(init=False)
 
     __table_args__ = (
         # allows fast lookup as to whether they didn't meet up
@@ -146,7 +150,7 @@ class HostRequestFeedback(Base, init=False, kw_only=True):
     request_quality: Mapped[HostRequestQuality | None] = mapped_column(Enum(HostRequestQuality), nullable=True)
     decline_reason: Mapped[str | None] = mapped_column(String, nullable=True)  # plain text
 
-    host_request: Mapped[HostRequest] = relationship()
+    host_request: Mapped[HostRequest] = relationship(init=False)
 
     __table_args__ = (
         # Each user can leave at most one friend reference to another user

--- a/app/backend/src/couchers/models/host_requests.py
+++ b/app/backend/src/couchers/models/host_requests.py
@@ -31,7 +31,7 @@ class HostRequestQuality(enum.Enum):
     low_quality = enum.auto()
 
 
-class HostRequest(Base):
+class HostRequest(Base, init=False, kw_only=True):
     """
     A request to stay with a host
     """
@@ -129,14 +129,14 @@ class HostRequest(Base):
         return f"HostRequest(id={self.conversation_id}, surfer_user_id={self.surfer_user_id}, host_user_id={self.host_user_id}...)"
 
 
-class HostRequestFeedback(Base):
+class HostRequestFeedback(Base, init=False, kw_only=True):
     """
     Private feedback from a host about a host request
     """
 
     __tablename__ = "host_request_feedbacks"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     time: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     host_request_id: Mapped[int] = mapped_column(ForeignKey("host_requests.id"))
 

--- a/app/backend/src/couchers/models/logging.py
+++ b/app/backend/src/couchers/models/logging.py
@@ -9,7 +9,7 @@ from couchers.config import config
 from couchers.models.base import Base
 
 
-class APICall(Base):
+class APICall(Base, init=False, kw_only=True):
     """
     API call logs
     """
@@ -17,7 +17,7 @@ class APICall(Base):
     __tablename__ = "api_calls"
     __table_args__ = {"schema": "logging"}
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     # whether the call was made using an api key or session cookies
     is_api_key: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())

--- a/app/backend/src/couchers/models/mod_note.py
+++ b/app/backend/src/couchers/models/mod_note.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from couchers.models.users import User
 
 
-class ModNote(Base):
+class ModNote(Base, init=False, kw_only=True):
     """
     A moderator note to a user. This could be a warning, just a note "hey, we did X", or any other similar message.
 
@@ -20,7 +20,7 @@ class ModNote(Base):
 
     __tablename__ = "mod_notes"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/app/backend/src/couchers/models/mod_note.py
+++ b/app/backend/src/couchers/models/mod_note.py
@@ -23,7 +23,7 @@ class ModNote(Base, init=False, kw_only=True):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     acknowledged: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # this is an internal ID to allow the mods to track different types of notes

--- a/app/backend/src/couchers/models/moderation.py
+++ b/app/backend/src/couchers/models/moderation.py
@@ -84,7 +84,7 @@ class ModerationState(Base, init=False, kw_only=True):
 
     visibility: Mapped[ModerationVisibility] = mapped_column(Enum(ModerationVisibility))
 
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     updated: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
     __table_args__ = (
@@ -113,7 +113,7 @@ class ModerationQueueItem(Base, init=False, kw_only=True):
     )
     moderation_state_id: Mapped[int] = mapped_column(ForeignKey("moderation_states.id"), index=True)
 
-    time_created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    time_created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     trigger: Mapped[ModerationTrigger] = mapped_column(Enum(ModerationTrigger))
     reason: Mapped[str] = mapped_column(String)
 

--- a/app/backend/src/couchers/models/moderation.py
+++ b/app/backend/src/couchers/models/moderation.py
@@ -64,7 +64,7 @@ class ModerationObjectType(enum.Enum):
     GROUP_CHAT = enum.auto()
 
 
-class ModerationState(Base):
+class ModerationState(Base, init=False, kw_only=True):
     """
     Moderation state for any moderatable object on the platform
 
@@ -98,7 +98,7 @@ class ModerationState(Base):
         return f"ModerationState(id={self.id}, type={self.object_type}, object_id={self.object_id}, visibility={self.visibility})"
 
 
-class ModerationQueueItem(Base):
+class ModerationQueueItem(Base, init=False, kw_only=True):
     """
     Action items in the moderation queue
 
@@ -139,7 +139,7 @@ class ModerationQueueItem(Base):
         )
 
 
-class ModerationLog(Base):
+class ModerationLog(Base, init=False, kw_only=True):
     """
     History of moderation actions
 

--- a/app/backend/src/couchers/models/moderation.py
+++ b/app/backend/src/couchers/models/moderation.py
@@ -121,7 +121,7 @@ class ModerationQueueItem(Base, init=False, kw_only=True):
     resolved_by_log_id: Mapped[int | None] = mapped_column(ForeignKey("moderation_log.id"), index=True)
 
     # Relationships
-    moderation_state: Mapped[ModerationState] = relationship()
+    moderation_state: Mapped[ModerationState] = relationship(init=False)
 
     __table_args__ = (
         # Fast lookup of unresolved items
@@ -165,8 +165,8 @@ class ModerationLog(Base, init=False, kw_only=True):
     reason: Mapped[str] = mapped_column(String)
 
     # Relationships
-    moderation_state: Mapped[ModerationState] = relationship()
-    moderator: Mapped[User] = relationship()
+    moderation_state: Mapped[ModerationState] = relationship(init=False)
+    moderator: Mapped[User] = relationship(init=False)
 
     __table_args__ = (
         # Fast lookup of log entries for a given state, ordered by time

--- a/app/backend/src/couchers/models/notifications.py
+++ b/app/backend/src/couchers/models/notifications.py
@@ -327,7 +327,7 @@ class PushNotificationSubscription(Base, init=False, kw_only=True):
     # when it was disabled
     disabled_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=DATETIME_INFINITY.isoformat())
 
-    user: Mapped[User] = relationship()
+    user: Mapped[User] = relationship(init=False)
 
     __table_args__ = (
         # web_push platform requires: endpoint, auth_key, p256dh_key, full_subscription_info
@@ -368,4 +368,4 @@ class PushNotificationDeliveryAttempt(Base, init=False, kw_only=True):
     receipt_status: Mapped[str | None] = mapped_column(String)  # "ok" or "error"
     receipt_error_code: Mapped[str | None] = mapped_column(String)  # e.g., "DeviceNotRegistered"
 
-    push_notification_subscription: Mapped[PushNotificationSubscription] = relationship()
+    push_notification_subscription: Mapped[PushNotificationSubscription] = relationship(init=False)

--- a/app/backend/src/couchers/models/notifications.py
+++ b/app/backend/src/couchers/models/notifications.py
@@ -190,7 +190,7 @@ class Notification(Base, init=False, kw_only=True):
     __tablename__ = "notifications"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     # recipient user id
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
@@ -248,7 +248,7 @@ class NotificationDelivery(Base, init=False, kw_only=True):
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     notification_id: Mapped[int] = mapped_column(ForeignKey("notifications.id"), index=True)
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     delivered: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     read: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     # todo: enum of "phone, web, digest"
@@ -298,7 +298,7 @@ class PushNotificationSubscription(Base, init=False, kw_only=True):
     __tablename__ = "push_notification_subscriptions"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     # which user this is connected to
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)

--- a/app/backend/src/couchers/models/notifications.py
+++ b/app/backend/src/couchers/models/notifications.py
@@ -167,10 +167,10 @@ class NotificationTopicAction(enum.Enum):
     general__new_blog_post = ("general:new_blog_post", [dt.push, dt.digest], True, nd.GeneralNewBlogPost)
 
 
-class NotificationPreference(Base):
+class NotificationPreference(Base, init=False, kw_only=True):
     __tablename__ = "notification_preferences"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
     topic_action: Mapped[NotificationTopicAction] = mapped_column(Enum(NotificationTopicAction))
@@ -182,14 +182,14 @@ class NotificationPreference(Base):
     __table_args__ = (UniqueConstraint("user_id", "topic_action", "delivery_type"),)
 
 
-class Notification(Base):
+class Notification(Base, init=False, kw_only=True):
     """
     Table for accumulating notifications until it is time to send email digest
     """
 
     __tablename__ = "notifications"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     # recipient user id
@@ -243,10 +243,10 @@ class Notification(Base):
         return self.topic_action.action
 
 
-class NotificationDelivery(Base):
+class NotificationDelivery(Base, init=False, kw_only=True):
     __tablename__ = "notification_deliveries"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     notification_id: Mapped[int] = mapped_column(ForeignKey("notifications.id"), index=True)
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     delivered: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
@@ -294,10 +294,10 @@ class PushNotificationDeliveryOutcome(enum.Enum):
     permanent_subscription_failure = enum.auto()
 
 
-class PushNotificationSubscription(Base):
+class PushNotificationSubscription(Base, init=False, kw_only=True):
     __tablename__ = "push_notification_subscriptions"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     # which user this is connected to
@@ -343,10 +343,10 @@ class PushNotificationSubscription(Base):
     )
 
 
-class PushNotificationDeliveryAttempt(Base):
+class PushNotificationDeliveryAttempt(Base, init=False, kw_only=True):
     __tablename__ = "push_notification_delivery_attempt"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     time: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     push_notification_subscription_id: Mapped[int] = mapped_column(

--- a/app/backend/src/couchers/models/postal_verification.py
+++ b/app/backend/src/couchers/models/postal_verification.py
@@ -39,14 +39,14 @@ class PostalVerificationStatus(enum.Enum):
     cancelled = enum.auto()
 
 
-class PostalVerificationAttempt(Base):
+class PostalVerificationAttempt(Base, init=False, kw_only=True):
     """
     An attempt to perform postal verification by sending a postcard with a code.
     """
 
     __tablename__ = "postal_verification_attempts"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 

--- a/app/backend/src/couchers/models/postal_verification.py
+++ b/app/backend/src/couchers/models/postal_verification.py
@@ -92,7 +92,7 @@ class PostalVerificationAttempt(Base, init=False, kw_only=True):
         return cls.status == PostalVerificationStatus.succeeded
 
     # Relationships
-    user: Mapped[User] = relationship()
+    user: Mapped[User] = relationship(init=False)
 
     # Constraints
     __table_args__ = (

--- a/app/backend/src/couchers/models/postal_verification.py
+++ b/app/backend/src/couchers/models/postal_verification.py
@@ -50,7 +50,7 @@ class PostalVerificationAttempt(Base, init=False, kw_only=True):
 
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     status: Mapped[PostalVerificationStatus] = mapped_column(
         Enum(PostalVerificationStatus),

--- a/app/backend/src/couchers/models/rest.py
+++ b/app/backend/src/couchers/models/rest.py
@@ -53,7 +53,7 @@ class UserBadge(Base, init=False, kw_only=True):
     # take this with a grain of salt, someone may get then lose a badge for whatever reason
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    user: Mapped[User] = relationship(back_populates="badges")
+    user: Mapped[User] = relationship(init=False, back_populates="badges")
 
 
 class FriendStatus(enum.Enum):
@@ -84,8 +84,10 @@ class FriendRelationship(Base, init=False, kw_only=True):
     time_sent: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     time_responded: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
-    from_user: Mapped[User] = relationship(backref="friends_from", foreign_keys="FriendRelationship.from_user_id")
-    to_user: Mapped[User] = relationship(backref="friends_to", foreign_keys="FriendRelationship.to_user_id")
+    from_user: Mapped[User] = relationship(
+        init=False, backref="friends_from", foreign_keys="FriendRelationship.from_user_id"
+    )
+    to_user: Mapped[User] = relationship(init=False, backref="friends_to", foreign_keys="FriendRelationship.to_user_id")
 
     __table_args__ = (
         # Ping looks up pending friend reqs, this speeds that up
@@ -123,7 +125,7 @@ class ContributorForm(Base, init=False, kw_only=True):
     contribute_ways: Mapped[list[str]] = mapped_column(ARRAY(String))
     expertise: Mapped[str | None] = mapped_column(String)
 
-    user: Mapped[User] = relationship(backref="contributor_forms")
+    user: Mapped[User] = relationship(init=False, backref="contributor_forms")
 
     @hybrid_property
     def is_filled(self) -> Any:
@@ -234,7 +236,7 @@ class AccountDeletionToken(Base, init=False, kw_only=True):
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     expiry: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
-    user: Mapped[User] = relationship(backref="account_deletion_tokens")
+    user: Mapped[User] = relationship(init=False, backref="account_deletion_tokens")
 
     @hybrid_property
     def is_valid(self) -> Any:
@@ -402,10 +404,10 @@ class Reference(Base, init=False, kw_only=True):
 
     is_deleted: Mapped[bool] = mapped_column(Boolean, default=False, server_default=expression.false())
 
-    from_user: Mapped[User] = relationship(backref="references_from", foreign_keys="Reference.from_user_id")
-    to_user: Mapped[User] = relationship(backref="references_to", foreign_keys="Reference.to_user_id")
+    from_user: Mapped[User] = relationship(init=False, backref="references_from", foreign_keys="Reference.from_user_id")
+    to_user: Mapped[User] = relationship(init=False, backref="references_to", foreign_keys="Reference.to_user_id")
 
-    host_request: Mapped[HostRequest | None] = relationship(backref="references")
+    host_request: Mapped[HostRequest | None] = relationship(init=False, backref="references")
 
     __table_args__ = (
         # Rating must be between 0 and 1, inclusive
@@ -477,7 +479,7 @@ class AccountDeletionReason(Base, init=False, kw_only=True):
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     reason: Mapped[str | None] = mapped_column(String)
 
-    user: Mapped[User] = relationship()
+    user: Mapped[User] = relationship(init=False)
 
 
 class ModerationUserList(Base, init=False, kw_only=True):
@@ -491,7 +493,7 @@ class ModerationUserList(Base, init=False, kw_only=True):
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     users: Mapped[list[User]] = relationship(
-        secondary="moderation_user_list_members", back_populates="moderation_user_lists"
+        init=False, secondary="moderation_user_list_members", back_populates="moderation_user_lists"
     )
 
 
@@ -540,7 +542,7 @@ class RateLimitViolation(Base, init=False, kw_only=True):
     action: Mapped[RateLimitAction] = mapped_column(Enum(RateLimitAction))
     is_hard_limit: Mapped[bool] = mapped_column(Boolean)
 
-    user: Mapped[User] = relationship()
+    user: Mapped[User] = relationship(init=False)
 
     __table_args__ = (
         # Fast lookup for rate limits in interval

--- a/app/backend/src/couchers/models/rest.py
+++ b/app/backend/src/couchers/models/rest.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from couchers.models import HostRequest, User
 
 
-class UserBadge(Base):
+class UserBadge(Base, init=False, kw_only=True):
     """
     A badge on a user's profile
     """
@@ -44,7 +44,7 @@ class UserBadge(Base):
     __tablename__ = "user_badges"
     __table_args__ = (UniqueConstraint("user_id", "badge_id"),)
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
     # corresponds to "id" in badges.json
@@ -63,7 +63,7 @@ class FriendStatus(enum.Enum):
     cancelled = enum.auto()
 
 
-class FriendRelationship(Base):
+class FriendRelationship(Base, init=False, kw_only=True):
     """
     Friendship relations between users
 
@@ -73,7 +73,7 @@ class FriendRelationship(Base):
 
     __tablename__ = "friend_relationships"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     from_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
     to_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
@@ -104,14 +104,14 @@ class ContributeOption(enum.Enum):
     no = enum.auto()
 
 
-class ContributorForm(Base):
+class ContributorForm(Base, init=False, kw_only=True):
     """
     Someone filled in the contributor form
     """
 
     __tablename__ = "contributor_forms"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
@@ -149,7 +149,7 @@ class ContributorForm(Base):
         return False
 
 
-class SignupFlow(Base):
+class SignupFlow(Base, init=False, kw_only=True):
     """
     Signup flows/incomplete users
 
@@ -158,7 +158,7 @@ class SignupFlow(Base):
 
     __tablename__ = "signup_flows"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     # housekeeping
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
@@ -224,7 +224,7 @@ class SignupFlow(Base):
         return self.email_verified & self.account_is_filled & (self.accepted_community_guidelines == GUIDELINES_VERSION)
 
 
-class AccountDeletionToken(Base):
+class AccountDeletionToken(Base, init=False, kw_only=True):
     __tablename__ = "account_deletion_tokens"
 
     token: Mapped[str] = mapped_column(String, primary_key=True)
@@ -244,7 +244,7 @@ class AccountDeletionToken(Base):
         return f"AccountDeletionToken(token={self.token}, user_id={self.user_id}, created={self.created}, expiry={self.expiry})"
 
 
-class UserActivity(Base):
+class UserActivity(Base, init=False, kw_only=True):
     """
     User activity: for each unique (user_id, period, ip_address, user_agent) tuple, keep track of number of api calls
 
@@ -253,7 +253,7 @@ class UserActivity(Base):
 
     __tablename__ = "user_activity"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     # the start of a period of time, e.g. 1 hour during which we bin activeness
@@ -279,7 +279,7 @@ class UserActivity(Base):
     )
 
 
-class InviteCode(Base):
+class InviteCode(Base, init=False, kw_only=True):
     __tablename__ = "invite_codes"
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
@@ -290,14 +290,14 @@ class InviteCode(Base):
     creator: Mapped[User] = relationship(foreign_keys=[creator_user_id])
 
 
-class ContentReport(Base):
+class ContentReport(Base, init=False, kw_only=True):
     """
     A piece of content reported to admins
     """
 
     __tablename__ = "content_reports"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     time: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
@@ -324,7 +324,7 @@ class ContentReport(Base):
     author_user: Mapped[User] = relationship(foreign_keys="ContentReport.author_user_id")
 
 
-class Email(Base):
+class Email(Base, init=False, kw_only=True):
     """
     Table of all dispatched emails for debugging purposes, etc.
     """
@@ -349,14 +349,14 @@ class Email(Base):
     source_data: Mapped[str | None] = mapped_column(String)
 
 
-class SMS(Base):
+class SMS(Base, init=False, kw_only=True):
     """
     Table of all sent SMSs for debugging purposes, etc.
     """
 
     __tablename__ = "smss"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     # timezone should always be UTC
     time: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
@@ -375,14 +375,14 @@ class ReferenceType(enum.Enum):
     hosted = enum.auto()  # The "from" user hosted the "to" user
 
 
-class Reference(Base):
+class Reference(Base, init=False, kw_only=True):
     """
     Reference from one user to another
     """
 
     __tablename__ = "references"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     # timezone should always be UTC
     time: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
@@ -446,14 +446,14 @@ class Reference(Base):
         return bool(self.rating <= 0.4 or not self.was_appropriate or self.private_text)
 
 
-class UserBlock(Base):
+class UserBlock(Base, init=False, kw_only=True):
     """
     Table of blocked users
     """
 
     __tablename__ = "user_blocks"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     blocking_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     blocked_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
@@ -469,10 +469,10 @@ class UserBlock(Base):
     )
 
 
-class AccountDeletionReason(Base):
+class AccountDeletionReason(Base, init=False, kw_only=True):
     __tablename__ = "account_deletion_reason"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     reason: Mapped[str | None] = mapped_column(String)
@@ -480,14 +480,14 @@ class AccountDeletionReason(Base):
     user: Mapped[User] = relationship()
 
 
-class ModerationUserList(Base):
+class ModerationUserList(Base, init=False, kw_only=True):
     """
     Represents a list of users listed together by a moderator
     """
 
     __tablename__ = "moderation_user_lists"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     users: Mapped[list[User]] = relationship(
@@ -495,7 +495,7 @@ class ModerationUserList(Base):
     )
 
 
-class ModerationUserListMember(Base):
+class ModerationUserListMember(Base, init=False, kw_only=True):
     """
     Association table for many-to-many relationship between users and moderation_user_lists
     """
@@ -506,10 +506,10 @@ class ModerationUserListMember(Base):
     moderation_list_id: Mapped[int] = mapped_column(ForeignKey("moderation_user_lists.id"), primary_key=True)
 
 
-class AntiBotLog(Base):
+class AntiBotLog(Base, init=False, kw_only=True):
     __tablename__ = "antibot_logs"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"))
 
@@ -531,10 +531,10 @@ class RateLimitAction(enum.Enum):
     chat_initiation = "chat initiation"
 
 
-class RateLimitViolation(Base):
+class RateLimitViolation(Base, init=False, kw_only=True):
     __tablename__ = "rate_limit_violations"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     action: Mapped[RateLimitAction] = mapped_column(Enum(RateLimitAction))
@@ -548,10 +548,10 @@ class RateLimitViolation(Base):
     )
 
 
-class Volunteer(Base):
+class Volunteer(Base, init=False, kw_only=True):
     __tablename__ = "volunteers"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), unique=True)
 
     display_name: Mapped[str | None] = mapped_column(String)

--- a/app/backend/src/couchers/models/rest.py
+++ b/app/backend/src/couchers/models/rest.py
@@ -51,7 +51,7 @@ class UserBadge(Base, init=False, kw_only=True):
     badge_id: Mapped[str] = mapped_column(String, index=True)
 
     # take this with a grain of salt, someone may get then lose a badge for whatever reason
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     user: Mapped[User] = relationship(init=False, back_populates="badges")
 
@@ -116,7 +116,7 @@ class ContributorForm(Base, init=False, kw_only=True):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     ideas: Mapped[str | None] = mapped_column(String)
     features: Mapped[str | None] = mapped_column(String)
@@ -163,7 +163,7 @@ class SignupFlow(Base, init=False, kw_only=True):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     # housekeeping
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     flow_token: Mapped[str] = mapped_column(String, unique=True)
     email_verified: Mapped[bool] = mapped_column(Boolean, default=False)
     email_sent: Mapped[bool] = mapped_column(Boolean, default=False)
@@ -233,7 +233,7 @@ class AccountDeletionToken(Base, init=False, kw_only=True):
 
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     expiry: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
     user: Mapped[User] = relationship(init=False, backref="account_deletion_tokens")
@@ -475,7 +475,7 @@ class AccountDeletionReason(Base, init=False, kw_only=True):
     __tablename__ = "account_deletion_reason"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     reason: Mapped[str | None] = mapped_column(String)
 
@@ -490,7 +490,7 @@ class ModerationUserList(Base, init=False, kw_only=True):
     __tablename__ = "moderation_user_lists"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     users: Mapped[list[User]] = relationship(
         init=False, secondary="moderation_user_list_members", back_populates="moderation_user_lists"
@@ -512,7 +512,7 @@ class AntiBotLog(Base, init=False, kw_only=True):
     __tablename__ = "antibot_logs"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"))
 
     ip_address: Mapped[str | None] = mapped_column(String)
@@ -537,7 +537,7 @@ class RateLimitViolation(Base, init=False, kw_only=True):
     __tablename__ = "rate_limit_violations"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
     action: Mapped[RateLimitAction] = mapped_column(Enum(RateLimitAction))
     is_hard_limit: Mapped[bool] = mapped_column(Boolean)

--- a/app/backend/src/couchers/models/static.py
+++ b/app/backend/src/couchers/models/static.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from couchers.models.base import Base, Geom
 
 
-class Language(Base):
+class Language(Base, init=False, kw_only=True):
     """
     Table of allowed languages (a subset of ISO639-3)
     """
@@ -19,7 +19,7 @@ class Language(Base):
     name: Mapped[str] = mapped_column(String, unique=True)
 
 
-class TimezoneArea(Base):
+class TimezoneArea(Base, init=False, kw_only=True):
     __tablename__ = "timezone_areas"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
@@ -36,7 +36,7 @@ class TimezoneArea(Base):
     )
 
 
-class Region(Base):
+class Region(Base, init=False, kw_only=True):
     """
     Table of regions
     """

--- a/app/backend/src/couchers/models/uploads.py
+++ b/app/backend/src/couchers/models/uploads.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from couchers.models.users import User
 
 
-class InitiatedUpload(Base):
+class InitiatedUpload(Base, init=False, kw_only=True):
     """
     Started downloads, not necessarily complete yet.
     """
@@ -34,7 +34,7 @@ class InitiatedUpload(Base):
         return (self.created <= func.now()) & (self.expiry >= func.now())
 
 
-class Upload(Base):
+class Upload(Base, init=False, kw_only=True):
     """
     Completed uploads.
     """
@@ -64,7 +64,7 @@ class Upload(Base):
         return self._url("full")
 
 
-class PhotoGallery(Base):
+class PhotoGallery(Base, init=False, kw_only=True):
     """
     Photo galleries for users or other entities.
     """
@@ -86,7 +86,7 @@ class PhotoGallery(Base):
     )
 
 
-class PhotoGalleryItem(Base):
+class PhotoGalleryItem(Base, init=False, kw_only=True):
     """
     Individual photos within a gallery with ordering and captions.
     """
@@ -95,8 +95,8 @@ class PhotoGalleryItem(Base):
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    gallery_id: Mapped[int] = mapped_column(ForeignKey("photo_galleries.id"), index=True)
-    upload_key: Mapped[str] = mapped_column(ForeignKey("uploads.key"))
+    gallery_id: Mapped[int] = mapped_column(ForeignKey("photo_galleries.id"), index=True, default=None)
+    upload_key: Mapped[str] = mapped_column(ForeignKey("uploads.key"), default=None)
 
     # Float position for ordering - allows inserting between items without shifting
     position: Mapped[float] = mapped_column(Float)

--- a/app/backend/src/couchers/models/uploads.py
+++ b/app/backend/src/couchers/models/uploads.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from couchers.models.users import User
 
 
-class InitiatedUpload(Base, init=False, kw_only=True):
+class InitiatedUpload(Base, kw_only=True):
     """
     Started downloads, not necessarily complete yet.
     """
@@ -22,7 +22,7 @@ class InitiatedUpload(Base, init=False, kw_only=True):
     key: Mapped[str] = mapped_column(String, primary_key=True)
 
     # timezones should always be UTC
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     expiry: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
     initiator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
@@ -34,7 +34,7 @@ class InitiatedUpload(Base, init=False, kw_only=True):
         return (self.created <= func.now()) & (self.expiry >= func.now())
 
 
-class Upload(Base, init=False, kw_only=True):
+class Upload(Base, kw_only=True):
     """
     Completed uploads.
     """
@@ -48,7 +48,7 @@ class Upload(Base, init=False, kw_only=True):
     creator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
     # photo credit, etc
-    credit: Mapped[str | None] = mapped_column(String, nullable=True)
+    credit: Mapped[str | None] = mapped_column(String, default=None)
 
     creator_user: Mapped[User] = relationship(init=False, backref="uploads", foreign_keys="Upload.creator_user_id")
 
@@ -64,14 +64,14 @@ class Upload(Base, init=False, kw_only=True):
         return self._url("full")
 
 
-class PhotoGallery(Base, init=False, kw_only=True):
+class PhotoGallery(Base, kw_only=True):
     """
     Photo galleries for users or other entities.
     """
 
     __tablename__ = "photo_galleries"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     # For now, galleries are owned by users, but this could be extended
     # in the future for communities, events, etc.
@@ -79,7 +79,7 @@ class PhotoGallery(Base, init=False, kw_only=True):
 
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
-    owner_user: Mapped[User] = relationship(foreign_keys=[owner_user_id], back_populates="galleries")
+    owner_user: Mapped[User] = relationship(init=False, foreign_keys=[owner_user_id], back_populates="galleries")
     photos: Mapped[list[PhotoGalleryItem]] = relationship(
         init=False,
         back_populates="gallery",
@@ -87,22 +87,22 @@ class PhotoGallery(Base, init=False, kw_only=True):
     )
 
 
-class PhotoGalleryItem(Base, init=False, kw_only=True):
+class PhotoGalleryItem(Base, kw_only=True):
     """
     Individual photos within a gallery with ordering and captions.
     """
 
     __tablename__ = "photo_gallery_items"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
-    gallery_id: Mapped[int] = mapped_column(ForeignKey("photo_galleries.id"), index=True, default=None)
-    upload_key: Mapped[str] = mapped_column(ForeignKey("uploads.key"), default=None)
+    gallery_id: Mapped[int] = mapped_column(ForeignKey("photo_galleries.id"), index=True)
+    upload_key: Mapped[str] = mapped_column(ForeignKey("uploads.key"))
 
     # Float position for ordering - allows inserting between items without shifting
     position: Mapped[float] = mapped_column(Float)
 
-    caption: Mapped[str | None] = mapped_column(String)
+    caption: Mapped[str | None] = mapped_column(String, default=None)
 
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 

--- a/app/backend/src/couchers/models/uploads.py
+++ b/app/backend/src/couchers/models/uploads.py
@@ -27,7 +27,7 @@ class InitiatedUpload(Base, init=False, kw_only=True):
 
     initiator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    initiator_user: Mapped[User] = relationship()
+    initiator_user: Mapped[User] = relationship(init=False)
 
     @hybrid_property
     def is_valid(self) -> Any:
@@ -50,7 +50,7 @@ class Upload(Base, init=False, kw_only=True):
     # photo credit, etc
     credit: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    creator_user: Mapped[User] = relationship(backref="uploads", foreign_keys="Upload.creator_user_id")
+    creator_user: Mapped[User] = relationship(init=False, backref="uploads", foreign_keys="Upload.creator_user_id")
 
     def _url(self, size: str) -> str:
         return urls.media_url(filename=self.filename, size=size)
@@ -81,6 +81,7 @@ class PhotoGallery(Base, init=False, kw_only=True):
 
     owner_user: Mapped[User] = relationship(foreign_keys=[owner_user_id], back_populates="galleries")
     photos: Mapped[list[PhotoGalleryItem]] = relationship(
+        init=False,
         back_populates="gallery",
         order_by="PhotoGalleryItem.position",
     )
@@ -105,8 +106,8 @@ class PhotoGalleryItem(Base, init=False, kw_only=True):
 
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    gallery: Mapped[PhotoGallery] = relationship(back_populates="photos")
-    upload: Mapped[Upload] = relationship()
+    gallery: Mapped[PhotoGallery] = relationship(init=False, back_populates="photos")
+    upload: Mapped[Upload] = relationship(init=False)
 
     __table_args__ = (
         # Ensure each upload is only in a gallery once

--- a/app/backend/src/couchers/models/uploads.py
+++ b/app/backend/src/couchers/models/uploads.py
@@ -22,7 +22,7 @@ class InitiatedUpload(Base, init=False, kw_only=True):
     key: Mapped[str] = mapped_column(String, primary_key=True)
 
     # timezones should always be UTC
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     expiry: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
     initiator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
@@ -44,7 +44,7 @@ class Upload(Base, init=False, kw_only=True):
     key: Mapped[str] = mapped_column(String, primary_key=True)
 
     filename: Mapped[str] = mapped_column(String)
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     creator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
     # photo credit, etc
@@ -77,7 +77,7 @@ class PhotoGallery(Base, init=False, kw_only=True):
     # in the future for communities, events, etc.
     owner_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     owner_user: Mapped[User] = relationship(foreign_keys=[owner_user_id], back_populates="galleries")
     photos: Mapped[list[PhotoGalleryItem]] = relationship(
@@ -104,7 +104,7 @@ class PhotoGalleryItem(Base, init=False, kw_only=True):
 
     caption: Mapped[str | None] = mapped_column(String)
 
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     gallery: Mapped[PhotoGallery] = relationship(init=False, back_populates="photos")
     upload: Mapped[Upload] = relationship(init=False)

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -95,7 +95,7 @@ class ProfilePublicVisibility(enum.Enum):
     full = enum.auto()
 
 
-class User(Base, init=False, kw_only=True):
+class User(Base, kw_only=True):
     """
     Basic user and profile details
     """
@@ -109,9 +109,9 @@ class User(Base, init=False, kw_only=True):
     # stored in libsodium hash format, can be null for email login
     hashed_password: Mapped[bytes] = mapped_column(Binary)
     # phone number in E.164 format with leading +, for example "+46701740605"
-    phone: Mapped[str | None] = mapped_column(String, nullable=True, server_default=expression.null())
+    phone: Mapped[str | None] = mapped_column(String, default=None, server_default=expression.null())
     # language preference -- defaults to empty string
-    ui_language_preference: Mapped[str | None] = mapped_column(String, nullable=True, server_default="")
+    ui_language_preference: Mapped[str | None] = mapped_column(String, default=None, server_default="")
 
     # timezones should always be UTC
     ## location
@@ -119,136 +119,142 @@ class User(Base, init=False, kw_only=True):
     # by GPS, it has the WGS84 geoid with lat/lon
     geom: Mapped[Geom] = mapped_column(Geometry(geometry_type="POINT", srid=4326))
     # randomized coordinates within a radius of 0.02-0.1 degrees, equates to about 2-10 km
-    randomized_geom: Mapped[Geom | None] = mapped_column(Geometry(geometry_type="POINT", srid=4326), nullable=True)
+    randomized_geom: Mapped[Geom | None] = mapped_column(Geometry(geometry_type="POINT", srid=4326), default=None)
     # their display location (displayed to other users), in meters
     geom_radius: Mapped[float] = mapped_column(Float)
     # the display address (text) shown on their profile
     city: Mapped[str] = mapped_column(String)
     # "Grew up in" on profile
-    hometown: Mapped[str | None] = mapped_column(String, nullable=True)
+    hometown: Mapped[str | None] = mapped_column(String, default=None)
 
-    regions_visited: Mapped[list[Region]] = relationship(secondary="regions_visited", order_by="Region.name")
-    regions_lived: Mapped[list[Region]] = relationship(secondary="regions_lived", order_by="Region.name")
+    regions_visited: Mapped[list[Region]] = relationship(
+        init=False, secondary="regions_visited", order_by="Region.name"
+    )
+    regions_lived: Mapped[list[Region]] = relationship(init=False, secondary="regions_lived", order_by="Region.name")
 
     timezone = column_property(
         sa_select(TimezoneArea.tzid).where(func.ST_Contains(TimezoneArea.geom, geom)).limit(1).scalar_subquery(),
         deferred=True,
     )
 
-    joined: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
-    last_active: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
-    profile_last_updated: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    joined: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
+    last_active: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
+    profile_last_updated: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), init=False
+    )
 
     public_visibility: Mapped[ProfilePublicVisibility] = mapped_column(
-        Enum(ProfilePublicVisibility), server_default="map_only"
+        Enum(ProfilePublicVisibility), server_default="map_only", init=False
     )
-    has_modified_public_visibility: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
+    has_modified_public_visibility: Mapped[bool] = mapped_column(Boolean, server_default=expression.false(), init=False)
 
     # id of the last message that they received a notification about
     last_notified_message_id: Mapped[int] = mapped_column(BigInteger, default=0)
     # same as above for host requests
-    last_notified_request_message_id: Mapped[int] = mapped_column(BigInteger, server_default=text("0"))
+    last_notified_request_message_id: Mapped[int] = mapped_column(BigInteger, server_default=text("0"), init=False)
 
     # display name
     name: Mapped[str] = mapped_column(String)
     gender: Mapped[str] = mapped_column(String)
-    pronouns: Mapped[str | None] = mapped_column(String, nullable=True)
+    pronouns: Mapped[str | None] = mapped_column(String, default=None)
     birthdate: Mapped[date] = mapped_column(Date)  # in the timezone of birthplace
 
-    avatar_key: Mapped[str | None] = mapped_column(ForeignKey("uploads.key"), nullable=True)
+    avatar_key: Mapped[str | None] = mapped_column(ForeignKey("uploads.key"), default=None)
 
     # Profile photo gallery for this user (photos about themselves)
-    profile_gallery_id: Mapped[int | None] = mapped_column(ForeignKey("photo_galleries.id"), nullable=True)
+    profile_gallery_id: Mapped[int | None] = mapped_column(ForeignKey("photo_galleries.id"), default=None)
 
     hosting_status: Mapped[HostingStatus] = mapped_column(Enum(HostingStatus))
-    meetup_status: Mapped[MeetupStatus] = mapped_column(Enum(MeetupStatus), server_default="open_to_meetup")
+    meetup_status: Mapped[MeetupStatus] = mapped_column(Enum(MeetupStatus), server_default="open_to_meetup", init=False)
 
     # community standing score
-    community_standing: Mapped[float | None] = mapped_column(Float, nullable=True)
+    community_standing: Mapped[float | None] = mapped_column(Float, default=None)
 
-    occupation: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
-    education: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
+    occupation: Mapped[str | None] = mapped_column(String, default=None)  # CommonMark without images
+    education: Mapped[str | None] = mapped_column(String, default=None)  # CommonMark without images
 
     # "Who I am" under "About Me" tab
-    about_me: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
+    about_me: Mapped[str | None] = mapped_column(String, default=None)  # CommonMark without images
     # "What I do in my free time" under "About Me" tab
-    things_i_like: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
+    things_i_like: Mapped[str | None] = mapped_column(String, default=None)  # CommonMark without images
     # "About my home" under "My Home" tab
-    about_place: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
+    about_place: Mapped[str | None] = mapped_column(String, default=None)  # CommonMark without images
     # "Additional information" under "About Me" tab
-    additional_information: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
+    additional_information: Mapped[str | None] = mapped_column(String, default=None)  # CommonMark without images
 
-    is_banned: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
-    is_deleted: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
-    is_superuser: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
-    is_editor: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
+    is_banned: Mapped[bool] = mapped_column(Boolean, server_default=expression.false(), init=False)
+    is_deleted: Mapped[bool] = mapped_column(Boolean, server_default=expression.false(), init=False)
+    is_superuser: Mapped[bool] = mapped_column(Boolean, server_default=expression.false(), init=False)
+    is_editor: Mapped[bool] = mapped_column(Boolean, server_default=expression.false(), init=False)
 
     # the undelete token allows a user to recover their account for a couple of days after deletion in case it was
     # accidental or they changed their mind
     # constraints make sure these are non-null only if is_deleted and that these are null in unison
-    undelete_token: Mapped[str | None] = mapped_column(String, nullable=True)
+    undelete_token: Mapped[str | None] = mapped_column(String, default=None)
     # validity of the undelete token
-    undelete_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    undelete_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
 
     # hosting preferences
-    max_guests: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    last_minute: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
-    has_pets: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
-    accepts_pets: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
-    pet_details: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
-    has_kids: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
-    accepts_kids: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
-    kid_details: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
-    has_housemates: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
-    housemate_details: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
-    wheelchair_accessible: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
-    smoking_allowed: Mapped[SmokingLocation | None] = mapped_column(Enum(SmokingLocation), nullable=True)
-    smokes_at_home: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
-    drinking_allowed: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
-    drinks_at_home: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    max_guests: Mapped[int | None] = mapped_column(Integer, default=None)
+    last_minute: Mapped[bool | None] = mapped_column(Boolean, default=None)
+    has_pets: Mapped[bool | None] = mapped_column(Boolean, default=None)
+    accepts_pets: Mapped[bool | None] = mapped_column(Boolean, default=None)
+    pet_details: Mapped[str | None] = mapped_column(String, default=None)  # CommonMark without images
+    has_kids: Mapped[bool | None] = mapped_column(Boolean, default=None)
+    accepts_kids: Mapped[bool | None] = mapped_column(Boolean, default=None)
+    kid_details: Mapped[str | None] = mapped_column(String, default=None)  # CommonMark without images
+    has_housemates: Mapped[bool | None] = mapped_column(Boolean, default=None)
+    housemate_details: Mapped[str | None] = mapped_column(String, default=None)  # CommonMark without images
+    wheelchair_accessible: Mapped[bool | None] = mapped_column(Boolean, default=None)
+    smoking_allowed: Mapped[SmokingLocation | None] = mapped_column(Enum(SmokingLocation), default=None)
+    smokes_at_home: Mapped[bool | None] = mapped_column(Boolean, default=None)
+    drinking_allowed: Mapped[bool | None] = mapped_column(Boolean, default=None)
+    drinks_at_home: Mapped[bool | None] = mapped_column(Boolean, default=None)
     # "Additional information" under "My Home" tab
-    other_host_info: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
+    other_host_info: Mapped[str | None] = mapped_column(String, default=None)  # CommonMark without images
 
     # "Sleeping privacy" (not long-form text)
-    sleeping_arrangement: Mapped[SleepingArrangement | None] = mapped_column(Enum(SleepingArrangement), nullable=True)
+    sleeping_arrangement: Mapped[SleepingArrangement | None] = mapped_column(Enum(SleepingArrangement), default=None)
     # "Sleeping arrangement" under "My Home" tab
-    sleeping_details: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
+    sleeping_details: Mapped[str | None] = mapped_column(String, default=None)  # CommonMark without images
     # "Local area information" under "My Home" tab
-    area: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
+    area: Mapped[str | None] = mapped_column(String, default=None)  # CommonMark without images
     # "House rules" under "My Home" tab
-    house_rules: Mapped[str | None] = mapped_column(String, nullable=True)  # CommonMark without images
-    parking: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    house_rules: Mapped[str | None] = mapped_column(String, default=None)  # CommonMark without images
+    parking: Mapped[bool | None] = mapped_column(Boolean, default=None)
     parking_details: Mapped[ParkingDetails | None] = mapped_column(
-        Enum(ParkingDetails), nullable=True
+        Enum(ParkingDetails), default=None
     )  # CommonMark without images
-    camping_ok: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    camping_ok: Mapped[bool | None] = mapped_column(Boolean, default=None)
 
     accepted_tos: Mapped[int] = mapped_column(Integer, default=0)
-    accepted_community_guidelines: Mapped[int] = mapped_column(Integer, server_default="0")
+    accepted_community_guidelines: Mapped[int] = mapped_column(Integer, server_default="0", init=False)
     # whether the user has filled in the contributor form
-    filled_contributor_form: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
+    filled_contributor_form: Mapped[bool] = mapped_column(Boolean, server_default=expression.false(), init=False)
 
     # number of onboarding emails sent
-    onboarding_emails_sent: Mapped[int] = mapped_column(Integer, server_default="0")
-    last_onboarding_email_sent: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    onboarding_emails_sent: Mapped[int] = mapped_column(Integer, server_default="0", init=False)
+    last_onboarding_email_sent: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
 
     # whether we need to sync the user's newsletter preferences with the newsletter server
-    in_sync_with_newsletter: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
+    in_sync_with_newsletter: Mapped[bool] = mapped_column(Boolean, server_default=expression.false(), init=False)
     # opted out of the newsletter
-    opt_out_of_newsletter: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
+    opt_out_of_newsletter: Mapped[bool] = mapped_column(Boolean, server_default=expression.false(), init=False)
 
     # set to null to receive no digests
-    digest_frequency: Mapped[timedelta | None] = mapped_column(Interval, nullable=True)
-    last_digest_sent: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=text("to_timestamp(0)"))
+    digest_frequency: Mapped[timedelta | None] = mapped_column(Interval, default=None)
+    last_digest_sent: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=text("to_timestamp(0)"), init=False
+    )
 
     # for changing their email
-    new_email: Mapped[str | None] = mapped_column(String, nullable=True)
+    new_email: Mapped[str | None] = mapped_column(String, default=None)
 
-    new_email_token: Mapped[str | None] = mapped_column(String, nullable=True)
-    new_email_token_created: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
-    new_email_token_expiry: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    new_email_token: Mapped[str | None] = mapped_column(String, default=None)
+    new_email_token_created: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
+    new_email_token_expiry: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
 
-    recommendation_score: Mapped[float] = mapped_column(Float, server_default="0")
+    recommendation_score: Mapped[float] = mapped_column(Float, server_default="0", init=False)
 
     # Columns for verifying their phone number. State chart:
     #                                       ,-------------------,
@@ -275,49 +281,53 @@ class User(Base, init=False, kw_only=True):
 
     # randomly generated Luhn 6-digit string
     phone_verification_token: Mapped[str | None] = mapped_column(
-        String(6), nullable=True, server_default=expression.null()
+        String(6), default=None, server_default=expression.null(), init=False
     )
 
     phone_verification_sent: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=text("to_timestamp(0)")
+        DateTime(timezone=True), server_default=text("to_timestamp(0)"), init=False
     )
     phone_verification_verified: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True, server_default=expression.null()
+        DateTime(timezone=True), default=None, server_default=expression.null(), init=False
     )
-    phone_verification_attempts: Mapped[int] = mapped_column(Integer, server_default=text("0"))
+    phone_verification_attempts: Mapped[int] = mapped_column(Integer, server_default=text("0"), init=False)
 
     # the stripe customer identifier if the user has donated to Couchers
     # e.g. cus_JjoXHttuZopv0t
     # for new US entity
-    stripe_customer_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    stripe_customer_id: Mapped[str | None] = mapped_column(String, default=None)
     # for old AU entity
-    stripe_customer_id_old: Mapped[str | None] = mapped_column(String, nullable=True)
+    stripe_customer_id_old: Mapped[str | None] = mapped_column(String, default=None)
 
-    has_passport_sex_gender_exception: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
+    has_passport_sex_gender_exception: Mapped[bool] = mapped_column(
+        Boolean, server_default=expression.false(), init=False
+    )
 
     #  checking for phone verification
     last_donated: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True, server_default=expression.null()
+        DateTime(timezone=True), default=None, server_default=expression.null()
     )
 
     # whether this user has all emails turned off
-    do_not_email: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
+    do_not_email: Mapped[bool] = mapped_column(Boolean, server_default=expression.false(), init=False)
 
-    avatar: Mapped[Upload | None] = relationship(foreign_keys="User.avatar_key")
-    profile_gallery: Mapped[PhotoGallery | None] = relationship(foreign_keys="User.profile_gallery_id")
+    avatar: Mapped[Upload | None] = relationship(init=False, foreign_keys="User.avatar_key")
+    profile_gallery: Mapped[PhotoGallery | None] = relationship(init=False, foreign_keys="User.profile_gallery_id")
 
-    admin_note: Mapped[str] = mapped_column(String, server_default=text("''"))
+    admin_note: Mapped[str] = mapped_column(String, server_default=text("''"), init=False)
 
     # whether mods have marked this user has having to update their location
-    needs_to_update_location: Mapped[bool] = mapped_column(Boolean, server_default=expression.false())
+    needs_to_update_location: Mapped[bool] = mapped_column(Boolean, server_default=expression.false(), init=False)
 
-    last_antibot: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=text("to_timestamp(0)"))
+    last_antibot: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=text("to_timestamp(0)"), init=False
+    )
 
     age = column_property(func.date_part("year", func.age(birthdate)))
 
     # ID of the invite code used to sign up (if any)
-    invite_code_id: Mapped[str | None] = mapped_column(ForeignKey("invite_codes.id"), nullable=True)
-    invite_code: Mapped[InviteCode | None] = relationship(foreign_keys=[invite_code_id])
+    invite_code_id: Mapped[str | None] = mapped_column(ForeignKey("invite_codes.id"), default=None)
+    invite_code: Mapped[InviteCode | None] = relationship(init=False, foreign_keys=[invite_code_id])
 
     moderation_user_lists: Mapped[list[ModerationUserList]] = relationship(
         init=False, secondary="moderation_user_list_members", back_populates="users"
@@ -537,7 +547,7 @@ class LanguageFluency(enum.Enum):
     fluent = 3
 
 
-class LanguageAbility(Base, init=False, kw_only=True):
+class LanguageAbility(Base, kw_only=True):
     __tablename__ = "language_abilities"
     __table_args__ = (
         # Users can only have one language ability per language
@@ -553,7 +563,7 @@ class LanguageAbility(Base, init=False, kw_only=True):
     language: Mapped[Language] = relationship(init=False)
 
 
-class RegionVisited(Base, init=False, kw_only=True):
+class RegionVisited(Base, kw_only=True):
     __tablename__ = "regions_visited"
     __table_args__ = (UniqueConstraint("user_id", "region_code"),)
 
@@ -562,7 +572,7 @@ class RegionVisited(Base, init=False, kw_only=True):
     region_code: Mapped[str] = mapped_column(ForeignKey("regions.code", deferrable=True))
 
 
-class RegionLived(Base, init=False, kw_only=True):
+class RegionLived(Base, kw_only=True):
     __tablename__ = "regions_lived"
     __table_args__ = (UniqueConstraint("user_id", "region_code"),)
 

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -320,19 +320,20 @@ class User(Base, init=False, kw_only=True):
     invite_code: Mapped[InviteCode | None] = relationship(foreign_keys=[invite_code_id])
 
     moderation_user_lists: Mapped[list[ModerationUserList]] = relationship(
-        secondary="moderation_user_list_members", back_populates="users"
+        init=False, secondary="moderation_user_list_members", back_populates="users"
     )
-    language_abilities: Mapped[list[LanguageAbility]] = relationship(back_populates="user")
+    language_abilities: Mapped[list[LanguageAbility]] = relationship(init=False, back_populates="user")
     galleries: Mapped[list[PhotoGallery]] = relationship(
-        foreign_keys="PhotoGallery.owner_user_id", back_populates="owner_user"
+        init=False, foreign_keys="PhotoGallery.owner_user_id", back_populates="owner_user"
     )
     mod_notes: DynamicMapped[ModNote] = relationship(
-        foreign_keys="ModNote.user_id", back_populates="user", lazy="dynamic"
+        init=False, foreign_keys="ModNote.user_id", back_populates="user", lazy="dynamic"
     )
 
-    badges: Mapped[list[UserBadge]] = relationship(back_populates="user")
+    badges: Mapped[list[UserBadge]] = relationship(init=False, back_populates="user")
 
     pending_activeness_probe: Mapped[ActivenessProbe | None] = relationship(
+        init=False,
         primaryjoin="and_(ActivenessProbe.user_id == User.id, ActivenessProbe.is_pending)",
         uselist=False,
         back_populates="user",
@@ -548,8 +549,8 @@ class LanguageAbility(Base, init=False, kw_only=True):
     language_code: Mapped[str] = mapped_column(ForeignKey("languages.code", deferrable=True))
     fluency: Mapped[LanguageFluency] = mapped_column(Enum(LanguageFluency))
 
-    user: Mapped[User] = relationship(back_populates="language_abilities")
-    language: Mapped[Language] = relationship()
+    user: Mapped[User] = relationship(init=False, back_populates="language_abilities")
+    language: Mapped[Language] = relationship(init=False)
 
 
 class RegionVisited(Base, init=False, kw_only=True):

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -95,14 +95,14 @@ class ProfilePublicVisibility(enum.Enum):
     full = enum.auto()
 
 
-class User(Base):
+class User(Base, init=False, kw_only=True):
     """
     Basic user and profile details
     """
 
     __tablename__ = "users"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     username: Mapped[str] = mapped_column(String, unique=True)
     email: Mapped[str] = mapped_column(String, unique=True)
@@ -536,14 +536,14 @@ class LanguageFluency(enum.Enum):
     fluent = 3
 
 
-class LanguageAbility(Base):
+class LanguageAbility(Base, init=False, kw_only=True):
     __tablename__ = "language_abilities"
     __table_args__ = (
         # Users can only have one language ability per language
         UniqueConstraint("user_id", "language_code"),
     )
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
     language_code: Mapped[str] = mapped_column(ForeignKey("languages.code", deferrable=True))
     fluency: Mapped[LanguageFluency] = mapped_column(Enum(LanguageFluency))
@@ -552,19 +552,19 @@ class LanguageAbility(Base):
     language: Mapped[Language] = relationship()
 
 
-class RegionVisited(Base):
+class RegionVisited(Base, init=False, kw_only=True):
     __tablename__ = "regions_visited"
     __table_args__ = (UniqueConstraint("user_id", "region_code"),)
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
     region_code: Mapped[str] = mapped_column(ForeignKey("regions.code", deferrable=True))
 
 
-class RegionLived(Base):
+class RegionLived(Base, init=False, kw_only=True):
     __tablename__ = "regions_lived"
     __table_args__ = (UniqueConstraint("user_id", "region_code"),)
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
     region_code: Mapped[str] = mapped_column(ForeignKey("regions.code", deferrable=True))

--- a/app/backend/src/couchers/models/verification.py
+++ b/app/backend/src/couchers/models/verification.py
@@ -59,7 +59,7 @@ class PassportSex(enum.Enum):
     unspecified = enum.auto()
 
 
-class StrongVerificationAttempt(Base):
+class StrongVerificationAttempt(Base, init=False, kw_only=True):
     """
     An attempt to perform strong verification
     """
@@ -67,7 +67,7 @@ class StrongVerificationAttempt(Base):
     __tablename__ = "strong_verification_attempts"
 
     # our verification id
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     # this is returned in the callback, and we look up the attempt via this
     verification_attempt_token: Mapped[str] = mapped_column(String, unique=True)
@@ -202,10 +202,10 @@ class StrongVerificationAttempt(Base):
     )
 
 
-class StrongVerificationCallbackEvent(Base):
+class StrongVerificationCallbackEvent(Base, init=False, kw_only=True):
     __tablename__ = "strong_verification_callback_events"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     verification_attempt_id: Mapped[int] = mapped_column(ForeignKey("strong_verification_attempts.id"), index=True)

--- a/app/backend/src/couchers/models/verification.py
+++ b/app/backend/src/couchers/models/verification.py
@@ -99,7 +99,7 @@ class StrongVerificationAttempt(Base, init=False, kw_only=True):
 
     passport_expiry_datetime = column_property(date_in_timezone(passport_expiry_date, "Etc/UTC"))  # type: ignore[arg-type]
 
-    user: Mapped[User] = relationship()
+    user: Mapped[User] = relationship(init=False)
 
     @hybrid_property
     def is_valid(self) -> bool:

--- a/app/backend/src/couchers/models/verification.py
+++ b/app/backend/src/couchers/models/verification.py
@@ -59,7 +59,7 @@ class PassportSex(enum.Enum):
     unspecified = enum.auto()
 
 
-class StrongVerificationAttempt(Base, init=False, kw_only=True):
+class StrongVerificationAttempt(Base, kw_only=True):
     """
     An attempt to perform strong verification
     """
@@ -73,7 +73,7 @@ class StrongVerificationAttempt(Base, init=False, kw_only=True):
     verification_attempt_token: Mapped[str] = mapped_column(String, unique=True)
 
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     status: Mapped[StrongVerificationAttemptStatus] = mapped_column(
         Enum(StrongVerificationAttemptStatus),
@@ -83,16 +83,16 @@ class StrongVerificationAttempt(Base, init=False, kw_only=True):
     ## full data
     has_full_data: Mapped[bool] = mapped_column(Boolean, default=False)
     # the data returned from iris, encrypted with a public key whose private key is kept offline
-    passport_encrypted_data: Mapped[bytes | None] = mapped_column(Binary, nullable=True)
-    passport_date_of_birth: Mapped[date | None] = mapped_column(Date, nullable=True)
-    passport_sex: Mapped[PassportSex | None] = mapped_column(Enum(PassportSex), nullable=True)
+    passport_encrypted_data: Mapped[bytes | None] = mapped_column(Binary, default=None)
+    passport_date_of_birth: Mapped[date | None] = mapped_column(Date, default=None)
+    passport_sex: Mapped[PassportSex | None] = mapped_column(Enum(PassportSex), default=None)
 
     ## minimal data: this will not be deleted
     has_minimal_data: Mapped[bool] = mapped_column(Boolean, default=False)
-    passport_expiry_date: Mapped[date | None] = mapped_column(Date, nullable=True)
-    passport_nationality: Mapped[str | None] = mapped_column(String, nullable=True)
+    passport_expiry_date: Mapped[date | None] = mapped_column(Date, default=None)
+    passport_nationality: Mapped[str | None] = mapped_column(String, default=None)
     # last three characters of the passport number
-    passport_last_three_document_chars: Mapped[str | None] = mapped_column(String, nullable=True)
+    passport_last_three_document_chars: Mapped[str | None] = mapped_column(String, default=None)
 
     iris_token: Mapped[str] = mapped_column(String, unique=True)
     iris_session_id: Mapped[int] = mapped_column(BigInteger, unique=True)
@@ -206,7 +206,7 @@ class StrongVerificationCallbackEvent(Base, init=False, kw_only=True):
     __tablename__ = "strong_verification_callback_events"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
-    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     verification_attempt_id: Mapped[int] = mapped_column(ForeignKey("strong_verification_attempts.id"), index=True)
 

--- a/app/backend/src/couchers/models/verification.py
+++ b/app/backend/src/couchers/models/verification.py
@@ -202,7 +202,7 @@ class StrongVerificationAttempt(Base, kw_only=True):
     )
 
 
-class StrongVerificationCallbackEvent(Base, init=False, kw_only=True):
+class StrongVerificationCallbackEvent(Base, kw_only=True):
     __tablename__ = "strong_verification_callback_events"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -57,6 +57,7 @@ from couchers.utils import (
     is_valid_name,
     is_valid_user_id,
     is_valid_username,
+    not_none,
     now,
 )
 
@@ -405,9 +406,9 @@ class API(api_pb2_grpc.APIServicer):
                     context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_language")
                 session.add(
                     LanguageAbility(
-                        user=user,
+                        user_id=user.id,
                         language_code=language_ability.code,
-                        fluency=fluency2sql[language_ability.fluency],
+                        fluency=not_none(fluency2sql[language_ability.fluency]),
                     )
                 )
 

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -50,6 +50,7 @@ from couchers.tasks import (
 from couchers.utils import (
     create_coordinate,
     create_session_cookies,
+    is_geom,
     is_valid_email,
     is_valid_name,
     is_valid_username,
@@ -324,21 +325,22 @@ class Auth(auth_pb2_grpc.AuthServicer):
             user = User(
                 name=flow.name,
                 email=flow.email,
-                username=flow.username,
-                hashed_password=flow.hashed_password,
-                birthdate=flow.birthdate,
-                gender=flow.gender,
-                hosting_status=flow.hosting_status,
-                city=flow.city,
-                geom=flow.geom,
-                geom_radius=flow.geom_radius,
-                accepted_tos=flow.accepted_tos,
-                accepted_community_guidelines=flow.accepted_community_guidelines,
-                onboarding_emails_sent=1,
+                username=not_none(flow.username),
+                hashed_password=not_none(flow.hashed_password),
+                birthdate=not_none(flow.birthdate),
+                gender=not_none(flow.gender),
+                hosting_status=not_none(flow.hosting_status),
+                city=not_none(flow.city),
+                geom=is_geom(flow.geom),
+                geom_radius=not_none(flow.geom_radius),
+                accepted_tos=not_none(flow.accepted_tos),
                 last_onboarding_email_sent=func.now(),
-                opt_out_of_newsletter=flow.opt_out_of_newsletter,
                 invite_code_id=flow.invite_code_id,
             )
+
+            user.accepted_community_guidelines = flow.accepted_community_guidelines
+            user.onboarding_emails_sent = 1
+            user.opt_out_of_newsletter = not_none(flow.opt_out_of_newsletter)
 
             session.add(user)
             session.flush()

--- a/app/backend/src/couchers/servicers/galleries.py
+++ b/app/backend/src/couchers/servicers/galleries.py
@@ -1,7 +1,5 @@
-from typing import cast
-
 import grpc
-from sqlalchemy import Table, select
+from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
 
@@ -184,10 +182,7 @@ class Galleries(galleries_pb2_grpc.GalleriesServicer):
 
         if new_position is not None:
             session.execute(
-                cast(Table, PhotoGalleryItem.__table__)
-                .update()
-                .where(PhotoGalleryItem.id == request.item_id)
-                .values(position=new_position)
+                update(PhotoGalleryItem).where(PhotoGalleryItem.id == request.item_id).values(position=new_position)
             )
 
         session.flush()

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -1,11 +1,10 @@
 import functools
 import json
 import logging
-from typing import cast
 
 import grpc
 from google.protobuf import empty_pb2
-from sqlalchemy import Table, select
+from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import or_
 
@@ -148,8 +147,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         self, request: notifications_pb2.MarkAllNotificationsSeenReq, context: CouchersContext, session: Session
     ) -> empty_pb2.Empty:
         session.execute(
-            cast(Table, Notification.__table__)
-            .update()
+            update(Notification)
             .values(is_seen=True)
             .where(Notification.user_id == context.user_id)
             .where(Notification.id <= request.latest_notification_id)

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -4,7 +4,7 @@ import typing
 from collections.abc import Sequence
 from datetime import date, datetime, timedelta
 from email.utils import formatdate
-from typing import Any, overload
+from typing import TYPE_CHECKING, Any, overload
 from zoneinfo import ZoneInfo
 
 import pytz
@@ -20,6 +20,9 @@ from sqlalchemy.types import DateTime
 from couchers.config import config
 from couchers.constants import EMAIL_REGEX, PREFERRED_LANGUAGE_COOKIE_EXPIRY
 from couchers.crypto import decrypt_page_token, encrypt_page_token
+
+if TYPE_CHECKING:
+    from couchers.models import Geom
 
 utc = pytz.UTC
 
@@ -414,4 +417,11 @@ def get_tz_as_text(tz_name: str) -> str:
 def not_none[T](x: T | None) -> T:
     if x is None:
         raise ValueError("Expected a value but got None")
+    return x
+
+
+def is_geom(x: Geom | None) -> Geom:
+    """not_none does not work with unions."""
+    if x is None:
+        raise ValueError("Expected a Geom but got None")
     return x

--- a/app/backend/src/dummy_data.py
+++ b/app/backend/src/dummy_data.py
@@ -2,12 +2,14 @@ import json
 import logging
 import os
 from datetime import date, timedelta
+from typing import Any, cast
 
 from dateutil import parser
 from sqlalchemy import select
 from sqlalchemy.sql import func
 
 from couchers.constants import GUIDELINES_VERSION, TOS_VERSION
+from couchers.context import CouchersContext
 from couchers.crypto import hash_password
 from couchers.db import session_scope
 from couchers.models import (
@@ -53,7 +55,7 @@ logger = logging.getLogger(__name__)
 SRC_DIR = os.path.dirname(__file__)
 
 
-def add_dummy_users():
+def add_dummy_users() -> None:
     logger.info("Adding dummy users")
     with session_scope() as session:
         if session.execute(select(func.count()).select_from(User)).scalar_one() > 0:
@@ -80,16 +82,17 @@ def add_dummy_users():
                 occupation=user["occupation"],
                 about_me=user["about_me"],
                 about_place=user["about_place"],
-                hosting_status=hostingstatus2sql[
+                hosting_status=hostingstatus2sql[  # type: ignore[arg-type]
                     HostingStatus.Value(
                         user["hosting_status"] if "hosting_status" in user else "HOSTING_STATUS_CANT_HOST"
                     )
                 ],
                 accepted_tos=TOS_VERSION,
-                accepted_community_guidelines=GUIDELINES_VERSION,
-                is_superuser=user.get("is_superuser", False),
-                is_editor=user.get("is_editor", user.get("is_superuser", False)),
             )
+            new_user.accepted_community_guidelines = GUIDELINES_VERSION
+            new_user.is_superuser = user.get("is_superuser", False)
+            new_user.is_editor = user.get("is_editor", user.get("is_superuser", False))
+
             session.add(new_user)
             session.flush()
 
@@ -112,12 +115,13 @@ def add_dummy_users():
 
             class _MockCouchersContext:
                 @property
-                def headers(self):
+                def headers(self) -> dict[str, str]:
                     return {}
 
+            ctx = cast(CouchersContext, _MockCouchersContext())
             if user.get("make_api_key", False):
                 token, _ = create_session(
-                    _MockCouchersContext(),
+                    ctx,
                     session,
                     new_user,
                     long_lived=True,
@@ -128,7 +132,7 @@ def add_dummy_users():
                 logger.info(f"API key for {new_user.username}: {token}")
 
             if user.get("make_session", False):
-                token, _ = create_session(_MockCouchersContext(), session, new_user, long_lived=False, set_cookie=False)
+                token, _ = create_session(ctx, session, new_user, long_lived=False, set_cookie=False)
                 logger.info(f"Session cookie for {new_user.username}: {token}")
 
         session.commit()
@@ -240,7 +244,7 @@ def add_dummy_users():
         session.commit()
 
 
-def add_dummy_communities():
+def add_dummy_communities() -> None:
     logger.info("Adding dummy communities")
     with session_scope() as session:
         if session.execute(select(func.count()).select_from(Node)).scalar_one() > 0:
@@ -251,9 +255,8 @@ def add_dummy_communities():
             data = json.loads(f.read())
 
         for community in data["communities"]:
-            geom = None
             if "coordinates" in community:
-                geom = create_polygon_lng_lat(community["coordinates"])
+                geom: Any = create_polygon_lng_lat(community["coordinates"])
             elif "osm_id" in community:
                 with open(f"{SRC_DIR}/data/osm/{community['osm_id']}.geojson") as f:
                     geojson = json.loads(f.read())
@@ -438,6 +441,6 @@ def add_dummy_communities():
             session.add(page_version)
 
 
-def add_dummy_data():
+def add_dummy_data() -> None:
     add_dummy_users()
     add_dummy_communities()

--- a/app/backend/src/tests/fixtures/db.py
+++ b/app/backend/src/tests/fixtures/db.py
@@ -19,7 +19,6 @@ from couchers.models import (
     HostingStatus,
     LanguageAbility,
     LanguageFluency,
-    MeetupStatus,
     ModerationUserList,
     PassportSex,
     PhotoGallery,
@@ -158,6 +157,46 @@ def autocommit_engine(url: str):
     engine.dispose()
 
 
+def make_user(**kwargs: Any) -> User:
+    username = "test_user_" + random_hex(16)
+
+    user = User(
+        username=username,
+        email=f"{username}@dev.couchers.org",
+        hashed_password=b"$argon2id$v=19$m=65536,t=2,p=1$4cjGg1bRaZ10k+7XbIDmFg$tZG7JaLrkfyfO7cS233ocq7P8rf3znXR7SAfUt34kJg",
+        name=username.capitalize(),
+        hosting_status=HostingStatus.cant_host,
+        city="Testing city",
+        hometown="Test hometown",
+        community_standing=0.5,
+        birthdate=date(year=2000, month=1, day=1),
+        gender="Woman",
+        pronouns="",
+        occupation="Tester",
+        education="UST(esting)",
+        about_me="I test things",
+        things_i_like="Code",
+        about_place="My place has a lot of testing paraphenelia",
+        additional_information="I can be a bit testy",
+        accepted_tos=TOS_VERSION,
+        geom=create_coordinate(40.7108, -73.9740),
+        geom_radius=100,
+        last_onboarding_email_sent=now(),
+        last_donated=now(),
+    )
+    user.accepted_community_guidelines = GUIDELINES_VERSION
+    user.onboarding_emails_sent = 1
+
+    # Ensure superusers are also editors (DB constraint)
+    if kwargs.get("is_superuser") and "is_editor" not in kwargs:
+        kwargs["is_editor"] = True
+
+    for key, value in kwargs.items():
+        setattr(user, key, value)
+
+    return user
+
+
 def generate_user(
     *,
     delete_user=False,
@@ -176,44 +215,8 @@ def generate_user(
     Use this most of the time
     """
     with session_scope() as session:
-        # Ensure superusers are also editors (DB constraint)
-        if kwargs.get("is_superuser") and "is_editor" not in kwargs:
-            kwargs["is_editor"] = True
+        user = make_user(**kwargs)
 
-        # default args
-        username = "test_user_" + random_hex(16)
-        user_opts = {
-            "username": username,
-            "email": f"{username}@dev.couchers.org",
-            # password is just 'password'
-            # this is hardcoded because the password is slow to hash (so would slow down tests otherwise)
-            "hashed_password": b"$argon2id$v=19$m=65536,t=2,p=1$4cjGg1bRaZ10k+7XbIDmFg$tZG7JaLrkfyfO7cS233ocq7P8rf3znXR7SAfUt34kJg",
-            "name": username.capitalize(),
-            "hosting_status": HostingStatus.cant_host,
-            "meetup_status": MeetupStatus.open_to_meetup,
-            "city": "Testing city",
-            "hometown": "Test hometown",
-            "community_standing": 0.5,
-            "birthdate": date(year=2000, month=1, day=1),
-            "gender": "Woman",
-            "pronouns": "",
-            "occupation": "Tester",
-            "education": "UST(esting)",
-            "about_me": "I test things",
-            "things_i_like": "Code",
-            "about_place": "My place has a lot of testing paraphenelia",
-            "additional_information": "I can be a bit testy",
-            # you need to make sure to update this logic to make sure the user is jailed/not on request
-            "accepted_tos": TOS_VERSION,
-            "accepted_community_guidelines": GUIDELINES_VERSION,
-            "geom": create_coordinate(40.7108, -73.9740),
-            "geom_radius": 100,
-            "onboarding_emails_sent": 1,
-            "last_onboarding_email_sent": now(),
-            "last_donated": now(),
-        } | kwargs
-
-        user = User(**user_opts)
         session.add(user)
         session.flush()
 

--- a/app/backend/src/tests/test_galleries.py
+++ b/app/backend/src/tests/test_galleries.py
@@ -700,8 +700,11 @@ def test_database_constraints_upload_uniqueness(db):
         session.add(upload)
         session.flush()
 
-        item1 = PhotoGalleryItem(gallery_id=user.profile_gallery_id, upload_key="key1", position=0.0)
-        item2 = PhotoGalleryItem(gallery_id=user.profile_gallery_id, upload_key="key1", position=1.0)
+        gallery_id = user.profile_gallery_id
+        assert gallery_id
+
+        item1 = PhotoGalleryItem(gallery_id=gallery_id, upload_key="key1", position=0.0)
+        item2 = PhotoGalleryItem(gallery_id=gallery_id, upload_key="key1", position=1.0)
         session.add_all([item1, item2])
 
         with pytest.raises(IntegrityError):

--- a/app/backend/src/tests/test_models.py
+++ b/app/backend/src/tests/test_models.py
@@ -5,7 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.sql import func
 
 from couchers.db import session_scope
-from couchers.models import User
+from tests.fixtures.db import make_user
 
 
 @pytest.fixture(autouse=True)
@@ -24,20 +24,22 @@ def test_user_age(db):
 
 
 def test_user_display_joined():
-    assert User(joined=datetime(2020, 7, 10, 16, 34, 1, 1)).display_joined == datetime(2020, 7, 10, 16, 0, 0, 0)
-    assert User(joined=datetime(2025, 7, 10, 16, 59, 1, 1)).display_joined == datetime(2025, 7, 10, 16, 0, 0, 0)
-    assert User(joined=datetime(2020, 7, 10, 16, 0, 1, 1)).display_joined == datetime(2020, 7, 10, 16, 0, 0, 0)
-    assert User(joined=datetime(2020, 7, 10, 0, 0, 0, 0)).display_joined == datetime(2020, 7, 10, 0, 0, 0, 0)
+    assert make_user(joined=datetime(2020, 7, 10, 16, 34, 1, 1)).display_joined == datetime(2020, 7, 10, 16, 0, 0, 0)
+    assert make_user(joined=datetime(2025, 7, 10, 16, 59, 1, 1)).display_joined == datetime(2025, 7, 10, 16, 0, 0, 0)
+    assert make_user(joined=datetime(2020, 7, 10, 16, 0, 1, 1)).display_joined == datetime(2020, 7, 10, 16, 0, 0, 0)
+    assert make_user(joined=datetime(2020, 7, 10, 0, 0, 0, 0)).display_joined == datetime(2020, 7, 10, 0, 0, 0, 0)
 
 
 def test_user_display_last_active():
-    assert User(last_active=datetime(2020, 7, 10, 16, 34, 1, 1)).display_last_active == datetime(
+    assert make_user(last_active=datetime(2020, 7, 10, 16, 34, 1, 1)).display_last_active == datetime(
         2020, 7, 10, 16, 0, 0, 0
     )
-    assert User(last_active=datetime(2025, 7, 10, 17, 59, 1, 1)).display_last_active == datetime(
+    assert make_user(last_active=datetime(2025, 7, 10, 17, 59, 1, 1)).display_last_active == datetime(
         2025, 7, 10, 17, 0, 0, 0
     )
-    assert User(last_active=datetime(2020, 7, 10, 16, 0, 1, 1)).display_last_active == datetime(
+    assert make_user(last_active=datetime(2020, 7, 10, 16, 0, 1, 1)).display_last_active == datetime(
         2020, 7, 10, 16, 0, 0, 0
     )
-    assert User(last_active=datetime(2020, 7, 10, 0, 0, 0, 0)).display_last_active == datetime(2020, 7, 10, 0, 0, 0, 0)
+    assert make_user(last_active=datetime(2020, 7, 10, 0, 0, 0, 0)).display_last_active == datetime(
+        2020, 7, 10, 0, 0, 0, 0
+    )

--- a/app/backend/uv.lock
+++ b/app/backend/uv.lock
@@ -285,6 +285,7 @@ dev = [
     { name = "types-grpcio" },
     { name = "types-protobuf" },
     { name = "types-psycopg2" },
+    { name = "types-python-dateutil" },
     { name = "types-pytz" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
@@ -342,6 +343,7 @@ dev = [
     { name = "types-grpcio", specifier = ">=1.0.0.20251009" },
     { name = "types-protobuf", specifier = ">=6.32.1.20251105" },
     { name = "types-psycopg2" },
+    { name = "types-python-dateutil", specifier = ">=2.9.0.20251115" },
     { name = "types-pytz", specifier = ">=2025.2.0.20250809" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
     { name = "types-requests", specifier = ">=2.32.4.20250913" },
@@ -1560,6 +1562,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9b/b3/2d09eaf35a084cffd329c584970a3fa07101ca465c13cad1576d7c392587/types_psycopg2-2.9.21.20251012.tar.gz", hash = "sha256:4cdafd38927da0cfde49804f39ab85afd9c6e9c492800e42f1f0c1a1b0312935", size = 26710, upload-time = "2025-10-12T02:55:39.5Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/0c/05feaf8cb51159f2c0af04b871dab7e98a2f83a3622f5f216331d2dd924c/types_psycopg2-2.9.21.20251012-py3-none-any.whl", hash = "sha256:712bad5c423fe979e357edbf40a07ca40ef775d74043de72bd4544ca328cc57e", size = 24883, upload-time = "2025-10-12T02:55:38.439Z" },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20251115"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/36/06d01fb52c0d57e9ad0c237654990920fa41195e4b3d640830dabf9eeb2f/types_python_dateutil-2.9.0.20251115.tar.gz", hash = "sha256:8a47f2c3920f52a994056b8786309b43143faa5a64d4cbb2722d6addabdf1a58", size = 16363, upload-time = "2025-11-15T03:00:13.717Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/0b/56961d3ba517ed0df9b3a27bfda6514f3d01b28d499d1bce9068cfe4edd1/types_python_dateutil-2.9.0.20251115-py3-none-any.whl", hash = "sha256:9cf9c1c582019753b8639a081deefd7e044b9fa36bd8217f565c6c4e36ee0624", size = 18251, upload-time = "2025-11-15T03:00:12.317Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add MappedAsDataclass to Base, and add `init=False` for all models so that they don't have a fully typed init. This is to avoid too much disruption
- Remove `init=False` for a subset of models. This enables typed init for them. 
- Fix the resulting errors for that subset of models

- Run mypy on app.py and dummy_data.py

## Overall approach to typing sqlalchemy models
- We disallow passing a related object when creating a model. No `Gallery(user=user)`, only `Gallery(user_id=user.id)`. 
- We disallow passing attributes that are created by the DB (`id`, `created` etc). If one needs to override them, one has to first create a model, and then set an attribute: `user = User(...); user.id = 42; session.add(user)`. 
- If a field is nullable, it has to have a `default=None` on a `mapped_column` so that mypy knows we don't have to pass it.