### PR TITLE
Backend: Rename _year email placeholder

### DIFF
--- a/app/backend/src/couchers/email/send.py
+++ b/app/backend/src/couchers/email/send.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 
 from couchers.config import config
 from couchers.email import queue_email
-from couchers.templates.v2 import CONTEXT_YEAR_KEY, Context, render_template, template_folder
+from couchers.templates.v2 import Context, render_template, template_folder
 from couchers.utils import now
 
 
@@ -18,9 +18,12 @@ def send_simple_pretty_email(
     It's for the few security emails where we don't have a user to email but send directly to an email address.
     """
 
-    template_args[CONTEXT_YEAR_KEY] = now().year
-    template_args["header_subject"] = subject
-    template_args["footer_email_is_critical"] = True  # Results in no unsubscribe footer.
+    template_args = {
+        **template_args,
+        "header_subject": subject,
+        "footer_copyright_year": now().year,
+        "footer_email_is_critical": True  # Results in no unsubscribe footer.
+    }
 
     # Format plaintext template
     plain_tmplt = (template_folder / f"{template_name}.txt").read_text()

--- a/app/backend/src/couchers/email/send.py
+++ b/app/backend/src/couchers/email/send.py
@@ -22,7 +22,7 @@ def send_simple_pretty_email(
         **template_args,
         "header_subject": subject,
         "footer_copyright_year": now().year,
-        "footer_email_is_critical": True  # Results in no unsubscribe footer.
+        "footer_email_is_critical": True,  # Results in no unsubscribe footer.
     }
 
     # Format plaintext template

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -43,6 +43,7 @@ def _send_email_notification(session: Session, user: User, notification: Notific
     timezone = ZoneInfo(user.timezone or "Etc/UTC")
 
     template_args = {
+        **rendered.template_args,
         "header_subject": rendered.subject,
         "header_preview": rendered.preview,
         "user": user,
@@ -55,7 +56,6 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         "footer_notification_topic_key": rendered.topic_key_unsubscribe_text,
         "footer_notification_topic_key_link": generate_unsub_topic_key(notification),
         "footer_do_not_email_link": generate_do_not_email(user),
-        **rendered.template_args,
     }
 
     # Format plaintext template

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -28,7 +28,7 @@ from couchers.notifications.render_push import render_push_notification
 from couchers.notifications.settings import get_preference
 from couchers.proto.internal import jobs_pb2
 from couchers.sql import moderation_state_column_visible
-from couchers.templates.v2 import CONTEXT_YEAR_KEY, Context, render_template, template_folder
+from couchers.templates.v2 import Context, render_template, template_folder
 from couchers.utils import now
 
 logger = logging.getLogger(__name__)
@@ -47,6 +47,7 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         "header_preview": rendered.preview,
         "user": user,
         "time": notification.created,
+        "footer_copyright_year": now().year,
         "footer_email_is_critical": rendered.is_critical,
         "footer_manage_notifications_link": urls.notification_settings_link(),
         "footer_notification_topic_action": rendered.topic_action_unsubscribe_text,
@@ -54,7 +55,6 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         "footer_notification_topic_key": rendered.topic_key_unsubscribe_text,
         "footer_notification_topic_key_link": generate_unsub_topic_key(notification),
         "footer_do_not_email_link": generate_do_not_email(user),
-        CONTEXT_YEAR_KEY: now().year,
         **rendered.template_args,
     }
 

--- a/app/backend/src/couchers/templates/v2.py
+++ b/app/backend/src/couchers/templates/v2.py
@@ -26,10 +26,6 @@ template_folder = Path(__file__).parent / ".." / ".." / ".." / "templates" / "v2
 md = MarkdownIt("zero", {"typographer": True}).enable(["smartquotes", "heading", "hr", "list", "link", "emphasis"])
 
 
-# Special context values expected by v2 filters
-CONTEXT_YEAR_KEY = "_year"
-
-
 @dataclass(frozen=True, slots=True, kw_only=True)
 class Context:
     """Context available to filter functions during templating."""

--- a/app/backend/templates/v2/_footer.mjml
+++ b/app/backend/templates/v2/_footer.mjml
@@ -4,7 +4,7 @@
           <mj-text align="center" font-size="10px" line-height="12px"> You're receiving this email because you signed up for Couchers.org.<br /> You can reach our support team at <a href="mailto:support@couchers.org">support@couchers.org</a>.<br /> All times are in {{ _timezone_display|v2sf }}, based on your profile location. </mj-text>
           <mj-text align="center" font-size="10px"><a href="https://couchers.org/donate">Donate</a> | <a href="https://github.com/Couchers-org/couchers">GitHub</a> | <a href="https://couchers.org/volunteer">Volunteer</a> | <a href="https://couchers.org/blog">Blog</a></mj-text>
           <mj-text align="center" font-size="8px" line-height="10px">
-            &copy; {{ _year|v2sf }} Couchers, Inc.<br />
+            &copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br />
             3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br />
             <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
           </mj-text>

--- a/app/backend/templates/v2/generated_html/account_deletion_complete.html
+++ b/app/backend/templates/v2/generated_html/account_deletion_complete.html
@@ -287,7 +287,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/account_deletion_recovered.html
+++ b/app/backend/templates/v2/generated_html/account_deletion_recovered.html
@@ -287,7 +287,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/account_deletion_start.html
+++ b/app/backend/templates/v2/generated_html/account_deletion_start.html
@@ -282,7 +282,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/activeness_probe.html
+++ b/app/backend/templates/v2/generated_html/activeness_probe.html
@@ -359,7 +359,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/api_key.html
+++ b/app/backend/templates/v2/generated_html/api_key.html
@@ -290,7 +290,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/badge.html
+++ b/app/backend/templates/v2/generated_html/badge.html
@@ -214,7 +214,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/chat_message.html
+++ b/app/backend/templates/v2/generated_html/chat_message.html
@@ -337,7 +337,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/chat_unseen_messages.html
+++ b/app/backend/templates/v2/generated_html/chat_unseen_messages.html
@@ -365,7 +365,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/comment_reply.html
+++ b/app/backend/templates/v2/generated_html/comment_reply.html
@@ -337,7 +337,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/discussion_comment.html
+++ b/app/backend/templates/v2/generated_html/discussion_comment.html
@@ -337,7 +337,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/discussion_create.html
+++ b/app/backend/templates/v2/generated_html/discussion_create.html
@@ -337,7 +337,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/donation_received.html
+++ b/app/backend/templates/v2/generated_html/donation_received.html
@@ -297,7 +297,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/email_changed_confirmation_new_email.html
+++ b/app/backend/templates/v2/generated_html/email_changed_confirmation_new_email.html
@@ -282,7 +282,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/event_cancel.html
+++ b/app/backend/templates/v2/generated_html/event_cancel.html
@@ -345,7 +345,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/event_comment.html
+++ b/app/backend/templates/v2/generated_html/event_comment.html
@@ -369,7 +369,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/event_create.html
+++ b/app/backend/templates/v2/generated_html/event_create.html
@@ -345,7 +345,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/event_delete.html
+++ b/app/backend/templates/v2/generated_html/event_delete.html
@@ -246,7 +246,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/event_invite_organizer.html
+++ b/app/backend/templates/v2/generated_html/event_invite_organizer.html
@@ -345,7 +345,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/event_reminder.html
+++ b/app/backend/templates/v2/generated_html/event_reminder.html
@@ -312,7 +312,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/event_update.html
+++ b/app/backend/templates/v2/generated_html/event_update.html
@@ -350,7 +350,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/friend_reference.html
+++ b/app/backend/templates/v2/generated_html/friend_reference.html
@@ -337,7 +337,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/friend_request.html
+++ b/app/backend/templates/v2/generated_html/friend_request.html
@@ -310,7 +310,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/friend_request_accepted.html
+++ b/app/backend/templates/v2/generated_html/friend_request_accepted.html
@@ -305,7 +305,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/host_reference.html
+++ b/app/backend/templates/v2/generated_html/host_reference.html
@@ -449,7 +449,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/host_request__message.html
+++ b/app/backend/templates/v2/generated_html/host_request__message.html
@@ -338,7 +338,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/host_request__new.html
+++ b/app/backend/templates/v2/generated_html/host_request__new.html
@@ -394,7 +394,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/host_request__plain.html
+++ b/app/backend/templates/v2/generated_html/host_request__plain.html
@@ -306,7 +306,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/mod_note.html
+++ b/app/backend/templates/v2/generated_html/mod_note.html
@@ -219,7 +219,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/new_blog_post.html
+++ b/app/backend/templates/v2/generated_html/new_blog_post.html
@@ -301,7 +301,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/onboarding1.html
+++ b/app/backend/templates/v2/generated_html/onboarding1.html
@@ -307,7 +307,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/onboarding2.html
+++ b/app/backend/templates/v2/generated_html/onboarding2.html
@@ -287,7 +287,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/password_reset.html
+++ b/app/backend/templates/v2/generated_html/password_reset.html
@@ -282,7 +282,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/reference_reminder.html
+++ b/app/backend/templates/v2/generated_html/reference_reminder.html
@@ -325,7 +325,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/security.html
+++ b/app/backend/templates/v2/generated_html/security.html
@@ -224,7 +224,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/signup_continue.html
+++ b/app/backend/templates/v2/generated_html/signup_continue.html
@@ -287,7 +287,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/signup_verify.html
+++ b/app/backend/templates/v2/generated_html/signup_verify.html
@@ -282,7 +282,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/backend/templates/v2/generated_html/strong_verification_success.html
+++ b/app/backend/templates/v2/generated_html/strong_verification_success.html
@@ -292,7 +292,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ _year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br> 3120 Winkler Ave, Unit 9. Fort Myers, FL 33916, USA.<br>
                                     <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
                                   </div>
                                 </td>

--- a/app/web/.env.development
+++ b/app/web/.env.development
@@ -1,10 +1,10 @@
-NEXT_PUBLIC_COUCHERS_ENV=dev
-NEXT_PUBLIC_API_BASE_URL="http://localhost:8888"
-NEXT_PUBLIC_MEDIA_BASE_URL="http://localhost:5001"
-NEXT_PUBLIC_CONSOLE_BASE_URL="http://localhost:10027"
-NEXT_PUBLIC_IS_POST_BETA_ENABLED=true
+NEXT_PUBLIC_COUCHERS_ENV=preview
+NEXT_PUBLIC_API_BASE_URL="https://next.couchershq.org/api"
+NEXT_PUBLIC_MEDIA_BASE_URL="https://dev-user-media.couchershq.org"
+NEXT_PUBLIC_CONSOLE_BASE_URL="https://next-console.couchershq.org"
 NEXT_PUBLIC_NOMINATIM_URL="https://nominatim.openstreetmap.org/"
-NEXT_PUBLIC_IS_VERIFICATION_ENABLED=true
-NEXT_PUBLIC_IS_COMMUNITIES_PART2_ENABLED=true
 NEXT_PUBLIC_STRIPE_KEY="pk_test_51KEzByIfR5z29g5khFE5samD8XKOGLcCrM1lhCkfOomGPUFAEYOw8uAqI2Nkv33wYdPM2FgTQNTC07IiNfHY1kLJ00Jqm8Ppai"
-NEXT_PUBLIC_GLOBAL_MESSAGE_URL="https://gm.couchershq.org/localdev.json"
+NEXT_PUBLIC_GLOBAL_MESSAGE_URL="https://gm.couchershq.org/next.json"
+NEXT_PUBLIC_STATSIG_CLIENT_KEY="client-OUFQyztG9ESDBytRkl0HdLQylUWbvbpV265YYap3UR8"
+# When enabled, all feature gates return true (useful for development/testing)
+NEXT_PUBLIC_STATSIG_PASS_ALL_GATES="1"

--- a/app/web/.env.development
+++ b/app/web/.env.development
@@ -1,10 +1,10 @@
-NEXT_PUBLIC_COUCHERS_ENV=preview
-NEXT_PUBLIC_API_BASE_URL="https://next.couchershq.org/api"
-NEXT_PUBLIC_MEDIA_BASE_URL="https://dev-user-media.couchershq.org"
-NEXT_PUBLIC_CONSOLE_BASE_URL="https://next-console.couchershq.org"
+NEXT_PUBLIC_COUCHERS_ENV=dev
+NEXT_PUBLIC_API_BASE_URL="http://localhost:8888"
+NEXT_PUBLIC_MEDIA_BASE_URL="http://localhost:5001"
+NEXT_PUBLIC_CONSOLE_BASE_URL="http://localhost:10027"
+NEXT_PUBLIC_IS_POST_BETA_ENABLED=true
 NEXT_PUBLIC_NOMINATIM_URL="https://nominatim.openstreetmap.org/"
+NEXT_PUBLIC_IS_VERIFICATION_ENABLED=true
+NEXT_PUBLIC_IS_COMMUNITIES_PART2_ENABLED=true
 NEXT_PUBLIC_STRIPE_KEY="pk_test_51KEzByIfR5z29g5khFE5samD8XKOGLcCrM1lhCkfOomGPUFAEYOw8uAqI2Nkv33wYdPM2FgTQNTC07IiNfHY1kLJ00Jqm8Ppai"
-NEXT_PUBLIC_GLOBAL_MESSAGE_URL="https://gm.couchershq.org/next.json"
-NEXT_PUBLIC_STATSIG_CLIENT_KEY="client-OUFQyztG9ESDBytRkl0HdLQylUWbvbpV265YYap3UR8"
-# When enabled, all feature gates return true (useful for development/testing)
-NEXT_PUBLIC_STATSIG_PASS_ALL_GATES="1"
+NEXT_PUBLIC_GLOBAL_MESSAGE_URL="https://gm.couchershq.org/localdev.json"


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
This is the last email placeholder that was still using the underscored-prefixed convention. Align it with all the other footer placeholders. `CONTEXT_YEAR_KEY` was also the last email-specific piece of code from `v2.py`. I intend to consolidate the two pieces of code setting this variable and other footer vars in a future PR.

**Please give clear steps for how the reviewer can best test this PR**
Trigger an email (e.g. send a couch request) and check the footer.

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A

**Backend checklist**
- [x] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)