### PR TITLE
Backend: Jinja templating: Remove v2avatar

### DIFF
--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -11,7 +11,7 @@ from couchers.i18n.localize import (
 )
 from couchers.models import Notification, NotificationTopicAction, User
 from couchers.notifications.quick_links import generate_quick_decline_link, generate_unsub_topic_action
-from couchers.proto import notification_data_pb2
+from couchers.proto import api_pb2, notification_data_pb2
 from couchers.utils import now, to_aware_datetime
 
 logger = logging.getLogger(__name__)
@@ -59,7 +59,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
                     "view_link": view_link,
                     "host_request": data.host_request,
                     "message": message,
-                    "other": other,
+                    "other": UserTemplateArgs.from_protobuf_user(other),
                 },
                 topic_action_unsubscribe_text="missed messages in host requests",
             )
@@ -75,7 +75,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
                     "quick_decline_link": generate_quick_decline_link(data.host_request),
                     "host_request": data.host_request,
                     "message": message,
-                    "other": other,
+                    "other": UserTemplateArgs.from_protobuf_user(other),
                     "text": data.text,
                 },
                 topic_action_unsubscribe_text="new host requests",
@@ -95,7 +95,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
                     "view_link": view_link,
                     "host_request": data.host_request,
                     "message": message,
-                    "other": other,
+                    "other": UserTemplateArgs.from_protobuf_user(other),
                     "text": data.text,
                 },
                 topic_action_unsubscribe_text=topic_action_unsub_text,
@@ -123,7 +123,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
                     "view_link": view_link,
                     "host_request": data.host_request,
                     "message": message,
-                    "other": other,
+                    "other": UserTemplateArgs.from_protobuf_user(other),
                 },
                 topic_action_unsubscribe_text=f"{actioned} host requests",
             )
@@ -138,7 +138,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
                     "view_link": view_link,
                     "host_request": data.host_request,
                     "message": description,
-                    "other": data.surfer,
+                    "other": UserTemplateArgs.from_protobuf_user(data.surfer),
                 },
                 topic_action_unsubscribe_text="Pending host request reminders",
             )
@@ -314,7 +314,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
             template_name="friend_request",
             template_args={
                 "friend_requests_link": urls.friend_requests_link(),
-                "other": other,
+                "other": UserTemplateArgs.from_protobuf_user(other),
             },
             topic_action_unsubscribe_text="new friend requests",
         )
@@ -327,8 +327,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
             preview=preview,
             template_name="friend_request_accepted",
             template_args={
-                "other_user_link": urls.user_link(username=other.username),
-                "other": other,
+                "other": UserTemplateArgs.from_protobuf_user(other),
             },
             topic_action_unsubscribe_text="accepted friend requests",
         )
