### PR TITLE
Add files to web app needed for universal linking on mobile

### DIFF
--- a/app/web/public/.well-known/apple-app-site-association
+++ b/app/web/public/.well-known/apple-app-site-association
@@ -1,0 +1,22 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appIDs": [
+          "S79633Q27Z.org.couchers.ios"
+        ],
+        "components": [
+          {
+            "/": "/*"
+          }
+        ]
+      }
+    ]
+  },
+  "webcredentials": {
+    "apps": [
+      "S79633Q27Z.org.couchers.ios"
+    ]
+  }
+}

--- a/app/web/public/.well-known/assetlinks.json
+++ b/app/web/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "org.couchers.android",
+      "sha256_cert_fingerprints": [
+        "38:5D:4D:F0:7C:43:95:81:0A:CB:8A:37:49:AC:FA:3B:46:CB:90:3C:B8:F3:C7:6B:F3:03:41:A2:8D:22:51:DF"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
Files needed for universal link a la the expo docs:
https://docs.expo.dev/linking/overview/#universal-linking

This is part of the functionality that allows links to redirect to the app if the user has it installed when they click on a couchers link via email, etc.

I checked and the apple TeamID and the Android SHA256 are not secret data as I was nervous 😅.