### PR TITLE
Frontend/bug reporter: Fix localized string concatenation.

### DIFF
--- a/app/web/components/Navigation/ReportButton.test.tsx
+++ b/app/web/components/Navigation/ReportButton.test.tsx
@@ -238,14 +238,9 @@ describe("ReportButton", () => {
       );
 
       const successAlert = await screen.findByRole("alert");
-      expect(
-        within(successAlert).getByText(t("global:report.bug.success_message"), {
-          exact: false,
-        }),
-      ).toBeVisible();
-      expect(await within(successAlert).findByRole("link")).toHaveTextContent(
-        "#1",
-      );
+      const bugLink = await within(successAlert).findByRole("link");
+      expect(bugLink).toBeVisible();
+      expect(bugLink).toHaveTextContent("#1");
       expect(reportBugMock).toHaveBeenCalledTimes(1);
       expect(reportBugMock).toHaveBeenCalledWith({
         description: "Log in is broken",

--- a/app/web/components/Navigation/ReportDialog.tsx
+++ b/app/web/components/Navigation/ReportDialog.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from "i18n";
 import { ReportBugRes } from "proto/bugs_pb";
 import { ComponentPropsWithRef, forwardRef, useState } from "react";
 import { useForm } from "react-hook-form";
+import { Trans } from "react-i18next";
 import { helpCenterReportContentURL } from "routes";
 import { service } from "service";
 import { theme } from "theme";
@@ -99,13 +100,17 @@ export default function ReportDialog({ open, onClose }: DialogProps) {
     <>
       {bug && (
         <Snackbar severity="success">
-          <>
-            {t("report.bug.success_message")}
-            <StyledLink variant="body2" href={bug.bugUrl}>
-              {bug.bugId}
-            </StyledLink>
-            .
-          </>
+          <Trans
+            i18nKey="report.bug.success_message2"
+            t={t}
+            components={{
+              id: (
+                <StyledLink variant="body2" href={bug.bugUrl}>
+                  {bug.bugId}
+                </StyledLink>
+              ),
+            }}
+          ></Trans>
         </Snackbar>
       )}
       <Dialog aria-labelledby="bug-reporter" open={open} onClose={handleClose}>

--- a/app/web/resources/locales/en.json
+++ b/app/web/resources/locales/en.json
@@ -99,7 +99,7 @@
       "problem_helper": "Brief description of the problem and how to reproduce it",
       "expect_label": "What happened? What should have happened?",
       "expect_helper": "Brief description of what you expected to happen instead",
-      "success_message": "Thank you for reporting that bug and making Couchers better, a report was sent to the developers! The bug ID is "
+      "success_message2": "Thank you for reporting that bug and making Couchers better, a report was sent to the developers! The bug ID is <id/>."
     },
     "content": {
       "button_label": "Report inappropriate content or behaviour",


### PR DESCRIPTION
The string concatenation prevents translation from languages which put the verb last or use different period characters, for example. This was reported by a translator, see comments on https://translate.couchershq.org/translate/couchers/web-app-global/en/?checksum=e6bd13a1e43f2796

I purposefully changed the string key because if we use an existing translation, we won't interpolate the bug id anywhere.

Since the new string includes an `<id/>` placeholder, it won't be found verbatim in the page, so I changed the test a little bit.

## Testing
Sent a bug report and validated that the link is clickable.

**Backend checklist**
**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` and `yarn lint --fix` in app/web, and run tests locally. -->
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me