### PR TITLE
Backend: Add presence-based notification suppression

### DIFF
--- a/app/backend/src/couchers/constants.py
+++ b/app/backend/src/couchers/constants.py
@@ -116,3 +116,6 @@ GALLERY_MAX_PHOTOS_NOT_VERIFIED = 1
 GALLERY_MAX_PHOTOS_VERIFIED = 4
 
 COMPLETED_PROFILE_MINIMUM_CHAR_LENGTH = 150
+
+# How long presence is considered active for suppressing notifications
+PRESENCE_ACTIVE_DURATION = timedelta(seconds=30)

--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -310,6 +310,11 @@ emails_counter: Counter = Counter(
     "Number of emails sent",
 )
 
+notification_suppressed_presence_counter: Counter = Counter(
+    "couchers_notification_suppressed_presence_total",
+    "Number of notifications suppressed because user is viewing conversation",
+)
+
 
 recaptchas_assessed_counter: Counter = Counter(
     "couchers_recaptchas_assessed_total",

--- a/app/backend/src/couchers/migrations/versions/a8c3d2e1f094_add_last_viewing_at.py
+++ b/app/backend/src/couchers/migrations/versions/a8c3d2e1f094_add_last_viewing_at.py
@@ -1,0 +1,27 @@
+"""Add last_viewing_at to group_chat_subscriptions
+
+Revision ID: a8c3d2e1f094
+Revises: 738c3c9f922e
+Create Date: 2026-02-05 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a8c3d2e1f094"
+down_revision = "738c3c9f922e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "group_chat_subscriptions",
+        sa.Column("last_viewing_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("group_chat_subscriptions", "last_viewing_at")

--- a/app/backend/src/couchers/models/conversations.py
+++ b/app/backend/src/couchers/models/conversations.py
@@ -90,6 +90,9 @@ class GroupChatSubscription(Base, kw_only=True):
         DateTime(timezone=True), server_default=DATETIME_MINUS_INFINITY.isoformat(), init=False
     )
 
+    # when the user last actively viewed this conversation (for presence-based notification suppression)
+    last_viewing_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
+
     user: Mapped[User] = relationship(init=False, backref="group_chat_subscriptions")
     group_chat: Mapped[GroupChat] = relationship(init=False, back_populates="subscriptions")
 

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -9,13 +9,13 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import func, not_, or_
 
-from couchers.constants import DATETIME_INFINITY, DATETIME_MINUS_INFINITY
+from couchers.constants import DATETIME_INFINITY, DATETIME_MINUS_INFINITY, PRESENCE_ACTIVE_DURATION
 from couchers.context import CouchersContext, make_background_user_context
 from couchers.db import session_scope
 from couchers.event_log import log_event
 from couchers.helpers.completed_profile import has_completed_profile
 from couchers.jobs.enqueue import queue_job
-from couchers.metrics import sent_messages_counter
+from couchers.metrics import notification_suppressed_presence_counter, sent_messages_counter
 from couchers.models import (
     Conversation,
     GroupChat,
@@ -179,6 +179,28 @@ def generate_message_notifications(payload: jobs_pb2.GenerateMessageNotification
             return
 
         context = make_background_user_context(user_id=message.author_id)
+        # Skip users who are currently viewing the conversation
+        presence_cutoff = now() - PRESENCE_ACTIVE_DURATION
+
+        # Count users suppressed due to presence (for metrics)
+        presence_suppressed_count = session.execute(
+            where_users_column_visible(
+                select(func.count(GroupChatSubscription.user_id))
+                .where(GroupChatSubscription.group_chat_id == message.conversation_id)
+                .where(GroupChatSubscription.user_id != message.author_id)
+                .where(GroupChatSubscription.joined <= message.time)
+                .where(or_(GroupChatSubscription.left == None, GroupChatSubscription.left >= message.time))
+                .where(not_(GroupChatSubscription.is_muted))
+                .where(GroupChatSubscription.last_viewing_at >= presence_cutoff),
+                context=context,
+                column=GroupChatSubscription.user_id,
+            )
+        ).scalar_one()
+
+        if presence_suppressed_count > 0:
+            notification_suppressed_presence_counter.inc(presence_suppressed_count)
+            logger.debug(f"Suppressed {presence_suppressed_count} notifications due to user presence")
+
         user_ids_to_notify = (
             session.execute(
                 where_users_column_visible(
@@ -187,7 +209,13 @@ def generate_message_notifications(payload: jobs_pb2.GenerateMessageNotification
                     .where(GroupChatSubscription.user_id != message.author_id)
                     .where(GroupChatSubscription.joined <= message.time)
                     .where(or_(GroupChatSubscription.left == None, GroupChatSubscription.left >= message.time))
-                    .where(not_(GroupChatSubscription.is_muted)),
+                    .where(not_(GroupChatSubscription.is_muted))
+                    .where(
+                        or_(
+                            GroupChatSubscription.last_viewing_at == None,
+                            GroupChatSubscription.last_viewing_at < presence_cutoff,
+                        )
+                    ),
                     context=context,
                     column=GroupChatSubscription.user_id,
                 )
@@ -594,6 +622,30 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "cant_unsee_messages")
 
         subscription.last_seen_message_id = request.last_seen_message_id
+
+        return empty_pb2.Empty()
+
+    def MarkGroupChatViewing(
+        self, request: conversations_pb2.MarkGroupChatViewingReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
+        subscription = _get_visible_message_subscription(session, context, request.group_chat_id)
+
+        if not subscription:
+            context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "chat_not_found")
+
+        subscription.last_viewing_at = func.now()
+
+        return empty_pb2.Empty()
+
+    def StopGroupChatViewing(
+        self, request: conversations_pb2.StopGroupChatViewingReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
+        subscription = _get_visible_message_subscription(session, context, request.group_chat_id)
+
+        if not subscription:
+            context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "chat_not_found")
+
+        subscription.last_viewing_at = None
 
         return empty_pb2.Empty()
 

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -2023,3 +2023,416 @@ def test_incomplete_profile(db):
             c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user3.id]))
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
         assert e.value.details() == "You have to complete your profile before you can send a message."
+
+
+def test_mark_conversation_viewing(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    make_friends(user1, user2)
+
+    with conversations_session(token1) as c:
+        res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id]))
+        group_chat_id = res.group_chat_id
+
+    moderator.approve_group_chat(group_chat_id)
+
+    # Initially, last_viewing_at should be None
+    with session_scope() as session:
+        sub = session.execute(
+            select(GroupChatSubscription)
+            .where(GroupChatSubscription.group_chat_id == group_chat_id)
+            .where(GroupChatSubscription.user_id == user2.id)
+        ).scalar_one()
+        assert sub.last_viewing_at is None
+
+    # Mark conversation as being viewed
+    with conversations_session(token2) as c:
+        c.MarkGroupChatViewing(conversations_pb2.MarkGroupChatViewingReq(group_chat_id=group_chat_id))
+
+    # Now last_viewing_at should be set
+    with session_scope() as session:
+        sub = session.execute(
+            select(GroupChatSubscription)
+            .where(GroupChatSubscription.group_chat_id == group_chat_id)
+            .where(GroupChatSubscription.user_id == user2.id)
+        ).scalar_one()
+        assert sub.last_viewing_at is not None
+        assert sub.last_viewing_at <= now()
+
+
+def test_mark_conversation_viewing_not_found(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    make_friends(user1, user2)
+
+    with conversations_session(token1) as c:
+        res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id]))
+        group_chat_id = res.group_chat_id
+
+    moderator.approve_group_chat(group_chat_id)
+
+    # Create a third user who is not a member
+    user3, token3 = generate_user()
+
+    with conversations_session(token3) as c:
+        with pytest.raises(grpc.RpcError) as e:
+            c.MarkGroupChatViewing(conversations_pb2.MarkGroupChatViewingReq(group_chat_id=group_chat_id))
+        assert e.value.code() == grpc.StatusCode.NOT_FOUND
+
+    # Non-existent chat
+    with conversations_session(token1) as c:
+        with pytest.raises(grpc.RpcError) as e:
+            c.MarkGroupChatViewing(conversations_pb2.MarkGroupChatViewingReq(group_chat_id=999999))
+        assert e.value.code() == grpc.StatusCode.NOT_FOUND
+
+
+def test_notification_suppressed_when_viewing(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    make_friends(user1, user2)
+
+    # Enable push notifications for user2
+    topic_action = NotificationTopicAction.chat__message
+    with notifications_session(token2) as notifications:
+        notifications.SetNotificationSettings(
+            notifications_pb2.SetNotificationSettingsReq(
+                preferences=[
+                    notifications_pb2.SingleNotificationPreference(
+                        topic=topic_action.topic,
+                        action=topic_action.action,
+                        delivery_method="push",
+                        enabled=True,
+                    )
+                ],
+            )
+        )
+
+    with conversations_session(token1) as c:
+        res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id]))
+        group_chat_id = res.group_chat_id
+
+    moderator.approve_group_chat(group_chat_id)
+
+    # User2 marks they are viewing the conversation
+    with conversations_session(token2) as c:
+        c.MarkGroupChatViewing(conversations_pb2.MarkGroupChatViewingReq(group_chat_id=group_chat_id))
+
+    # User1 sends a message
+    with conversations_session(token1) as c:
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Hello"))
+
+    # Process background jobs
+    while process_job():
+        pass
+
+    # User2 should NOT have received a notification because they were viewing
+    with session_scope() as session:
+        notif_count = (
+            session.execute(
+                select(Notification)
+                .where(Notification.user_id == user2.id)
+                .where(Notification.topic_action == topic_action)
+            )
+            .scalars()
+            .all()
+        )
+        assert len(notif_count) == 0
+
+
+def test_notification_sent_when_not_viewing(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    make_friends(user1, user2)
+
+    # Enable push notifications for user2
+    topic_action = NotificationTopicAction.chat__message
+    with notifications_session(token2) as notifications:
+        notifications.SetNotificationSettings(
+            notifications_pb2.SetNotificationSettingsReq(
+                preferences=[
+                    notifications_pb2.SingleNotificationPreference(
+                        topic=topic_action.topic,
+                        action=topic_action.action,
+                        delivery_method="push",
+                        enabled=True,
+                    )
+                ],
+            )
+        )
+
+    with conversations_session(token1) as c:
+        res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id]))
+        group_chat_id = res.group_chat_id
+
+    moderator.approve_group_chat(group_chat_id)
+
+    # User2 does NOT mark they are viewing (last_viewing_at stays None)
+
+    # User1 sends a message
+    with conversations_session(token1) as c:
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Hello"))
+
+    # Process background jobs
+    while process_job():
+        pass
+
+    # User2 SHOULD have received a notification
+    with session_scope() as session:
+        notif_count = (
+            session.execute(
+                select(Notification)
+                .where(Notification.user_id == user2.id)
+                .where(Notification.topic_action == topic_action)
+            )
+            .scalars()
+            .all()
+        )
+        assert len(notif_count) == 1
+
+
+def test_notification_sent_when_presence_expired(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    make_friends(user1, user2)
+
+    # Enable push notifications for user2
+    topic_action = NotificationTopicAction.chat__message
+    with notifications_session(token2) as notifications:
+        notifications.SetNotificationSettings(
+            notifications_pb2.SetNotificationSettingsReq(
+                preferences=[
+                    notifications_pb2.SingleNotificationPreference(
+                        topic=topic_action.topic,
+                        action=topic_action.action,
+                        delivery_method="push",
+                        enabled=True,
+                    )
+                ],
+            )
+        )
+
+    with conversations_session(token1) as c:
+        res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id]))
+        group_chat_id = res.group_chat_id
+
+    moderator.approve_group_chat(group_chat_id)
+
+    # Manually set last_viewing_at to 31 seconds ago (just past the 30s threshold)
+    with session_scope() as session:
+        sub = session.execute(
+            select(GroupChatSubscription)
+            .where(GroupChatSubscription.group_chat_id == group_chat_id)
+            .where(GroupChatSubscription.user_id == user2.id)
+        ).scalar_one()
+        sub.last_viewing_at = now() - timedelta(seconds=31)
+        session.commit()
+
+    # User1 sends a message
+    with conversations_session(token1) as c:
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Hello"))
+
+    # Process background jobs
+    while process_job():
+        pass
+
+    # User2 SHOULD have received a notification (presence expired)
+    with session_scope() as session:
+        notif_count = (
+            session.execute(
+                select(Notification)
+                .where(Notification.user_id == user2.id)
+                .where(Notification.topic_action == topic_action)
+            )
+            .scalars()
+            .all()
+        )
+        assert len(notif_count) == 1
+
+
+def test_notification_suppressed_when_presence_just_active(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    make_friends(user1, user2)
+
+    # Enable push notifications for user2
+    topic_action = NotificationTopicAction.chat__message
+    with notifications_session(token2) as notifications:
+        notifications.SetNotificationSettings(
+            notifications_pb2.SetNotificationSettingsReq(
+                preferences=[
+                    notifications_pb2.SingleNotificationPreference(
+                        topic=topic_action.topic,
+                        action=topic_action.action,
+                        delivery_method="push",
+                        enabled=True,
+                    )
+                ],
+            )
+        )
+
+    with conversations_session(token1) as c:
+        res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id]))
+        group_chat_id = res.group_chat_id
+
+    moderator.approve_group_chat(group_chat_id)
+
+    # Manually set last_viewing_at to 29 seconds ago (just within the 30s threshold)
+    with session_scope() as session:
+        sub = session.execute(
+            select(GroupChatSubscription)
+            .where(GroupChatSubscription.group_chat_id == group_chat_id)
+            .where(GroupChatSubscription.user_id == user2.id)
+        ).scalar_one()
+        sub.last_viewing_at = now() - timedelta(seconds=29)
+        session.commit()
+
+    # User1 sends a message
+    with conversations_session(token1) as c:
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Hello"))
+
+    # Process background jobs
+    while process_job():
+        pass
+
+    # User2 should NOT have received a notification (presence still active)
+    with session_scope() as session:
+        notif_count = (
+            session.execute(
+                select(Notification)
+                .where(Notification.user_id == user2.id)
+                .where(Notification.topic_action == topic_action)
+            )
+            .scalars()
+            .all()
+        )
+        assert len(notif_count) == 0
+
+
+def test_stop_group_chat_viewing(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    make_friends(user1, user2)
+
+    with conversations_session(token1) as c:
+        res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id]))
+        group_chat_id = res.group_chat_id
+
+    moderator.approve_group_chat(group_chat_id)
+
+    # Mark conversation as being viewed
+    with conversations_session(token2) as c:
+        c.MarkGroupChatViewing(conversations_pb2.MarkGroupChatViewingReq(group_chat_id=group_chat_id))
+
+    # Verify last_viewing_at is set
+    with session_scope() as session:
+        sub = session.execute(
+            select(GroupChatSubscription)
+            .where(GroupChatSubscription.group_chat_id == group_chat_id)
+            .where(GroupChatSubscription.user_id == user2.id)
+        ).scalar_one()
+        assert sub.last_viewing_at is not None
+
+    # Stop viewing the conversation
+    with conversations_session(token2) as c:
+        c.StopGroupChatViewing(conversations_pb2.StopGroupChatViewingReq(group_chat_id=group_chat_id))
+
+    # Now last_viewing_at should be None
+    with session_scope() as session:
+        sub = session.execute(
+            select(GroupChatSubscription)
+            .where(GroupChatSubscription.group_chat_id == group_chat_id)
+            .where(GroupChatSubscription.user_id == user2.id)
+        ).scalar_one()
+        assert sub.last_viewing_at is None
+
+
+def test_stop_group_chat_viewing_not_found(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    make_friends(user1, user2)
+
+    with conversations_session(token1) as c:
+        res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id]))
+        group_chat_id = res.group_chat_id
+
+    moderator.approve_group_chat(group_chat_id)
+
+    # Create a third user who is not a member
+    user3, token3 = generate_user()
+
+    with conversations_session(token3) as c:
+        with pytest.raises(grpc.RpcError) as e:
+            c.StopGroupChatViewing(conversations_pb2.StopGroupChatViewingReq(group_chat_id=group_chat_id))
+        assert e.value.code() == grpc.StatusCode.NOT_FOUND
+
+    # Non-existent chat
+    with conversations_session(token1) as c:
+        with pytest.raises(grpc.RpcError) as e:
+            c.StopGroupChatViewing(conversations_pb2.StopGroupChatViewingReq(group_chat_id=999999))
+        assert e.value.code() == grpc.StatusCode.NOT_FOUND
+
+
+def test_stop_viewing_enables_notifications(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    make_friends(user1, user2)
+
+    # Enable push notifications for user2
+    topic_action = NotificationTopicAction.chat__message
+    with notifications_session(token2) as notifications:
+        notifications.SetNotificationSettings(
+            notifications_pb2.SetNotificationSettingsReq(
+                preferences=[
+                    notifications_pb2.SingleNotificationPreference(
+                        topic=topic_action.topic,
+                        action=topic_action.action,
+                        delivery_method="push",
+                        enabled=True,
+                    )
+                ],
+            )
+        )
+
+    with conversations_session(token1) as c:
+        res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id]))
+        group_chat_id = res.group_chat_id
+
+    moderator.approve_group_chat(group_chat_id)
+
+    # User2 marks they are viewing the conversation
+    with conversations_session(token2) as c:
+        c.MarkGroupChatViewing(conversations_pb2.MarkGroupChatViewingReq(group_chat_id=group_chat_id))
+
+    # User2 stops viewing the conversation
+    with conversations_session(token2) as c:
+        c.StopGroupChatViewing(conversations_pb2.StopGroupChatViewingReq(group_chat_id=group_chat_id))
+
+    # User1 sends a message
+    with conversations_session(token1) as c:
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Hello"))
+
+    # Process background jobs
+    while process_job():
+        pass
+
+    # User2 SHOULD have received a notification (they stopped viewing)
+    with session_scope() as session:
+        notif_count = (
+            session.execute(
+                select(Notification)
+                .where(Notification.user_id == user2.id)
+                .where(Notification.topic_action == topic_action)
+            )
+            .scalars()
+            .all()
+        )
+        assert len(notif_count) == 1

--- a/app/proto/conversations.proto
+++ b/app/proto/conversations.proto
@@ -39,6 +39,18 @@ service Conversations {
     // Marks the last message that has been seen in this group chat
   }
 
+  rpc MarkGroupChatViewing(MarkGroupChatViewingReq) returns (google.protobuf.Empty) {
+    // Marks that the user is currently viewing a group chat
+    //
+    // Raises: NOT_FOUND if the group chat does not exist or user is not a member
+  }
+
+  rpc StopGroupChatViewing(StopGroupChatViewingReq) returns (google.protobuf.Empty) {
+    // Marks that the user has stopped viewing a group chat
+    //
+    // Raises: NOT_FOUND if the group chat does not exist or user is not a member
+  }
+
   rpc MuteGroupChat(MuteGroupChatReq) returns (google.protobuf.Empty) {
     // Mutes or unmutes a group chat
     // when muted, you don't get notifications from that group chat
@@ -219,6 +231,14 @@ message GetGroupChatMessagesRes {
 message MarkLastSeenGroupChatReq {
   uint64 group_chat_id = 1;
   uint64 last_seen_message_id = 2;
+}
+
+message MarkGroupChatViewingReq {
+  uint64 group_chat_id = 1;
+}
+
+message StopGroupChatViewingReq {
+  uint64 group_chat_id = 1;
 }
 
 message MuteGroupChatReq {


### PR DESCRIPTION
## Summary

- Add `last_viewing_at` column to `GroupChatSubscription` model (+ migration)
- Add `MarkGroupChatViewing` and `StopGroupChatViewing` RPCs to `conversations.proto`
- Skip push notifications for users actively viewing a conversation (within 30s window)
- Add Prometheus counter `notification_suppressed_presence_total`
- Add `PRESENCE_ACTIVE_DURATION` constant (30s)

Part 3 of 5 — notification improvements. Independent of PRs 1-2, but required by PR 4.

## Testing

- 4 new presence tests in `test_conversations.py` (mark viewing, stop viewing, boundary conditions)
- Tests cover: 30s threshold, explicit stop, notifications resume after timeout

**Backend checklist**
- [x] Added tests for new code
- [x] Added migration for database changes
- [x] Run the backend locally and it works