### PR TITLE
Backend/emails: Generalize list-unsubscribe header

### DIFF
--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -24,7 +24,7 @@ from couchers.notifications.quick_links import (
     generate_unsub_topic_action,
     generate_unsub_topic_key,
 )
-from couchers.notifications.render_email import render_email_notification
+from couchers.notifications.render_email import render_email_notification, get_list_unsubscribe_header
 from couchers.notifications.render_push import render_push_notification
 from couchers.notifications.settings import get_preference
 from couchers.notifications.utils import ACCOUNT_DELETION_TOPIC
@@ -70,11 +70,15 @@ def _send_email_notification(session: Session, user: User, notification: Notific
     else:
         template_args["footer_email_is_critical"] = False
         template_args["footer_manage_notifications_link"] = urls.notification_settings_link()
-        template_args["footer_notification_topic_action"] = rendered.topic_action_unsubscribe_text
-        template_args["footer_notification_topic_action_link"] = generate_unsub_topic_action(notification)
-        template_args["footer_notification_topic_key"] = rendered.topic_key_unsubscribe_text
-        template_args["footer_notification_topic_key_link"] = generate_unsub_topic_key(notification)
         template_args["footer_do_not_email_link"] = generate_do_not_email(user)
+
+        if rendered.topic_action_unsubscribe_text:
+            template_args["footer_notification_topic_action"] = rendered.topic_action_unsubscribe_text
+            template_args["footer_notification_topic_action_link"] = generate_unsub_topic_action(notification)
+
+        if rendered.topic_key_unsubscribe_text:
+            template_args["footer_notification_topic_key"] = rendered.topic_key_unsubscribe_text
+            template_args["footer_notification_topic_key_link"] = generate_unsub_topic_key(notification)
 
     # Format plaintext template
     plain_tmplt_body = (template_folder / f"{rendered.template_name}.txt").read_text()
@@ -88,10 +92,7 @@ def _send_email_notification(session: Session, user: User, notification: Notific
     )
     html = html_tmplt.render(template_args, loc_context)
 
-    list_unsubscribe_header = None
-    if rendered.list_unsubscribe_url:
-        list_unsubscribe_header = f"<{rendered.list_unsubscribe_url}>"
-
+    list_unsubscribe_header = get_list_unsubscribe_header(notification)
     queue_email(
         session,
         sender_name=config["NOTIFICATION_EMAIL_SENDER"],

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -24,7 +24,7 @@ from couchers.notifications.quick_links import (
     generate_unsub_topic_action,
     generate_unsub_topic_key,
 )
-from couchers.notifications.render_email import render_email_notification, get_list_unsubscribe_header
+from couchers.notifications.render_email import get_list_unsubscribe_header, render_email_notification
 from couchers.notifications.render_push import render_push_notification
 from couchers.notifications.settings import get_preference
 from couchers.notifications.utils import ACCOUNT_DELETION_TOPIC

--- a/app/backend/src/couchers/notifications/quick_links.py
+++ b/app/backend/src/couchers/notifications/quick_links.py
@@ -22,6 +22,7 @@ from couchers.models import (
     MeetupStatus,
     Notification,
     NotificationDeliveryType,
+    NotificationTopicAction,
     User,
 )
 from couchers.notifications import settings
@@ -84,6 +85,18 @@ def generate_quick_decline_link(host_request: requests_pb2.HostRequest) -> str:
             ),
         )
     )
+
+
+def can_unsubscribe_topic_key(topic: str | NotificationTopicAction) -> bool:
+    """
+    Determines whether a user can unsubscribe from all notification actions
+    concerning a given topic.
+    """
+    if isinstance(topic, NotificationTopicAction):
+        topic = topic.topic
+    # We currently only support unsubscribing from chat topics
+    return topic == NotificationTopicAction.chat__message.topic
+
 
 
 def respond_quick_link(request: auth_pb2.UnsubscribeReq, context: CouchersContext, session: Session) -> str:

--- a/app/backend/src/couchers/notifications/quick_links.py
+++ b/app/backend/src/couchers/notifications/quick_links.py
@@ -98,7 +98,6 @@ def can_unsubscribe_topic_key(topic: str | NotificationTopicAction) -> bool:
     return topic == NotificationTopicAction.chat__message.topic
 
 
