### PR TITLE
Codeowners: Narrow down Weblate integrations matching

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
+# Only the last matching line's owners are added to the PR
 * @aapeliv
+/app/**/locales/*.json @tristanlabelle # Watch Weblate integrations
 /app/web/ @nabramow
 /docs/ @aapeliv @nabramow
-/app/**/locales/*.json @tristanlabelle


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
Codeowners doesn't accumulate reviewers from different rules, only the last one wins, unfortunately. I ended up being the only reviewer added to all frontend PRs touching `en.json`.

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)