### PR TITLE
Refactor permission checks in interceptors

### DIFF
--- a/app/backend/src/couchers/descriptor_pool.py
+++ b/app/backend/src/couchers/descriptor_pool.py
@@ -22,21 +22,5 @@ def get_descriptor_pool() -> descriptor_pool.DescriptorPool:
     pool = descriptor_pool.DescriptorPool()
     desc = descriptor_pb2.FileDescriptorSet.FromString(get_descriptors_pb())
     for file_descriptor in desc.file:
-        # Sanity check: I don't think it should ever have more than one service.
-        assert len(file_descriptor.service) in (0, 1)
-
-        # Validate that all services have auth levels specified in .proto files.
-        # Media service is called only by the backend, so it doesn't have an auth level.
-        if file_descriptor.service and (service := file_descriptor.service[0]) and service.name != "Media":
-            level = service.options.Extensions[annotations_pb2.auth_level]
-            if level not in {
-                annotations_pb2.AUTH_LEVEL_OPEN,
-                annotations_pb2.AUTH_LEVEL_JAILED,
-                annotations_pb2.AUTH_LEVEL_SECURE,
-                annotations_pb2.AUTH_LEVEL_EDITOR,
-                annotations_pb2.AUTH_LEVEL_ADMIN,
-            }:
-                raise ValueError(f"{level=}, {service=}")
-
         pool.Add(file_descriptor)  # type: ignore[no-untyped-call]
     return pool

--- a/app/backend/src/couchers/descriptor_pool.py
+++ b/app/backend/src/couchers/descriptor_pool.py
@@ -22,5 +22,21 @@ def get_descriptor_pool() -> descriptor_pool.DescriptorPool:
     pool = descriptor_pool.DescriptorPool()
     desc = descriptor_pb2.FileDescriptorSet.FromString(get_descriptors_pb())
     for file_descriptor in desc.file:
+        # Sanity check: I don't think it should ever have more than one service.
+        assert len(file_descriptor.service) in (0, 1)
+
+        # Validate that all services have auth levels specified in .proto files.
+        # Media service is called only by the backend, so it doesn't have an auth level.
+        if file_descriptor.service and (service := file_descriptor.service[0]) and service.name != "Media":
+            level = service.options.Extensions[annotations_pb2.auth_level]
+            if level not in {
+                annotations_pb2.AUTH_LEVEL_OPEN,
+                annotations_pb2.AUTH_LEVEL_JAILED,
+                annotations_pb2.AUTH_LEVEL_SECURE,
+                annotations_pb2.AUTH_LEVEL_EDITOR,
+                annotations_pb2.AUTH_LEVEL_ADMIN,
+            }:
+                raise ValueError(f"{level=}, {service=}")
+
         pool.Add(file_descriptor)  # type: ignore[no-untyped-call]
     return pool

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Callable
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from os import getpid
 from threading import get_ident
@@ -12,6 +12,7 @@ from typing import Any, NoReturn, cast, overload
 import grpc
 import sentry_sdk
 from google.protobuf.descriptor import ServiceDescriptor
+from google.protobuf.descriptor_pool import DescriptorPool
 from google.protobuf.message import Message
 from opentelemetry import trace
 from sqlalchemy import Function, select
@@ -32,6 +33,7 @@ from couchers.descriptor_pool import get_descriptor_pool
 from couchers.metrics import observe_in_servicer_duration_histogram
 from couchers.models import APICall, User, UserActivity, UserSession
 from couchers.proto import annotations_pb2
