### PR TITLE
Frontend: Fix pluralization of chars remaining messages

### DIFF
--- a/app/web/features/profile/edit/EditProfilePage.test.tsx
+++ b/app/web/features/profile/edit/EditProfilePage.test.tsx
@@ -200,7 +200,7 @@ describe("Edit profile", () => {
 
     expect(
       await screen.findByText(
-        /Please write at least 50 characters to unlock messaging and requests/i,
+        /Please write at least 50 more characters to unlock messaging and requests/i,
       ),
     ).toBeInTheDocument();
 
@@ -210,7 +210,7 @@ describe("Edit profile", () => {
     await waitFor(() => {
       expect(
         screen.queryByText(
-          /Please write at least 50 characters to unlock messaging and requests/i,
+          /Please write at least 50 more characters to unlock messaging and requests/i,
         ),
       ).not.toBeInTheDocument();
     });

--- a/app/web/features/profile/locales/en.json
+++ b/app/web/features/profile/locales/en.json
@@ -39,8 +39,8 @@
   },
   "edit": "Edit Profile",
   "helper_text": {
-    "characters_remaining_one": "<bold>Please write at least {{count}} character to unlock messaging and requests.</bold> Genuine profiles build a community of trust. The more you share, the easier it is to connect!",
-    "characters_remaining_other": "<bold>Please write at least {{count}} characters to unlock messaging and requests.</bold> Genuine profiles build a community of trust. The more you share, the easier it is to connect!",
+    "characters_remaining_one": "<bold>Please write {{count}} more character to unlock messaging and requests.</bold> Genuine profiles build a community of trust. The more you share, the easier it is to connect!",
+    "characters_remaining_other": "<bold>Please write {{count}} more characters to unlock messaging and requests.</bold> Genuine profiles build a community of trust. The more you share, the easier it is to connect!",
     "missing_profile_photo": "Please add a photo to complete your profile."
   },
   "section_tabs_a11y_label": "tabs for user's details",

--- a/app/web/features/profile/locales/en.json
+++ b/app/web/features/profile/locales/en.json
@@ -39,8 +39,8 @@
   },
   "edit": "Edit Profile",
   "helper_text": {
-    "characters_remaining_one": "<bold>Please write {{count}} more character to unlock messaging and requests.</bold> Genuine profiles build a community of trust. The more you share, the easier it is to connect!",
-    "characters_remaining_other": "<bold>Please write {{count}} more characters to unlock messaging and requests.</bold> Genuine profiles build a community of trust. The more you share, the easier it is to connect!",
+    "characters_remaining_one": "<bold>Please write at least {{count}} more character to unlock messaging and requests.</bold> Genuine profiles build a community of trust. The more you share, the easier it is to connect!",
+    "characters_remaining_other": "<bold>Please write at least {{count}} more characters to unlock messaging and requests.</bold> Genuine profiles build a community of trust. The more you share, the easier it is to connect!",
     "missing_profile_photo": "Please add a photo to complete your profile."
   },
   "section_tabs_a11y_label": "tabs for user's details",
@@ -236,7 +236,8 @@
     "request": "Request",
     "request_description": "Share your plans for the visit and include why you're requesting to stay with this particular host",
     "request_description_empty": "Please write a request message",
-    "request_char_length_too_short": "Please write at least {{charactersRemaining}} more characters to send a host request.",
+    "request_chars_remaining_one": "Please write at least {{count}} more character to send a host request.",
+    "request_chars_remaining_other": "Please write at least {{count}} more characters to send a host request.",
     "stay_type_a11y_text": "stay type",
     "success": "Request sent!",
     "guest_count": "Number of guests"

--- a/app/web/features/profile/view/NewHostRequest.tsx
+++ b/app/web/features/profile/view/NewHostRequest.tsx
@@ -173,10 +173,9 @@ export default function NewHostRequest({
               required: t("profile:request_form.request_description_empty"),
               minLength: {
                 value: MIN_LENGTH,
-                message: t(
-                  "profile:request_form.request_char_length_too_short",
-                  { charactersRemaining: MIN_LENGTH - textField.length },
-                ),
+                message: t("profile:request_form.request_chars_remaining", {
+                  count: MIN_LENGTH - textField.length,
+                }),
               },
             })}
             label={t("profile:request_form.request")}
@@ -189,8 +188,8 @@ export default function NewHostRequest({
               errors.text?.message
                 ? errors.text.message
                 : MIN_LENGTH - textField.length > 0
-                  ? t("profile:request_form.request_char_length_too_short", {
-                      charactersRemaining: MIN_LENGTH - textField.length,
+                  ? t("profile:request_form.request_chars_remaining", {
+                      count: MIN_LENGTH - textField.length,
                     })
                   : ""
             }


### PR DESCRIPTION
@vas2525 reported that "Please write at least {{count}} character to unlock messaging and requests." looks like a static string, and shouldn't be pluralizable. It's actually a dynamic string, so I changed the spelling to "more characters" to point it out.

Another similar string used "more characters", but was not pluralizable, so I changed its placeholder to "{{count}}" and changed the key since we don't want to reuse old translations that have incorrect placeholder names.

## Testing
N/A

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` and `yarn lint --fix` in app/web, and run tests locally. -->
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me