### PR TITLE
Backend: Localize push notifs enabled notification

### DIFF
--- a/app/backend/src/couchers/notifications/locales/en.json
+++ b/app/backend/src/couchers/notifications/locales/en.json
@@ -1,5 +1,12 @@
 {
   "push": {
+    "adhoc": {
+      "push_enabled": {
+        "title": "Push notifications enabled",
+        "ios_title": "Push Notifications Enabled",
+        "body": "You'll now receive notifications on this device."
+      }
+    },
     "account_deletion__start": {
       "title": "Account deletion requested",
       "ios_title": "Account Deletion Requested",
@@ -20,11 +27,6 @@
       "title": "Still open to hosting?",
       "ios_title": "Still Open to Hosting?",
       "body": "Log in to confirm your hosting status."
-    },
-    "adhoc__push_enabled": {
-      "title": "Push notifications enabled",
-      "ios_title": "Push Notifications Enabled",
-      "body": "You'll now receive notifications on this device."
     },
     "api_key__create": {
       "title": "API key created",

--- a/app/backend/src/couchers/notifications/locales/en.json
+++ b/app/backend/src/couchers/notifications/locales/en.json
@@ -21,6 +21,11 @@
       "ios_title": "Still Open to Hosting?",
       "body": "Log in to confirm your hosting status."
     },
+    "adhoc__push_enabled": {
+      "title": "Push notifications enabled",
+      "ios_title": "Push Notifications Enabled",
+      "body": "You'll now receive notifications on this device."
+    },
     "api_key__create": {
       "title": "API key created",
       "ios_title": "API Key Created",

--- a/app/backend/src/couchers/notifications/locales/en.json
+++ b/app/backend/src/couchers/notifications/locales/en.json
@@ -1,12 +1,5 @@
 {
   "push": {
-    "adhoc": {
-      "push_enabled": {
-        "title": "Push notifications enabled",
-        "ios_title": "Push Notifications Enabled",
-        "body": "You'll now receive notifications on this device."
-      }
-    },
     "account_deletion__start": {
       "title": "Account deletion requested",
       "ios_title": "Account Deletion Requested",
@@ -27,6 +20,11 @@
       "title": "Still open to hosting?",
       "ios_title": "Still Open to Hosting?",
       "body": "Log in to confirm your hosting status."
+    },
+    "adhoc__push_enabled": {
+      "title": "Push notifications enabled",
+      "ios_title": "Push Notifications Enabled",
+      "body": "You'll now receive notifications on this device."
     },
     "api_key__create": {
       "title": "API key created",

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -694,7 +694,7 @@ class _Renderer:
 def render_adhoc_push_notification(name: str, locale: str) -> PushNotificationContent:
     """Renders a push notification that doesn't have an assigned topic-action."""
     renderer = _Renderer(locale, timezone=ZoneInfo("Etc/UTC")) # Timezone irrelevant, we're not formatting dates
-    return renderer._get_content(string_group=f"adhoc.{name}")
+    return renderer._get_content(string_group=f"adhoc__{name}")
 
 
 @lru_cache(maxsize=1)

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -691,9 +691,10 @@ class _Renderer:
         )
 
 
-def render_custom(string_group: str, locale: str) -> PushNotificationContent:
+def render_adhoc_push_notification(name: str, locale: str) -> PushNotificationContent:
+    """Renders a push notification that doesn't have an assigned topic-action."""
     renderer = _Renderer(locale, timezone=ZoneInfo("Etc/UTC")) # Timezone irrelevant, we're not formatting dates
-    return renderer._get_content(string_group=string_group)
+    return renderer._get_content(string_group=f"adhoc.{name}")
 
 
 @lru_cache(maxsize=1)

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -691,6 +691,11 @@ class _Renderer:
         )
 
 
+def render_custom(string_group: str, locale: str) -> PushNotificationContent:
+    renderer = _Renderer(locale, timezone=ZoneInfo("Etc/UTC")) # Timezone irrelevant, we're not formatting dates
+    return renderer._get_content(string_group=string_group)
+
+
 @lru_cache(maxsize=1)
 def _get_notifs_i18next() -> I18Next:
     """Gets the I18Next instance for notifications."""

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -693,7 +693,7 @@ class _Renderer:
 
 def render_adhoc_push_notification(name: str, locale: str) -> PushNotificationContent:
     """Renders a push notification that doesn't have an assigned topic-action."""
-    renderer = _Renderer(locale, timezone=ZoneInfo("Etc/UTC")) # Timezone irrelevant, we're not formatting dates
+    renderer = _Renderer(locale, timezone=ZoneInfo("Etc/UTC"))  # Timezone irrelevant, we're not formatting dates
     return renderer._get_content(string_group=f"adhoc__{name}")
 
 

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -258,9 +258,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             push_notification_subscription_id=subscription.id,
             user_id=context.user_id,
             topic_action="adhoc:push_enabled",
-            content=render_adhoc_push_notification(
-                "push_enabled",
-                locale=context.ui_language_preference or "en"),
+            content=render_adhoc_push_notification("push_enabled", locale=context.ui_language_preference or "en"),
         )
 
         return empty_pb2.Empty()

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -22,7 +22,7 @@ from couchers.models import (
     User,
 )
 from couchers.notifications.push import PushNotificationContent, push_to_subscription, push_to_user
-from couchers.notifications.render_push import render_custom, render_push_notification
+from couchers.notifications.render_push import render_adhoc_push_notification, render_push_notification
 from couchers.notifications.settings import (
     PreferenceNotUserEditableError,
     get_topic_actions_by_delivery_type,
@@ -258,8 +258,8 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             push_notification_subscription_id=subscription.id,
             user_id=context.user_id,
             topic_action="adhoc:setup",
-            content=render_custom(
-                string_group="adhoc__push_enabled",
+            content=render_adhoc_push_notification(
+                string_group="push_enabled",
                 locale=context.ui_language_preference or "en"),
         )
 

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -259,7 +259,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             user_id=context.user_id,
             topic_action="adhoc:setup",
             content=render_adhoc_push_notification(
-                string_group="push_enabled",
+                "push_enabled",
                 locale=context.ui_language_preference or "en"),
         )
 

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -22,7 +22,7 @@ from couchers.models import (
     User,
 )
 from couchers.notifications.push import PushNotificationContent, push_to_subscription, push_to_user
-from couchers.notifications.render_push import render_push_notification
+from couchers.notifications.render_push import render_custom, render_push_notification
 from couchers.notifications.settings import (
     PreferenceNotUserEditableError,
     get_topic_actions_by_delivery_type,
@@ -258,11 +258,9 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             push_notification_subscription_id=subscription.id,
             user_id=context.user_id,
             topic_action="adhoc:setup",
-            content=PushNotificationContent(
-                title="Push notifications enabled",
-                ios_title="Push Notifications Enabled",
-                body="You'll now receive notifications on this device.",
-            ),
+            content=render_custom(
+                string_group="adhoc__push_enabled",
+                locale=context.ui_language_preference or "en"),
         )
 
         return empty_pb2.Empty()

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -257,7 +257,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             session,
             push_notification_subscription_id=subscription.id,
             user_id=context.user_id,
-            topic_action="adhoc:setup",
+            topic_action="adhoc:push_enabled",
             content=render_adhoc_push_notification(
                 "push_enabled",
                 locale=context.ui_language_preference or "en"),


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
Push notifications are now translatable, except that one that says push notifications have been enabled, since it's an ad-hoc notification. Make it translatable.

Note that there are other notifications in this file but they are all test notifications and I don't think they can be seen by an end user.

**Please give clear steps for how the reviewer can best test this PR**
You'd have to re-register for push notifications against a backend from this PR's branch.

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A

**Backend checklist**
- [x] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)