### PR TITLE
Frontend/i18n: Allow pt to fallback to pt-BR and es to es-419

### DIFF
--- a/app/web/next-i18next.config.js
+++ b/app/web/next-i18next.config.js
@@ -6,8 +6,9 @@ const { allLanguages } = require("./i18n/allLanguages");
 const fallbackLng = {
   default: ["en"],
   "pt-BR": ["pt", "en"],
-  "pt-PT": ["pt-BR", "en"],
+  pt: ["pt-BR", "en"],
   "es-419": ["es", "en"],
+  es: ["es-419", "en"],
   "fr-CA": ["fr", "en"],
   zh: ["zh-Hans", "en"],
 };


### PR DESCRIPTION
European and Brazilian Portuguese are mutually intelligible, so both can fallback to each other in case a string is missing. As per convo with Brazilian translator, this was broken.

We have no locale named `pt-PT`, fix it to `pt`.

Also added mutual fallbacks for Castellano (Spanish from Spain) and Latam Spanish for the same reason.

Note: Backend has a similar issue, tracking as https://github.com/Couchers-org/couchers/issues/7725 . Fix in #7760

## Testing
Before: 
<img width="1470" height="179" alt="image" src="https://github.com/user-attachments/assets/185d7406-63f0-4e81-9172-5e4e08cc80d7" />

After:
<img width="1469" height="185" alt="image" src="https://github.com/user-attachments/assets/a9b7c0a0-3fa8-4538-b4fc-5872f35e6729" />

`pt.json` only has:

```json
{
  "location": "Localização"
}
```

Also verified `pt-BR` to `pt` fallback using the communities pages (where `pt` is ahead).

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` and `yarn lint --fix` in app/web, and run tests locally. -->
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me