### PR TITLE
Fix prometheus metrics for background jobs

### DIFF
--- a/app/backend/Makefile
+++ b/app/backend/Makefile
@@ -5,6 +5,9 @@ UV_VERSION=0.9.21
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 PROTO_IMAGE=registry.gitlab.com/couchers/grpc
 
+DB_PASSWORD := "203d805f4b62c0a1b2f1f6b82d4583dfe563ec1619b83ce22ee414e8376a25e7"
+DB_CONNECTION_STRING := "postgresql://postgres:${DB_PASSWORD}@localhost:6545/postgres"
+
 protos:
 	docker pull -q ${PROTO_IMAGE}
 	docker run --rm -w /app -v $(realpath ${ROOT_DIR}..):/app ${PROTO_IMAGE} ./generate_protos.sh
@@ -64,3 +67,13 @@ teardown-db:
 # make test file=test_file.py::TestClass::test_method → runs a specific test
 test:
 	uv run pytest $(if $(file),src/tests/$(file),src/tests)
+
+
+run-deps:
+	docker compose -f ../docker-compose.local-backend.yml up -d --build --wait
+
+# Run backend locally with all needed dependencies (db etc).
+# You can also execute "run_locally.py" from an IDE to attach a debugger to it
+# (be sure to run "make run-deps" before!)
+run: run-deps
+	uv run src/run_locally.py

--- a/app/backend/readme.md
+++ b/app/backend/readme.md
@@ -62,28 +62,26 @@ cd app/backend
 uv sync
 ```
 
-In a terminal, run all containerized services except the backend with config set up for .
+Then start a local backend with all dependencies (postgres, maildev, etc.):
 
 ```sh