+from couchers.proto.annotations_pb2 import AuthLevel
 from couchers.utils import (
     create_lang_cookie,
     create_session_cookies,
@@ -45,13 +47,9 @@ from couchers.utils import (
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, kw_only=True)
 class UserAuthInfo:
-    """
-    Information about an authenticated user session.
-
-    Returned by _try_get_and_update_user_details when a valid session is found.
-    """
+    """Information about an authenticated user session."""
 
     user_id: int
     is_jailed: bool
@@ -59,6 +57,8 @@ class UserAuthInfo:
     is_superuser: bool
     token_expiry: datetime
     ui_language_preference: str | None
+    token: str = field(repr=False)
+    is_api_key: bool
 
 
 def _binned_now() -> Function[Any]:
@@ -132,6 +132,8 @@ def _try_get_and_update_user_details(
             is_superuser=user.is_superuser,
             token_expiry=user_session.expiry,
             ui_language_preference=user.ui_language_preference,
+            token=token,
+            is_api_key=is_api_key,
         )
 
 
@@ -253,88 +255,39 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
         start = perf_counter_ns()
 
         method = handler_call_details.method
-        # method is of the form "/org.couchers.api.core.API/GetUser"
-        _, service_name, method_name = method.split("/")
 
         try:
-            service: ServiceDescriptor = self._pool.FindServiceByName(service_name)  # type: ignore[no-untyped-call]
-            service_options = service.GetOptions()
-        except KeyError:
-            return abort_handler(NONEXISTENT_API_CALL_ERROR_MESSAGE, grpc.StatusCode.UNIMPLEMENTED)
+            auth_level = find_auth_level(self._pool, method)
+        except AbortError as bal:
+            return abort_handler(bal.msg, bal.code)
 
-        auth_level = service_options.Extensions[annotations_pb2.auth_level]
-
-        # if unknown auth level, then it wasn't set and something's wrong
-        if auth_level == annotations_pb2.AUTH_LEVEL_UNKNOWN:
-            return abort_handler(MISSING_AUTH_LEVEL_ERROR_MESSAGE, grpc.StatusCode.INTERNAL)
-
-        assert auth_level in [
-            annotations_pb2.AUTH_LEVEL_OPEN,
-            annotations_pb2.AUTH_LEVEL_JAILED,
-            annotations_pb2.AUTH_LEVEL_SECURE,
-            annotations_pb2.AUTH_LEVEL_EDITOR,
-            annotations_pb2.AUTH_LEVEL_ADMIN,
-        ]
-
-        headers = dict(handler_call_details.invocation_metadata)
-
-        if "cookie" in headers and "authorization" in headers:
-            # for security reasons, only one of "cookie" or "authorization" can be present
+        try:
+            headers = parse_headers(dict(handler_call_details.invocation_metadata))
+        except BadHeaders:
             return unauthenticated_handler(COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE)
-        elif "cookie" in headers:
-            # the session token is passed in cookies, i.e. in the `cookie` header
-            token, is_api_key = parse_session_cookie(headers), False
-        elif "authorization" in headers:
-            # the session token is passed in the `authorization` header
-            token, is_api_key = parse_api_key(headers), True
-        else:
-            # no session found
-            token, is_api_key = None, False
 
-        ip_address = cast(str | None, headers.get("x-couchers-real-ip"))
-        user_agent = cast(str | None, headers.get("user-agent"))
+        auth_info = _try_get_and_update_user_details(
+            headers.token, headers.is_api_key, headers.ip_address, headers.user_agent
+        )
 
-        auth_info = _try_get_and_update_user_details(token, is_api_key, ip_address, user_agent)
+        if error_handler := check_auth(auth_info, auth_level):
+            return error_handler
 
-        if not auth_info:
-            # Invalid or no session - clear credentials
-            token = None
-            is_api_key = False
-
-            # if this isn't an open service, fail
-            if auth_level != annotations_pb2.AUTH_LEVEL_OPEN:
-                return unauthenticated_handler(UNAUTHORIZED_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED)
-        else:
-            # a valid user session was found - check permissions
-            if auth_level == annotations_pb2.AUTH_LEVEL_ADMIN and not auth_info.is_superuser:
-                return unauthenticated_handler(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED)
-
-            if auth_level == annotations_pb2.AUTH_LEVEL_EDITOR and not auth_info.is_editor:
-                return unauthenticated_handler(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED)
-
-            # if the user is jailed and this is isn't an open or jailed service, fail
-            if auth_info.is_jailed and auth_level not in [
-                annotations_pb2.AUTH_LEVEL_OPEN,
-                annotations_pb2.AUTH_LEVEL_JAILED,
-            ]:
-                return unauthenticated_handler(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED)
-
-        handler = continuation(handler_call_details)
-        if not handler:
+        if not (handler := continuation(handler_call_details)):
             raise RuntimeError(f"No handler in '{method}'")
 
-        prev_function = handler.unary_unary
-        if not prev_function:
+        if not (prev_function := handler.unary_unary):
             raise RuntimeError(f"No prev_function in '{method}', {handler}")
 
         def function_without_couchers_stuff(req: Message, grpc_context: grpc.ServicerContext) -> Message | None:
-            couchers_context: CouchersContext = make_interactive_context(
+            couchers_context = make_interactive_context(
                 grpc_context=grpc_context,
                 user_id=auth_info.user_id if auth_info else None,
-                is_api_key=is_api_key,
-                token=token,
+                is_api_key=auth_info.is_api_key if auth_info else False,
+                token=auth_info.token if auth_info else None,
                 ui_language_preference=auth_info.ui_language_preference if auth_info else None,
             )
+
             with session_scope() as session:
                 try:
                     _res = prev_function(req, couchers_context, session)  # type: ignore[call-arg, arg-type]
@@ -351,8 +304,8 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                         response=res,
                         traceback=None,
                         perf_report=None,
-                        ip_address=ip_address,
-                        user_agent=user_agent,
+                        ip_address=headers.ip_address,
+                        user_agent=headers.user_agent,
                     )
                     observe_in_servicer_duration_histogram(method, couchers_context._user_id, "", "", duration / 1000)
                 except Exception as e:
@@ -376,8 +329,8 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                         response=None,
                         traceback=traceback,
                         perf_report=None,
-                        ip_address=ip_address,
-                        user_agent=user_agent,
+                        ip_address=headers.ip_address,
+                        user_agent=headers.user_agent,
                     )
                     observe_in_servicer_duration_histogram(
                         method, couchers_context._user_id, code or "", type(e).__name__, duration / 1000
@@ -390,19 +343,13 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
 
                     raise e
 
-            if auth_info and not is_api_key:
-                # Sanity check. If auth_info is present, then we should have a token.
-                if token is None:
-                    raise RuntimeError(f"{token=}, {auth_info.token_expiry=}")
-
+            if auth_info and not auth_info.is_api_key:
                 # check the two cookies are in sync & that language preference cookie is correct
-                if parse_user_id_cookie(headers) != str(auth_info.user_id):
+                if headers.user_id != str(auth_info.user_id):
                     couchers_context.set_cookies(
-                        create_session_cookies(token, auth_info.user_id, auth_info.token_expiry)
+                        create_session_cookies(auth_info.token, auth_info.user_id, auth_info.token_expiry)
                     )
-                if auth_info.ui_language_preference and auth_info.ui_language_preference != parse_ui_lang_cookie(
-                    headers
-                ):
+                if auth_info.ui_language_preference and auth_info.ui_language_preference != headers.ui_lang:
                     couchers_context.set_cookies(create_lang_cookie(auth_info.ui_language_preference))
 
             if not grpc_context.is_active():
@@ -417,6 +364,112 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             request_deserializer=handler.request_deserializer,
             response_serializer=handler.response_serializer,
         )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CouchersHeaders:
