### PR TITLE
Backend: Escape jinja2 placeholders by default

### DIFF
--- a/app/backend/src/couchers/email/send.py
+++ b/app/backend/src/couchers/email/send.py
@@ -32,8 +32,7 @@ def send_simple_pretty_email(
         "footer_email_is_critical": True,  # Results in no unsubscribe footer.
     }
 
-    # Not yet localizable
-    html_context = Context(output_html=True, timezone=ZoneInfo("Etc/UTC"), locale="en")
+    html_context = Context(output_html=True, timezone=timezone, locale=locale)
     plaintext_context = replace(html_context, output_html=False)
 
     # Format plaintext template

--- a/app/backend/src/couchers/email/send.py
+++ b/app/backend/src/couchers/email/send.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -31,32 +32,18 @@ def send_simple_pretty_email(
         "footer_email_is_critical": True,  # Results in no unsubscribe footer.
     }
 
+    # Not yet localizable
+    html_context = Context(output_html=True, timezone=ZoneInfo("Etc/UTC"), locale="en")
+    plaintext_context = replace(html_context, output_html=False)
+
     # Format plaintext template
     plain_tmplt = (template_folder / f"{template_name}.txt").read_text()
     plain_tmplt_footer = (template_folder / "_footer.txt").read_text()
-    plain = render_template(
-        plain_tmplt + plain_tmplt_footer,
-        template_args,
-        Context(
-            output_html=False,
-            # Not yet localizable
-            timezone=ZoneInfo("Etc/UTC"),
-            locale="en",
-        ),
-    )
+    plain = render_template(plain_tmplt + plain_tmplt_footer, template_args, plaintext_context)
 
     # Format html template
     html_tmplt = (template_folder / "generated_html" / f"{template_name}.html").read_text()
