### PR TITLE
Frontend/i18n: Improve request status changed translatability

### DIFF
--- a/app/web/features/messages/constants.ts
+++ b/app/web/features/messages/constants.ts
@@ -13,4 +13,17 @@ export const requestStatusToTransKey = {
     "host_request_status.rejected",
 } as const;
 
+export const requestStatusChangedMessageToTransKey = {
+  [HostRequestStatus.HOST_REQUEST_STATUS_ACCEPTED]:
+    "control_message.host_request_status_changed.accepted",
+  [HostRequestStatus.HOST_REQUEST_STATUS_CANCELLED]:
+    "control_message.host_request_status_changed.cancelled",
+  [HostRequestStatus.HOST_REQUEST_STATUS_CONFIRMED]:
+    "control_message.host_request_status_changed.confirmed",
+  [HostRequestStatus.HOST_REQUEST_STATUS_REJECTED]:
+    "control_message.host_request_status_changed.rejected",
+  // There's no flow in which a request status transitions back to pending.
+  [HostRequestStatus.HOST_REQUEST_STATUS_PENDING]: null,
+} as const;
+
 export const MARK_LAST_SEEN_TIMEOUT = 500;

--- a/app/web/features/messages/locales/en.json
+++ b/app/web/features/messages/locales/en.json
@@ -120,7 +120,6 @@
     "user_left_chat_text": "{{user}} left the chat",
     "admin_assignment_text": "{{user}} made {{target_user}} an admin",
     "admin_removal_text": "{{user}} removed {{target_user}} as admin",
-    "host_request_status_changed_text": "{{user}} changed the request to {{status}}",
     "host_request_status_changed": {
       "accepted": "{{user}} has accepted the request",
       "cancelled": "{{user}} has cancelled the request",

--- a/app/web/features/messages/locales/en.json
+++ b/app/web/features/messages/locales/en.json
@@ -121,6 +121,12 @@
     "admin_assignment_text": "{{user}} made {{target_user}} an admin",
     "admin_removal_text": "{{user}} removed {{target_user}} as admin",
     "host_request_status_changed_text": "{{user}} changed the request to {{status}}",
+    "host_request_status_changed": {
+      "accepted": "{{user}} has accepted the request",
+      "cancelled": "{{user}} has cancelled the request",
+      "confirmed": "{{user}} has confirmed the request",
+      "rejected": "{{user}} has rejected the request"
+    },
     "unknown_message_text": "Unknown control message"
   },
   "host_request_status": {

--- a/app/web/features/messages/utils.ts
+++ b/app/web/features/messages/utils.ts
@@ -1,9 +1,9 @@
 import { useLiteUsers } from "features/userQueries/useLiteUsers";
 import { TFunction } from "i18next";
-import { GroupChat, Message } from "proto/conversations_pb";
+import { GroupChat, HostRequestStatus, Message } from "proto/conversations_pb";
 import { firstName } from "utils/names";
 
-import { requestStatusToTransKey } from "./constants";
+import { requestStatusChangedMessageToTransKey } from "./constants";
 
 export function isControlMessage(message: Message.AsObject) {
   return !message.text;
@@ -53,12 +53,14 @@ export function controlMessage({
       target_user,
     });
   } else if (message.hostRequestStatusChanged) {
-    return t("control_message.host_request_status_changed_text", {
-      user,
-      status: t(
-        requestStatusToTransKey[message.hostRequestStatusChanged.status],
-      ),
-    });
+    let transKey =
+      requestStatusChangedMessageToTransKey[
+        message.hostRequestStatusChanged.status
+      ];
+    if (transKey == null) {
+      throw Error(t("control_message.unknown_message_text"));
+    }
+    return t(transKey, { user: userCap });
   } else {
     throw Error(t("control_message.unknown_message_text"));
   }

--- a/app/web/features/messages/utils.ts
+++ b/app/web/features/messages/utils.ts
@@ -1,6 +1,6 @@
 import { useLiteUsers } from "features/userQueries/useLiteUsers";
 import { TFunction } from "i18next";
-import { GroupChat, HostRequestStatus, Message } from "proto/conversations_pb";
+import { GroupChat, Message } from "proto/conversations_pb";
 import { firstName } from "utils/names";
 
 import { requestStatusChangedMessageToTransKey } from "./constants";
@@ -53,7 +53,7 @@ export function controlMessage({
       target_user,
     });
   } else if (message.hostRequestStatusChanged) {
-    let transKey =
+    const transKey =
       requestStatusChangedMessageToTransKey[
         message.hostRequestStatusChanged.status
       ];


### PR DESCRIPTION
Fixes #7756, a minor issue with the "request status changed" message that resulted in awkward capitalization and possibly grammar.

Before:

<img width="390" height="146" alt="image" src="https://github.com/user-attachments/assets/85673718-5b76-447e-a245-7c55efa51c48" />

After:

<img width="349" height="367" alt="image" src="https://github.com/user-attachments/assets/2ece347a-e30f-4bb7-9750-43e6a169940f" />

## Testing
Ran frontend against NEXT backend and looked at existing host request.

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` and `yarn lint --fix` in app/web, and run tests locally. -->
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
