### PR TITLE
DRAFT Add Justfiles

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,25 @@
+# Justfile for the backend of the application
+# Run 'just [command]' in app/backend to execute the specified command
+
+# See app/backend/readme.md.
+
+PROTO_IMAGE := "registry.gitlab.com/couchers/grpc"
+DB_PASSWORD := "203d805f4b62c0a1b2f1f6b82d4583dfe563ec1619b83ce22ee414e8376a25e7"
+APP_DIR := justfile_directory() + "/app"
+
+# Generate protocol buffer files
+protos:
+    docker pull -q {{PROTO_IMAGE}}
+    docker run --rm -w /app -v {{APP_DIR}}:/app {{PROTO_IMAGE}} ./generate_protos.sh
+
+# Connect to the local development database
+db:
+    PGPASSWORD={{DB_PASSWORD}} psql -h localhost -p 6545 -U postgres -d postgres
+
+# Run backend locally with all needed dependencies (db etc).
+run-backend:
+    #!/usr/bin/env bash
+    cd app/backend
+    just run-backend
+
+alias rb := run-backend

--- a/Justfile
+++ b/Justfile
@@ -20,6 +20,19 @@ db:
 run-backend:
     #!/usr/bin/env bash
     cd app/backend
-    just run-backend
+    just run
 
 alias rb := run-backend
+
+
+setup-frontend:
+    #!/usr/bin/env bash
+    cd app/web
+    just setup
+
+run-frontend:
+    #!/usr/bin/env bash
+    cd app/web
+    just run
+
+alias rf := run-frontend

--- a/app/backend/Justfile
+++ b/app/backend/Justfile
@@ -1,0 +1,80 @@
+# Justfile for the backend of the application
+# Run 'just [command]' in app/backend to execute the specified command
+
+set dotenv-load := true
+set dotenv-filename := "../backend.dev.env"
+
+DB_PASSWORD := "203d805f4b62c0a1b2f1f6b82d4583dfe563ec1619b83ce22ee414e8376a25e7"
+DB_CONNECTION_STRING := "postgresql://postgres:" + DB_PASSWORD + "@localhost:6545/postgres"
+
+# Running `just` without arguments executes this (qc stands for quality control).
+[default]
+qc: fmt mypy test
+
+# Quick quality check.
+qqc: fmt mypy
+
+# Run backend locally with all needed dependencies (db etc).
+run-backend:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    docker compose -f ../docker-compose.local-backend.yml up -d --build --wait
+    export DATABASE_CONNECTION_STRING={{DB_CONNECTION_STRING}}
+    export SMTP_HOST=localhost
+    export OPENTELEMETRY_ENDPOINT=localhost:4317
+    uv run src/app.py
+
+alias rb := run-backend
+
+# Connect to the local development database
+db:
+    PGPASSWORD={{DB_PASSWORD}} psql -h localhost -p 6545 -U postgres -d postgres
+
+# Downgrade the local database to the previous migration
+downgrade:
+    DATABASE_CONNECTION_STRING={{DB_CONNECTION_STRING}} uv run alembic downgrade -1
+
+# Upgrade the local database to the next migration
+upgrade:
+    DATABASE_CONNECTION_STRING={{DB_CONNECTION_STRING}} uv run alembic upgrade +1
+
+# Linters.
+format:
+    uv run ruff check --fix . && uv run ruff format .
+
+fmt: format
+
+mypy:
+    uv run mypy src
+
+# Running tests.
+
+# Start a Postgres container for backend tests
+setup-test-db:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        COMPOSE_FILES="-f ../docker-compose.test.yml -f ../docker-compose.testmac.yml"
+    else
+        COMPOSE_FILES="-f ../docker-compose.test.yml"
+    fi
+    docker compose $COMPOSE_FILES up -d --wait --no-deps postgres_tests
+    docker compose $COMPOSE_FILES exec postgres_tests psql -U postgres -c \
+        "CREATE EXTENSION IF NOT EXISTS postgis; \
+         CREATE EXTENSION IF NOT EXISTS pg_trgm; \
+         CREATE EXTENSION IF NOT EXISTS btree_gist"
+
+# Tear down the test database
+teardown-db:
+    docker compose -f ../docker-compose.test.yml down
+
+# Run backend tests with optional file argument
+# Usage:
+# just test                                → runs all tests
+# just test src/tests/test_file.py         → runs tests in a specific file
+test file="":
+    #!/usr/bin/env bash
+    just setup-test-db
+    set -euo pipefail
+    export DATABASE_CONNECTION_STRING=postgresql://postgres:06b3890acd2c235c41be0bbfe22f1b386a04bf02eedf8c977486355616be2aa1@localhost:6544/testdb
+    uv run pytest {{ file }}

