### PR TITLE
Backend: Decouple i18n functions from email templating

### DIFF
--- a/app/backend/src/couchers/i18n/i18n.py
+++ b/app/backend/src/couchers/i18n/i18n.py
@@ -5,8 +5,8 @@ from functools import lru_cache
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
-from google.protobuf.timestamp_pb2 import Timestamp
 import phonenumbers
+from google.protobuf.timestamp_pb2 import Timestamp
 
 from couchers.i18n.constants import LANGUAGE_FALLBACKS
 from couchers.i18n.i18next import I18Next

--- a/app/backend/src/couchers/i18n/i18n.py
+++ b/app/backend/src/couchers/i18n/i18n.py
@@ -6,10 +6,12 @@ from pathlib import Path
 from zoneinfo import ZoneInfo
 
 from google.protobuf.timestamp_pb2 import Timestamp
+import phonenumbers
 
 from couchers.i18n.constants import LANGUAGE_FALLBACKS
 from couchers.i18n.i18next import I18Next
 from couchers.i18n.plurals import PluralRules
+from couchers.models.users import User
 from couchers.utils import to_aware_datetime
 
 
@@ -78,36 +80,50 @@ def localize_date(date: datetime.date, locale: str) -> str:
     return date.strftime("%A %-d %B %Y")
 
 
+def localize_date_from_iso(date: str, locale: str) -> str:
+    """Formats a date in ISO YYYY-MM-DD format for the given locale."""
+    return localize_date(datetime.date.fromisoformat(date), locale)
+
+
 def localize_time(time: datetime.time, locale: str) -> str:
     """Formats a date- and timezone-agnostic time for the given locale."""
     # TODO(#7590): Account for locale
     return time.strftime("%-I:%M %p (%H:%M)")
 
 
-def localize_datetime(datetime: datetime.datetime, timezone: ZoneInfo | None, locale: str) -> str:
+def localize_datetime(datetime: datetime.datetime | Timestamp, timezone: ZoneInfo | None, locale: str) -> str:
     """
     Formats a date and time for the given locale.
 
     Args:
-        datetime: The date to be formatted.
+        datetime: The datetime or timestamp to be formatted.
         timezone: An optional timezone in which to interpret the date. If None, uses datetime's timezone.
         locale: The locale for which to format the date.
 
     Returns:
         The localized date and time string.
     """
+    if isinstance(datetime, Timestamp):
+        datetime = to_aware_datetime(datetime)
+
     # A timezone-unaware datetime is almost certainly a bug, so we don't support it.
     assert datetime.tzinfo is not None, "Cannot localize a timezone-unaware datetime."
+
     if timezone is not None:
         datetime = datetime.astimezone(timezone)
+
     localized_date = localize_date(datetime.date(), locale)
     localized_time = localize_time(datetime.time(), locale)
+
     # TODO(#7590): Account for locale
     return f"{localized_date} at {localized_time}"
 
 
-def localize_timestamp(timestamp: Timestamp, timezone: ZoneInfo, locale: str) -> str:
-    """
-    Formats a timestamp into date and time strings for the given timezone and locale
-    """
-    return localize_datetime(to_aware_datetime(timestamp), timezone, locale)
+def localize_datetime_for_user(datetime: datetime.datetime | Timestamp, user: User) -> str:
+    timezone = ZoneInfo(user.timezone or "Etc/UTC")
+    return localize_datetime(datetime, timezone, user.ui_language_preference or "en")
+
+
+def format_phone_number(value: str) -> str:
+    """Formats a phone number from E.164 format to the international format."""
+    return phonenumbers.format_number(phonenumbers.parse(value), phonenumbers.PhoneNumberFormat.INTERNATIONAL)

--- a/app/backend/src/couchers/i18n/i18n.py
+++ b/app/backend/src/couchers/i18n/i18n.py
@@ -1,11 +1,16 @@
+import datetime
 import json
 from collections.abc import Mapping
 from functools import lru_cache
 from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from google.protobuf.timestamp_pb2 import Timestamp
 
 from couchers.i18n.constants import LANGUAGE_FALLBACKS
 from couchers.i18n.i18next import I18Next
 from couchers.i18n.plurals import PluralRules
+from couchers.utils import to_aware_datetime
 
 
 @lru_cache(maxsize=1)
