### PR TITLE
Backend tests: Switch PushCollector to pop model

### DIFF
--- a/app/backend/src/tests/fixtures/misc.py
+++ b/app/backend/src/tests/fixtures/misc.py
@@ -59,13 +59,10 @@ class Push:
     ttl: int | None = None
 
 
-@dataclass(frozen=True, slots=True, init=False)
 class PushCollector:
-    by_user: dict[int, list[Push]]
-    """Collected notifications by user id, chronologically."""
-
     def __init__(self):
-        self.by_user = {}
+        self.by_user: dict[int, list[Push]] = {}
+        """Collected notifications by user id, chronologically."""
 
     def push_to_user(self, session: Session, user_id: int, **kwargs: Any) -> None:
         if user_id not in self.by_user:

--- a/app/backend/src/tests/fixtures/misc.py
+++ b/app/backend/src/tests/fixtures/misc.py
@@ -59,30 +59,32 @@ class Push:
     ttl: int | None = None
 
 
+@dataclass(frozen=True, slots=True, init=False)
 class PushCollector:
-    def __init__(self):
-        # pairs of (user_id, push)
-        self.pushes: list[tuple[int, Push]] = []
+    by_user: dict[int, list[Push]]
+    """Collected notifications by user id, chronologically."""
 
-    def by_user(self, user_id: int) -> list[Push]:
-        return [push for uid, push in self.pushes if uid == user_id]
+    def __init__(self):
+        self.by_user = {}
 
     def push_to_user(self, session: Session, user_id: int, **kwargs: Any) -> None:
-        self.pushes.append((user_id, Push(**kwargs)))
+        if user_id not in self.by_user:
+            self.by_user[user_id] = []
+        self.by_user[user_id].append(Push(**kwargs))
 
     def count_for_user(self, user_id: int) -> int:
-        return len(self.by_user(user_id))
+        return len(self.by_user.get(user_id, []))
 
-    def get_for_user(
-        self,
-        user_id: int,
-        index: int | None = None,
-    ) -> Push:
-        pushes = self.by_user(user_id)
-        if index is None:
-            assert len(pushes) == 1, "Expected a single user notification"
-            return pushes[0]
-        return pushes[index]
+    def pop_for_user(self, user_id: int, last: bool = False) -> Push:
+        """
+        Removes and returns the oldest push notification received by the given user,
+        optionally asserting that it is the last one.
+        """
+        pushes = self.by_user.get(user_id)
+        assert pushes, f"No notifications to pop for user {user_id}."
+        if last:
+            assert len(pushes) == 1, f"Expected a single notification for user {user_id}."
+        return pushes.pop(0)
 
 
 class Moderator:

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -167,7 +167,7 @@ def test_ChangePasswordV2_normal(db, fast_passwords, push_collector: PushCollect
     mock.assert_called_once()
     assert email_fields(mock).subject == "[TEST] Your password was changed"
 
-    push = push_collector.get_for_user(user.id)
+    push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Password changed"
     assert push.content.body == "Your password was changed."
 
@@ -543,7 +543,7 @@ def test_ChangeEmailV2(db, fast_passwords, push_collector: PushCollector):
         token = user_updated.new_email_token
 
     process_jobs()
-    push = push_collector.get_for_user(user_id, index=0)
+    push = push_collector.pop_for_user(user_id, last=True)
     assert push.content.title == "Email change requested"
     assert push.content.body == f"Use the link we sent to {new_email} to confirm your new address."
 
@@ -563,7 +563,7 @@ def test_ChangeEmailV2(db, fast_passwords, push_collector: PushCollector):
         assert user.new_email_token_expiry is None
 
     process_jobs()
-    push = push_collector.get_for_user(user_id, index=1)
+    push = push_collector.pop_for_user(user_id, last=True)
     assert push.content.title == "Email verified"
     assert push.content.body == "Your new email address has been verified."
 
@@ -594,7 +594,7 @@ def test_ChangeEmailV2_sends_proper_emails(db, fast_passwords, push_collector: P
             uq_str2 in jobs[0].payload and uq_str1 in jobs[1].payload
         )
 
-    push = push_collector.get_for_user(user.id)
+    push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Email change requested"
     assert push.content.body == f"Use the link we sent to {new_email} to confirm your new address."
 
@@ -685,7 +685,7 @@ def test_full_delete_account_with_recovery(db, push_collector: PushCollector):
         with mock_notification_email() as mock:
             account.DeleteAccount(account_pb2.DeleteAccountReq(confirm=True))
 
-    push = push_collector.get_for_user(user_id, index=0)
+    push = push_collector.pop_for_user(user_id, last=True)
     assert push.content.title == "Account deletion requested"
     assert push.content.body == "Use the link we emailed you to confirm."
 
@@ -724,7 +724,7 @@ def test_full_delete_account_with_recovery(db, push_collector: PushCollector):
                 )
             )
 
