### PR TITLE
Add node_type enum to Node model and only notify cities or lower communities

### DIFF
--- a/app/backend/src/couchers/constants.py
+++ b/app/backend/src/couchers/constants.py
@@ -84,11 +84,6 @@ EVENT_REMINDER_TIMEDELTA = timedelta(hours=24)
 
 COMMUNITIES_SEARCH_FUZZY_SIMILARITY_THRESHOLD = 0.35
 
-# Maximum node ID considered a "global" community (excluded from some notifications and event filters)
-# Node IDs <= this value are treated as too large for email notifications, etc.
-# Currently this is just the Global Community (node_id=1)
-GLOBAL_COMMUNITY_MAX_NODE_ID = 1
-
 UNKNOWN_ERROR_MESSAGE = "An unknown backend error occurred. Please consider filing a bug!"
 
 # NOTE: these codes are on purpose not translatable

--- a/app/backend/src/couchers/helpers/clusters.py
+++ b/app/backend/src/couchers/helpers/clusters.py
@@ -4,14 +4,32 @@ from geoalchemy2.shape import from_shape
 from shapely.geometry.base import BaseGeometry
 from sqlalchemy.orm import Session
 
-from couchers.models import Cluster, ClusterRole, ClusterSubscription, Node, Page, PageType, PageVersion, Thread
+from couchers.models import (
+    Cluster,
+    ClusterRole,
+    ClusterSubscription,
+    Node,
+    NodeType,
+    Page,
+    PageType,
+    PageVersion,
+    Thread,
+)
+
+CHILD_NODE_TYPE = {
+    None: NodeType.world,
+    NodeType.world: NodeType.region,
+    NodeType.region: NodeType.subregion,
+    NodeType.subregion: NodeType.locality,
+    NodeType.locality: NodeType.sublocality,
+}
 
 DEFAULT_PAGE_CONTENT = "There is nothing here yet..."
 DEFAULT_PAGE_TITLE_TEMPLATE = "Main page for the {name} {type}"
 
 
-def create_node(session: Session, geom: BaseGeometry, parent_node_id: int | None) -> Node:
-    node = Node(geom=from_shape(geom), parent_node_id=parent_node_id)
+def create_node(session: Session, geom: BaseGeometry, parent_node_id: int | None, node_type: NodeType) -> Node:
+    node = Node(geom=from_shape(geom), parent_node_id=parent_node_id, node_type=node_type)
     session.add(node)
     session.flush()
     return node

--- a/app/backend/src/couchers/migrations/versions/dc28e9bd2b31_add_node_type.py
+++ b/app/backend/src/couchers/migrations/versions/dc28e9bd2b31_add_node_type.py
@@ -1,7 +1,7 @@
 """Add node_type to nodes
 
 Revision ID: dc28e9bd2b31
-Revises: 2e9def7290b9
+Revises: 0e07dbb98ffc
 Create Date: 2026-02-15 14:00:00.000000
 
 """
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "dc28e9bd2b31"
-down_revision = "2e9def7290b9"
+down_revision = "0e07dbb98ffc"
 branch_labels = None
 depends_on = None
 

--- a/app/backend/src/couchers/migrations/versions/dc28e9bd2b31_add_node_type.py
+++ b/app/backend/src/couchers/migrations/versions/dc28e9bd2b31_add_node_type.py
@@ -35,13 +35,16 @@ def upgrade():
             JOIN node_depth nd ON n.parent_node_id = nd.id
         )
         UPDATE nodes
+        UPDATE nodes
         SET node_type = CASE nd.depth
             WHEN 0 THEN 'world'
             WHEN 1 THEN 'region'
             WHEN 2 THEN 'subregion'
             WHEN 3 THEN 'locality'
-            WHEN 4 THEN 'sublocality'
+            ELSE 'sublocality'
         END::nodetype
