### PR TITLE
Backend: build fix: dataclass parameter name

### DIFF
--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -772,7 +772,7 @@ def render_email_notification(user: User, notification: Notification) -> Rendere
     raise NotImplementedError(f"Unknown topic-action: {notification.topic}:{notification.action}")
 
 
-@dataclass(frozen=True, slots=True, kw_args=True)
+@dataclass(frozen=True, slots=True, kw_only=True)
 class UserTemplateArgs:
     """
     A user's information for email template placeholders.


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
CI let me merge https://github.com/Couchers-org/couchers/pull/7666 which has a bogus dataclass parameter :/

**Backend checklist**
Mypy is happy now
- [ ] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)