@@ -65,3 +70,44 @@ def localize_string(lang: str | None, key: str, *, substitutions: Mapping[str, s
         The translated string with substitutions applied
     """
     return get_i18next().localize(key, lang or "en", substitutions)
+
+
+def localize_date(date: datetime.date, locale: str) -> str:
+    """Formats a time- and timezone-agnostic date for the given locale."""
+    # TODO(#7590): Account for locale
+    return date.strftime("%A %-d %B %Y")
+
+
+def localize_time(time: datetime.time, locale: str) -> str:
+    """Formats a date- and timezone-agnostic time for the given locale."""
+    # TODO(#7590): Account for locale
+    return time.strftime("%-I:%M %p (%H:%M)")
+
+
+def localize_datetime(datetime: datetime.datetime, timezone: ZoneInfo | None, locale: str) -> str:
+    """
+    Formats a date and time for the given locale.
+
+    Args:
+        datetime: The date to be formatted.
+        timezone: An optional timezone in which to interpret the date. If None, uses datetime's timezone.
+        locale: The locale for which to format the date.
+
+    Returns:
+        The localized date and time string.
+    """
+    # A timezone-unaware datetime is almost certainly a bug, so we don't support it.
+    assert datetime.tzinfo is not None, "Cannot localize a timezone-unaware datetime."
+    if timezone is not None:
+        datetime = datetime.astimezone(timezone)
+    localized_date = localize_date(datetime.date(), locale)
+    localized_time = localize_time(datetime.time(), locale)
+    # TODO(#7590): Account for locale
+    return f"{localized_date} at {localized_time}"
+
+
+def localize_timestamp(timestamp: Timestamp, timezone: ZoneInfo, locale: str) -> str:
+    """
+    Formats a timestamp into date and time strings for the given timezone and locale
+    """
+    return localize_datetime(to_aware_datetime(timestamp), timezone, locale)

--- a/app/backend/src/couchers/i18n/i18n.py
+++ b/app/backend/src/couchers/i18n/i18n.py
@@ -1,6 +1,6 @@
-import datetime
 import json
 from collections.abc import Mapping
+from datetime import date, datetime, time
 from functools import lru_cache
 from pathlib import Path
 from zoneinfo import ZoneInfo
@@ -74,24 +74,24 @@ def localize_string(lang: str | None, key: str, *, substitutions: Mapping[str, s
     return get_i18next().localize(key, lang or "en", substitutions)
 
 
-def localize_date(date: datetime.date, locale: str) -> str:
+def localize_date(value: date, locale: str) -> str:
     """Formats a time- and timezone-agnostic date for the given locale."""
     # TODO(#7590): Account for locale
-    return date.strftime("%A %-d %B %Y")
+    return value.strftime("%A %-d %B %Y")
 
 
-def localize_date_from_iso(date: str, locale: str) -> str:
+def localize_date_from_iso(value: str, locale: str) -> str:
     """Formats a date in ISO YYYY-MM-DD format for the given locale."""
-    return localize_date(datetime.date.fromisoformat(date), locale)
+    return localize_date(date.fromisoformat(value), locale)
 
 
-def localize_time(time: datetime.time, locale: str) -> str:
+def localize_time(value: time, locale: str) -> str:
     """Formats a date- and timezone-agnostic time for the given locale."""
     # TODO(#7590): Account for locale
-    return time.strftime("%-I:%M %p (%H:%M)")
+    return value.strftime("%-I:%M %p (%H:%M)")
 
 
-def localize_datetime(datetime: datetime.datetime | Timestamp, timezone: ZoneInfo | None, locale: str) -> str:
+def localize_datetime(value: datetime | Timestamp, timezone: ZoneInfo | None, locale: str) -> str:
     """
     Formats a date and time for the given locale.
 
@@ -103,25 +103,25 @@ def localize_datetime(datetime: datetime.datetime | Timestamp, timezone: ZoneInf
     Returns:
         The localized date and time string.
     """
-    if isinstance(datetime, Timestamp):
-        datetime = to_aware_datetime(datetime)
+    if isinstance(value, Timestamp):
+        value = to_aware_datetime(value)
 
     # A timezone-unaware datetime is almost certainly a bug, so we don't support it.
-    assert datetime.tzinfo is not None, "Cannot localize a timezone-unaware datetime."
+    assert value.tzinfo is not None, "Cannot localize a timezone-unaware datetime."
 
     if timezone is not None:
-        datetime = datetime.astimezone(timezone)
+        value = value.astimezone(timezone)
 
-    localized_date = localize_date(datetime.date(), locale)
-    localized_time = localize_time(datetime.time(), locale)
+    localized_date = localize_date(value.date(), locale)
+    localized_time = localize_time(value.time(), locale)
 
     # TODO(#7590): Account for locale
     return f"{localized_date} at {localized_time}"
 
 
-def localize_datetime_for_user(datetime: datetime.datetime | Timestamp, user: User) -> str:
+def localize_datetime_for_user(value: datetime | Timestamp, user: User) -> str:
     timezone = ZoneInfo(user.timezone or "Etc/UTC")
-    return localize_datetime(datetime, timezone, user.ui_language_preference or "en")
+    return localize_datetime(value, timezone, user.ui_language_preference or "en")
 
 
 def format_phone_number(value: str) -> str:

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -53,15 +53,13 @@ def _send_email_notification(session: Session, user: User, notification: Notific
     email_lang = "en"
     if config["ENABLE_NOTIFICATION_TRANSLATIONS"]:
         email_lang = user.ui_language_preference or "en"
-
-    filter_context = FilterContext(timezone=ZoneInfo(user.timezone or "Etc/UTC"), locale=email_lang, plaintext=True)
+    timezone = ZoneInfo(user.timezone or "Etc/UTC")
 
     template_args = {
         "header_subject": rendered.subject,
         "header_preview": rendered.preview,
         "user": user,
         "time": notification.created,
-        FilterContext.KEY: filter_context,
         "footer_email_is_critical": rendered.is_critical,
         "footer_manage_notifications_link": urls.notification_settings_link(),
         "footer_notification_topic_action": rendered.topic_action_unsubscribe_text,
@@ -73,13 +71,15 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         **rendered.template_args,
     }
 
+    # Format plaintext template
+    template_args[FilterContext.KEY] = FilterContext(timezone=timezone, locale=email_lang, plaintext=True)
     plain_tmplt = (template_folder / f"{rendered.template_name}.txt").read_text()
     plain_tmplt_footer = (template_folder / "_footer.txt").read_text()
-    filter_context.plaintext = True
     plain = env.from_string(plain_tmplt + plain_tmplt_footer).render(template_args)
 
+    # Format html template
+    template_args[FilterContext.KEY] = FilterContext(timezone=timezone, locale=email_lang, plaintext=False)
     html_tmplt = (template_folder / "generated_html" / f"{rendered.template_name}.html").read_text()
-    filter_context.plaintext = False
     html = env.from_string(html_tmplt).render(template_args)
 
     if user.do_not_email and not rendered.is_critical:

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 from google.protobuf import empty_pb2
 from jinja2 import Environment, FileSystemLoader
@@ -30,13 +31,11 @@ from couchers.notifications.settings import get_preference
 from couchers.proto.internal import jobs_pb2
 from couchers.sql import moderation_state_column_visible
 from couchers.templates.v2 import (
-    CONTEXT_PLAINTEXT_KEY,
-    CONTEXT_TIMEZONE_DISPLAY_KEY,
-    CONTEXT_TRANSLATION_LANGUAGE_KEY,
     CONTEXT_YEAR_KEY,
+    FilterContext,
     add_filters,
 )
-from couchers.utils import get_tz_as_text, now
+from couchers.utils import now
 
 logger = logging.getLogger(__name__)
 
@@ -55,11 +54,14 @@ def _send_email_notification(session: Session, user: User, notification: Notific
     if config["ENABLE_NOTIFICATION_TRANSLATIONS"]:
         email_lang = user.ui_language_preference or "en"
 
+    filter_context = FilterContext(timezone=ZoneInfo(user.timezone or "Etc/UTC"), locale=email_lang, plaintext=True)
+
     template_args = {
         "header_subject": rendered.subject,
         "header_preview": rendered.preview,
         "user": user,
         "time": notification.created,
+        FilterContext.KEY: filter_context,
         "footer_email_is_critical": rendered.is_critical,
         "footer_manage_notifications_link": urls.notification_settings_link(),
         "footer_notification_topic_action": rendered.topic_action_unsubscribe_text,
@@ -67,18 +69,17 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         "footer_notification_topic_key": rendered.topic_key_unsubscribe_text,
         "footer_notification_topic_key_link": generate_unsub_topic_key(notification),
         "footer_do_not_email_link": generate_do_not_email(user),
-        CONTEXT_TRANSLATION_LANGUAGE_KEY: email_lang,
         CONTEXT_YEAR_KEY: now().year,
-        CONTEXT_TIMEZONE_DISPLAY_KEY: get_tz_as_text(user.timezone or "Etc/UTC"),
         **rendered.template_args,
     }
 
     plain_tmplt = (template_folder / f"{rendered.template_name}.txt").read_text()
     plain_tmplt_footer = (template_folder / "_footer.txt").read_text()
-    plain_template_args = {**template_args, CONTEXT_PLAINTEXT_KEY: True}  # Strip html from translations.
-    plain = env.from_string(plain_tmplt + plain_tmplt_footer).render(plain_template_args)
+    filter_context.plaintext = True
+    plain = env.from_string(plain_tmplt + plain_tmplt_footer).render(template_args)
 
     html_tmplt = (template_folder / "generated_html" / f"{rendered.template_name}.html").read_text()
+    filter_context.plaintext = False
     html = env.from_string(html_tmplt).render(template_args)
 
     if user.do_not_email and not rendered.is_critical:

--- a/app/backend/src/couchers/notifications/render.py
+++ b/app/backend/src/couchers/notifications/render.py
@@ -3,11 +3,11 @@ from dataclasses import dataclass
 from typing import Any
 
 from couchers import urls
-from couchers.i18n.i18n import localize_string
+from couchers.i18n.i18n import format_phone_number, localize_date_from_iso, localize_datetime_for_user, localize_string
 from couchers.models import Notification, NotificationTopicAction, User
 from couchers.notifications.quick_links import generate_quick_decline_link, generate_unsub_topic_action
 from couchers.proto import notification_data_pb2
-from couchers.templates.v2 import v2date, v2esc, v2phone, v2timestamp
+from couchers.templates.v2 import v2esc
 from couchers.utils import now, to_aware_datetime
 
 logger = logging.getLogger(__name__)
@@ -203,7 +203,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
         )
     elif notification.topic_action == NotificationTopicAction.phone_number__change:
         title = "Phone verification started"
-        message = f"You started phone number verification with the number <b>{v2phone(data.phone)}</b>."
+        message = f"You started phone number verification with the number <b>{format_phone_number(data.phone)}</b>."
         return RenderedEmailNotification(
             is_critical=True,
             subject=title,
@@ -216,8 +216,8 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
         )
     elif notification.topic_action == NotificationTopicAction.phone_number__verify:
         title = "Phone successfully verified"
-        message = f"Your phone was successfully verified as <b>{v2phone(data.phone)}</b> on Couchers.org."
-        message_plain = f"Your phone was successfully verified as {v2phone(data.phone)} on Couchers.org."
+        message = f"Your phone was successfully verified as <b>{format_phone_number(data.phone)}</b> on Couchers.org."
+        message_plain = f"Your phone was successfully verified as {format_phone_number(data.phone)} on Couchers.org."
         return RenderedEmailNotification(
             is_critical=True,
             subject=title,
@@ -244,10 +244,9 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
         )
     elif notification.topic_action == NotificationTopicAction.birthdate__change:
         title = "Your date of birth was changed"
-        message = (
-            f"Your date of birth on Couchers.org was changed to <b>{v2date(data.birthdate, user)}</b> by an admin."
-        )
-        message_plain = f"Your date of birth on Couchers.org was changed to {v2date(data.birthdate, user)} by an admin."
+        birthdate = localize_date_from_iso(data.birthdate, user.ui_language_preference or "en")
+        message = f"Your date of birth on Couchers.org was changed to <b>{birthdate}</b> by an admin."
+        message_plain = f"Your date of birth on Couchers.org was changed to {birthdate} by an admin."
         return RenderedEmailNotification(
             is_critical=True,
             subject=title,
@@ -400,7 +399,9 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
         )
     elif notification.topic == "event":
         event = data.event
-        time_display = f"{v2timestamp(event.start_time, user)} - {v2timestamp(event.end_time, user)}"
+        start_time = localize_datetime_for_user(event.start_time, user)
+        end_time = localize_datetime_for_user(event.end_time, user)
+        time_display = f"{start_time} - {end_time}"
         event_link = urls.event_link(occurrence_id=event.event_id, slug=event.slug)
         if notification.action in ["create_approved", "create_any"]:
             # create_approved = invitation, approved by mods

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -6,10 +6,11 @@ import logging
 from typing import Any, assert_never
 
 from couchers import urls
+from couchers.i18n.i18n import format_phone_number, localize_date_from_iso, localize_datetime_for_user
 from couchers.models import Notification, NotificationTopicAction, User
 from couchers.notifications.push import PushNotificationContent
 from couchers.proto import events_pb2, notification_data_pb2
-from couchers.templates.v2 import v2avatar, v2date, v2esc, v2phone, v2timestamp
+from couchers.templates.v2 import v2avatar, v2esc
 
 logger = logging.getLogger(__name__)
 
@@ -195,9 +196,10 @@ def _badge__remove(data: notification_data_pb2.BadgeRemove) -> PushNotificationC
 
 
 def _birthdate__change(data: notification_data_pb2.BirthdateChange, user: User) -> PushNotificationContent:
+    birth_date = localize_date_from_iso(data.birthdate, user.ui_language_preference or "en")
     return PushNotificationContent(
         title="Your date of birth was changed",
-        body=f"Your date of birth on Couchers.org was changed to {v2date(data.birthdate, user)} by an admin.",
+        body=f"Your date of birth on Couchers.org was changed to {birth_date} by an admin.",
         action_url=urls.account_settings_link(),
     )
 
@@ -262,7 +264,9 @@ def _email_address__verify() -> PushNotificationContent:
 
 
 def _get_event_time_display(event: events_pb2.Event, user: User) -> str:
-    return f"{v2timestamp(event.start_time, user)} - {v2timestamp(event.end_time, user)}"
+    start_time = localize_datetime_for_user(event.start_time, user)
+    end_time = localize_datetime_for_user(event.end_time, user)
+    return f"{start_time} - {end_time}"
 
 
 def _event__create_any(data: notification_data_pb2.EventCreate, user: User) -> PushNotificationContent:
@@ -378,9 +382,11 @@ def _general__new_blog_post(data: notification_data_pb2.GeneralNewBlogPost) -> P
 
 
 def _host_request__create(data: notification_data_pb2.HostRequestCreate, user: User) -> PushNotificationContent:
+    from_date = localize_date_from_iso(data.host_request.from_date, user.ui_language_preference or "en")
+    to_date = localize_date_from_iso(data.host_request.to_date, user.ui_language_preference or "en")
     return PushNotificationContent(
         title=f"{data.surfer.name} sent you a host request",
-        body=f"Dates: {v2date(data.host_request.from_date, user)} to {v2date(data.host_request.to_date, user)}.\n\n{data.text}",
+        body=f"Dates: {from_date} to {to_date}.\n\n{data.text}",
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
         icon_url=v2avatar(data.surfer),
     )
@@ -391,9 +397,11 @@ def _host_request__message(data: notification_data_pb2.HostRequestMessage, user:
         title = f"{data.user.name} sent you a message in their host request"
     else:
         title = f"{data.user.name} sent you a message in your host request"
+    from_date = localize_date_from_iso(data.host_request.from_date, user.ui_language_preference or "en")
+    to_date = localize_date_from_iso(data.host_request.to_date, user.ui_language_preference or "en")
     return PushNotificationContent(
         title=title,
-        body=f"Dates: {v2date(data.host_request.from_date, user)} to {v2date(data.host_request.to_date, user)}.\n\n{data.text}",
+        body=f"Dates: {from_date} to {to_date}.\n\n{data.text}",
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
         icon_url=v2avatar(data.user),
     )
@@ -505,7 +513,7 @@ def _password_reset__complete() -> PushNotificationContent:
 def _phone_number__change(data: notification_data_pb2.PhoneNumberChange) -> PushNotificationContent:
     return PushNotificationContent(
         title="Phone verification started",
-        body=f"You started phone number verification with the number {v2phone(data.phone)}.",
+        body=f"You started phone number verification with the number {format_phone_number(data.phone)}.",
         action_url=urls.feature_preview_link(),
     )
 
@@ -513,7 +521,7 @@ def _phone_number__change(data: notification_data_pb2.PhoneNumberChange) -> Push
 def _phone_number__verify(data: notification_data_pb2.PhoneNumberVerify) -> PushNotificationContent:
     return PushNotificationContent(
         title="Phone successfully verified",
-        body=f"Your phone was successfully verified as {v2phone(data.phone)} on Couchers.org.",
+        body=f"Your phone was successfully verified as {format_phone_number(data.phone)} on Couchers.org.",
         action_url=urls.feature_preview_link(),
     )
 

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -20,9 +20,9 @@ from sqlalchemy.orm import Session
 from couchers import urls
 from couchers.config import config
 from couchers.email import queue_email
-from couchers.i18n.i18n import localize_string
+from couchers.i18n.i18n import localize_date, localize_string, localize_time, localize_timestamp
 from couchers.models import User
-from couchers.utils import get_tz_as_text, now, to_aware_datetime
+from couchers.utils import get_tz_as_text, now
 
 logger = logging.getLogger(__name__)
 
@@ -65,17 +65,17 @@ def v2date(value: date | str, user: User) -> str:
     # todo: user locale-based date formatting
     if isinstance(value, str):
         value = date.fromisoformat(value)
-    return value.strftime("%A %-d %B %Y")
+    return localize_date(value, user.ui_language_preference or "en")
 
 
 def v2time(value: datetime, user: User) -> str:
-    tz = ZoneInfo(user.timezone or "Etc/UTC")
-    return value.astimezone(tz=tz).strftime("%-I:%M %p (%H:%M)")
+    value = value.astimezone(ZoneInfo(user.timezone or "Etc/UTC"))
+    return localize_time(value, user.ui_language_preference or "en")
 
 
 def v2timestamp(value: Timestamp, user: User) -> str:
     tz = ZoneInfo(user.timezone or "Etc/UTC")
-    return to_aware_datetime(value).astimezone(tz=tz).strftime("%A %-d %B %Y at %-I:%M %p (%H:%M)")
+    return localize_timestamp(value, tz, user.ui_language_preference or "en")
 
 
 def v2avatar(user: Any) -> str:

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -37,7 +37,7 @@ md = MarkdownIt("zero", {"typographer": True}).enable(["smartquotes", "heading",
 CONTEXT_YEAR_KEY = "_year"
 
 
-@dataclass(slots=True, kw_only=True)
+@dataclass(frozen=True, slots=True, kw_only=True)
 class FilterContext:
     """Context passed to filter functions."""
 
@@ -184,26 +184,29 @@ def send_simple_pretty_email(
 
     It's for the few security emails where we don't have a user to email but send directly to an email address.
     """
-    filter_context = FilterContext(
+
+    template_args[CONTEXT_YEAR_KEY] = now().year
+    template_args["header_subject"] = subject
+    template_args["footer_email_is_critical"] = True  # Results in no unsubscribe footer.
+
+    # Format plaintext template
+    template_args[FilterContext.KEY] = FilterContext(
         # Not yet localizable
         timezone=ZoneInfo("Etc/UTC"),
         locale="en",
         plaintext=True,
     )
-
-    template_args[FilterContext.KEY] = filter_context
-
-    template_args[CONTEXT_YEAR_KEY] = now().year
-
-    template_args["header_subject"] = subject
-    template_args["footer_email_is_critical"] = True  # Results in no unsubscribe footer.
-
     plain_tmplt = (template_folder / f"{template_name}.txt").read_text()
     plain_tmplt_footer = (template_folder / "_footer.txt").read_text()
-    filter_context.plaintext = True
     plain = env.from_string(plain_tmplt + plain_tmplt_footer).render(template_args)
 
-    filter_context.plaintext = False
+    # Format html template
+    template_args[FilterContext.KEY] = FilterContext(
+        # Not yet localizable
+        timezone=ZoneInfo("Etc/UTC"),
+        locale="en",
+        plaintext=False,
+    )
     html_tmplt = (template_folder / "generated_html" / f"{template_name}.html").read_text()
     html = env.from_string(html_tmplt).render(template_args)
 

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -2,15 +2,15 @@
 template mailer/push notification formatter v2
 """
 
+from dataclasses import dataclass
 import logging
 import re
 from datetime import date, datetime
 from html import escape
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 from zoneinfo import ZoneInfo
 
-import phonenumbers
 from google.protobuf.timestamp_pb2 import Timestamp
 from jinja2 import Environment, FileSystemLoader, pass_context
 from jinja2.runtime import Context
@@ -20,9 +20,8 @@ from sqlalchemy.orm import Session
 from couchers import urls
 from couchers.config import config
 from couchers.email import queue_email
-from couchers.i18n.i18n import localize_date, localize_string, localize_time, localize_timestamp
-from couchers.models import User
-from couchers.utils import get_tz_as_text, now
+from couchers.i18n.i18n import format_phone_number, localize_date, localize_string, localize_time, localize_datetime
+from couchers.utils import now
 
 logger = logging.getLogger(__name__)
 
@@ -36,9 +35,26 @@ md = MarkdownIt("zero", {"typographer": True}).enable(["smartquotes", "heading",
 
 # Special context values expected by v2 filters
 CONTEXT_YEAR_KEY = "_year"
-CONTEXT_TIMEZONE_DISPLAY_KEY = "_timezone_display"
-CONTEXT_TRANSLATION_LANGUAGE_KEY = "_lang"
-CONTEXT_PLAINTEXT_KEY = "_plain"
+
+@dataclass(slots=True, kw_only=True)
+class FilterContext:
+    """Context passed to filter functions."""
+
+    KEY: ClassVar[str] = "_filter_context"
+
+    timezone: ZoneInfo
+    """The timezone to use when formatting times."""
+
+    locale: str
+    """The locale to use when localizing strings or formatting times."""
+
+    plaintext: bool
+    """If true, strips html tags from localized strings."""
+
+    @staticmethod
+    def get(jinja2_context: Context) -> FilterContext:
+        filter_context: FilterContext = jinja2_context[FilterContext.KEY]
+        return filter_context
 
 
 def v2esc(value: Any) -> str:
@@ -58,24 +74,26 @@ def v2url(value: str) -> str:
 
 
 def v2phone(value: str) -> str:
-    return phonenumbers.format_number(phonenumbers.parse(value), phonenumbers.PhoneNumberFormat.INTERNATIONAL)
+    return format_phone_number(value)
 
 
-def v2date(value: date | str, user: User) -> str:
-    # todo: user locale-based date formatting
-    if isinstance(value, str):
-        value = date.fromisoformat(value)
-    return localize_date(value, user.ui_language_preference or "en")
+@pass_context
+def v2date(context: Context, value: date) -> str:
+    filter_context = FilterContext.get(context)
+    return localize_date(value, filter_context.locale)
 
 
-def v2time(value: datetime, user: User) -> str:
-    value = value.astimezone(ZoneInfo(user.timezone or "Etc/UTC"))
-    return localize_time(value, user.ui_language_preference or "en")
+@pass_context
+def v2time(context: Context, value: datetime) -> str:
+    filter_context = FilterContext.get(context)
+    value = value.astimezone(filter_context.timezone)
+    return localize_time(value.time(), filter_context.locale)
 
 
-def v2timestamp(value: Timestamp, user: User) -> str:
-    tz = ZoneInfo(user.timezone or "Etc/UTC")
-    return localize_timestamp(value, tz, user.ui_language_preference or "en")
+@pass_context
+def v2timestamp(context: Context, value: Timestamp) -> str:
+    filter_context = FilterContext.get(context)
+    return localize_datetime(value, filter_context.timezone, filter_context.locale)
 
 
 def v2avatar(user: Any) -> str:
@@ -115,16 +133,16 @@ def v2translate(context: Context, key: str, **kwargs: Any) -> str:
         {{ "greeting_key"|v2translate(name=user.name) }}
     """
 
-    lang: str = context[CONTEXT_TRANSLATION_LANGUAGE_KEY]
+    filter_context = FilterContext.get(context)
 
     # Prevent html injection
     escaped_substitutions = {k: escape(str(v)) for k, v in kwargs.items()}
 
-    translated = localize_string(lang, key, substitutions=escaped_substitutions)
+    translated = localize_string(filter_context.locale, key, substitutions=escaped_substitutions)
 
     # Translations may include simple formatting HTML like <b> or <a>,
     # but those should not appear in plain text emails.
-    if context.parent.get(CONTEXT_PLAINTEXT_KEY) == True:
+    if filter_context.plaintext:
         # Doesn't support nesting, but should be sufficient for our needs
         translated = re.sub(r"<(\w+).*?>(.*?)</\1>", replace_tag, translated)
         translated = re.sub(r"<br\s*/?>", "\n", translated)
@@ -163,17 +181,26 @@ def send_simple_pretty_email(
 
     It's for the few security emails where we don't have a user to email but send directly to an email address.
     """
-    template_args[CONTEXT_TRANSLATION_LANGUAGE_KEY] = "en"  # Not yet localizable
+    filter_context = FilterContext(
+        # Not yet localizable
+        timezone=ZoneInfo("Etc/UTC"),
+        locale="en",
+        plaintext=True
+    )
+
+    template_args[FilterContext.KEY] = filter_context
+
     template_args[CONTEXT_YEAR_KEY] = now().year
-    template_args[CONTEXT_TIMEZONE_DISPLAY_KEY] = get_tz_as_text("Etc/UTC")
 
     template_args["header_subject"] = subject
     template_args["footer_email_is_critical"] = True  # Results in no unsubscribe footer.
 
     plain_tmplt = (template_folder / f"{template_name}.txt").read_text()
     plain_tmplt_footer = (template_folder / "_footer.txt").read_text()
+    filter_context.plaintext = True
     plain = env.from_string(plain_tmplt + plain_tmplt_footer).render(template_args)
 
+    filter_context.plaintext = False
     html_tmplt = (template_folder / "generated_html" / f"{template_name}.html").read_text()
     html = env.from_string(html_tmplt).render(template_args)
 

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -2,9 +2,9 @@
 template mailer/push notification formatter v2
 """
 
-from dataclasses import dataclass
 import logging
 import re
+from dataclasses import dataclass
 from datetime import date, datetime
 from html import escape
 from pathlib import Path
@@ -20,7 +20,7 @@ from sqlalchemy.orm import Session
 from couchers import urls
 from couchers.config import config
 from couchers.email import queue_email
-from couchers.i18n.i18n import format_phone_number, localize_date, localize_string, localize_time, localize_datetime
+from couchers.i18n.i18n import format_phone_number, localize_date, localize_datetime, localize_string, localize_time
 from couchers.utils import now
 
 logger = logging.getLogger(__name__)
@@ -35,6 +35,7 @@ md = MarkdownIt("zero", {"typographer": True}).enable(["smartquotes", "heading",
 
 # Special context values expected by v2 filters
 CONTEXT_YEAR_KEY = "_year"
+
 
 @dataclass(slots=True, kw_only=True)
 class FilterContext:
@@ -78,8 +79,10 @@ def v2phone(value: str) -> str:
 
 
 @pass_context
-def v2date(context: Context, value: date) -> str:
+def v2date(context: Context, value: date | str) -> str:
     filter_context = FilterContext.get(context)
+    if isinstance(value, str):
+        value = date.fromisoformat(value)
     return localize_date(value, filter_context.locale)
 
 
@@ -185,7 +188,7 @@ def send_simple_pretty_email(
         # Not yet localizable
         timezone=ZoneInfo("Etc/UTC"),
         locale="en",
-        plaintext=True
+        plaintext=True,
     )
 
     template_args[FilterContext.KEY] = filter_context

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -53,7 +53,7 @@ class FilterContext:
     """If true, strips html tags from localized strings."""
 
     @staticmethod
-    def get(jinja2_context: Context) -> FilterContext:
+    def from_jinja(jinja2_context: Context) -> FilterContext:
         filter_context: FilterContext = jinja2_context[FilterContext.KEY]
         return filter_context
 
@@ -80,7 +80,7 @@ def v2phone(value: str) -> str:
 
 @pass_context
 def v2date(context: Context, value: date | str) -> str:
-    filter_context = FilterContext.get(context)
+    filter_context = FilterContext.from_jinja(context)
     if isinstance(value, str):
         value = date.fromisoformat(value)
     return localize_date(value, filter_context.locale)
@@ -88,14 +88,14 @@ def v2date(context: Context, value: date | str) -> str:
 
 @pass_context
 def v2time(context: Context, value: datetime) -> str:
-    filter_context = FilterContext.get(context)
+    filter_context = FilterContext.from_jinja(context)
     value = value.astimezone(filter_context.timezone)
     return localize_time(value.time(), filter_context.locale)
 
 
 @pass_context
 def v2timestamp(context: Context, value: Timestamp) -> str:
-    filter_context = FilterContext.get(context)
+    filter_context = FilterContext.from_jinja(context)
     return localize_datetime(value, filter_context.timezone, filter_context.locale)
 
 
@@ -136,7 +136,7 @@ def v2translate(context: Context, key: str, **kwargs: Any) -> str:
         {{ "greeting_key"|v2translate(name=user.name) }}
     """
 
-    filter_context = FilterContext.get(context)
+    filter_context = FilterContext.from_jinja(context)
 
     # Prevent html injection
     escaped_substitutions = {k: escape(str(v)) for k, v in kwargs.items()}

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -12,6 +12,7 @@ from couchers.constants import DATETIME_INFINITY
 from couchers.context import make_background_user_context
 from couchers.crypto import b64decode
 from couchers.db import session_scope
+from couchers.i18n.i18n import localize_datetime_for_user
 from couchers.jobs.worker import process_job
 from couchers.models import (
     DeviceType,
@@ -38,7 +39,6 @@ from couchers.proto import (
 )
 from couchers.proto.internal import unsubscribe_pb2
 from couchers.servicers.api import user_model_to_pb
-from couchers.templates.v2 import v2timestamp
 from couchers.utils import not_none, now
 from tests.fixtures.db import generate_user
 from tests.fixtures.misc import PushCollector, email_fields, mock_notification_email, process_jobs
@@ -596,7 +596,7 @@ def test_event_reminder_email_sent(db):
     user, token = generate_user()
     title = "Board Game Night"
     start_event_time = timestamp_pb2.Timestamp(seconds=1751690400)
-    expected_time_str = v2timestamp(start_event_time, user)
+    expected_time_str = localize_datetime_for_user(start_event_time, user)
 
     with mock_notification_email() as mock:
         with session_scope() as session:

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -10,6 +10,7 @@ from sqlalchemy_utils import refresh_materialized_view
 from couchers.constants import HOST_REQUEST_MIN_LENGTH_UTF16
 from couchers.crypto import b64decode
 from couchers.db import session_scope
+from couchers.i18n.i18n import localize_date
 from couchers.models import (
     Message,
     MessageType,
@@ -23,7 +24,6 @@ from couchers.proto import (
 )
 from couchers.proto.internal import unsubscribe_pb2
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_HOURS
-from couchers.templates.v2 import v2date
 from couchers.utils import create_coordinate, now, today
 from tests.fixtures.db import generate_user
 from tests.fixtures.misc import PushCollector, email_fields, mock_notification_email
@@ -57,16 +57,19 @@ def test_create_request(db, moderator):
         geom_radius=hosting_radius,
     )
 
-    today_plus_2 = (today() + timedelta(days=2)).isoformat()
-    today_plus_3 = (today() + timedelta(days=3)).isoformat()
-    today_minus_2 = (today() - timedelta(days=2)).isoformat()
-    today_minus_3 = (today() - timedelta(days=3)).isoformat()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
+    today_minus_2 = today() - timedelta(days=2)
+    today_minus_3 = today() - timedelta(days=3)
 
     with requests_session(token1) as api:
         with pytest.raises(grpc.RpcError) as e:
             api.CreateHostRequest(
                 requests_pb2.CreateHostRequestReq(
-                    host_user_id=user1.id, from_date=today_plus_2, to_date=today_plus_3, text=valid_request_text()
+                    host_user_id=user1.id,
+                    from_date=today_plus_2.isoformat(),
+                    to_date=today_plus_3.isoformat(),
+                    text=valid_request_text(),
                 )
             )
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
@@ -75,7 +78,10 @@ def test_create_request(db, moderator):
         with pytest.raises(grpc.RpcError) as e:
             api.CreateHostRequest(
                 requests_pb2.CreateHostRequestReq(
-                    host_user_id=999, from_date=today_plus_2, to_date=today_plus_3, text=valid_request_text()
+                    host_user_id=999,
+                    from_date=today_plus_2.isoformat(),
+                    to_date=today_plus_3.isoformat(),
+                    text=valid_request_text(),
                 )
             )
         assert e.value.code() == grpc.StatusCode.NOT_FOUND
@@ -84,7 +90,10 @@ def test_create_request(db, moderator):
         with pytest.raises(grpc.RpcError) as e:
             api.CreateHostRequest(
                 requests_pb2.CreateHostRequestReq(
-                    host_user_id=user2.id, from_date=today_plus_3, to_date=today_plus_2, text=valid_request_text()
+                    host_user_id=user2.id,
+                    from_date=today_plus_3.isoformat(),
+                    to_date=today_plus_2.isoformat(),
+                    text=valid_request_text(),
                 )
             )
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
@@ -93,7 +102,10 @@ def test_create_request(db, moderator):
         with pytest.raises(grpc.RpcError) as e:
             api.CreateHostRequest(
                 requests_pb2.CreateHostRequestReq(
-                    host_user_id=user2.id, from_date=today_minus_3, to_date=today_plus_2, text=valid_request_text()
+                    host_user_id=user2.id,
+                    from_date=today_minus_3.isoformat(),
+                    to_date=today_plus_2.isoformat(),
+                    text=valid_request_text(),
                 )
             )
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
@@ -102,7 +114,10 @@ def test_create_request(db, moderator):
         with pytest.raises(grpc.RpcError) as e:
             api.CreateHostRequest(
                 requests_pb2.CreateHostRequestReq(
-                    host_user_id=user2.id, from_date=today_plus_2, to_date=today_minus_2, text=valid_request_text()
+                    host_user_id=user2.id,
+                    from_date=today_plus_2.isoformat(),
+                    to_date=today_minus_2.isoformat(),
+                    text=valid_request_text(),
                 )
             )
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
@@ -111,7 +126,10 @@ def test_create_request(db, moderator):
         with pytest.raises(grpc.RpcError) as e:
             api.CreateHostRequest(
                 requests_pb2.CreateHostRequestReq(
-                    host_user_id=user2.id, from_date="2020-00-06", to_date=today_minus_2, text=valid_request_text()
+                    host_user_id=user2.id,
+                    from_date="2020-00-06",
+                    to_date=today_minus_2.isoformat(),
+                    text=valid_request_text(),
                 )
             )
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
@@ -120,7 +138,10 @@ def test_create_request(db, moderator):
         with pytest.raises(grpc.RpcError) as e:
             api.CreateHostRequest(
                 requests_pb2.CreateHostRequestReq(
-                    host_user_id=user2.id, from_date=today_plus_2, to_date=today_plus_3, text="Too short."
+                    host_user_id=user2.id,
+                    from_date=today_plus_2.isoformat(),
+                    to_date=today_plus_3.isoformat(),
+                    text="Too short.",
                 )
             )
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
@@ -129,8 +150,8 @@ def test_create_request(db, moderator):
         res = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text(),
             )
         )
@@ -153,14 +174,14 @@ def test_create_request(db, moderator):
 
     today_ = today()
     today_plus_one_year = today_ + timedelta(days=365)
-    today_plus_one_year_plus_2 = (today_plus_one_year + timedelta(days=2)).isoformat()
-    today_plus_one_year_plus_3 = (today_plus_one_year + timedelta(days=3)).isoformat()
+    today_plus_one_year_plus_2 = today_plus_one_year + timedelta(days=2)
+    today_plus_one_year_plus_3 = today_plus_one_year + timedelta(days=3)
     with pytest.raises(grpc.RpcError) as e:
         api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_one_year_plus_2,
-                to_date=today_plus_one_year_plus_3,
+                from_date=today_plus_one_year_plus_2.isoformat(),
+                to_date=today_plus_one_year_plus_3.isoformat(),
                 text=valid_request_text("Test from date after one year"),
             )
         )
@@ -171,8 +192,8 @@ def test_create_request(db, moderator):
         api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_one_year_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_one_year_plus_3.isoformat(),
                 text=valid_request_text("Test to date one year after from date"),
             )
         )
@@ -183,13 +204,16 @@ def test_create_request(db, moderator):
 def test_create_request_incomplete_profile(db):
     user1, token1 = generate_user(complete_profile=False)
     user2, _ = generate_user()
-    today_plus_2 = (today() + timedelta(days=2)).isoformat()
-    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
     with requests_session(token1) as api:
         with pytest.raises(grpc.RpcError) as e:
             api.CreateHostRequest(
                 requests_pb2.CreateHostRequestReq(
-                    host_user_id=user2.id, from_date=today_plus_2, to_date=today_plus_3, text=valid_request_text()
+                    host_user_id=user2.id,
+                    from_date=today_plus_2.isoformat(),
+                    to_date=today_plus_3.isoformat(),
+                    text=valid_request_text(),
                 )
             )
     assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
@@ -199,8 +223,8 @@ def test_create_request_incomplete_profile(db):
 def test_excessive_requests_are_reported(db):
     """Test that excessive host requests are first reported in a warning email and finally lead blocking of further requests."""
     user, token = generate_user()
-    today_plus_2 = (today() + timedelta(days=2)).isoformat()
-    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
     rate_limit_definition = RATE_LIMIT_DEFINITIONS[RateLimitAction.host_request]
     with requests_session(token) as api:
         # Test warning email
@@ -210,8 +234,8 @@ def test_excessive_requests_are_reported(db):
                 _ = api.CreateHostRequest(
                     requests_pb2.CreateHostRequestReq(
                         host_user_id=host_user.id,
-                        from_date=today_plus_2,
-                        to_date=today_plus_3,
+                        from_date=today_plus_2.isoformat(),
+                        to_date=today_plus_3.isoformat(),
                         text=valid_request_text(),
                     )
                 )
@@ -221,8 +245,8 @@ def test_excessive_requests_are_reported(db):
             _ = api.CreateHostRequest(
                 requests_pb2.CreateHostRequestReq(
                     host_user_id=host_user.id,
-                    from_date=today_plus_2,
-                    to_date=today_plus_3,
+                    from_date=today_plus_2.isoformat(),
+                    to_date=today_plus_3.isoformat(),
                     text=valid_request_text("Excessive test request"),
                 )
             )
@@ -239,8 +263,8 @@ def test_excessive_requests_are_reported(db):
                 _ = api.CreateHostRequest(
                     requests_pb2.CreateHostRequestReq(
                         host_user_id=host_user.id,
-                        from_date=today_plus_2,
-                        to_date=today_plus_3,
+                        from_date=today_plus_2.isoformat(),
+                        to_date=today_plus_3.isoformat(),
                         text=valid_request_text(),
                     )
                 )
@@ -251,8 +275,8 @@ def test_excessive_requests_are_reported(db):
                 _ = api.CreateHostRequest(
                     requests_pb2.CreateHostRequestReq(
                         host_user_id=host_user.id,
-                        from_date=today_plus_2,
-                        to_date=today_plus_3,
+                        from_date=today_plus_2.isoformat(),
+                        to_date=today_plus_3.isoformat(),
                         text=valid_request_text("Excessive test request"),
                     )
                 )
@@ -283,14 +307,14 @@ def test_GetHostRequest(db):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
     user3, token3 = generate_user()
-    today_plus_2 = (today() + timedelta(days=2)).isoformat()
-    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
     with requests_session(token1) as api:
         host_request_id = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test request 1"),
             )
         ).host_request_id
@@ -312,14 +336,14 @@ def test_ListHostRequests(db, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
     user3, token3 = generate_user()
-    today_plus_2 = (today() + timedelta(days=2)).isoformat()
-    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
     with requests_session(token1) as api:
         host_request_1 = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test request 1"),
             )
         ).host_request_id
@@ -327,8 +351,8 @@ def test_ListHostRequests(db, moderator):
         host_request_2 = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user3.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test request 2"),
             )
         ).host_request_id
@@ -360,8 +384,8 @@ def test_ListHostRequests(db, moderator):
         host_request_3 = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user1.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test request 3"),
             )
         ).host_request_id
@@ -391,14 +415,14 @@ def test_ListHostRequests_pagination_regression(db, moderator):
     """
     user1, token1 = generate_user()
     user2, token2 = generate_user()
-    today_plus_2 = (today() + timedelta(days=2)).isoformat()
-    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
     with requests_session(token1) as api:
         host_request_1 = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test request 1"),
             )
         ).host_request_id
@@ -406,8 +430,8 @@ def test_ListHostRequests_pagination_regression(db, moderator):
         host_request_2 = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test request 2"),
             )
         ).host_request_id
@@ -415,8 +439,8 @@ def test_ListHostRequests_pagination_regression(db, moderator):
         host_request_3 = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test request 3"),
             )
         ).host_request_id
@@ -486,15 +510,15 @@ def test_ListHostRequests_pagination_regression(db, moderator):
 def test_ListHostRequests_active_filter(db, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
-    today_plus_2 = (today() + timedelta(days=2)).isoformat()
-    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
 
     with requests_session(token1) as api:
         request_id = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test request 1"),
             )
         ).host_request_id