+    token: str | None = field(repr=False)
+    is_api_key: bool
+    ip_address: str | None
+    user_agent: str | None
+    ui_lang: str | None
+    user_id: str | None
+
+
+def parse_headers(headers: dict[str, str | bytes]) -> CouchersHeaders:
+    if "cookie" in headers and "authorization" in headers:
+        # for security reasons, only one of "cookie" or "authorization" can be present
+        raise BadHeaders("Both cookies and authorization are present in headers")
+    elif "cookie" in headers:
+        # the session token is passed in cookies, i.e., in the `cookie` header
+        token, is_api_key = parse_session_cookie(headers), False
+    elif "authorization" in headers:
+        # the session token is passed in the `authorization` header
+        token, is_api_key = parse_api_key(headers), True
+    else:
+        # no session found
+        token, is_api_key = None, False
+
+    ip_address = headers.get("x-couchers-real-ip")
+    user_agent = headers.get("user-agent")
+
+    ui_lang = parse_ui_lang_cookie(headers)
+    user_id = parse_user_id_cookie(headers)
+
+    return CouchersHeaders(
+        token=token,
+        is_api_key=is_api_key,
+        ip_address=ip_address if isinstance(ip_address, str) else None,
+        user_agent=user_agent if isinstance(user_agent, str) else None,
+        ui_lang=ui_lang,
+        user_id=user_id,
+    )
+
+
+class BadHeaders(Exception):
+    pass
+
+
+class AbortError(Exception):
+    def __init__(self, msg: str, code: grpc.StatusCode) -> None:
+        self.msg = msg
+        self.code = code
+
+
+def find_auth_level(pool: DescriptorPool, method: str) -> AuthLevel.ValueType:
+    # method is of the form "/org.couchers.api.core.API/GetUser"
+    _, service_name, method_name = method.split("/")
+
+    try:
+        service: ServiceDescriptor = pool.FindServiceByName(service_name)  # type: ignore[no-untyped-call]
+        service_options = service.GetOptions()
+    except KeyError:
+        raise AbortError(NONEXISTENT_API_CALL_ERROR_MESSAGE, grpc.StatusCode.UNIMPLEMENTED) from None
+
+    level = service_options.Extensions[annotations_pb2.auth_level]
+    validate_auth_level(level)
+
+    return level
+
+
+def validate_auth_level(auth_level: AuthLevel.ValueType) -> None:
+    # if unknown auth level, then it wasn't set and something's wrong
+    if auth_level == annotations_pb2.AUTH_LEVEL_UNKNOWN:
+        raise AbortError(MISSING_AUTH_LEVEL_ERROR_MESSAGE, grpc.StatusCode.INTERNAL)
+
+    if auth_level not in {
+        annotations_pb2.AUTH_LEVEL_OPEN,
+        annotations_pb2.AUTH_LEVEL_JAILED,
+        annotations_pb2.AUTH_LEVEL_SECURE,
+        annotations_pb2.AUTH_LEVEL_EDITOR,
+        annotations_pb2.AUTH_LEVEL_ADMIN,
+    }:
+        raise AbortError(MISSING_AUTH_LEVEL_ERROR_MESSAGE, grpc.StatusCode.INTERNAL)
+
+
+def check_auth(
+    auth_info: UserAuthInfo | None, auth_level: AuthLevel.ValueType
+) -> grpc.RpcMethodHandler[Any, Any] | None:
+    if not auth_info:
+        # if this isn't an open service, fail
+        if auth_level != annotations_pb2.AUTH_LEVEL_OPEN:
+            return unauthenticated_handler(UNAUTHORIZED_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED)
+    else:
+        # a valid user session was found - check permissions
+        if auth_level == annotations_pb2.AUTH_LEVEL_ADMIN and not auth_info.is_superuser:
+            return unauthenticated_handler(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED)
+
+        if auth_level == annotations_pb2.AUTH_LEVEL_EDITOR and not auth_info.is_editor:
+            return unauthenticated_handler(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED)
+
+        # if the user is jailed and this isn't an open or jailed service, fail
+        if auth_info.is_jailed and auth_level not in [
+            annotations_pb2.AUTH_LEVEL_OPEN,
+            annotations_pb2.AUTH_LEVEL_JAILED,
+        ]:
+            return unauthenticated_handler(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED)
+
+    return None
 
 
 class MediaInterceptor(grpc.ServerInterceptor):

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -73,7 +73,7 @@ def _try_get_and_update_user_details(
 
     Also updates the user's last active time, token last active time, and increments API call count.
 
-    Returns UserAuthInfo if valid session found, None otherwise.
+    Returns UserAuthInfo if a valid session is found, None otherwise.
     """
     if not token:
         return None
@@ -99,40 +99,40 @@ def _try_get_and_update_user_details(
 
         if not result:
             return None
+
+        user, user_session, user_activity = result._tuple()
+
+        # update user last active time if it's been a while
+        if now() - user.last_active > timedelta(minutes=5):
+            user.last_active = func.now()
+
+        # let's update the token
+        user_session.last_seen = func.now()
+        user_session.api_calls += 1
+
+        if user_activity:
+            user_activity.api_calls += 1
         else:
-            user, user_session, user_activity = result._tuple()
-
-            # update user last active time if it's been a while
-            if now() - user.last_active > timedelta(minutes=5):
-                user.last_active = func.now()
-
-            # let's update the token
-            user_session.last_seen = func.now()
-            user_session.api_calls += 1
-
-            if user_activity:
-                user_activity.api_calls += 1
-            else:
-                session.add(
-                    UserActivity(
-                        user_id=user.id,
-                        period=_binned_now(),
-                        ip_address=ip_address,
-                        user_agent=user_agent,
-                        api_calls=1,
-                    )
+            session.add(
+                UserActivity(
+                    user_id=user.id,
+                    period=_binned_now(),
+                    ip_address=ip_address,
+                    user_agent=user_agent,
+                    api_calls=1,
                 )
-
-            session.commit()
-
-            return UserAuthInfo(
-                user_id=user.id,
-                is_jailed=user.is_jailed,
-                is_editor=user.is_editor,
-                is_superuser=user.is_superuser,
-                token_expiry=user_session.expiry,
-                ui_language_preference=user.ui_language_preference,
             )
+
+        session.commit()
+
+        return UserAuthInfo(
+            user_id=user.id,
+            is_jailed=user.is_jailed,
+            is_editor=user.is_editor,
+            is_superuser=user.is_superuser,
+            token_expiry=user_session.expiry,
+            ui_language_preference=user.ui_language_preference,
+        )
 
 
 def abort_handler[T, R](

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -189,7 +189,7 @@ def _sanitized_bytes(proto: Message | None) -> bytes | None:
 def _store_log(
     *,
     method: str,
-    status_code: str | None,
+    status_code: str | None = None,
     duration: float,
     user_id: int | None,
     is_api_key: bool,
@@ -258,8 +258,8 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
 
         try:
             auth_level = find_auth_level(self._pool, method)
-        except AbortError as bal:
-            return abort_handler(bal.msg, bal.code)
+        except AbortError as ae:
+            return abort_handler(ae.msg, ae.code)
 
         try:
             headers = parse_headers(dict(handler_call_details.invocation_metadata))
@@ -270,8 +270,10 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             headers.token, headers.is_api_key, headers.ip_address, headers.user_agent
         )
 
-        if error_handler := check_auth(auth_info, auth_level):
-            return error_handler
+        try:
+            check_permissions(auth_info, auth_level)
+        except AbortError as ae:
+            return unauthenticated_handler(ae.msg, ae.code)
 
         if not (handler := continuation(handler_call_details)):
             raise RuntimeError(f"No handler in '{method}'")
@@ -444,29 +446,25 @@ def validate_auth_level(auth_level: AuthLevel.ValueType) -> None:
         raise AbortError(MISSING_AUTH_LEVEL_ERROR_MESSAGE, grpc.StatusCode.INTERNAL)
 
 
-def check_auth(
-    auth_info: UserAuthInfo | None, auth_level: AuthLevel.ValueType
-) -> grpc.RpcMethodHandler[Any, Any] | None:
+def check_permissions(auth_info: UserAuthInfo | None, auth_level: AuthLevel.ValueType) -> None:
     if not auth_info:
         # if this isn't an open service, fail
         if auth_level != annotations_pb2.AUTH_LEVEL_OPEN:
-            return unauthenticated_handler(UNAUTHORIZED_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED)
+            raise AbortError(UNAUTHORIZED_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED)
     else:
         # a valid user session was found - check permissions
         if auth_level == annotations_pb2.AUTH_LEVEL_ADMIN and not auth_info.is_superuser:
-            return unauthenticated_handler(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED)
+            raise AbortError(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED)
 
         if auth_level == annotations_pb2.AUTH_LEVEL_EDITOR and not auth_info.is_editor:
-            return unauthenticated_handler(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED)
+            raise AbortError(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED)
 
         # if the user is jailed and this isn't an open or jailed service, fail
         if auth_info.is_jailed and auth_level not in [
             annotations_pb2.AUTH_LEVEL_OPEN,
             annotations_pb2.AUTH_LEVEL_JAILED,
         ]:
-            return unauthenticated_handler(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED)
-
-    return None
+            raise AbortError(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED)
 
 
 class MediaInterceptor(grpc.ServerInterceptor):

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
@@ -195,8 +195,8 @@ def _store_log(
     is_api_key: bool,
     request: Message,
     response: Message | None,
-    traceback: str | None,
-    perf_report: str | None,
+    traceback: str | None = None,
+    perf_report: str | None = None,
     ip_address: str | None,
     user_agent: str | None,
 ) -> None:
@@ -296,14 +296,11 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                     duration = (finished - start) / 1e6  # ms
                     _store_log(
                         method=method,
-                        status_code=None,
                         duration=duration,
                         user_id=couchers_context._user_id,
                         is_api_key=cast(bool, couchers_context._is_api_key),
                         request=req,
                         response=res,
-                        traceback=None,
-                        perf_report=None,
                         ip_address=headers.ip_address,
                         user_agent=headers.user_agent,
                     )
@@ -328,7 +325,6 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                         request=req,
                         response=None,
                         traceback=traceback,
-                        perf_report=None,
                         ip_address=headers.ip_address,
                         user_agent=headers.user_agent,
                     )
@@ -376,7 +372,7 @@ class CouchersHeaders:
     user_id: str | None
 
 
-def parse_headers(headers: dict[str, str | bytes]) -> CouchersHeaders:
+def parse_headers(headers: Mapping[str, str | bytes]) -> CouchersHeaders:
     if "cookie" in headers and "authorization" in headers:
         # for security reasons, only one of "cookie" or "authorization" can be present
         raise BadHeaders("Both cookies and authorization are present in headers")
@@ -427,6 +423,7 @@ def find_auth_level(pool: DescriptorPool, method: str) -> AuthLevel.ValueType:
         raise AbortError(NONEXISTENT_API_CALL_ERROR_MESSAGE, grpc.StatusCode.UNIMPLEMENTED) from None
 
     level = service_options.Extensions[annotations_pb2.auth_level]
+
     validate_auth_level(level)
 
     return level

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -1,7 +1,7 @@
 import http.cookies
 import re
 import typing
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import date, datetime, timedelta
 from email.utils import formatdate
 from typing import TYPE_CHECKING, Any, overload
@@ -275,7 +275,7 @@ def create_lang_cookie(lang: str) -> list[str]:
     ]
 
 
-def parse_session_cookie(headers: dict[str, str | bytes]) -> str | None:
+def parse_session_cookie(headers: Mapping[str, str | bytes]) -> str | None:
     """
     Returns our session cookie value (aka token) or None
     """
@@ -293,7 +293,7 @@ def parse_session_cookie(headers: dict[str, str | bytes]) -> str | None:
     return cookie.value
 
 
-def parse_user_id_cookie(headers: dict[str, str | bytes]) -> str | None:
+def parse_user_id_cookie(headers: Mapping[str, str | bytes]) -> str | None:
     """
     Returns our session cookie value (aka token) or None
     """
@@ -311,7 +311,7 @@ def parse_user_id_cookie(headers: dict[str, str | bytes]) -> str | None:
     return cookie.value
 
 
-def parse_ui_lang_cookie(headers: dict[str, str | bytes]) -> str | None:
+def parse_ui_lang_cookie(headers: Mapping[str, str | bytes]) -> str | None:
     """
     Returns language cookie or None
     """
@@ -329,7 +329,7 @@ def parse_ui_lang_cookie(headers: dict[str, str | bytes]) -> str | None:
     return cookie.value
 
 
-def parse_api_key(headers: dict[str, str | bytes]) -> str | None:
+def parse_api_key(headers: Mapping[str, str | bytes]) -> str | None:
     """
     Returns a bearer token (API key) from the `authorization` header, or None if invalid/not present
     """

--- a/app/backend/src/tests/fixtures/sessions.py
+++ b/app/backend/src/tests/fixtures/sessions.py
@@ -1,7 +1,7 @@
 from collections.abc import Generator
 from concurrent import futures
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, NoReturn
 
 import grpc
 from grpc._server import _validate_generic_rpc_handlers
@@ -91,7 +91,7 @@ class CookieMetadataPlugin(grpc.AuthMetadataPlugin):
         callback((("cookie", f"couchers-sesh={self.token}"),), None)
 
 
-class _MetadataKeeperInterceptor(grpc.UnaryUnaryClientInterceptor):
+class MetadataKeeperInterceptor(grpc.UnaryUnaryClientInterceptor):
     def __init__(self):
         self.latest_headers = {}
 
@@ -151,12 +151,12 @@ class MockGrpcContext:
 
     def __init__(self):
         self._initial_metadata = []
-        self._invocation_metadata = []
+        self._invocation_metadata: list[tuple[str, str]] = []
 
-    def abort(self, code, details):
+    def abort(self, code: grpc.StatusCode, details: str) -> NoReturn:
         raise FakeRpcError(code, details)
 
-    def invocation_metadata(self):
+    def invocation_metadata(self) -> list[tuple[str, str]]:
         return self._invocation_metadata
 
     def send_initial_metadata(self, metadata):
@@ -167,7 +167,7 @@ class FakeChannel:
     """
     Mock gRPC channel for testing that orchestrates context creation.
 
-    This holds test state (token) and creates proper CouchersContext
+    This holds the test state (token) and creates proper CouchersContext
     instances when handlers are invoked.
     """
 
@@ -183,10 +183,10 @@ class FakeChannel:
         handler = self.handlers[uri]
 
         def fake_handler(request):
+            # What does this test?
             auth_info = _try_get_and_update_user_details(
                 self._token, is_api_key=False, ip_address="127.0.0.1", user_agent="Testing User-Agent"
             )
-
             _check_user_perms(uri, auth_info)
 
             # Do a full serialization cycle on the request and the
@@ -226,7 +226,7 @@ def run_server(grpc_channel_options=(), token: str | None = None):
 
         try:
             with grpc.secure_channel(f"localhost:{port}", creds, options=grpc_channel_options) as channel:
-                metadata_interceptor = _MetadataKeeperInterceptor()
+                metadata_interceptor = MetadataKeeperInterceptor()
                 channel = grpc.intercept_channel(channel, metadata_interceptor)
                 yield srv, channel, metadata_interceptor
         finally:
@@ -237,7 +237,7 @@ def run_server(grpc_channel_options=(), token: str | None = None):
 @contextmanager
 def auth_api_session(
     grpc_channel_options=(),
-) -> Generator[tuple[auth_pb2_grpc.AuthStub, grpc.UnaryUnaryClientInterceptor]]:
+) -> Generator[tuple[auth_pb2_grpc.AuthStub, MetadataKeeperInterceptor]]:
     """
     Create an Auth API for testing
 

--- a/app/backend/src/tests/fixtures/sessions.py
+++ b/app/backend/src/tests/fixtures/sessions.py
@@ -9,11 +9,15 @@ from grpc._server import _validate_generic_rpc_handlers
 from couchers.context import make_interactive_context
 from couchers.db import session_scope
 from couchers.descriptor_pool import get_descriptor_pool
-from couchers.interceptors import CouchersMiddlewareInterceptor, UserAuthInfo, _try_get_and_update_user_details
+from couchers.interceptors import (
+    CouchersMiddlewareInterceptor,
+    _try_get_and_update_user_details,
+    check_permissions,
+    find_auth_level,
+)
 from couchers.proto import (
     account_pb2_grpc,
     admin_pb2_grpc,
-    annotations_pb2,
     api_pb2_grpc,
     auth_pb2_grpc,
     blocking_pb2_grpc,
@@ -103,45 +107,15 @@ class MetadataKeeperInterceptor(grpc.UnaryUnaryClientInterceptor):
 
 
 class FakeRpcError(grpc.RpcError):
-    def __init__(self, code, details):
+    def __init__(self, code: grpc.StatusCode, details: str):
         self._code = code
         self._details = details
 
-    def code(self):
+    def code(self) -> grpc.StatusCode:
         return self._code
 
-    def details(self):
+    def details(self) -> str:
         return self._details
-
-
-def _check_user_perms(method: str, auth_info: UserAuthInfo | None) -> None:
-    # method is of the form "/org.couchers.api.core.API/GetUser"
-    _, service_name, method_name = method.split("/")
-
-    service_options = get_descriptor_pool().FindServiceByName(service_name).GetOptions()
-    auth_level = service_options.Extensions[annotations_pb2.auth_level]
-    assert auth_level != annotations_pb2.AUTH_LEVEL_UNKNOWN
-    assert auth_level in [
-        annotations_pb2.AUTH_LEVEL_OPEN,
-        annotations_pb2.AUTH_LEVEL_JAILED,
-        annotations_pb2.AUTH_LEVEL_SECURE,
-        annotations_pb2.AUTH_LEVEL_EDITOR,
-        annotations_pb2.AUTH_LEVEL_ADMIN,
-    ]
-
-    if not auth_info:
-        assert auth_level == annotations_pb2.AUTH_LEVEL_OPEN
-    else:
-        assert not (auth_level == annotations_pb2.AUTH_LEVEL_ADMIN and not auth_info.is_superuser), (
-            "Non-superuser tried to call superuser API"
-        )
-        assert not (auth_level == annotations_pb2.AUTH_LEVEL_EDITOR and not auth_info.is_editor), (
-            "Non-editor tried to call editor API"
-        )
-        assert not (
-            auth_info.is_jailed
-            and auth_level not in [annotations_pb2.AUTH_LEVEL_OPEN, annotations_pb2.AUTH_LEVEL_JAILED]
-        ), "User is jailed but tried to call non-open/non-jailed API"
 
 
 class MockGrpcContext:
@@ -174,30 +148,29 @@ class FakeChannel:
     def __init__(self, token: str | None = None):
         self.handlers: dict[str, Any] = {}
         self._token = token
+        self._pool = get_descriptor_pool()
 
     def add_generic_rpc_handlers(self, generic_rpc_handlers: Any):
         _validate_generic_rpc_handlers(generic_rpc_handlers)
         self.handlers.update(generic_rpc_handlers[0]._method_handlers)
 
-    def unary_unary(self, uri, request_serializer, response_deserializer):
-        handler = self.handlers[uri]
+    def unary_unary(self, method, request_serializer, response_deserializer):
+        handler = self.handlers[method]
 
         def fake_handler(request):
-            # What does this test?
             auth_info = _try_get_and_update_user_details(
                 self._token, is_api_key=False, ip_address="127.0.0.1", user_agent="Testing User-Agent"
             )
-            _check_user_perms(uri, auth_info)
+            auth_level = find_auth_level(self._pool, method)
+            check_permissions(auth_info, auth_level)
 
             # Do a full serialization cycle on the request and the
             # response to catch accidental use of unserializable data.
             request = handler.request_deserializer(request_serializer(request))
 
             with session_scope() as session:
-                mock_grpc_ctx = MockGrpcContext()
-
                 context = make_interactive_context(
-                    grpc_context=mock_grpc_ctx,
+                    grpc_context=MockGrpcContext(),
                     user_id=auth_info.user_id if auth_info else None,
                     is_api_key=False,
                     token=self._token if auth_info else None,

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -24,7 +24,7 @@ from couchers.models import (
 from couchers.proto import api_pb2, auth_pb2
 from tests.fixtures.db import generate_user
 from tests.fixtures.misc import PushCollector, email_fields, mock_notification_email
-from tests.fixtures.sessions import api_session, auth_api_session, real_api_session
+from tests.fixtures.sessions import MetadataKeeperInterceptor, api_session, auth_api_session, real_api_session
 
 
 @pytest.fixture(autouse=True)
@@ -32,7 +32,7 @@ def _(testconfig, fast_passwords):
     pass
 
 
-def get_session_cookie_tokens(metadata_interceptor):
+def get_session_cookie_tokens(metadata_interceptor: MetadataKeeperInterceptor) -> tuple[str, str]:
     set_cookies = [val for key, val in metadata_interceptor.latest_header_raw if key == "set-cookie"]
     sesh = http.cookies.SimpleCookie([v for v in set_cookies if "sesh" in v][0])["couchers-sesh"].value
     uid = http.cookies.SimpleCookie([v for v in set_cookies if "user-id" in v][0])["couchers-user-id"].value

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -21,7 +21,7 @@ from couchers.interceptors import (
     CouchersMiddlewareInterceptor,
     ErrorSanitizationInterceptor,
     UserAuthInfo,
-    check_auth,
+    check_permissions,
     find_auth_level,
     parse_headers,
     validate_auth_level,
@@ -703,8 +703,7 @@ def test_validate_auth_level_with_admin():
 
 
 def test_check_auth_open_service_without_auth():
-    result = check_auth(None, annotations_pb2.AUTH_LEVEL_OPEN)
-    assert result is None
+    check_permissions(None, annotations_pb2.AUTH_LEVEL_OPEN)
 
 
 def test_check_auth_open_service_with_auth():
@@ -718,13 +717,12 @@ def test_check_auth_open_service_with_auth():
         token="abc123",
         is_api_key=False,
     )
-    result = check_auth(auth_info, annotations_pb2.AUTH_LEVEL_OPEN)
-    assert result is None
+    check_permissions(auth_info, annotations_pb2.AUTH_LEVEL_OPEN)
 
 
 def test_check_auth_secure_service_without_auth():
-    result = check_auth(None, annotations_pb2.AUTH_LEVEL_SECURE)
-    assert result is not None
+    with pytest.raises(AbortError):
+        check_permissions(None, annotations_pb2.AUTH_LEVEL_SECURE)
 
 
 def test_check_auth_secure_service_with_normal_auth():
@@ -738,8 +736,7 @@ def test_check_auth_secure_service_with_normal_auth():
         token="abc123",
         is_api_key=False,
     )
-    result = check_auth(auth_info, annotations_pb2.AUTH_LEVEL_SECURE)
-    assert result is None
+    check_permissions(auth_info, annotations_pb2.AUTH_LEVEL_SECURE)
 
 
 def test_check_auth_secure_service_with_jailed_user():
@@ -753,8 +750,8 @@ def test_check_auth_secure_service_with_jailed_user():
         token="abc123",
         is_api_key=False,
     )
-    result = check_auth(auth_info, annotations_pb2.AUTH_LEVEL_SECURE)
-    assert result is not None
+    with pytest.raises(AbortError):
+        check_permissions(auth_info, annotations_pb2.AUTH_LEVEL_SECURE)
 
 
 def test_check_auth_jailed_service_with_jailed_user():
@@ -768,13 +765,12 @@ def test_check_auth_jailed_service_with_jailed_user():
         token="abc123",
         is_api_key=False,
     )
-    result = check_auth(auth_info, annotations_pb2.AUTH_LEVEL_JAILED)
-    assert result is None
+    check_permissions(auth_info, annotations_pb2.AUTH_LEVEL_JAILED)
 
 
 def test_check_auth_jailed_service_without_auth():
-    result = check_auth(None, annotations_pb2.AUTH_LEVEL_JAILED)
-    assert result is not None
+    with pytest.raises(AbortError):
+        check_permissions(None, annotations_pb2.AUTH_LEVEL_JAILED)
 
 
 def test_check_auth_editor_service_without_editor():
@@ -788,8 +784,8 @@ def test_check_auth_editor_service_without_editor():
         token="abc123",
         is_api_key=False,
     )
