### PR TITLE
Frontend/profile: Switch pronouns to text input for i18n

### DIFF
--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -783,59 +783,11 @@ export default function EditProfileForm() {
               </SectionSubtitle>
 
               <FieldGroup>
-                <Typography variant="h3" gutterBottom>
-                  {t("profile:edit_profile_headings.pronouns")}
-                </Typography>
-                <Controller
-                  control={control}
+                <StyledProfileTextInput
+                  id="pronouns"
+                  {...register("pronouns")}
+                  label={t("profile:edit_profile_headings.pronouns")}
                   defaultValue={user.pronouns}
-                  name="pronouns"
-                  render={({ field }) => {
-                    const other =
-                      field.value === t("profile:pronouns.woman") ||
-                      field.value === t("profile:pronouns.man")
-                        ? ""
-                        : field.value;
-                    return (
-                      <RadioGroupContainer>
-                        <StyledRadioGroup
-                          {...field}
-                          row
-                          aria-label={t(
-                            "profile:edit_profile_headings.pronouns",
-                          )}
-                          name="pronouns"
-                          value={field.value}
-                          onChange={(_, value) => field.onChange(value)}
-                        >
-                          <FormControlLabel
-                            value={t("profile:pronouns.woman")}
-                            control={<Radio />}
-                            label={t("profile:pronouns.woman")}
-                          />
-                          <FormControlLabel
-                            value={t("profile:pronouns.man")}
-                            control={<Radio />}
-                            label={t("profile:pronouns.man")}
-                          />
-                          <FormControlLabel
-                            value={other}
-                            control={<Radio />}
-                            label={
-                              <TextField
-                                id="pronouns-other"
-                                variant="standard"
-                                onChange={(event) =>
-                                  field.onChange(event.target.value)
-                                }
-                                value={other}
-                              />
-                            }
-                          />
-                        </StyledRadioGroup>
-                      </RadioGroupContainer>
-                    );
-                  }}
                 />
               </FieldGroup>
 

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -543,6 +543,16 @@ export default function EditProfileForm() {
               </FieldGroup>
 
               <FieldGroup>
+                <StyledProfileTextInput
+                  id="pronouns"
+                  {...register("pronouns")}
+                  label={t("profile:edit_profile_headings.pronouns")}
+                  defaultValue={user.pronouns}
+                  placeholder={t("profile:edit_profile_pronouns_placeholder")}
+                />
+              </FieldGroup>
+
+              <FieldGroup>
                 <SectionSubtitle>
                   {t("profile:edit_profile_headings.location_subtitle")}
                 </SectionSubtitle>
@@ -760,15 +770,6 @@ export default function EditProfileForm() {
                   "profile:edit_profile_headings.personal_information_subtitle",
                 )}
               </SectionSubtitle>
-
-              <FieldGroup>
-                <StyledProfileTextInput
-                  id="pronouns"
-                  {...register("pronouns")}
-                  label={t("profile:edit_profile_headings.pronouns")}
-                  defaultValue={user.pronouns}
-                />
-              </FieldGroup>
 
               {languages && (
                 <FieldGroup>

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -2,11 +2,8 @@ import { Cancel, CheckCircle, Help, InfoOutlined } from "@mui/icons-material";
 import {
   Box,
   DialogContent,
-  FormControlLabel,
   List,
   ListItem,
-  Radio,
-  RadioGroup,
   styled,
   Tooltip,
   Typography,
@@ -20,7 +17,6 @@ import EditLocationMap from "components/EditLocationMap";
 import GalleryEditor from "components/GalleryEditor/GalleryEditor";
 import Snackbar from "components/Snackbar";
 import StyledLink from "components/StyledLink";
-import TextField from "components/TextField";
 import { useLanguages } from "features/profile/hooks/useLanguages";
 import { useRegions } from "features/profile/hooks/useRegions";
 import useUpdateUserProfile from "features/profile/hooks/useUpdateUserProfile";
@@ -100,14 +96,6 @@ const SectionSubtitle = styled(Typography)(({ theme }) => ({
 
 const FieldGroup = styled(Box)(({ theme }) => ({
   marginBottom: theme.spacing(3),
-}));
-
-const RadioGroupContainer = styled(Box)(({ theme }) => ({
-  marginTop: theme.spacing(1),
-  "& .MuiFormControlLabel-root": {
-    marginRight: theme.spacing(3),
-    marginBottom: theme.spacing(1),
-  },
 }));
 
 const HelpTextContainer = styled(Box)(({ theme }) => ({
@@ -247,15 +235,6 @@ const styledField = <C extends React.ComponentType<React.ComponentProps<C>>>(
 const StyledProfileTextInput = styledField(ProfileTextInput);
 
 const StyledProfileMarkdownInput = styledField(ProfileMarkdownInput);
-
-const StyledRadioGroup = styled(RadioGroup)(() => ({
-  display: "flex",
-  flexDirection: "column",
-  [theme.breakpoints.up("sm")]: {
-    display: "grid",
-    gridTemplateColumns: "repeat(3, 1fr)",
-  },
-}));
 
 export default function EditProfileForm() {
   const { t } = useTranslation([GLOBAL, AUTH, PROFILE]);

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -2,11 +2,8 @@ import { Cancel, CheckCircle, Help, InfoOutlined } from "@mui/icons-material";
 import {
   Box,
   DialogContent,
-  FormControlLabel,
   List,
   ListItem,
-  Radio,
-  RadioGroup,
   styled,
   Typography,
 } from "@mui/material";
@@ -19,7 +16,6 @@ import EditLocationMap from "components/EditLocationMap";
 import GalleryEditor from "components/GalleryEditor/GalleryEditor";
 import Snackbar from "components/Snackbar";
 import StyledLink from "components/StyledLink";
-import TextField from "components/TextField";
 import { useLanguages } from "features/profile/hooks/useLanguages";
 import { useRegions } from "features/profile/hooks/useRegions";
 import useUpdateUserProfile from "features/profile/hooks/useUpdateUserProfile";
@@ -90,14 +86,6 @@ const SectionSubtitle = styled(Typography)(({ theme }) => ({
 
 const FieldGroup = styled(Box)(({ theme }) => ({
   marginBottom: theme.spacing(3),
-}));
-
-const RadioGroupContainer = styled(Box)(({ theme }) => ({
-  marginTop: theme.spacing(1),
-  "& .MuiFormControlLabel-root": {
-    marginRight: theme.spacing(3),
-    marginBottom: theme.spacing(1),
-  },
 }));
 
 const HelpTextContainer = styled(Box)(({ theme }) => ({
@@ -199,15 +187,6 @@ const styledField = <C extends React.ComponentType<React.ComponentProps<C>>>(
 const StyledProfileTextInput = styledField(ProfileTextInput);
 
 const StyledProfileMarkdownInput = styledField(ProfileMarkdownInput);
-
-const StyledRadioGroup = styled(RadioGroup)(() => ({
-  display: "flex",
-  flexDirection: "column",
-  [theme.breakpoints.up("sm")]: {
-    display: "grid",
-    gridTemplateColumns: "repeat(3, 1fr)",
-  },
-}));
 
 export default function EditProfileForm() {
   const { t } = useTranslation([GLOBAL, AUTH, PROFILE]);

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -682,59 +682,11 @@ export default function EditProfileForm() {
               </SectionSubtitle>
 
               <FieldGroup>
-                <Typography variant="h3" gutterBottom>
-                  {t("profile:edit_profile_headings.pronouns")}
-                </Typography>
-                <Controller
-                  control={control}
+                <StyledProfileTextInput
+                  id="pronouns"
+                  {...register("pronouns")}
+                  label={t("profile:edit_profile_headings.pronouns")}
                   defaultValue={user.pronouns}
-                  name="pronouns"
-                  render={({ field }) => {
-                    const other =
-                      field.value === t("profile:pronouns.woman") ||
-                      field.value === t("profile:pronouns.man")
-                        ? ""
-                        : field.value;
-                    return (
-                      <RadioGroupContainer>
-                        <StyledRadioGroup
-                          {...field}
-                          row
-                          aria-label={t(
-                            "profile:edit_profile_headings.pronouns",
-                          )}
-                          name="pronouns"
-                          value={field.value}
-                          onChange={(_, value) => field.onChange(value)}
-                        >
-                          <FormControlLabel
-                            value={t("profile:pronouns.woman")}
-                            control={<Radio />}
-                            label={t("profile:pronouns.woman")}
-                          />
-                          <FormControlLabel
-                            value={t("profile:pronouns.man")}
-                            control={<Radio />}
-                            label={t("profile:pronouns.man")}
-                          />
-                          <FormControlLabel
-                            value={other}
-                            control={<Radio />}
-                            label={
-                              <TextField
-                                id="pronouns-other"
-                                variant="standard"
-                                onChange={(event) =>
-                                  field.onChange(event.target.value)
-                                }
-                                value={other}
-                              />
-                            }
-                          />
-                        </StyledRadioGroup>
-                      </RadioGroupContainer>
-                    );
-                  }}
                 />
               </FieldGroup>
 

--- a/app/web/features/profile/locales/en.json
+++ b/app/web/features/profile/locales/en.json
@@ -89,7 +89,7 @@
     "meetup_status": "Meetup status",
     "hosting_status": "Hosting status",
     "name": "Name",
-    "pronouns": "Pronouns",
+    "pronouns": "Pronouns (optional)",
     "hometown": "Grew up in",
     "occupation": "Occupation",
     "education": "Education",
@@ -105,6 +105,7 @@
     "location_subtitle": "Approximate location of your home"
   },
   "edit_profile_name_required": "Name required",
+  "edit_profile_pronouns_placeholder": "e.g. she/her",
   "edit_home_questions": {
     "accept_drinking": "Okay with people drinking",
     "accept_pets": "Hosts people with pets",

--- a/app/web/features/profile/locales/en.json
+++ b/app/web/features/profile/locales/en.json
@@ -138,10 +138,6 @@
     "man": "Man",
     "woman": "Woman"
   },
-  "pronouns": {
-    "man": "he / him",
-    "woman": "she / her"
-  },
   "edit_profile_tab_bar_a11y_label": "tabs to edit different parts of your profile",
   "info_unanswered": "Ask me",
   "my_connections": "My connections",

--- a/app/web/features/profile/locales/en.json
+++ b/app/web/features/profile/locales/en.json
@@ -145,10 +145,6 @@
     "man": "Man",
     "woman": "Woman"
   },
-  "pronouns": {
-    "man": "he / him",
-    "woman": "she / her"
-  },
   "edit_profile_tab_bar_a11y_label": "tabs to edit different parts of your profile",
   "info_unanswered": "Ask me",
   "my_connections": "My connections",


### PR DESCRIPTION
Fixes #7438, see that bug for why a radio button is problematic for internationalization.

## Testing
<img width="646" height="553" alt="image" src="https://github.com/user-attachments/assets/47a60d76-7b6e-4d2a-8c67-5e344f1fd734" />
<img width="201" height="205" alt="image" src="https://github.com/user-attachments/assets/f442fe66-ecd4-40c9-9849-568fb22c8d8b" />
<img width="595" height="92" alt="image" src="https://github.com/user-attachments/assets/fea6b0a9-b413-4277-b48d-e9c3a3c3beea" />

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` and `yarn lint --fix` in app/web, and run tests locally. -->
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me