-    push = push_collector.get_for_user(user_id, index=1)
+    push = push_collector.pop_for_user(user_id, last=True)
     assert push.content.title == "Account deleted"
     assert push.content.body == "You can restore it within 7 days using the link we emailed you."
 
@@ -763,7 +763,7 @@ def test_full_delete_account_with_recovery(db, push_collector: PushCollector):
                 )
             )
 
-    push = push_collector.get_for_user(user_id, index=2)
+    push = push_collector.pop_for_user(user_id, last=True)
     assert push.content.title == "Account restored"
     assert push.content.body == "Welcome back!"
 

--- a/app/backend/src/tests/test_activeness_probes.py
+++ b/app/backend/src/tests/test_activeness_probes.py
@@ -51,7 +51,7 @@ def test_activeness_probes_happy_path_inactive(db, push_collector: PushCollector
         assert res.hosting_status == api_pb2.HOSTING_STATUS_CANT_HOST
         assert res.meetup_status == api_pb2.MEETUP_STATUS_WANTS_TO_MEETUP
 
-    push = push_collector.get_for_user(user.id)
+    push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Still open to hosting?"
     assert push.content.body == "Log in to confirm your hosting status."
 
@@ -84,7 +84,7 @@ def test_activeness_probes_happy_path_active(db, push_collector: PushCollector):
         assert res.hosting_status == api_pb2.HOSTING_STATUS_CAN_HOST
         assert res.meetup_status == api_pb2.MEETUP_STATUS_WANTS_TO_MEETUP
 
-    push = push_collector.get_for_user(user.id)
+    push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Still open to hosting?"
     assert push.content.body == "Log in to confirm your hosting status."
 

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -124,7 +124,7 @@ def test_ChangeUserGender(db, push_collector: PushCollector):
     assert "Machine" in e.plain
     assert "Machine" in e.html
 
-    push = push_collector.get_for_user(normal_user.id)
+    push = push_collector.pop_for_user(normal_user.id, last=True)
     assert push.content.title == "Gender changed"
     assert push.content.body == "An admin changed your gender to Machine."
 
@@ -157,7 +157,7 @@ def test_ChangeUserBirthdate(db, push_collector: PushCollector):
     assert "1990" in e.plain
     assert "1990" in e.html
 
-    push = push_collector.get_for_user(normal_user.id)
+    push = push_collector.pop_for_user(normal_user.id, last=True)
     assert push.content.title == "Birthdate changed"
     assert push.content.body == "An admin changed your date of birth to Friday 25 May 1990."
 
@@ -368,7 +368,7 @@ def test_CreateApiKey(db, push_collector: PushCollector):
     assert "support@couchers.org" in e.plain
     assert "support@couchers.org" in e.html
 
-    push = push_collector.get_for_user(normal_user.id)
+    push = push_collector.pop_for_user(normal_user.id, last=True)
     assert push.content.title == "API key created"
     assert push.content.body == "Details were sent to you via email."
 
@@ -403,7 +403,7 @@ def test_badges(db, push_collector: PushCollector):
         # badge emails are disabled by default
         mock.assert_not_called()
 
-        push = push_collector.get_for_user(normal_user.id)
+        push = push_collector.pop_for_user(normal_user.id, last=True)
         assert push.content.title == "New profile badge: Swagster"
         assert push.content.body == "The Swagster badge was added to your profile."
 
@@ -428,7 +428,7 @@ def test_badges(db, push_collector: PushCollector):
         # badge emails are disabled by default
         mock.assert_not_called()
 
-        push = push_collector.get_for_user(normal_user.id, index=1)
+        push = push_collector.pop_for_user(normal_user.id, last=True)
         assert push.content.title == "Profile badge removed"
         assert push.content.body == "The Swagster badge was removed from your profile."
 
@@ -712,7 +712,7 @@ def test_admin_delete_account_url(db, push_collector: PushCollector):
                 )
             )
 