@@ -375,7 +374,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
             preview="You received a message on Couchers.org!",
             template_name="chat_message",
             template_args={
-                "author": data.author,
+                "author": UserTemplateArgs.from_protobuf_user(data.author),
                 "message": data.message,
                 "text": data.text,
                 "view_link": urls.chat_link(chat_id=data.group_chat_id),
@@ -391,7 +390,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
             template_args={
                 "items": [
                     {
-                        "author": item.author,
+                        "author": UserTemplateArgs.from_protobuf_user(item.author),
                         "message": item.message,
                         "text": item.text,
                         "view_link": urls.chat_link(chat_id=item.group_chat_id),
@@ -410,7 +409,6 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
         if notification.action in ["create_approved", "create_any"]:
             # create_approved = invitation, approved by mods
             # create_any = new event created by anyone (no need for approval) -- off by default
-            body = f"{time_display}\n"
             if notification.action == "create_approved":
                 subject = f'{data.inviting_user.name} invited you to "{event.title}"'
                 start_text = "You've been invited to a new event"
@@ -427,7 +425,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
                 preview=f"{start_text} on Couchers.org!",
                 template_name="event_create",
                 template_args={
-                    "inviting_user": data.inviting_user,
+                    "inviting_user": UserTemplateArgs.from_protobuf_user(data.inviting_user),
                     "time_display": time_display,
                     "start_text": start_text,
                     "nearby": "nearby" if data.nearby else None,
@@ -449,7 +447,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
                 preview="An event you are subscribed to was updated.",
                 template_name="event_update",
                 template_args={
-                    "updating_user": data.updating_user,
+                    "updating_user": UserTemplateArgs.from_protobuf_user(data.updating_user),
                     "time_display": time_display,
                     "event": event,
                     "updated_text": updated_text,
@@ -463,7 +461,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
                 preview="An event you are subscribed to has been cancelled.",
                 template_name="event_cancel",
                 template_args={
-                    "cancelling_user": data.cancelling_user,
+                    "cancelling_user": UserTemplateArgs.from_protobuf_user(data.cancelling_user),
                     "time_display": time_display,
                     "event": event,
                     "view_link": event_link,
@@ -487,7 +485,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
                 preview="You were invited to co-organize an event on Couchers.org.",
                 template_name="event_invite_organizer",
                 template_args={
-                    "inviting_user": data.inviting_user,
+                    "inviting_user": UserTemplateArgs.from_protobuf_user(data.inviting_user),
                     "time_display": time_display,
                     "event": event,
                     "view_link": event_link,
@@ -500,7 +498,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
                 preview="Someone commented on an event you are attending.",
                 template_name="event_comment",
                 template_args={
-                    "author": data.author,
+                    "author": UserTemplateArgs.from_protobuf_user(data.author),
                     "time_display": time_display,
                     "event": event,
                     "content": data.reply.content,
@@ -529,7 +527,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
                 preview="Someone created a discussion in a community or group you are subscribed to.",
                 template_name="discussion_create",
                 template_args={
-                    "author": data.author,
+                    "author": UserTemplateArgs.from_protobuf_user(data.author),
                     "discussion": discussion,
                     "view_link": discussion_link,
                 },
@@ -541,7 +539,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
                 preview="Someone commented on your discussion.",
                 template_name="discussion_comment",
                 template_args={
-                    "author": data.author,
+                    "author": UserTemplateArgs.from_protobuf_user(data.author),
                     "discussion": discussion,
                     "reply": data.reply,
                     "view_link": discussion_link,
@@ -564,7 +562,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
             preview="Someone replied in a comment thread you have participated in.",
             template_name="comment_reply",
             template_args={
-                "author": data.author,
+                "author": UserTemplateArgs.from_protobuf_user(data.author),
                 "title": title,
                 "reply": data.reply,
                 "view_link": view_link,
@@ -579,7 +577,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
                 preview=data.text,
                 template_name="friend_reference",
                 template_args={
-                    "from_user": data.from_user,
+                    "from_user": UserTemplateArgs.from_protobuf_user(data.from_user),
                     "profile_references_link": urls.profile_references_link(),
                     "text": data.text,
                 },
@@ -604,7 +602,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
                 preview=preview,
                 template_name="host_reference",
                 template_args={
-                    "from_user": data.from_user,
+                    "from_user": UserTemplateArgs.from_protobuf_user(data.from_user),
                     "leave_reference_link": leave_reference_link,
                     "profile_references_link": profile_references_link,
                     "text": data.text,
@@ -628,7 +626,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
                 preview=preview,
                 template_name="reference_reminder",
                 template_args={
-                    "other_user": data.other_user,
+                    "other_user": UserTemplateArgs.from_protobuf_user(data.other_user),
                     "leave_reference_link": leave_reference_link,
                     "days_left": str(data.days_left),
                     "surfed": surfed,
@@ -772,3 +770,27 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
         )
 
     raise NotImplementedError(f"Unknown topic-action: {notification.topic}:{notification.action}")
+
+
+@dataclass
+class UserTemplateArgs:
+    """
+    A user's information for email template placeholders.
+    Allows decoupling from protocol buffer objects.
+    """
+
+    name: str
+    age: int
+    city: str
+    avatar_url: str
+    profile_url: str
+
+    @staticmethod
+    def from_protobuf_user(user: api_pb2.User) -> UserTemplateArgs:
+        return UserTemplateArgs(
+            name=user.name,
+            age=user.age,
+            city=user.city,
+            avatar_url=user.avatar_thumbnail_url or urls.icon_url(),
+            profile_url=urls.user_link(username=user.username),
+        )

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -9,8 +9,7 @@ from couchers import urls
 from couchers.i18n.localize import format_phone_number, localize_date_from_iso, localize_datetime_for_user
 from couchers.models import Notification, NotificationTopicAction, User
 from couchers.notifications.push import PushNotificationContent
-from couchers.proto import events_pb2, notification_data_pb2
-from couchers.templates.v2 import v2avatar
+from couchers.proto import api_pb2, events_pb2, notification_data_pb2
 
 logger = logging.getLogger(__name__)
 
@@ -143,6 +142,10 @@ def render_push_notification(user: User, notification: Notification) -> PushNoti
             assert_never(notification.topic_action)
 
 
+def _avatar_url_or_default(user: api_pb2.User) -> str:
+    return user.avatar_thumbnail_url or urls.icon_url()
+
+
 def _account_deletion__start(data: notification_data_pb2.AccountDeletionStart) -> PushNotificationContent:
     return PushNotificationContent(
         title="Account deletion initiated",
@@ -208,7 +211,7 @@ def _chat__message(data: notification_data_pb2.ChatMessage) -> PushNotificationC
     return PushNotificationContent(
         title=data.message,
         body=data.text,
-        icon_url=v2avatar(data.author),
+        icon_url=_avatar_url_or_default(data.author),
         action_url=urls.chat_link(chat_id=data.group_chat_id),
     )
 
@@ -233,7 +236,7 @@ def _discussion__create(data: notification_data_pb2.DiscussionCreate) -> PushNot
     return PushNotificationContent(
         title=data.discussion.title,
         body=f"{data.author.name} created a discussion in {data.discussion.owner_title}: {data.discussion.title}\n\n{data.discussion.content}",
-        icon_url=v2avatar(data.author),
+        icon_url=_avatar_url_or_default(data.author),
         action_url=urls.discussion_link(discussion_id=data.discussion.discussion_id, slug=data.discussion.slug),
     )
 
@@ -242,7 +245,7 @@ def _discussion__comment(data: notification_data_pb2.DiscussionComment) -> PushN
     return PushNotificationContent(
         title=data.discussion.title,
         body=f"{data.author.name} commented:\n\n{data.reply.content}",
-        icon_url=v2avatar(data.author),
+        icon_url=_avatar_url_or_default(data.author),
         action_url=urls.discussion_link(discussion_id=data.discussion.discussion_id, slug=data.discussion.slug),
     )
 
@@ -274,7 +277,7 @@ def _event__create_any(data: notification_data_pb2.EventCreate, user: User) -> P
     return PushNotificationContent(
         title=f'{data.inviting_user.name} created an event called "{data.event.title}"',
         body=f"{time_display}\nCreated by {data.inviting_user.name}\n\n{data.event.content}",
-        icon_url=v2avatar(data.inviting_user),
+        icon_url=_avatar_url_or_default(data.inviting_user),
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
 
@@ -284,7 +287,7 @@ def _event__create_approved(data: notification_data_pb2.EventCreate, user: User)
     return PushNotificationContent(
         title=f'{data.inviting_user.name} invited you to "{data.event.title}"',
         body=f"{time_display}\nInvited by {data.inviting_user.name}\n\n{data.event.content}",
-        icon_url=v2avatar(data.inviting_user),
+        icon_url=_avatar_url_or_default(data.inviting_user),
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
 
@@ -295,7 +298,7 @@ def _event__update(data: notification_data_pb2.EventUpdate, user: User) -> PushN
     return PushNotificationContent(
         title=f'{data.updating_user.name} updated "{data.event.title}"',
         body=f"{time_display}\n{data.updating_user.name} updated: {updated_text}\n\n{data.event.content}",
-        icon_url=v2avatar(data.updating_user),
+        icon_url=_avatar_url_or_default(data.updating_user),
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
 
@@ -305,7 +308,7 @@ def _event__invite_organizer(data: notification_data_pb2.EventInviteOrganizer, u
     return PushNotificationContent(
         title=f'{data.inviting_user.name} invited you to co-organize "{data.event.title}"',
         body=f"{time_display}\nInvited to co-organize by {data.inviting_user.name}\n\n{data.event.content}",
-        icon_url=v2avatar(data.inviting_user),
+        icon_url=_avatar_url_or_default(data.inviting_user),
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
 
@@ -315,7 +318,7 @@ def _event__comment(data: notification_data_pb2.EventComment, user: User) -> Pus
     return PushNotificationContent(
         title=f'{data.author.name} commented on "{data.event.title}"',
         body=f"{time_display}\n{data.author.name} commented:\n\n{data.reply.content}",
-        icon_url=v2avatar(data.author),
+        icon_url=_avatar_url_or_default(data.author),
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
 
@@ -334,7 +337,7 @@ def _event__cancel(data: notification_data_pb2.EventCancel, user: User) -> PushN
     return PushNotificationContent(
         title=f'{data.cancelling_user.name} cancelled "{data.event.title}"',
         body=f"{time_display}\nThe event has been cancelled by {data.cancelling_user.name}.\n\n{data.event.content}",
-        icon_url=v2avatar(data.cancelling_user),
+        icon_url=_avatar_url_or_default(data.cancelling_user),
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
 
@@ -351,7 +354,7 @@ def _friend_request__create(data: notification_data_pb2.FriendRequestCreate) -> 
     return PushNotificationContent(
         title=f"{data.other_user.name} wants to be your friend",
         body=f"You've received a friend request from {data.other_user.name}",
-        icon_url=v2avatar(data.other_user),
+        icon_url=_avatar_url_or_default(data.other_user),
         action_url=urls.friend_requests_link(),
     )
 
@@ -360,7 +363,7 @@ def _friend_request__accept(data: notification_data_pb2.FriendRequestAccept) -> 
     return PushNotificationContent(
         title=f"{data.other_user.name} accepted your friend request!",
         body=f"{data.other_user.name} has accepted your friend request",
-        icon_url=v2avatar(data.other_user),
+        icon_url=_avatar_url_or_default(data.other_user),
         action_url=urls.user_link(username=data.other_user.username),
     )
 
@@ -388,7 +391,7 @@ def _host_request__create(data: notification_data_pb2.HostRequestCreate, user: U
         title=f"{data.surfer.name} sent you a host request",
         body=f"Dates: {from_date} to {to_date}.\n\n{data.text}",
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
-        icon_url=v2avatar(data.surfer),
+        icon_url=_avatar_url_or_default(data.surfer),
     )
 
 
@@ -403,7 +406,7 @@ def _host_request__message(data: notification_data_pb2.HostRequestMessage, user:
         title=title,
         body=f"Dates: {from_date} to {to_date}.\n\n{data.text}",
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
-        icon_url=v2avatar(data.user),
+        icon_url=_avatar_url_or_default(data.user),
     )
 
 
@@ -413,7 +416,7 @@ def _host_request__missed_messages(data: notification_data_pb2.HostRequestMissed
         title=f"{data.user.name} sent you message(s) in {their_your} host request",
         body="Check the app for more info.",
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
-        icon_url=v2avatar(data.user),
+        icon_url=_avatar_url_or_default(data.user),
     )
 
 
@@ -422,7 +425,7 @@ def _host_request__reminder(data: notification_data_pb2.HostRequestReminder) -> 
         title=f"You have a pending host request from {data.surfer.name}!",
         body="Please respond to the request!",
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
-        icon_url=v2avatar(data.surfer),
+        icon_url=_avatar_url_or_default(data.surfer),
     )
 
 
@@ -431,7 +434,7 @@ def _host_request__accept(data: notification_data_pb2.HostRequestAccept) -> Push
         title=f"{data.host.name} accepted your host request",
         body="Check the app for more info.",
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
-        icon_url=v2avatar(data.host),
+        icon_url=_avatar_url_or_default(data.host),
     )
 
 
@@ -440,7 +443,7 @@ def _host_request__reject(data: notification_data_pb2.HostRequestReject) -> Push
         title=f"{data.host.name} rejected your host request",
         body="Check the app for more info.",
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
-        icon_url=v2avatar(data.host),
+        icon_url=_avatar_url_or_default(data.host),
     )
 
 
@@ -449,7 +452,7 @@ def _host_request__cancel(data: notification_data_pb2.HostRequestCancel) -> Push
         title=f"{data.surfer.name} cancelled their host request",
         body="Check the app for more info.",
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
-        icon_url=v2avatar(data.surfer),
+        icon_url=_avatar_url_or_default(data.surfer),
     )
 
 
@@ -458,7 +461,7 @@ def _host_request__confirm(data: notification_data_pb2.HostRequestConfirm) -> Pu
         title=f"{data.surfer.name} confirmed their host request",
         body="Check the app for more info.",
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
-        icon_url=v2avatar(data.surfer),
+        icon_url=_avatar_url_or_default(data.surfer),
     )
 
 
@@ -562,7 +565,7 @@ def _reference__receive_friend(data: notification_data_pb2.ReferenceReceiveFrien
     return PushNotificationContent(
         title=f"You've received a friend reference from {data.from_user.name}!",
         body=data.text,
-        icon_url=v2avatar(data.from_user),
+        icon_url=_avatar_url_or_default(data.from_user),
         action_url=urls.profile_references_link(),
     )
 
@@ -585,7 +588,7 @@ def _reference__receive(
     return PushNotificationContent(
         title=f"You've received a reference from {data.from_user.name}!",
         body=body,
-        icon_url=v2avatar(data.from_user),
+        icon_url=_avatar_url_or_default(data.from_user),
         action_url=action_url,
     )
 
@@ -608,7 +611,7 @@ def _reference__reminder(data: notification_data_pb2.ReferenceReminder, referenc
     return PushNotificationContent(
         title=f"You have {data.days_left} days to write a reference for {data.other_user.name}!",
         body="It's a nice gesture to write references and helps us build a community together! References will become visible 2 weeks after the stay, or when you've both written a reference for each other, whichever happens first.",
-        icon_url=v2avatar(data.other_user),
+        icon_url=_avatar_url_or_default(data.other_user),
         action_url=leave_reference_link,
     )
 
@@ -636,7 +639,7 @@ def _thread__reply(data: notification_data_pb2.ThreadReply) -> PushNotificationC
     return PushNotificationContent(
         title=title,
         body=f"{data.author.name} replied:\n\n{data.reply.content}",
-        icon_url=v2avatar(data.author),
+        icon_url=_avatar_url_or_default(data.author),
         action_url=view_link,
     )
 

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -17,7 +17,6 @@ from jinja2 import Environment, FileSystemLoader, pass_context
 from jinja2.runtime import Context as JinjaContext
 from markdown_it import MarkdownIt
 
-from couchers import urls
 from couchers.i18n.localize import format_phone_number, localize_date, localize_datetime, localize_string, localize_time
 
 logger = logging.getLogger(__name__)
@@ -93,12 +92,6 @@ def v2timestamp(jinja_context: JinjaContext, value: Timestamp) -> str:
     return localize_datetime(value, context.timezone, context.locale)
 
 
-def v2avatar(user: Any) -> str:
-    if not user.avatar_thumbnail_url:
-        return urls.icon_url()
-    return user.avatar_thumbnail_url  # type: ignore[no-any-return]
-
-
 def v2quote(value: str) -> str:
     """
     Multiline quote, use in place of markdown in plaintext emails
@@ -164,7 +157,6 @@ def _get_jinja2_env() -> Environment:
     env.filters["v2date"] = v2date
     env.filters["v2time"] = v2time
     env.filters["v2timestamp"] = v2timestamp
-    env.filters["v2avatar"] = v2avatar
     env.filters["v2quote"] = v2quote
     env.filters["v2markdown"] = v2markdown
     env.filters["v2translate"] = v2translate

--- a/app/backend/templates/v2/chat_message.mjml
+++ b/app/backend/templates/v2/chat_message.mjml
@@ -9,7 +9,7 @@
     <mj-table>
       <tr>
         <td style="width: 100px;">
-          <img width="80px" style="border-radius: 80px" src="{{ author|v2avatar }}" />
+          <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}" />
         </td>
         <td>
           <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br />{{ author.city|v2esc }}

--- a/app/backend/templates/v2/chat_unseen_messages.mjml
+++ b/app/backend/templates/v2/chat_unseen_messages.mjml
@@ -15,7 +15,7 @@
     <mj-table>
       <tr>
         <td style="width: 100px;">
-          <img width="80px" style="border-radius: 80px" src="{{ item.author|v2avatar }}" />
+          <img width="80px" style="border-radius: 80px" src="{{ item.author.avatar_url }}" />
         </td>
         <td>
           <b>{{ item.author.name|v2esc }}</b>, {{ item.author.age|v2esc }}<br />{{ item.author.city|v2esc }}

--- a/app/backend/templates/v2/comment_reply.mjml
+++ b/app/backend/templates/v2/comment_reply.mjml
@@ -9,7 +9,7 @@
     <mj-table>
       <tr>
         <td style="width: 100px;">
-          <img width="80px" style="border-radius: 80px" src="{{ author|v2avatar }}" />
+          <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}" />
         </td>
         <td>
           <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br />{{ author.city|v2esc }}

--- a/app/backend/templates/v2/discussion_comment.mjml
+++ b/app/backend/templates/v2/discussion_comment.mjml
@@ -9,7 +9,7 @@
     <mj-table>
       <tr>
         <td style="width: 100px;">
-          <img width="80px" style="border-radius: 80px" src="{{ author|v2avatar }}" />
+          <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}" />
         </td>
         <td>
           <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br />{{ author.city|v2esc }}

--- a/app/backend/templates/v2/discussion_create.mjml
+++ b/app/backend/templates/v2/discussion_create.mjml
@@ -9,7 +9,7 @@
     <mj-table>
       <tr>
         <td style="width: 100px;">
-          <img width="80px" style="border-radius: 80px" src="{{ author|v2avatar }}" />
+          <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}" />
         </td>
         <td>
           <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br />{{ author.city|v2esc }}

--- a/app/backend/templates/v2/event_cancel.mjml
+++ b/app/backend/templates/v2/event_cancel.mjml
@@ -13,7 +13,7 @@
     <mj-table>
       <tr>
         <td style="width: 100px;">
-          <img width="80px" style="border-radius: 80px" src="{{ cancelling_user|v2avatar }}" />
+          <img width="80px" style="border-radius: 80px" src="{{ cancelling_user.avatar_url }}" />
         </td>
         <td>
           <b>Cancelled by {{ cancelling_user.name|v2esc }}</b>, {{ cancelling_user.age|v2esc }}<br />{{ cancelling_user.city|v2esc }}

--- a/app/backend/templates/v2/event_comment.mjml
+++ b/app/backend/templates/v2/event_comment.mjml
@@ -9,7 +9,7 @@
     <mj-table>
       <tr>
         <td style="width: 100px;">
-          <img width="80px" style="border-radius: 80px" src="{{ author|v2avatar }}" />
+          <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}" />
         </td>
         <td>
           <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br />{{ author.city|v2esc }}

--- a/app/backend/templates/v2/event_create.mjml
+++ b/app/backend/templates/v2/event_create.mjml
@@ -13,7 +13,7 @@
     <mj-table>
       <tr>
         <td style="width: 100px;">
-          <img width="80px" style="border-radius: 80px" src="{{ inviting_user|v2avatar }}" />
+          <img width="80px" style="border-radius: 80px" src="{{ inviting_user.avatar_url }}" />
         </td>
         <td>
           <b>Organized by {{ inviting_user.name|v2esc }}</b>, {{ inviting_user.age|v2esc }}<br />{{ inviting_user.city|v2esc }}

--- a/app/backend/templates/v2/event_invite_organizer.mjml
+++ b/app/backend/templates/v2/event_invite_organizer.mjml
@@ -13,7 +13,7 @@
     <mj-table>
       <tr>
         <td style="width: 100px;">
-          <img width="80px" style="border-radius: 80px" src="{{ inviting_user|v2avatar }}" />
+          <img width="80px" style="border-radius: 80px" src="{{ inviting_user.avatar_url }}" />
         </td>
         <td>
           <b>Invited by {{ inviting_user.name|v2esc }}</b>, {{ inviting_user.age|v2esc }}<br />{{ inviting_user.city|v2esc }}

--- a/app/backend/templates/v2/event_update.mjml
+++ b/app/backend/templates/v2/event_update.mjml
@@ -14,7 +14,7 @@
     <mj-table>
       <tr>
         <td style="width: 100px;">
-          <img width="80px" style="border-radius: 80px" src="{{ updating_user|v2avatar }}" />
+          <img width="80px" style="border-radius: 80px" src="{{ updating_user.avatar_url }}" />
         </td>
         <td>
           <b>Updated by {{ updating_user.name|v2esc }}</b>, {{ updating_user.age|v2esc }}<br />{{ updating_user.city|v2esc }}

--- a/app/backend/templates/v2/friend_reference.mjml
+++ b/app/backend/templates/v2/friend_reference.mjml
@@ -9,7 +9,7 @@
     <mj-table>
       <tr>
         <td style="width: 100px;">
-          <img width="80px" style="border-radius: 80px" src="{{ from_user|v2avatar }}" />
+          <img width="80px" style="border-radius: 80px" src="{{ from_user.avatar_url }}" />
         </td>
         <td>
           <b>{{ from_user.name|v2esc }}</b>, {{ from_user.age|v2esc }}<br />{{ from_user.city|v2esc }}

--- a/app/backend/templates/v2/friend_request.mjml
+++ b/app/backend/templates/v2/friend_request.mjml
@@ -9,7 +9,7 @@
     <mj-table>
       <tr>
         <td style="width: 100px;">
-          <img width="80px" style="border-radius: 80px" src="{{ other|v2avatar }}" />
+          <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}" />
         </td>
         <td>
           <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br />{{ other.city|v2esc }}

--- a/app/backend/templates/v2/friend_request_accepted.mjml
+++ b/app/backend/templates/v2/friend_request_accepted.mjml
@@ -9,7 +9,7 @@
     <mj-table>
       <tr>
         <td style="width: 100px;">
-          <img width="80px" style="border-radius: 80px" src="{{ other|v2avatar }}" />
+          <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}" />
         </td>
         <td>
           <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br />{{ other.city|v2esc }}
@@ -20,7 +20,7 @@
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ other_user_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ other.profile_url|v2url }}">
       <b>View their profile</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/friend_request_accepted.txt
+++ b/app/backend/templates/v2/friend_request_accepted.txt
@@ -2,7 +2,7 @@ Hi {{ user.name }}!
 
 {{ other.name }} has accepted your friend request! Check it out here:
 
-<{{ other_user_link }}>
+<{{ other.profile_url }}>
 
 
 We hope you continue making new friends!

--- a/app/backend/templates/v2/generated_html/chat_message.html
+++ b/app/backend/templates/v2/generated_html/chat_message.html
@@ -199,7 +199,7 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ author|v2avatar }}">
+                                        <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}">
                                       </td>
                                       <td>
                                         <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br>{{ author.city|v2esc }}

--- a/app/backend/templates/v2/generated_html/chat_unseen_messages.html
+++ b/app/backend/templates/v2/generated_html/chat_unseen_messages.html
@@ -225,7 +225,7 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ item.author|v2avatar }}">
+                                        <img width="80px" style="border-radius: 80px" src="{{ item.author.avatar_url }}">
                                       </td>
                                       <td>
                                         <b>{{ item.author.name|v2esc }}</b>, {{ item.author.age|v2esc }}<br>{{ item.author.city|v2esc }}

--- a/app/backend/templates/v2/generated_html/comment_reply.html
+++ b/app/backend/templates/v2/generated_html/comment_reply.html
@@ -199,7 +199,7 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ author|v2avatar }}">
+                                        <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}">
                                       </td>
                                       <td>
                                         <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br>{{ author.city|v2esc }}

--- a/app/backend/templates/v2/generated_html/discussion_comment.html
+++ b/app/backend/templates/v2/generated_html/discussion_comment.html
@@ -199,7 +199,7 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ author|v2avatar }}">
+                                        <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}">
                                       </td>
                                       <td>
                                         <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br>{{ author.city|v2esc }}

--- a/app/backend/templates/v2/generated_html/discussion_create.html
+++ b/app/backend/templates/v2/generated_html/discussion_create.html
@@ -199,7 +199,7 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ author|v2avatar }}">
+                                        <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}">
                                       </td>
                                       <td>
                                         <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br>{{ author.city|v2esc }}

--- a/app/backend/templates/v2/generated_html/event_cancel.html
+++ b/app/backend/templates/v2/generated_html/event_cancel.html
@@ -207,7 +207,7 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ cancelling_user|v2avatar }}">
+                                        <img width="80px" style="border-radius: 80px" src="{{ cancelling_user.avatar_url }}">
                                       </td>
                                       <td>
                                         <b>Cancelled by {{ cancelling_user.name|v2esc }}</b>, {{ cancelling_user.age|v2esc }}<br>{{ cancelling_user.city|v2esc }}

--- a/app/backend/templates/v2/generated_html/event_comment.html
+++ b/app/backend/templates/v2/generated_html/event_comment.html
@@ -199,7 +199,7 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ author|v2avatar }}">
+                                        <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}">
                                       </td>
                                       <td>
                                         <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br>{{ author.city|v2esc }}

--- a/app/backend/templates/v2/generated_html/event_create.html
+++ b/app/backend/templates/v2/generated_html/event_create.html
@@ -207,7 +207,7 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ inviting_user|v2avatar }}">
+                                        <img width="80px" style="border-radius: 80px" src="{{ inviting_user.avatar_url }}">
                                       </td>
                                       <td>
                                         <b>Organized by {{ inviting_user.name|v2esc }}</b>, {{ inviting_user.age|v2esc }}<br>{{ inviting_user.city|v2esc }}

--- a/app/backend/templates/v2/generated_html/event_invite_organizer.html
+++ b/app/backend/templates/v2/generated_html/event_invite_organizer.html
@@ -207,7 +207,7 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ inviting_user|v2avatar }}">
+                                        <img width="80px" style="border-radius: 80px" src="{{ inviting_user.avatar_url }}">
                                       </td>
                                       <td>
                                         <b>Invited by {{ inviting_user.name|v2esc }}</b>, {{ inviting_user.age|v2esc }}<br>{{ inviting_user.city|v2esc }}

--- a/app/backend/templates/v2/generated_html/event_update.html
+++ b/app/backend/templates/v2/generated_html/event_update.html
@@ -212,7 +212,7 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ updating_user|v2avatar }}">
+                                        <img width="80px" style="border-radius: 80px" src="{{ updating_user.avatar_url }}">
                                       </td>
                                       <td>
                                         <b>Updated by {{ updating_user.name|v2esc }}</b>, {{ updating_user.age|v2esc }}<br>{{ updating_user.city|v2esc }}

--- a/app/backend/templates/v2/generated_html/friend_reference.html
+++ b/app/backend/templates/v2/generated_html/friend_reference.html
@@ -199,7 +199,7 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ from_user|v2avatar }}">
+                                        <img width="80px" style="border-radius: 80px" src="{{ from_user.avatar_url }}">
                                       </td>
                                       <td>
                                         <b>{{ from_user.name|v2esc }}</b>, {{ from_user.age|v2esc }}<br>{{ from_user.city|v2esc }}

--- a/app/backend/templates/v2/generated_html/friend_request.html
+++ b/app/backend/templates/v2/generated_html/friend_request.html
@@ -199,7 +199,7 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ other|v2avatar }}">
+                                        <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}">
                                       </td>
                                       <td>
                                         <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br>{{ other.city|v2esc }}

--- a/app/backend/templates/v2/generated_html/friend_request_accepted.html
+++ b/app/backend/templates/v2/generated_html/friend_request_accepted.html
@@ -199,7 +199,7 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ other|v2avatar }}">
+                                        <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}">
                                       </td>
                                       <td>
                                         <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br>{{ other.city|v2esc }}
@@ -233,7 +233,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ other_user_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ other.profile_url|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>View their profile</b>
                                           </a>
                                         </td>

--- a/app/backend/templates/v2/generated_html/host_reference.html
+++ b/app/backend/templates/v2/generated_html/host_reference.html
@@ -199,7 +199,7 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ from_user|v2avatar }}">
+                                        <img width="80px" style="border-radius: 80px" src="{{ from_user.avatar_url }}">
                                       </td>
                                       <td>
                                         <b>{{ from_user.name|v2esc }}</b>, {{ from_user.age|v2esc }}<br>{{ from_user.city|v2esc }}

--- a/app/backend/templates/v2/generated_html/host_request__message.html
+++ b/app/backend/templates/v2/generated_html/host_request__message.html
@@ -199,7 +199,7 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ other|v2avatar }}">
+                                        <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}">
                                       </td>
                                       <td>
                                         <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br>{{ other.city|v2esc }}

--- a/app/backend/templates/v2/generated_html/host_request__new.html
+++ b/app/backend/templates/v2/generated_html/host_request__new.html
@@ -209,7 +209,7 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ other|v2avatar }}">
+                                        <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}">
                                       </td>
                                       <td>
                                         <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br>{{ other.city|v2esc }}

--- a/app/backend/templates/v2/generated_html/host_request__plain.html
+++ b/app/backend/templates/v2/generated_html/host_request__plain.html
@@ -199,7 +199,7 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ other|v2avatar }}">
+                                        <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}">
                                       </td>
                                       <td>
                                         <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br>{{ other.city|v2esc }}

--- a/app/backend/templates/v2/generated_html/reference_reminder.html
+++ b/app/backend/templates/v2/generated_html/reference_reminder.html
@@ -204,7 +204,7 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ other_user|v2avatar }}">
+                                        <img width="80px" style="border-radius: 80px" src="{{ other_user.avatar_url }}">
                                       </td>
                                       <td>
                                         <b>{{ other_user.name|v2esc }}</b>, {{ other_user.age|v2esc }}<br>{{ other_user.city|v2esc }}

--- a/app/backend/templates/v2/host_reference.mjml
+++ b/app/backend/templates/v2/host_reference.mjml
@@ -9,7 +9,7 @@
     <mj-table>
       <tr>
         <td style="width: 100px;">
-          <img width="80px" style="border-radius: 80px" src="{{ from_user|v2avatar }}" />
+          <img width="80px" style="border-radius: 80px" src="{{ from_user.avatar_url }}" />
         </td>
         <td>
           <b>{{ from_user.name|v2esc }}</b>, {{ from_user.age|v2esc }}<br />{{ from_user.city|v2esc }}

--- a/app/backend/templates/v2/host_request__message.mjml
+++ b/app/backend/templates/v2/host_request__message.mjml
@@ -9,7 +9,7 @@
     <mj-table>
       <tr>
         <td style="width: 100px;">
-          <img width="80px" style="border-radius: 80px" src="{{ other|v2avatar }}" />
+          <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}" />
         </td>
         <td>
           <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br />{{ other.city|v2esc }}

--- a/app/backend/templates/v2/host_request__new.mjml
+++ b/app/backend/templates/v2/host_request__new.mjml
@@ -9,7 +9,7 @@
     <mj-table>
       <tr>
         <td style="width: 100px;">
-          <img width="80px" style="border-radius: 80px" src="{{ other|v2avatar }}" />
+          <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}" />
         </td>
         <td>
           <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br />{{ other.city|v2esc }}

--- a/app/backend/templates/v2/host_request__plain.mjml
+++ b/app/backend/templates/v2/host_request__plain.mjml
@@ -9,7 +9,7 @@
     <mj-table>
       <tr>
         <td style="width: 100px;">
-          <img width="80px" style="border-radius: 80px" src="{{ other|v2avatar }}" />
+          <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}" />
         </td>
         <td>
           <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br />{{ other.city|v2esc }}

--- a/app/backend/templates/v2/reference_reminder.mjml
+++ b/app/backend/templates/v2/reference_reminder.mjml
@@ -10,7 +10,7 @@
     <mj-table>
       <tr>
         <td style="width: 100px;">
-          <img width="80px" style="border-radius: 80px" src="{{ other_user|v2avatar }}" />
+          <img width="80px" style="border-radius: 80px" src="{{ other_user.avatar_url }}" />
         </td>
         <td>
           <b>{{ other_user.name|v2esc }}</b>, {{ other_user.age|v2esc }}<br />{{ other_user.city|v2esc }}


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
Removes `v2avatar` templating filter in favor of a `UserTemplatingArgs` dataclass such that emails templating has a contract for a user object decoupled from protobufs and with useful avatar/profile urls already resolved.

In addition to the stronger templating contract, this was the last jinja filter that wasn't purely about text manipulation, which will help me layer email templating above generic jinja text templating.

**Please give clear steps for how the reviewer can best test this PR**
Covered by existing tests, or send a message to get a new message notification email.

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A

**Backend checklist**
- [x] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)