### PR TITLE
Fix snackbar clickaway so works on mobile app

### DIFF
--- a/app/web/components/Snackbar/Snackbar.tsx
+++ b/app/web/components/Snackbar/Snackbar.tsx
@@ -33,8 +33,17 @@ export default function Snackbar({
         onClose();
       }}
       anchorOrigin={{ vertical: "top", horizontal: "center" }}
+      // Prevent snackbar from blocking touch interactions on mobile WebViews
+      disableWindowBlurListener
+      slotProps={{
+        clickAwayListener: {
+          mouseEvent: false,
+          touchEvent: false,
+        },
+      }}
+      sx={{ pointerEvents: "none" }}
     >
-      <MuiAlert severity={severity}>
+      <MuiAlert severity={severity} sx={{ pointerEvents: "auto" }}>
         {
           // Search for the error in the ugly grpc error object keys
           // Replace it with the nice error if found


### PR DESCRIPTION
Bug reported on slack:

* Fix the snackbar so it doesn't block the whole screen on mobile when it pops up.