-    result = check_auth(auth_info, annotations_pb2.AUTH_LEVEL_EDITOR)
-    assert result is not None
+    with pytest.raises(AbortError):
+        check_permissions(auth_info, annotations_pb2.AUTH_LEVEL_EDITOR)
 
 
 def test_check_auth_editor_service_with_editor():
@@ -803,8 +799,7 @@ def test_check_auth_editor_service_with_editor():
         token="abc123",
         is_api_key=False,
     )
-    result = check_auth(auth_info, annotations_pb2.AUTH_LEVEL_EDITOR)
-    assert result is None
+    check_permissions(auth_info, annotations_pb2.AUTH_LEVEL_EDITOR)
 
 
 def test_check_auth_admin_service_without_superuser():
@@ -818,8 +813,8 @@ def test_check_auth_admin_service_without_superuser():
         token="abc123",
         is_api_key=False,
     )
-    result = check_auth(auth_info, annotations_pb2.AUTH_LEVEL_ADMIN)
-    assert result is not None
+    with pytest.raises(AbortError):
+        check_permissions(auth_info, annotations_pb2.AUTH_LEVEL_ADMIN)
 
 
 def test_check_auth_admin_service_with_superuser():
@@ -833,10 +828,9 @@ def test_check_auth_admin_service_with_superuser():
         token="abc123",
         is_api_key=False,
     )
