### PR TITLE
Revert "Backend/emails: Split notification policy from email rendering (#7827)"

### DIFF
--- a/app/backend/src/couchers/models/notifications.py
+++ b/app/backend/src/couchers/models/notifications.py
@@ -46,19 +46,12 @@ dt_empty: list[NotificationDeliveryType] = []
 
 
 class NotificationTopicAction(enum.Enum):
-    """
-    Identifies a type of notification by the topic it relates to and the action triggered.
-    The grouping by topic allows users to unsubscribe from notifications in two ways:
-    - All notifications of a certain type (topic+action), e.g. all friend requests.
-    - All notifications about a certain instance of a topic,
-      e.g. all notifications about an event, where the key is the event id.
-    """
-
     def __init__(
         self, topic_action: str, defaults: list[NotificationDeliveryType], user_editable: bool, data_type: type
     ) -> None:
         self.topic, self.action = topic_action.split(":")
         self.defaults = defaults
+        # for now user editable == not a security notification
         self.user_editable = user_editable
 
         self.data_type = data_type
@@ -69,11 +62,6 @@ class NotificationTopicAction(enum.Enum):
     @property
     def display(self) -> str:
         return f"{self.topic}:{self.action}"
-
-    @property
-    def is_critical(self) -> bool:
-        """Whether the notification is critical cannot be disabled."""
-        return not self.user_editable
 
     def __str__(self) -> str:
         return self.display
@@ -156,7 +144,7 @@ class NotificationTopicAction(enum.Enum):
     birthdate__change = ("birthdate:change", dt_sec, False, nd.BirthdateChange)
     api_key__create = ("api_key:create", dt_sec, False, nd.ApiKeyCreate)
 
-    donation__received = ("donation:received", dt_sec, False, nd.DonationReceived)
+    donation__received = ("donation:received", dt_sec, True, nd.DonationReceived)
 
     onboarding__reminder = ("onboarding:reminder", dt_sec, True, empty_pb2.Empty)
 

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -27,7 +27,6 @@ from couchers.notifications.quick_links import (
 from couchers.notifications.render_email import render_email_notification
 from couchers.notifications.render_push import render_push_notification
 from couchers.notifications.settings import get_preference
-from couchers.notifications.utils import ACCOUNT_DELETION_TOPIC
 from couchers.proto.internal import jobs_pb2
 from couchers.sql import moderation_state_column_visible
 from couchers.templating import Jinja2Template, template_folder
@@ -37,18 +36,6 @@ logger = logging.getLogger(__name__)
 
 
 def _send_email_notification(session: Session, user: User, notification: Notification) -> None:
-    if user.do_not_email and not notification.topic_action.is_critical:
-        logger.info(f"Not emailing {user} based on notification {notification.topic_action} due to emails turned off")
-        return
-
-    if user.is_banned:
-        logger.info(f"Tried emailing {user} based on notification {notification.topic_action} but user is banned")
-        return
-
-    if user.is_deleted and notification.topic != ACCOUNT_DELETION_TOPIC:
-        logger.info(f"Tried emailing {user} based on notification {notification.topic_action} but user is deleted")
-        return
-
     loc_context = LocalizationContext.from_user(user)
     if not config["ENABLE_NOTIFICATION_TRANSLATIONS"]:
         loc_context = dataclasses.replace(loc_context, locale="en")
@@ -63,18 +50,14 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         "time": notification.created,
         "footer_timezone_name": loc_context.localized_timezone,
         "footer_copyright_year": now().year,
+        "footer_email_is_critical": rendered.is_critical,
+        "footer_manage_notifications_link": urls.notification_settings_link(),
+        "footer_notification_topic_action": rendered.topic_action_unsubscribe_text,
+        "footer_notification_topic_action_link": generate_unsub_topic_action(notification),
+        "footer_notification_topic_key": rendered.topic_key_unsubscribe_text,
+        "footer_notification_topic_key_link": generate_unsub_topic_key(notification),
+        "footer_do_not_email_link": generate_do_not_email(user),
     }
-
-    if notification.topic_action.is_critical:
-        template_args["footer_email_is_critical"] = True
-    else:
-        template_args["footer_email_is_critical"] = False
-        template_args["footer_manage_notifications_link"] = urls.notification_settings_link()
-        template_args["footer_notification_topic_action"] = rendered.topic_action_unsubscribe_text
-        template_args["footer_notification_topic_action_link"] = generate_unsub_topic_action(notification)
-        template_args["footer_notification_topic_key"] = rendered.topic_key_unsubscribe_text
-        template_args["footer_notification_topic_key_link"] = generate_unsub_topic_key(notification)
-        template_args["footer_do_not_email_link"] = generate_do_not_email(user)
 
     # Format plaintext template
     plain_tmplt_body = (template_folder / f"{rendered.template_name}.txt").read_text()
