### PR TITLE
Add nginx config to proxy Sentry requests through our server

### DIFF
--- a/app/nginx/sites-enabled/web.conf
+++ b/app/nginx/sites-enabled/web.conf
@@ -22,6 +22,25 @@ server {
         proxy_http_version 1.1;
         proxy_pass http://web:3000;
     }
+
+    # Proxy requests to Sentry to avoid ad blockers.
+    location /sentry-tunnel/ {
+      # Remove /sentry-tunnel/ prefix and keep the rest of the path
+      rewrite ^/sentry-tunnel/(.*) /$1 break;
+
+      # This token is already exposed on the frontend, and Sentry docs mention that
+      # it's fine to expose it.
+      proxy_pass https://5594adb1a53e41bfbb9f2cc5c91e2dbd@o782870.ingest.sentry.io;
+      proxy_set_header Host o782870.ingest.sentry.io;
+      proxy_set_header X-Real-IP $remote_addr;
+
+      # Standard proxy headers (optional but recommended)
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+
+      # SSL configuration for upstream
+      proxy_ssl_server_name on;
+  }
 }
 
 server {


### PR DESCRIPTION
This is needed to avoid ad-blockers cancelling requests to sentry. Described in their docs here https://docs.sentry.io/platforms/javascript/troubleshooting/#using-the-tunnel-option

We'll need to configure sentry in web too