### PR TITLE
Sync color scheme so works on initial load

### DIFF
--- a/app/web/components/NativeColorSchemeSync.tsx
+++ b/app/web/components/NativeColorSchemeSync.tsx
@@ -1,0 +1,28 @@
+import { useColorScheme } from "@mui/material/styles";
+import { useIsNativeEmbed } from "platform/nativeLink";
+import { useEffect } from "react";
+
+/**
+ * Syncs the web app's color scheme to the native mobile app on initial load.
+ * This ensures the native UI matches the web app's theme preference.
+ */
+export default function NativeColorSchemeSync() {
+  const { mode } = useColorScheme();
+  const isNativeEmbed = useIsNativeEmbed();
+
+  useEffect(() => {
+    if (!isNativeEmbed || !window.ReactNativeWebView) return;
+
+    // Send the current color scheme to native app
+    // "system" mode sends null so native follows system preference
+    const nativeMode = mode === "system" ? null : mode;
+    window.ReactNativeWebView.postMessage(
+      JSON.stringify({
+        type: "COLOR_SCHEME_CHANGE",
+        mode: nativeMode,
+      }),
+    );
+  }, [isNativeEmbed, mode]);
+
+  return null;
+}

--- a/app/web/components/Navigation/DarkModeToggle.tsx
+++ b/app/web/components/Navigation/DarkModeToggle.tsx
@@ -24,15 +24,7 @@ export default function DarkModeToggle() {
   const isDark = resolvedMode === "dark";
 
   const handleToggle = () => {
-    const newMode = isDark ? "light" : "dark";
-    setMode(newMode);
-
-    // Notify native mobile app of color scheme change
-    if (window.ReactNativeWebView) {
-      window.ReactNativeWebView.postMessage(
-        JSON.stringify({ type: "COLOR_SCHEME_CHANGE", mode: newMode }),
-      );
-    }
+    setMode(isDark ? "light" : "dark");
   };
 
   const tooltipText = isDark

--- a/app/web/features/auth/DarkModeSettings.tsx
+++ b/app/web/features/auth/DarkModeSettings.tsx
@@ -36,25 +36,12 @@ export default function DarkModeSettings() {
 
   const handleToggle = () => {
     setIsTransitioning(true);
-    let newMode: "light" | "dark" | "system";
     if (mode === "light") {
-      newMode = "dark";
+      setMode("dark");
     } else if (mode === "dark") {
-      newMode = "system";
+      setMode("system");
     } else {
-      newMode = "light";
-    }
-    setMode(newMode);
-
-    // Notify native mobile app of color scheme change
-    // For "system" mode, send null so native follows system preference
-    if (window.ReactNativeWebView) {
-      window.ReactNativeWebView.postMessage(
-        JSON.stringify({
-          type: "COLOR_SCHEME_CHANGE",
-          mode: newMode === "system" ? null : newMode,
-        }),
-      );
+      setMode("light");
     }
   };
 

--- a/app/web/pages/_app.tsx
+++ b/app/web/pages/_app.tsx
@@ -12,6 +12,7 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { EnvironmentBanner } from "components/EnvironmentBanner";
 import ErrorBoundary from "components/ErrorBoundary";
 import HtmlMeta from "components/HtmlMeta";
+import NativeColorSchemeSync from "components/NativeColorSchemeSync";
 import AuthProvider from "features/auth/AuthProvider";
 import { ReactQueryClientProvider } from "features/reactQueryClient";
 import StatsigProvider from "features/statsig/StatsigProvider";
@@ -80,6 +81,7 @@ function MyApp(props: AppWithLayoutProps) {
                 <AuthProvider>
                   <StatsigProvider>
                     <CssBaseline />
+                    <NativeColorSchemeSync />
                     <EnvironmentBanner />
                     <HtmlMeta />
                     {getLayout(<Component {...pageProps} />)}


### PR DESCRIPTION
Fixing this so it also works on initial app load to sync dark mode state between mobile and web.