@@ -519,15 +543,15 @@ def test_RespondHostRequests(db, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
     user3, token3 = generate_user()
-    today_plus_2 = (today() + timedelta(days=2)).isoformat()
-    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
 
     with requests_session(token1) as api:
         request_id = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test request 1"),
             )
         ).host_request_id
@@ -650,14 +674,14 @@ def test_RespondHostRequests(db, moderator):
 def test_get_host_request_messages(db, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
-    today_plus_2 = (today() + timedelta(days=2)).isoformat()
-    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
     with requests_session(token1) as api:
         res = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test request 1"),
             )
         )
@@ -723,14 +747,14 @@ def test_SendHostRequestMessage(db, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
     user3, token3 = generate_user()
-    today_plus_2 = (today() + timedelta(days=2)).isoformat()
-    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
     with requests_session(token1) as api:
         host_request_id = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test request 1"),
             )
         ).host_request_id
@@ -815,14 +839,14 @@ def test_get_updates(db, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
     user3, token3 = generate_user()
-    today_plus_2 = (today() + timedelta(days=2)).isoformat()
-    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
     with requests_session(token1) as api:
         host_request_id = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test message 0"),
             )
         ).host_request_id
@@ -847,8 +871,8 @@ def test_get_updates(db, moderator):
         api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test message 4"),
             )
         )
