### PR TITLE
Backend/i18n: Fix locale in pre-auth requests (inc. community guidelines)

### DIFF
--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -283,18 +283,12 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             raise RuntimeError(f"No prev_function in '{method}', {handler}")
 
         def function_without_couchers_stuff(req: Message, grpc_context: grpc.ServicerContext) -> Message | None:
-            ui_language_preference: str | None = None
-            if auth_info and auth_info.ui_language_preference:
-                ui_language_preference = auth_info.ui_language_preference
-            elif headers.ui_lang:
-                ui_language_preference = headers.ui_lang
-
             couchers_context = make_interactive_context(
                 grpc_context=grpc_context,
                 user_id=auth_info.user_id if auth_info else None,
                 is_api_key=auth_info.is_api_key if auth_info else False,
                 token=auth_info.token if auth_info else None,
-                ui_language_preference=ui_language_preference,
+                ui_language_preference=(auth_info.ui_language_preference if auth_info else None) or headers.ui_lang,
             )
 
             with session_scope() as session:

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -283,12 +283,18 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             raise RuntimeError(f"No prev_function in '{method}', {handler}")
 
         def function_without_couchers_stuff(req: Message, grpc_context: grpc.ServicerContext) -> Message | None:
+            ui_language_preference: str | None = None
+            if auth_info and auth_info.ui_language_preference:
+                ui_language_preference = auth_info.ui_language_preference
+            elif headers.ui_lang:
+                ui_language_preference = headers.ui_lang
+
             couchers_context = make_interactive_context(
                 grpc_context=grpc_context,
                 user_id=auth_info.user_id if auth_info else None,
                 is_api_key=auth_info.is_api_key if auth_info else False,
                 token=auth_info.token if auth_info else None,
-                ui_language_preference=auth_info.ui_language_preference if auth_info else None,
+                ui_language_preference=ui_language_preference,
             )
 
             with session_scope() as session:


### PR DESCRIPTION
See #6860 . Community guidelines were always in English because our `CouchersContext` object only got its locale from the auth info, which is unavailable while creating a new user. Fixes it by falling back to the language cookie in that case.

Closes #6860

## Testing
Create a new user, notice the community guidelines are now translated.

<img width="806" height="339" alt="image" src="https://github.com/user-attachments/assets/bf4c4ee3-effd-4e56-a34c-8bbefe5647a3" />

**Backend checklist**
<!-- To avoid CI failures, first run `make format` in app/backend and run tests locally. -->
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me