-    push = push_collector.get_for_user(user_id, index=0)
+    push = push_collector.pop_for_user(user_id, last=True)
     assert push.content.title == "Account deleted"
     assert push.content.body == "You can restore it within 7 days using the link we emailed you."
     mock.assert_called_once()

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -865,7 +865,7 @@ def test_friend_request_flow(db, push_collector: PushCollector):
         assert len(res.user_ids) == 1
         assert res.user_ids[0] == user1.id
 
-    assert push_collector.count_for_user(user2.id) == 1
+    assert push_collector.count_for_user(user2.id) == 0
     push = push_collector.pop_for_user(user1.id, last=True)
     assert push.content.title == f"{user2.name} accepted your friend request"
     assert push.content.body == f"You are now friends with {user2.name}."

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -806,7 +806,7 @@ def test_friend_request_flow(db, push_collector: PushCollector):
         with api_session(token1) as api:
             api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user2.id))
 
-    push = push_collector.get_for_user(user2.id)
+    push = push_collector.pop_for_user(user2.id, last=True)
     assert push.content.title == f"Friend request from {user1.name}"
     assert push.content.body == f"{user1.name} wants to be your friend."
 
@@ -866,7 +866,7 @@ def test_friend_request_flow(db, push_collector: PushCollector):
         assert res.user_ids[0] == user1.id
 
     assert push_collector.count_for_user(user2.id) == 1
-    push = push_collector.get_for_user(user1.id, index=0)
+    push = push_collector.pop_for_user(user1.id, last=True)
     assert push.content.title == f"{user2.name} accepted your friend request"
     assert push.content.body == f"You are now friends with {user2.name}."
 

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -423,12 +423,10 @@ def test_password_reset_v2(db, push_collector: PushCollector):
     assert "support@couchers.org" in e.plain
     assert "support@couchers.org" in e.html
 
-    push = push_collector.get_for_user(
-        user.id,
-        index=0,
-    )
+    push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Password reset requested"
     assert push.content.body == "Use the link we sent by email to complete it."
+
     # make sure bad password are caught
     with auth_api_session() as (auth_api, metadata_interceptor):
         with pytest.raises(grpc.RpcError) as err:
@@ -446,7 +444,7 @@ def test_password_reset_v2(db, push_collector: PushCollector):
                 auth_pb2.CompletePasswordResetV2Req(password_reset_token=password_reset_token, new_password=pwd)
             )
 
-    push = push_collector.get_for_user(user.id, index=1)
+    push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Password reset"
     assert push.content.body == "Your password was successfully reset."
 

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -1214,31 +1214,31 @@ def test_update_badges(db, push_collector: PushCollector):
 
     print(push_collector.pushes)
 
-    push = push_collector.get_for_user(user1.id, index=0)
+    push = push_collector.pop_for_user(user1.id, last=False)
     assert push.content.title == "New profile badge: Founder"
     assert push.content.body == "The Founder badge was added to your profile."
 
-    push = push_collector.get_for_user(user1.id, index=1)
+    push = push_collector.pop_for_user(user1.id, last=True)
     assert push.content.title == "New profile badge: Board Member"
     assert push.content.body == "The Board Member badge was added to your profile."
 