--- a/app/backend/Justfile
+++ b/app/backend/Justfile
@@ -15,7 +15,7 @@ qc: fmt mypy test
 qqc: fmt mypy
 
 # Run backend locally with all needed dependencies (db etc).
-run-backend:
+run:
     #!/usr/bin/env bash
     set -euo pipefail
     docker compose -f ../docker-compose.local-backend.yml up -d --build --wait
@@ -24,7 +24,7 @@ run-backend:
     export OPENTELEMETRY_ENDPOINT=localhost:4317
     uv run src/app.py
 
-alias rb := run-backend
+alias rb := run
 
 # Connect to the local development database
 db:

--- a/app/backend/readme.md
+++ b/app/backend/readme.md
@@ -1,83 +1,91 @@
 # Couchers.org backend
 
-This is the backend for Couchers.org built in Python. The React web frontend and React Native apps make API calls to it using [gRPC](https://grpc.io/) which are defined via [Protocol Buffers](https://protobuf.dev/). The business logic manipulates a [PostgreSQL](https://www.postgresql.org/) database via [SQLAlchemy](https://www.sqlalchemy.org/). Geospatial features are provided by the [PostGIS extension](https://postgis.net/).
+This is the backend for Couchers.org built in Python. The React web frontend and React Native apps 
+make API calls to it using [gRPC](https://grpc.io/) which are defined via [Protocol Buffers](https://protobuf.dev/). The business
+logic manipulates a [PostgreSQL](https://www.postgresql.org/) database via [SQLAlchemy](https://www.sqlalchemy.org/). Geospatial features are provided 
+by the [PostGIS extension](https://postgis.net/).
 
 ## Prerequisites
 
-- **Linux or macOS**. If you are using Windows, please [install Ubuntu via WSL2](https://documentation.ubuntu.com/wsl/en/latest/guides/install-ubuntu-wsl2/), then follow these instructions inside Ubuntu.
+- **Linux or macOS**. If you are using Windows, please [install Ubuntu via WSL2](https://documentation.ubuntu.com/wsl/en/latest/guides/install-ubuntu-wsl2/), then 
+  follow these instructions inside Ubuntu.
 - **Docker engine**. Please refer to the [Docker install documentation](https://docs.docker.com/engine/install/) for how to set it up.
+- **just command runner**. [Find a package for your OS](https://just.systems/man/en/packages.html). 
 - **A clone of the Couchers git repo**. `git clone https://github.com/Couchers-org/couchers.git`
 
 ### Up-to-date protocol buffers
 
-All steps assume you have up-to-date API definitions generated using protobuf and grpc. If you make or pull changes to \*.proto files, you'll need to rerun this:
+All steps assume you have up-to-date API definitions generated using protobuf and grpc. 
+If you make or pull changes to \*.proto files, you'll need to rerun this:
 
 ```sh
-cd app
-docker run --rm -w /app -v $(pwd):/app registry.gitlab.com/couchers/grpc ./generate_protos.sh
+just protos
 ```
 
 ## Building and running in Docker
 
-To spin up a complete copy of the database, backend, and proxies needed to run the platform, run the following command:
+To spin up a complete copy of the database, backend, and proxies needed to run the platform,
+run the following command:
 
 ```sh
 docker compose up --build
 ```
 
-This will not currently run the frontend, to do that, please follow the instructions in [app/web/readme.md](../web/readme.md) under *Quick Start*, then *Running against a local backend*.
+This will not currently run the frontend, to do that, please follow the instructions 
+in [app/web/readme.md](../web/readme.md) under *Quick Start*, then *Running against a local backend*.
 
-### Running tests in docker
+[//]: # (These commands don't exist - probably invented by claude? But we should add them.)
+[//]: # (### Running tests in docker)
 
-You can run all backend tests in docker with the following commands:
+[//]: # ()
+[//]: # (You can run all backend tests in docker with the following commands:)
 
-```sh
-cd app/backend
+[//]: # ()
+[//]: # (```sh)
 
-# Run all tests
-make docker-test
+[//]: # (cd app/backend)
 
-# Or run a single file's tests
-make docker-test file=test_filename.py
+[//]: # ()
+[//]: # (# Run all tests)
 
-# Teardown the test database when done
-make teardown-docker-test
-```
+[//]: # (make docker-test)
+
+[//]: # ()
+[//]: # (# Or run a single file's tests)
+
+[//]: # (make docker-test file=test_filename.py)
+
+[//]: # ()
+[//]: # (# Teardown the test database when done)
+
+[//]: # (make teardown-docker-test)
+
+[//]: # (```)
 
 ## Running the backend locally
 
-For quicker iteration, you can run the backend locally and have it talk to the rest of the containerized services.
+For quicker iteration, you can run the backend locally and have it talk to the rest 
+of the containerized services.
 
 You'll need to have Python UV installed and dependencies sync'ed:
 
 ```sh
 cd app/backend
-make setup
+# other installation methods https://github.com/astral-sh/uv?tab=readme-ov-file#installation
+curl -fsSL https://astral.sh/uv/install.sh | sh  
 uv sync --frozen
 ```
 
-In a terminal, run all containerized services except the backend.
+Run backend and all containerized services needed for it.
 
 ```sh
-cd app
-docker compose --file docker-compose.local-backend.yml up --build
+just run-backend
+# or 'just rb' for short
 ```
 
-In another terminal, run the backend locally:
 
-```sh
-cd app/backend
-
-# Use backend environment variables, overriding the host names of containerized services.
-set -a && source ../backend.dev.env && set +a
-export DATABASE_CONNECTION_STRING=${DATABASE_CONNECTION_STRING/postgres:6545/localhost:6545}
-export SMTP_HOST=localhost
-export OPENTELEMETRY_ENDPOINT=localhost:4317
-
-uv run src/app.py
-```
-
-If you find that the proxy/media services can't talk to your local backend, try setting the `BACKEND_HOST=host.docker.internal` environment variable before running the services via `docker compose`.
+If you find that the proxy/media services can't talk to your local backend, try setting 
+the `BACKEND_HOST=host.docker.internal` environment variable before running `just run-backend`
 
 ### Running tests locally
 
@@ -86,14 +94,12 @@ This is the recommended approach.
 ```sh
 cd app/backend
 
-# Start the test database
-make setup-db
+# Will set up a postgres database in docker, and run all tests
+just test
 
-# Now run the test against the testing postgres database
-make test
-
-# Or run a single file's tests, add your filename
-make test file=[test_filename.py]
+# Run a single file, or a particular test
+just test src/tests/test_account.py
+just test src/tests/test_account.py::test_reminders
 ```
 
 ## Q/A:

--- a/app/backend/readme.md
+++ b/app/backend/readme.md
@@ -10,7 +10,7 @@ by the [PostGIS extension](https://postgis.net/).
 - **Linux or macOS**. If you are using Windows, please [install Ubuntu via WSL2](https://documentation.ubuntu.com/wsl/en/latest/guides/install-ubuntu-wsl2/), then 
   follow these instructions inside Ubuntu.
 - **Docker engine**. Please refer to the [Docker install documentation](https://docs.docker.com/engine/install/) for how to set it up.
-- **just command runner**. [Find a package for your OS](https://just.systems/man/en/packages.html). 
+- **just command runner**. [Find a package for your OS here](https://just.systems/man/en/packages.html). 
 - **A clone of the Couchers git repo**. `git clone https://github.com/Couchers-org/couchers.git`
 
 ### Up-to-date protocol buffers

--- a/app/backend/src/couchers/models/host_requests.py
+++ b/app/backend/src/couchers/models/host_requests.py
@@ -122,7 +122,7 @@ class HostRequest(Base, kw_only=True):
         )
 
     @can_write_reference.expression
-    def can_write_reference_expr(cls) -> Any:  # noqa: ARG003,D102
+    def can_write_reference_expr(cls) -> Any:
         return (
             ((cls.status == HostRequestStatus.confirmed) | (cls.status == HostRequestStatus.accepted))
             & (func.now() >= cls.start_time_to_write_reference)

--- a/app/readme.md
+++ b/app/readme.md
@@ -1,6 +1,7 @@
 # Couchers.org app
 
-Our docs are divided between the **web frontend** (TypeScript/React) and the **backend** (everything else). To run everything locally, refer to the backend guide which will point you to the right place.
+Our docs are divided between the **web frontend** (TypeScript/React) and the **backend** (everything else).
+To run everything locally, refer to the backend guide which will point you to the right place.
 
 ## Frontend
 

--- a/app/web/Justfile
+++ b/app/web/Justfile
@@ -1,0 +1,20 @@
+setup:
+    #!/usr/bin/env bash
+    ## Set up node & yarn
+    # install the requires node version
+    which nvm > /dev/null 2>1 || "You need to install nvm. Install it with 'curl -sL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash'"
+    nvm install
+
+    # install yarn
+    npm install --global yarn
+
+    ## Download & extract the latest protos
+    curl -sL https://develop--protos.preview.couchershq.org/ts.tar.gz | tar xz
+
+    # install dependencies
+    yarn install
+
+run:
+     yarn start
+
+alias rf := run

--- a/app/web/readme.md
+++ b/app/web/readme.md
@@ -4,16 +4,19 @@ This is the react/nextjs web frontend for Couchers.org. We are using Typescript 
 
 Communication with the backend is via [protobuf messages](https://github.com/protocolbuffers/protobuf-javascript) over [grpc-web](https://github.com/grpc/grpc-web). You can find some helpful documentation on [protobuf messages in javascript here](https://protobuf.dev/protobuf-javascript/).
 
-_Readme last updated: 2025/08/23._
+_Readme last updated: 2026/01/13._
 
 ## Quick Start
 
 _These instructions should work directly on Linux and macOS. If you are using Windows, please [install Ubuntu via WSL2](https://documentation.ubuntu.com/wsl/en/latest/guides/install-ubuntu-wsl2/), then follow these instructions inside Ubuntu._
 
+First, install `just`. It's a command runner that we use instead of `make`. 
+[Find a package for your OS here](https://just.systems/man/en/packages.html). 
+
 You need `nodejs` v20. We recommend using `nvm` (the [node version manager](https://github.com/nvm-sh/nvm)) to do this. You can install it with:
 
 ```sh
-curl -sL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+curl -sL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
 ```
 
 **You will need to restart your terminal before `nvm` becomes available.**
@@ -34,25 +37,14 @@ You also need `git`, `curl`, and `tar`, they should be preinstalled or be availa
 Now run the following commands to get up and running:
 
 ```sh
-## Check out the repo and navigate to app/web
-# clone the git repo
+# Clone the git repo
 git clone https://github.com/Couchers-org/couchers.git
-# navigate into the repo and app/web
-cd couchers/app/web
 
-## Set up node & yarn
-# install the requires node version
-nvm install
-# install yarn
-npm install --global yarn
+# Install everything you need for frontend (assumes you have nvm and just installed, see Quick Start above)
+just setup-frontend
 
-## Download & extract the latest protos
-curl -sL https://develop--protos.preview.couchershq.org/ts.tar.gz | tar xz
-
-# install dependencies
-yarn install
-# start the frontend
-yarn start
+# Run the frontend
+just run-frontend  # or 'just rf'
 ```
 
 The frontend will now be up at <http://localhost:3000>.
@@ -105,8 +97,7 @@ The React frontend communicates with the backend using Protocol Buffers over gRP
 You can compile the protos locally if you have [installed Docker](https://docs.docker.com/engine/install/) (this is how the built protos are generated in the CI pipeline):
 
 ```sh
-cd app
-docker run --rm -w /app -v $(pwd):/app registry.gitlab.com/couchers/grpc ./generate_protos.sh
+just protos
 ```
 
 The TypeScript definitions will be generated into `app/web/proto` (all the other definitions will also be generated into the right places, for the Python backend, etc).
@@ -117,7 +108,7 @@ You can always download the latest protos at <https://develop--protos.preview.co
 
 The Quick Start instructions show you how to run only the frontend, pointing to the staging (next) backend/database. This is normally enough for most frontend development (since generally backend features are developed before the frontend implementation), but there may be cases where you want to run a modified backend. In order to do so, you need to do two things:
 
-1. compile the protos locally (see above) and run the local backend, and
+1. compile the protos locally (by running `just protos`, see above) and run the local backend, and
 2. update the frontend environment variables to point to the local backend.
 
 The following shows the quick version. You'll need docker and docker compose installed.
@@ -128,9 +119,10 @@ In one terminal, compile protos, run the backend and rest of the infrastructure:
 ## terminal 1
 cd app
 # compile protos
-docker run --rm -w /app -v $(pwd):/app registry.gitlab.com/couchers/grpc ./generate_protos.sh
-# launch the rest of the docker containers
-docker compose up
+just protos
+# launch docker containers
+docker compose up 
+# or "docker compose up -d" to launch them in the background
 ```
 
 In another one, run the frontend:
@@ -146,7 +138,7 @@ yarn start
 
 ## Sentry error logging
 
-We self-host sentry to capture errors. It can be accessed at https://couchers.sentry.io/.
+We use Sentry to capture errors. It can be accessed at https://couchers.sentry.io.
 
 ## Other dev commands
 

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ The code in this repository is licensed under the [MIT license](license.md).
 
 If you found an issue with the app, or have a suggestion/feature you'd like to raise, please add it to the Issues (in the issues tab on GitHub). A developer will come and triage the issue and add it to the backlog.
 
-If you are a **frontend developer**, we have an up to date Quick Start at [app/web/readme.md](app/web/readme.md).
+If you are a **frontend developer**, we have an up-to-date Quick Start at [app/web/readme.md](app/web/readme.md).
 
 If you are a **backend or full stack developer**, there is a Quick Start at [app/backend/readme.md](app/backend/readme.md).
 


### PR DESCRIPTION
[just](https://just.systems/man/en/introduction.html) is a better version of `make`. The main features (for me) are sane syntax and error messages, and the ability to run a recipe from any subdirectory. Which means we can define `protos` recipe in the top-level Justfile, and call it from anywhere :) 

The tool seems to be well-supported and widely used, and old enough to be stable. Since no one has a huge affection for `make`, why not give this a try.