@@ -87,6 +70,18 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         source=(template_folder / "generated_html" / f"{rendered.template_name}.html").read_text(), html=True
     )
     html = html_tmplt.render(template_args, loc_context)
+
+    if user.do_not_email and not rendered.is_critical:
+        logger.info(f"Not emailing {user} based on template {rendered.template_name} due to emails turned off")
+        return
+
+    if user.is_banned:
+        logger.info(f"Tried emailing {user} based on template {rendered.template_name} but user is banned")
+        return
+
+    if user.is_deleted and not rendered.allow_deleted:
+        logger.info(f"Tried emailing {user} based on template {rendered.template_name} but user is deleted")
+        return
 
     list_unsubscribe_header = None
     if rendered.list_unsubscribe_url:

--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -15,6 +15,10 @@ logger = logging.getLogger(__name__)
 
 @dataclass(kw_only=True)
 class RenderedEmailNotification:
+    # whether the notification is critical and cannot be turned off
+    is_critical: bool = False
+    # whether this email can be sent to someone who is deleted
+    allow_deleted: bool = False
     # email subject
     subject: str
     # shows up when listing emails in many clients
@@ -137,6 +141,7 @@ def render_email_notification(
         title = "Your password was changed"
         message = "Your login password for Couchers.org was changed."
         return RenderedEmailNotification(
+            is_critical=True,
             subject=title,
             preview=message,
             template_name="security",
@@ -148,6 +153,7 @@ def render_email_notification(
     elif notification.topic_action == NotificationTopicAction.password_reset__start:
         message = "Someone initiated a password change on your account."
         return RenderedEmailNotification(
+            is_critical=True,
             subject="Reset your Couchers.org password",
             preview=message,
             template_name="password_reset",
@@ -159,6 +165,7 @@ def render_email_notification(
         title = "Your password was successfully reset"
         message = "Your password on Couchers.org was changed. If that was you, then no further action is needed."
         return RenderedEmailNotification(
+            is_critical=True,
             subject=title,
             preview=title,
             template_name="security",
@@ -171,6 +178,7 @@ def render_email_notification(
         title = "An email change was initiated on your account"
         message = f"An email change to the email <b>{data.new_email}</b> was initiated on your account."
         return RenderedEmailNotification(
+            is_critical=True,
             subject=title,
             preview=title,
             template_name="security",
@@ -183,6 +191,7 @@ def render_email_notification(
         title = "Email change completed"
         message = "Your new email address has been verified."
         return RenderedEmailNotification(
+            is_critical=True,
             subject=title,
             preview=message,
             template_name="security",
@@ -195,6 +204,7 @@ def render_email_notification(
         title = "Phone verification started"
         message = f"You started phone number verification with the number <b>{format_phone_number(data.phone)}</b>."
         return RenderedEmailNotification(
+            is_critical=True,
             subject=title,
             preview=message,
             template_name="security",
@@ -208,6 +218,7 @@ def render_email_notification(
         message = f"Your phone was successfully verified as <b>{format_phone_number(data.phone)}</b> on Couchers.org."
         message_plain = f"Your phone was successfully verified as {format_phone_number(data.phone)} on Couchers.org."
         return RenderedEmailNotification(
+            is_critical=True,
             subject=title,
             preview=message_plain,
             template_name="security",
@@ -221,6 +232,7 @@ def render_email_notification(
         message = f"Your gender on Couchers.org was changed to <b>{data.gender}</b> by an admin."
         message_plain = f"Your gender on Couchers.org was changed to {data.gender} by an admin."
         return RenderedEmailNotification(
+            is_critical=True,
             subject=title,
             preview=message_plain,
             template_name="security",
@@ -235,6 +247,7 @@ def render_email_notification(
         message = f"Your date of birth on Couchers.org was changed to <b>{birthdate}</b> by an admin."
         message_plain = f"Your date of birth on Couchers.org was changed to {birthdate} by an admin."
         return RenderedEmailNotification(
+            is_critical=True,
             subject=title,
             preview=message_plain,
             template_name="security",
@@ -245,6 +258,7 @@ def render_email_notification(
         )
     elif notification.topic_action == NotificationTopicAction.api_key__create:
         return RenderedEmailNotification(
+            is_critical=True,
             subject="Your API key for Couchers.org",
             preview="We have issued you an API key as per your request.",
             template_name="api_key",
@@ -277,6 +291,7 @@ def render_email_notification(
             },
         )
         return RenderedEmailNotification(
+            is_critical=True,
             subject=title,
             preview=message,
             template_name="donation_received",
@@ -284,7 +299,6 @@ def render_email_notification(
                 "amount": data.amount,
                 "receipt_url": data.receipt_url,
             },
-            topic_action_unsubscribe_text="donations received",
         )
     elif notification.topic_action == NotificationTopicAction.friend_request__create:
         other = data.other_user
@@ -314,6 +328,8 @@ def render_email_notification(
         )
     elif notification.topic_action == NotificationTopicAction.account_deletion__start:
         return RenderedEmailNotification(
+            is_critical=True,
+            allow_deleted=True,
             subject="Confirm your Couchers.org account deletion",
             preview="Please confirm that you want to delete your Couchers.org account.",
             template_name="account_deletion_start",
@@ -324,6 +340,8 @@ def render_email_notification(
     elif notification.topic_action == NotificationTopicAction.account_deletion__complete:
         title = "Your Couchers.org account has been deleted"
         return RenderedEmailNotification(
+            is_critical=True,
+            allow_deleted=True,
             subject=title,
             preview="We have deleted your Couchers.org account, to undo, follow the link in this email.",
             template_name="account_deletion_complete",
@@ -336,6 +354,8 @@ def render_email_notification(
         title = "Your Couchers.org account has been recovered!"
         subtitle = "We have recovered your Couchers.org account as per your request! Welcome back!"
         return RenderedEmailNotification(
+            is_critical=True,
+            allow_deleted=True,
             subject=title,
             preview=subtitle,
             template_name="account_deletion_recovered",
@@ -634,6 +654,7 @@ def render_email_notification(
         title = "You have received a mod note"
         message = "You have received an important note from the moderators. You must read and acknowledge it before continuing to use the platform."
         return RenderedEmailNotification(
+            is_critical=True,
             subject=title,
             preview=message,
             template_name="mod_note",
@@ -643,6 +664,7 @@ def render_email_notification(
         title = "Strong Verification succeeded"
         message = "You have been verified with Strong Verification! You will now see a tick next to your name on the platform."
         return RenderedEmailNotification(
+            is_critical=True,
             subject=title,
             preview=message,
             template_name="strong_verification_success",
@@ -661,6 +683,7 @@ def render_email_notification(
         else:
             raise Exception("Shouldn't get here")
         return RenderedEmailNotification(
+            is_critical=True,
             subject=title,
             preview=title,
             template_name="security",
@@ -674,6 +697,7 @@ def render_email_notification(
             title = "Your verification postcard is on its way"
             message = f"We've sent a postcard with your verification code to {data.city}, {data.country}. It should arrive within 1-3 weeks depending on your location. Once it arrives, enter the code on the platform to complete verification."
             return RenderedEmailNotification(
+                is_critical=True,
                 subject=title,
                 preview=message,
                 template_name="security",
@@ -686,6 +710,7 @@ def render_email_notification(
             title = "Postal Verification succeeded"
             message = "You have been verified with Postal Verification! Your address has been confirmed."
             return RenderedEmailNotification(
+                is_critical=True,
                 subject=title,
                 preview=message,
                 template_name="security",
@@ -705,6 +730,7 @@ def render_email_notification(
                     "Your postal verification attempt has failed. You can start a new verification attempt."
                 )
             return RenderedEmailNotification(
+                is_critical=True,
                 subject=title,
                 preview=title,
                 template_name="security",

--- a/app/backend/src/couchers/notifications/utils.py
+++ b/app/backend/src/couchers/notifications/utils.py
@@ -3,5 +3,3 @@ from couchers.models import NotificationTopicAction
 enum_from_topic_action: dict[tuple[str, str], NotificationTopicAction] = {
     (item.topic, item.action): item for item in NotificationTopicAction
 }
-
-ACCOUNT_DELETION_TOPIC = NotificationTopicAction.account_deletion__start.topic


### PR DESCRIPTION
This reverts commit 57c7a71d883edd3467c0356b4149e1fbdda378c1.

@aapeliv asked for more discussion about the changes to notifications. I'll repush a PR for further review.

## Testing
N/A, this is a revert.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me