### PR TITLE
Optimize web builds

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -238,6 +238,8 @@ build:web:
   artifacts:
     paths:
       - artifacts/
+  tags:
+    - saas-linux-large-amd64
 
 build:web-next:
   needs: ["protos"]
@@ -266,6 +268,8 @@ build:web-next:
   artifacts:
     paths:
       - artifacts/
+  tags:
+    - saas-linux-large-amd64
 
 build:nginx-next:
   needs: []

--- a/app/web/Dockerfile.prod
+++ b/app/web/Dockerfile.prod
@@ -8,7 +8,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 
 COPY package.json yarn.lock ./
 # https://github.com/yarnpkg/yarn/issues/8242
-RUN yarn config set network-timeout 300000 && yarn install --frozen-lockfile
+RUN yarn config set network-timeout 300000 && yarn install --frozen-lockfile && yarn cache clean
 
 COPY . .
 
@@ -31,7 +31,7 @@ ENV NEXT_PUBLIC_COMMIT_SHA=$commit_sha
 ARG commit_timestamp
 ENV NEXT_PUBLIC_COMMIT_TIMESTAMP=$commit_timestamp
 
-RUN yarn build && yarn injectsourcemaps
+RUN yarn build && yarn injectsourcemaps && rm -rf .next/cache node_modules/.cache
 
 FROM node:22-bookworm-slim AS runner
 

--- a/app/web/Dockerfile.prod
+++ b/app/web/Dockerfile.prod
@@ -4,7 +4,7 @@ ARG environment=development
 WORKDIR /app
 
 # disable next.js telemetry
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED=1
 
 COPY package.json yarn.lock ./
 # https://github.com/yarnpkg/yarn/issues/8242
@@ -14,9 +14,8 @@ COPY . .
 
 RUN cp .env.$environment env && \
     rm .env.* && \
-    mv env .env.local
-
-RUN if [ "$environment" = "production" ]; then cp public/robots-prod.txt public/robots.txt; fi
+    mv env .env.local && \
+    if [ "$environment" = "production" ]; then cp public/robots-prod.txt public/robots.txt; fi
 
 # These are used during yarn build by Next.js
 ARG version
@@ -32,14 +31,12 @@ ENV NEXT_PUBLIC_COMMIT_SHA=$commit_sha
 ARG commit_timestamp
 ENV NEXT_PUBLIC_COMMIT_TIMESTAMP=$commit_timestamp
 
-RUN yarn build
-
-RUN yarn injectsourcemaps
+RUN yarn build && yarn injectsourcemaps
 
 FROM node:22-bookworm-slim AS runner
 
 WORKDIR /app
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
 


### PR DESCRIPTION
- Run all web builds on large CI nodes (2-2.5 minutes speedup)
- Merge a couple of RUN commands in Dockerfile.prod to save some bytes
- Clear yarn/next/node_modules cache in Dockerfile, since that cache is never used and makes images bigger. Bigger images -> longer pull times -> longer CI
