### PR TITLE
Send web dark mode changes to mobile app

### DIFF
--- a/app/web/components/GalleryEditor/GalleryEditor.tsx
+++ b/app/web/components/GalleryEditor/GalleryEditor.tsx
@@ -480,17 +480,20 @@ export default function GalleryEditor({
             {!canAddMore && !hasStrongVerification && (
               <InfoBox
                 sx={{
-                  backgroundColor: theme.palette.grey[50],
-                  border: `1px solid ${theme.palette.grey[300]}`,
+                  backgroundColor: "var(--mui-palette-grey-50)",
+                  border: `1px solid var(--mui-palette-grey-300)`,
                   marginTop: 1,
                 }}
               >
                 <InfoOutlined fontSize="small" sx={{ color: "primary.main" }} />
-                <Typography variant="body2" color="text.secondary">
+                <Typography
+                  variant="body2"
+                  color="var(--mui-palette-text-secondary)"
+                >
                   {t("profile:gallery.verification_required_for_more_photos")}{" "}
                   <a
                     href={`${settingsRoute}#strong-verification`}
-                    style={{ color: theme.palette.primary.main }}
+                    style={{ color: "var(--mui-palette-primary-main)" }}
                     target="_blank"
                     rel="noopener noreferrer"
                   >

--- a/app/web/components/Navigation/DarkModeToggle.tsx
+++ b/app/web/components/Navigation/DarkModeToggle.tsx
@@ -24,8 +24,15 @@ export default function DarkModeToggle() {
   const isDark = resolvedMode === "dark";
 
   const handleToggle = () => {
-    // Simply toggle between light and dark
-    setMode(isDark ? "light" : "dark");
+    const newMode = isDark ? "light" : "dark";
+    setMode(newMode);
+
+    // Notify native mobile app of color scheme change
+    if (window.ReactNativeWebView) {
+      window.ReactNativeWebView.postMessage(
+        JSON.stringify({ type: "COLOR_SCHEME_CHANGE", mode: newMode }),
+      );
+    }
   };
 
   const tooltipText = isDark

--- a/app/web/components/Navigation/Navigation.tsx
+++ b/app/web/components/Navigation/Navigation.tsx
@@ -438,8 +438,8 @@ export default function Navigation() {
                 gap: 2,
               }}
             >
-              {!isMobile && <LanguagePickerSelect />}
               <DarkModeToggle />
+              {!isMobile && <LanguagePickerSelect />}
               {!isLoginPage && (
                 <Button
                   variant="outlined"

--- a/app/web/features/auth/DarkModeSettings.tsx
+++ b/app/web/features/auth/DarkModeSettings.tsx
@@ -36,12 +36,25 @@ export default function DarkModeSettings() {
 
   const handleToggle = () => {
     setIsTransitioning(true);
+    let newMode: "light" | "dark" | "system";
     if (mode === "light") {
-      setMode("dark");
+      newMode = "dark";
     } else if (mode === "dark") {
-      setMode("system");
+      newMode = "system";
     } else {
-      setMode("light");
+      newMode = "light";
+    }
+    setMode(newMode);
+
+    // Notify native mobile app of color scheme change
+    // For "system" mode, send null so native follows system preference
+    if (window.ReactNativeWebView) {
+      window.ReactNativeWebView.postMessage(
+        JSON.stringify({
+          type: "COLOR_SCHEME_CHANGE",
+          mode: newMode === "system" ? null : newMode,
+        }),
+      );
     }
   };
 

--- a/app/web/features/profile/view/ProfilePhotoGallery.tsx
+++ b/app/web/features/profile/view/ProfilePhotoGallery.tsx
@@ -34,7 +34,7 @@ const StyledImageListItem = styled(ImageListItem)(({ theme }) => ({
   overflow: "hidden",
   borderRadius: theme.shape.borderRadius,
   transition: "box-shadow 0.2s ease, transform 0.2s ease",
-  border: `1px solid ${theme.palette.grey[300]}`,
+  border: `1px solid var(--mui-palette-grey-300)`,
   "&:hover": {
     boxShadow: theme.shadows[4],
     transform: "scale(1.02)",


### PR DESCRIPTION
When toggling dark mode in the web app, send a message to the native mobile app so it can sync its native UI components (bottom nav, status bar). Uses window.ReactNativeWebView.postMessage when running inside the mobile app's WebView.

- Fix some dark mode variables that got merged from profile galleries incorrectly
- Move logged out dark mode toggle in nav bar to match logged in.