### PR TITLE
Backend/i18n: Remove "v2" from template module name

### DIFF
--- a/app/backend/src/couchers/email/send.py
+++ b/app/backend/src/couchers/email/send.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 from couchers.config import config
 from couchers.email import queue_email
 from couchers.i18n import LocalizationContext
-from couchers.templates.v2 import Jinja2Template, template_folder
+from couchers.templating import Jinja2Template, template_folder
 from couchers.utils import now
 
 

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -29,7 +29,7 @@ from couchers.notifications.render_push import render_push_notification
 from couchers.notifications.settings import get_preference
 from couchers.proto.internal import jobs_pb2
 from couchers.sql import moderation_state_column_visible
-from couchers.templates.v2 import Jinja2Template, template_folder
+from couchers.templating import Jinja2Template, template_folder
 from couchers.utils import now
 
 logger = logging.getLogger(__name__)

--- a/app/backend/src/couchers/templating.py
+++ b/app/backend/src/couchers/templating.py
@@ -25,7 +25,9 @@ logger = logging.getLogger(__name__)
 
 template_folder = Path(__file__).parent / ".." / ".." / "templates" / "emails"
 
-_markdown = MarkdownIt("zero", {"typographer": True}).enable(["smartquotes", "heading", "hr", "list", "link", "emphasis"])
+_markdown = MarkdownIt("zero", {"typographer": True}).enable(
+    ["smartquotes", "heading", "hr", "list", "link", "emphasis"]
+)
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/app/backend/src/couchers/templating.py
+++ b/app/backend/src/couchers/templating.py
@@ -23,7 +23,7 @@ from couchers.i18n.localize import get_main_i18next
 
 logger = logging.getLogger(__name__)
 