@@ -899,15 +923,15 @@ def test_archive_host_request(db, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
 
-    today_plus_2 = (today() + timedelta(days=2)).isoformat()
-    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
 
     with requests_session(token1) as api:
         host_request_id = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test message 0"),
             )
         ).host_request_id
@@ -944,14 +968,14 @@ def test_mark_last_seen(db, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
     user3, token3 = generate_user()
-    today_plus_2 = (today() + timedelta(days=2)).isoformat()
-    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
     with requests_session(token1) as api:
         host_request_id = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test message 0"),
             )
         ).host_request_id
@@ -959,8 +983,8 @@ def test_mark_last_seen(db, moderator):
         host_request_id_2 = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test message 0a"),
             )
         ).host_request_id
@@ -1015,8 +1039,8 @@ def test_mark_last_seen(db, moderator):
         host_request_id_3 = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user1.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Another test request"),
             )
         ).host_request_id
@@ -1049,8 +1073,8 @@ def test_response_rate(db, moderator):
     user2, token2 = generate_user()
     user3, token3 = generate_user(delete_user=True)
 
-    today_plus_2 = (today() + timedelta(days=2)).isoformat()
-    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
 
     with session_scope() as session:
         refresh_materialized_view(session, "user_response_rates")
@@ -1070,8 +1094,8 @@ def test_response_rate(db, moderator):
         host_request_1 = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test request"),
             )
         ).host_request_id
