### PR TITLE
Clarify signup email confirmation page title

### DIFF
--- a/app/web/features/auth/locales/en.json
+++ b/app/web/features/auth/locales/en.json
@@ -156,7 +156,7 @@
   },
   "logged_out_message": "You were logged out.",
   "sign_up_completed_title": "Thank you for signing up!",
-  "sign_up_need_verification_title": "Almost there, one last thing!",
+  "sign_up_need_verification_title": "One last thing: confirm your email.",
   "sign_up_resend_verification_email_help": "Didn't receive the email? Click <2>here to resend the verification link</2>.",
   "sign_up_resend_verification_done": "Done! We've sent you another email.",
   "sign_up_completed_prompt": "We have sent an email with a verification link to your email address. Please click the link to activate your account.",


### PR DESCRIPTION
Changed the signup verification page title from "Almost there, one last thing!" to "One last thing: confirm your email." This makes it immediately clear what the user needs to do, instead of keeping it a mystery.

## Testing
Locale string change only — no functional change.

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me