+        FROM node_depth nd
+        WHERE nodes.id = nd.id
         FROM node_depth nd
         WHERE nodes.id = nd.id
         """

--- a/app/backend/src/couchers/migrations/versions/dc28e9bd2b31_add_node_type.py
+++ b/app/backend/src/couchers/migrations/versions/dc28e9bd2b31_add_node_type.py
@@ -35,7 +35,6 @@ def upgrade():
             JOIN node_depth nd ON n.parent_node_id = nd.id
         )
         UPDATE nodes
-        UPDATE nodes
         SET node_type = CASE nd.depth
             WHEN 0 THEN 'world'
             WHEN 1 THEN 'region'
@@ -43,8 +42,6 @@ def upgrade():
             WHEN 3 THEN 'locality'
             ELSE 'sublocality'
         END::nodetype
-        FROM node_depth nd
-        WHERE nodes.id = nd.id
         FROM node_depth nd
         WHERE nodes.id = nd.id
         """

--- a/app/backend/src/couchers/migrations/versions/dc28e9bd2b31_add_node_type.py
+++ b/app/backend/src/couchers/migrations/versions/dc28e9bd2b31_add_node_type.py
@@ -1,7 +1,7 @@
 """Add node_type to nodes
 
 Revision ID: dc28e9bd2b31
-Revises: eeae61c8ee09
+Revises: 2e9def7290b9
 Create Date: 2026-02-15 14:00:00.000000
 
 """
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "dc28e9bd2b31"
-down_revision = "eeae61c8ee09"
+down_revision = "2e9def7290b9"
 branch_labels = None
 depends_on = None
 

--- a/app/backend/src/couchers/migrations/versions/dc28e9bd2b31_add_node_type.py
+++ b/app/backend/src/couchers/migrations/versions/dc28e9bd2b31_add_node_type.py
@@ -1,0 +1,55 @@
+"""Add node_type to nodes
+
+Revision ID: dc28e9bd2b31
+Revises: eeae61c8ee09
+Create Date: 2026-02-15 14:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "dc28e9bd2b31"
+down_revision = "eeae61c8ee09"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    nodetype_enum = sa.Enum("world", "region", "subregion", "locality", "sublocality", name="nodetype")
+    nodetype_enum.create(op.get_bind())
+
+    op.add_column("nodes", sa.Column("node_type", nodetype_enum, nullable=True))
+
+    # Backfill using a recursive CTE that computes depth from the root
+    op.execute(
+        """
+        WITH RECURSIVE node_depth AS (
+            SELECT id, 0 AS depth
+            FROM nodes
+            WHERE parent_node_id IS NULL
+            UNION ALL
+            SELECT n.id, nd.depth + 1
+            FROM nodes n
+            JOIN node_depth nd ON n.parent_node_id = nd.id
+        )
+        UPDATE nodes
+        SET node_type = CASE nd.depth
+            WHEN 0 THEN 'world'
+            WHEN 1 THEN 'region'
+            WHEN 2 THEN 'subregion'
+            WHEN 3 THEN 'locality'
+            WHEN 4 THEN 'sublocality'
+        END::nodetype
+        FROM node_depth nd
+        WHERE nodes.id = nd.id
+        """
+    )
+
+    op.alter_column("nodes", "node_type", nullable=False)
+
+
+def downgrade():
+    op.drop_column("nodes", "node_type")
+    sa.Enum(name="nodetype").drop(op.get_bind())

--- a/app/backend/src/couchers/models/clusters.py
+++ b/app/backend/src/couchers/models/clusters.py
@@ -33,6 +33,14 @@ if TYPE_CHECKING:
     from couchers.models import Discussion, Event, Thread, Upload, User
 
 
+class NodeType(enum.Enum):
+    world = enum.auto()
+    region = enum.auto()
+    subregion = enum.auto()
+    locality = enum.auto()
+    sublocality = enum.auto()
+
+
 class Node(Base, kw_only=True):
     """
     Node, i.e., geographical subdivision of the world
@@ -49,6 +57,8 @@ class Node(Base, kw_only=True):
         server_default=communities_seq.next_value(),
         init=False,
     )
+
+    node_type: Mapped[NodeType] = mapped_column(Enum(NodeType))
 
     # name and description come from the official cluster
     parent_node_id: Mapped[int | None] = mapped_column(ForeignKey("nodes.id"), default=None, index=True)