-cd app
-docker compose --file docker-compose.local-backend.yml up --build
-```
-
-In another terminal, run the backend outside Docker:
-
-```sh
-cd app/backend
-
-# Use backend environment variables, overriding the host names of containerized services.
-set -a && source ../backend.dev.env && set +a
-export DATABASE_CONNECTION_STRING=${DATABASE_CONNECTION_STRING/postgres:6545/localhost:6545}
-export SMTP_HOST=localhost
-export OPENTELEMETRY_ENDPOINT=localhost:4317
-
-uv run src/app.py
+make run
 ```
 
 If you find that the proxy/media services can't talk to your local backend, try setting the `BACKEND_HOST=host.docker.internal` environment variable before running the services via `docker compose`.
+
+
+## Running under a debugger
+
+Run dependencies with docker compose:
+```sh
+cd app/backend
+make run-deps
+```
+
+Then execute app/backend/src/run_locally.py with your debugger of choice. It will have all the correct 
+env variables and will connect to the services (db, etc.) running in docker.
+
 
 ### Running tests outside Docker
 

--- a/app/backend/src/app.py
+++ b/app/backend/src/app.py
@@ -1,5 +1,4 @@
 import logging
-import multiprocessing
 import signal
 import sys
 from os import environ
@@ -7,9 +6,11 @@ from tempfile import TemporaryDirectory
 from types import TracebackType
 
 # these two lines need to be at the top of the file before we span child processes
-# this temp dir will be destroyed when prometheus_multiproc_dir is destroyed, aka at the end of the program
-prometheus_multiproc_dir = TemporaryDirectory()
-environ["PROMETHEUS_MULTIPROC_DIR"] = prometheus_multiproc_dir.name
+# this temp dir will be destroyed when prometheus_multiproc_dir is destroyed, aka at the end of the program.
+# Also note that this should only be done in the main process.
+if __name__ == "__main__":
+    prometheus_multiproc_dir = TemporaryDirectory()
+    environ["PROMETHEUS_MULTIPROC_DIR"] = prometheus_multiproc_dir.name
 # ruff: noqa: E402
 
 import sentry_sdk
@@ -33,11 +34,6 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# This is required so that the worker processes export metrics to prometheus.
-# Not sure what is going on here, but Python 3.14 changed the default method to "forkserver",
-# and it appears to have broken the metrics.
-multiprocessing.set_start_method("fork")
-
 
 def log_unhandled_exception(
     exc_type: type[BaseException],
@@ -52,30 +48,30 @@ def log_unhandled_exception(
     logger.critical("Unhandled exception", exc_info=(exc_type, exc_value, exc_traceback))
 
 
-sys.excepthook = log_unhandled_exception
+def common_init() -> None:
+    sys.excepthook = log_unhandled_exception
 
-if config["SENTRY_ENABLED"]:
-    # Sends exception tracebacks to Sentry, a cloud service for collecting exceptions
-    sentry_sdk.init(
-        config["SENTRY_URL"],
-        traces_sample_rate=0.0,
-        environment=config["COOKIE_DOMAIN"],
-        release=config["VERSION"],
-        # The global excepthook picks up already handled gRPC errors (e.g. grpc.StatusCode.NOT_FOUND)
-        disabled_integrations=[
-            excepthook.ExcepthookIntegration(),
-        ],
-    )
+    if config["SENTRY_ENABLED"]:
+        # Sends exception tracebacks to Sentry, a cloud service for collecting exceptions
+        sentry_sdk.init(
+            config["SENTRY_URL"],
+            traces_sample_rate=0.0,
+            environment=config["COOKIE_DOMAIN"],
+            release=config["VERSION"],
+            # The global excepthook picks up already handled gRPC errors (e.g. grpc.StatusCode.NOT_FOUND)
+            disabled_integrations=[
+                excepthook.ExcepthookIntegration(),
+            ],
+        )
 
-logger.info("Checking DB connection")
-with session_scope() as session:
-    res = session.execute(text("SELECT 42;"))
-    if list(res) != [(42,)]:
-        raise Exception("Failed to connect to DB")
+    logger.info("Checking DB connection")
+    with session_scope() as session:
+        res = session.execute(text("SELECT 42;"))
+        if list(res) != [(42,)]:
+            raise Exception("Failed to connect to DB")
 
 
-# In other processes __name__ is __mp_main__
-if __name__ == "__main__":
+def main() -> None:
     # used to export metrics
     create_prometheus_server(8000)
 
@@ -91,7 +87,7 @@ if __name__ == "__main__":
     logger.info("Starting")
 
     if config["ROLE"] in ["scheduler", "all"]:
-        scheduler = start_jobs_scheduler()
+        start_jobs_scheduler()
 
     if config["ROLE"] in ["worker", "all"]:
         for _ in range(config["BACKGROUND_WORKER_COUNT"]):
@@ -115,3 +111,10 @@ if __name__ == "__main__":
     logger.info("App waiting for signal...")
 
     signal.pause()
+
+
+if __name__ == "__main__":
+    common_init()
+    main()
+elif __name__ == "__mp_main__":  # processes created via multiprocessing
+    common_init()

--- a/app/backend/src/run_locally.py
+++ b/app/backend/src/run_locally.py
@@ -1,0 +1,56 @@
+"""You can execute this script from pycharm/vscode's debugger!"""
+
+import os
+from collections.abc import Generator
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+def parse_env_lines(file: Path) -> Generator[tuple[str, str]]:
+    for line in file.resolve().read_text().splitlines():
+        if not line.strip() or line.startswith("#"):
+            continue
+        name, value = line.split("=", maxsplit=1)
+        yield name, value
+
+
+def read_db_password() -> str:
+    postgres_env = parse_env_lines(Path(__file__).parent / "../../postgres.dev.env")
+    db_password = dict(postgres_env)["POSTGRES_PASSWORD"]
+    return db_password
+
+
+def update_env() -> None:
+    backend_env = parse_env_lines(Path(__file__).parent / "../../backend.dev.env")
+    db_password = read_db_password()
+
+    envs = {
+        **dict(backend_env),
+        "SMTP_HOST": "localhost",
+        "OPENTELEMETRY_ENDPOINT": "localhost:4317",
+        "DATABASE_CONNECTION_STRING": f"postgresql://postgres:{db_password}@localhost:6545/postgres",
+    }
+
+    os.environ.update(envs)
+
+
+def main() -> None:
+    update_env()
+
+    if __name__ == "__main__":
+        # It's not created in app.py, since it's under __name__ == "__main__".
+        # Note that we have to do it before importing "app"
+        prometheus_multiproc_dir = TemporaryDirectory()
+        os.environ["PROMETHEUS_MULTIPROC_DIR"] = prometheus_multiproc_dir.name
+
+    # Only import it here because it has side effects.
+    import app
+
+    if __name__ == "__main__":
+        app.common_init()
+        app.main()
+    elif __name__ == "__mp_main__":  # processes created via multiprocessing
+        app.common_init()
+
+
+main()


### PR DESCRIPTION
This PR does two things:

## Fix Prom metrics for jobs

The issue was that under the `forkserver` method (the default on python 3.14), `app.py` was executed two times, and therefore two temporary directories were created. The jobs were writing their metrics to a directory that the main process knew nothing about, so they weren't collected. I fixed it by creating a temporary directory in the main process only. Then it's inherited by the children.


## Add a python script and make command to run backend locally

Run `make run` to start all dependencies and a run a python process locally. Or execute `run_locally.py` in a debugger (I tried pycharm). The script handles setting the correct env variables.

