### PR TITLE
Backend/i18n: Support spaces in  {{placeholders}}.

### DIFF
--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -136,7 +136,7 @@ class StringTemplate:
     def parse(value: str) -> StringTemplate:
         last_index = 0
         segments: list[StringSegment] = []
-        for match in re.finditer(r"\{\{([^\}]+)\}\}", value):
+        for match in re.finditer(r"\{\{\s*([^\}]+?)\s*\}\}", value):
             if match.start() > last_index:
                 segments.append(StringSegment(text=value[last_index : match.start()], is_variable=False))
             segments.append(StringSegment(text=match.group(1), is_variable=True))

--- a/app/backend/src/tests/test_i18next.py
+++ b/app/backend/src/tests/test_i18next.py
@@ -16,6 +16,12 @@ def test_substitution():
     assert i18next.localize("greeting", "en", {"name": "world"}) == "hello world!"
 
 
+def test_placeholder_with_spacing():
+    i18next = I18Next()
+    i18next.add_language("en", PluralRules.en).add_string("greeting", "hello {{ name }}!")
+    assert i18next.localize("greeting", "en", {"name": "world"}) == "hello world!"
+
+
 def test_localized():
     i18next = I18Next()
     en = i18next.add_language("en", PluralRules.en)


### PR DESCRIPTION
The javascript i18next implementation supports it whereas the Python one didn't.

## Testing
Added a test

**Backend checklist**
<!-- To avoid CI failures, first run `make format` in app/backend and run tests locally. -->
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me