-    push = push_collector.get_for_user(user2.id, index=0)
+    push = push_collector.pop_for_user(user2.id, last=False)
     assert push.content.title == "New profile badge: Founder"
     assert push.content.body == "The Founder badge was added to your profile."
 
-    push = push_collector.get_for_user(user2.id, index=1)
+    push = push_collector.pop_for_user(user2.id, last=True)
     assert push.content.title == "New profile badge: Board Member"
     assert push.content.body == "The Board Member badge was added to your profile."
 
-    push = push_collector.get_for_user(user4.id, index=0)
+    push = push_collector.pop_for_user(user4.id, last=True)
     assert push.content.title == "New profile badge: Verified Phone"
     assert push.content.body == "The Verified Phone badge was added to your profile."
 
-    push = push_collector.get_for_user(user5.id, index=0)
+    push = push_collector.pop_for_user(user5.id, last=False)
     assert push.content.title == "Profile badge removed"
     assert push.content.body == "The Board Member badge was removed from your profile."
 
-    push = push_collector.get_for_user(user5.id, index=1)
+    push = push_collector.pop_for_user(user5.id, last=True)
     assert push.content.title == "New profile badge: Verified Phone"
     assert push.content.body == "The Verified Phone badge was added to your profile."
 
@@ -1503,19 +1503,19 @@ def test_update_badges_volunteers(db, push_collector: PushCollector):
         assert "past_volunteer" not in user6_badges
 
     # Check notifications for volunteer badge users
-    push = push_collector.get_for_user(user3.id)
+    push = push_collector.pop_for_user(user3.id, last=True)
     assert push.content.title == "New profile badge: Active Volunteer"
     assert push.content.body == "The Active Volunteer badge was added to your profile."
 
-    push = push_collector.get_for_user(user4.id)
+    push = push_collector.pop_for_user(user4.id, last=True)
     assert push.content.title == "New profile badge: Past Volunteer"
     assert push.content.body == "The Past Volunteer badge was added to your profile."
 
-    push = push_collector.get_for_user(user5.id)
+    push = push_collector.pop_for_user(user5.id, last=True)
     assert push.content.title == "Profile badge removed"
     assert push.content.body == "The Active Volunteer badge was removed from your profile."
 
-    push = push_collector.get_for_user(user6.id)
+    push = push_collector.pop_for_user(user6.id, last=True)
     assert push.content.title == "Profile badge removed"
     assert push.content.body == "The Past Volunteer badge was removed from your profile."
 
