### PR TITLE
Fix squashed mobile text field labels

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -51,6 +51,7 @@ To run the app locally in development, use `yarn start` (not Docker)
 - Use StyledLink.tsx component or import from next/link for links to preserve routing, NOT MUI Link
 - Always put types at the top of the file below the imports
 - Add Tanstack queryKeys to app/web/features/queryKeys.ts if they are used more than one place.
+- Use slotProps rather than InputLabelProps for MUI. InputLabelProps is deprecated now.
 
 ### Internationalization (i18n)
 - **Never hardcode English text** - always use the `t()` function or `<Trans>` component for user-facing text

--- a/app/web/components/Datepicker.tsx
+++ b/app/web/components/Datepicker.tsx
@@ -81,7 +81,7 @@ const Datepicker = ({
                 <span data-testid={`${name}-helper-text`}>{helperText}</span>
               ),
               variant,
-              InputLabelProps: { shrink: true },
+              slotProps: { inputLabel: { shrink: true } },
               InputProps: {
                 ...(inputProps || {}),
                 className,

--- a/app/web/components/EditLocationMap.tsx
+++ b/app/web/components/EditLocationMap.tsx
@@ -342,7 +342,7 @@ export default function EditLocationMap({
           error={error !== ""}
           id="display-address"
           ref={locationDisplayRef}
-          InputLabelProps={{ shrink: shrinkLabel }}
+          slotProps={{ inputLabel: { shrink: shrinkLabel } }}
           fullWidth
           variant={variant}
           label={t("components.edit_location_map.display_location_label")}

--- a/app/web/components/Navigation/ReportDialog.tsx
+++ b/app/web/components/Navigation/ReportDialog.tsx
@@ -174,14 +174,14 @@ export default function ReportDialog({ open, onClose }: DialogProps) {
               />
             </DialogContent>
             <DialogActions>
-              <Button type="submit" loading={isPending} onClick={onSubmit}>
-                {t("submit")}
-              </Button>
               <Button
                 onClick={() => handleClose({}, "button")}
                 variant="outlined"
               >
                 {t("cancel")}
+              </Button>
+              <Button type="submit" loading={isPending} onClick={onSubmit}>
+                {t("submit")}
               </Button>
             </DialogActions>
           </form>

--- a/app/web/components/TextField.tsx
+++ b/app/web/components/TextField.tsx
@@ -34,7 +34,9 @@ const StyledMuiTextField = styled(MuiTextField)<TextFieldProps>(
 );
 
 type AccessibleTextFieldProps = Omit<TextFieldProps, "variant"> & {
-  id: BaseTextFieldProps["id"];
+  // id is required for accessibility, but optional when used inside Autocomplete
+  // (Autocomplete provides the id via inputProps)
+  id?: BaseTextFieldProps["id"];
   onChange?: TextFieldProps["onChange"];
   variant?: "filled" | "outlined" | "standard";
 };

--- a/app/web/components/TextField.tsx
+++ b/app/web/components/TextField.tsx
@@ -4,6 +4,7 @@ import {
   TextFieldProps,
 } from "@mui/material";
 import { BaseTextFieldProps } from "@mui/material/TextField";
+import { useIsNativeEmbed } from "platform/nativeLink";
 import React, { forwardRef } from "react";
 
 const StyledMuiTextField = styled(MuiTextField)<TextFieldProps>(
@@ -43,9 +44,20 @@ const TextField = forwardRef<
   AccessibleTextFieldProps
 >(
   (
-    { className, variant = "outlined", helperText, name, ...otherProps },
+    {
+      className,
+      variant = "outlined",
+      helperText,
+      name,
+      slotProps,
+      ...otherProps
+    },
     ref,
   ) => {
+    // In WebViews, MUI's floating label positioning can break due to CSS transform issues.
+    // Force labels to always be in "shrunk" position to avoid overlap with input border.
+    const isNativeEmbed = useIsNativeEmbed();
+
     return (
       <StyledMuiTextField
         {...otherProps}
@@ -57,6 +69,15 @@ const TextField = forwardRef<
         }
         multiline={otherProps.multiline !== undefined}
         className={className}
+        slotProps={{
+          ...slotProps,
+          inputLabel: {
+            ...(typeof slotProps?.inputLabel === "object"
+              ? slotProps.inputLabel
+              : {}),
+            ...(isNativeEmbed && { shrink: true }),
+          },
+        }}
       />
     );
   },

--- a/app/web/components/Timepicker.tsx
+++ b/app/web/components/Timepicker.tsx
@@ -76,7 +76,7 @@ const Timepicker = ({
                 className,
                 "aria-label": t("global:change_time"),
               },
-              InputLabelProps: { shrink: true },
+              slotProps: { inputLabel: { shrink: true } },
               sx: {
                 "& .MuiOutlinedInput-root": {
                   backgroundColor: "var(--mui-palette-primary-main)",

--- a/app/web/features/communities/CommunitiesPage/CommunitySearch.tsx
+++ b/app/web/features/communities/CommunitiesPage/CommunitySearch.tsx
@@ -155,7 +155,6 @@ export default function CommunitySearch() {
       renderInput={(params) => (
         <TextField
           {...params}
-          id="community-search"
           label={t("communities:search_communities")}
           variant="outlined"
           placeholder={t("communities:search_communities_placeholder")}

--- a/app/web/features/communities/CommunitiesPage/CommunitySearch.tsx
+++ b/app/web/features/communities/CommunitiesPage/CommunitySearch.tsx
@@ -3,9 +3,9 @@ import {
   Autocomplete as MuiAutocomplete,
   InputAdornment,
   styled,
-  TextField,
 } from "@mui/material";
 import StyledLink from "components/StyledLink";
+import TextField from "components/TextField";
 import useAccountInfo from "features/auth/useAccountInfo";
 import { Trans, useTranslation } from "i18n";
 import { COMMUNITIES } from "i18n/namespaces";
@@ -155,6 +155,7 @@ export default function CommunitySearch() {
       renderInput={(params) => (
         <TextField
           {...params}
+          id="community-search"
           label={t("communities:search_communities")}
           variant="outlined"
           placeholder={t("communities:search_communities_placeholder")}

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -8,7 +8,6 @@ import {
   Radio,
   RadioGroup,
   styled,
-  TextField,
   Typography,
 } from "@mui/material";
 import Alert from "components/Alert";
@@ -20,6 +19,7 @@ import EditLocationMap from "components/EditLocationMap";
 import GalleryEditor from "components/GalleryEditor/GalleryEditor";
 import Snackbar from "components/Snackbar";
 import StyledLink from "components/StyledLink";
+import TextField from "components/TextField";
 import { useLanguages } from "features/profile/hooks/useLanguages";
 import { useRegions } from "features/profile/hooks/useRegions";
 import useUpdateUserProfile from "features/profile/hooks/useUpdateUserProfile";
@@ -722,6 +722,7 @@ export default function EditProfileForm() {
                             control={<Radio />}
                             label={
                               <TextField
+                                id="pronouns-other"
                                 variant="standard"
                                 onChange={(event) =>
                                   field.onChange(event.target.value)

--- a/app/web/features/profile/view/leaveReference/formSteps/PrivateFeedback.tsx
+++ b/app/web/features/profile/view/leaveReference/formSteps/PrivateFeedback.tsx
@@ -5,7 +5,6 @@ import {
   Radio,
   RadioGroup,
   styled,
-  TextField,
   Typography,
   useMediaQuery,
 } from "@mui/material";
@@ -15,6 +14,7 @@ import Divider from "components/Divider";
 import RatingsSlider from "components/RatingsSlider/RatingsSlider";
 import StyledLink from "components/StyledLink";
 import TextBody from "components/TextBody";
+import TextField from "components/TextField";
 import { useProfileUser } from "features/profile/hooks/useProfileUser";
 import ReferenceStepHeader from "features/profile/view/leaveReference/formSteps/ReferenceStepHeader";
 import {

--- a/app/web/features/search/FloatingSearchControls.tsx
+++ b/app/web/features/search/FloatingSearchControls.tsx
@@ -6,13 +6,13 @@ import {
   Select,
   SelectChangeEvent,
   styled,
-  TextField,
   Tooltip,
   useMediaQuery,
 } from "@mui/material";
 import IconButton from "components/IconButton";
 import { SearchIcon } from "components/Icons";
 import LocationAutocompleteOutlined from "components/LocationAutocomplete/LocationAutocompleteOutlined";
+import TextField from "components/TextField";
 import { useTranslation } from "i18n";
 import { SEARCH } from "i18n/namespaces";
 import { useState } from "react";
@@ -254,6 +254,7 @@ const FloatingSearchControls = ({
             )}
             {searchType === "keyword" && (
               <StyledTextField
+                id="keyword-search"
                 fullWidth={false}
                 placeholder={t("search:form.keywords.field_label")}
                 name={t("search:form.keywords.field_label")}

--- a/app/web/platform/nativeLink.ts
+++ b/app/web/platform/nativeLink.ts
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 function getReactNativeWebView(): typeof window.ReactNativeWebView {
-  if (window && window.ReactNativeWebView) {
+  if (typeof window !== "undefined" && window.ReactNativeWebView) {
     return window.ReactNativeWebView;
   }
 }
@@ -11,12 +11,7 @@ function isNativeEmbed(): boolean {
 }
 
 export function useIsNativeEmbed(): boolean {
-  const [isNative, setIsNative] = useState(false);
-
-  useEffect(() => {
-    setIsNative(isNativeEmbed());
-  }, []);
-
+  const [isNative] = useState(() => isNativeEmbed());
   return isNative;
 }
 


### PR DESCRIPTION
The labels for text fields were squashed on native mobile devices only.

Fix this by adding `{ shrink: true }` to TextField when `isNativeEmbed` is true.