### PR TITLE
Backend: further abstract which notifications can be sent to deleted users

### DIFF
--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -27,7 +27,7 @@ from couchers.notifications.quick_links import (
 from couchers.notifications.render_email import render_email_notification
 from couchers.notifications.render_push import render_push_notification
 from couchers.notifications.settings import get_preference
-from couchers.notifications.utils import ACCOUNT_DELETION_TOPIC
+from couchers.notifications.utils import can_notify_deleted_user
 from couchers.proto.internal import jobs_pb2
 from couchers.sql import moderation_state_column_visible
 from couchers.templating import Jinja2Template, template_folder
@@ -45,7 +45,7 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         logger.info(f"Tried emailing {user} based on notification {notification.topic_action} but user is banned")
         return
 
-    if user.is_deleted and notification.topic != ACCOUNT_DELETION_TOPIC:
+    if user.is_deleted and not can_notify_deleted_user(notification.topic_action):
         logger.info(f"Tried emailing {user} based on notification {notification.topic_action} but user is deleted")
         return
 

--- a/app/backend/src/couchers/notifications/utils.py
+++ b/app/backend/src/couchers/notifications/utils.py
@@ -4,4 +4,13 @@ enum_from_topic_action: dict[tuple[str, str], NotificationTopicAction] = {
     (item.topic, item.action): item for item in NotificationTopicAction
 }
 
-ACCOUNT_DELETION_TOPIC = NotificationTopicAction.account_deletion__start.topic
+
+_DELETED_USER_NOTIFICATIONS = {
+    NotificationTopicAction.account_deletion__start,
+    NotificationTopicAction.account_deletion__complete,
+    NotificationTopicAction.account_deletion__recovered,
+}
+
+
+def can_notify_deleted_user(topic_action: NotificationTopicAction) -> bool:
+    return topic_action in _DELETED_USER_NOTIFICATIONS


### PR DESCRIPTION
Decouples testing for that with knowing about the account deletion flow, and allows to later expand the set of allowed cases.

## Testing
N/A

**Backend checklist**
<!-- To avoid CI failures, first run `make format` in app/backend and run tests locally. -->
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me