### PR TITLE
Photo galleries Part I: Dual write to galleries and avatar key

### DIFF
--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -354,7 +354,7 @@ class API(api_pb2_grpc.APIServicer):
                 if user.profile_gallery:
                     # Add the new avatar as the only photo
                     item = PhotoGalleryItem(
-                        gallery_id=user.profile_gallery_id,
+                        gallery_id=user.profile_gallery.id,
                         upload_key=request.avatar_key.value,
                         position=0.0,
                     )

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -32,6 +32,7 @@ from couchers.models import (
     Notification,
     NotificationDeliveryType,
     ParkingDetails,
+    PhotoGalleryItem,
     RateLimitAction,
     Reference,
     RegionLived,
@@ -343,8 +344,21 @@ class API(api_pb2_grpc.APIServicer):
         if request.HasField("avatar_key"):
             if request.avatar_key.is_null:
                 user.avatar_key = None
+                # Also remove all photos from gallery?
+                if user.profile_gallery:
+                    for photo in user.profile_gallery.photos:
+                        session.delete(photo)
             else:
                 user.avatar_key = request.avatar_key.value
+                # Also add to gallery at position 0 (dual-write)
+                if user.profile_gallery:
+                    # Add the new avatar as the only photo
+                    item = PhotoGalleryItem(
+                        gallery_id=user.profile_gallery_id,
+                        upload_key=request.avatar_key.value,
+                        position=0.0,
+                    )
+                    session.add(item)
 
         # if request.HasField("gender"):
         #     user.gender = request.gender.value

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -8,7 +8,15 @@ from sqlalchemy import select, update
 from couchers.db import session_scope
 from couchers.jobs.handlers import update_badges
 from couchers.materialized_views import refresh_materialized_views_rapid
-from couchers.models import FriendRelationship, FriendStatus, LanguageFluency, RateLimitAction, User
+from couchers.models import (
+    FriendRelationship,
+    FriendStatus,
+    LanguageFluency,
+    PhotoGalleryItem,
+    RateLimitAction,
+    Upload,
+    User,
+)
 from couchers.proto import admin_pb2, api_pb2, blocking_pb2, jail_pb2, notifications_pb2
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_HOURS
 from couchers.resources import get_badge_dict
@@ -625,6 +633,90 @@ def test_update_profile_do_not_email(db):
             api.UpdateProfile(api_pb2.UpdateProfileReq(meetup_status=api_pb2.MEETUP_STATUS_OPEN_TO_MEETUP))
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
         assert e.value.details() == "You cannot enable meeting up while you have emails turned off in your settings."
+
+
+def test_update_profile_avatar_dual_write(db):
+    """Test that setting avatar_key also writes to profile gallery (dual-write)"""
+    user, token = generate_user()
+
+    # Create an upload for the user
+    with session_scope() as session:
+        upload = Upload(
+            key="test_avatar_key_123",
+            filename="avatar.jpg",
+            creator_user_id=user.id,
+        )
+        session.add(upload)
+        session.commit()
+
+    # Set avatar via UpdateProfile
+    with api_session(token) as api:
+        api.UpdateProfile(api_pb2.UpdateProfileReq(avatar_key=api_pb2.NullableStringValue(value="test_avatar_key_123")))
+
+    # Verify both avatar_key and gallery were updated
+    with session_scope() as session:
+        db_user = session.execute(select(User).where(User.id == user.id)).scalar_one()
+
+        # avatar_key should be set
+        assert db_user.avatar_key == "test_avatar_key_123"
+
+        # Gallery should also have the photo
+        gallery_items = (
+            session.execute(select(PhotoGalleryItem).where(PhotoGalleryItem.gallery_id == db_user.profile_gallery_id))
+            .scalars()
+            .all()
+        )
+        assert len(gallery_items) == 1
+        assert gallery_items[0].upload_key == "test_avatar_key_123"
+        assert gallery_items[0].position == 0.0
+
+
+def test_update_profile_avatar_dual_write_clear(db):
+    """Test that clearing avatar_key also clears the profile gallery"""
+    user, token = generate_user()
+
+    # Create an upload and set it as avatar
+    with session_scope() as session:
+        upload = Upload(
+            key="test_avatar_to_clear",
+            filename="avatar.jpg",
+            creator_user_id=user.id,
+        )
+        session.add(upload)
+        session.commit()
+
+    with api_session(token) as api:
+        # First set the avatar
+        api.UpdateProfile(
+            api_pb2.UpdateProfileReq(avatar_key=api_pb2.NullableStringValue(value="test_avatar_to_clear"))
+        )
+
+    # Verify it's set
+    with session_scope() as session:
+        db_user = session.execute(select(User).where(User.id == user.id)).scalar_one()
+        assert db_user.avatar_key == "test_avatar_to_clear"
+        gallery_items = (
+            session.execute(select(PhotoGalleryItem).where(PhotoGalleryItem.gallery_id == db_user.profile_gallery_id))
+            .scalars()
+            .all()
+        )
+        assert len(gallery_items) == 1
+
+    # Now clear the avatar
+    with api_session(token) as api:
+        api.UpdateProfile(api_pb2.UpdateProfileReq(avatar_key=api_pb2.NullableStringValue(is_null=True)))
+
+    # Verify both are cleared
+    with session_scope() as session:
+        db_user = session.execute(select(User).where(User.id == user.id)).scalar_one()
+        assert db_user.avatar_key is None
+
+        gallery_items = (
+            session.execute(select(PhotoGalleryItem).where(PhotoGalleryItem.gallery_id == db_user.profile_gallery_id))
+            .scalars()
+            .all()
+        )
+        assert len(gallery_items) == 0
 
 
 def test_language_abilities(db):


### PR DESCRIPTION
Breaking this PR up into smaller bits so we can discuss part by part and maybe the review is less overwhelming ;-).

For this PR I am adding code when a user adds a profile photo that it adds to both galleries and avatar_key.

The overall goal is to replace avatar_key with galleries and allow multiple profile photos.

The next steps:
- Migration to migrate existing avatar_keys into galleries #7671 
- Convert frontend to use profile_gallery_id instead of avatar_key (with existing UI)
- Remove avatar_key entirely
- Do new UI design to allow multiple photos

**TO TEST:**
- Run backend locally `docker compose up --build`
- In `.env.development` replace this value with local version: `NEXT_PUBLIC_API_BASE_URL="http://localhost:8888"
`
- In `web` folder run `yarn` to install deps and then `yarn start`
- Go to localhost:3000 in browser and login with `aapeli` dummy user
- Upload a photo via EditProfile and save
- Check DB. `users` table should have `avatar` key and `profile_gallery_items` table should have an `upload_key` with the same id.
- Replace with a different photo
- `profile_gallery_items` should have a new row added and `users` table should reference the new upload_key as the avatar_key