### PR TITLE
Backend/emails: Split notification policy from email rendering

### DIFF
--- a/app/backend/src/couchers/models/notifications.py
+++ b/app/backend/src/couchers/models/notifications.py
@@ -59,6 +59,7 @@ class NotificationTopicAction(enum.Enum):
     ) -> None:
         self.topic, self.action = topic_action.split(":")
         self.defaults = defaults
+        # for now user editable == not a security notification
         self.user_editable = user_editable
 
         self.data_type = data_type
@@ -69,11 +70,6 @@ class NotificationTopicAction(enum.Enum):
     @property
     def display(self) -> str:
         return f"{self.topic}:{self.action}"
-
-    @property
-    def is_security(self) -> bool:
-        """Whether this is a security-related notification that cannot be unsubscribed from."""
-        return not self.user_editable
 
     def __str__(self) -> str:
         return self.display

--- a/app/backend/src/couchers/models/notifications.py
+++ b/app/backend/src/couchers/models/notifications.py
@@ -54,7 +54,6 @@ class NotificationTopicAction(enum.Enum):
       e.g. all notifications about an event, where the key is the event id.
     """
 
-
     def __init__(
         self, topic_action: str, defaults: list[NotificationDeliveryType], user_editable: bool, data_type: type
     ) -> None:

--- a/app/backend/src/couchers/models/notifications.py
+++ b/app/backend/src/couchers/models/notifications.py
@@ -59,7 +59,6 @@ class NotificationTopicAction(enum.Enum):
     ) -> None:
         self.topic, self.action = topic_action.split(":")
         self.defaults = defaults
-        # for now user editable == not a security notification
         self.user_editable = user_editable
 
         self.data_type = data_type
@@ -70,6 +69,11 @@ class NotificationTopicAction(enum.Enum):
     @property
     def display(self) -> str:
         return f"{self.topic}:{self.action}"
+
+    @property
+    def is_critical(self) -> bool:
+        """Whether the notification is critical cannot be disabled."""
+        return not self.user_editable
 
     def __str__(self) -> str:
         return self.display

--- a/app/backend/src/couchers/models/notifications.py
+++ b/app/backend/src/couchers/models/notifications.py
@@ -46,12 +46,20 @@ dt_empty: list[NotificationDeliveryType] = []
 
 
 class NotificationTopicAction(enum.Enum):
+    """
+    Identifies a type of notification by the topic it relates to and the action triggered.
+    The grouping by topic allows users to unsubscribe from notifications in two ways:
+    - All notifications of a certain type (topic+action), e.g. all friend requests.
+    - All notifications about a certain instance of a topic,
+      e.g. all notifications about an event, where the key is the event id.
+    """
+
+
     def __init__(
         self, topic_action: str, defaults: list[NotificationDeliveryType], user_editable: bool, data_type: type
     ) -> None:
         self.topic, self.action = topic_action.split(":")
         self.defaults = defaults
-        # for now user editable == not a security notification
         self.user_editable = user_editable
 
         self.data_type = data_type
@@ -62,6 +70,11 @@ class NotificationTopicAction(enum.Enum):
     @property
     def display(self) -> str:
         return f"{self.topic}:{self.action}"
+
+    @property
+    def is_security(self) -> bool:
+        """Whether this is a security-related notification that cannot be unsubscribed from."""
+        return not self.user_editable
 
     def __str__(self) -> str:
         return self.display

--- a/app/backend/src/couchers/models/notifications.py
+++ b/app/backend/src/couchers/models/notifications.py
@@ -156,7 +156,7 @@ class NotificationTopicAction(enum.Enum):
     birthdate__change = ("birthdate:change", dt_sec, False, nd.BirthdateChange)
     api_key__create = ("api_key:create", dt_sec, False, nd.ApiKeyCreate)
 
-    donation__received = ("donation:received", dt_sec, True, nd.DonationReceived)
+    donation__received = ("donation:received", dt_sec, False, nd.DonationReceived)
 
     onboarding__reminder = ("onboarding:reminder", dt_sec, True, empty_pb2.Empty)
 

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -24,9 +24,10 @@ from couchers.notifications.quick_links import (
     generate_unsub_topic_action,
     generate_unsub_topic_key,
 )
-from couchers.notifications.render_email import render_email_notification, can_notify_deleted_user
+from couchers.notifications.render_email import render_email_notification
 from couchers.notifications.render_push import render_push_notification
 from couchers.notifications.settings import get_preference
+from couchers.notifications.utils import ACCOUNT_DELETION_TOPIC
 from couchers.proto.internal import jobs_pb2
 from couchers.sql import moderation_state_column_visible
 from couchers.templating import Jinja2Template, template_folder
@@ -44,7 +45,7 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         logger.info(f"Tried emailing {user} based on notification {notification.topic_action} but user is banned")
         return
 
-    if user.is_deleted and not can_notify_deleted_user(notification.topic_action):
+    if user.is_deleted and notification.topic != ACCOUNT_DELETION_TOPIC:
         logger.info(f"Tried emailing {user} based on notification {notification.topic_action} but user is deleted")
         return
 

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -63,14 +63,18 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         "time": notification.created,
         "footer_timezone_name": loc_context.localized_timezone,
         "footer_copyright_year": now().year,
-        "footer_email_is_critical": notification.topic_action.is_critical,
-        "footer_manage_notifications_link": urls.notification_settings_link(),
-        "footer_notification_topic_action": rendered.topic_action_unsubscribe_text,
-        "footer_notification_topic_action_link": generate_unsub_topic_action(notification),
-        "footer_notification_topic_key": rendered.topic_key_unsubscribe_text,
-        "footer_notification_topic_key_link": generate_unsub_topic_key(notification),
-        "footer_do_not_email_link": generate_do_not_email(user),
     }
+
+    if notification.topic_action.user_editable:
+        template_args["footer_email_is_critical"] = False
+        template_args["footer_manage_notifications_link"] = urls.notification_settings_link()
+        template_args["footer_notification_topic_action"] = rendered.topic_action_unsubscribe_text
+        template_args["footer_notification_topic_action_link"] = generate_unsub_topic_action(notification)
+        template_args["footer_notification_topic_key"] = rendered.topic_key_unsubscribe_text
+        template_args["footer_notification_topic_key_link"] = generate_unsub_topic_key(notification)
+        template_args["footer_do_not_email_link"] = generate_do_not_email(user)
+    else:
+        template_args["footer_email_is_critical"] = True
 
     # Format plaintext template
     plain_tmplt_body = (template_folder / f"{rendered.template_name}.txt").read_text()

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -24,7 +24,7 @@ from couchers.notifications.quick_links import (
     generate_unsub_topic_action,
     generate_unsub_topic_key,
 )
-from couchers.notifications.render_email import render_email_notification
+from couchers.notifications.render_email import render_email_notification, can_notify_deleted_user
 from couchers.notifications.render_push import render_push_notification
 from couchers.notifications.settings import get_preference
 from couchers.proto.internal import jobs_pb2
@@ -36,6 +36,18 @@ logger = logging.getLogger(__name__)
 
 
 def _send_email_notification(session: Session, user: User, notification: Notification) -> None:
+    if user.do_not_email and not notification.topic_action.is_critical:
+        logger.info(f"Not emailing {user} based on notification {notification.topic_action} due to emails turned off")
+        return
+
+    if user.is_banned:
+        logger.info(f"Tried emailing {user} based on notification {notification.topic_action} but user is banned")
+        return
+
+    if user.is_deleted and not can_notify_deleted_user(notification.topic_action):
+        logger.info(f"Tried emailing {user} based on notification {notification.topic_action} but user is deleted")
+        return
+
     loc_context = LocalizationContext.from_user(user)
     if not config["ENABLE_NOTIFICATION_TRANSLATIONS"]:
         loc_context = dataclasses.replace(loc_context, locale="en")
@@ -50,7 +62,7 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         "time": notification.created,
         "footer_timezone_name": loc_context.localized_timezone,
         "footer_copyright_year": now().year,
-        "footer_email_is_critical": rendered.is_critical,
+        "footer_email_is_critical": notification.topic_action.is_critical,
         "footer_manage_notifications_link": urls.notification_settings_link(),
         "footer_notification_topic_action": rendered.topic_action_unsubscribe_text,
         "footer_notification_topic_action_link": generate_unsub_topic_action(notification),
@@ -70,18 +82,6 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         source=(template_folder / "generated_html" / f"{rendered.template_name}.html").read_text(), html=True
     )
     html = html_tmplt.render(template_args, loc_context)
-
-    if user.do_not_email and not rendered.is_critical:
-        logger.info(f"Not emailing {user} based on template {rendered.template_name} due to emails turned off")
-        return
-
-    if user.is_banned:
-        logger.info(f"Tried emailing {user} based on template {rendered.template_name} but user is banned")
-        return
-
-    if user.is_deleted and not rendered.allow_deleted:
-        logger.info(f"Tried emailing {user} based on template {rendered.template_name} but user is deleted")
-        return
 
     list_unsubscribe_header = None
     if rendered.list_unsubscribe_url:

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -65,7 +65,9 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         "footer_copyright_year": now().year,
     }
 
-    if notification.topic_action.user_editable:
+    if notification.topic_action.is_critical:
+        template_args["footer_email_is_critical"] = True
+    else:
         template_args["footer_email_is_critical"] = False
         template_args["footer_manage_notifications_link"] = urls.notification_settings_link()
         template_args["footer_notification_topic_action"] = rendered.topic_action_unsubscribe_text
@@ -73,8 +75,6 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         template_args["footer_notification_topic_key"] = rendered.topic_key_unsubscribe_text
         template_args["footer_notification_topic_key_link"] = generate_unsub_topic_key(notification)
         template_args["footer_do_not_email_link"] = generate_do_not_email(user)
-    else:
-        template_args["footer_email_is_critical"] = True
 
     # Format plaintext template
     plain_tmplt_body = (template_folder / f"{rendered.template_name}.txt").read_text()

--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -15,10 +15,6 @@ logger = logging.getLogger(__name__)
 
 @dataclass(kw_only=True)
 class RenderedEmailNotification:
-    # whether the notification is critical and cannot be turned off
-    is_critical: bool = False
-    # whether this email can be sent to someone who is deleted
-    allow_deleted: bool = False
     # email subject
     subject: str
     # shows up when listing emails in many clients
@@ -33,6 +29,17 @@ class RenderedEmailNotification:
     topic_key_unsubscribe_text: str | None = None
     # url to unsubscribe with one click
     list_unsubscribe_url: str | None = None
+
+
+_DELETED_USER_ALLOWED_NOTIFICATIONS = {
+    NotificationTopicAction.account_deletion__start,
+    NotificationTopicAction.account_deletion__complete,
+    NotificationTopicAction.account_deletion__recovered,
+}
+
+
+def can_notify_deleted_user(topic_action: NotificationTopicAction) -> bool:
+    return topic_action in _DELETED_USER_ALLOWED_NOTIFICATIONS
 
 
 def render_email_notification(
@@ -141,7 +148,6 @@ def render_email_notification(
         title = "Your password was changed"
         message = "Your login password for Couchers.org was changed."
         return RenderedEmailNotification(
-            is_critical=True,
             subject=title,
             preview=message,
             template_name="security",
@@ -153,7 +159,6 @@ def render_email_notification(
     elif notification.topic_action == NotificationTopicAction.password_reset__start:
         message = "Someone initiated a password change on your account."
         return RenderedEmailNotification(
-            is_critical=True,
             subject="Reset your Couchers.org password",
             preview=message,
             template_name="password_reset",
@@ -165,7 +170,6 @@ def render_email_notification(
         title = "Your password was successfully reset"
         message = "Your password on Couchers.org was changed. If that was you, then no further action is needed."
         return RenderedEmailNotification(
-            is_critical=True,
             subject=title,
             preview=title,
             template_name="security",
@@ -178,7 +182,6 @@ def render_email_notification(
         title = "An email change was initiated on your account"
         message = f"An email change to the email <b>{data.new_email}</b> was initiated on your account."
         return RenderedEmailNotification(
-            is_critical=True,
             subject=title,
             preview=title,
             template_name="security",
@@ -191,7 +194,6 @@ def render_email_notification(
         title = "Email change completed"
         message = "Your new email address has been verified."
         return RenderedEmailNotification(
-            is_critical=True,
             subject=title,
             preview=message,
             template_name="security",
@@ -204,7 +206,6 @@ def render_email_notification(
         title = "Phone verification started"
         message = f"You started phone number verification with the number <b>{format_phone_number(data.phone)}</b>."
         return RenderedEmailNotification(
-            is_critical=True,
             subject=title,
             preview=message,
             template_name="security",
@@ -218,7 +219,6 @@ def render_email_notification(
         message = f"Your phone was successfully verified as <b>{format_phone_number(data.phone)}</b> on Couchers.org."
         message_plain = f"Your phone was successfully verified as {format_phone_number(data.phone)} on Couchers.org."
         return RenderedEmailNotification(
-            is_critical=True,
             subject=title,
             preview=message_plain,
             template_name="security",
@@ -232,7 +232,6 @@ def render_email_notification(
         message = f"Your gender on Couchers.org was changed to <b>{data.gender}</b> by an admin."
         message_plain = f"Your gender on Couchers.org was changed to {data.gender} by an admin."
         return RenderedEmailNotification(
-            is_critical=True,
             subject=title,
             preview=message_plain,
             template_name="security",
@@ -247,7 +246,6 @@ def render_email_notification(
         message = f"Your date of birth on Couchers.org was changed to <b>{birthdate}</b> by an admin."
         message_plain = f"Your date of birth on Couchers.org was changed to {birthdate} by an admin."
         return RenderedEmailNotification(
-            is_critical=True,
             subject=title,
             preview=message_plain,
             template_name="security",
@@ -258,7 +256,6 @@ def render_email_notification(
         )
     elif notification.topic_action == NotificationTopicAction.api_key__create:
         return RenderedEmailNotification(
-            is_critical=True,
             subject="Your API key for Couchers.org",
             preview="We have issued you an API key as per your request.",
             template_name="api_key",
@@ -291,7 +288,6 @@ def render_email_notification(
             },
         )
         return RenderedEmailNotification(
-            is_critical=True,
             subject=title,
             preview=message,
             template_name="donation_received",
@@ -328,8 +324,6 @@ def render_email_notification(
         )
     elif notification.topic_action == NotificationTopicAction.account_deletion__start:
         return RenderedEmailNotification(
-            is_critical=True,
-            allow_deleted=True,
             subject="Confirm your Couchers.org account deletion",
             preview="Please confirm that you want to delete your Couchers.org account.",
             template_name="account_deletion_start",
@@ -340,8 +334,6 @@ def render_email_notification(
     elif notification.topic_action == NotificationTopicAction.account_deletion__complete:
         title = "Your Couchers.org account has been deleted"
         return RenderedEmailNotification(
-            is_critical=True,
-            allow_deleted=True,
             subject=title,
             preview="We have deleted your Couchers.org account, to undo, follow the link in this email.",
             template_name="account_deletion_complete",
@@ -354,8 +346,6 @@ def render_email_notification(
         title = "Your Couchers.org account has been recovered!"
         subtitle = "We have recovered your Couchers.org account as per your request! Welcome back!"
         return RenderedEmailNotification(
-            is_critical=True,
-            allow_deleted=True,
             subject=title,
             preview=subtitle,
             template_name="account_deletion_recovered",
@@ -654,7 +644,6 @@ def render_email_notification(
         title = "You have received a mod note"
         message = "You have received an important note from the moderators. You must read and acknowledge it before continuing to use the platform."
         return RenderedEmailNotification(
-            is_critical=True,
             subject=title,
             preview=message,
             template_name="mod_note",
@@ -664,7 +653,6 @@ def render_email_notification(
         title = "Strong Verification succeeded"
         message = "You have been verified with Strong Verification! You will now see a tick next to your name on the platform."
         return RenderedEmailNotification(
-            is_critical=True,
             subject=title,
             preview=message,
             template_name="strong_verification_success",
@@ -683,7 +671,6 @@ def render_email_notification(
         else:
             raise Exception("Shouldn't get here")
         return RenderedEmailNotification(
-            is_critical=True,
             subject=title,
             preview=title,
             template_name="security",
@@ -697,7 +684,6 @@ def render_email_notification(
             title = "Your verification postcard is on its way"
             message = f"We've sent a postcard with your verification code to {data.city}, {data.country}. It should arrive within 1-3 weeks depending on your location. Once it arrives, enter the code on the platform to complete verification."
             return RenderedEmailNotification(
-                is_critical=True,
                 subject=title,
                 preview=message,
                 template_name="security",
@@ -710,7 +696,6 @@ def render_email_notification(
             title = "Postal Verification succeeded"
             message = "You have been verified with Postal Verification! Your address has been confirmed."
             return RenderedEmailNotification(
-                is_critical=True,
                 subject=title,
                 preview=message,
                 template_name="security",
@@ -730,7 +715,6 @@ def render_email_notification(
                     "Your postal verification attempt has failed. You can start a new verification attempt."
                 )
             return RenderedEmailNotification(
-                is_critical=True,
                 subject=title,
                 preview=title,
                 template_name="security",

--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -31,17 +31,6 @@ class RenderedEmailNotification:
     list_unsubscribe_url: str | None = None
 
 
-_DELETED_USER_ALLOWED_NOTIFICATIONS = {
-    NotificationTopicAction.account_deletion__start,
-    NotificationTopicAction.account_deletion__complete,
-    NotificationTopicAction.account_deletion__recovered,
-}
-
-
-def can_notify_deleted_user(topic_action: NotificationTopicAction) -> bool:
-    return topic_action in _DELETED_USER_ALLOWED_NOTIFICATIONS
-
-
 def render_email_notification(
     notification: Notification, loc_context: LocalizationContext
 ) -> RenderedEmailNotification:
@@ -295,6 +284,7 @@ def render_email_notification(
                 "amount": data.amount,
                 "receipt_url": data.receipt_url,
             },
+            topic_action_unsubscribe_text="donations received",
         )
     elif notification.topic_action == NotificationTopicAction.friend_request__create:
         other = data.other_user

--- a/app/backend/src/couchers/notifications/utils.py
+++ b/app/backend/src/couchers/notifications/utils.py
@@ -3,3 +3,5 @@ from couchers.models import NotificationTopicAction
 enum_from_topic_action: dict[tuple[str, str], NotificationTopicAction] = {
     (item.topic, item.action): item for item in NotificationTopicAction
 }
+
+ACCOUNT_DELETION_TOPIC = NotificationTopicAction.account_deletion__start.topic

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -366,7 +366,9 @@ def test_send_donation_email(db, monkeypatch):
     with session_scope() as session:
         email = session.execute(select(Email)).scalar_one()
         assert email.subject == "[TEST] Thank you for your donation to Couchers.org!"
-        assert email.plain.startswith("""Dear Testy von Test,
+        assert (
+            email.plain
+            == """Dear Testy von Test,
 
 Thank you so much for your donation of $20 to Couchers.org.
 
@@ -390,8 +392,9 @@ Couchers.org Founders
 
 ---
 
-Edit your notification settings at
-""")
+This is a security email, you cannot unsubscribe from it.
+"""
+        )
 
         assert "Thank you so much for your donation of $20 to Couchers.org." in email.html
         assert email.sender_name == "Couchers.org"

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -366,9 +366,7 @@ def test_send_donation_email(db, monkeypatch):
     with session_scope() as session:
         email = session.execute(select(Email)).scalar_one()
         assert email.subject == "[TEST] Thank you for your donation to Couchers.org!"
-        assert (
-            email.plain
-            == """Dear Testy von Test,
+        assert email.plain.startswith("""Dear Testy von Test,
 
 Thank you so much for your donation of $20 to Couchers.org.
 
@@ -392,9 +390,8 @@ Couchers.org Founders
 
 ---
 
-This is a security email, you cannot unsubscribe from it.
-"""
-        )
+Edit your notification settings at
+""")
 
         assert "Thank you so much for your donation of $20 to Couchers.org." in email.html
         assert email.sender_name == "Couchers.org"


### PR DESCRIPTION
The notification email rendering code also decided if an email was rendered as critical and could be sent to deleted user. Splitting the concerns is a step towards having that code only return the fully rendered subject+body. It also allows us to bail out early if the email should not be sent instead of having to render it.

The decision about whether an email is critical duplicated the `topic_comment.user_editable` logic with two exceptions, which both seemed like bugs:

- `activeness:probe` is not user editable, but was not rendered as a critical email, so we still offered to "Manage notification preferences".
- `donation:received` is user editable, but was rendered as critical. It shouldn't be user editable since we provide the receipt link in the email.

The logic about what notifications can be sent to deleted user is also easily extractable and expressible as whether it concerns the account_deletion topic.

## Testing
Ran the backend locally, got an email to be sent and saw it in maildev.

**Backend checklist**
<!-- To avoid CI failures, first run `make format` in app/backend and run tests locally. -->
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me