### PR TITLE
Backend: Encapsulate jinja templating

### DIFF
--- a/app/backend/src/couchers/email/send.py
+++ b/app/backend/src/couchers/email/send.py
@@ -1,0 +1,61 @@
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from sqlalchemy.orm import Session
+
+from couchers.config import config
+from couchers.email import queue_email
+from couchers.templates.v2 import CONTEXT_YEAR_KEY, Context, render_template, template_folder
+from couchers.utils import now
+
+
+def send_simple_pretty_email(
+    session: Session, recipient: str, subject: str, template_name: str, template_args: dict[str, Any]
+) -> None:
+    """
+    This is a simplified version of couchers.notifications.background._send_email_notification
+
+    It's for the few security emails where we don't have a user to email but send directly to an email address.
+    """
+
+    template_args[CONTEXT_YEAR_KEY] = now().year
+    template_args["header_subject"] = subject
+    template_args["footer_email_is_critical"] = True  # Results in no unsubscribe footer.
+
+    # Format plaintext template
+    plain_tmplt = (template_folder / f"{template_name}.txt").read_text()
+    plain_tmplt_footer = (template_folder / "_footer.txt").read_text()
+    plain = render_template(
+        plain_tmplt + plain_tmplt_footer,
+        template_args,
+        Context(
+            # Not yet localizable
+            timezone=ZoneInfo("Etc/UTC"),
+            locale="en",
+            plaintext=True,
+        ),
+    )
+
+    # Format html template
+    html_tmplt = (template_folder / "generated_html" / f"{template_name}.html").read_text()
+    html = render_template(
+        html_tmplt,
+        template_args,
+        Context(
+            # Not yet localizable
+            timezone=ZoneInfo("Etc/UTC"),
+            locale="en",
+            plaintext=False,
+        ),
+    )
+
+    queue_email(
+        session,
+        sender_name=config["NOTIFICATION_EMAIL_SENDER"],
+        sender_email=config["NOTIFICATION_EMAIL_ADDRESS"],
+        recipient=recipient,
+        subject=config["NOTIFICATION_PREFIX"] + subject,
+        plain=plain,
+        html=html,
+        source_data=config["VERSION"] + f"/{template_name}",
+    )

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -1,9 +1,7 @@
 import logging
-from pathlib import Path
 from zoneinfo import ZoneInfo
 
 from google.protobuf import empty_pb2
-from jinja2 import Environment, FileSystemLoader
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import exists, func
@@ -25,26 +23,15 @@ from couchers.notifications.quick_links import (
     generate_unsub_topic_action,
     generate_unsub_topic_key,
 )
-from couchers.notifications.render import render_email_notification
+from couchers.notifications.render_email import render_email_notification
 from couchers.notifications.render_push import render_push_notification
 from couchers.notifications.settings import get_preference
 from couchers.proto.internal import jobs_pb2
 from couchers.sql import moderation_state_column_visible
-from couchers.templates.v2 import (
-    CONTEXT_YEAR_KEY,
-    FilterContext,
-    add_filters,
-)
+from couchers.templates.v2 import CONTEXT_YEAR_KEY, Context, render_template, template_folder
 from couchers.utils import now
 
 logger = logging.getLogger(__name__)
-
-template_folder = Path(__file__).parent / ".." / ".." / ".." / "templates" / "v2"
-
-loader = FileSystemLoader(template_folder)
-env = Environment(loader=loader, trim_blocks=True)
-
-add_filters(env)
 
 
 def _send_email_notification(session: Session, user: User, notification: Notification) -> None:
@@ -72,15 +59,15 @@ def _send_email_notification(session: Session, user: User, notification: Notific
     }
 
     # Format plaintext template
-    template_args[FilterContext.KEY] = FilterContext(timezone=timezone, locale=email_lang, plaintext=True)
     plain_tmplt = (template_folder / f"{rendered.template_name}.txt").read_text()
     plain_tmplt_footer = (template_folder / "_footer.txt").read_text()