-
 def respond_quick_link(request: auth_pb2.UnsubscribeReq, context: CouchersContext, session: Session) -> str:
     """
     Returns a response string or uses context.abort upon error

--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -6,7 +6,8 @@ from couchers import urls
 from couchers.i18n import LocalizationContext
 from couchers.i18n.localize import format_phone_number
 from couchers.models import Notification, NotificationTopicAction
-from couchers.notifications.quick_links import generate_quick_decline_link, generate_unsub_topic_action
+from couchers.notifications.quick_links import generate_quick_decline_link, generate_unsub_topic_action, generate_unsub_topic_key
+from couchers.notifications.utils import can_unsubscribe_topic_key
 from couchers.proto import api_pb2, notification_data_pb2
 from couchers.utils import now, to_aware_datetime
 
@@ -27,8 +28,6 @@ class RenderedEmailNotification:
     topic_action_unsubscribe_text: str | None = None
     # the link label on the topic_key unsubscribe link
     topic_key_unsubscribe_text: str | None = None
-    # url to unsubscribe with one click
-    list_unsubscribe_url: str | None = None
 
 
 def render_email_notification(
@@ -265,8 +264,7 @@ def render_email_notification(
                 "actioned": actioned,
                 "unsub_type": "badge additions" if notification.action == "add" else "badge removals",
             },
-            topic_action_unsubscribe_text="badge additions" if notification.action == "add" else "badge removals",
-            list_unsubscribe_url=generate_unsub_topic_action(notification),
+            topic_action_unsubscribe_text="badge additions" if notification.action == "add" else "badge removals"
         )
     elif notification.topic_action == NotificationTopicAction.donation__received:
         title = loc_context.localize_string("notifications.donation_received.title")
@@ -739,6 +737,21 @@ def render_email_notification(
         )
 
     raise NotImplementedError(f"Unknown topic-action: {notification.topic}:{notification.action}")
+
+
+def get_list_unsubscribe_header(notification: Notification) -> str | None:
+    if notification.topic_action.is_critical:
+        return None
+
+    # We can only have one List-Unsubscribe header.
+    # Prefer topic-key unsubscription as it is more specific than topic-action (e.g. current chat, not all chats).
+    list_unsubscribe_url: str
+    if can_unsubscribe_topic_key(notification.topic):
+        list_unsubscribe_url = generate_unsub_topic_key(notification)
+    else:
+        list_unsubscribe_url = generate_unsub_topic_action(notification)
+
+    return f"<{list_unsubscribe_url}>"
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -7,11 +7,11 @@ from couchers.i18n import LocalizationContext
 from couchers.i18n.localize import format_phone_number
 from couchers.models import Notification, NotificationTopicAction
 from couchers.notifications.quick_links import (
+    can_unsubscribe_topic_key,
     generate_quick_decline_link,
     generate_unsub_topic_action,
     generate_unsub_topic_key,
 )
-from couchers.notifications.utils import can_unsubscribe_topic_key
 from couchers.proto import api_pb2, notification_data_pb2
 from couchers.utils import now, to_aware_datetime
 

--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -6,7 +6,11 @@ from couchers import urls
 from couchers.i18n import LocalizationContext
 from couchers.i18n.localize import format_phone_number
 from couchers.models import Notification, NotificationTopicAction
-from couchers.notifications.quick_links import generate_quick_decline_link, generate_unsub_topic_action, generate_unsub_topic_key
+from couchers.notifications.quick_links import (
+    generate_quick_decline_link,
+    generate_unsub_topic_action,
+    generate_unsub_topic_key,
+)
 from couchers.notifications.utils import can_unsubscribe_topic_key
 from couchers.proto import api_pb2, notification_data_pb2
 from couchers.utils import now, to_aware_datetime
@@ -264,7 +268,7 @@ def render_email_notification(
                 "actioned": actioned,
                 "unsub_type": "badge additions" if notification.action == "add" else "badge removals",
             },
-            topic_action_unsubscribe_text="badge additions" if notification.action == "add" else "badge removals"
+            topic_action_unsubscribe_text="badge additions" if notification.action == "add" else "badge removals",
         )
     elif notification.topic_action == NotificationTopicAction.donation__received:
         title = loc_context.localize_string("notifications.donation_received.title")

--- a/app/backend/src/couchers/notifications/utils.py
+++ b/app/backend/src/couchers/notifications/utils.py
@@ -6,6 +6,7 @@ enum_from_topic_action: dict[tuple[str, str], NotificationTopicAction] = {
 
 ACCOUNT_DELETION_TOPIC = NotificationTopicAction.account_deletion__start.topic
 
+
 def can_unsubscribe_topic_key(topic: str | NotificationTopicAction) -> bool:
     """
     Determines whether a user can unsubscribe from all notification actions

--- a/app/backend/src/couchers/notifications/utils.py
+++ b/app/backend/src/couchers/notifications/utils.py
@@ -5,4 +5,3 @@ enum_from_topic_action: dict[tuple[str, str], NotificationTopicAction] = {
 }
 
 ACCOUNT_DELETION_TOPIC = NotificationTopicAction.account_deletion__start.topic
-

--- a/app/backend/src/couchers/notifications/utils.py
+++ b/app/backend/src/couchers/notifications/utils.py
@@ -6,13 +6,3 @@ enum_from_topic_action: dict[tuple[str, str], NotificationTopicAction] = {
 
 ACCOUNT_DELETION_TOPIC = NotificationTopicAction.account_deletion__start.topic
 
-
-def can_unsubscribe_topic_key(topic: str | NotificationTopicAction) -> bool:
-    """
-    Determines whether a user can unsubscribe from all notification actions
-    concerning a given topic.
-    """
-    if isinstance(topic, NotificationTopicAction):
-        topic = topic.topic
-    # We currently only support unsubscribing from chat topics
-    return topic == NotificationTopicAction.chat__message.topic

--- a/app/backend/src/couchers/notifications/utils.py
+++ b/app/backend/src/couchers/notifications/utils.py
@@ -5,3 +5,13 @@ enum_from_topic_action: dict[tuple[str, str], NotificationTopicAction] = {
 }
 
 ACCOUNT_DELETION_TOPIC = NotificationTopicAction.account_deletion__start.topic
+
+def can_unsubscribe_topic_key(topic: str | NotificationTopicAction) -> bool:
+    """
+    Determines whether a user can unsubscribe from all notification actions
+    concerning a given topic.
+    """
+    if isinstance(topic, NotificationTopicAction):
+        topic = topic.topic
+    # We currently only support unsubscribing from chat topics
+    return topic == NotificationTopicAction.chat__message.topic


### PR DESCRIPTION
The `list-unsubscribe` smtp header was only set for a few notifications. Instead of adding it individually to all notifications, this adds a function to determine if a topic supports topic-key unsubscription, so the list-unsubscribe header logic can be decoupled from the email rendering logic, which is now only about rendering the body and title.

While doing this change I found this possible issue with our unsubscription logic: #7842

## Testing
N/A

**Backend checklist**
<!-- To avoid CI failures, first run `make format` in app/backend and run tests locally. -->
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me