### PR TITLE
Bug: Didn't Stay - Make comment box optional

### DIFF
--- a/app/web/features/profile/view/leaveReference/formSteps/DidStay.tsx
+++ b/app/web/features/profile/view/leaveReference/formSteps/DidStay.tsx
@@ -91,10 +91,10 @@ const DidStay = ({
   const { didStay, reasonDidntMeetup } = watch();
 
   const onSubmitDidNotStay = handleSubmit(async () => {
-    if (!didStay && hostRequestId && reasonDidntMeetup) {
+    if (!didStay && hostRequestId) {
       await indicateDidntMeetup({
         hostRequestId,
-        reasonDidntMeetup,
+        reasonDidntMeetup: reasonDidntMeetup || "",
       });
 
       setReferenceValues({ ...referenceData, didStay: false });


### PR DESCRIPTION
Closes #6451 

This says it's optional but wasn't allowing submit unless filled. This fixes it.