@@ -1547,7 +1547,7 @@ def test_update_badges_volunteer_status_change(db, push_collector: PushCollector
         assert "volunteer" in user3_badges
         assert "past_volunteer" not in user3_badges
 
-    push = push_collector.get_for_user(user3.id)
+    push = push_collector.pop_for_user(user3.id, last=True)
     assert push.content.title == "New profile badge: Active Volunteer"
     assert push.content.body == "The Active Volunteer badge was added to your profile."
 
@@ -1565,11 +1565,11 @@ def test_update_badges_volunteer_status_change(db, push_collector: PushCollector
         assert "past_volunteer" in user3_badges
 
     # Check both badges were updated
-    push = push_collector.get_for_user(user3.id, index=1)
+    push = push_collector.pop_for_user(user3.id, last=False)
     assert push.content.title == "Profile badge removed"
     assert push.content.body == "The Active Volunteer badge was removed from your profile."
 
-    push = push_collector.get_for_user(user3.id, index=2)
+    push = push_collector.pop_for_user(user3.id, last=True)
     assert push.content.title == "New profile badge: Past Volunteer"
     assert push.content.body == "The Past Volunteer badge was added to your profile."
 

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -1212,7 +1212,7 @@ def test_update_badges(db, push_collector: PushCollector):
 
     assert badge_tuples == expected  # type: ignore[comparison-overlap]
 
-    print(push_collector.pushes)
+    print(push_collector.by_user)
 
     push = push_collector.pop_for_user(user1.id, last=False)
     assert push.content.title == "New profile badge: Founder"

--- a/app/backend/src/tests/test_discussions.py
+++ b/app/backend/src/tests/test_discussions.py
@@ -189,11 +189,11 @@ def test_discussion_notifications_regression(db, push_collector: PushCollector):
     process_jobs()
 
     # User2 should get 2 notifications about 2 replies to their comment, User3 should get 1 notification about 1 reply
-    push = push_collector.get_for_user(user2_id, last=False)
+    push = push_collector.pop_for_user(user2_id, last=False)
     assert push.content.title == f"{user3.name} • dummy title"
     assert push.topic_action == "thread:reply"
 
-    push = push_collector.get_for_user(user2_id, last=True)
+    push = push_collector.pop_for_user(user2_id, last=True)
     assert push.content.title == f"{user.name} • dummy title"
     assert push.topic_action == "thread:reply"
 

--- a/app/backend/src/tests/test_discussions.py
+++ b/app/backend/src/tests/test_discussions.py
@@ -89,7 +89,7 @@ def test_create_and_get_discussion(db, push_collector: PushCollector):
 
     process_jobs()
 
-    push = push_collector.get_for_user(user2_id)
+    push = push_collector.pop_for_user(user2_id, last=True)
     assert push.content.title == "New discussion: dummy title"
     assert push.content.body == f"{user.name} started the discussion in Testing Community."
 
@@ -189,16 +189,14 @@ def test_discussion_notifications_regression(db, push_collector: PushCollector):
     process_jobs()
 
     # User2 should get 2 notifications about 2 replies to their comment, User3 should get 1 notification about 1 reply
-    assert push_collector.count_for_user(user2_id) == 2
-
-    push = push_collector.get_for_user(user2_id, index=0)
+    push = push_collector.get_for_user(user2_id, last=False)
     assert push.content.title == f"{user3.name} • dummy title"
     assert push.topic_action == "thread:reply"
 
-    push = push_collector.get_for_user(user2_id, index=1)
+    push = push_collector.get_for_user(user2_id, last=True)
     assert push.content.title == f"{user.name} • dummy title"
     assert push.topic_action == "thread:reply"
 
-    push = push_collector.get_for_user(user3.id)
+    push = push_collector.pop_for_user(user3.id, last=True)
     assert push.content.title == f"{user.name} • dummy title"
     assert push.topic_action == "thread:reply"

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -2157,8 +2157,8 @@ def test_event_threads(db, push_collector: PushCollector):
 
     process_jobs()
 
-    assert push_collector.get_for_user(user1.id).content.title == f"{user2.name} • Dummy Title"
-    assert push_collector.get_for_user(user2.id).content.title == f"{user3.name} • Dummy Title"
+    assert push_collector.pop_for_user(user1.id, last=True).content.title == f"{user2.name} • Dummy Title"
+    assert push_collector.pop_for_user(user2.id, last=True).content.title == f"{user3.name} • Dummy Title"
     assert push_collector.count_for_user(user4_id) == 0
 
 

--- a/app/backend/src/tests/test_jail.py
+++ b/app/backend/src/tests/test_jail.py
@@ -290,7 +290,7 @@ def test_modnotes(db, push_collector: PushCollector):
         fields = email_fields(mock)
 
         assert fields.subject == "[TEST] You have received a mod note"
-        push = push_collector.get_for_user(user.id)
+        push = push_collector.pop_for_user(user.id, last=True)
         assert push.content.title == "New moderator note"
         assert (
             push.content.body

--- a/app/backend/src/tests/test_moderation.py
+++ b/app/backend/src/tests/test_moderation.py
@@ -2359,7 +2359,7 @@ def test_group_chat_message_notifications_suppressed_before_approval(db, push_co
         gc = session.execute(select(GroupChat).where(GroupChat.conversation_id == gc_id)).scalar_one()
         assert gc.moderation_state.visibility == ModerationVisibility.VISIBLE
 
-    # User2 should now have 1 notification for the first message sent before approval
+    # User2 should have received 1 notification for the first message sent before approval
     push = push_collector.pop_for_user(user2.id, last=True)
     assert push.content.title == user1.name
     assert push.content.body == "Hello before approval"
@@ -2377,5 +2377,5 @@ def test_group_chat_message_notifications_suppressed_before_approval(db, push_co
     while process_job():
         pass
 
-    # User2 SHOULD now have 2 notifications total
-    assert push_collector.count_for_user(user2.id) == 2
+    # User2 should have received another notification
+    assert push_collector.count_for_user(user2.id) == 1

--- a/app/backend/src/tests/test_moderation.py
+++ b/app/backend/src/tests/test_moderation.py
@@ -588,7 +588,7 @@ def test_approved_host_request_in_lists_and_notifications(db, push_collector: Pu
         assert res.host_requests[0].host_request_id == host_request_id
 
     # After approval, the host should have received a push notification
-    assert push_collector.get_for_user(user2.id).topic_action == "host_request:create"
+    assert push_collector.pop_for_user(user2.id, last=True).topic_action == "host_request:create"
 
 
 def test_hidden_host_request_invisible_to_all(db):
@@ -2198,7 +2198,7 @@ def test_host_request_message_notifications_suppressed_before_approval(db, push_
     # 2. host_request:message (Follow-up message 1)
     # 3. host_request:message (Follow-up message 2)
     assert push_collector.count_for_user(host.id) == 3
-    push = push_collector.get_for_user(host.id, index=0)
+    push = push_collector.pop_for_user(host.id, last=False)
     assert push.content.title == f"New host request from {surfer.name}"
 
 
@@ -2270,7 +2270,7 @@ def test_host_request_notifications_sent_after_approval(db, push_collector: Push
         moderator.approve_host_request(hr_id)
 
     # Host should have received 1 notification (the approval notification)
-    assert push_collector.count_for_user(host.id) == 1
+    push_collector.pop_for_user(host.id, last=True)
 
     # Host accepts the request - surfer should be notified
     with requests_session(host_token) as api:
@@ -2284,8 +2284,7 @@ def test_host_request_notifications_sent_after_approval(db, push_collector: Push
             )
 
     # Surfer should have 1 notification (the accept notification)
-    assert push_collector.count_for_user(surfer.id) == 1
-    push = push_collector.get_for_user(surfer.id, index=0)
+    push = push_collector.pop_for_user(surfer.id, last=True)
     assert push.content.title == f"{host.name} accepted your host request"
 
     # Surfer confirms - host should be notified
@@ -2299,9 +2298,8 @@ def test_host_request_notifications_sent_after_approval(db, push_collector: Push
                 )
             )
 
-    # Host should now have 2 notifications (approval + confirm)
-    assert push_collector.count_for_user(host.id) == 2
-    push = push_collector.get_for_user(host.id, index=1)
+    # Host should now have received the confirmation notifications
+    push = push_collector.pop_for_user(host.id, last=True)
     assert push.content.title == f"{surfer.name} confirmed their host request"
 
 
@@ -2362,7 +2360,7 @@ def test_group_chat_message_notifications_suppressed_before_approval(db, push_co
         assert gc.moderation_state.visibility == ModerationVisibility.VISIBLE
 
     # User2 should now have 1 notification for the first message sent before approval
-    push = push_collector.get_for_user(user2.id)
+    push = push_collector.pop_for_user(user2.id, last=True)
     assert push.content.title == user1.name
     assert push.content.body == "Hello before approval"
 

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -473,6 +473,7 @@ def test_SendTestPushNotification(db, push_collector: PushCollector):
     assert push.content.title == "Push notifications test"
     assert push.content.body == "If you see this, then it's working :)"
 
+
 def test_SendBlogPostNotification(db, push_collector: PushCollector):
     super_user, super_token = generate_user(is_superuser=True)
 

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -469,15 +469,9 @@ def test_SendTestPushNotification(db, push_collector: PushCollector):
         notifications.SendTestPushNotification(empty_pb2.Empty())
 
     assert push_collector.count_for_user(user.id) == 1
-    push = push_collector.get_for_user(user.id, index=0)
+    push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Push notifications test"
     assert push.content.body == "If you see this, then it's working :)"
-    # the above two are equivalent to this
-
-    push = push_collector.get_for_user(user.id, index=0)
-    assert push.content.title == "Push notifications test"
-    assert push.content.body == "If you see this, then it's working :)"
-
 
 def test_SendBlogPostNotification(db, push_collector: PushCollector):
     super_user, super_token = generate_user(is_superuser=True)
@@ -539,12 +533,12 @@ def test_SendBlogPostNotification(db, push_collector: PushCollector):
     assert "https://couchers.org/blog/2025/05/11/v0.9.9-release" in email_fields(mock).html
     assert "https://couchers.org/blog/2025/05/11/v0.9.9-release" in email_fields(mock).plain
 
-    push = push_collector.get_for_user(user1.id)
+    push = push_collector.pop_for_user(user1.id, last=True)
     assert push.content.title == "New blog post: Couchers.org v0.9.9 Release Notes"
     assert push.content.body == "Read about last major updates before v1!"
     assert push.content.action_url == "https://couchers.org/blog/2025/05/11/v0.9.9-release"
 
-    push = push_collector.get_for_user(user2.id)
+    push = push_collector.pop_for_user(user2.id, last=True)
     assert push.content.title == "New blog post: Couchers.org v0.9.9 Release Notes"
     assert push.content.body == "Read about last major updates before v1!"
     assert push.content.action_url == "https://couchers.org/blog/2025/05/11/v0.9.9-release"
@@ -765,7 +759,7 @@ def test_SendTestMobilePushNotification(db, push_collector: PushCollector):
     with notifications_session(token) as notifications:
         notifications.SendTestMobilePushNotification(empty_pb2.Empty())
 
-    push = push_collector.get_for_user(user.id)
+    push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Mobile notifications test"
     assert push.content.body == "If you see this on your phone, everything is wired up correctly 🎉"
 
@@ -1047,7 +1041,7 @@ def test_SendDevPushNotification_success(db, push_collector: PushCollector):
             )
         )
 
-    push = push_collector.get_for_user(user.id)
+    push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Test Dev Title"
     assert push.content.body == "Test dev notification body"
     assert push.content.action_url == "https://example.com/action"
@@ -1071,7 +1065,7 @@ def test_SendDevPushNotification_minimal(db, push_collector: PushCollector):
             )
         )
 
-    push = push_collector.get_for_user(user.id)
+    push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Minimal Title"
     assert push.content.body == "Minimal body"
     assert push.topic_action == "adhoc:testing"

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -538,7 +538,7 @@ def test_WriteFriendReference_with_private_text(db, push_collector: PushCollecto
     assert e.subject == f"[TEST] You've received a friend reference from {user1.name}!"
     assert e.recipient == user2.email
 
-    push = push_collector.get_for_user(user2.id)
+    push = push_collector.pop_for_user(user2.id, last=True)
     assert push.content.title == f"New friend reference from {user1.name}"
     assert push.content.body == "They were nice!"
 
@@ -865,7 +865,7 @@ def test_WriteHostRequestReference_private_text(db, push_collector: PushCollecto
     assert e.subject == f"[TEST] You've received a reference from {user1.name}!"
     assert e.recipient == user2.email
 
-    push = push_collector.get_for_user(user2.id)
+    push = push_collector.pop_for_user(user2.id, last=True)
     assert push.content.title == f"New reference from {user1.name}"
     assert push.content.body == f"{user1.name} left you a reference, now it's your turn to write theirs!"
 

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -1336,7 +1336,7 @@ def test_request_notifications(db, push_collector: PushCollector, moderator):
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.plain
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.html
 
-    assert push_collector.get_for_user(host.id).content.title == f"New host request from {surfer.name}"
+    assert push_collector.pop_for_user(host.id, last=True).content.title == f"New host request from {surfer.name}"
 
     with requests_session(host_token) as api:
         with mock_notification_email() as mock:
@@ -1364,7 +1364,7 @@ def test_request_notifications(db, push_collector: PushCollector, moderator):
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.plain
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.html
 
-    assert push_collector.get_for_user(surfer.id).content.title == f"{host.name} accepted your host request"
+    assert push_collector.pop_for_user(surfer.id, last=True).content.title == f"{host.name} accepted your host request"
 
 
 def test_quick_decline(db, push_collector: PushCollector, moderator):
@@ -1406,7 +1406,7 @@ def test_quick_decline(db, push_collector: PushCollector, moderator):
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.plain
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.html
 
-    assert push_collector.get_for_user(host.id).content.title == f"New host request from {surfer.name}"
+    assert push_collector.pop_for_user(host.id, last=True).content.title == f"New host request from {surfer.name}"
 
     # very ugly
     # http://localhost:3000/quick-link?payload=CAEiGAoOZnJpZW5kX3JlcXVlc3QSBmFjY2VwdA==&sig=BQdk024NTATm8zlR0krSXTBhP5U9TlFv7VhJeIHZtUg=

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -699,6 +699,9 @@ def test_strong_verification_delete_data_cant_reverify(db, monkeypatch, push_col
             == api.GetUser(api_pb2.GetUserReq(user=user.username)).has_strong_verification
         )
 
+    # There should be a notification confirming it
+    push_collector.pop_for_user(user.id, last=True)
+
     # check removing SV data
     with account_session(token) as account:
         account.DeleteStrongVerificationData(empty_pb2.Empty())
@@ -791,7 +794,7 @@ def test_strong_verification_delete_data_cant_reverify(db, monkeypatch, push_col
         assert verification_attempt.user_id == user.id
         assert verification_attempt.status == StrongVerificationAttemptStatus.duplicate
 
-    push = push_collector.get_for_user(user.id, index=1)
+    push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Strong Verification failed"
     assert (
         push.content.body
@@ -942,7 +945,7 @@ def test_strong_verification_duplicate_other_user(db, monkeypatch, push_collecto
         assert verification_attempt.user_id == user2.id
         assert verification_attempt.status == StrongVerificationAttemptStatus.duplicate
 
-    push = push_collector.get_for_user(user2.id, index=0)
+    push = push_collector.pop_for_user(user2.id, last=True)
     assert push.content.title == "Strong Verification failed"
     assert (
         push.content.body
@@ -1017,7 +1020,7 @@ def test_strong_verification_non_passport(db, monkeypatch, push_collector: PushC
         assert verification_attempt.user_id == user.id
         assert verification_attempt.status == StrongVerificationAttemptStatus.failed
 
-    push = push_collector.get_for_user(user.id, index=0)
+    push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Strong Verification failed"
     assert (
         push.content.body

--- a/app/backend/src/tests/test_verification.py
+++ b/app/backend/src/tests/test_verification.py
@@ -71,7 +71,7 @@ def test_ChangePhone(db, monkeypatch, push_collector: PushCollector):
             assert len(user.phone_verification_token) == 6
 
         process_jobs()
-        push = push_collector.get_for_user(user_id)
+        push = push_collector.pop_for_user(user_id, last=True)
         assert push.content.title == "Phone verification started"
         assert push.content.body == "You started phone number verification with the number +46 70 174 06 05."
 
@@ -133,7 +133,7 @@ def test_VerifyPhone(push_collector: PushCollector):
         account.VerifyPhone(account_pb2.VerifyPhoneReq(token="111112"))
 
         process_jobs()
-        push = push_collector.get_for_user(user.id)
+        push = push_collector.pop_for_user(user.id, last=True)
         assert push.content.title == "Phone verification completed"
         assert push.content.body == "Your phone number was successfully verified as +46 70 174 06 05."
 


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
`get_for_user` required keeping track of the total number of notifications generated during the test. `pop_for_user` keeps each part of the test more separate, and naturally bakes in assertions that we haven't received extra notifications.

**Backend checklist**
- [x] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)