### PR TITLE
Backend/devex: Fix VSCode Python env resolution

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,7 +56,7 @@
   "editor.insertSpaces": true,
   "files.trimTrailingWhitespace": true,
   "eslint.useFlatConfig": false,
-  "python-env.workspaceSearchPaths": [ "app/backend/.venv/bin" ],
+  "python-env.workspaceSearchPaths": [ "app/backend/.venv" ],
   "python.testing.cwd": "app/backend/src/tests",
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,7 +56,7 @@
   "editor.insertSpaces": true,
   "files.trimTrailingWhitespace": true,
   "eslint.useFlatConfig": false,
-  "python.defaultInterpreterPath": "app/backend/.venv/bin/python3",
+  "python-env.workspaceSearchPaths": [ "app/backend/.venv/bin" ],
   "python.testing.cwd": "app/backend/src/tests",
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true


### PR DESCRIPTION
I noticed that my VSCode's Pylance extension was picking up my system's Python 3.12, resulting in lots of squiggles since we use 3.14 and it wasn't able to find some dependencies. Tests were also not discovered.

This setting tells the whole Python extension ecosystem where to find the backend venv. I confirmed it switched to 3.14 and resolved squiggles.

## Testing
Compared squiggles on imports and `notification.topic_action` before/after, saw that tests are now enumerated.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