--- a/app/backend/src/couchers/servicers/communities.py
+++ b/app/backend/src/couchers/servicers/communities.py
@@ -22,6 +22,7 @@ from couchers.models import (
     Event,
     EventOccurrence,
     Node,
+    NodeType,
     Page,
     PageType,
     User,
@@ -37,6 +38,14 @@ from couchers.utils import Timestamp_from_datetime, dt_from_millis, millis_from_
 logger = logging.getLogger(__name__)
 
 MAX_PAGINATION_LENGTH = 25
+
+nodetype2api = {
+    NodeType.world: communities_pb2.NODE_TYPE_WORLD,
+    NodeType.region: communities_pb2.NODE_TYPE_REGION,
+    NodeType.subregion: communities_pb2.NODE_TYPE_SUBREGION,
+    NodeType.locality: communities_pb2.NODE_TYPE_LOCALITY,
+    NodeType.sublocality: communities_pb2.NODE_TYPE_SUBLOCALITY,
+}
 
 
 def _parents_to_pb(session: Session, node_id: int) -> list[groups_pb2.Parent]:
@@ -113,6 +122,7 @@ def communities_to_pb(
             can_moderate=can_moderate,
             discussions_enabled=official_cluster.discussions_enabled,
             events_enabled=official_cluster.events_enabled,
+            node_type=nodetype2api[node.node_type],
         )
         for node, official_cluster, can_moderate in zip(nodes, official_clusters, can_moderates)
     ]
@@ -563,6 +573,7 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
                     member_count=member_count or 1,
                     parents=_parents_to_pb(session, node.id),
                     created=Timestamp_from_datetime(node.created),
+                    node_type=nodetype2api[node.node_type],
                 )
                 for node, cluster, member_count, user_subscription in results
             ],

--- a/app/backend/src/couchers/servicers/editor.py
+++ b/app/backend/src/couchers/servicers/editor.py
@@ -13,7 +13,7 @@ from sqlalchemy.sql import exists, update
 from couchers import urls
 from couchers.context import CouchersContext
 from couchers.db import session_scope
-from couchers.helpers.clusters import create_cluster, create_node
+from couchers.helpers.clusters import CHILD_NODE_TYPE, create_cluster, create_node
 from couchers.jobs.enqueue import queue_job
 from couchers.materialized_views import LiteUser
 from couchers.models import EventCommunityInviteRequest, Node, User, Volunteer
@@ -86,7 +86,15 @@ class Editor(editor_pb2_grpc.EditorServicer):
         geom = load_community_geom(request.geojson, context)
 
         parent_node_id = request.parent_node_id if request.parent_node_id != 0 else None
-        node = create_node(session, geom, parent_node_id)
+        if parent_node_id is not None:
+            parent_node = session.execute(select(Node).where(Node.id == parent_node_id)).scalar_one_or_none()
+            if not parent_node:
+                context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "parent_node_not_found")
+            parent_type = parent_node.node_type
+        else:
+            parent_type = None
+        node_type = CHILD_NODE_TYPE[parent_type]
+        node = create_node(session, geom, parent_node_id, node_type)
         create_cluster(session, node.id, request.name, request.description, context.user_id, request.admin_ids, True)
 
         return community_to_pb(session, node, context)

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -9,7 +9,6 @@ from sqlalchemy import Select, select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import and_, func, or_, update
 
-from couchers.constants import GLOBAL_COMMUNITY_MAX_NODE_ID
 from couchers.context import CouchersContext, make_background_user_context
 from couchers.db import can_moderate_node, get_parent_node_at_location, session_scope
 from couchers.event_log import log_event
