### PR TITLE
Fix mark all read buttons issues

### DIFF
--- a/app/web/features/connections/friends/useRespondToFriendRequest.ts
+++ b/app/web/features/connections/friends/useRespondToFriendRequest.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { friendRequestKey, userKey } from "features/queryKeys";
+import { friendRequestKey, pingQueryKey, userKey } from "features/queryKeys";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { FriendRequest, User } from "proto/api_pb";
 import { service } from "service";
@@ -72,7 +72,7 @@ export default function useRespondToFriendRequest() {
         queryKey: userKey(friendRequest.userId),
       });
       queryClient.invalidateQueries({
-        queryKey: ["ping"],
+        queryKey: [pingQueryKey],
       });
     },
   });

--- a/app/web/features/messages/locales/en.json
+++ b/app/web/features/messages/locales/en.json
@@ -1,5 +1,8 @@
 {
   "mark_all_read_button_text": "Mark all as read",
+  "mark_all_read_button_text_chats": "Mark all chats as read",
+  "mark_all_read_button_text_hosting": "Mark all host requests as read",
+  "mark_all_read_button_text_surfing": "Mark all surf requests as read",
   "request_closed_message": "This host request is closed. To continue chatting, send the other person a normal message.",
   "write_reference_button_text": "Write a Reference",
   "close_request_dialog_title": "Are you done messaging?",

--- a/app/web/features/messages/requests/MarkAllReadButton.test.tsx
+++ b/app/web/features/messages/requests/MarkAllReadButton.test.tsx
@@ -85,7 +85,7 @@ describe("MarkAllReadButton", () => {
     const user = userEvent.setup();
     await user.click(
       await screen.findByRole("button", {
-        name: t("messages:mark_all_read_button_text"),
+        name: t("messages:mark_all_read_button_text_chats"),
       }),
     );
 
@@ -107,7 +107,7 @@ describe("MarkAllReadButton", () => {
 
     await user.click(
       await screen.findByRole("button", {
-        name: t("messages:mark_all_read_button_text"),
+        name: t("messages:mark_all_read_button_text_hosting"),
       }),
     );
 
@@ -133,7 +133,7 @@ describe("MarkAllReadButton", () => {
 
     await user.click(
       await screen.findByRole("button", {
-        name: t("messages:mark_all_read_button_text"),
+        name: t("messages:mark_all_read_button_text_chats"),
       }),
     );
 

--- a/app/web/features/messages/requests/MarkAllReadButton.tsx
+++ b/app/web/features/messages/requests/MarkAllReadButton.tsx
@@ -3,7 +3,11 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import Button from "components/Button";
 import { DoneAllIcon } from "components/Icons";
 import Snackbar from "components/Snackbar";
-import { groupChatsListKey, hostRequestsListKey } from "features/queryKeys";
+import {
+  groupChatsListKey,
+  hostRequestsListKey,
+  pingQueryKey,
+} from "features/queryKeys";
 import { useTranslation } from "i18n";
 import { MESSAGES } from "i18n/namespaces";
 import { service } from "service";
@@ -74,10 +78,14 @@ export default function MarkAllReadButton({
 
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [hostRequestsListKey()],
+        queryKey: hostRequestsListKey(),
       });
       queryClient.invalidateQueries({
         queryKey: [groupChatsListKey],
+      });
+      // Invalidate ping to update badge counts in tabs
+      queryClient.invalidateQueries({
+        queryKey: [pingQueryKey],
       });
     },
   });
@@ -96,7 +104,7 @@ export default function MarkAllReadButton({
       >
         <MarkAsReadIconStyled />
         <Typography component="span">
-          {t("mark_all_read_button_text")}
+          {t(`mark_all_read_button_text_${type}`)}
         </Typography>
       </MarkAsReadButtonStyled>
     </>

--- a/app/web/features/notifications/NotificationsFeed/NotificationsFeed.tsx
+++ b/app/web/features/notifications/NotificationsFeed/NotificationsFeed.tsx
@@ -182,7 +182,6 @@ const NotificationsFeed = ({
           data-testid="notifications-feed--more-options"
           open={isInternalMenuOpen}
           onClose={handleInternalMenuClose}
-          onClick={handleInternalMenuClose}
           slotProps={{
             paper: {
               elevation: 0,

--- a/app/web/features/notifications/utils/helpers.ts
+++ b/app/web/features/notifications/utils/helpers.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { listNotificationsQueryKey } from "features/queryKeys";
+import { listNotificationsQueryKey, pingQueryKey } from "features/queryKeys";
 import Sentry from "platform/sentry";
 import { ListNotificationsRes } from "proto/notifications_pb";
 import { service } from "service";
@@ -187,6 +187,12 @@ export const useMarkAllNotificationsSeen = () => {
           };
         },
       );
+    },
+    onSuccess: () => {
+      // Invalidate the ping query to update the notification badge count
+      queryClient.invalidateQueries({
+        queryKey: [pingQueryKey],
+      });
     },
     onError: (error) => {
       Sentry.captureException(error, {

--- a/app/web/features/queryKeys.ts
+++ b/app/web/features/queryKeys.ts
@@ -12,6 +12,7 @@ export const tosQueryKey = "tos";
 export const communityGuidelinesQueryKey = "communityGuidelines";
 export const notificationSettingsQueryKey = "notificationSettings";
 export const listNotificationsQueryKey = "listNotifications";
+export const pingQueryKey = "ping";
 export const username2Id = "username2Id";
 export const volunteerInfoQueryKey = "volunteerInfo";
 

--- a/app/web/features/useNotifications.ts
+++ b/app/web/features/useNotifications.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { pingInterval } from "appConstants";
 import { useAuthContext } from "features/auth/AuthProvider";
+import { pingQueryKey } from "features/queryKeys";
 import { RpcError } from "grpc-web";
 import { service } from "service";
 
@@ -13,7 +14,7 @@ export default function useNotifications() {
     PingRes.AsObject,
     RpcError
   >({
-    queryKey: ["ping"],
+    queryKey: [pingQueryKey],
     queryFn: () => service.api.ping(),
     enabled: authenticated && !jailed,
     refetchInterval: pingInterval,


### PR DESCRIPTION
Closes #4098 
Closes #7678

* Changes strings in messages view to make it clear the "Mark all read" button only clears the current tab. Previously it seemed it should do all tabs but looking at the code it was not that way by design.
* Fixes issue with "mark all read" in notifications feed not working the first time

<img width="932" height="456" alt="Screenshot 2026-01-20 at 11 31 46" src="https://github.com/user-attachments/assets/ed4b2040-64d0-4655-95de-7aa13bed7e8e" />

<img width="478" height="274" alt="Screenshot 2026-01-20 at 11 31 54" src="https://github.com/user-attachments/assets/9d7d0350-c1a3-4936-bc90-331c6652b897" />
