### PR TITLE
fix: update email regex to disallow dots before @ and consecutive dots

### DIFF
--- a/app/backend/src/couchers/constants.py
+++ b/app/backend/src/couchers/constants.py
@@ -8,7 +8,7 @@ TOS_VERSION = 2
 # community guidelines version
 GUIDELINES_VERSION = 1
 
-EMAIL_REGEX = r"^[0-9a-z][0-9a-z\-\_\+\.]*@([0-9a-z\-]+\.)*[0-9a-z\-]+\.[a-z]{2,}$"
+EMAIL_REGEX = r"^[0-9a-z]([0-9a-z\-\_\+]|(\.[0-9a-z\-\_\+]))*@([0-9a-z\-]+\.)*[0-9a-z\-]+\.[a-z]{2,}$"
 
 BANNED_USERNAME_PHRASES = [
     "admin",

--- a/app/backend/src/couchers/migrations/versions/2e9def7290b9_update_email_regex_disallow_dots.py
+++ b/app/backend/src/couchers/migrations/versions/2e9def7290b9_update_email_regex_disallow_dots.py
@@ -16,7 +16,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.drop_constraint("valid_email", "users")
+    op.drop_constraint("ck_users_valid_email", "users")
     op.create_check_constraint(
         "valid_email",
         "users",

--- a/app/backend/src/couchers/migrations/versions/2e9def7290b9_update_email_regex_disallow_dots.py
+++ b/app/backend/src/couchers/migrations/versions/2e9def7290b9_update_email_regex_disallow_dots.py
@@ -1,7 +1,7 @@
 """Update email regex to disallow dots before @ and consecutive dots
 
-Revision ID: e7a2b3c4d5f6
-Revises: f016e6defa9d
+Revision ID: 2e9def7290b9
+Revises: eeae61c8ee09
 Create Date: 2026-02-16 04:23:00.000000
 
 """
@@ -9,8 +9,8 @@ Create Date: 2026-02-16 04:23:00.000000
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "e7a2b3c4d5f6"
-down_revision = "f016e6defa9d"
+revision = "2e9def7290b9"
+down_revision = "eeae61c8ee09"
 branch_labels = None
 depends_on = None
 

--- a/app/backend/src/couchers/migrations/versions/e7a2b3c4d5f6_update_email_regex_disallow_dots.py
+++ b/app/backend/src/couchers/migrations/versions/e7a2b3c4d5f6_update_email_regex_disallow_dots.py
@@ -1,0 +1,28 @@
+"""Update email regex to disallow dots before @ and consecutive dots
+
+Revision ID: e7a2b3c4d5f6
+Revises: f016e6defa9d
+Create Date: 2026-02-16 04:23:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e7a2b3c4d5f6"
+down_revision = "f016e6defa9d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("valid_email", "users")
+    op.create_check_constraint(
+        "valid_email",
+        "users",
+        r"email ~ '^[0-9a-z]([0-9a-z\-\_\+]|(\.[0-9a-z\-\_\+]))*@([0-9a-z\-]+\.)*[0-9a-z\-]+\.[a-z]{2,}$'",
+    )
+
+
+def downgrade() -> None:
+    raise Exception("Can't downgrade")

--- a/app/backend/src/tests/test_db.py
+++ b/app/backend/src/tests/test_db.py
@@ -41,11 +41,17 @@ def test_is_valid_email() -> None:
     assert is_valid_email("a@b.cc")
     assert is_valid_email("te.st+email.valid@a.org.au.xx.yy")
     assert is_valid_email("invalid@yahoo.co.uk")
+    assert is_valid_email("user+tag@example.com")
+    assert is_valid_email("first.last@example.com")
     assert not is_valid_email("invalid@.yahoo.co.uk")
     assert not is_valid_email("test email@couchers.org")
     assert not is_valid_email(".testemail@couchers.org")
     assert not is_valid_email("testemail@couchersorg")
     assert not is_valid_email("b@xxb....blabla")
+    # dot immediately before @ (the original bug)
+    assert not is_valid_email("user.@example.com")
+    # consecutive dots in local part
+    assert not is_valid_email("user..name@example.com")
 
 
 def test_is_valid_username() -> None:

--- a/app/web/utils/validation.ts
+++ b/app/web/utils/validation.ts
@@ -5,7 +5,7 @@ export const validatePassword = (password: string) => {
   return password.length >= 8 && password.length < 256;
 };
 export const emailValidationPattern =
-  /^[0-9a-z][0-9a-z\-_+.]*@([0-9a-z-]+\.)*[0-9a-z-]+\.[a-z]{2,}$/i;
+  /^[0-9a-z]([0-9a-z\-_+]|(\.[0-9a-z\-_+]))*@([0-9a-z-]+\.)*[0-9a-z-]+\.[a-z]{2,}$/i;
 export const timePattern = /\d{2}:\d{2}/;
 
 export function validatePastDate(stringDate: string) {


### PR DESCRIPTION
Updates the EMAIL_REGEX pattern in both backend and frontend to prevent:
- Dots immediately before @ (e.g., user.@example.com)
- Consecutive dots (e.g., user..name@example.com)

New regex uses alternation to ensure dots in the local part are always followed by a valid non-dot character. Includes a database migration to update the existing check constraint on the users table.

Fixes #7315

*Describe briefly what this PR is doing and why.*

<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Backend checklist**
<!-- To avoid CI failures, first run `make format` in app/backend and run tests locally. -->
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` and `yarn lint --fix` in app/web, and run tests locally. -->
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, you can merge it if you have write access.
--->
