### PR TITLE
Go back to truncating the tables in tests

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -309,7 +309,6 @@ test:backend:
   variables:
     POSTGRES_PASSWORD: c765064a49d18a95
     DATABASE_CONNECTION_STRING: "postgresql://postgres:c765064a49d18a95@postgres/testdb"
-    RUN_MIGRATION_TEST: true
     TEST_SCHEMA_OUTPUT_DIR: /app/schema_dumps
   before_script:
     # install the latest postgres from their repos to get pg_dump compatible with later postgres

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 from sqlalchemy import Connection, Engine
 from sqlalchemy.sql import text
 
-# Set up environment variables before any imports
+# Set up environment variables before any couchers imports (they trigger config loading)
 prometheus_multiproc_dir = TemporaryDirectory()
 os.environ["PROMETHEUS_MULTIPROC_DIR"] = prometheus_multiproc_dir.name
 
@@ -18,8 +18,8 @@ if "DATABASE_CONNECTION_STRING" not in os.environ:  # pragma: no cover
         "postgresql://postgres:06b3890acd2c235c41be0bbfe22f1b386a04bf02eedf8c977486355616be2aa1@localhost:6544/testdb"
     )
 
-
 from couchers.config import config  # noqa: E402
+from couchers.models import Base  # noqa: E402
 from tests.fixtures.db import (  # noqa: E402
     autocommit_engine,
     create_schema_from_models,
@@ -54,63 +54,95 @@ def postgres_conn(postgres_engine: Engine) -> Generator[Connection]:
 
 
 @pytest.fixture(scope="session")
-def template_db(postgres_conn: Connection) -> str:
+def testdb_engine() -> Generator[Engine]:
     """
-    Creates a template database with all the extensions, tables,
-    and static data (languages, regions.) This is done only once: then
-    we copy this template for every test. It's much faster than creating
-    a database without a template or deleting data from all tables between
-    tests. The tables are created from SQLA metadata, not by running the
-    migrations - again, for speed.
+    SQLAlchemy engine connected to "testdb" database.
+    """
+    dsn = config["DATABASE_CONNECTION_STRING"]
+    with autocommit_engine(dsn) as engine:
+        yield engine
+
+
+@pytest.fixture(scope="session")
+def testdb_conn(testdb_engine: Engine) -> Generator[Connection]:
+    """
+    Connection to testdb for truncating tables between tests.
+    """
+    with testdb_engine.connect() as conn:
+        yield conn
+
+
+# Static tables that should not be truncated between tests
+STATIC_TABLES = frozenset({"languages", "timezone_areas", "regions"})
+
+
+@pytest.fixture(scope="session")
+def setup_testdb(postgres_conn: Connection, testdb_engine: Engine) -> None:
+    """
+    Creates the test database with all the extensions, tables,
+    and static data (languages, regions, timezones). This is done only once
+    per session. Between tests, we truncate all non-static tables.
     """
     # running in non-UTC catches some timezone errors
     os.environ["TZ"] = "America/New_York"
 
-    name = "couchers_template"
+    postgres_conn.execute(text("DROP DATABASE IF EXISTS testdb WITH (FORCE)"))
+    postgres_conn.execute(text("CREATE DATABASE testdb"))
 
-    postgres_conn.execute(text(f"DROP DATABASE IF EXISTS {name}"))
-    postgres_conn.execute(text(f"CREATE DATABASE {name}"))
-
-    template_dsn = re.sub(
-        r"/testdb$",
-        f"/{name}",
-        config["DATABASE_CONNECTION_STRING"],
-    )
-
-    with autocommit_engine(template_dsn) as engine:
-        with engine.connect() as conn:
-            conn.execute(
-                text(
-                    "CREATE SCHEMA logging;"
-                    "CREATE EXTENSION IF NOT EXISTS postgis;"
-                    "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
-                    "CREATE EXTENSION IF NOT EXISTS btree_gist;"
-                )
+    with testdb_engine.connect() as conn:
+        conn.execute(
+            text(
+                "CREATE SCHEMA logging;"
+                "CREATE EXTENSION IF NOT EXISTS postgis;"
+                "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+                "CREATE EXTENSION IF NOT EXISTS btree_gist;"
             )
+        )
 
-            create_schema_from_models(engine)
-            populate_testing_resources(conn)
+        create_schema_from_models(testdb_engine)
+        populate_testing_resources(conn)
 
-    return name
+
+def _truncate_non_static_tables(conn: Connection) -> None:
+    """
+    Truncates all non-static tables.
+    Static tables (languages, timezone_areas, regions) are preserved.
+    """
+    tables_to_truncate = []
+    for name in Base.metadata.tables.keys():
+        # Skip static tables
+        if name in STATIC_TABLES:
+            continue
+        # Handle schema-qualified names (e.g., "logging.api_calls" -> logging."api_calls")
+        if "." in name:
+            schema, table = name.split(".", 1)
+            tables_to_truncate.append(f'{schema}."{table}"')
+        else:
+            tables_to_truncate.append(f'"{name}"')
+    if tables_to_truncate:
+        conn.execute(text(f"TRUNCATE {', '.join(tables_to_truncate)} RESTART IDENTITY CASCADE"))
+
+    # Reset standalone sequences, not owned by any table column
+    # (RESTART IDENTITY only resets sequences owned by truncated columns)
+    conn.execute(text("ALTER SEQUENCE communities_seq RESTART WITH 1"))
+    conn.execute(text("ALTER SEQUENCE moderation_seq RESTART WITH 2000000"))
 
 
 @pytest.fixture
-def db(template_db: str, postgres_conn: Connection) -> None:
+def db(setup_testdb: None, testdb_conn: Connection) -> None:
     """
-    Creates a fresh database for a test by copying a template. The template has
-    the migrations applied and is populated with static data (regions, languages, etc.)
+    Truncates all non-static tables before each test.
+    Static tables (languages, timezone_areas, regions) are preserved.
     """
-    postgres_conn.execute(text("DROP DATABASE IF EXISTS testdb WITH (FORCE)"))
-    postgres_conn.execute(text(f"CREATE DATABASE testdb WITH TEMPLATE {template_db}"))
+    _truncate_non_static_tables(testdb_conn)
 
 
 @pytest.fixture(scope="class")
-def db_class(template_db: str, postgres_conn: Connection) -> None:
+def db_class(setup_testdb: None, testdb_conn: Connection) -> None:
     """
     The same as above, but with a different scope. Used in test_communities.py.
     """
-    postgres_conn.execute(text("DROP DATABASE IF EXISTS testdb WITH (FORCE)"))
-    postgres_conn.execute(text(f"CREATE DATABASE testdb WITH TEMPLATE {template_db}"))
+    _truncate_non_static_tables(testdb_conn)
 
 
 @pytest.fixture(scope="class")

--- a/app/backend/src/tests/fixtures/db.py
+++ b/app/backend/src/tests/fixtures/db.py
@@ -1,4 +1,4 @@
-import os
+import subprocess
 from collections.abc import Sequence
 from contextlib import contextmanager
 from datetime import date, timedelta
@@ -356,8 +356,9 @@ def add_users_to_new_moderation_list(users: list[User]) -> int:
         return moderation_user_list.id
 
 
-def run_migration_test():
-    return os.environ.get("RUN_MIGRATION_TEST", "false").lower() == "true"
+def pg_dump_is_available() -> bool:
+    result = subprocess.run(["which", "pg_dump"], stdout=subprocess.PIPE, encoding="ascii")
+    return result.returncode == 0
 
 
 def make_volunteer(started_volunteering: date, show_on_team_page: bool = True, **kwargs: Any) -> Volunteer:

--- a/app/backend/src/tests/test_db.py
+++ b/app/backend/src/tests/test_db.py
@@ -11,7 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.sql import func
 
 from couchers.config import config
-from couchers.db import apply_migrations, get_parent_node_at_location, session_scope
+from couchers.db import _get_base_engine, apply_migrations, get_parent_node_at_location, session_scope
 from couchers.jobs.handlers import DatabaseInconsistencyError, check_database_consistency
 from couchers.models import User
 from couchers.utils import (
@@ -21,7 +21,13 @@ from couchers.utils import (
     is_valid_username,
     parse_date,
 )
-from tests.fixtures.db import create_schema_from_models, drop_database, generate_user, run_migration_test
+from tests.fixtures.db import (
+    create_schema_from_models,
+    drop_database,
+    generate_user,
+    pg_dump_is_available,
+    populate_testing_resources,
+)
 from tests.test_communities import create_1d_point, get_community_id, testing_communities  # noqa
 
 
@@ -132,8 +138,25 @@ def strip_leading_whitespace(lines: list[str]) -> list[str]:
     return [s.lstrip() for s in lines]
 
 
-@pytest.mark.skipif(not run_migration_test(), reason="Migration test disabled")
-def test_migrations(db, testconfig: dict[str, Any]) -> None:
+@pytest.fixture
+def restore_db_after_migration_test(db):
+    try:
+        yield
+    finally:
+        # Dispose the engine's connection pool since we dropped/recreated PostGIS extension,
+        # which invalidates cached operator OIDs in existing connections
+        engine = _get_base_engine()
+        engine.dispose()
+
+        # Restore test resources since we destroyed the database
+        # This is needed because setup_testdb is session-scoped and won't run again
+        with engine.connect() as conn:
+            populate_testing_resources(conn)
+            conn.commit()
+
+
+@pytest.mark.skipif(not pg_dump_is_available(), reason="Can't run migration tests without pg_dump")
+def test_migrations(db, testconfig: dict[str, Any], restore_db_after_migration_test) -> None:
     """
     This test will only run successfully if you have `pg_dump` installed and everything set up, which only happens if the
     test is being run within Gitlab CI where we do all that setup. So we disable it unless explicitly marked to run.


### PR DESCRIPTION
It's almost 2x faster on my local mac, and about a minute faster in CI (this run took 7:40m as against the usualy 8:40-9:15)

When I implemented the template db approach, I was running it against x86 Postgres on my ARM mac - in this setup template db was a clear win. But after moving to the native ARM build of Postgres, the results are reversed. I guess truncating is more CPU-heavy? 

This also makes it so migration test runs whenever `pg_dump` is installed instead of relying on an env variable.