-    html = render_template(
-        html_tmplt,
-        template_args,
-        Context(
-            output_html=True,
-            # Not yet localizable
-            timezone=ZoneInfo("Etc/UTC"),
-            locale="en",
-        ),
-    )
+    html = render_template(html_tmplt, template_args, html_context)
 
     queue_email(
         session,

--- a/app/backend/src/couchers/email/send.py
+++ b/app/backend/src/couchers/email/send.py
@@ -34,13 +34,29 @@ def send_simple_pretty_email(
     # Format plaintext template
     plain_tmplt = (template_folder / f"{template_name}.txt").read_text()
     plain_tmplt_footer = (template_folder / "_footer.txt").read_text()
-    plain_context = Context(timezone=timezone, locale="en", plaintext=True)
-    plain = render_template(plain_tmplt + plain_tmplt_footer, template_args, plain_context)
+    plain = render_template(
+        plain_tmplt + plain_tmplt_footer,
+        template_args,
+        Context(
+            output_html=False,
+            # Not yet localizable
+            timezone=ZoneInfo("Etc/UTC"),
+            locale="en",
+        ),
+    )
 
     # Format html template
     html_tmplt = (template_folder / "generated_html" / f"{template_name}.html").read_text()
-    html_context = Context(timezone=timezone, locale="en", plaintext=False)
-    html = render_template(html_tmplt, template_args, html_context)
+    html = render_template(
+        html_tmplt,
+        template_args,
+        Context(
+            output_html=True,
+            # Not yet localizable
+            timezone=ZoneInfo("Etc/UTC"),
+            locale="en",
+        ),
+    )
 
     queue_email(
         session,

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import replace
 from zoneinfo import ZoneInfo
 
 from google.protobuf import empty_pb2
@@ -41,7 +42,9 @@ def _send_email_notification(session: Session, user: User, notification: Notific
     locale = "en"
     if config["ENABLE_NOTIFICATION_TRANSLATIONS"]:
         locale = user.ui_language_preference or "en"
-    timezone = ZoneInfo(user.timezone or "Etc/UTC")
+
+    html_context = Context(output_html=True, timezone=ZoneInfo(user.timezone or "Etc/UTC"), locale=email_lang)
+    plaintext_context = replace(html_context, output_html=False)
 
     template_args = {
         **rendered.template_args,
@@ -63,13 +66,11 @@ def _send_email_notification(session: Session, user: User, notification: Notific
     # Format plaintext template
     plain_tmplt = (template_folder / f"{rendered.template_name}.txt").read_text()
     plain_tmplt_footer = (template_folder / "_footer.txt").read_text()
-    plain = render_template(
-        plain_tmplt + plain_tmplt_footer, template_args, Context(timezone=timezone, locale=locale, plaintext=True)
-    )
+    plain = render_template(plain_tmplt + plain_tmplt_footer, template_args, plaintext_context)
 
     # Format html template
     html_tmplt = (template_folder / "generated_html" / f"{rendered.template_name}.html").read_text()
-    html = render_template(html_tmplt, template_args, Context(timezone=timezone, locale=locale, plaintext=False))
+    html = render_template(html_tmplt, template_args, html_context)
 
     if user.do_not_email and not rendered.is_critical:
         logger.info(f"Not emailing {user} based on template {rendered.template_name} due to emails turned off")

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -42,8 +42,9 @@ def _send_email_notification(session: Session, user: User, notification: Notific
     locale = "en"
     if config["ENABLE_NOTIFICATION_TRANSLATIONS"]:
         locale = user.ui_language_preference or "en"
+    timezone = ZoneInfo(user.timezone or "Etc/UTC")
 
-    html_context = Context(output_html=True, timezone=ZoneInfo(user.timezone or "Etc/UTC"), locale=email_lang)
+    html_context = Context(output_html=True, timezone=timezone, locale=locale)
     plaintext_context = replace(html_context, output_html=False)
 
     template_args = {

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -60,7 +60,7 @@ class Context:
 
 def _make_jinja_env(context: Context) -> Environment:
     env = Environment(trim_blocks=True)
-    env.autoescape = False # We do escaping in _format_default
+    env.autoescape = False  # We do escaping in _format_default
     env.finalize = lambda value: _format_default(value, context)
     env.filters["multiline"] = _filter_multiline
     env.filters["quotelines"] = _filter_quotelines
@@ -71,6 +71,7 @@ def _make_jinja_env(context: Context) -> Environment:
     env.filters["datetime"] = _filter_datetime
     env.filters["translate"] = _filter_translate
     return env
+
 
 def _format_default(value: Any, context: Context) -> str:
     """Formats a placeholder value into a jinja template with useful defaults."""
@@ -94,7 +95,7 @@ def _filter_multiline(jinja_context: JinjaContext, value: Any) -> str | Markup:
     """Converts newlines to HTML line breaks, if rendering HTML."""
     context = Context.from_jinja(jinja_context)
     if Context.from_jinja(jinja_context).output_html:
-        value = _format_default(value, context) # Escape input HTML unless Markup()
+        value = _format_default(value, context)  # Escape input HTML unless Markup()
         return Markup(value.replace("\n", "<br>"))
     else:
         return value

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -104,8 +104,10 @@ def _filter_multiline(jinja_context: JinjaContext, value: Any) -> str | Markup:
     if Context.from_jinja(jinja_context).output_html:
         value = _format_default(value, context)  # Escape input HTML unless Markup()
         return Markup(value.replace("\n", "<br>"))
-    else:
+    elif isinstance(value, Markup):
         return value
+    else:
+        return _format_default(value, context)
 
 
 @pass_context
@@ -202,8 +204,12 @@ def _replace_html_tag_match(match: re.Match[str]) -> str:
         # <a href="url">text</a> -> <url>
         # If no url, fallback to text.
         href_attr = re.search(r'\bhref="([^"]+)"', match.group("attrs"))
-        plaintext = href_attr.group(1) if href_attr else inner_text
-        return f"<{plaintext}>"
+        link_text: str
+        if href_attr:
+            link_text = href_attr.group(1).removeprefix("mailto:")
+        else:
+            link_text = inner_text
+        return f"<{link_text}>"
     else:
         # <b>hello</b> -> hello
         return inner_text

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -4,20 +4,21 @@ template mailer/push notification formatter v2
 
 import logging
 import re
-from dataclasses import dataclass
-from datetime import date, datetime
-from functools import lru_cache
+from dataclasses import dataclass, field
+from datetime import date, datetime, time
 from html import escape
 from pathlib import Path
 from typing import Any, ClassVar
 from zoneinfo import ZoneInfo
 
 from google.protobuf.timestamp_pb2 import Timestamp
-from jinja2 import Environment, FileSystemLoader, pass_context
+from jinja2 import Environment, pass_context
 from jinja2.runtime import Context as JinjaContext
 from markdown_it import MarkdownIt
+from markupsafe import Markup
 
-from couchers.i18n.localize import format_phone_number, localize_date, localize_datetime, localize_string, localize_time
+from couchers.i18n.i18next import I18Next
+from couchers.i18n.localize import get_i18next, localize_date, localize_datetime, localize_time
 
 logger = logging.getLogger(__name__)
 
@@ -26,20 +27,40 @@ template_folder = Path(__file__).parent / ".." / ".." / ".." / "templates" / "v2
 md = MarkdownIt("zero", {"typographer": True}).enable(["smartquotes", "heading", "hr", "list", "link", "emphasis"])
 
 
+def render_template(template: str, args: dict[str, Any], context: Context) -> str:
+    """Renders an a jinja2 template which may use our jinja2 filters."""
+
+    env = Environment(trim_blocks=True)
+    env.autoescape = context.output_html
+    env.finalize = lambda value: _finalize(value, context)
+    env.filters["multiline"] = _filter_multiline
+    env.filters["quotelines"] = _filter_quotelines
+    env.filters["markdown"] = _filter_markdown
+    env.filters["html"] = _filter_html
+    env.filters["date"] = _filter_date
+    env.filters["time"] = _filter_time
+    env.filters["datetime"] = _filter_datetime
+    env.filters["translate"] = _filter_translate
+
+    args = {**args, Context.KEY: context}
+    return env.from_string(template).render(args)
+
+
 @dataclass(frozen=True, slots=True, kw_only=True)
 class Context:
     """Context available to filter functions during templating."""
 
     KEY: ClassVar[str] = "_filter_context"
 
-    timezone: ZoneInfo
-    """The timezone to use when formatting times."""
+    output_html: bool = True
+
+    i18next: I18Next = field(default_factory=get_i18next)
 
     locale: str
     """The locale to use when localizing strings or formatting times."""
 
-    plaintext: bool
-    """If true, strips html tags from localized strings."""
+    timezone: ZoneInfo
+    """The timezone to use when formatting times."""
 
     @staticmethod
     def from_jinja(jinja_context: JinjaContext) -> Context:
@@ -47,28 +68,56 @@ class Context:
         return context
 
 
-def v2esc(value: Any) -> str:
-    return escape(str(value))
-
-
-def v2multiline(value: str) -> str:
-    return "<br />".join(value.splitlines())
-
-
-def v2sf(value: str) -> str:
-    return value
-
-
-def v2url(value: str) -> str:
-    return value
-
-
-def v2phone(value: str) -> str:
-    return format_phone_number(value)
+def _finalize(value: Any, context: Context) -> Any:
+    match value:
+        case date():
+            return localize_date(value, context.locale)
+        case datetime():
+            return localize_datetime(value, context.timezone, context.locale)
+        case time():
+            return localize_time(value, context.locale)
+        case Timestamp():
+            return localize_datetime(value, context.timezone, context.locale)
+        case _:
+            return value
 
 
 @pass_context
-def v2date(jinja_context: JinjaContext, value: date | str) -> str:
+def _filter_multiline(jinja_context: JinjaContext, value: str) -> str | Markup:
+    # Escape the HTML but render newlines as HTML.
+    if Context.from_jinja(jinja_context).output_html:
+        return Markup(escape(value).replace("\n", "<br>"))
+    else:
+        return value
+
+
+@pass_context
+def _filter_quotelines(jinja_context: JinjaContext, value: str) -> str:
+    """If plaintext, prefixes each line to indicate a quote."""
+    if Context.from_jinja(jinja_context).output_html:
+        return value
+    else:
+        return "\n".join(f"> {line}" for line in value.splitlines())
+
+
+@pass_context
+def _filter_markdown(jinja_context: JinjaContext, value: str) -> Markup:
+    """Renders markdown into html."""
+    context = Context.from_jinja(jinja_context)
+    if context.output_html:
+        return Markup(md.render(value))
+    else:
+        return Markup(value)
+
+
+@pass_context
+def _filter_html(jinja_context: JinjaContext, value: Any) -> Markup:
+    """Marks a string as safely containing HTML, so it won't get escaped."""
+    return Markup(value)
+
+
+@pass_context
+def _filter_date(jinja_context: JinjaContext, value: date | str) -> str:
     context = Context.from_jinja(jinja_context)
     if isinstance(value, str):
         value = date.fromisoformat(value)
@@ -76,30 +125,54 @@ def v2date(jinja_context: JinjaContext, value: date | str) -> str:
 
 
 @pass_context
-def v2time(jinja_context: JinjaContext, value: datetime) -> str:
+def _filter_time(jinja_context: JinjaContext, value: datetime | time) -> str:
     context = Context.from_jinja(jinja_context)
-    value = value.astimezone(context.timezone)
-    return localize_time(value.time(), context.locale)
+    if isinstance(value, datetime):
+        value = value.astimezone(context.timezone).time()
+    return localize_time(value, context.locale)
 
 
 @pass_context
-def v2timestamp(jinja_context: JinjaContext, value: Timestamp) -> str:
+def _filter_datetime(jinja_context: JinjaContext, value: datetime | Timestamp) -> str:
     context = Context.from_jinja(jinja_context)
     return localize_datetime(value, context.timezone, context.locale)
 
 
-def v2quote(value: str) -> str:
+@pass_context
+def _filter_translate(jinja_context: JinjaContext, key: str, **kwargs: Any) -> Markup:
     """
-    Multiline quote, use in place of markdown in plaintext emails
+    Jinja2 filter to translate a string key with substitutions.
+
+    Usage in template:
+        {{ "greeting_key"|translate(name=user.name) }}
     """
-    return "\n> ".join([""] + value.splitlines())
+
+    context = Context.from_jinja(jinja_context)
+
+    # Translated strings are trusted and may include HTML tags,
+    # but substitutions are untrusted and shouldn't.
+
+    substitutions = kwargs
+    if context.output_html:
+        substitutions = {k: escape(str(v)) for k, v in kwargs.items()}
+
+    value = context.i18next.get_string(key, context.locale, substitutions)
+
+    if context.output_html:
+        # Translated strings may contain newlines for convenience.
+        # Turn them into HTML like breaks.
+        value = value.replace("\n", "<br>")
+    else:
+        # Translated strings may contain simple and trusted tags.
+        # But since we're not outputting HTML, strip them.
+        # Doesn't support nesting, but should be sufficient for our needs.
+        value = re.sub(r"<(\w+).*?>(.*?)</\1>", _replace_html_tag_match, value)
+        value = re.sub(r"<br\s*/?>", "\n", value)
+
+    return Markup(value)
 
 
-def v2markdown(value: str) -> str:
-    return md.render(value)  # type: ignore[no-any-return]
-
-
-def replace_tag(match: re.Match[str]) -> str:
+def _replace_html_tag_match(match: re.Match[str]) -> str:
     tag = match.group(1)
     inner_text = match.group(2)
     if tag.lower() == "a":
@@ -108,61 +181,3 @@ def replace_tag(match: re.Match[str]) -> str:
     else:
         # <b>hello</b> -> hello
         return inner_text
-
-
-@pass_context
-def v2translate(jinja_context: JinjaContext, key: str, **kwargs: Any) -> str:
-    """
-    Jinja2 filter to translate a string key with substitutions.
-
-    Usage in template:
-        {{ "greeting_key"|v2translate(name=user.name) }}
-    """
-
-    context = Context.from_jinja(jinja_context)
-
-    # Prevent html injection
-    escaped_substitutions = {k: escape(str(v)) for k, v in kwargs.items()}
-
-    translated = localize_string(context.locale, key, substitutions=escaped_substitutions)
-
-    # Translations may include simple formatting HTML like <b> or <a>,
-    # but those should not appear in plain text emails.
-    if context.plaintext:
-        # Doesn't support nesting, but should be sufficient for our needs
-        translated = re.sub(r"<(\w+).*?>(.*?)</\1>", replace_tag, translated)
-        translated = re.sub(r"<br\s*/?>", "\n", translated)
-
-    else:
-        # HTML support, email flavored
-        # mjml rendering converts <br /> to <br>, so prefer that form.
-        translated = translated.replace("\n", "<br>")
-
-    return translated
-
-
-@lru_cache(maxsize=1)
-def _get_jinja2_env() -> Environment:
-    loader = FileSystemLoader(template_folder)
-    env = Environment(loader=loader, trim_blocks=True)
-    env.filters["v2esc"] = v2esc
-    env.filters["v2multiline"] = v2multiline
-    env.filters["v2sf"] = v2sf
-    env.filters["v2url"] = v2url
-    env.filters["v2phone"] = v2phone
-    env.filters["v2date"] = v2date
-    env.filters["v2time"] = v2time
-    env.filters["v2timestamp"] = v2timestamp
-    env.filters["v2quote"] = v2quote
-    env.filters["v2markdown"] = v2markdown
-    env.filters["v2translate"] = v2translate
-    return env
-
-
-def render_template(template: str, args: dict[str, Any], context: Context) -> str:
-    """Renders an a jinja2 template which may use our jinja2 filters."""
-
-    # Append to the context values used by filters
-    env = _get_jinja2_env()
-    args = {**args, Context.KEY: context}
-    return env.from_string(template).render(args)

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -77,11 +77,15 @@ def _get_jinja_env() -> Environment:
 
 @pass_context
 def _finalize(jinja_context: JinjaContext, value: Any) -> str:
+    """
+    Converts a placeholder value into a string for output in a jinja template.
+    For example, "{{ my_date }}" will honor the context's locale and timezone.
+    """
     return _format_default(value, Context.from_jinja(jinja_context))
 
 
 def _format_default(value: Any, context: Context) -> str:
-    """Formats a placeholder value into a jinja template with useful defaults."""
+    """Formats a placeholder value into a string with useful defaults."""
     match value:
         case date():
             return localize_date(value, context.locale)

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -30,20 +30,8 @@ md = MarkdownIt("zero", {"typographer": True}).enable(["smartquotes", "heading",
 def render_template(template: str, args: dict[str, Any], context: Context) -> str:
     """Renders an a jinja2 template which may use our jinja2 filters."""
 
-    env = Environment(trim_blocks=True)
-    env.autoescape = context.output_html
-    env.finalize = lambda value: _finalize(value, context)
-    env.filters["multiline"] = _filter_multiline
-    env.filters["quotelines"] = _filter_quotelines
-    env.filters["markdown"] = _filter_markdown
-    env.filters["html"] = _filter_html
-    env.filters["date"] = _filter_date
-    env.filters["time"] = _filter_time
-    env.filters["datetime"] = _filter_datetime
-    env.filters["translate"] = _filter_translate
-
     args = {**args, Context.KEY: context}
-    return env.from_string(template).render(args)
+    return _make_jinja_env(context).from_string(template).render(args)
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -52,9 +40,8 @@ class Context:
 
     KEY: ClassVar[str] = "_filter_context"
 
-    output_html: bool = True
-
-    i18next: I18Next = field(default_factory=get_i18next)
+    output_html: bool
+    """If true, the output format supports HTML, so placeholders will be escaped by default."""
 
     locale: str
     """The locale to use when localizing strings or formatting times."""
@@ -62,13 +49,31 @@ class Context:
     timezone: ZoneInfo
     """The timezone to use when formatting times."""
 
+    i18next: I18Next = field(default_factory=get_i18next)
+    """The I18Next instance to be used to resolve localized strings."""
+
     @staticmethod
     def from_jinja(jinja_context: JinjaContext) -> Context:
         context: Context = jinja_context[Context.KEY]
         return context
 
 
-def _finalize(value: Any, context: Context) -> Any:
+def _make_jinja_env(context: Context) -> Environment:
+    env = Environment(trim_blocks=True)
+    env.autoescape = False # We do escaping in _format_default
+    env.finalize = lambda value: _format_default(value, context)
+    env.filters["multiline"] = _filter_multiline
+    env.filters["quotelines"] = _filter_quotelines
+    env.filters["markdown"] = _filter_markdown
+    env.filters["html"] = _filter_html
+    env.filters["date"] = _filter_date
+    env.filters["time"] = _filter_time
+    env.filters["datetime"] = _filter_datetime
+    env.filters["translate"] = _filter_translate
+    return env
+
+def _format_default(value: Any, context: Context) -> str:
+    """Formats a placeholder value into a jinja template with useful defaults."""
     match value:
         case date():
             return localize_date(value, context.locale)
@@ -78,21 +83,25 @@ def _finalize(value: Any, context: Context) -> Any:
             return localize_time(value, context.locale)
         case Timestamp():
             return localize_datetime(value, context.timezone, context.locale)
+        case Markup():
+            return str(value)
         case _:
-            return value
+            return escape(str(value)) if context.output_html else str(value)
 
 
 @pass_context
-def _filter_multiline(jinja_context: JinjaContext, value: str) -> str | Markup:
-    # Escape the HTML but render newlines as HTML.
+def _filter_multiline(jinja_context: JinjaContext, value: Any) -> str | Markup:
+    """Converts newlines to HTML line breaks, if rendering HTML."""
+    context = Context.from_jinja(jinja_context)
     if Context.from_jinja(jinja_context).output_html:
-        return Markup(escape(value).replace("\n", "<br>"))
+        value = _format_default(value, context) # Escape input HTML unless Markup()
+        return Markup(value.replace("\n", "<br>"))
     else:
         return value
 
 
 @pass_context
-def _filter_quotelines(jinja_context: JinjaContext, value: str) -> str:
+def _filter_quotelines(jinja_context: JinjaContext, value: str | Markup) -> str | Markup:
     """If plaintext, prefixes each line to indicate a quote."""
     if Context.from_jinja(jinja_context).output_html:
         return value
@@ -110,22 +119,25 @@ def _filter_markdown(jinja_context: JinjaContext, value: str) -> Markup:
         return Markup(value)
 
 
-@pass_context
-def _filter_html(jinja_context: JinjaContext, value: Any) -> Markup:
+def _filter_html(value: Any) -> Markup:
     """Marks a string as safely containing HTML, so it won't get escaped."""
     return Markup(value)
 
 
 @pass_context
-def _filter_date(jinja_context: JinjaContext, value: date | str) -> str:
+def _filter_date(jinja_context: JinjaContext, value: date | datetime | str) -> str:
+    """Formats a date using the context's locale."""
     context = Context.from_jinja(jinja_context)
     if isinstance(value, str):
         value = date.fromisoformat(value)
+    if isinstance(value, datetime):
+        value = value.astimezone(context.timezone).date()
     return localize_date(value, context.locale)
 
 
 @pass_context
 def _filter_time(jinja_context: JinjaContext, value: datetime | time) -> str:
+    """Formats a time using the context's locale."""
     context = Context.from_jinja(jinja_context)
     if isinstance(value, datetime):
         value = value.astimezone(context.timezone).time()
@@ -134,6 +146,7 @@ def _filter_time(jinja_context: JinjaContext, value: datetime | time) -> str:
 
 @pass_context
 def _filter_datetime(jinja_context: JinjaContext, value: datetime | Timestamp) -> str:
+    """Formats a date+time using the context's locale and timezone."""
     context = Context.from_jinja(jinja_context)
     return localize_datetime(value, context.timezone, context.locale)
 
@@ -141,7 +154,7 @@ def _filter_datetime(jinja_context: JinjaContext, value: datetime | Timestamp) -
 @pass_context
 def _filter_translate(jinja_context: JinjaContext, key: str, **kwargs: Any) -> Markup:
     """
-    Jinja2 filter to translate a string key with substitutions.
+    Looks up a localized string, applying substitutions.
 
     Usage in template:
         {{ "greeting_key"|translate(name=user.name) }}
@@ -149,35 +162,40 @@ def _filter_translate(jinja_context: JinjaContext, key: str, **kwargs: Any) -> M
 
     context = Context.from_jinja(jinja_context)
 
-    # Translated strings are trusted and may include HTML tags,
-    # but substitutions are untrusted and shouldn't.
+    # Stringify substitutions, applying default formatting and
+    # escaping unless they have been marked as safely containing HTML.
+    substitutions: dict[str, str | int] = {}
+    for k, v in kwargs.items():
+        match v:
+            case int():
+                substitutions[k] = v
+            case _:
+                substitutions[k] = _format_default(v, context)
 
-    substitutions = kwargs
+    value = context.i18next.localize(key, context.locale, substitutions)
+
+    # Translated strings are trusted to contain simple HTML tags,
+    # they can also have newlines for translator convenience.
     if context.output_html:
-        substitutions = {k: escape(str(v)) for k, v in kwargs.items()}
-
-    value = context.i18next.get_string(key, context.locale, substitutions)
-
-    if context.output_html:
-        # Translated strings may contain newlines for convenience.
-        # Turn them into HTML like breaks.
+        # Turn newlines into HTML line breaks.
         value = value.replace("\n", "<br>")
     else:
-        # Translated strings may contain simple and trusted tags.
-        # But since we're not outputting HTML, strip them.
+        # Strip HTML tags that came from the strings since we're not outputting HTML.
         # Doesn't support nesting, but should be sufficient for our needs.
-        value = re.sub(r"<(\w+).*?>(.*?)</\1>", _replace_html_tag_match, value)
+        value = re.sub(r"<(?P<name>\w+)(?P<attrs>[^>]*)>(?P<inner>.*?)</(?P=name)>", _replace_html_tag_match, value)
         value = re.sub(r"<br\s*/?>", "\n", value)
 
     return Markup(value)
 
 
 def _replace_html_tag_match(match: re.Match[str]) -> str:
-    tag = match.group(1)
-    inner_text = match.group(2)
-    if tag.lower() == "a":
-        # <a href="url">text</a> -> <text>
-        return f"<{inner_text}>"
+    inner_text = match.group("inner")
+    if match.group("name").lower() == "a":
+        # <a href="url">text</a> -> <url>
+        # If no url, fallback to text.
+        href_attr = re.search(r'\bhref="([^"]+)"', match.group("attrs"))
+        plaintext = href_attr.group(1) if href_attr else inner_text
+        return f"<{plaintext}>"
     else:
         # <b>hello</b> -> hello
         return inner_text

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -6,6 +6,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
+from functools import lru_cache
 from html import escape
 from pathlib import Path
 from typing import Any, ClassVar
@@ -18,7 +19,7 @@ from markdown_it import MarkdownIt
 from markupsafe import Markup
 
 from couchers.i18n.i18next import I18Next
-from couchers.i18n.localize import get_i18next, localize_date, localize_datetime, localize_time
+from couchers.i18n.localize import get_main_i18next, localize_date, localize_datetime, localize_time
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ def render_template(template: str, args: dict[str, Any], context: Context) -> st
     """Renders an a jinja2 template which may use our jinja2 filters."""
 
     args = {**args, Context.KEY: context}
-    return _make_jinja_env(context).from_string(template).render(args)
+    return _get_jinja_env().from_string(template).render(args)
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -49,7 +50,7 @@ class Context:
     timezone: ZoneInfo
     """The timezone to use when formatting times."""
 
-    i18next: I18Next = field(default_factory=get_i18next)
+    i18next: I18Next = field(default_factory=get_main_i18next)
     """The I18Next instance to be used to resolve localized strings."""
 
     @staticmethod
@@ -58,10 +59,11 @@ class Context:
         return context
 
 
-def _make_jinja_env(context: Context) -> Environment:
+@lru_cache(maxsize=1)
+def _get_jinja_env() -> Environment:
     env = Environment(trim_blocks=True)
-    env.autoescape = False  # We do escaping in _format_default
-    env.finalize = lambda value: _format_default(value, context)
+    env.autoescape = False  # We do escaping in _finalize
+    env.finalize = _finalize
     env.filters["multiline"] = _filter_multiline
     env.filters["quotelines"] = _filter_quotelines
     env.filters["markdown"] = _filter_markdown
@@ -71,6 +73,11 @@ def _make_jinja_env(context: Context) -> Environment:
     env.filters["datetime"] = _filter_datetime
     env.filters["translate"] = _filter_translate
     return env
+
+
+@pass_context
+def _finalize(jinja_context: JinjaContext, value: Any) -> str:
+    return _format_default(value, Context.from_jinja(jinja_context))
 
 
 def _format_default(value: Any, context: Context) -> str:

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -1,3 +1,4 @@
+import html
 import json
 import re
 from urllib.parse import parse_qs, urlparse
@@ -176,7 +177,7 @@ def test_unsubscribe(db):
         if "payload" not in link:
             continue
         print(link)
-        url_parts = urlparse(link)
+        url_parts = urlparse(html.unescape(link))
         params = parse_qs(url_parts.query)
         print(params["payload"][0])
         payload = unsubscribe_pb2.UnsubscribePayload.FromString(b64decode(params["payload"][0]))
@@ -237,7 +238,7 @@ def test_unsubscribe_do_not_email(db):
         if "payload" not in link:
             continue
         print(link)
-        url_parts = urlparse(link)
+        url_parts = urlparse(html.unescape(link))
         params = parse_qs(url_parts.query)
         print(params["payload"][0])
         payload = unsubscribe_pb2.UnsubscribePayload.FromString(b64decode(params["payload"][0]))

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -1,3 +1,4 @@
+import html
 import re
 from datetime import timedelta
 from urllib.parse import parse_qs, urlparse
@@ -1414,7 +1415,7 @@ def test_quick_decline(db, push_collector: PushCollector, moderator):
         if "payload" not in link:
             continue
         print(link)
-        url_parts = urlparse(link)
+        url_parts = urlparse(html.unescape(link))
         params = parse_qs(url_parts.query)
         print(params["payload"][0])
         payload = unsubscribe_pb2.UnsubscribePayload.FromString(b64decode(params["payload"][0]))

--- a/app/backend/src/tests/test_templates.py
+++ b/app/backend/src/tests/test_templates.py
@@ -1,7 +1,6 @@
 # Tests jinja template rendering
 
 from typing import Any
-from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 from couchers.i18n.i18next import I18Next
@@ -24,74 +23,73 @@ def _render_template(
         language = mock_i18next.add_language(lang_code, PluralRules.en)
         language.load_json_dict(strings)
 
-    with patch("couchers.i18n.localize.get_main_i18next", new=lambda: mock_i18next):
-        return render_template(
-            template_str, template_args or {}, Context(timezone=ZoneInfo("Etc/UTC"), locale=lang, plaintext=plain)
-        )
+    return render_template(
+        template_str,
+        template_args or {},
+        Context(output_html=not plain, i18next=mock_i18next, locale=lang, timezone=ZoneInfo("Etc/UTC")),
+    )
 
 
 def _greeting_dict(value: str) -> dict[str, dict[str, str]]:
     return {"en": {"greeting": value}}
 
 
-def test_v2translate_no_substitutions() -> None:
-    translated = _render_template(
-        template_str='{{ "greeting"|v2translate }}', translation_dict=_greeting_dict("Hello!")
-    )
+def test_translate_no_substitutions() -> None:
+    translated = _render_template(template_str='{{ "greeting"|translate }}', translation_dict=_greeting_dict("Hello!"))
     assert translated == "Hello!"
 
 
-def test_v2translate_multiple_languages() -> None:
+def test_translate_multiple_languages() -> None:
     translated = _render_template(
-        template_str='{{ "greeting"|v2translate }}',
+        template_str='{{ "greeting"|translate }}',
         lang="fr",
         translation_dict={"en": {"greeting": "Hello!"}, "fr": {"greeting": "Bonjour!"}},
     )
     assert translated == "Bonjour!"
 
 
-def test_v2translate_with_substitutions() -> None:
+def test_translate_with_substitutions() -> None:
     translated = _render_template(
-        template_str='{{ "greeting"|v2translate(name=user_name) }}',
+        template_str='{{ "greeting"|translate(name=user_name) }}',
         template_args={"user_name": "Jack"},
         translation_dict=_greeting_dict("Hello, {{name}}!"),
     )
     assert translated == "Hello, Jack!"
 
 
-def test_v2translate_escaping() -> None:
+def test_translate_escaping() -> None:
     translated = _render_template(
-        template_str='{{ "greeting"|v2translate(name=name) }}',
+        template_str='{{ "greeting"|translate(name=name) }}',
         template_args={"name": "<script />"},
         translation_dict=_greeting_dict("Hello, {{name}}!"),
     )
     assert translated == "Hello, &lt;script /&gt;!"
 
 
-def test_v2translate_translation_tags() -> None:
+def test_translate_translation_tags() -> None:
     translated = _render_template(
-        template_str='{{ "greeting"|v2translate }}', translation_dict=_greeting_dict("<b>Hello!</b>")
+        template_str='{{ "greeting"|translate }}', translation_dict=_greeting_dict("<b>Hello!</b>")
     )
     assert translated == "<b>Hello!</b>"
 
 
-def test_v2translate_newlines_br() -> None:
+def test_translate_newlines_br() -> None:
     translated = _render_template(
-        template_str='{{ "greeting"|v2translate }}', translation_dict=_greeting_dict("Hello!\nWelcome!")
+        template_str='{{ "greeting"|translate }}', translation_dict=_greeting_dict("Hello!\nWelcome!")
     )
     assert translated == "Hello!<br>Welcome!"
 
 
-def test_v2translate_plain_strip_tags() -> None:
+def test_translate_plain_strip_tags() -> None:
     translated = _render_template(
-        template_str='{{ "greeting"|v2translate }}', plain=True, translation_dict=_greeting_dict("<b>Hello!</b>")
+        template_str='{{ "greeting"|translate }}', plain=True, translation_dict=_greeting_dict("<b>Hello!</b>")
     )
     assert translated == "Hello!"
 
 
-def test_v2translate_plain_strip_links() -> None:
+def test_translate_plain_strip_links() -> None:
     translated = _render_template(
-        template_str='{{ "greeting"|v2translate }}',
+        template_str='{{ "greeting"|translate }}',
         plain=True,
         translation_dict=_greeting_dict('<a href="#foo">Hello!</a>'),
     )

--- a/app/backend/src/tests/test_templates.py
+++ b/app/backend/src/tests/test_templates.py
@@ -137,3 +137,12 @@ def test_translate_plain_strip_links() -> None:
         output_html=False,
     )
     assert rendered == "<https://example.com>"
+
+
+def test_translate_plain_strip_mailto() -> None:
+    rendered = _render_template(
+        '{{ "greeting"|translate }}',
+        translation_dict=_greeting_dict('<a href="mailto:me@example.com">Hello!</a>'),
+        output_html=False,
+    )
+    assert rendered == "<me@example.com>"

--- a/app/backend/src/tests/test_templates.py
+++ b/app/backend/src/tests/test_templates.py
@@ -1,5 +1,7 @@
 # Tests jinja template rendering
 
+from datetime import date
+from markupsafe import Markup
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -13,21 +15,66 @@ from couchers.templates.v2 import (
 
 def _render_template(
     template_str: str,
-    translation_dict: dict[str, dict[str, str]],
-    template_args: dict[str, Any] | None = None,
-    plain: bool = False,
+    *,
+    args: dict[str, Any] | None = None,
+    translation_dict: dict[str, dict[str, str]] | None = None,
+    output_html: bool = True,
     lang: str = "en",
 ) -> str:
     mock_i18next = I18Next()
-    for lang_code, strings in translation_dict.items():
-        language = mock_i18next.add_language(lang_code, PluralRules.en)
-        language.load_json_dict(strings)
+    if translation_dict:
+        for lang_code, strings in translation_dict.items():
+            language = mock_i18next.add_language(lang_code, PluralRules.en)
+            language.load_json_dict(strings)
 
-    return render_template(
-        template_str,
-        template_args or {},
-        Context(output_html=not plain, i18next=mock_i18next, locale=lang, timezone=ZoneInfo("Etc/UTC")),
-    )
+    context = Context(
+        output_html=output_html,
+        i18next=mock_i18next,
+        locale=lang,
+        timezone=ZoneInfo("Etc/UTC"))
+
+    return render_template(template_str, args or {}, context)
+
+def test_multiline() -> None:
+    rendered = _render_template(
+        "{{ text|multiline }}",
+        args={ "text": "a\nb" },
+        output_html=False)
+    assert rendered == "a\nb"
+
+    rendered = _render_template(
+        "{{ text|multiline }}",
+        args={ "text": "a\nb" },
+        output_html=True)
+    assert rendered == "a<br>b"
+
+def test_quotelines() -> None:
+    rendered = _render_template(
+        "{{ text|quotelines }}",
+        args={ "text": "a\nb" },
+        output_html=False)
+    assert rendered == "> a\n> b"
+
+def test_html_escaping() -> None:
+    rendered = _render_template(
+        "Hello {{ name }}!",
+        args={ "name": "<script />" },
+        output_html=True)
+    assert rendered == "Hello &lt;script /&gt;!"
+
+def test_safe_html() -> None:
+    rendered = _render_template(
+        "Hello {{ name|html }}!",
+        args={ "name": "<script />" },
+        output_html=True)
+    assert rendered == "Hello <script />!"
+
+def test_date_formatting() -> None:
+    the_date = date(1970, 1, 1)
+    rendered = _render_template("Date: {{ date }}",
+        args={ "date": the_date },
+        lang="en")
+    assert rendered == "Date: Thursday 1 January 1970"
 
 
 def _greeting_dict(value: str) -> dict[str, dict[str, str]]:
@@ -35,62 +82,79 @@ def _greeting_dict(value: str) -> dict[str, dict[str, str]]:
 
 
 def test_translate_no_substitutions() -> None:
-    translated = _render_template(template_str='{{ "greeting"|translate }}', translation_dict=_greeting_dict("Hello!"))
-    assert translated == "Hello!"
+    rendered = _render_template('{{ "greeting"|translate }}', translation_dict=_greeting_dict("Hello!"))
+    assert rendered == "Hello!"
 
 
 def test_translate_multiple_languages() -> None:
-    translated = _render_template(
-        template_str='{{ "greeting"|translate }}',
-        lang="fr",
+    rendered = _render_template(
+        '{{ "greeting"|translate }}',
         translation_dict={"en": {"greeting": "Hello!"}, "fr": {"greeting": "Bonjour!"}},
+        lang="fr",
     )
-    assert translated == "Bonjour!"
+    assert rendered == "Bonjour!"
 
 
 def test_translate_with_substitutions() -> None:
-    translated = _render_template(
-        template_str='{{ "greeting"|translate(name=user_name) }}',
-        template_args={"user_name": "Jack"},
+    rendered = _render_template(
+        '{{ "greeting"|translate(name=user_name) }}',
+        args={"user_name": "Jack"},
         translation_dict=_greeting_dict("Hello, {{name}}!"),
     )
-    assert translated == "Hello, Jack!"
+    assert rendered == "Hello, Jack!"
 
 
-def test_translate_escaping() -> None:
-    translated = _render_template(
-        template_str='{{ "greeting"|translate(name=name) }}',
-        template_args={"name": "<script />"},
+def test_translate_substitution_escaping() -> None:
+    rendered = _render_template(
+        '{{ "greeting"|translate(name=name) }}',
+        args={"name": "<script />"},
         translation_dict=_greeting_dict("Hello, {{name}}!"),
+        output_html=True
     )
-    assert translated == "Hello, &lt;script /&gt;!"
+    assert rendered == "Hello, &lt;script /&gt;!"
+
+
+def test_translate_substitution_safe_html() -> None:
+    rendered = _render_template(
+        '{{ "greeting"|translate(name=name) }}',
+        args={"name": Markup("<script />") },
+        translation_dict=_greeting_dict("Hello, {{name}}!"),
+        output_html=True
+    )
+    assert rendered == "Hello, <script />!"
 
 
 def test_translate_translation_tags() -> None:
-    translated = _render_template(
-        template_str='{{ "greeting"|translate }}', translation_dict=_greeting_dict("<b>Hello!</b>")
+    rendered = _render_template(
+        '{{ "greeting"|translate }}',
+        translation_dict=_greeting_dict("<b>Hello!</b>"),
+        output_html=True
     )
-    assert translated == "<b>Hello!</b>"
+    assert rendered == "<b>Hello!</b>"
 
 
 def test_translate_newlines_br() -> None:
-    translated = _render_template(
-        template_str='{{ "greeting"|translate }}', translation_dict=_greeting_dict("Hello!\nWelcome!")
+    rendered = _render_template(
+        '{{ "greeting"|translate }}',
+        translation_dict=_greeting_dict("Hello!\nWelcome!"),
+        output_html=True
     )
-    assert translated == "Hello!<br>Welcome!"
+    assert rendered == "Hello!<br>Welcome!"
 
 
 def test_translate_plain_strip_tags() -> None:
-    translated = _render_template(
-        template_str='{{ "greeting"|translate }}', plain=True, translation_dict=_greeting_dict("<b>Hello!</b>")
+    rendered = _render_template(
+        '{{ "greeting"|translate }}',
+        translation_dict=_greeting_dict("<b>Hello!</b>"),
+        output_html=False
     )
-    assert translated == "Hello!"
+    assert rendered == "Hello!"
 
 
 def test_translate_plain_strip_links() -> None:
-    translated = _render_template(
-        template_str='{{ "greeting"|translate }}',
-        plain=True,
-        translation_dict=_greeting_dict('<a href="#foo">Hello!</a>'),
+    rendered = _render_template(
+        '{{ "greeting"|translate }}',
+        translation_dict=_greeting_dict('<a href="https://example.com">Hello!</a>'),
+        output_html=False
     )
-    assert translated == "<Hello!>"
+    assert rendered == "<https://example.com>"

--- a/app/backend/src/tests/test_templates.py
+++ b/app/backend/src/tests/test_templates.py
@@ -1,9 +1,10 @@
 # Tests jinja template rendering
 
 from datetime import date
-from markupsafe import Markup
 from typing import Any
 from zoneinfo import ZoneInfo
+
+from markupsafe import Markup
 
 from couchers.i18n.i18next import I18Next
 from couchers.i18n.plurals import PluralRules
@@ -27,53 +28,37 @@ def _render_template(
             language = mock_i18next.add_language(lang_code, PluralRules.en)
             language.load_json_dict(strings)
 
-    context = Context(
-        output_html=output_html,
-        i18next=mock_i18next,
-        locale=lang,
-        timezone=ZoneInfo("Etc/UTC"))
+    context = Context(output_html=output_html, i18next=mock_i18next, locale=lang, timezone=ZoneInfo("Etc/UTC"))
 
     return render_template(template_str, args or {}, context)
 
+
 def test_multiline() -> None:
-    rendered = _render_template(
-        "{{ text|multiline }}",
-        args={ "text": "a\nb" },
-        output_html=False)
+    rendered = _render_template("{{ text|multiline }}", args={"text": "a\nb"}, output_html=False)
     assert rendered == "a\nb"
 
-    rendered = _render_template(
-        "{{ text|multiline }}",
-        args={ "text": "a\nb" },
-        output_html=True)
+    rendered = _render_template("{{ text|multiline }}", args={"text": "a\nb"}, output_html=True)
     assert rendered == "a<br>b"
 
+
 def test_quotelines() -> None:
-    rendered = _render_template(
-        "{{ text|quotelines }}",
-        args={ "text": "a\nb" },
-        output_html=False)
+    rendered = _render_template("{{ text|quotelines }}", args={"text": "a\nb"}, output_html=False)
     assert rendered == "> a\n> b"
 
+
 def test_html_escaping() -> None:
-    rendered = _render_template(
-        "Hello {{ name }}!",
-        args={ "name": "<script />" },
-        output_html=True)
+    rendered = _render_template("Hello {{ name }}!", args={"name": "<script />"}, output_html=True)
     assert rendered == "Hello &lt;script /&gt;!"
 
+
 def test_safe_html() -> None:
-    rendered = _render_template(
-        "Hello {{ name|html }}!",
-        args={ "name": "<script />" },
-        output_html=True)
+    rendered = _render_template("Hello {{ name|html }}!", args={"name": "<script />"}, output_html=True)
     assert rendered == "Hello <script />!"
+
 
 def test_date_formatting() -> None:
     the_date = date(1970, 1, 1)
-    rendered = _render_template("Date: {{ date }}",
-        args={ "date": the_date },
-        lang="en")
+    rendered = _render_template("Date: {{ date }}", args={"date": the_date}, lang="en")
     assert rendered == "Date: Thursday 1 January 1970"
 
 
@@ -109,7 +94,7 @@ def test_translate_substitution_escaping() -> None:
         '{{ "greeting"|translate(name=name) }}',
         args={"name": "<script />"},
         translation_dict=_greeting_dict("Hello, {{name}}!"),
-        output_html=True
+        output_html=True,
     )
     assert rendered == "Hello, &lt;script /&gt;!"
 
@@ -117,36 +102,30 @@ def test_translate_substitution_escaping() -> None:
 def test_translate_substitution_safe_html() -> None:
     rendered = _render_template(
         '{{ "greeting"|translate(name=name) }}',
-        args={"name": Markup("<script />") },
+        args={"name": Markup("<script />")},
         translation_dict=_greeting_dict("Hello, {{name}}!"),
-        output_html=True
+        output_html=True,
     )
     assert rendered == "Hello, <script />!"
 
 
 def test_translate_translation_tags() -> None:
     rendered = _render_template(
-        '{{ "greeting"|translate }}',
-        translation_dict=_greeting_dict("<b>Hello!</b>"),
-        output_html=True
+        '{{ "greeting"|translate }}', translation_dict=_greeting_dict("<b>Hello!</b>"), output_html=True
     )
     assert rendered == "<b>Hello!</b>"
 
 
 def test_translate_newlines_br() -> None:
     rendered = _render_template(
-        '{{ "greeting"|translate }}',
-        translation_dict=_greeting_dict("Hello!\nWelcome!"),
-        output_html=True
+        '{{ "greeting"|translate }}', translation_dict=_greeting_dict("Hello!\nWelcome!"), output_html=True
     )
     assert rendered == "Hello!<br>Welcome!"
 
 
 def test_translate_plain_strip_tags() -> None:
     rendered = _render_template(
-        '{{ "greeting"|translate }}',
-        translation_dict=_greeting_dict("<b>Hello!</b>"),
-        output_html=False
+        '{{ "greeting"|translate }}', translation_dict=_greeting_dict("<b>Hello!</b>"), output_html=False
     )
     assert rendered == "Hello!"
 
@@ -155,6 +134,6 @@ def test_translate_plain_strip_links() -> None:
     rendered = _render_template(
         '{{ "greeting"|translate }}',
         translation_dict=_greeting_dict('<a href="https://example.com">Hello!</a>'),
-        output_html=False
+        output_html=False,
     )
     assert rendered == "<https://example.com>"

--- a/app/backend/templates/v2/_footer.mjml
+++ b/app/backend/templates/v2/_footer.mjml
@@ -1,10 +1,10 @@
       <mj-section padding="0px">
         <mj-column>
           <mj-divider border-color="#00a398" border-width="1px"></mj-divider>
-          <mj-text align="center" font-size="10px" line-height="12px"> You're receiving this email because you signed up for Couchers.org.<br /> You can reach our support team at <a href="mailto:support@couchers.org">support@couchers.org</a>.<br /> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location. </mj-text>
+          <mj-text align="center" font-size="10px" line-height="12px"> You're receiving this email because you signed up for Couchers.org.<br /> You can reach our support team at <a href="mailto:support@couchers.org">support@couchers.org</a>.<br /> All times are in {{ footer_timezone_name }}, based on your profile location. </mj-text>
           <mj-text align="center" font-size="10px"><a href="https://couchers.org/donate">Donate</a> | <a href="https://github.com/Couchers-org/couchers">GitHub</a> | <a href="https://couchers.org/volunteer">Volunteer</a> | <a href="https://couchers.org/blog">Blog</a></mj-text>
           <mj-text align="center" font-size="8px" line-height="10px">
-            &copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br />
+            &copy; {{ footer_copyright_year }} Couchers, Inc.<br />
             3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br />
             <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
           </mj-text>

--- a/app/backend/templates/v2/_header.mjml
+++ b/app/backend/templates/v2/_header.mjml
@@ -1,7 +1,7 @@
 <mjml>
   <mj-head>
-    <mj-title>{{ header_subject|v2esc }}</mj-title>
-    <mj-preview>{{ header_preview|v2esc }}</mj-preview>
+    <mj-title>{{ header_subject }}</mj-title>
+    <mj-preview>{{ header_preview }}</mj-preview>
     <mj-attributes>
       <mj-text color="#333" />
     </mj-attributes>

--- a/app/backend/templates/v2/account_deletion_complete.mjml
+++ b/app/backend/templates/v2/account_deletion_complete.mjml
@@ -1,14 +1,14 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
     <mj-text>You have successfully deleted your account from Couchers.org.</mj-text>
     <mj-text>We are sad to see you go, but wish you the best in your future travels. You are always welcome back on the Couchers.org platform :)</mj-text>
-    <mj-text>If you change your mind, <b>you have {{ days|v2esc }} days to retrieve your account</b> by clicking the following link and following the prompt:</mj-text>
+    <mj-text>If you change your mind, <b>you have {{ days }} days to retrieve your account</b> by clicking the following link and following the prompt:</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ undelete_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ undelete_link }}">
       <b>Recover Account</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/account_deletion_recovered.mjml
+++ b/app/backend/templates/v2/account_deletion_recovered.mjml
@@ -1,13 +1,13 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
     <mj-text><b>Your account on Couchers.org has been successfully recovered!</b></mj-text>
     <mj-text>We are so glad you decided to stay! To log back in, click the following link:</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ app_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ app_link }}">
       <b>Log back in</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/account_deletion_start.mjml
+++ b/app/backend/templates/v2/account_deletion_start.mjml
@@ -1,13 +1,13 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
     <mj-text><b>You requested that we delete your account from Couchers.org.</b></mj-text>
     <mj-text>To complete this process, please confirm by clicking the following button:</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ deletion_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ deletion_link }}">
       <b>Confirm Account Deletion</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/activeness_probe.mjml
+++ b/app/backend/templates/v2/activeness_probe.mjml
@@ -1,12 +1,12 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text>We noticed you haven't logged in for a while and wanted to check if you're still open to hosting surfers. To keep your "Can Host" status, please log back in within the next {{ days_left|v2esc }} days. Otherwise, we'll change your hosting status to "Can't Host."</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text>We noticed you haven't logged in for a while and wanted to check if you're still open to hosting surfers. To keep your "Can Host" status, please log back in within the next {{ days_left }} days. Otherwise, we'll change your hosting status to "Can't Host."</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ app_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ app_link }}">
       <b>Log back in to respond</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/api_key.mjml
+++ b/app/backend/templates/v2/api_key.mjml
@@ -1,17 +1,17 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
     <mj-text>You recently requested an API key for Couchers.org. We've issued you with the following API key:</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="10px 20px" text-align="left">
   <mj-column background-color="#eee" border-radius="10px" padding="10px 0px">
-    <mj-text><code>{{ api_key|v2esc }}</code></mj-text>
+    <mj-text><code>{{ api_key }}</code></mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>The key expires {{ expiry|v2timestamp }}.</mj-text>
+    <mj-text>The key expires {{ expiry|datetime }}.</mj-text>
     <mj-text>This API key is unique to your account; do not share it with anyone, it gives complete access to your account, and you are reponsible for any actions taken using this API key.</mj-text>
     <mj-text>Please remember to abide by our Terms of Service, our Community Guidelines, and other policies while using our APIs. All access is logged and analyzed, and we may terminate your access or account if you abuse the service.</mj-text>
     <mj-text>If you did not initiate this action, please contact us by emailing <a href="mailto:support@couchers.org">support@couchers.org</a> so we can sort this out as soon as possible!</mj-text>

--- a/app/backend/templates/v2/api_key.txt
+++ b/app/backend/templates/v2/api_key.txt
@@ -4,7 +4,7 @@ You recently requested an API key for Couchers.org. We've issued you with the fo
 
 {{ api_key }}
 
-The key expires {{ expiry|v2timestamp }}.
+The key expires {{ expiry|datetime }}.
 
 This API key is unique to your account; do not share it with anyone, it gives complete access to your account, and you are reponsible for any actions taken using this API key.</mj-text>
 

--- a/app/backend/templates/v2/badge.mjml
+++ b/app/backend/templates/v2/badge.mjml
@@ -1,6 +1,6 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text>The <b>{{ badge_name|v2esc }}</b> badge was {{ actioned|v2esc }} your profile.</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text>The <b>{{ badge_name }}</b> badge was {{ actioned }} your profile.</mj-text>
   </mj-column>
 </mj-section>

--- a/app/backend/templates/v2/chat_message.mjml
+++ b/app/backend/templates/v2/chat_message.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>{{ message|v2esc }}</b> at {{ time|v2time }}.</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text><b>{{ message }}</b> at {{ time|time }}.</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">
@@ -12,7 +12,7 @@
           <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}" />
         </td>
         <td>
-          <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br />{{ author.city|v2esc }}
+          <b>{{ author.name }}</b>, {{ author.age }}<br />{{ author.city }}
         </td>
       </tr>
     </mj-table>
@@ -20,12 +20,12 @@
 </mj-section>
 <mj-section padding="10px 20px" text-align="left">
   <mj-column background-color="#eee" border-radius="10px" padding="10px 0px">
-    <mj-text>{{ text|v2esc|v2multiline }}</mj-text>
+    <mj-text>{{ text|multiline }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link }}">
       <b>Go to messages</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/chat_message.txt
+++ b/app/backend/templates/v2/chat_message.txt
@@ -1,11 +1,11 @@
 Hi {{ user.name }},
 
-{{ message }} at {{ time|v2time }}.
+{{ message }} at {{ time|time }}.
 
 
 The message is below:
 
-{{ text|v2quote }}
+{{ text|quotelines }}
 
 
 

--- a/app/backend/templates/v2/chat_unseen_messages.mjml
+++ b/app/backend/templates/v2/chat_unseen_messages.mjml
@@ -1,13 +1,13 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
     <mj-text>You have unseen messages on Couchers.org, here's the latest:</mj-text>
   </mj-column>
 </mj-section>
 <!-- {% for item in items %} -->
 <mj-section padding="0px">
   <mj-column>
-    <mj-text><b>{{ item.message|v2esc }}</b>.</mj-text>
+    <mj-text><b>{{ item.message }}</b>.</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">
@@ -18,7 +18,7 @@
           <img width="80px" style="border-radius: 80px" src="{{ item.author.avatar_url }}" />
         </td>
         <td>
-          <b>{{ item.author.name|v2esc }}</b>, {{ item.author.age|v2esc }}<br />{{ item.author.city|v2esc }}
+          <b>{{ item.author.name }}</b>, {{ item.author.age }}<br />{{ item.author.city }}
         </td>
       </tr>
     </mj-table>
@@ -26,12 +26,12 @@
 </mj-section>
 <mj-section padding="10px 20px" text-align="left">
   <mj-column background-color="#eee" border-radius="10px" padding="10px 0px">
-    <mj-text>{{ item.text|v2esc|v2multiline }}</mj-text>
+    <mj-text>{{ item.text|multiline }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ item.view_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ item.view_link }}">
       <b>View this message</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/chat_unseen_messages.txt
+++ b/app/backend/templates/v2/chat_unseen_messages.txt
@@ -8,7 +8,7 @@ You have unseen messages on Couchers.org, here's the latest:
 
 {{ item.message }}.
 
-{{ item.text|v2quote }}
+{{ item.text|quotelines }}
 
 View this message: <{{ item.view_link }}>
 

--- a/app/backend/templates/v2/comment_reply.mjml
+++ b/app/backend/templates/v2/comment_reply.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>{{ author.name|v2esc }}</b> replied in <b>{{ title|v2esc }}</b>:</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text><b>{{ author.name }}</b> replied in <b>{{ title }}</b>:</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">
@@ -12,7 +12,7 @@
           <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}" />
         </td>
         <td>
-          <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br />{{ author.city|v2esc }}
+          <b>{{ author.name }}</b>, {{ author.age }}<br />{{ author.city }}
         </td>
       </tr>
     </mj-table>
@@ -20,12 +20,12 @@
 </mj-section>
 <mj-section padding="10px 20px" text-align="left">
   <mj-column background-color="#eee" border-radius="10px" padding="10px 0px">
-    <mj-text>{{ reply.content|v2markdown }}</mj-text>
+    <mj-text>{{ reply.content|markdown }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link }}">
       <b>View discussion</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/comment_reply.txt
+++ b/app/backend/templates/v2/comment_reply.txt
@@ -2,7 +2,7 @@ Hi {{ user.name }},
 
 {{ author.name }} replied in {{ title }}:
 
-{{ reply.content|v2quote }}
+{{ reply.content|quotelines }}
 
 
 You can view the discussion here: <{{ view_link }}>

--- a/app/backend/templates/v2/discussion_comment.mjml
+++ b/app/backend/templates/v2/discussion_comment.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>{{ author.name|v2esc }}</b> commented on your discussion <b>{{ discussion.title|v2esc }}</b> in <b>{{ discussion.owner_title|v2esc }}</b>:</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text><b>{{ author.name }}</b> commented on your discussion <b>{{ discussion.title }}</b> in <b>{{ discussion.owner_title }}</b>:</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">
@@ -12,7 +12,7 @@
           <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}" />
         </td>
         <td>
-          <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br />{{ author.city|v2esc }}
+          <b>{{ author.name }}</b>, {{ author.age }}<br />{{ author.city }}
         </td>
       </tr>
     </mj-table>
@@ -20,12 +20,12 @@
 </mj-section>
 <mj-section padding="10px 20px" text-align="left">
   <mj-column background-color="#eee" border-radius="10px" padding="10px 0px">
-    <mj-text>{{ reply.content|v2markdown }}</mj-text>
+    <mj-text>{{ reply.content|markdown }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link }}">
       <b>View discussion</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/discussion_comment.txt
+++ b/app/backend/templates/v2/discussion_comment.txt
@@ -2,7 +2,7 @@ Hi {{ user.name }},
 
 {{ author.name }} commented on your discussion {{ discussion.title }} in {{ discussion.owner_title }}:
 
-{{ reply.content|v2quote }}
+{{ reply.content|quotelines }}
 
 
 You can view the discussion here: <{{ view_link }}>

--- a/app/backend/templates/v2/discussion_create.mjml
+++ b/app/backend/templates/v2/discussion_create.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>{{ author.name|v2esc }}</b> created a new discussion called <b>{{ discussion.title|v2esc }}</b> in <b>{{ discussion.owner_title|v2esc }}</b>:</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text><b>{{ author.name }}</b> created a new discussion called <b>{{ discussion.title }}</b> in <b>{{ discussion.owner_title }}</b>:</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">
@@ -12,7 +12,7 @@
           <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}" />
         </td>
         <td>
-          <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br />{{ author.city|v2esc }}
+          <b>{{ author.name }}</b>, {{ author.age }}<br />{{ author.city }}
         </td>
       </tr>
     </mj-table>
@@ -20,12 +20,12 @@
 </mj-section>
 <mj-section padding="10px 20px" text-align="left">
   <mj-column background-color="#eee" border-radius="10px" padding="10px 0px">
-    <mj-text>{{ discussion.content|v2markdown }}</mj-text>
+    <mj-text>{{ discussion.content|markdown }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link }}">
       <b>View discussion</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/discussion_create.txt
+++ b/app/backend/templates/v2/discussion_create.txt
@@ -2,7 +2,7 @@ Hi {{ user.name }},
 
 {{ author.name }} created a new discussion called {{ discussion.title }} in {{ discussion.owner_title }}:
 
-{{ discussion.content|v2quote }}
+{{ discussion.content|quotelines }}
 
 
 You can view the discussion here: <{{ view_link }}>

--- a/app/backend/templates/v2/donation_received.mjml
+++ b/app/backend/templates/v2/donation_received.mjml
@@ -1,23 +1,23 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>{{ "notifications.dear_name"|v2translate(name=user.name) }}</mj-text>
-    <mj-text>{{ "notifications.donation_received.thanks_amount"|v2translate(amount=amount) }}</mj-text>
-    <mj-text>{{ "notifications.donation_received.purpose"|v2translate }}</mj-text>
-    <mj-text>{{ "notifications.donation_received.invoice_receipt_info"|v2translate }}</mj-text>
+    <mj-text>{{ "notifications.dear_name"|translate(name=user.name) }}</mj-text>
+    <mj-text>{{ "notifications.donation_received.thanks_amount"|translate(amount=amount) }}</mj-text>
+    <mj-text>{{ "notifications.donation_received.purpose"|translate }}</mj-text>
+    <mj-text>{{ "notifications.donation_received.invoice_receipt_info"|translate }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ receipt_url|v2url }}">
-      <b>{{ "notifications.donation_received.download_invoice"|v2translate }}</b>
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ receipt_url }}">
+      <b>{{ "notifications.donation_received.download_invoice"|translate }}</b>
     </mj-button>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>{{ "notifications.donation_received.questions_contact"|v2translate }}</mj-text>
-    <mj-text>{{ "notifications.donation_received.generosity_helps"|v2translate }}</mj-text>
-    <mj-text><b>{{ "notifications.thank_you"|v2translate }}</b></mj-text>
-    <mj-text>{{ "notifications.founders_signature"|v2translate }}</mj-text>
+    <mj-text>{{ "notifications.donation_received.questions_contact"|translate }}</mj-text>
+    <mj-text>{{ "notifications.donation_received.generosity_helps"|translate }}</mj-text>
+    <mj-text><b>{{ "notifications.thank_you"|translate }}</b></mj-text>
+    <mj-text>{{ "notifications.founders_signature"|translate }}</mj-text>
   </mj-column>
 </mj-section>

--- a/app/backend/templates/v2/donation_received.txt
+++ b/app/backend/templates/v2/donation_received.txt
@@ -1,19 +1,19 @@
-{{ "notifications.dear_name"|v2translate(name=user.name) }}
+{{ "notifications.dear_name"|translate(name=user.name) }}
 
-{{ "notifications.donation_received.thanks_amount"|v2translate(amount=amount) }}
+{{ "notifications.donation_received.thanks_amount"|translate(amount=amount) }}
 
-{{ "notifications.donation_received.purpose"|v2translate }}
+{{ "notifications.donation_received.purpose"|translate }}
 
 
-{{ "notifications.donation_received.invoice_receipt_info"|v2translate }}
+{{ "notifications.donation_received.invoice_receipt_info"|translate }}
 
 <{{ receipt_url }}>
 
-{{ "notifications.donation_received.questions_contact"|v2translate }}
+{{ "notifications.donation_received.questions_contact"|translate }}
 
-{{ "notifications.donation_received.generosity_helps"|v2translate }}
+{{ "notifications.donation_received.generosity_helps"|translate }}
 
 
-{{ "notifications.thank_you"|v2translate }}
+{{ "notifications.thank_you"|translate }}
 
-{{ "notifications.founders_signature"|v2translate }}
+{{ "notifications.founders_signature"|translate }}

--- a/app/backend/templates/v2/email_changed_confirmation_new_email.mjml
+++ b/app/backend/templates/v2/email_changed_confirmation_new_email.mjml
@@ -1,13 +1,13 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text>You requested that your email be changed to this email address on Couchers.org. Your old email address is <b>{{ user.email|v2esc }}</b>. This is the final step in the process.</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text>You requested that your email be changed to this email address on Couchers.org. Your old email address is <b>{{ user.email }}</b>. This is the final step in the process.</mj-text>
     <mj-text>To complete this change, please confirm your email by clicking the following link:</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ confirmation_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ confirmation_link }}">
       <b>Confirm new email</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/event_cancel.mjml
+++ b/app/backend/templates/v2/event_cancel.mjml
@@ -1,10 +1,10 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
     <mj-text>An event you are subscribed to has been cancelled:</mj-text>
-    <mj-text><b>{{ event.title|v2esc }}</b><br />
-      {{ time_display|v2esc }}<br />
-      <i>{% if event.online_information.link %}<a href="{{ event.online_information.link|v2url }}">Online</a>{% endif %}{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}</i>
+    <mj-text><b>{{ event.title }}</b><br />
+      {{ time_display }}<br />
+      <i>{% if event.online_information.link %}<a href="{{ event.online_information.link }}">Online</a>{% endif %}{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}</i>
     </mj-text>
   </mj-column>
 </mj-section>
@@ -16,7 +16,7 @@
           <img width="80px" style="border-radius: 80px" src="{{ cancelling_user.avatar_url }}" />
         </td>
         <td>
-          <b>Cancelled by {{ cancelling_user.name|v2esc }}</b>, {{ cancelling_user.age|v2esc }}<br />{{ cancelling_user.city|v2esc }}
+          <b>Cancelled by {{ cancelling_user.name }}</b>, {{ cancelling_user.age }}<br />{{ cancelling_user.city }}
         </td>
       </tr>
     </mj-table>
@@ -24,12 +24,12 @@
 </mj-section>
 <mj-section padding="10px 20px" text-align="left">
   <mj-column background-color="#eee" border-radius="10px" padding="10px 0px">
-    <mj-text>{{ event.content|v2markdown }}</mj-text>
+    <mj-text>{{ event.content|markdown }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link }}">
       <b>View event</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/event_cancel.txt
+++ b/app/backend/templates/v2/event_cancel.txt
@@ -5,12 +5,12 @@ An event you are subscribed to has been cancelled:
 {{ event.title }}
 {{ time_display }}
 
-{% if event.online_information.link %}<a href="{{ event.online_information.link|v2url }}">Online</a>{% endif %}{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}
+{% if event.online_information.link %}<a href="{{ event.online_information.link }}">Online</a>{% endif %}{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}
 
 Cancelled by {{ cancelling_user.name }}
 
 
-{{ event.content|v2quote }}
+{{ event.content|quotelines }}
 
 
 You can still view the event here: <{{ view_link }}>

--- a/app/backend/templates/v2/event_comment.mjml
+++ b/app/backend/templates/v2/event_comment.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>{{ author.name|v2esc }}</b> commented on the event <b>{{ event.title|v2esc }}</b>:</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text><b>{{ author.name }}</b> commented on the event <b>{{ event.title }}</b>:</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">
@@ -12,7 +12,7 @@
           <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}" />
         </td>
         <td>
-          <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br />{{ author.city|v2esc }}
+          <b>{{ author.name }}</b>, {{ author.age }}<br />{{ author.city }}
         </td>
       </tr>
     </mj-table>
@@ -20,21 +20,21 @@
 </mj-section>
 <mj-section padding="10px 20px" text-align="left">
   <mj-column background-color="#eee" border-radius="10px" padding="10px 0px">
-    <mj-text>{{ content|v2markdown }}</mj-text>
+    <mj-text>{{ content|markdown }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
     <mj-text>Here are the details of the event:</mj-text>
-    <mj-text><b>{{ event.title|v2esc }}</b><br />
-      {{ time_display|v2esc }}<br />
-      <i>{% if event.online_information.link %}<a href="{{ event.online_information.link|v2url }}">Online</a>{% endif %}{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}</i>
+    <mj-text><b>{{ event.title }}</b><br />
+      {{ time_display }}<br />
+      <i>{% if event.online_information.link %}<a href="{{ event.online_information.link }}">Online</a>{% endif %}{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}</i>
     </mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link }}">
       <b>View event</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/event_comment.txt
+++ b/app/backend/templates/v2/event_comment.txt
@@ -2,7 +2,7 @@ Hi {{ user.name }},
 
 {{ author.name }} commented on the event {{ event.title }}:
 
-{{ content|v2quote }}
+{{ content|quotelines }}
 
 
 
@@ -11,10 +11,10 @@ Here are the details of the event:
 {{ event.title }}
 {{ time_display }}
 
-{% if event.online_information.link %}<a href="{{ event.online_information.link|v2url }}">Online</a>{% endif %}{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}
+{% if event.online_information.link %}<a href="{{ event.online_information.link }}">Online</a>{% endif %}{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}
 
 
-{{ event.content|v2quote }}
+{{ event.content|quotelines }}
 
 
 

--- a/app/backend/templates/v2/event_create.mjml
+++ b/app/backend/templates/v2/event_create.mjml
@@ -1,10 +1,10 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text>{{ start_text|v2esc }} {% if community.name %}in the <a href="{{ community_link|v2url }}">{{ community.name|v2esc }}</a> community{% else %}nearby{% endif %}:</mj-text>
-    <mj-text><b>{{ event.title|v2esc }}</b><br />
-      {{ time_display|v2esc }}<br />
-      <i>{% if event.online_information.link %}<a href="{{ event.online_information.link|v2url }}">Online</a>{% endif %}{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}</i>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text>{{ start_text }} {% if community.name %}in the <a href="{{ community_link }}">{{ community.name }}</a> community{% else %}nearby{% endif %}:</mj-text>
+    <mj-text><b>{{ event.title }}</b><br />
+      {{ time_display }}<br />
+      <i>{% if event.online_information.link %}<a href="{{ event.online_information.link }}">Online</a>{% endif %}{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}</i>
     </mj-text>
   </mj-column>
 </mj-section>
@@ -16,7 +16,7 @@
           <img width="80px" style="border-radius: 80px" src="{{ inviting_user.avatar_url }}" />
         </td>
         <td>
-          <b>Organized by {{ inviting_user.name|v2esc }}</b>, {{ inviting_user.age|v2esc }}<br />{{ inviting_user.city|v2esc }}
+          <b>Organized by {{ inviting_user.name }}</b>, {{ inviting_user.age }}<br />{{ inviting_user.city }}
         </td>
       </tr>
     </mj-table>
@@ -24,12 +24,12 @@
 </mj-section>
 <mj-section padding="10px 20px" text-align="left">
   <mj-column background-color="#eee" border-radius="10px" padding="10px 0px">
-    <mj-text>{{ event.content|v2markdown }}</mj-text>
+    <mj-text>{{ event.content|markdown }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link }}">
       <b>View event</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/event_create.txt
+++ b/app/backend/templates/v2/event_create.txt
@@ -5,12 +5,12 @@ Hi {{ user.name }},
 {{ event.title }}
 {{ time_display }}
 
-{% if event.online_information.link %}<a href="{{ event.online_information.link|v2url }}">Online</a>{% endif %}{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}
+{% if event.online_information.link %}<a href="{{ event.online_information.link }}">Online</a>{% endif %}{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}
 
 Organized by {{ inviting_user.name }}
 
 
-{{ event.content|v2quote }}
+{{ event.content|quotelines }}
 
 
 

--- a/app/backend/templates/v2/event_delete.mjml
+++ b/app/backend/templates/v2/event_delete.mjml
@@ -1,10 +1,10 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
     <mj-text>An event you are subscribed to has been deleted by the moderators:</mj-text>
-    <mj-text><b>{{ event.title|v2esc }}</b><br />
-      {{ time_display|v2esc }}<br />
-      <i>{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}</i>
+    <mj-text><b>{{ event.title }}</b><br />
+      {{ time_display }}<br />
+      <i>{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}</i>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/app/backend/templates/v2/event_delete.txt
+++ b/app/backend/templates/v2/event_delete.txt
@@ -5,7 +5,7 @@ An event you are subscribed to has been deleted by the moderators.
 {{ event.title }}
 {{ time_display }}
 
-{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}
+{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}
 
 Best,
 The Couchers.org team

--- a/app/backend/templates/v2/event_invite_organizer.mjml
+++ b/app/backend/templates/v2/event_invite_organizer.mjml
@@ -1,10 +1,10 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>{{ inviting_user.name|v2esc }} invited you to co-organize "{{ event.title|v2esc }}".</b> The event information is below:</mj-text>
-    <mj-text><b>{{ event.title|v2esc }}</b><br />
-      {{ time_display|v2esc }}<br />
-      <i>{% if event.online_information.link %}<a href="{{ event.online_information.link|v2url }}">Online</a>{% endif %}{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}</i>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text><b>{{ inviting_user.name }} invited you to co-organize "{{ event.title }}".</b> The event information is below:</mj-text>
+    <mj-text><b>{{ event.title }}</b><br />
+      {{ time_display }}<br />
+      <i>{% if event.online_information.link %}<a href="{{ event.online_information.link }}">Online</a>{% endif %}{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}</i>
     </mj-text>
   </mj-column>
 </mj-section>
@@ -16,7 +16,7 @@
           <img width="80px" style="border-radius: 80px" src="{{ inviting_user.avatar_url }}" />
         </td>
         <td>
-          <b>Invited by {{ inviting_user.name|v2esc }}</b>, {{ inviting_user.age|v2esc }}<br />{{ inviting_user.city|v2esc }}
+          <b>Invited by {{ inviting_user.name }}</b>, {{ inviting_user.age }}<br />{{ inviting_user.city }}
         </td>
       </tr>
     </mj-table>
@@ -24,12 +24,12 @@
 </mj-section>
 <mj-section padding="10px 20px" text-align="left">
   <mj-column background-color="#eee" border-radius="10px" padding="10px 0px">
-    <mj-text>{{ event.content|v2markdown }}</mj-text>
+    <mj-text>{{ event.content|markdown }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link }}">
       <b>View event</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/event_invite_organizer.txt
+++ b/app/backend/templates/v2/event_invite_organizer.txt
@@ -5,10 +5,10 @@ Hi {{ user.name }},
 {{ event.title }}
 {{ time_display }}
 
-{% if event.online_information.link %}<a href="{{ event.online_information.link|v2url }}">Online</a>{% endif %}{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}
+{% if event.online_information.link %}<a href="{{ event.online_information.link }}">Online</a>{% endif %}{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}
 
 
-{{ event.content|v2quote }}
+{{ event.content|quotelines }}
 
 
 

--- a/app/backend/templates/v2/event_reminder.mjml
+++ b/app/backend/templates/v2/event_reminder.mjml
@@ -1,21 +1,21 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
     <mj-text>This is a reminder that the following event is starting in less than 24 hours:</mj-text>
-    <mj-text><b>{{ event.title|v2esc }}</b><br />
-      {{ time_display|v2esc }}<br />
-      <i>{% if event.online_information.link %}<a href="{{ event.online_information.link|v2url }}">Online</a>{% endif %}{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}</i>
+    <mj-text><b>{{ event.title }}</b><br />
+      {{ time_display }}<br />
+      <i>{% if event.online_information.link %}<a href="{{ event.online_information.link }}">Online</a>{% endif %}{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}</i>
     </mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="10px 20px" text-align="left">
   <mj-column background-color="#eee" border-radius="10px" padding="10px 0px">
-    <mj-text>{{ event.content|v2markdown }}</mj-text>
+    <mj-text>{{ event.content|markdown }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link }}">
       <b>View event</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/event_reminder.txt
+++ b/app/backend/templates/v2/event_reminder.txt
@@ -5,10 +5,10 @@ This is a reminder that the following event is starting in less than 24 hours:
 {{ event.title }}
 {{ time_display }}
 
-{% if event.online_information.link %}<a href="{{ event.online_information.link|v2url }}">Online</a>{% endif %}{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}
+{% if event.online_information.link %}<a href="{{ event.online_information.link }}">Online</a>{% endif %}{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}
 
 
-{{ event.content|v2quote }}
+{{ event.content|quotelines }}
 
 
 

--- a/app/backend/templates/v2/event_update.mjml
+++ b/app/backend/templates/v2/event_update.mjml
@@ -1,11 +1,11 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
     <mj-text>An event you are subscribed to was updated.</mj-text>
-    <mj-text>The following information was updated: <b>{{ updated_text|v2esc }}</b>. Here is the updated event:</mj-text>
-    <mj-text><b>{{ event.title|v2esc }}</b><br />
-      {{ time_display|v2esc }}<br />
-      <i>{% if event.online_information.link %}<a href="{{ event.online_information.link|v2url }}">Online</a>{% endif %}{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}</i>
+    <mj-text>The following information was updated: <b>{{ updated_text }}</b>. Here is the updated event:</mj-text>
+    <mj-text><b>{{ event.title }}</b><br />
+      {{ time_display }}<br />
+      <i>{% if event.online_information.link %}<a href="{{ event.online_information.link }}">Online</a>{% endif %}{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}</i>
     </mj-text>
   </mj-column>
 </mj-section>
@@ -17,7 +17,7 @@
           <img width="80px" style="border-radius: 80px" src="{{ updating_user.avatar_url }}" />
         </td>
         <td>
-          <b>Updated by {{ updating_user.name|v2esc }}</b>, {{ updating_user.age|v2esc }}<br />{{ updating_user.city|v2esc }}
+          <b>Updated by {{ updating_user.name }}</b>, {{ updating_user.age }}<br />{{ updating_user.city }}
         </td>
       </tr>
     </mj-table>
@@ -25,12 +25,12 @@
 </mj-section>
 <mj-section padding="10px 20px" text-align="left">
   <mj-column background-color="#eee" border-radius="10px" padding="10px 0px">
-    <mj-text>{{ event.content|v2markdown }}</mj-text>
+    <mj-text>{{ event.content|markdown }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link }}">
       <b>View event</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/event_update.txt
+++ b/app/backend/templates/v2/event_update.txt
@@ -7,12 +7,12 @@ The following information was updated: {{ updated_text }}. Here is the updated e
 {{ event.title }}
 {{ time_display }}
 
-{% if event.online_information.link %}<a href="{{ event.online_information.link|v2url }}">Online</a>{% endif %}{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}
+{% if event.online_information.link %}<a href="{{ event.online_information.link }}">Online</a>{% endif %}{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}
 
 Updated by {{ updating_user.name }}
 
 
-{{ event.content|v2quote }}
+{{ event.content|quotelines }}
 
 
 

--- a/app/backend/templates/v2/friend_reference.mjml
+++ b/app/backend/templates/v2/friend_reference.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>{{ from_user.name|v2esc }} wrote a friend reference for you</b> at {{ time|v2time }}!</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text><b>{{ from_user.name }} wrote a friend reference for you</b> at {{ time|time }}!</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">
@@ -12,7 +12,7 @@
           <img width="80px" style="border-radius: 80px" src="{{ from_user.avatar_url }}" />
         </td>
         <td>
-          <b>{{ from_user.name|v2esc }}</b>, {{ from_user.age|v2esc }}<br />{{ from_user.city|v2esc }}
+          <b>{{ from_user.name }}</b>, {{ from_user.age }}<br />{{ from_user.city }}
         </td>
       </tr>
     </mj-table>
@@ -20,12 +20,12 @@
 </mj-section>
 <mj-section padding="10px 20px" text-align="left">
   <mj-column background-color="#eee" border-radius="10px" padding="10px 0px">
-    <mj-text>{{ text|v2esc|v2multiline }}</mj-text>
+    <mj-text>{{ text|multiline }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ profile_references_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ profile_references_link }}">
       <b>View the reference on your profile</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/friend_reference.txt
+++ b/app/backend/templates/v2/friend_reference.txt
@@ -4,7 +4,7 @@ Hi {{ user.name }}!
 
 This is what they wrote:
 
-{{ text|v2quote }}
+{{ text|quotelines }}
 
 
 You can see it on your profile here:

--- a/app/backend/templates/v2/friend_request.mjml
+++ b/app/backend/templates/v2/friend_request.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>You've received a friend request from {{ other.name|v2esc }}</b> at {{ time|v2time }}!</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text><b>You've received a friend request from {{ other.name }}</b> at {{ time|time }}!</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">
@@ -12,7 +12,7 @@
           <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}" />
         </td>
         <td>
-          <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br />{{ other.city|v2esc }}
+          <b>{{ other.name }}</b>, {{ other.age }}<br />{{ other.city }}
         </td>
       </tr>
     </mj-table>
@@ -20,7 +20,7 @@
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ friend_requests_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ friend_requests_link }}">
       <b>View friend requests</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/friend_request_accepted.mjml
+++ b/app/backend/templates/v2/friend_request_accepted.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>{{ other.name|v2esc }} has accepted your friend request</b> at {{ time|v2time }}!</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text><b>{{ other.name }} has accepted your friend request</b> at {{ time|time }}!</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">
@@ -12,7 +12,7 @@
           <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}" />
         </td>
         <td>
-          <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br />{{ other.city|v2esc }}
+          <b>{{ other.name }}</b>, {{ other.age }}<br />{{ other.city }}
         </td>
       </tr>
     </mj-table>
@@ -20,7 +20,7 @@
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ other.profile_url|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ other.profile_url }}">
       <b>View their profile</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/generated_html/account_deletion_complete.html
+++ b/app/backend/templates/v2/generated_html/account_deletion_complete.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,7 +167,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
@@ -182,7 +182,7 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">If you change your mind, <b>you have {{ days|v2esc }} days to retrieve your account</b> by clicking the following link and following the prompt:</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">If you change your mind, <b>you have {{ days }} days to retrieve your account</b> by clicking the following link and following the prompt:</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -210,7 +210,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ undelete_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ undelete_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>Recover Account</b>
                                           </a>
                                         </td>
@@ -277,7 +277,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -287,7 +287,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/account_deletion_recovered.html
+++ b/app/backend/templates/v2/generated_html/account_deletion_recovered.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,7 +167,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
@@ -205,7 +205,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ app_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ app_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>Log back in</b>
                                           </a>
                                         </td>
@@ -277,7 +277,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -287,7 +287,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/account_deletion_start.html
+++ b/app/backend/templates/v2/generated_html/account_deletion_start.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,7 +167,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
@@ -205,7 +205,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ deletion_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ deletion_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>Confirm Account Deletion</b>
                                           </a>
                                         </td>
@@ -272,7 +272,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -282,7 +282,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/activeness_probe.html
+++ b/app/backend/templates/v2/generated_html/activeness_probe.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,12 +167,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">We noticed you haven't logged in for a while and wanted to check if you're still open to hosting surfers. To keep your "Can Host" status, please log back in within the next {{ days_left|v2esc }} days. Otherwise, we'll change your hosting status to "Can't Host."</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">We noticed you haven't logged in for a while and wanted to check if you're still open to hosting surfers. To keep your "Can Host" status, please log back in within the next {{ days_left }} days. Otherwise, we'll change your hosting status to "Can't Host."</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -200,7 +200,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ app_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ app_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>Log back in to respond</b>
                                           </a>
                                         </td>
@@ -349,7 +349,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -359,7 +359,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/api_key.html
+++ b/app/backend/templates/v2/generated_html/api_key.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,7 +167,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
@@ -200,7 +200,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><code>{{ api_key|v2esc }}</code></div>
+                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><code>{{ api_key }}</code></div>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -228,7 +228,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">The key expires {{ expiry|v2timestamp }}.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">The key expires {{ expiry|datetime }}.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -280,7 +280,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -290,7 +290,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/badge.html
+++ b/app/backend/templates/v2/generated_html/badge.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,12 +167,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">The <b>{{ badge_name|v2esc }}</b> badge was {{ actioned|v2esc }} your profile.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">The <b>{{ badge_name }}</b> badge was {{ actioned }} your profile.</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -204,7 +204,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -214,7 +214,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/chat_message.html
+++ b/app/backend/templates/v2/generated_html/chat_message.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,12 +167,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ message|v2esc }}</b> at {{ time|v2time }}.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ message }}</b> at {{ time|time }}.</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -202,7 +202,7 @@
                                         <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}">
                                       </td>
                                       <td>
-                                        <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br>{{ author.city|v2esc }}
+                                        <b>{{ author.name }}</b>, {{ author.age }}<br>{{ author.city }}
                                       </td>
                                     </tr>
                                   </table>
@@ -233,7 +233,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ text|v2esc|v2multiline }}</div>
+                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ text|multiline }}</div>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -265,7 +265,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ view_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ view_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>Go to messages</b>
                                           </a>
                                         </td>
@@ -327,7 +327,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -337,7 +337,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/chat_unseen_messages.html
+++ b/app/backend/templates/v2/generated_html/chat_unseen_messages.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,7 +167,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
@@ -198,7 +198,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ item.message|v2esc }}</b>.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ item.message }}</b>.</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -228,7 +228,7 @@
                                         <img width="80px" style="border-radius: 80px" src="{{ item.author.avatar_url }}">
                                       </td>
                                       <td>
-                                        <b>{{ item.author.name|v2esc }}</b>, {{ item.author.age|v2esc }}<br>{{ item.author.city|v2esc }}
+                                        <b>{{ item.author.name }}</b>, {{ item.author.age }}<br>{{ item.author.city }}
                                       </td>
                                     </tr>
                                   </table>
@@ -259,7 +259,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ item.text|v2esc|v2multiline }}</div>
+                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ item.text|multiline }}</div>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -291,7 +291,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ item.view_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ item.view_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>View this message</b>
                                           </a>
                                         </td>
@@ -355,7 +355,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -365,7 +365,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/comment_reply.html
+++ b/app/backend/templates/v2/generated_html/comment_reply.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,12 +167,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ author.name|v2esc }}</b> replied in <b>{{ title|v2esc }}</b>:</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ author.name }}</b> replied in <b>{{ title }}</b>:</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -202,7 +202,7 @@
                                         <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}">
                                       </td>
                                       <td>
-                                        <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br>{{ author.city|v2esc }}
+                                        <b>{{ author.name }}</b>, {{ author.age }}<br>{{ author.city }}
                                       </td>
                                     </tr>
                                   </table>
@@ -233,7 +233,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ reply.content|v2markdown }}</div>
+                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ reply.content|markdown }}</div>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -265,7 +265,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ view_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ view_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>View discussion</b>
                                           </a>
                                         </td>
@@ -327,7 +327,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -337,7 +337,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/discussion_comment.html
+++ b/app/backend/templates/v2/generated_html/discussion_comment.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,12 +167,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ author.name|v2esc }}</b> commented on your discussion <b>{{ discussion.title|v2esc }}</b> in <b>{{ discussion.owner_title|v2esc }}</b>:</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ author.name }}</b> commented on your discussion <b>{{ discussion.title }}</b> in <b>{{ discussion.owner_title }}</b>:</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -202,7 +202,7 @@
                                         <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}">
                                       </td>
                                       <td>
-                                        <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br>{{ author.city|v2esc }}
+                                        <b>{{ author.name }}</b>, {{ author.age }}<br>{{ author.city }}
                                       </td>
                                     </tr>
                                   </table>
@@ -233,7 +233,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ reply.content|v2markdown }}</div>
+                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ reply.content|markdown }}</div>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -265,7 +265,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ view_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ view_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>View discussion</b>
                                           </a>
                                         </td>
@@ -327,7 +327,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -337,7 +337,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/discussion_create.html
+++ b/app/backend/templates/v2/generated_html/discussion_create.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,12 +167,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ author.name|v2esc }}</b> created a new discussion called <b>{{ discussion.title|v2esc }}</b> in <b>{{ discussion.owner_title|v2esc }}</b>:</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ author.name }}</b> created a new discussion called <b>{{ discussion.title }}</b> in <b>{{ discussion.owner_title }}</b>:</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -202,7 +202,7 @@
                                         <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}">
                                       </td>
                                       <td>
-                                        <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br>{{ author.city|v2esc }}
+                                        <b>{{ author.name }}</b>, {{ author.age }}<br>{{ author.city }}
                                       </td>
                                     </tr>
                                   </table>
@@ -233,7 +233,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ discussion.content|v2markdown }}</div>
+                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ discussion.content|markdown }}</div>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -265,7 +265,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ view_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ view_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>View discussion</b>
                                           </a>
                                         </td>
@@ -327,7 +327,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -337,7 +337,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/donation_received.html
+++ b/app/backend/templates/v2/generated_html/donation_received.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,22 +167,22 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.dear_name"|v2translate(name=user.name) }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.dear_name"|translate(name=user.name) }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received.thanks_amount"|v2translate(amount=amount) }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received.thanks_amount"|translate(amount=amount) }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received.purpose"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received.purpose"|translate }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received.invoice_receipt_info"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received.invoice_receipt_info"|translate }}</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -210,8 +210,8 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ receipt_url|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
-                                            <b>{{ "notifications.donation_received.download_invoice"|v2translate }}</b>
+                                          <a href="{{ receipt_url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                            <b>{{ "notifications.donation_received.download_invoice"|translate }}</b>
                                           </a>
                                         </td>
                                       </tr>
@@ -240,22 +240,22 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received.questions_contact"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received.questions_contact"|translate }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received.generosity_helps"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.donation_received.generosity_helps"|translate }}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ "notifications.thank_you"|v2translate }}</b></div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ "notifications.thank_you"|translate }}</b></div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.founders_signature"|v2translate }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ "notifications.founders_signature"|translate }}</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -287,7 +287,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -297,7 +297,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/email_changed_confirmation_new_email.html
+++ b/app/backend/templates/v2/generated_html/email_changed_confirmation_new_email.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,12 +167,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">You requested that your email be changed to this email address on Couchers.org. Your old email address is <b>{{ user.email|v2esc }}</b>. This is the final step in the process.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">You requested that your email be changed to this email address on Couchers.org. Your old email address is <b>{{ user.email }}</b>. This is the final step in the process.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -205,7 +205,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ confirmation_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ confirmation_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>Confirm new email</b>
                                           </a>
                                         </td>
@@ -272,7 +272,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -282,7 +282,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/event_cancel.html
+++ b/app/backend/templates/v2/generated_html/event_cancel.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,7 +167,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
@@ -177,9 +177,9 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ event.title|v2esc }}</b><br>
-                                    {{ time_display|v2esc }}<br>
-                                    <i>{% if event.online_information.link %}<a href="{{ event.online_information.link|v2url }}" style="color: #00a398;">Online</a>{% endif %}{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}</i>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ event.title }}</b><br>
+                                    {{ time_display }}<br>
+                                    <i>{% if event.online_information.link %}<a href="{{ event.online_information.link }}" style="color: #00a398;">Online</a>{% endif %}{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}</i>
                                   </div>
                                 </td>
                               </tr>
@@ -210,7 +210,7 @@
                                         <img width="80px" style="border-radius: 80px" src="{{ cancelling_user.avatar_url }}">
                                       </td>
                                       <td>
-                                        <b>Cancelled by {{ cancelling_user.name|v2esc }}</b>, {{ cancelling_user.age|v2esc }}<br>{{ cancelling_user.city|v2esc }}
+                                        <b>Cancelled by {{ cancelling_user.name }}</b>, {{ cancelling_user.age }}<br>{{ cancelling_user.city }}
                                       </td>
                                     </tr>
                                   </table>
@@ -241,7 +241,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ event.content|v2markdown }}</div>
+                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ event.content|markdown }}</div>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -273,7 +273,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ view_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ view_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>View event</b>
                                           </a>
                                         </td>
@@ -335,7 +335,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -345,7 +345,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/event_comment.html
+++ b/app/backend/templates/v2/generated_html/event_comment.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,12 +167,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ author.name|v2esc }}</b> commented on the event <b>{{ event.title|v2esc }}</b>:</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ author.name }}</b> commented on the event <b>{{ event.title }}</b>:</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -202,7 +202,7 @@
                                         <img width="80px" style="border-radius: 80px" src="{{ author.avatar_url }}">
                                       </td>
                                       <td>
-                                        <b>{{ author.name|v2esc }}</b>, {{ author.age|v2esc }}<br>{{ author.city|v2esc }}
+                                        <b>{{ author.name }}</b>, {{ author.age }}<br>{{ author.city }}
                                       </td>
                                     </tr>
                                   </table>
@@ -233,7 +233,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ content|v2markdown }}</div>
+                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ content|markdown }}</div>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -266,9 +266,9 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ event.title|v2esc }}</b><br>
-                                    {{ time_display|v2esc }}<br>
-                                    <i>{% if event.online_information.link %}<a href="{{ event.online_information.link|v2url }}" style="color: #00a398;">Online</a>{% endif %}{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}</i>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ event.title }}</b><br>
+                                    {{ time_display }}<br>
+                                    <i>{% if event.online_information.link %}<a href="{{ event.online_information.link }}" style="color: #00a398;">Online</a>{% endif %}{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}</i>
                                   </div>
                                 </td>
                               </tr>
@@ -297,7 +297,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ view_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ view_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>View event</b>
                                           </a>
                                         </td>
@@ -359,7 +359,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -369,7 +369,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/event_create.html
+++ b/app/backend/templates/v2/generated_html/event_create.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,19 +167,19 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ start_text|v2esc }} {% if community.name %}in the <a href="{{ community_link|v2url }}" style="color: #00a398;">{{ community.name|v2esc }}</a> community{% else %}nearby{% endif %}:</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ start_text }} {% if community.name %}in the <a href="{{ community_link }}" style="color: #00a398;">{{ community.name }}</a> community{% else %}nearby{% endif %}:</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ event.title|v2esc }}</b><br>
-                                    {{ time_display|v2esc }}<br>
-                                    <i>{% if event.online_information.link %}<a href="{{ event.online_information.link|v2url }}" style="color: #00a398;">Online</a>{% endif %}{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}</i>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ event.title }}</b><br>
+                                    {{ time_display }}<br>
+                                    <i>{% if event.online_information.link %}<a href="{{ event.online_information.link }}" style="color: #00a398;">Online</a>{% endif %}{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}</i>
                                   </div>
                                 </td>
                               </tr>
@@ -210,7 +210,7 @@
                                         <img width="80px" style="border-radius: 80px" src="{{ inviting_user.avatar_url }}">
                                       </td>
                                       <td>
-                                        <b>Organized by {{ inviting_user.name|v2esc }}</b>, {{ inviting_user.age|v2esc }}<br>{{ inviting_user.city|v2esc }}
+                                        <b>Organized by {{ inviting_user.name }}</b>, {{ inviting_user.age }}<br>{{ inviting_user.city }}
                                       </td>
                                     </tr>
                                   </table>
@@ -241,7 +241,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ event.content|v2markdown }}</div>
+                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ event.content|markdown }}</div>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -273,7 +273,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ view_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ view_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>View event</b>
                                           </a>
                                         </td>
@@ -335,7 +335,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -345,7 +345,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/event_delete.html
+++ b/app/backend/templates/v2/generated_html/event_delete.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,7 +167,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
@@ -177,9 +177,9 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ event.title|v2esc }}</b><br>
-                                    {{ time_display|v2esc }}<br>
-                                    <i>{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}</i>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ event.title }}</b><br>
+                                    {{ time_display }}<br>
+                                    <i>{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}</i>
                                   </div>
                                 </td>
                               </tr>
@@ -236,7 +236,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -246,7 +246,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/event_invite_organizer.html
+++ b/app/backend/templates/v2/generated_html/event_invite_organizer.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,19 +167,19 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ inviting_user.name|v2esc }} invited you to co-organize "{{ event.title|v2esc }}".</b> The event information is below:</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ inviting_user.name }} invited you to co-organize "{{ event.title }}".</b> The event information is below:</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ event.title|v2esc }}</b><br>
-                                    {{ time_display|v2esc }}<br>
-                                    <i>{% if event.online_information.link %}<a href="{{ event.online_information.link|v2url }}" style="color: #00a398;">Online</a>{% endif %}{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}</i>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ event.title }}</b><br>
+                                    {{ time_display }}<br>
+                                    <i>{% if event.online_information.link %}<a href="{{ event.online_information.link }}" style="color: #00a398;">Online</a>{% endif %}{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}</i>
                                   </div>
                                 </td>
                               </tr>
@@ -210,7 +210,7 @@
                                         <img width="80px" style="border-radius: 80px" src="{{ inviting_user.avatar_url }}">
                                       </td>
                                       <td>
-                                        <b>Invited by {{ inviting_user.name|v2esc }}</b>, {{ inviting_user.age|v2esc }}<br>{{ inviting_user.city|v2esc }}
+                                        <b>Invited by {{ inviting_user.name }}</b>, {{ inviting_user.age }}<br>{{ inviting_user.city }}
                                       </td>
                                     </tr>
                                   </table>
@@ -241,7 +241,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ event.content|v2markdown }}</div>
+                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ event.content|markdown }}</div>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -273,7 +273,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ view_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ view_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>View event</b>
                                           </a>
                                         </td>
@@ -335,7 +335,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -345,7 +345,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/event_reminder.html
+++ b/app/backend/templates/v2/generated_html/event_reminder.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,7 +167,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
@@ -177,9 +177,9 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ event.title|v2esc }}</b><br>
-                                    {{ time_display|v2esc }}<br>
-                                    <i>{% if event.online_information.link %}<a href="{{ event.online_information.link|v2url }}" style="color: #00a398;">Online</a>{% endif %}{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}</i>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ event.title }}</b><br>
+                                    {{ time_display }}<br>
+                                    <i>{% if event.online_information.link %}<a href="{{ event.online_information.link }}" style="color: #00a398;">Online</a>{% endif %}{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}</i>
                                   </div>
                                 </td>
                               </tr>
@@ -208,7 +208,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ event.content|v2markdown }}</div>
+                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ event.content|markdown }}</div>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -240,7 +240,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ view_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ view_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>View event</b>
                                           </a>
                                         </td>
@@ -302,7 +302,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -312,7 +312,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/event_update.html
+++ b/app/backend/templates/v2/generated_html/event_update.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,7 +167,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
@@ -177,14 +177,14 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">The following information was updated: <b>{{ updated_text|v2esc }}</b>. Here is the updated event:</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">The following information was updated: <b>{{ updated_text }}</b>. Here is the updated event:</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ event.title|v2esc }}</b><br>
-                                    {{ time_display|v2esc }}<br>
-                                    <i>{% if event.online_information.link %}<a href="{{ event.online_information.link|v2url }}" style="color: #00a398;">Online</a>{% endif %}{% if event.offline_information.address|v2esc %}{{ event.offline_information.address }}{% endif %}</i>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ event.title }}</b><br>
+                                    {{ time_display }}<br>
+                                    <i>{% if event.online_information.link %}<a href="{{ event.online_information.link }}" style="color: #00a398;">Online</a>{% endif %}{% if event.offline_information.address %}{{ event.offline_information.address }}{% endif %}</i>
                                   </div>
                                 </td>
                               </tr>
@@ -215,7 +215,7 @@
                                         <img width="80px" style="border-radius: 80px" src="{{ updating_user.avatar_url }}">
                                       </td>
                                       <td>
-                                        <b>Updated by {{ updating_user.name|v2esc }}</b>, {{ updating_user.age|v2esc }}<br>{{ updating_user.city|v2esc }}
+                                        <b>Updated by {{ updating_user.name }}</b>, {{ updating_user.age }}<br>{{ updating_user.city }}
                                       </td>
                                     </tr>
                                   </table>
@@ -246,7 +246,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ event.content|v2markdown }}</div>
+                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ event.content|markdown }}</div>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -278,7 +278,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ view_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ view_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>View event</b>
                                           </a>
                                         </td>
@@ -340,7 +340,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -350,7 +350,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/friend_reference.html
+++ b/app/backend/templates/v2/generated_html/friend_reference.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,12 +167,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ from_user.name|v2esc }} wrote a friend reference for you</b> at {{ time|v2time }}!</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ from_user.name }} wrote a friend reference for you</b> at {{ time|time }}!</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -202,7 +202,7 @@
                                         <img width="80px" style="border-radius: 80px" src="{{ from_user.avatar_url }}">
                                       </td>
                                       <td>
-                                        <b>{{ from_user.name|v2esc }}</b>, {{ from_user.age|v2esc }}<br>{{ from_user.city|v2esc }}
+                                        <b>{{ from_user.name }}</b>, {{ from_user.age }}<br>{{ from_user.city }}
                                       </td>
                                     </tr>
                                   </table>
@@ -233,7 +233,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ text|v2esc|v2multiline }}</div>
+                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ text|multiline }}</div>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -265,7 +265,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ profile_references_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ profile_references_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>View the reference on your profile</b>
                                           </a>
                                         </td>
@@ -327,7 +327,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -337,7 +337,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/friend_request.html
+++ b/app/backend/templates/v2/generated_html/friend_request.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,12 +167,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>You've received a friend request from {{ other.name|v2esc }}</b> at {{ time|v2time }}!</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>You've received a friend request from {{ other.name }}</b> at {{ time|time }}!</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -202,7 +202,7 @@
                                         <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}">
                                       </td>
                                       <td>
-                                        <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br>{{ other.city|v2esc }}
+                                        <b>{{ other.name }}</b>, {{ other.age }}<br>{{ other.city }}
                                       </td>
                                     </tr>
                                   </table>
@@ -233,7 +233,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ friend_requests_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ friend_requests_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>View friend requests</b>
                                           </a>
                                         </td>
@@ -300,7 +300,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -310,7 +310,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/friend_request_accepted.html
+++ b/app/backend/templates/v2/generated_html/friend_request_accepted.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,12 +167,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ other.name|v2esc }} has accepted your friend request</b> at {{ time|v2time }}!</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ other.name }} has accepted your friend request</b> at {{ time|time }}!</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -202,7 +202,7 @@
                                         <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}">
                                       </td>
                                       <td>
-                                        <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br>{{ other.city|v2esc }}
+                                        <b>{{ other.name }}</b>, {{ other.age }}<br>{{ other.city }}
                                       </td>
                                     </tr>
                                   </table>
@@ -233,7 +233,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ other.profile_url|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ other.profile_url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>View their profile</b>
                                           </a>
                                         </td>
@@ -295,7 +295,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -305,7 +305,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/host_reference.html
+++ b/app/backend/templates/v2/generated_html/host_reference.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,12 +167,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ from_user.name|v2esc }} just wrote a reference for you</b> from when you {% if surfed %}surfed with{% else %}hosted{% endif %} them.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ from_user.name }} just wrote a reference for you</b> from when you {% if surfed %}surfed with{% else %}hosted{% endif %} them.</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -202,7 +202,7 @@
                                         <img width="80px" style="border-radius: 80px" src="{{ from_user.avatar_url }}">
                                       </td>
                                       <td>
-                                        <b>{{ from_user.name|v2esc }}</b>, {{ from_user.age|v2esc }}<br>{{ from_user.city|v2esc }}
+                                        <b>{{ from_user.name }}</b>, {{ from_user.age }}<br>{{ from_user.city }}
                                       </td>
                                     </tr>
                                   </table>
@@ -259,7 +259,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ text|v2esc|v2multiline }}</div>
+                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ text|multiline }}</div>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -291,7 +291,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ profile_references_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ profile_references_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>View the reference on your profile</b>
                                           </a>
                                         </td>
@@ -323,7 +323,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Please go and write a reference for them too. It's a nice gesture and helps us build a community together! When you've both written a reference, both references will become visible. Otherwise {{ from_user.name|v2esc }}'s reference will become visible 2 weeks after the end of your interaction, after which you cannot write a reference back.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Please go and write a reference for them too. It's a nice gesture and helps us build a community together! When you've both written a reference, both references will become visible. Otherwise {{ from_user.name }}'s reference will become visible 2 weeks after the end of your interaction, after which you cannot write a reference back.</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -351,8 +351,8 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ leave_reference_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
-                                            <b>Write a reference for {{ from_user.name|v2esc }}</b>
+                                          <a href="{{ leave_reference_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                            <b>Write a reference for {{ from_user.name }}</b>
                                           </a>
                                         </td>
                                       </tr>
@@ -439,7 +439,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -449,7 +449,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/host_request__message.html
+++ b/app/backend/templates/v2/generated_html/host_request__message.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,12 +167,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ message|v2esc }}</b> at {{ time|v2time }}.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ message }}</b> at {{ time|time }}.</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -202,8 +202,8 @@
                                         <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}">
                                       </td>
                                       <td>
-                                        <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br>{{ other.city|v2esc }}
-                                        <br>From <b>{{ host_request.from_date|v2date }}</b> to <b>{{ host_request.to_date|v2date }}</b>.
+                                        <b>{{ other.name }}</b>, {{ other.age }}<br>{{ other.city }}
+                                        <br>From <b>{{ host_request.from_date|date }}</b> to <b>{{ host_request.to_date|date }}</b>.
                                       </td>
                                     </tr>
                                   </table>
@@ -234,7 +234,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ text|v2esc|v2multiline }}</div>
+                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ text|multiline }}</div>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -266,7 +266,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ view_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ view_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>View host request</b>
                                           </a>
                                         </td>
@@ -328,7 +328,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -338,7 +338,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/host_request__new.html
+++ b/app/backend/templates/v2/generated_html/host_request__new.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -105,8 +105,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -177,12 +177,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ message|v2esc }}</b> at {{ time|v2time }}.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ message }}</b> at {{ time|time }}.</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -212,8 +212,8 @@
                                         <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}">
                                       </td>
                                       <td>
-                                        <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br>{{ other.city|v2esc }}
-                                        <br>From <b>{{ host_request.from_date|v2date }}</b> to <b>{{ host_request.to_date|v2date }}</b>.
+                                        <b>{{ other.name }}</b>, {{ other.age }}<br>{{ other.city }}
+                                        <br>From <b>{{ host_request.from_date|date }}</b> to <b>{{ host_request.to_date|date }}</b>.
                                       </td>
                                     </tr>
                                   </table>
@@ -244,7 +244,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ text|v2esc|v2multiline }}</div>
+                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ text|multiline }}</div>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -276,7 +276,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ view_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ view_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>View host request</b>
                                           </a>
                                         </td>
@@ -298,7 +298,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ quick_decline_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ quick_decline_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>Quick Decline (no login needed)</b>
                                           </a>
                                         </td>
@@ -384,7 +384,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -394,7 +394,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/host_request__plain.html
+++ b/app/backend/templates/v2/generated_html/host_request__plain.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,12 +167,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ message|v2esc }}</b> at {{ time|v2time }}.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ message }}</b> at {{ time|time }}.</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -202,8 +202,8 @@
                                         <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}">
                                       </td>
                                       <td>
-                                        <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br>{{ other.city|v2esc }}
-                                        <br>From <b>{{ host_request.from_date|v2date }}</b> to <b>{{ host_request.to_date|v2date }}</b>.
+                                        <b>{{ other.name }}</b>, {{ other.age }}<br>{{ other.city }}
+                                        <br>From <b>{{ host_request.from_date|date }}</b> to <b>{{ host_request.to_date|date }}</b>.
                                       </td>
                                     </tr>
                                   </table>
@@ -234,7 +234,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ view_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ view_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>View host request</b>
                                           </a>
                                         </td>
@@ -296,7 +296,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -306,7 +306,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/mod_note.html
+++ b/app/backend/templates/v2/generated_html/mod_note.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,7 +167,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
@@ -209,7 +209,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -219,7 +219,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/new_blog_post.html
+++ b/app/backend/templates/v2/generated_html/new_blog_post.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,7 +167,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
@@ -196,12 +196,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ title|v2esc }}</b></div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>{{ title }}</b></div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ blurb|v2esc }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ blurb }}</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -229,7 +229,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ url|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>Read the post</b>
                                           </a>
                                         </td>
@@ -291,7 +291,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -301,7 +301,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/onboarding1.html
+++ b/app/backend/templates/v2/generated_html/onboarding1.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,7 +167,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
@@ -215,7 +215,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ edit_profile_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ edit_profile_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>Complete your profile</b>
                                           </a>
                                         </td>
@@ -250,7 +250,7 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Link: <a href="{{ app_link|v2url }}" style="color: #00a398;">{{ app_link|v2url }}</a></div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Link: <a href="{{ app_link }}" style="color: #00a398;">{{ app_link }}</a></div>
                                 </td>
                               </tr>
                               <tr>
@@ -297,7 +297,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -307,7 +307,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/onboarding2.html
+++ b/app/backend/templates/v2/generated_html/onboarding2.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,7 +167,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
@@ -205,7 +205,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ edit_profile_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ edit_profile_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>Go to edit your profile</b>
                                           </a>
                                         </td>
@@ -277,7 +277,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -287,7 +287,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/password_reset.html
+++ b/app/backend/templates/v2/generated_html/password_reset.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,7 +167,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
@@ -205,7 +205,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ password_reset_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ password_reset_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>Reset password</b>
                                           </a>
                                         </td>
@@ -272,7 +272,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -282,7 +282,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/reference_reminder.html
+++ b/app/backend/templates/v2/generated_html/reference_reminder.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,17 +167,17 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>You have {{ days_left|v2esc }} days left to write a reference for {{ other_user.name|v2esc }}</b> from when you {% if surfed %}surfed with{% else %}hosted{% endif %} them.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;"><b>You have {{ days_left }} days left to write a reference for {{ other_user.name }}</b> from when you {% if surfed %}surfed with{% else %}hosted{% endif %} them.</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">If you didn't end up meeting {{ other_user.name|v2esc }}, please use the reference flow to let us know (and we'll stop reminding you to write a reference).</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">If you didn't end up meeting {{ other_user.name }}, please use the reference flow to let us know (and we'll stop reminding you to write a reference).</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -207,7 +207,7 @@
                                         <img width="80px" style="border-radius: 80px" src="{{ other_user.avatar_url }}">
                                       </td>
                                       <td>
-                                        <b>{{ other_user.name|v2esc }}</b>, {{ other_user.age|v2esc }}<br>{{ other_user.city|v2esc }}
+                                        <b>{{ other_user.name }}</b>, {{ other_user.age }}<br>{{ other_user.city }}
                                       </td>
                                     </tr>
                                   </table>
@@ -238,8 +238,8 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ leave_reference_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
-                                            <b>Write a reference for {{ other_user.name|v2esc }}</b>
+                                          <a href="{{ leave_reference_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                            <b>Write a reference for {{ other_user.name }}</b>
                                           </a>
                                         </td>
                                       </tr>
@@ -315,7 +315,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -325,7 +325,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/security.html
+++ b/app/backend/templates/v2/generated_html/security.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,12 +167,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ message|v2sf }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ message }}</div>
                                 </td>
                               </tr>
                               <tr>
@@ -214,7 +214,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -224,7 +224,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/signup_continue.html
+++ b/app/backend/templates/v2/generated_html/signup_continue.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,7 +167,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ flow.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ flow.name }},</div>
                                 </td>
                               </tr>
                               <tr>
@@ -205,7 +205,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ signup_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ signup_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>Finish signing up</b>
                                           </a>
                                         </td>
@@ -277,7 +277,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -287,7 +287,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/signup_verify.html
+++ b/app/backend/templates/v2/generated_html/signup_verify.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,7 +167,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ flow.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ flow.name }},</div>
                                 </td>
                               </tr>
                               <tr>
@@ -205,7 +205,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#00a398" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#00a398;" valign="middle">
-                                          <a href="{{ signup_link|v2url }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
+                                          <a href="{{ signup_link }}" style="display: inline-block; background: #00a398; color: white; font-family: Ubuntu, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: normal; line-height: 120%; margin: 0; text-decoration: none; text-transform: none; padding: 10px 25px; mso-padding-alt: 0px; border-radius: 5px;" target="_blank">
                                             <b>Confirm your email address</b>
                                           </a>
                                         </td>
@@ -272,7 +272,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -282,7 +282,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/strong_verification_success.html
+++ b/app/backend/templates/v2/generated_html/strong_verification_success.html
@@ -2,7 +2,7 @@
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
 <head>
-  <title>{{ header_subject|v2esc }}</title>
+  <title>{{ header_subject }}</title>
   <!--[if !mso]><!-->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<![endif]-->
@@ -95,8 +95,8 @@
 </head>
 
 <body style="word-spacing:normal;background-color:#eeeeee;">
-  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview|v2esc }}</div>
-  <div aria-label="{{ header_subject|v2esc }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
+  <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ header_preview }}</div>
+  <div aria-label="{{ header_subject }}" aria-roledescription="email" style="background-color:#eeeeee;" role="article" lang="und" dir="auto">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -167,12 +167,12 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name|v2esc }},</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">Hi {{ user.name }},</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ message|v2sf }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ message }}</div>
                                 </td>
                               </tr>
                               <tr>
@@ -282,7 +282,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>
@@ -292,7 +292,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/host_reference.mjml
+++ b/app/backend/templates/v2/host_reference.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>{{ from_user.name|v2esc }} just wrote a reference for you</b> from when you {% if surfed %}surfed with{% else %}hosted{% endif %} them.</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text><b>{{ from_user.name }} just wrote a reference for you</b> from when you {% if surfed %}surfed with{% else %}hosted{% endif %} them.</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">
@@ -12,7 +12,7 @@
           <img width="80px" style="border-radius: 80px" src="{{ from_user.avatar_url }}" />
         </td>
         <td>
-          <b>{{ from_user.name|v2esc }}</b>, {{ from_user.age|v2esc }}<br />{{ from_user.city|v2esc }}
+          <b>{{ from_user.name }}</b>, {{ from_user.age }}<br />{{ from_user.city }}
         </td>
       </tr>
     </mj-table>
@@ -26,12 +26,12 @@
 </mj-section>
 <mj-section padding="10px 20px" text-align="left">
   <mj-column background-color="#eee" border-radius="10px" padding="10px 0px">
-    <mj-text>{{ text|v2esc|v2multiline }}</mj-text>
+    <mj-text>{{ text|multiline }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ profile_references_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ profile_references_link }}">
       <b>View the reference on your profile</b>
     </mj-button>
   </mj-column>
@@ -39,13 +39,13 @@
 <!-- {% else %} -->
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Please go and write a reference for them too. It's a nice gesture and helps us build a community together! When you've both written a reference, both references will become visible. Otherwise {{ from_user.name|v2esc }}'s reference will become visible 2 weeks after the end of your interaction, after which you cannot write a reference back.</mj-text>
+    <mj-text>Please go and write a reference for them too. It's a nice gesture and helps us build a community together! When you've both written a reference, both references will become visible. Otherwise {{ from_user.name }}'s reference will become visible 2 weeks after the end of your interaction, after which you cannot write a reference back.</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ leave_reference_link|v2url }}">
-      <b>Write a reference for {{ from_user.name|v2esc }}</b>
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ leave_reference_link }}">
+      <b>Write a reference for {{ from_user.name }}</b>
     </mj-button>
   </mj-column>
 </mj-section>

--- a/app/backend/templates/v2/host_reference.txt
+++ b/app/backend/templates/v2/host_reference.txt
@@ -5,7 +5,7 @@ Hi {{ user.name }}!
 {% if both_written %}
 This is what they wrote:
 
-{{ text|v2quote }}
+{{ text|quotelines }}
 
 Thanks for using Couchers to organize this interaction! We hope you had an enjoyable, fulfilling time.
 

--- a/app/backend/templates/v2/host_request__message.mjml
+++ b/app/backend/templates/v2/host_request__message.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>{{ message|v2esc }}</b> at {{ time|v2time }}.</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text><b>{{ message }}</b> at {{ time|time }}.</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">
@@ -12,8 +12,8 @@
           <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}" />
         </td>
         <td>
-          <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br />{{ other.city|v2esc }}
-          <br />From <b>{{ host_request.from_date|v2date }}</b> to <b>{{ host_request.to_date|v2date }}</b>.
+          <b>{{ other.name }}</b>, {{ other.age }}<br />{{ other.city }}
+          <br />From <b>{{ host_request.from_date|date }}</b> to <b>{{ host_request.to_date|date }}</b>.
         </td>
       </tr>
     </mj-table>
@@ -21,12 +21,12 @@
 </mj-section>
 <mj-section padding="10px 20px" text-align="left">
   <mj-column background-color="#eee" border-radius="10px" padding="10px 0px">
-    <mj-text>{{ text|v2esc|v2multiline }}</mj-text>
+    <mj-text>{{ text|multiline }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link }}">
       <b>View host request</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/host_request__message.txt
+++ b/app/backend/templates/v2/host_request__message.txt
@@ -1,16 +1,16 @@
 Hi {{ user.name }},
 
-{{ message }} at {{ time|v2time }}.
+{{ message }} at {{ time|time }}.
 
 Request details:
 
 {{ other.name }}, {{ other.age }}
 {{ other.city }}.
-Dates: {{ host_request.from_date|v2date }} to {{ host_request.to_date|v2date }}.
+Dates: {{ host_request.from_date|date }} to {{ host_request.to_date|date }}.
 
 They wrote the following message:
 
-{{ text|v2quote }}
+{{ text|quotelines }}
 
 
 

--- a/app/backend/templates/v2/host_request__new.mjml
+++ b/app/backend/templates/v2/host_request__new.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>{{ message|v2esc }}</b> at {{ time|v2time }}.</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text><b>{{ message }}</b> at {{ time|time }}.</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">
@@ -12,8 +12,8 @@
           <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}" />
         </td>
         <td>
-          <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br />{{ other.city|v2esc }}
-          <br />From <b>{{ host_request.from_date|v2date }}</b> to <b>{{ host_request.to_date|v2date }}</b>.
+          <b>{{ other.name }}</b>, {{ other.age }}<br />{{ other.city }}
+          <br />From <b>{{ host_request.from_date|date }}</b> to <b>{{ host_request.to_date|date }}</b>.
         </td>
       </tr>
     </mj-table>
@@ -21,17 +21,17 @@
 </mj-section>
 <mj-section padding="10px 20px" text-align="left">
   <mj-column background-color="#eee" border-radius="10px" padding="10px 0px">
-    <mj-text>{{ text|v2esc|v2multiline }}</mj-text>
+    <mj-text>{{ text|multiline }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link }}">
       <b>View host request</b>
     </mj-button>
   </mj-column>
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ quick_decline_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ quick_decline_link }}">
       <b>Quick Decline (no login needed)</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/host_request__new.txt
+++ b/app/backend/templates/v2/host_request__new.txt
@@ -1,16 +1,16 @@
 Hi {{ user.name }},
 
-{{ message }} at {{ time|v2time }}.
+{{ message }} at {{ time|time }}.
 
 Request details:
 
 {{ other.name }}, {{ other.age }}
 {{ other.city }}.
-Dates: {{ host_request.from_date|v2date }} to {{ host_request.to_date|v2date }}.
+Dates: {{ host_request.from_date|date }} to {{ host_request.to_date|date }}.
 
 They wrote the following message:
 
-{{ text|v2quote }}
+{{ text|quotelines }}
 
 
 Quick decline (no login needed): <{{ quick_decline_link }}>

--- a/app/backend/templates/v2/host_request__plain.mjml
+++ b/app/backend/templates/v2/host_request__plain.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>{{ message|v2esc }}</b> at {{ time|v2time }}.</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text><b>{{ message }}</b> at {{ time|time }}.</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">
@@ -12,8 +12,8 @@
           <img width="80px" style="border-radius: 80px" src="{{ other.avatar_url }}" />
         </td>
         <td>
-          <b>{{ other.name|v2esc }}</b>, {{ other.age|v2esc }}<br />{{ other.city|v2esc }}
-          <br />From <b>{{ host_request.from_date|v2date }}</b> to <b>{{ host_request.to_date|v2date }}</b>.
+          <b>{{ other.name }}</b>, {{ other.age }}<br />{{ other.city }}
+          <br />From <b>{{ host_request.from_date|date }}</b> to <b>{{ host_request.to_date|date }}</b>.
         </td>
       </tr>
     </mj-table>
@@ -21,7 +21,7 @@
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ view_link }}">
       <b>View host request</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/host_request__plain.txt
+++ b/app/backend/templates/v2/host_request__plain.txt
@@ -1,12 +1,12 @@
 Hi {{ user.name }},
 
-{{ message }} at {{ time|v2time }}.
+{{ message }} at {{ time|time }}.
 
 Request details:
 
 {{ other.name }}, {{ other.age }}
 {{ other.city }}.
-Dates: {{ host_request.from_date|v2date }} to {{ host_request.to_date|v2date }}.
+Dates: {{ host_request.from_date|date }} to {{ host_request.to_date|date }}.
 
 
 

--- a/app/backend/templates/v2/mod_note.mjml
+++ b/app/backend/templates/v2/mod_note.mjml
@@ -1,6 +1,6 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
     <mj-text>You have received an important note from the moderators. You must read and acknowledge it before continuing to use the platform.</mj-text>
     <mj-text>Best,<br />The Couchers.org Team</mj-text>
   </mj-column>

--- a/app/backend/templates/v2/new_blog_post.mjml
+++ b/app/backend/templates/v2/new_blog_post.mjml
@@ -1,18 +1,18 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
     <mj-text>We published a new blog post:</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-text><b>{{ title|v2esc }}</b></mj-text>
-    <mj-text>{{ blurb|v2esc }}</mj-text>
+    <mj-text><b>{{ title }}</b></mj-text>
+    <mj-text>{{ blurb }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ url|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ url }}">
       <b>Read the post</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/onboarding1.mjml
+++ b/app/backend/templates/v2/onboarding1.mjml
@@ -1,6 +1,6 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
     <mj-text>Welcome to Couchers.org, and our growing worldwide community of couch surfers. We are excited that you have joined us!</mj-text>
     <mj-text>We are still a small platform and are growing quickly. As an early user, you have a vital role in shaping the future of the platform. You can help us set the scene and culture as we grow bigger, as well as test functionality and provide feedback as we develop new features.</mj-text>
     <mj-text>Please take some time to explore the platform. As a first step, please write a bit about yourself on your profile. Please upload a photo and fill in some profile text, you can even copy your description from your account on other platforms if you're feeling lazy :P</mj-text>
@@ -9,7 +9,7 @@
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ edit_profile_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ edit_profile_link }}">
       <b>Complete your profile</b>
     </mj-button>
   </mj-column>
@@ -17,7 +17,7 @@
 <mj-section padding="0px">
   <mj-column>
     <mj-text>Otherwise, please share the link with any of your couch surfing friends that you trust! This platform can only grow with your help bringing the best people to it.</mj-text>
-    <mj-text>Link: <a href="{{ app_link|v2url }}">{{ app_link|v2url }}</a></mj-text>
+    <mj-text>Link: <a href="{{ app_link }}">{{ app_link }}</a></mj-text>
     <mj-text>The platform is still under development, and features are actively being built by our amazing team of Couchers.org contributors around the world. We would like to hear your feedback and thoughts on what we've built and what we're working on.</mj-text>
     <mj-text>Thanks so much for joining the platform. We're really excited to have you here and as part of our growing community!</mj-text>
     <mj-text>Best,<br />Aapeli<br />Couchers.org Co-founder<br /><a href="mailto:aapeli@couchers.org">aapeli@couchers.org</a> (feel free to shoot me an email at any time)<br /><br /><a href="https://couchers.org/user/aapeli">https://couchers.org/user/aapeli</a></mj-text>

--- a/app/backend/templates/v2/onboarding2.mjml
+++ b/app/backend/templates/v2/onboarding2.mjml
@@ -1,13 +1,13 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
     <mj-text>I hope you've taken a bit of time to look around the Couchers.org platform!</mj-text>
     <mj-text>We would ask one big favour of you: please fill out your profile by adding a photo and some text.</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ edit_profile_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ edit_profile_link }}">
       <b>Go to edit your profile</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/password_reset.mjml
+++ b/app/backend/templates/v2/password_reset.mjml
@@ -1,13 +1,13 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
     <mj-text>You asked for your password to be reset on Couchers.org.</mj-text>
     <mj-text>To complete this change, click on the following link:</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ password_reset_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ password_reset_link }}">
       <b>Reset password</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/reference_reminder.mjml
+++ b/app/backend/templates/v2/reference_reminder.mjml
@@ -1,8 +1,8 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text><b>You have {{ days_left|v2esc }} days left to write a reference for {{ other_user.name|v2esc }}</b> from when you {% if surfed %}surfed with{% else %}hosted{% endif %} them.</mj-text>
-    <mj-text>If you didn't end up meeting {{ other_user.name|v2esc }}, please use the reference flow to let us know (and we'll stop reminding you to write a reference).</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text><b>You have {{ days_left }} days left to write a reference for {{ other_user.name }}</b> from when you {% if surfed %}surfed with{% else %}hosted{% endif %} them.</mj-text>
+    <mj-text>If you didn't end up meeting {{ other_user.name }}, please use the reference flow to let us know (and we'll stop reminding you to write a reference).</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px" text-align="left">
@@ -13,7 +13,7 @@
           <img width="80px" style="border-radius: 80px" src="{{ other_user.avatar_url }}" />
         </td>
         <td>
-          <b>{{ other_user.name|v2esc }}</b>, {{ other_user.age|v2esc }}<br />{{ other_user.city|v2esc }}
+          <b>{{ other_user.name }}</b>, {{ other_user.age }}<br />{{ other_user.city }}
         </td>
       </tr>
     </mj-table>
@@ -21,8 +21,8 @@
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ leave_reference_link|v2url }}">
-      <b>Write a reference for {{ other_user.name|v2esc }}</b>
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ leave_reference_link }}">
+      <b>Write a reference for {{ other_user.name }}</b>
     </mj-button>
   </mj-column>
 </mj-section>

--- a/app/backend/templates/v2/security.mjml
+++ b/app/backend/templates/v2/security.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text>{{ message|v2sf }}</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text>{{ message }}</mj-text>
     <mj-text>If you did not initiate this action, please contact us by emailing <a href="mailto:support@couchers.org">support@couchers.org</a> so we can sort this out as soon as possible!</mj-text>
     <mj-text>Best,<br />The Couchers.org Team</mj-text>
   </mj-column>

--- a/app/backend/templates/v2/signup_continue.mjml
+++ b/app/backend/templates/v2/signup_continue.mjml
@@ -1,13 +1,13 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ flow.name|v2esc }},</mj-text>
+    <mj-text>Hi {{ flow.name }},</mj-text>
     <mj-text>Please finish signing up for Couchers.org.</mj-text>
     <mj-text>Please click on this link to continue:</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ signup_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ signup_link }}">
       <b>Finish signing up</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/signup_verify.mjml
+++ b/app/backend/templates/v2/signup_verify.mjml
@@ -1,13 +1,13 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ flow.name|v2esc }},</mj-text>
+    <mj-text>Hi {{ flow.name }},</mj-text>
     <mj-text>Thanks for signing up for Couchers.org!</mj-text>
     <mj-text>To finish setting up your account, please click on the following link to activate your email:</mj-text>
   </mj-column>
 </mj-section>
 <mj-section padding="0px">
   <mj-column>
-    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ signup_link|v2url }}">
+    <mj-button background-color="#00a398" color="white" border-radius="5px" href="{{ signup_link }}">
       <b>Confirm your email address</b>
     </mj-button>
   </mj-column>

--- a/app/backend/templates/v2/strong_verification_success.mjml
+++ b/app/backend/templates/v2/strong_verification_success.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0px">
   <mj-column>
-    <mj-text>Hi {{ user.name|v2esc }},</mj-text>
-    <mj-text>{{ message|v2sf }}</mj-text>
+    <mj-text>Hi {{ user.name }},</mj-text>
+    <mj-text>{{ message }}</mj-text>
     <mj-text>Thanks for verifying—you're helping make Couchers.org safer for everyone.</mj-text>
     <mj-text>Verification is free for you, but it does come at a cost to us. As a nonprofit run by volunteers, we rely on donations to cover expenses like keeping our servers running, verification, and tools for volunteers and community builders.</mj-text>
     <mj-text>If you're able, please consider donating to help keep Couchers.org running and growing.</mj-text>


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
Our use of jinja2 templates requires carefully adding a filter to every placeholder to make sure they get escaped if needed. This is error prone. This PR changes the default to escaping HTML tags, and adds a filter that explicitly marks a placeholder as safely containing HTML tags instead. This requires updating all email templates. It also:

- Renames filters to remove the `v2` prefix.
- Adds default formatting logic such that unmarked date/datetime/time objects get formatted with the context's locale.
- Supports providing the `I18Next` object for translation. (Emails will use a different object, and it improves mocking)
- Adds more unit tests

**Please give clear steps for how the reviewer can best test this PR**
Plenty of unit tests were added. Email coverage is thin though, so run the backend with maildev and get an email or two to confirm.

<img width="1050" height="518" alt="image" src="https://github.com/user-attachments/assets/6685893c-8706-492e-9c20-a82bc99423ba" />

<img width="1150" height="859" alt="image" src="https://github.com/user-attachments/assets/591b8a41-cc2d-4e98-ab6a-a5efd83869c6" />

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A

**Backend checklist**
- [x] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)