@@ -1092,8 +1116,8 @@ def test_response_rate(db, moderator):
         host_request_2 = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test request"),
             )
         ).host_request_id
@@ -1114,8 +1138,8 @@ def test_response_rate(db, moderator):
         host_request_3 = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test request"),
             )
         ).host_request_id
@@ -1195,8 +1219,8 @@ def test_response_rate(db, moderator):
         host_request_4 = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test request"),
             )
         ).host_request_id
@@ -1213,8 +1237,8 @@ def test_response_rate(db, moderator):
         host_request_5 = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=user2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("Test request"),
             )
         ).host_request_id
@@ -1277,15 +1301,15 @@ def test_request_notifications(db, push_collector: PushCollector, moderator):
     host, host_token = generate_user(complete_profile=True)
     surfer, surfer_token = generate_user(complete_profile=True)
 
-    today_plus_2 = (today() + timedelta(days=2)).isoformat()
-    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
 
     with requests_session(surfer_token) as api:
         hr_id = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=host.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("can i stay plz"),
             )
         ).host_request_id
@@ -1303,10 +1327,10 @@ def test_request_notifications(db, push_collector: PushCollector, moderator):
     assert "quick decline" in e.html.lower()
     assert surfer.name in e.plain
     assert surfer.name in e.html
-    assert v2date(today_plus_2, host) in e.plain
-    assert v2date(today_plus_2, host) in e.html
-    assert v2date(today_plus_3, host) in e.plain
-    assert v2date(today_plus_3, host) in e.html
+    assert localize_date(today_plus_2, host.ui_language_preference or "en") in e.plain
+    assert localize_date(today_plus_2, host.ui_language_preference or "en") in e.html
+    assert localize_date(today_plus_3, host.ui_language_preference or "en") in e.plain
+    assert localize_date(today_plus_3, host.ui_language_preference or "en") in e.html
     assert "http://localhost:5001/img/thumbnail/" not in e.plain
     assert "http://localhost:5001/img/thumbnail/" in e.html
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.plain
@@ -1331,10 +1355,10 @@ def test_request_notifications(db, push_collector: PushCollector, moderator):
     assert host.name in e.html
     assert surfer.name in e.plain
     assert surfer.name in e.html