-    result = check_auth(auth_info, annotations_pb2.AUTH_LEVEL_ADMIN)
-    assert result is None
+    check_permissions(auth_info, annotations_pb2.AUTH_LEVEL_ADMIN)
 
 
 def test_check_auth_admin_service_without_auth():
-    result = check_auth(None, annotations_pb2.AUTH_LEVEL_ADMIN)
-    assert result is not None
+    with pytest.raises(AbortError):
+        check_permissions(None, annotations_pb2.AUTH_LEVEL_ADMIN)

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -1,22 +1,37 @@
 from concurrent import futures
 from contextlib import contextmanager
+from unittest.mock import Mock
 
 import grpc
 import pytest
 from google.protobuf import empty_pb2
+from google.protobuf.descriptor import ServiceDescriptor
+from google.protobuf.descriptor_pool import DescriptorPool
 from sqlalchemy import select
 
+from couchers.constants import (
+    MISSING_AUTH_LEVEL_ERROR_MESSAGE,
+    NONEXISTENT_API_CALL_ERROR_MESSAGE,
+)
 from couchers.crypto import random_hex
 from couchers.db import session_scope
 from couchers.interceptors import (
+    AbortError,
+    BadHeaders,
     CouchersMiddlewareInterceptor,
     ErrorSanitizationInterceptor,
+    UserAuthInfo,
+    check_auth,
+    find_auth_level,
+    parse_headers,
+    validate_auth_level,
 )
 from couchers.metrics import servicer_duration_histogram
 from couchers.models import APICall, UserSession
