### PR TITLE
fix: add NOTIFICATIONS namespace to pages missing push notification banner translations

### DIFF
--- a/app/web/pages/delete-account.tsx
+++ b/app/web/pages/delete-account.tsx
@@ -3,7 +3,11 @@ import ConfirmDeleteAccount from "features/auth/deletion/ConfirmDeleteAccount";
 import { AUTH, GLOBAL, NOTIFICATIONS } from "i18n/namespaces";
 import { translationStaticProps } from "i18n/server-side-translations";
 
-export const getStaticProps = translationStaticProps([GLOBAL, AUTH, NOTIFICATIONS]);
+export const getStaticProps = translationStaticProps([
+  GLOBAL,
+  AUTH,
+  NOTIFICATIONS,
+]);
 
 export default function ConfirmDeleteAccountPage() {
   return <ConfirmDeleteAccount />;

--- a/app/web/pages/delete-account.tsx
+++ b/app/web/pages/delete-account.tsx
@@ -1,9 +1,9 @@
 import { appGetLayout } from "components/AppRoute";
 import ConfirmDeleteAccount from "features/auth/deletion/ConfirmDeleteAccount";
-import { AUTH, GLOBAL } from "i18n/namespaces";
+import { AUTH, GLOBAL, NOTIFICATIONS } from "i18n/namespaces";
 import { translationStaticProps } from "i18n/server-side-translations";
 
-export const getStaticProps = translationStaticProps([GLOBAL, AUTH]);
+export const getStaticProps = translationStaticProps([GLOBAL, AUTH, NOTIFICATIONS]);
 
 export default function ConfirmDeleteAccountPage() {
   return <ConfirmDeleteAccount />;

--- a/app/web/pages/login.tsx
+++ b/app/web/pages/login.tsx
@@ -1,9 +1,9 @@
 import { appGetLayout } from "components/AppRoute";
 import Login from "features/auth/login/Login";
-import { AUTH, GLOBAL, LANDING } from "i18n/namespaces";
+import { AUTH, GLOBAL, LANDING, NOTIFICATIONS } from "i18n/namespaces";
 import { translationStaticProps } from "i18n/server-side-translations";
 
-export const getStaticProps = translationStaticProps([GLOBAL, AUTH, LANDING]);
+export const getStaticProps = translationStaticProps([GLOBAL, AUTH, LANDING, NOTIFICATIONS]);
 
 export default function LoginPage() {
   return <Login />;

--- a/app/web/pages/login.tsx
+++ b/app/web/pages/login.tsx
@@ -3,7 +3,12 @@ import Login from "features/auth/login/Login";
 import { AUTH, GLOBAL, LANDING, NOTIFICATIONS } from "i18n/namespaces";
 import { translationStaticProps } from "i18n/server-side-translations";
 
-export const getStaticProps = translationStaticProps([GLOBAL, AUTH, LANDING, NOTIFICATIONS]);
+export const getStaticProps = translationStaticProps([
+  GLOBAL,
+  AUTH,
+  LANDING,
+  NOTIFICATIONS,
+]);
 
 export default function LoginPage() {
   return <Login />;

--- a/app/web/pages/quick-link.tsx
+++ b/app/web/pages/quick-link.tsx
@@ -3,7 +3,11 @@ import Unsubscribe from "features/auth/QuickLink";
 import { AUTH, GLOBAL, NOTIFICATIONS } from "i18n/namespaces";
 import { translationStaticProps } from "i18n/server-side-translations";
 
-export const getStaticProps = translationStaticProps([GLOBAL, AUTH, NOTIFICATIONS]);
+export const getStaticProps = translationStaticProps([
+  GLOBAL,
+  AUTH,
+  NOTIFICATIONS,
+]);
 
 export default function QuickLinkPage() {
   return <Unsubscribe />;

--- a/app/web/pages/quick-link.tsx
+++ b/app/web/pages/quick-link.tsx
@@ -1,9 +1,9 @@
 import { appGetLayout } from "components/AppRoute";
 import Unsubscribe from "features/auth/QuickLink";
-import { AUTH, GLOBAL } from "i18n/namespaces";
+import { AUTH, GLOBAL, NOTIFICATIONS } from "i18n/namespaces";
 import { translationStaticProps } from "i18n/server-side-translations";
 
-export const getStaticProps = translationStaticProps([GLOBAL, AUTH]);
+export const getStaticProps = translationStaticProps([GLOBAL, AUTH, NOTIFICATIONS]);
 
 export default function QuickLinkPage() {
   return <Unsubscribe />;

--- a/app/web/pages/recover-account.tsx
+++ b/app/web/pages/recover-account.tsx
@@ -1,9 +1,9 @@
 import { appGetLayout } from "components/AppRoute";
 import RecoverAccount from "features/auth/deletion/RecoverAccount";
-import { AUTH, GLOBAL } from "i18n/namespaces";
+import { AUTH, GLOBAL, NOTIFICATIONS } from "i18n/namespaces";
 import { translationStaticProps } from "i18n/server-side-translations";
 
-export const getStaticProps = translationStaticProps([GLOBAL, AUTH]);
+export const getStaticProps = translationStaticProps([GLOBAL, AUTH, NOTIFICATIONS]);
 
 export default function RecoverAccountPage() {
   return <RecoverAccount />;

--- a/app/web/pages/recover-account.tsx
+++ b/app/web/pages/recover-account.tsx
@@ -3,7 +3,11 @@ import RecoverAccount from "features/auth/deletion/RecoverAccount";
 import { AUTH, GLOBAL, NOTIFICATIONS } from "i18n/namespaces";
 import { translationStaticProps } from "i18n/server-side-translations";
 
-export const getStaticProps = translationStaticProps([GLOBAL, AUTH, NOTIFICATIONS]);
+export const getStaticProps = translationStaticProps([
+  GLOBAL,
+  AUTH,
+  NOTIFICATIONS,
+]);
 
 export default function RecoverAccountPage() {
   return <RecoverAccount />;

--- a/app/web/pages/unsubscribe.tsx
+++ b/app/web/pages/unsubscribe.tsx
@@ -2,10 +2,10 @@
 // new links go to quick-link.tsx
 import { appGetLayout } from "components/AppRoute";
 import QuickLink from "features/auth/QuickLink";
-import { AUTH, GLOBAL } from "i18n/namespaces";
+import { AUTH, GLOBAL, NOTIFICATIONS } from "i18n/namespaces";
 import { translationStaticProps } from "i18n/server-side-translations";
 
-export const getStaticProps = translationStaticProps([GLOBAL, AUTH]);
+export const getStaticProps = translationStaticProps([GLOBAL, AUTH, NOTIFICATIONS]);
 
 export default function UnsubscribePage() {
   return <QuickLink />;

--- a/app/web/pages/unsubscribe.tsx
+++ b/app/web/pages/unsubscribe.tsx
@@ -5,7 +5,11 @@ import QuickLink from "features/auth/QuickLink";
 import { AUTH, GLOBAL, NOTIFICATIONS } from "i18n/namespaces";
 import { translationStaticProps } from "i18n/server-side-translations";
 
-export const getStaticProps = translationStaticProps([GLOBAL, AUTH, NOTIFICATIONS]);
+export const getStaticProps = translationStaticProps([
+  GLOBAL,
+  AUTH,
+  NOTIFICATIONS,
+]);
 
 export default function UnsubscribePage() {
   return <QuickLink />;


### PR DESCRIPTION
Adds the `NOTIFICATIONS` translation namespace to pages that were missing it. The `PushNotificationBanner` component is rendered via `Navigation` on all pages, but these pages didn't load the `NOTIFICATIONS` namespace, causing raw translation keys to be displayed instead of translated text.

Fixes #7863

Generated with [Claude Code](https://claude.ai/claude-code)