-    assert v2date(today_plus_2, surfer) in e.plain
-    assert v2date(today_plus_2, surfer) in e.html
-    assert v2date(today_plus_3, surfer) in e.plain
-    assert v2date(today_plus_3, surfer) in e.html
+    assert localize_date(today_plus_2, surfer.ui_language_preference or "en") in e.plain
+    assert localize_date(today_plus_2, surfer.ui_language_preference or "en") in e.html
+    assert localize_date(today_plus_3, surfer.ui_language_preference or "en") in e.plain
+    assert localize_date(today_plus_3, surfer.ui_language_preference or "en") in e.html
     assert "http://localhost:5001/img/thumbnail/" not in e.plain
     assert "http://localhost:5001/img/thumbnail/" in e.html
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.plain
@@ -1347,15 +1371,15 @@ def test_quick_decline(db, push_collector: PushCollector, moderator):
     host, host_token = generate_user(complete_profile=True)
     surfer, surfer_token = generate_user(complete_profile=True)
 
-    today_plus_2 = (today() + timedelta(days=2)).isoformat()
-    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
 
     with requests_session(surfer_token) as api:
         hr_id = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=host.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("can i stay plz"),
             )
         ).host_request_id
@@ -1373,10 +1397,10 @@ def test_quick_decline(db, push_collector: PushCollector, moderator):
     assert "quick decline" in e.html.lower()
     assert surfer.name in e.plain
     assert surfer.name in e.html