-from couchers.proto import account_pb2, admin_pb2, api_pb2, auth_pb2
+from couchers.proto import account_pb2, admin_pb2, annotations_pb2, api_pb2, auth_pb2
 from couchers.servicers.account import Account
 from couchers.servicers.api import API
+from couchers.utils import now
 from tests.fixtures.db import generate_user
 from tests.fixtures.sessions import real_admin_session
 
@@ -555,3 +570,273 @@ def test_auth_levels(db):
             call_rpc(empty_pb2.Empty())
         assert err.value.code() == grpc.StatusCode.INTERNAL
         assert err.value.details() == "Internal authentication error."
+
+
+def test_parse_headers_with_session_cookie():
+    headers = {"cookie": "couchers-sesh=abc123; other-cookie=value"}
+    result = parse_headers(headers)
+    assert result.token == "abc123"
+    assert result.is_api_key is False
+
+
+def test_parse_headers_with_authorization_header():
+    headers = {"authorization": "Bearer abc123"}
+    result = parse_headers(headers)
+    assert result.token == "abc123"
+    assert result.is_api_key is True
+
+
+def test_parse_headers_with_both_cookie_and_authorization():
+    headers = {"cookie": "couchers-sesh=abc123", "authorization": "Bearer xyz789"}
+    with pytest.raises(BadHeaders, match="Both cookies and authorization are present in headers"):
+        parse_headers(headers)
+
+
+def test_parse_headers_with_neither_cookie_nor_authorization():
+    result = parse_headers({})
+    assert result.token is None
+    assert result.is_api_key is False
+
+
+def test_parse_headers_with_all_optional_headers():
+    headers = {
+        "cookie": "couchers-sesh=abc123; couchers-user-id=42; NEXT_LOCALE=en",
+        "x-couchers-real-ip": "192.168.1.1",
+        "user-agent": "TestAgent/1.0",
+    }
+    result = parse_headers(headers)
+    assert result.token == "abc123"
+    assert result.is_api_key is False
+    assert result.ip_address == "192.168.1.1"
+    assert result.user_agent == "TestAgent/1.0"
+    assert result.ui_lang == "en"
+    assert result.user_id == "42"
+
+
+def test_parse_headers_with_bytes_ip_address():
+    headers: dict[str, str | bytes] = {
+        "cookie": "couchers-sesh=abc123",
+        "x-couchers-real-ip": b"192.168.1.1",
+    }
+    result = parse_headers(headers)
+    assert result.ip_address is None
+
+
+def test_parse_headers_with_bytes_user_agent():
+    headers: dict[str, str | bytes] = {
+        "cookie": "couchers-sesh=abc123",
+        "user-agent": b"TestAgent/1.0",
+    }
+    result = parse_headers(headers)
+    assert result.user_agent is None
+
+
+def test_parse_headers_malformed_authorization():
+    headers = {"authorization": "bearer abc123"}
+    result = parse_headers(headers)
+    assert result.token is None
+    assert result.is_api_key is True
+
+
+def test_find_auth_level_with_valid_service():
+    pool = Mock(spec=DescriptorPool)
+    service_desc = Mock(spec=ServiceDescriptor)
+    service_options = Mock()
+    service_options.Extensions = {annotations_pb2.auth_level: annotations_pb2.AUTH_LEVEL_SECURE}
+    service_desc.GetOptions.return_value = service_options
+    pool.FindServiceByName.return_value = service_desc
+
+    result = find_auth_level(pool, "/org.couchers.api.core.API/GetUser")
+    assert result == annotations_pb2.AUTH_LEVEL_SECURE
+    pool.FindServiceByName.assert_called_once_with("org.couchers.api.core.API")
+
+
+def test_find_auth_level_with_nonexistent_service():
+    pool = Mock(spec=DescriptorPool)
+    pool.FindServiceByName.side_effect = KeyError("Service not found")
+
+    with pytest.raises(AbortError) as exc:
+        find_auth_level(pool, "/org.couchers.nonexistent.Service/Method")
+    assert exc.value.msg == NONEXISTENT_API_CALL_ERROR_MESSAGE
+    assert exc.value.code == grpc.StatusCode.UNIMPLEMENTED
+
+
+def test_find_auth_level_with_unknown_auth_level():
+    pool = Mock(spec=DescriptorPool)
+    service_desc = Mock(spec=ServiceDescriptor)
+    service_options = Mock()
+    service_options.Extensions = {annotations_pb2.auth_level: annotations_pb2.AUTH_LEVEL_UNKNOWN}
+    service_desc.GetOptions.return_value = service_options
+    pool.FindServiceByName.return_value = service_desc
+
+    with pytest.raises(AbortError) as exc:
+        find_auth_level(pool, "/org.couchers.api.core.API/GetUser")
+    assert exc.value.msg == MISSING_AUTH_LEVEL_ERROR_MESSAGE
+    assert exc.value.code == grpc.StatusCode.INTERNAL
+
+
+def test_validate_auth_level_with_unknown():
+    with pytest.raises(AbortError) as exc:
+        validate_auth_level(annotations_pb2.AUTH_LEVEL_UNKNOWN)
+    assert exc.value.msg == MISSING_AUTH_LEVEL_ERROR_MESSAGE
+    assert exc.value.code == grpc.StatusCode.INTERNAL
+
+
+def test_validate_auth_level_with_open():
+    validate_auth_level(annotations_pb2.AUTH_LEVEL_OPEN)
+
+
+def test_validate_auth_level_with_jailed():
+    validate_auth_level(annotations_pb2.AUTH_LEVEL_JAILED)
+
+
+def test_validate_auth_level_with_secure():
+    validate_auth_level(annotations_pb2.AUTH_LEVEL_SECURE)
+
+
+def test_validate_auth_level_with_editor():
+    validate_auth_level(annotations_pb2.AUTH_LEVEL_EDITOR)
+
+
+def test_validate_auth_level_with_admin():
+    validate_auth_level(annotations_pb2.AUTH_LEVEL_ADMIN)
+
+
+def test_check_auth_open_service_without_auth():
+    result = check_auth(None, annotations_pb2.AUTH_LEVEL_OPEN)
+    assert result is None
+
+
+def test_check_auth_open_service_with_auth():
+    auth_info = UserAuthInfo(
+        user_id=1,
+        is_jailed=False,
+        is_editor=False,
+        is_superuser=False,
+        token_expiry=now(),
+        ui_language_preference="en",
+        token="abc123",
+        is_api_key=False,
+    )
+    result = check_auth(auth_info, annotations_pb2.AUTH_LEVEL_OPEN)
+    assert result is None
+
+
+def test_check_auth_secure_service_without_auth():
+    result = check_auth(None, annotations_pb2.AUTH_LEVEL_SECURE)
+    assert result is not None
+
+
+def test_check_auth_secure_service_with_normal_auth():
+    auth_info = UserAuthInfo(
+        user_id=1,
+        is_jailed=False,
+        is_editor=False,
+        is_superuser=False,
+        token_expiry=now(),
+        ui_language_preference="en",
+        token="abc123",
+        is_api_key=False,
+    )
+    result = check_auth(auth_info, annotations_pb2.AUTH_LEVEL_SECURE)
+    assert result is None
+
+
+def test_check_auth_secure_service_with_jailed_user():
+    auth_info = UserAuthInfo(
+        user_id=1,
+        is_jailed=True,
+        is_editor=False,
+        is_superuser=False,
+        token_expiry=now(),
+        ui_language_preference="en",
+        token="abc123",
+        is_api_key=False,
+    )
+    result = check_auth(auth_info, annotations_pb2.AUTH_LEVEL_SECURE)
+    assert result is not None
+
+
+def test_check_auth_jailed_service_with_jailed_user():
+    auth_info = UserAuthInfo(
+        user_id=1,
+        is_jailed=True,
+        is_editor=False,
+        is_superuser=False,
+        token_expiry=now(),
+        ui_language_preference="en",
+        token="abc123",
+        is_api_key=False,
+    )
+    result = check_auth(auth_info, annotations_pb2.AUTH_LEVEL_JAILED)
+    assert result is None
+
+
+def test_check_auth_jailed_service_without_auth():
+    result = check_auth(None, annotations_pb2.AUTH_LEVEL_JAILED)
+    assert result is not None
+
+
+def test_check_auth_editor_service_without_editor():
+    auth_info = UserAuthInfo(
+        user_id=1,
+        is_jailed=False,
+        is_editor=False,
+        is_superuser=False,
+        token_expiry=now(),
+        ui_language_preference="en",
+        token="abc123",
+        is_api_key=False,
+    )
+    result = check_auth(auth_info, annotations_pb2.AUTH_LEVEL_EDITOR)
+    assert result is not None
+
+
+def test_check_auth_editor_service_with_editor():
+    auth_info = UserAuthInfo(
+        user_id=1,
+        is_jailed=False,
+        is_editor=True,
+        is_superuser=False,
+        token_expiry=now(),
+        ui_language_preference="en",
+        token="abc123",
+        is_api_key=False,
+    )
+    result = check_auth(auth_info, annotations_pb2.AUTH_LEVEL_EDITOR)
+    assert result is None
+
+
+def test_check_auth_admin_service_without_superuser():
+    auth_info = UserAuthInfo(
+        user_id=1,
+        is_jailed=False,
+        is_editor=True,
+        is_superuser=False,
+        token_expiry=now(),
+        ui_language_preference="en",
+        token="abc123",
+        is_api_key=False,
+    )
+    result = check_auth(auth_info, annotations_pb2.AUTH_LEVEL_ADMIN)
+    assert result is not None
+
+
+def test_check_auth_admin_service_with_superuser():
+    auth_info = UserAuthInfo(
+        user_id=1,
+        is_jailed=False,
+        is_editor=True,
+        is_superuser=True,
+        token_expiry=now(),
+        ui_language_preference="en",
+        token="abc123",
+        is_api_key=False,
+    )
+    result = check_auth(auth_info, annotations_pb2.AUTH_LEVEL_ADMIN)
+    assert result is None
+
+
+def test_check_auth_admin_service_without_auth():
+    result = check_auth(None, annotations_pb2.AUTH_LEVEL_ADMIN)
+    assert result is not None

--- a/app/backend/src/tests/test_jail.py
+++ b/app/backend/src/tests/test_jail.py
@@ -21,7 +21,7 @@ def test_jail_basic(db):
     user1, token1 = generate_user()
 
     with real_api_session(token1) as api:
-        res = api.Ping(api_pb2.PingReq())
+        api.Ping(api_pb2.PingReq())
 
     with real_jail_session(token1) as jail:
         res = jail.JailInfo(empty_pb2.Empty())
@@ -35,7 +35,7 @@ def test_jail_basic(db):
     user2, token2 = generate_user(accepted_tos=0)
 
     with real_api_session(token2) as api, pytest.raises(grpc.RpcError) as e:
-        res = api.Ping(api_pb2.PingReq())
+        api.Ping(api_pb2.PingReq())
     assert e.value.code() == grpc.StatusCode.UNAUTHENTICATED
 
     with real_jail_session(token2) as jail:


### PR DESCRIPTION
- Extract checking auth level and permissions into functions
- Reuse these functions in FakeChannel instead of relying on their copy-pasted versions
- Unit test these functions (the benefit is that the tests don't require a database since they're testing pure functions)

Note that there's no change in behaviour, and all the existing tests still pass.