### PR TITLE
Add show all languages checkbox to settings for staging 

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -50,6 +50,7 @@ To run the app locally in development, use `yarn start` (not Docker)
 - Prefer modern 2025 design patterns for UI components
 - Use StyledLink.tsx component or import from next/link for links to preserve routing, NOT MUI Link
 - Always put types at the top of the file below the imports
+- Add Tanstack queryKeys to app/web/features/queryKeys.ts if they are used more than one place.
 
 ### Internationalization (i18n)
 - **Never hardcode English text** - always use the `t()` function or `<Trans>` component for user-facing text

--- a/app/web/features/auth/Settings.tsx
+++ b/app/web/features/auth/Settings.tsx
@@ -119,6 +119,9 @@ export default function Settings() {
             )}
           </MarginWrapper>
           <MarginWrapper>
+            <DarkModeSettings />
+          </MarginWrapper>
+          <MarginWrapper>
             <NotificationSettings />
           </MarginWrapper>
           <MarginWrapper>
@@ -150,9 +153,6 @@ export default function Settings() {
           </MarginWrapper>
           <MarginWrapper>
             <LanguagePickerSettings />
-          </MarginWrapper>
-          <MarginWrapper>
-            <DarkModeSettings />
           </MarginWrapper>
           <MarginWrapper>
             <DoNotEmail />

--- a/app/web/features/queryKeys.ts
+++ b/app/web/features/queryKeys.ts
@@ -155,3 +155,6 @@ export const newUsersListKey = "newUsersList";
 // Public
 export const volunteersKey = "volunteers";
 export const donationStatsKey = "donationStats";
+
+// Translate
+export const showAllLanguagesQueryKey = "showAllLanguages";

--- a/app/web/features/translate/LanguagePickerSelect.tsx
+++ b/app/web/features/translate/LanguagePickerSelect.tsx
@@ -28,6 +28,7 @@ import { service } from "service";
 import { theme } from "theme";
 
 import { ALMOST_DONE_CUTOFF } from "./constants";
+import { useShowAllLanguages } from "./useShowAllLanguages";
 import { getAvailableLanguages } from "./utils";
 
 interface StyledMuiSelectProps {
@@ -75,6 +76,7 @@ export default function LanguagePickerSelect({
   const { t } = useTranslation([GLOBAL]);
 
   const { data: languages, isLoading, error } = useWeblateStats();
+  const { showAllLanguages } = useShowAllLanguages();
 
   const [isOpen, setIsOpen] = useState(false);
   const [isChangingLanguage, setIsChangingLanguage] = useState(false);
@@ -118,10 +120,10 @@ export default function LanguagePickerSelect({
   };
 
   const renderFlag = (flagCode: string, percent?: number) => {
+    const shouldGreyOut = percent !== undefined && percent < ALMOST_DONE_CUTOFF;
     const commonStyles = {
-      filter:
-        percent && percent < ALMOST_DONE_CUTOFF ? "grayscale(100%)" : "none",
-      opacity: percent && percent < ALMOST_DONE_CUTOFF ? 0.4 : 1,
+      filter: shouldGreyOut ? "grayscale(100%)" : "none",
+      opacity: shouldGreyOut ? 0.4 : 1,
     } as const;
 
     if (flagCode === "CAT") {
@@ -141,9 +143,9 @@ export default function LanguagePickerSelect({
       />
     );
   };
-  // Languages with < 50% translated are hidden from language selector
+  // Languages with < 50% translated are hidden from language selector (unless showAllLanguages is enabled)
   // Languages with < 80% translated are greyed out
-  const availableLanguages = getAvailableLanguages(languages);
+  const availableLanguages = getAvailableLanguages(languages, showAllLanguages);
 
   const menuItems: React.ReactNode[] | undefined = isLoading
     ? []

--- a/app/web/features/translate/LanguagePickerSettings.tsx
+++ b/app/web/features/translate/LanguagePickerSettings.tsx
@@ -1,4 +1,4 @@
-import { Link, Typography } from "@mui/material";
+import { Checkbox, FormControlLabel, Link, Typography } from "@mui/material";
 import { Trans, useTranslation } from "i18n";
 import { LANGUAGE_MAP } from "i18n/constants";
 import { GLOBAL } from "i18n/namespaces";
@@ -7,6 +7,7 @@ import { translateJobURL, translateRoute } from "routes";
 
 import Button from "../../components/Button";
 import LanguagePickerSelect from "./LanguagePickerSelect";
+import { useShowAllLanguages } from "./useShowAllLanguages";
 
 interface ChangeLanguageProps {
   className?: string;
@@ -19,6 +20,8 @@ export default function LanguagePickerSettings({
   const router = useRouter();
   const { locale } = router;
   const languageName = LANGUAGE_MAP[locale || "en"]?.name;
+  const { isAvailable, showAllLanguages, setShowAllLanguages } =
+    useShowAllLanguages();
 
   return (
     <div className={className}>
@@ -60,6 +63,28 @@ export default function LanguagePickerSettings({
             {t("global:language_preference.translation_progress.view_progress")}
           </Button>
         </Typography>
+        {isAvailable && (
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={showAllLanguages}
+                onChange={(e) => setShowAllLanguages(e.target.checked)}
+              />
+            }
+            label={
+              <div>
+                <Typography variant="body1" component="span" fontWeight="bold">
+                  {t("global:language_preference.show_all_languages")}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {t(
+                    "global:language_preference.show_all_languages_description",
+                  )}
+                </Typography>
+              </div>
+            }
+          />
+        )}
       </>
     </div>
   );

--- a/app/web/features/translate/useShowAllLanguages.ts
+++ b/app/web/features/translate/useShowAllLanguages.ts
@@ -1,0 +1,46 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { showAllLanguagesQueryKey } from "features/queryKeys";
+import { useCallback } from "react";
+
+const STORAGE_KEY = "showAllLanguages";
+
+const isNonProduction =
+  process.env.NEXT_PUBLIC_COUCHERS_ENV !== "prod" &&
+  process.env.NODE_ENV !== "test";
+
+/**
+ * Hook to manage the "show all languages" setting for translators.
+ * This setting is only available on non-production environments (stage/local dev).
+ * When enabled, the language picker shows all languages regardless of translation completion percentage.
+ */
+export function useShowAllLanguages() {
+  const queryClient = useQueryClient();
+
+  const { data: showAllLanguages = false } = useQuery({
+    queryKey: [showAllLanguagesQueryKey],
+    queryFn: () => {
+      if (typeof window === "undefined" || !isNonProduction) return false;
+      return localStorage.getItem(STORAGE_KEY) === "true";
+    },
+    staleTime: Infinity,
+  });
+
+  const setShowAllLanguages = useCallback(
+    (value: boolean) => {
+      if (!isNonProduction) return;
+
+      localStorage.setItem(STORAGE_KEY, String(value));
+      queryClient.setQueryData([showAllLanguagesQueryKey], value);
+    },
+    [queryClient],
+  );
+
+  return {
+    /** Whether the feature is available (non-production environment) */
+    isAvailable: isNonProduction,
+    /** Whether to show all languages in the picker */
+    showAllLanguages: isNonProduction && showAllLanguages,
+    /** Set the setting to a specific value */
+    setShowAllLanguages,
+  };
+}

--- a/app/web/features/translate/utils.ts
+++ b/app/web/features/translate/utils.ts
@@ -33,10 +33,13 @@ export function isLanguageProductionReady(
 }
 
 /**
- * Filter languages for display in language picker (>= 50% translated)
+ * Filter languages for display in language picker (>= 50% translated by default)
+ * @param languages - Array of languages with translation stats
+ * @param showAll - If true, bypasses the SELECTOR_CUTOFF filter (for translators on stage)
  */
 export function getAvailableLanguages(
   languages: WeblateLanguage[] | undefined,
+  showAll = false,
 ): WeblateLanguage[] {
   if (!languages) {
     return [];
@@ -46,7 +49,7 @@ export function getAvailableLanguages(
     .filter(
       (language) =>
         LANGUAGE_MAP[language.code.replace("_", "-")] &&
-        language.translated_percent >= SELECTOR_CUTOFF,
+        (showAll || language.translated_percent >= SELECTOR_CUTOFF),
     )
     .sort((a, b) => {
       // Sort by translation percentage (>= 80% first), then alphabetically

--- a/app/web/resources/locales/en.json
+++ b/app/web/resources/locales/en.json
@@ -77,7 +77,9 @@
       "complete_percent": "{{percent}}% complete",
       "info_text": "💡 Languages with 50-80% completion appear greyed out in the language picker. Languages with less than 50% completion are hidden from the language picker. To encourage contributors, languages below 20% are shown on this site.",
       "view_progress": "View translation progress"
-    }
+    },
+    "show_all_languages": "Show all languages in language picker",
+    "show_all_languages_description": "When enabled, the language picker will show all languages regardless of translation completion percentage. This shows on staging only to help test languages that are still in progress."
   },
   "meetup_status": {
     "wants_to_meetup": "Wants to meet",


### PR DESCRIPTION
Closes #7691 
Closes #7676

Adds a toggle under "Account Settings" that allows a user to toggle on all languages for testing. This is visible on staging environment only.

Also moves dark mode up below push notification settings as requested in #7676.

<img width="1099" height="293" alt="Screenshot 2026-01-20 at 17 00 13" src="https://github.com/user-attachments/assets/f1bbc5bc-2990-45a4-98e5-2a6f3fecbedb" />