-    assert v2date(today_plus_2, host) in e.plain
-    assert v2date(today_plus_2, host) in e.html
-    assert v2date(today_plus_3, host) in e.plain
-    assert v2date(today_plus_3, host) in e.html
+    assert localize_date(today_plus_2, host.ui_language_preference or "en") in e.plain
+    assert localize_date(today_plus_2, host.ui_language_preference or "en") in e.html
+    assert localize_date(today_plus_3, host.ui_language_preference or "en") in e.plain
+    assert localize_date(today_plus_3, host.ui_language_preference or "en") in e.html
     assert "http://localhost:5001/img/thumbnail/" not in e.plain
     assert "http://localhost:5001/img/thumbnail/" in e.html
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.plain
@@ -1418,31 +1442,31 @@ def test_host_req_feedback(db, moderator):
     host3, host3_token = generate_user(complete_profile=True)
     surfer, surfer_token = generate_user(complete_profile=True)
 
-    today_plus_2 = (today() + timedelta(days=2)).isoformat()
-    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
 
     with requests_session(surfer_token) as api:
         hr_id = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=host.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("can i stay plz"),
             )
         ).host_request_id
         hr2_id = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=host2.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("can i stay plz"),
             )
         ).host_request_id
         hr3_id = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=host3.id,
-                from_date=today_plus_2,
-                to_date=today_plus_3,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
                 text=valid_request_text("can i stay plz"),
             )
         ).host_request_id

--- a/app/backend/src/tests/test_templates.py
+++ b/app/backend/src/tests/test_templates.py
@@ -2,14 +2,14 @@
 
 from typing import Any
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 from jinja2 import Environment
 
 from couchers.i18n.i18next import I18Next
 from couchers.i18n.plurals import PluralRules
 from couchers.templates.v2 import (
-    CONTEXT_PLAINTEXT_KEY,
-    CONTEXT_TRANSLATION_LANGUAGE_KEY,
+    FilterContext,
     add_filters,
 )
 
@@ -25,12 +25,8 @@ def _render_template(
     lang: str = "en",
 ) -> str:
     template = _env.from_string(template_str)
-    template_args = {
-        **(template_args or {}),
-        CONTEXT_TRANSLATION_LANGUAGE_KEY: lang,
-    }
-    if plain:
-        template_args[CONTEXT_PLAINTEXT_KEY] = True
+    template_args = (template_args or {}).copy()
+    template_args[FilterContext.KEY] = FilterContext(timezone=ZoneInfo("Etc/UTC"), locale=lang, plaintext=plain)
 
     mock_i18next = I18Next()
     for lang_code, strings in translation_dict.items():

--- a/app/backend/templates/v2/api_key.mjml
+++ b/app/backend/templates/v2/api_key.mjml
@@ -11,7 +11,7 @@
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>The key expires {{ expiry|v2timestamp(user) }}.</mj-text>
+    <mj-text>The key expires {{ expiry|v2timestamp }}.</mj-text>
     <mj-text>This API key is unique to your account; do not share it with anyone, it gives complete access to your account, and you are reponsible for any actions taken using this API key.</mj-text>
     <mj-text>Please remember to abide by our Terms of Service, our Community Guidelines, and other policies while using our APIs. All access is logged and analyzed, and we may terminate your access or account if you abuse the service.</mj-text>
     <mj-text>If you did not initiate this action, please contact us by emailing <a href="mailto:support@couchers.org">support@couchers.org</a> so we can sort this out as soon as possible!</mj-text>

--- a/app/backend/templates/v2/api_key.txt
+++ b/app/backend/templates/v2/api_key.txt
@@ -4,7 +4,7 @@ You recently requested an API key for Couchers.org. We've issued you with the fo
 
 {{ api_key }}
 
-The key expires {{ expiry|v2timestamp(user) }}.
+The key expires {{ expiry|v2timestamp }}.
 
 This API key is unique to your account; do not share it with anyone, it gives complete access to your account, and you are reponsible for any actions taken using this API key.</mj-text>
 

--- a/app/backend/templates/v2/chat_message.mjml
+++ b/app/backend/templates/v2/chat_message.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
     <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>{{ message|v2esc }}</b> at {{ time|v2time(user) }}.</mj-text>
+    <mj-text><b>{{ message|v2esc }}</b> at {{ time|v2time }}.</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">

--- a/app/backend/templates/v2/chat_message.txt
+++ b/app/backend/templates/v2/chat_message.txt
@@ -1,6 +1,6 @@
 Hi {{ user.name }},
 
-{{ message }} at {{ time|v2time(user) }}.
+{{ message }} at {{ time|v2time }}.
 
 
 The message is below:

--- a/app/backend/templates/v2/friend_reference.mjml
+++ b/app/backend/templates/v2/friend_reference.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
     <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>{{ from_user.name|v2esc }} wrote a friend reference for you</b> at {{ time|v2time(user) }}!</mj-text>
+    <mj-text><b>{{ from_user.name|v2esc }} wrote a friend reference for you</b> at {{ time|v2time }}!</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">

--- a/app/backend/templates/v2/friend_request.mjml
+++ b/app/backend/templates/v2/friend_request.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
     <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>You've received a friend request from {{ other.name|v2esc }}</b> at {{ time|v2time(user) }}!</mj-text>
+    <mj-text><b>You've received a friend request from {{ other.name|v2esc }}</b> at {{ time|v2time }}!</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">

--- a/app/backend/templates/v2/friend_request_accepted.mjml
+++ b/app/backend/templates/v2/friend_request_accepted.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
     <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>{{ other.name|v2esc }} has accepted your friend request</b> at {{ time|v2time(user) }}!</mj-text>
+    <mj-text><b>{{ other.name|v2esc }} has accepted your friend request</b> at {{ time|v2time }}!</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">

--- a/app/backend/templates/v2/generated_html/api_key.html
+++ b/app/backend/templates/v2/generated_html/api_key.html
@@ -228,7 +228,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">The key expires {{ expiry|v2timestamp(user) }}.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">The key expires {{ expiry|v2timestamp }}.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/chat_message.html
+++ b/app/backend/templates/v2/generated_html/chat_message.html
@@ -172,7 +172,7 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ message|v2esc }}</b> at {{ time|v2time(user) }}.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ message|v2esc }}</b> at {{ time|v2time }}.</div>
                                 </td>
                               </tr>
                             </tbody>

