### PR TITLE
Backend: iOS notifs title/subtitle

### DIFF
--- a/app/backend/proto/internal/jobs.proto
+++ b/app/backend/proto/internal/jobs.proto
@@ -48,6 +48,10 @@ message SendRawPushNotificationPayloadV2 {
   int64 user_id = 7;
   string topic_action = 8;
   string key = 9;
+  // iOS has two fields for the title and different guidelines.
+  // If missing fallback to normal title + no subtitle
+  string ios_title = 10;
+  string ios_subtitle = 11;
 }
 
 message GenerateMessageNotificationsPayload {

--- a/app/backend/src/couchers/notifications/expo_api.py
+++ b/app/backend/src/couchers/notifications/expo_api.py
@@ -14,6 +14,7 @@ def send_expo_push_notification(
     token: str,
     title: str,
     body: str,
+    ios_subtitle: str | None = None,
     data: dict[str, Any] | None = None,
     collapse_key: str | None = None,
 ) -> dict[str, Any]:
@@ -27,6 +28,8 @@ def send_expo_push_notification(
         "priority": "high",
         "channelId": "default",
     }
+    if ios_subtitle:
+        message["subtitle"] = ios_subtitle
 
     if collapse_key:
         message["collapseKey"] = collapse_key

--- a/app/backend/src/couchers/notifications/push.py
+++ b/app/backend/src/couchers/notifications/push.py
@@ -127,6 +127,8 @@ def push_to_subscription(
             push_notification_subscription_id=push_notification_subscription_id,
             ttl=ttl,
             title=title,
+            ios_title=content.ios_title,
+            ios_subtitle=content.ios_subtitle,
             body=body,
             icon=icon_url,
             url=action_url,

--- a/app/backend/src/couchers/notifications/send_raw_push_notification.py
+++ b/app/backend/src/couchers/notifications/send_raw_push_notification.py
@@ -14,6 +14,7 @@ from couchers.models import (
     PushNotificationPlatform,
     PushNotificationSubscription,
 )
+from couchers.models.notifications import DeviceType
 from couchers.notifications.expo_api import send_expo_push_notification
 from couchers.notifications.web_push_api import send_web_push
 from couchers.proto.internal import jobs_pb2
@@ -122,9 +123,19 @@ def _send_expo(
     if payload.topic_action and payload.key:
         collapse_key = f"{payload.topic_action}_{payload.key}"
 
+    title: str
+    ios_subtitle: str | None = None
+    if sub.device_type == DeviceType.ios and payload.ios_title:
+        # Prefer the iOS-specific title/subtitle pair if available.
+        title = payload.ios_title
+        ios_subtitle = payload.ios_subtitle
+    else:
+        title = payload.title
+
     result = send_expo_push_notification(
         token=not_none(sub.token),
-        title=payload.title,
+        title=title,
+        ios_subtitle=ios_subtitle,
         body=payload.body,
         data={
             "url": payload.url,


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
Since #7587, our notifications have special title/subtitle pairs for iOS, but this information wasn't used yet. This PR selects the iOS title/subtitle when pushing to an expo subscription to an iOS device.

⚠️ Reviewers! I don't have an iOS device and need help for testing this.

Closes #7617

**Please give clear steps for how the reviewer can best test this PR**
Testing requires an iOS device, which I do not have. Trigger a notification and validate that it corresponds the iOS title/subtitle pair defined in https://github.com/Couchers-org/couchers/blob/43a5b9d9ecc56cd2d1580d92f7ea06e7d3415a15/app/backend/src/couchers/notifications/locales/en.json . In specific, the title should be Title Cased.

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A

**Backend checklist**
- [x] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)
