### PR TITLE
Backend/emails: Fix missing timezone name

### DIFF
--- a/app/backend/src/couchers/email/send.py
+++ b/app/backend/src/couchers/email/send.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from couchers.config import config
 from couchers.email import queue_email
+from couchers.i18n.localize import localize_timezone
 from couchers.templates.v2 import Context, render_template, template_folder
 from couchers.utils import now
 
@@ -18,9 +19,14 @@ def send_simple_pretty_email(
     It's for the few security emails where we don't have a user to email but send directly to an email address.
     """
 
+    # Not yet localizable
+    timezone = ZoneInfo("Etc/UTC")
+    locale = "en"
+
     template_args = {
         **template_args,
         "header_subject": subject,
+        "footer_timezone_name": localize_timezone(timezone, locale),
         "footer_copyright_year": now().year,
         "footer_email_is_critical": True,  # Results in no unsubscribe footer.
     }
@@ -28,29 +34,13 @@ def send_simple_pretty_email(
     # Format plaintext template
     plain_tmplt = (template_folder / f"{template_name}.txt").read_text()
     plain_tmplt_footer = (template_folder / "_footer.txt").read_text()
-    plain = render_template(
-        plain_tmplt + plain_tmplt_footer,
-        template_args,
-        Context(
-            # Not yet localizable
-            timezone=ZoneInfo("Etc/UTC"),
-            locale="en",
-            plaintext=True,
-        ),
-    )
+    plain_context = Context(timezone=timezone, locale="en", plaintext=True)
+    plain = render_template(plain_tmplt + plain_tmplt_footer, template_args, plain_context)
 
     # Format html template
     html_tmplt = (template_folder / "generated_html" / f"{template_name}.html").read_text()
-    html = render_template(
-        html_tmplt,
-        template_args,
-        Context(
-            # Not yet localizable
-            timezone=ZoneInfo("Etc/UTC"),
-            locale="en",
-            plaintext=False,
-        ),
-    )
+    html_context = Context(timezone=timezone, locale="en", plaintext=False)
+    html = render_template(html_tmplt, template_args, html_context)
 
     queue_email(
         session,

--- a/app/backend/src/couchers/i18n/localize.py
+++ b/app/backend/src/couchers/i18n/localize.py
@@ -120,6 +120,9 @@ def localize_datetime_for_user(value: datetime | Timestamp, user: User) -> str:
     timezone = ZoneInfo(user.timezone or "Etc/UTC")
     return localize_datetime(value, timezone, user.ui_language_preference or "en")
 
+def localize_timezone(timezone: ZoneInfo, locale: str) -> str:
+    # TODO(#7590): Account for locale
+    return datetime.now(tz=timezone).strftime("%Z/UTC%z")
 
 def format_phone_number(value: str) -> str:
     """Formats a phone number from E.164 format to the international format."""

--- a/app/backend/src/couchers/i18n/localize.py
+++ b/app/backend/src/couchers/i18n/localize.py
@@ -120,9 +120,11 @@ def localize_datetime_for_user(value: datetime | Timestamp, user: User) -> str:
     timezone = ZoneInfo(user.timezone or "Etc/UTC")
     return localize_datetime(value, timezone, user.ui_language_preference or "en")
 
+
 def localize_timezone(timezone: ZoneInfo, locale: str) -> str:
     # TODO(#7590): Account for locale
     return datetime.now(tz=timezone).strftime("%Z/UTC%z")
+
 
 def format_phone_number(value: str) -> str:
     """Formats a phone number from E.164 format to the international format."""

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -11,6 +11,7 @@ from couchers.config import config
 from couchers.context import make_background_user_context
 from couchers.db import session_scope
 from couchers.email import queue_email
+from couchers.i18n.localize import localize_timezone
 from couchers.models import (
     Notification,
     NotificationDelivery,
@@ -37,9 +38,9 @@ logger = logging.getLogger(__name__)
 def _send_email_notification(session: Session, user: User, notification: Notification) -> None:
     rendered = render_email_notification(user, notification)
 
-    email_lang = "en"
+    locale = "en"
     if config["ENABLE_NOTIFICATION_TRANSLATIONS"]:
-        email_lang = user.ui_language_preference or "en"
+        locale = user.ui_language_preference or "en"
     timezone = ZoneInfo(user.timezone or "Etc/UTC")
 
     template_args = {
@@ -48,6 +49,7 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         "header_preview": rendered.preview,
         "user": user,
         "time": notification.created,
+        "footer_timezone_name": localize_timezone(timezone, locale),
         "footer_copyright_year": now().year,
         "footer_email_is_critical": rendered.is_critical,
         "footer_manage_notifications_link": urls.notification_settings_link(),
@@ -62,12 +64,12 @@ def _send_email_notification(session: Session, user: User, notification: Notific
     plain_tmplt = (template_folder / f"{rendered.template_name}.txt").read_text()
     plain_tmplt_footer = (template_folder / "_footer.txt").read_text()
     plain = render_template(
-        plain_tmplt + plain_tmplt_footer, template_args, Context(timezone=timezone, locale=email_lang, plaintext=True)
+        plain_tmplt + plain_tmplt_footer, template_args, Context(timezone=timezone, locale=locale, plaintext=True)
     )
 
     # Format html template
     html_tmplt = (template_folder / "generated_html" / f"{rendered.template_name}.html").read_text()
-    html = render_template(html_tmplt, template_args, Context(timezone=timezone, locale=email_lang, plaintext=False))
+    html = render_template(html_tmplt, template_args, Context(timezone=timezone, locale=locale, plaintext=False))
 
     if user.do_not_email and not rendered.is_critical:
         logger.info(f"Not emailing {user} based on template {rendered.template_name} due to emails turned off")

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -5,7 +5,6 @@ from collections.abc import Mapping, Sequence
 from datetime import date, datetime, timedelta
 from email.utils import formatdate
 from typing import TYPE_CHECKING, Any, overload
-from zoneinfo import ZoneInfo
 
 import pytz
 from geoalchemy2 import WKBElement, WKTElement

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -411,10 +411,6 @@ def last_active_coarsen(dt: datetime) -> datetime:
     return dt.replace(minute=0, second=0, microsecond=0)
 
 
-def get_tz_as_text(tz_name: str) -> str:
-    return datetime.now(tz=ZoneInfo(tz_name)).strftime("%Z/UTC%z")
-
-
 def not_none[T](x: T | None) -> T:
     if x is None:
         raise ValueError("Expected a value but got None")

--- a/app/backend/templates/v2/_footer.mjml
+++ b/app/backend/templates/v2/_footer.mjml
@@ -1,7 +1,7 @@
       <mj-section padding="0px">
         <mj-column>
           <mj-divider border-color="#00a398" border-width="1px"></mj-divider>
-          <mj-text align="center" font-size="10px" line-height="12px"> You're receiving this email because you signed up for Couchers.org.<br /> You can reach our support team at <a href="mailto:support@couchers.org">support@couchers.org</a>.<br /> All times are in {{ _timezone_display|v2sf }}, based on your profile location. </mj-text>
+          <mj-text align="center" font-size="10px" line-height="12px"> You're receiving this email because you signed up for Couchers.org.<br /> You can reach our support team at <a href="mailto:support@couchers.org">support@couchers.org</a>.<br /> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location. </mj-text>
           <mj-text align="center" font-size="10px"><a href="https://couchers.org/donate">Donate</a> | <a href="https://github.com/Couchers-org/couchers">GitHub</a> | <a href="https://couchers.org/volunteer">Volunteer</a> | <a href="https://couchers.org/blog">Blog</a></mj-text>
           <mj-text align="center" font-size="8px" line-height="10px">
             &copy; {{ footer_copyright_year|v2sf }} Couchers, Inc.<br />

--- a/app/backend/templates/v2/generated_html/account_deletion_complete.html
+++ b/app/backend/templates/v2/generated_html/account_deletion_complete.html
@@ -277,7 +277,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/account_deletion_recovered.html
+++ b/app/backend/templates/v2/generated_html/account_deletion_recovered.html
@@ -277,7 +277,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/account_deletion_start.html
+++ b/app/backend/templates/v2/generated_html/account_deletion_start.html
@@ -272,7 +272,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/activeness_probe.html
+++ b/app/backend/templates/v2/generated_html/activeness_probe.html
@@ -349,7 +349,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/api_key.html
+++ b/app/backend/templates/v2/generated_html/api_key.html
@@ -280,7 +280,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/badge.html
+++ b/app/backend/templates/v2/generated_html/badge.html
@@ -204,7 +204,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/chat_message.html
+++ b/app/backend/templates/v2/generated_html/chat_message.html
@@ -327,7 +327,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/chat_unseen_messages.html
+++ b/app/backend/templates/v2/generated_html/chat_unseen_messages.html
@@ -355,7 +355,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/comment_reply.html
+++ b/app/backend/templates/v2/generated_html/comment_reply.html
@@ -327,7 +327,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/discussion_comment.html
+++ b/app/backend/templates/v2/generated_html/discussion_comment.html
@@ -327,7 +327,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/discussion_create.html
+++ b/app/backend/templates/v2/generated_html/discussion_create.html
@@ -327,7 +327,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/donation_received.html
+++ b/app/backend/templates/v2/generated_html/donation_received.html
@@ -287,7 +287,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/email_changed_confirmation_new_email.html
+++ b/app/backend/templates/v2/generated_html/email_changed_confirmation_new_email.html
@@ -272,7 +272,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/event_cancel.html
+++ b/app/backend/templates/v2/generated_html/event_cancel.html
@@ -335,7 +335,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/event_comment.html
+++ b/app/backend/templates/v2/generated_html/event_comment.html
@@ -359,7 +359,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/event_create.html
+++ b/app/backend/templates/v2/generated_html/event_create.html
@@ -335,7 +335,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/event_delete.html
+++ b/app/backend/templates/v2/generated_html/event_delete.html
@@ -236,7 +236,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/event_invite_organizer.html
+++ b/app/backend/templates/v2/generated_html/event_invite_organizer.html
@@ -335,7 +335,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/event_reminder.html
+++ b/app/backend/templates/v2/generated_html/event_reminder.html
@@ -302,7 +302,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/event_update.html
+++ b/app/backend/templates/v2/generated_html/event_update.html
@@ -340,7 +340,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/friend_reference.html
+++ b/app/backend/templates/v2/generated_html/friend_reference.html
@@ -327,7 +327,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/friend_request.html
+++ b/app/backend/templates/v2/generated_html/friend_request.html
@@ -300,7 +300,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/friend_request_accepted.html
+++ b/app/backend/templates/v2/generated_html/friend_request_accepted.html
@@ -295,7 +295,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/host_reference.html
+++ b/app/backend/templates/v2/generated_html/host_reference.html
@@ -439,7 +439,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/host_request__message.html
+++ b/app/backend/templates/v2/generated_html/host_request__message.html
@@ -328,7 +328,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/host_request__new.html
+++ b/app/backend/templates/v2/generated_html/host_request__new.html
@@ -384,7 +384,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/host_request__plain.html
+++ b/app/backend/templates/v2/generated_html/host_request__plain.html
@@ -296,7 +296,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/mod_note.html
+++ b/app/backend/templates/v2/generated_html/mod_note.html
@@ -209,7 +209,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/new_blog_post.html
+++ b/app/backend/templates/v2/generated_html/new_blog_post.html
@@ -291,7 +291,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/onboarding1.html
+++ b/app/backend/templates/v2/generated_html/onboarding1.html
@@ -297,7 +297,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/onboarding2.html
+++ b/app/backend/templates/v2/generated_html/onboarding2.html
@@ -277,7 +277,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/password_reset.html
+++ b/app/backend/templates/v2/generated_html/password_reset.html
@@ -272,7 +272,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/reference_reminder.html
+++ b/app/backend/templates/v2/generated_html/reference_reminder.html
@@ -315,7 +315,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/security.html
+++ b/app/backend/templates/v2/generated_html/security.html
@@ -214,7 +214,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/signup_continue.html
+++ b/app/backend/templates/v2/generated_html/signup_continue.html
@@ -277,7 +277,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/signup_verify.html
+++ b/app/backend/templates/v2/generated_html/signup_verify.html
@@ -272,7 +272,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/strong_verification_success.html
+++ b/app/backend/templates/v2/generated_html/strong_verification_success.html
@@ -282,7 +282,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ _timezone_display|v2sf }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name|v2sf }}, based on your profile location.</div>
                                 </td>
                               </tr>
                               <tr>


### PR DESCRIPTION
**Describe briefly what this PR is doing and why**
Emails include "All times are in \<timezone\>" in the footer, but this was broken in #7638 (presumably) and was now blank. Restores it while aligning the placeholder name to follow convention and extracting a `localize_` function for timezone names (for when I hook up CLDR).

Closes #7729

**Please give clear steps for how the reviewer can best test this PR**
Send a request so you'll receive an email and check its footer.

*Please include any necessary dev environment, .env, etc. adjustments.*
N/A

<!---
Checklists - you can remove one that is not applicable (ie. remove backend checklist if you only worked on the web frontend)
If you need help with any of these, please ask :)
--->
**Backend checklist**
- [x] Formatted my code by running `make format` in `app/backend`
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] All tests pass
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Other**
*Untick the following if you'd prefer that maintainers don't push commits/merge your branch.*
- [x] A maintainer can push commits to my branch
- [x] A maintainer can merge my PR (you can also merge after approval)