--- a/app/backend/templates/v2/generated_html/friend_reference.html
+++ b/app/backend/templates/v2/generated_html/friend_reference.html
@@ -172,7 +172,7 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ from_user.name|v2esc }} wrote a friend reference for you</b> at {{ time|v2time(user) }}!</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ from_user.name|v2esc }} wrote a friend reference for you</b> at {{ time|v2time }}!</div>
                                 </td>
                               </tr>
                             </tbody>

--- a/app/backend/templates/v2/generated_html/friend_request.html
+++ b/app/backend/templates/v2/generated_html/friend_request.html
@@ -172,7 +172,7 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>You've received a friend request from {{ other.name|v2esc }}</b> at {{ time|v2time(user) }}!</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>You've received a friend request from {{ other.name|v2esc }}</b> at {{ time|v2time }}!</div>
                                 </td>
                               </tr>
                             </tbody>

--- a/app/backend/templates/v2/generated_html/friend_request_accepted.html
+++ b/app/backend/templates/v2/generated_html/friend_request_accepted.html
@@ -172,7 +172,7 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ other.name|v2esc }} has accepted your friend request</b> at {{ time|v2time(user) }}!</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ other.name|v2esc }} has accepted your friend request</b> at {{ time|v2time }}!</div>
                                 </td>
                               </tr>
                             </tbody>

--- a/app/backend/templates/v2/generated_html/host_request__message.html
+++ b/app/backend/templates/v2/generated_html/host_request__message.html
@@ -172,7 +172,7 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ message|v2esc }}</b> at {{ time|v2time(user) }}.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ message|v2esc }}</b> at {{ time|v2time }}.</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -203,7 +203,7 @@
                                       </td>
                                       <td>
                                         <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br>{{ other.city|v2esc }}
-                                        <br>From <b>{{ host_request.from_date|v2date(user) }}</b> to <b>{{ host_request.to_date|v2date(user) }}</b>.
+                                        <br>From <b>{{ host_request.from_date|v2date }}</b> to <b>{{ host_request.to_date|v2date }}</b>.
                                       </td>
                                     </tr>
                                   </table>

--- a/app/backend/templates/v2/generated_html/host_request__new.html
+++ b/app/backend/templates/v2/generated_html/host_request__new.html
@@ -182,7 +182,7 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ message|v2esc }}</b> at {{ time|v2time(user) }}.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ message|v2esc }}</b> at {{ time|v2time }}.</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -213,7 +213,7 @@
                                       </td>
                                       <td>
                                         <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br>{{ other.city|v2esc }}
-                                        <br>From <b>{{ host_request.from_date|v2date(user) }}</b> to <b>{{ host_request.to_date|v2date(user) }}</b>.
+                                        <br>From <b>{{ host_request.from_date|v2date }}</b> to <b>{{ host_request.to_date|v2date }}</b>.
                                       </td>
                                     </tr>
                                   </table>

--- a/app/backend/templates/v2/generated_html/host_request__plain.html
+++ b/app/backend/templates/v2/generated_html/host_request__plain.html
@@ -172,7 +172,7 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ message|v2esc }}</b> at {{ time|v2time(user) }}.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ message|v2esc }}</b> at {{ time|v2time }}.</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -203,7 +203,7 @@
                                       </td>
                                       <td>
                                         <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br>{{ other.city|v2esc }}
-                                        <br>From <b>{{ host_request.from_date|v2date(user) }}</b> to <b>{{ host_request.to_date|v2date(user) }}</b>.
+                                        <br>From <b>{{ host_request.from_date|v2date }}</b> to <b>{{ host_request.to_date|v2date }}</b>.
                                       </td>
                                     </tr>
                                   </table>

--- a/app/backend/templates/v2/host_request__message.mjml
+++ b/app/backend/templates/v2/host_request__message.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
     <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>{{ message|v2esc }}</b> at {{ time|v2time(user) }}.</mj-text>
+    <mj-text><b>{{ message|v2esc }}</b> at {{ time|v2time }}.</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">
@@ -13,7 +13,7 @@
         </td>
         <td>
           <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br />{{ other.city|v2esc }}
-          <br />From <b>{{ host_request.from_date|v2date(user) }}</b> to <b>{{ host_request.to_date|v2date(user) }}</b>.
+          <br />From <b>{{ host_request.from_date|v2date }}</b> to <b>{{ host_request.to_date|v2date }}</b>.
         </td>
       </tr>
     </mj-table>

--- a/app/backend/templates/v2/host_request__message.txt
+++ b/app/backend/templates/v2/host_request__message.txt
@@ -1,12 +1,12 @@
 Hi {{ user.name }},
 
-{{ message }} at {{ time|v2time(user) }}.
+{{ message }} at {{ time|v2time }}.
 
 Request details:
 
 {{ other.name }}, {{ other.age }}
 {{ other.city }}.
-Dates: {{ host_request.from_date|v2date(user) }} to {{ host_request.to_date|v2date(user) }}.
+Dates: {{ host_request.from_date|v2date }} to {{ host_request.to_date|v2date }}.
 
 They wrote the following message:
 

--- a/app/backend/templates/v2/host_request__new.mjml
+++ b/app/backend/templates/v2/host_request__new.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
     <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>{{ message|v2esc }}</b> at {{ time|v2time(user) }}.</mj-text>
+    <mj-text><b>{{ message|v2esc }}</b> at {{ time|v2time }}.</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">
@@ -13,7 +13,7 @@
         </td>
         <td>
           <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br />{{ other.city|v2esc }}
-          <br />From <b>{{ host_request.from_date|v2date(user) }}</b> to <b>{{ host_request.to_date|v2date(user) }}</b>.
+          <br />From <b>{{ host_request.from_date|v2date }}</b> to <b>{{ host_request.to_date|v2date }}</b>.
         </td>
       </tr>
     </mj-table>

--- a/app/backend/templates/v2/host_request__new.txt
+++ b/app/backend/templates/v2/host_request__new.txt
@@ -1,12 +1,12 @@
 Hi {{ user.name }},
 
-{{ message }} at {{ time|v2time(user) }}.
+{{ message }} at {{ time|v2time }}.
 
 Request details:
 
 {{ other.name }}, {{ other.age }}
 {{ other.city }}.
-Dates: {{ host_request.from_date|v2date(user) }} to {{ host_request.to_date|v2date(user) }}.
+Dates: {{ host_request.from_date|v2date }} to {{ host_request.to_date|v2date }}.
 
 They wrote the following message:
 

--- a/app/backend/templates/v2/host_request__plain.mjml
+++ b/app/backend/templates/v2/host_request__plain.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
     <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>{{ message|v2esc }}</b> at {{ time|v2time(user) }}.</mj-text>
+    <mj-text><b>{{ message|v2esc }}</b> at {{ time|v2time }}.</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">
@@ -13,7 +13,7 @@
         </td>
         <td>
           <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br />{{ other.city|v2esc }}
-          <br />From <b>{{ host_request.from_date|v2date(user) }}</b> to <b>{{ host_request.to_date|v2date(user) }}</b>.
+          <br />From <b>{{ host_request.from_date|v2date }}</b> to <b>{{ host_request.to_date|v2date }}</b>.
         </td>
       </tr>
     </mj-table>

--- a/app/backend/templates/v2/host_request__plain.txt
+++ b/app/backend/templates/v2/host_request__plain.txt
@@ -1,12 +1,12 @@
 Hi {{ user.name }},
 
-{{ message }} at {{ time|v2time(user) }}.
+{{ message }} at {{ time|v2time }}.
 
 Request details:
 
 {{ other.name }}, {{ other.age }}
 {{ other.city }}.
-Dates: {{ host_request.from_date|v2date(user) }} to {{ host_request.to_date|v2date(user) }}.
+Dates: {{ host_request.from_date|v2date }} to {{ host_request.to_date|v2date }}.
 
 
 


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
Different parts of our backend need to localize dates and times, and currently they need to use email templating functions to do that. This PR splits the responsibility.

1. Adds `localize_date`, `localize_time`, etc. functions to i18n
2. Update non-email templating uses of `v2date`, `v2time`, etc. to use new i18n functions
3. Update `v2date`, `v2time`, etc. to take their locale and timezone from the email formatting context rather than an argument being passed down.

This is working towards further encapsulating email formatting and the v2*** functions.

**Please give clear steps for how the reviewer can best test this PR**
Run existing tests.

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A

**Backend checklist**
- [x] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)