-    plain = env.from_string(plain_tmplt + plain_tmplt_footer).render(template_args)
+    plain = render_template(
+        plain_tmplt + plain_tmplt_footer, template_args, Context(timezone=timezone, locale=email_lang, plaintext=True)
+    )
 
     # Format html template
-    template_args[FilterContext.KEY] = FilterContext(timezone=timezone, locale=email_lang, plaintext=False)
     html_tmplt = (template_folder / "generated_html" / f"{rendered.template_name}.html").read_text()
-    html = env.from_string(html_tmplt).render(template_args)
+    html = render_template(html_tmplt, template_args, Context(timezone=timezone, locale=email_lang, plaintext=False))
 
     if user.do_not_email and not rendered.is_critical:
         logger.info(f"Not emailing {user} based on template {rendered.template_name} due to emails turned off")

--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -12,7 +12,6 @@ from couchers.i18n.localize import (
 from couchers.models import Notification, NotificationTopicAction, User
 from couchers.notifications.quick_links import generate_quick_decline_link, generate_unsub_topic_action
 from couchers.proto import notification_data_pb2
-from couchers.templates.v2 import v2esc
 from couchers.utils import now, to_aware_datetime
 
 logger = logging.getLogger(__name__)
@@ -322,7 +321,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
     elif notification.topic_action == NotificationTopicAction.friend_request__accept:
         other = data.other_user
         title = f"{other.name} accepted your friend request!"
-        preview = f"{v2esc(other.name)} has accepted your friend request"
+        preview = f"{other.name} has accepted your friend request"
         return RenderedEmailNotification(
             subject=title,
             preview=preview,
@@ -577,7 +576,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
             title = f"You've received a friend reference from {data.from_user.name}!"
             return RenderedEmailNotification(
                 subject=title,
-                preview=v2esc(data.text),
+                preview=data.text,
                 template_name="friend_reference",
                 template_args={
                     "from_user": data.from_user,
@@ -597,12 +596,12 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
             )
             profile_references_link = urls.profile_references_link()
             if data.text:
-                body = v2esc(data.text)
+                preview = data.text
             else:
-                body = "Please go and write a reference for them too. It's a nice gesture and helps us build a community together!"
+                preview = "Please go and write a reference for them too. It's a nice gesture and helps us build a community together!"
             return RenderedEmailNotification(
                 subject=title,
-                preview=body,
+                preview=preview,
                 template_name="host_reference",
                 template_args={
                     "from_user": data.from_user,

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -10,7 +10,7 @@ from couchers.i18n.localize import format_phone_number, localize_date_from_iso, 
 from couchers.models import Notification, NotificationTopicAction, User
 from couchers.notifications.push import PushNotificationContent
 from couchers.proto import events_pb2, notification_data_pb2
-from couchers.templates.v2 import v2avatar, v2esc
+from couchers.templates.v2 import v2avatar
 
 logger = logging.getLogger(__name__)
 
@@ -359,7 +359,7 @@ def _friend_request__create(data: notification_data_pb2.FriendRequestCreate) -> 
 def _friend_request__accept(data: notification_data_pb2.FriendRequestAccept) -> PushNotificationContent:
     return PushNotificationContent(
         title=f"{data.other_user.name} accepted your friend request!",
-        body=f"{v2esc(data.other_user.name)} has accepted your friend request",
+        body=f"{data.other_user.name} has accepted your friend request",
         icon_url=v2avatar(data.other_user),
         action_url=urls.user_link(username=data.other_user.username),
     )
@@ -473,13 +473,13 @@ def _onboarding__reminder(key: str, user: User) -> PushNotificationContent:
     if key == "1":
         return PushNotificationContent(
             title="Welcome to Couchers.org and the future of couch surfing",
-            body=f"Hi {v2esc(user.name)}! We are excited that you have joined us! Please take a moment to complete your profile with a picture and a bit of text about yourself!",
+            body=f"Hi {user.name}! We are excited that you have joined us! Please take a moment to complete your profile with a picture and a bit of text about yourself!",
             action_url=urls.edit_profile_link(),
         )
     elif key == "2":
         return PushNotificationContent(
             title="Please complete your profile on Couchers.org!",
-            body=f"Hi {v2esc(user.name)}! We would ask one big favour of you: please fill out your profile by adding a photo and some text.",
+            body=f"Hi {user.name}! We would ask one big favour of you: please fill out your profile by adding a photo and some text.",
             action_url=urls.edit_profile_link(),
         )
     else:
@@ -571,7 +571,7 @@ def _reference__receive(
     data: notification_data_pb2.ReferenceReceiveHostRequest, reference_type: str
 ) -> PushNotificationContent:
     if data.text:
-        body = v2esc(data.text)
+        body = data.text
         action_url = urls.profile_references_link()
     else:
         body = (

--- a/app/backend/src/couchers/tasks.py
+++ b/app/backend/src/couchers/tasks.py
@@ -10,6 +10,7 @@ from couchers.config import config
 from couchers.constants import SIGNUP_EMAIL_TOKEN_VALIDITY
 from couchers.crypto import urlsafe_secure_token
 from couchers.db import session_scope
+from couchers.email.send import send_simple_pretty_email
 from couchers.models import (
     AccountDeletionReason,
     Cluster,
@@ -27,7 +28,6 @@ from couchers.models import (
     User,
 )
 from couchers.rate_limits.definitions import RATE_LIMIT_HOURS
-from couchers.templates.v2 import send_simple_pretty_email
 from couchers.utils import now
 
 logger = logging.getLogger(__name__)

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -6,6 +6,7 @@ import logging
 import re
 from dataclasses import dataclass
 from datetime import date, datetime
+from functools import lru_cache
 from html import escape
 from pathlib import Path
 from typing import Any, ClassVar
@@ -13,22 +14,15 @@ from zoneinfo import ZoneInfo
 
 from google.protobuf.timestamp_pb2 import Timestamp
 from jinja2 import Environment, FileSystemLoader, pass_context
-from jinja2.runtime import Context
+from jinja2.runtime import Context as JinjaContext
 from markdown_it import MarkdownIt
-from sqlalchemy.orm import Session
 
 from couchers import urls
-from couchers.config import config
-from couchers.email import queue_email
 from couchers.i18n.localize import format_phone_number, localize_date, localize_datetime, localize_string, localize_time
-from couchers.utils import now
 
 logger = logging.getLogger(__name__)
 
 template_folder = Path(__file__).parent / ".." / ".." / ".." / "templates" / "v2"
-
-loader = FileSystemLoader(template_folder)
-env = Environment(loader=loader, trim_blocks=True)
 
 md = MarkdownIt("zero", {"typographer": True}).enable(["smartquotes", "heading", "hr", "list", "link", "emphasis"])
 
@@ -38,8 +32,8 @@ CONTEXT_YEAR_KEY = "_year"
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class FilterContext:
-    """Context passed to filter functions."""
+class Context:
+    """Context available to filter functions during templating."""
 
     KEY: ClassVar[str] = "_filter_context"
 
@@ -53,9 +47,9 @@ class FilterContext:
     """If true, strips html tags from localized strings."""
 
     @staticmethod
-    def from_jinja(jinja2_context: Context) -> FilterContext:
-        filter_context: FilterContext = jinja2_context[FilterContext.KEY]
-        return filter_context
+    def from_jinja(jinja_context: JinjaContext) -> Context:
+        context: Context = jinja_context[Context.KEY]
+        return context
 
 
 def v2esc(value: Any) -> str:
@@ -79,24 +73,24 @@ def v2phone(value: str) -> str:
 
 
 @pass_context
-def v2date(context: Context, value: date | str) -> str:
-    filter_context = FilterContext.from_jinja(context)
+def v2date(jinja_context: JinjaContext, value: date | str) -> str:
+    context = Context.from_jinja(jinja_context)
     if isinstance(value, str):
         value = date.fromisoformat(value)
-    return localize_date(value, filter_context.locale)
+    return localize_date(value, context.locale)
 
 
 @pass_context
-def v2time(context: Context, value: datetime) -> str:
-    filter_context = FilterContext.from_jinja(context)
-    value = value.astimezone(filter_context.timezone)
-    return localize_time(value.time(), filter_context.locale)
+def v2time(jinja_context: JinjaContext, value: datetime) -> str:
+    context = Context.from_jinja(jinja_context)
+    value = value.astimezone(context.timezone)
+    return localize_time(value.time(), context.locale)
 
 
 @pass_context
-def v2timestamp(context: Context, value: Timestamp) -> str:
-    filter_context = FilterContext.from_jinja(context)
-    return localize_datetime(value, filter_context.timezone, filter_context.locale)
+def v2timestamp(jinja_context: JinjaContext, value: Timestamp) -> str:
+    context = Context.from_jinja(jinja_context)
+    return localize_datetime(value, context.timezone, context.locale)
 
 
 def v2avatar(user: Any) -> str:
@@ -128,7 +122,7 @@ def replace_tag(match: re.Match[str]) -> str:
 
 
 @pass_context
-def v2translate(context: Context, key: str, **kwargs: Any) -> str:
+def v2translate(jinja_context: JinjaContext, key: str, **kwargs: Any) -> str:
     """
     Jinja2 filter to translate a string key with substitutions.
 
@@ -136,16 +130,16 @@ def v2translate(context: Context, key: str, **kwargs: Any) -> str:
         {{ "greeting_key"|v2translate(name=user.name) }}
     """
 
-    filter_context = FilterContext.from_jinja(context)
+    context = Context.from_jinja(jinja_context)
 
     # Prevent html injection
     escaped_substitutions = {k: escape(str(v)) for k, v in kwargs.items()}
 
-    translated = localize_string(filter_context.locale, key, substitutions=escaped_substitutions)
+    translated = localize_string(context.locale, key, substitutions=escaped_substitutions)
 
     # Translations may include simple formatting HTML like <b> or <a>,
     # but those should not appear in plain text emails.
-    if filter_context.plaintext:
+    if context.plaintext:
         # Doesn't support nesting, but should be sufficient for our needs
         translated = re.sub(r"<(\w+).*?>(.*?)</\1>", replace_tag, translated)
         translated = re.sub(r"<br\s*/?>", "\n", translated)
@@ -158,7 +152,10 @@ def v2translate(context: Context, key: str, **kwargs: Any) -> str:
     return translated
 
 
-def add_filters(env: Environment) -> None:
+@lru_cache(maxsize=1)
+def _get_jinja2_env() -> Environment:
+    loader = FileSystemLoader(template_folder)
+    env = Environment(loader=loader, trim_blocks=True)
     env.filters["v2esc"] = v2esc
     env.filters["v2multiline"] = v2multiline
     env.filters["v2sf"] = v2sf
@@ -171,52 +168,13 @@ def add_filters(env: Environment) -> None:
     env.filters["v2quote"] = v2quote
     env.filters["v2markdown"] = v2markdown
     env.filters["v2translate"] = v2translate
+    return env
 
 
-add_filters(env)
+def render_template(template: str, args: dict[str, Any], context: Context) -> str:
+    """Renders an a jinja2 template which may use our jinja2 filters."""
 
-
-def send_simple_pretty_email(
-    session: Session, recipient: str, subject: str, template_name: str, template_args: dict[str, Any]
-) -> None:
-    """
-    This is a simplified version of couchers.notifications.background._send_email_notification
-
-    It's for the few security emails where we don't have a user to email but send directly to an email address.
-    """
-
-    template_args[CONTEXT_YEAR_KEY] = now().year
-    template_args["header_subject"] = subject
-    template_args["footer_email_is_critical"] = True  # Results in no unsubscribe footer.
-
-    # Format plaintext template
-    template_args[FilterContext.KEY] = FilterContext(
-        # Not yet localizable
-        timezone=ZoneInfo("Etc/UTC"),
-        locale="en",
-        plaintext=True,
-    )
-    plain_tmplt = (template_folder / f"{template_name}.txt").read_text()
-    plain_tmplt_footer = (template_folder / "_footer.txt").read_text()
-    plain = env.from_string(plain_tmplt + plain_tmplt_footer).render(template_args)
-
-    # Format html template
-    template_args[FilterContext.KEY] = FilterContext(
-        # Not yet localizable
-        timezone=ZoneInfo("Etc/UTC"),
-        locale="en",
-        plaintext=False,
-    )
-    html_tmplt = (template_folder / "generated_html" / f"{template_name}.html").read_text()
-    html = env.from_string(html_tmplt).render(template_args)
-
-    queue_email(
-        session,
-        sender_name=config["NOTIFICATION_EMAIL_SENDER"],
-        sender_email=config["NOTIFICATION_EMAIL_ADDRESS"],
-        recipient=recipient,
-        subject=config["NOTIFICATION_PREFIX"] + subject,
-        plain=plain,
-        html=html,
-        source_data=config["VERSION"] + f"/{template_name}",
-    )
+    # Append to the context values used by filters
+    env = _get_jinja2_env()
+    args = {**args, Context.KEY: context}
+    return env.from_string(template).render(args)

--- a/app/backend/src/tests/test_templates.py
+++ b/app/backend/src/tests/test_templates.py
@@ -4,17 +4,12 @@ from typing import Any
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
-from jinja2 import Environment
-
 from couchers.i18n.i18next import I18Next
 from couchers.i18n.plurals import PluralRules
 from couchers.templates.v2 import (
-    FilterContext,
-    add_filters,
+    Context,
+    render_template,
 )
-
-_env = Environment()
-add_filters(_env)
 
 
 def _render_template(
@@ -24,17 +19,15 @@ def _render_template(
     plain: bool = False,
     lang: str = "en",
 ) -> str:
-    template = _env.from_string(template_str)
-    template_args = (template_args or {}).copy()
-    template_args[FilterContext.KEY] = FilterContext(timezone=ZoneInfo("Etc/UTC"), locale=lang, plaintext=plain)
-
     mock_i18next = I18Next()
     for lang_code, strings in translation_dict.items():
         language = mock_i18next.add_language(lang_code, PluralRules.en)
         language.load_json_dict(strings)
 
     with patch("couchers.i18n.localize.get_i18next", new=lambda: mock_i18next):
-        return template.render(template_args)
+        return render_template(
+            template_str, template_args or {}, Context(timezone=ZoneInfo("Etc/UTC"), locale=lang, plaintext=plain)
+        )
 
 
 def _greeting_dict(value: str) -> dict[str, dict[str, str]]:

--- a/app/backend/templates/v2/_header.mjml
+++ b/app/backend/templates/v2/_header.mjml
@@ -1,7 +1,7 @@
 <mjml>
   <mj-head>
-    <mj-title>{{ header_subject }}</mj-title>
-    <mj-preview>{{ header_preview }}</mj-preview>
+    <mj-title>{{ header_subject|v2esc }}</mj-title>
+    <mj-preview>{{ header_preview|v2esc }}</mj-preview>
     <mj-attributes>
       <mj-text color="#333" />
     </mj-attributes>

--- a/app/backend/templates/v2/generated_html/account_deletion_complete.html
+++ b/app/backend/templates/v2/generated_html/account_deletion_complete.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/account_deletion_recovered.html
+++ b/app/backend/templates/v2/generated_html/account_deletion_recovered.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/account_deletion_start.html
+++ b/app/backend/templates/v2/generated_html/account_deletion_start.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/activeness_probe.html
+++ b/app/backend/templates/v2/generated_html/activeness_probe.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/api_key.html
+++ b/app/backend/templates/v2/generated_html/api_key.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/badge.html
+++ b/app/backend/templates/v2/generated_html/badge.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/chat_message.html
+++ b/app/backend/templates/v2/generated_html/chat_message.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/chat_unseen_messages.html
+++ b/app/backend/templates/v2/generated_html/chat_unseen_messages.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/comment_reply.html
+++ b/app/backend/templates/v2/generated_html/comment_reply.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/discussion_comment.html
+++ b/app/backend/templates/v2/generated_html/discussion_comment.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/discussion_create.html
+++ b/app/backend/templates/v2/generated_html/discussion_create.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/donation_received.html
+++ b/app/backend/templates/v2/generated_html/donation_received.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/email_changed_confirmation_new_email.html
+++ b/app/backend/templates/v2/generated_html/email_changed_confirmation_new_email.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/event_cancel.html
+++ b/app/backend/templates/v2/generated_html/event_cancel.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/event_comment.html
+++ b/app/backend/templates/v2/generated_html/event_comment.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/event_create.html
+++ b/app/backend/templates/v2/generated_html/event_create.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/event_delete.html
+++ b/app/backend/templates/v2/generated_html/event_delete.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/event_invite_organizer.html
+++ b/app/backend/templates/v2/generated_html/event_invite_organizer.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/event_reminder.html
+++ b/app/backend/templates/v2/generated_html/event_reminder.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/event_update.html
+++ b/app/backend/templates/v2/generated_html/event_update.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/friend_reference.html
+++ b/app/backend/templates/v2/generated_html/friend_reference.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/friend_request.html
+++ b/app/backend/templates/v2/generated_html/friend_request.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/friend_request_accepted.html
+++ b/app/backend/templates/v2/generated_html/friend_request_accepted.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/host_reference.html
+++ b/app/backend/templates/v2/generated_html/host_reference.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/host_request__message.html
+++ b/app/backend/templates/v2/generated_html/host_request__message.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/host_request__new.html
+++ b/app/backend/templates/v2/generated_html/host_request__new.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -105,8 +105,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/host_request__plain.html
+++ b/app/backend/templates/v2/generated_html/host_request__plain.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/mod_note.html
+++ b/app/backend/templates/v2/generated_html/mod_note.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/new_blog_post.html
+++ b/app/backend/templates/v2/generated_html/new_blog_post.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/onboarding1.html
+++ b/app/backend/templates/v2/generated_html/onboarding1.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/onboarding2.html
+++ b/app/backend/templates/v2/generated_html/onboarding2.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/password_reset.html
+++ b/app/backend/templates/v2/generated_html/password_reset.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/reference_reminder.html
+++ b/app/backend/templates/v2/generated_html/reference_reminder.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/security.html
+++ b/app/backend/templates/v2/generated_html/security.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/signup_continue.html
+++ b/app/backend/templates/v2/generated_html/signup_continue.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/signup_verify.html
+++ b/app/backend/templates/v2/generated_html/signup_verify.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/app/backend/templates/v2/generated_html/strong_verification_success.html
+++ b/app/backend/templates/v2/generated_html/strong_verification_success.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject }}</title>
+  <title>{{ header_subject|v2esc }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
-  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
+  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
This PR is part of a refactoring sequence of our email code leading to this layering, each of which depends only on the lower one:

- Notification -> email rendering layer. Renders a notification into an email. <-- Mostly already exists.
- Email templating layer: Encapsulates header/footer and plaintext/html templating of emails. <-- Next PR
- Base templating layer: Uses jinja2 to template strings with our custom filters. Not email-specific. <-- This PR

This specific PR accomplishes:

- Further abstraction of jinja2 templating such that only `templates/v2.py` needs to create the Jinja context. Other clients pass a higher-level context object that specifies localization info.
- Remove dependencies on `v2esc` since filters will eventually be fully encapsulated in `templates/v2.py`. I also fixed the title/preview not being escaped consistently.
- Moves `send_simple_pretty_email` out of the templating file.

Next up I'll extract the email templating logic such that `send_simple_pretty_email` and `_send_email_notification` don't both have to know about email header/footer details.

**Please give clear steps for how the reviewer can best test this PR**
Tests already cover emails, or use maildev with a notification.

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A

**Backend checklist**
- [x] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)