-template_folder = Path(__file__).parent / ".." / ".." / "templates" / "emails"
+template_folder = Path(__file__).parent / ".." / ".." / "templates" / "v2"
 
 _markdown = MarkdownIt("zero", {"typographer": True}).enable(
     ["smartquotes", "heading", "hr", "list", "link", "emphasis"]

--- a/app/backend/src/couchers/templating.py
+++ b/app/backend/src/couchers/templating.py
@@ -1,5 +1,5 @@
 """
-template mailer/push notification formatter v2
+Provides string templating functionality using jinja2, with custom filters for localization.
 """
 
 import logging
@@ -23,9 +23,9 @@ from couchers.i18n.localize import get_main_i18next
 
 logger = logging.getLogger(__name__)
 
-template_folder = Path(__file__).parent / ".." / ".." / ".." / "templates" / "v2"
+template_folder = Path(__file__).parent / ".." / ".." / "templates" / "emails"
 
-md = MarkdownIt("zero", {"typographer": True}).enable(["smartquotes", "heading", "hr", "list", "link", "emphasis"])
+_markdown = MarkdownIt("zero", {"typographer": True}).enable(["smartquotes", "heading", "hr", "list", "link", "emphasis"])
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -131,7 +131,7 @@ def _filter_markdown(jinja_context: JinjaContext, value: str) -> Markup:
     """Renders markdown into html."""
     filter_context = _FilterContext.from_jinja(jinja_context)
     if filter_context.output_html:
-        return Markup(md.render(value))
+        return Markup(_markdown.render(value))
     else:
         return Markup(value)
 

--- a/app/backend/src/tests/test_templates.py
+++ b/app/backend/src/tests/test_templates.py
@@ -9,33 +9,11 @@ from markupsafe import Markup
 from couchers.i18n import LocalizationContext
 from couchers.i18n.i18next import I18Next
 from couchers.i18n.plurals import PluralRules
-from couchers.templates.v2 import Jinja2Template
-
-
-def _render_template(
-    template_str: str,
-    *,
-    args: dict[str, Any] | None = None,
-    translation_dict: dict[str, dict[str, str]] | None = None,
-    output_html: bool = True,
-    lang: str = "en",
-) -> str:
-    mock_i18next = I18Next()
-    if translation_dict:
-        for lang_code, strings in translation_dict.items():
-            language = mock_i18next.add_language(lang_code, PluralRules.en)
-            language.load_json_dict(strings)
-
-    template = Jinja2Template(source=template_str, html=output_html)
-    loc_context = LocalizationContext(locale=lang, timezone=ZoneInfo("Etc/UTC"))
-    return template.render(args or {}, loc_context, i18next=mock_i18next)
-
-
-_en_utc_loc_context = LocalizationContext(locale="en", timezone=ZoneInfo("Etc/UTC"))
+from couchers.templating import Jinja2Template
 
 
 def _render_en_utc(template: Jinja2Template, args: dict[str, Any]) -> str:
-    return template.render(args, _en_utc_loc_context, i18next=I18Next())
+    return template.render(args, LocalizationContext.en_utc(), i18next=I18Next())
 
 
 def test_multiline() -> None:
@@ -80,18 +58,10 @@ def _greeting_i18next(value: str) -> I18Next:
     return i18next
 
 
-def _i18next_from_dict(value: dict[str, dict[str, str]]) -> I18Next:
-    i18next = I18Next()
-    for lang_code, strings in value.items():
-        language = i18next.add_language(lang_code, PluralRules.en)
-        language.load_json_dict(strings)
-    return i18next
-
-
 def test_translate_no_substitutions() -> None:
     template = Jinja2Template(source='{{ "greeting"|translate }}', html=False)
     i18next = _greeting_i18next("Hello!")
-    rendered = template.render({}, _en_utc_loc_context, i18next)
+    rendered = template.render({}, LocalizationContext.en_utc(), i18next)
     assert rendered == "Hello!"
 
 
@@ -108,54 +78,54 @@ def test_translate_multiple_languages() -> None:
 def test_translate_with_substitutions() -> None:
     template = Jinja2Template(source='{{ "greeting"|translate(name=user_name) }}', html=False)
     i18next = _greeting_i18next("Hello, {{name}}!")
-    rendered = template.render({"user_name": "Jack"}, _en_utc_loc_context, i18next)
+    rendered = template.render({"user_name": "Jack"}, LocalizationContext.en_utc(), i18next)
     assert rendered == "Hello, Jack!"
 
 
 def test_translate_substitution_escaping() -> None:
     template = Jinja2Template(source='{{ "greeting"|translate(name=name) }}', html=True)
     i18next = _greeting_i18next("Hello, {{name}}!")
-    rendered = template.render({"name": "<script />"}, _en_utc_loc_context, i18next)
+    rendered = template.render({"name": "<script />"}, LocalizationContext.en_utc(), i18next)
     assert rendered == "Hello, &lt;script /&gt;!"
 
 
 def test_translate_substitution_safe_html() -> None:
     template = Jinja2Template(source='{{ "greeting"|translate(name=name) }}', html=True)
     i18next = _greeting_i18next("Hello, {{name}}!")
-    rendered = template.render({"name": Markup("<script />")}, _en_utc_loc_context, i18next)
+    rendered = template.render({"name": Markup("<script />")}, LocalizationContext.en_utc(), i18next)
     assert rendered == "Hello, <script />!"
 
 
 def test_translate_translation_tags() -> None:
     template = Jinja2Template(source='{{ "greeting"|translate }}', html=True)
     i18next = _greeting_i18next("<b>Hello!</b>")
-    rendered = template.render({}, _en_utc_loc_context, i18next)
+    rendered = template.render({}, LocalizationContext.en_utc(), i18next)
     assert rendered == "<b>Hello!</b>"
 
 
 def test_translate_newlines_br() -> None:
     template = Jinja2Template(source='{{ "greeting"|translate }}', html=True)
     i18next = _greeting_i18next("Hello!\nWelcome!")
-    rendered = template.render({}, _en_utc_loc_context, i18next)
+    rendered = template.render({}, LocalizationContext.en_utc(), i18next)
     assert rendered == "Hello!<br>Welcome!"
 
 
 def test_translate_plain_strip_tags() -> None:
     template = Jinja2Template(source='{{ "greeting"|translate }}', html=False)
     i18next = _greeting_i18next("<b>Hello!</b>")
-    rendered = template.render({}, _en_utc_loc_context, i18next)
+    rendered = template.render({}, LocalizationContext.en_utc(), i18next)
     assert rendered == "Hello!"
 
 
 def test_translate_plain_strip_links() -> None:
     template = Jinja2Template(source='{{ "greeting"|translate }}', html=False)
     i18next = _greeting_i18next('<a href="https://example.com">Hello!</a>')
-    rendered = template.render({}, _en_utc_loc_context, i18next)
+    rendered = template.render({}, LocalizationContext.en_utc(), i18next)
     assert rendered == "<https://example.com>"
 
 
 def test_translate_plain_strip_mailto() -> None:
     template = Jinja2Template(source='{{ "greeting"|translate }}', html=False)
     i18next = _greeting_i18next('<a href="mailto:me@example.com">Hello!</a>')
-    rendered = template.render({}, _en_utc_loc_context, i18next)
+    rendered = template.render({}, LocalizationContext.en_utc(), i18next)
     assert rendered == "<me@example.com>"

--- a/app/backend/src/tests/test_templating.py
+++ b/app/backend/src/tests/test_templating.py
@@ -58,6 +58,14 @@ def _greeting_i18next(value: str) -> I18Next:
     return i18next
 
 
+def _i18next_from_dict(value: dict[str, dict[str, str]]) -> I18Next:
+    i18next = I18Next()
+    for lang_code, strings in value.items():
+        language = i18next.add_language(lang_code, PluralRules.en)
+        language.load_json_dict(strings)
+    return i18next
+
+
 def test_translate_no_substitutions() -> None:
     template = Jinja2Template(source='{{ "greeting"|translate }}', html=False)
     i18next = _greeting_i18next("Hello!")


### PR DESCRIPTION
There was probably a v1 some time in the past but by this point it's long gone and I've already removed the "v2" prefix to filter functions. It's time to give this module a new name.

Also cleans up some leftover dead/repeated code from the `LocalizationContext` refactoring that introduced `Jinja2Template`.

I'm not renaming the templates/v2 folder in this change. Should I?

## Testing
mypy, pytest, leaving the rest to CI

**Backend checklist**
<!-- To avoid CI failures, first run `make format` in app/backend and run tests locally. -->
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me