### PR TITLE
fix: align translation progress status labels

### DIFF
--- a/app/web/features/translate/TranslationProgress.tsx
+++ b/app/web/features/translate/TranslationProgress.tsx
@@ -334,6 +334,7 @@ export default function TranslationProgress() {
                         color={
                           percent < HIDDEN_CUTOFF ? "text.secondary" : "primary"
                         }
+                        sx={{ minWidth: 80, textAlign: "right" }}
                       >
                         {percent.toFixed(1)}%
                       </Typography>


### PR DESCRIPTION
## Summary

Fixes the misalignment of status labels (Complete, Midway, Early Stage, etc.) on the Translation Progress page. The percentage text before each status chip varied in width depending on digit count, causing the chips to shift horizontally. Fixed by giving the percentage text a fixed minimum width with right alignment.

Fixes #7109

<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Backend checklist**
<!-- To avoid CI failures, first run `make format` in app/backend and run tests locally. -->
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` and `yarn lint --fix` in app/web, and run tests locally. -->
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, you can merge it if you have write access.
--->