@@ -27,6 +26,7 @@ from couchers.models import (
     EventSubscription,
     ModerationObjectType,
     Node,
+    NodeType,
     Thread,
     Upload,
     User,
@@ -265,8 +265,8 @@ def get_users_to_notify_for_new_event(session: Session, occurrence: EventOccurre
     Returns the users to notify, as well as the community id that is being notified (None if based on geo search)
     """
     cluster = occurrence.event.parent_node.official_cluster
-    if cluster.parent_node_id <= GLOBAL_COMMUNITY_MAX_NODE_ID:
-        logger.info("The Global Community is too big for email notifications.")
+    if occurrence.event.parent_node.node_type in (NodeType.world, NodeType.region):
+        logger.info("Global and region communities are too big for email notifications.")
         return [], occurrence.event.parent_node_id
     elif occurrence.creator_user in cluster.admins or cluster.is_leaf:
         return list(cluster.members.where(User.is_visible)), occurrence.event.parent_node_id
@@ -1221,7 +1221,9 @@ class Events(events_pb2_grpc.EventsServicer):
         query = query.where(or_(*where_))
 
         if request.my_communities_exclude_global:
-            query = query.where(Event.parent_node_id > GLOBAL_COMMUNITY_MAX_NODE_ID)
+            query = query.join(Node, Node.id == Event.parent_node_id).where(
+                Node.node_type.not_in([NodeType.world, NodeType.region])
+            )
 
         if not request.include_cancelled:
             query = query.where(~EventOccurrence.is_cancelled)

--- a/app/backend/src/dummy_data.py
+++ b/app/backend/src/dummy_data.py
@@ -12,6 +12,7 @@ from couchers.constants import GUIDELINES_VERSION, TOS_VERSION
 from couchers.context import CouchersContext
 from couchers.crypto import hash_password
 from couchers.db import session_scope
+from couchers.helpers.clusters import CHILD_NODE_TYPE
 from couchers.models import (
     Cluster,
     ClusterRole,
@@ -279,9 +280,11 @@ def add_dummy_communities() -> None:
                     .where(Cluster.name == community["parent"])
                 ).scalar_one()
 
+            parent_node_type = parent_node.node_type if parent_name else None
             node = Node(
                 geom=to_multi(geom),
                 parent_node_id=parent_node.id if parent_name else None,
+                node_type=CHILD_NODE_TYPE[parent_node_type],
             )
 
             session.add(node)

--- a/app/backend/src/tests/test_communities.py
+++ b/app/backend/src/tests/test_communities.py
@@ -8,6 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from couchers.db import is_user_in_node_geography, session_scope
+from couchers.helpers.clusters import CHILD_NODE_TYPE
 from couchers.materialized_views import refresh_materialized_views
 from couchers.models import (
     Cluster,
@@ -66,9 +67,11 @@ def create_community(
     extra_members: list[User],
     parent: Node | None,
 ) -> Node:
+    node_type = CHILD_NODE_TYPE[parent.node_type if parent else None]
     node = Node(
         geom=to_multi(create_1d_polygon(interval_lb, interval_ub)),
         parent_node_id=parent.id if parent else None,
+        node_type=node_type,
     )
     session.add(node)
     session.flush()

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -433,16 +433,17 @@ def test_email_deleted_users_regression(db, moderator: Moderator):
     delete_user, _ = generate_user()
 
     with session_scope() as session:
-        create_community(session, 10, 2, "Global Community", [super_user], [], None)
-        create_community(
+        w = create_community(session, 0, 2, "Global Community", [super_user], [], None)
+        r = create_community(session, 0, 2, "Region", [super_user], [], w)
+        c_id = create_community(
             session,
             0,
             2,
             "Non-global Community",
             [super_user],
             [creating_user, normal_user, ban_user, delete_user],
-            None,
-        )
+            r,
+        ).id
 
     enforce_community_memberships()
 
@@ -454,6 +455,7 @@ def test_email_deleted_users_regression(db, moderator: Moderator):
                 title="Dummy Title",
                 content="Dummy content.",
                 photo_key=None,
+                parent_community_id=c_id,
                 offline_information=events_pb2.OfflineEventInformation(
                     address="Near Null Island",
                     lat=0.1,

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -1822,12 +1822,15 @@ def test_ListMyEvents(db, moderator: Moderator):
     user5, token5 = generate_user()
 
     with session_scope() as session:
-        # Create global community first (node_id=1), then a child community (node_id=2)
-        # This allows testing my_communities_exclude_global
+        # Create global (world) -> region -> subregion hierarchy
+        # my_communities_exclude_global filters out world and region level communities
         global_community = create_community(session, 0, 100, "Global", [user3], [], None)
         c_id = global_community.id
-        child_community = create_community(session, 0, 50, "Child Community", [user3, user4], [], global_community)
-        c2_id = child_community.id
+        region_community = create_community(session, 0, 50, "Region Community", [user3, user4], [], global_community)
+        subregion_community = create_community(
+            session, 0, 25, "Subregion Community", [user3, user4], [], region_community
+        )
+        c2_id = subregion_community.id
 
     start = now()
 
@@ -2390,7 +2393,8 @@ def test_community_invite_requests(db, moderator: Moderator):
 
     with session_scope() as session:
         w = create_community(session, 0, 2, "World Community", [user5], [], None)
-        c_id = create_community(session, 0, 2, "Community", [user1, user3, user4], [], w).id
+        r = create_community(session, 0, 2, "Region", [user5], [], w)
+        c_id = create_community(session, 0, 2, "Community", [user1, user3, user4], [], r).id
 
     enforce_community_memberships()
 
@@ -2771,10 +2775,11 @@ def test_event_create_notification_deferred_until_approval(db, push_collector: P
     user1, token1 = generate_user()
     user2, token2 = generate_user()
 
-    # Need parent+child so child community's node_id > GLOBAL_COMMUNITY_MAX_NODE_ID (1)
+    # Need world -> region -> subregion so the subregion community gets notifications
     with session_scope() as session:
-        parent = create_community(session, 0, 10, "Parent", [user1], [], None)
-        create_community(session, 0, 2, "Child", [user2], [], parent)
+        world = create_community(session, 0, 10, "World", [user1], [], None)
+        region = create_community(session, 0, 5, "Region", [user1], [], world)
+        create_community(session, 0, 2, "Child", [user2], [], region)
 
     start_time = now() + timedelta(hours=2)
     end_time = start_time + timedelta(hours=3)

--- a/app/backend/src/tests/test_model_constraints.py
+++ b/app/backend/src/tests/test_model_constraints.py
@@ -3,7 +3,17 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql import func
 
 from couchers.db import session_scope
-from couchers.models import ActivenessProbe, ActivenessProbeStatus, Cluster, Node, Page, PageType, PageVersion, Thread
+from couchers.models import (
+    ActivenessProbe,
+    ActivenessProbeStatus,
+    Cluster,
+    Node,
+    NodeType,
+    Page,
+    PageType,
+    PageVersion,
+    Thread,
+)
 from couchers.utils import create_polygon_lat_lng, to_multi
 from tests.fixtures.db import generate_user
 from tests.test_communities import create_1d_polygon, create_community
@@ -18,7 +28,7 @@ def test_node_constraints(db):
     # check we can't have two official clusters for a given node
     with pytest.raises(IntegrityError) as e:
         with session_scope() as session:
-            node = Node(geom=to_multi(create_1d_polygon(0, 2)))
+            node = Node(geom=to_multi(create_1d_polygon(0, 2)), node_type=NodeType.world)
             session.add(node)
             session.flush()
             cluster1 = Cluster(
@@ -72,7 +82,9 @@ def test_page_constraints(db):
     assert "one_owner" in str(e.value)
 
     with session_scope() as session:
-        node = Node(geom=to_multi(create_polygon_lat_lng([[0, 0], [0, 2], [2, 2], [2, 0], [0, 0]])))
+        node = Node(
+            geom=to_multi(create_polygon_lat_lng([[0, 0], [0, 2], [2, 2], [2, 0], [0, 0]])), node_type=NodeType.world
+        )
         session.add(node)
         session.flush()
         cluster = Cluster(

--- a/app/backend/src/tests/test_pages.py
+++ b/app/backend/src/tests/test_pages.py
@@ -4,7 +4,18 @@ from google.protobuf import wrappers_pb2
 
 from couchers.crypto import random_hex
 from couchers.db import session_scope
-from couchers.models import Cluster, ClusterRole, ClusterSubscription, Node, Page, PageType, PageVersion, Thread, Upload
+from couchers.models import (
+    Cluster,
+    ClusterRole,
+    ClusterSubscription,
+    Node,
+    NodeType,
+    Page,
+    PageType,
+    PageVersion,
+    Thread,
+    Upload,
+)
 from couchers.proto import pages_pb2
 from couchers.utils import create_polygon_lat_lng, now, to_aware_datetime, to_multi
 from tests.fixtures.db import generate_user
@@ -571,7 +582,9 @@ def test_page_transfer(db):
     user3, token3 = generate_user()
     with session_scope() as session:
         # create a community
-        node = Node(geom=to_multi(create_polygon_lat_lng([[0, 0], [0, 2], [2, 2], [2, 0], [0, 0]])))
+        node = Node(
+            geom=to_multi(create_polygon_lat_lng([[0, 0], [0, 2], [2, 2], [2, 0], [0, 0]])), node_type=NodeType.world
+        )
         session.add(node)
         session.flush()
         community_cluster = Cluster(

--- a/app/proto/communities.proto
+++ b/app/proto/communities.proto
@@ -11,6 +11,15 @@ import "events.proto";
 import "groups.proto";
 import "pages.proto";
 
+enum NodeType {
+  NODE_TYPE_UNSPECIFIED = 0;
+  NODE_TYPE_WORLD = 1;
+  NODE_TYPE_REGION = 2;
+  NODE_TYPE_SUBREGION = 3;
+  NODE_TYPE_LOCALITY = 4;
+  NODE_TYPE_SUBLOCALITY = 5;
+}
+
 service Communities {
   option (auth_level) = AUTH_LEVEL_SECURE;
 
@@ -118,6 +127,7 @@ message Community {
   bool can_moderate = 13;
   bool discussions_enabled = 14;
   bool events_enabled = 15;
+  NodeType node_type = 16;
 }
 
 message GetCommunityReq {
@@ -295,6 +305,7 @@ message CommunitySummary {
   // list of parents, ordered according to inclusion, for hierarchical ordering
   repeated org.couchers.api.groups.Parent parents = 6;
   google.protobuf.Timestamp created = 7;
+  NodeType node_type = 8;
 }
 
 message ListAllCommunitiesReq {

--- a/app/web/features/communities/CommunitiesPage/CommunitySearch.test.tsx
+++ b/app/web/features/communities/CommunitiesPage/CommunitySearch.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Sentry from "platform/sentry";
-import { CommunitySummary } from "proto/communities_pb";
+import { CommunitySummary, NodeType } from "proto/communities_pb";
 import { routeToCommunity } from "routes";
 import * as communitiesService from "service/communities";
 import wrapper from "test/hookWrapper";
@@ -52,6 +52,7 @@ const mockCommunities: CommunitySummary.AsObject[] = [
     member: false,
     memberCount: 10,
     created: { seconds: 1577800000, nanos: 0 },
+    nodeType: NodeType.NODE_TYPE_LOCALITY,
   },
   {
     communityId: 3,
@@ -70,6 +71,7 @@ const mockCommunities: CommunitySummary.AsObject[] = [
     member: false,
     memberCount: 8,
     created: { seconds: 1577900000, nanos: 0 },
+    nodeType: NodeType.NODE_TYPE_LOCALITY,
   },
   {
     communityId: 4,
@@ -88,6 +90,7 @@ const mockCommunities: CommunitySummary.AsObject[] = [
     member: false,
     memberCount: 15,
     created: { seconds: 1578000000, nanos: 0 },
+    nodeType: NodeType.NODE_TYPE_LOCALITY,
   },
 ];
 

--- a/app/web/test/fixtures/community.json
+++ b/app/web/test/fixtures/community.json
@@ -39,5 +39,6 @@
   "adminCount": 2,
   "nearbyUserCount": 3,
   "eventsEnabled": true,
-  "discussionsEnabled": true
+  "discussionsEnabled": true,
+  "nodeType": 4
 }


### PR DESCRIPTION
Add an explicit `node_type` label to each node so it declares its hierarchy level: `world`, `region`, `subregion`, `locality`, `sublocality`. Previously the level was only implicit based on tree depth.

- Add `NodeType` enum and NOT NULL `node_type` column to the `Node` model
- Add `NodeType` proto enum and populate it on `Community` and `CommunitySummary` messages
- Add `CHILD_NODE_TYPE` mapping and require `node_type` in `create_node` helper
- Migration backfills existing nodes via a recursive CTE computing depth from the root

## Testing

- Ran `make format` and all checks pass
- `pytest src/tests/test_communities.py` — 24 passed
- `pytest src/tests/test_model_constraints.py src/tests/test_pages.py` — 17 passed
- `pytest src/tests/test_editor.py` — 24 passed

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me