### PR TITLE
Fix #5432: Preserve form data when host request validation fails

### DIFF
--- a/app/web/features/profile/view/NewHostRequest.tsx
+++ b/app/web/features/profile/view/NewHostRequest.tsx
@@ -92,6 +92,7 @@ export default function NewHostRequest({
     onSuccess: () => {
       setIsRequesting(false);
       setIsRequestSuccess(true);
+      reset();
     },
   });
 
@@ -99,7 +100,6 @@ export default function NewHostRequest({
 
   const onSubmit = handleSubmit((data) => {
     mutate(data);
-    reset();
   });
 
   const watchFromDate = watch("fromDate", undefined);


### PR DESCRIPTION
## Summary

- Move `reset()` call from `onSubmit` handler to `onSuccess` callback in `NewHostRequest.tsx`
- This preserves the user's typed message when the API returns a validation error (e.g., dates > 1 year apart), instead of clearing the form and losing their input
- Matches the pattern used in other forms like `CommentForm.tsx` and `CreateDiscussionForm.tsx`

Closes #5432

## Testing

1. Go to a host's profile and click "Request to stay"
2. Fill in the form with dates more than 1 year apart and type a message
3. Submit — the API will return a validation error
4. Verify the form data (including the message) is preserved, not cleared

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [x] Clicked around my changes running locally and it works

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me