### PR TITLE
Backend/devex: Support F5 debugging in VS Code.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Backend",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "${workspaceFolder}/app/backend/.venv/bin/python3",
+      "program": "${workspaceFolder}/app/backend/src/run_locally.py",
+      "cwd": "${workspaceFolder}/app/backend",
+      "preLaunchTask": "uv sync backend",
+      "console": "integratedTerminal",
+      "subProcess": true
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "uv sync backend",
+      "type": "shell",
+      "command": "uv sync",
+      "options": {
+        "cwd": "${workspaceFolder}/app/backend"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds `launch.json` and `tasks.json` to support starting a local backend with the debugger attached in VS Code, leveraging `run_locally.py` added in #7732.

I'm not sure VS code is honoring the venv python I specified in `launch.json`, but the end results is working, so whatever.

## Testing
Use the debug pane to start debugging or press F5. I was able to hit a breakpoint in code responding to a request from the frontend.

<img width="1847" height="425" alt="image" src="https://github.com/user-attachments/assets/6cd1ed98-3a3c-49d2-8736-51a3bbd264e8" />

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me