### PR TITLE
Add frontend error handling for > 20MB image

### DIFF
--- a/app/web/components/ImageInput/ImageInput.test.tsx
+++ b/app/web/components/ImageInput/ImageInput.test.tsx
@@ -15,6 +15,7 @@ import i18n from "test/i18n";
 import { server } from "test/restMock";
 import { assertErrorAlert, mockConsoleError, MockedService } from "test/utils";
 
+import { MAX_FILE_SIZE } from "./constants";
 import ImageInput from "./ImageInput";
 
 const { t } = i18n;
@@ -193,6 +194,29 @@ describe.each`
     );
 
     expect(await screen.findByText("Whoops")).toBeVisible();
+  });
+
+  it("displays an error for files exceeding max size without uploading", async () => {
+    // Create a file larger than MAX_FILE_SIZE (20MB)
+    const largeFileSize = MAX_FILE_SIZE + 1;
+    const largeFile = new File(
+      [new ArrayBuffer(largeFileSize)],
+      "large-image.jpg",
+      { type: "image/jpeg" },
+    );
+
+    const user = userEvent.setup({ applyAccept: false });
+
+    await user.upload(
+      screen.getByLabelText(t("profile:select_an_image")) as HTMLInputElement,
+      largeFile,
+    );
+
+    // Verify error message is displayed
+    expect(await screen.findByText(IMAGE_TOO_LARGE)).toBeVisible();
+
+    // Verify upload was NOT called (client-side validation prevented it)
+    expect(uploadFileMock).not.toHaveBeenCalled();
   });
 
   it("calls onUploading callback during image upload", async () => {

--- a/app/web/components/ImageInput/ImageInput.tsx
+++ b/app/web/components/ImageInput/ImageInput.tsx
@@ -11,9 +11,10 @@ import React, { useCallback, useRef, useState } from "react";
 import { Control, useController } from "react-hook-form";
 import { service } from "service";
 import { ImageInputValues } from "service/api";
+import { IMAGE_TOO_LARGE } from "service/constants";
 import { base64ToFile, useNativeImagePicker } from "utils/nativeLink";
 
-import { DEFAULT_HEIGHT, DEFAULT_WIDTH } from "./constants";
+import { DEFAULT_HEIGHT, DEFAULT_WIDTH, MAX_FILE_SIZE } from "./constants";
 
 interface ImageInputProps {
   className?: string;
@@ -96,6 +97,7 @@ function ImageInput(props: AvatarInputProps | RectImgInputProps) {
 
   const [imageUrl, setImageUrl] = useState(initialPreviewSrc);
   const [readerError, setReaderError] = useState("");
+  const [fileSizeError, setFileSizeError] = useState("");
 
   const mutation = useMutation<ImageInputValues, Error, File>({
     mutationFn: (file) => service.api.uploadFile(file),
@@ -124,8 +126,16 @@ function ImageInput(props: AvatarInputProps | RectImgInputProps) {
 
   const handleChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     setReaderError("");
+    setFileSizeError("");
     if (!event.target.files?.length) return;
     const file = event.target.files[0];
+
+    // Check file size before uploading
+    if (file.size > MAX_FILE_SIZE) {
+      setFileSizeError(IMAGE_TOO_LARGE);
+      return;
+    }
+
     try {
       const base64 = await new Promise<string>((resolve, reject) => {
         const reader = new FileReader();
@@ -157,17 +167,25 @@ function ImageInput(props: AvatarInputProps | RectImgInputProps) {
   // Native app WebView file input is unreliable on iOS - use native image picker instead
   const handleNativeImagePick = useCallback(async () => {
     setReaderError("");
+    setFileSizeError("");
     try {
       const result = await pickImage();
       if (result.success) {
         const dataUrl = `data:${result.mimeType};base64,${result.imageBase64}`;
-        setImageUrl(dataUrl);
         const extension = result.mimeType.split("/")[1] || "jpg";
         const file = base64ToFile(
           result.imageBase64,
           result.mimeType,
           `image.${extension}`,
         );
+
+        // Check file size before uploading
+        if (file.size > MAX_FILE_SIZE) {
+          setFileSizeError(IMAGE_TOO_LARGE);
+          return;
+        }
+
+        setImageUrl(dataUrl);
         mutation.mutate(file);
       }
     } catch (e) {
@@ -184,6 +202,7 @@ function ImageInput(props: AvatarInputProps | RectImgInputProps) {
         <Alert severity="error">{mutation.error?.message || ""}</Alert>
       )}
       {readerError && <Alert severity="error">{readerError}</Alert>}
+      {fileSizeError && <Alert severity="error">{fileSizeError}</Alert>}
       <FlexWrapper>
         <StyledInput
           aria-label={t("profile:select_an_image")}

--- a/app/web/components/ImageInput/constants.ts
+++ b/app/web/components/ImageInput/constants.ts
@@ -1,2 +1,5 @@
 export const DEFAULT_HEIGHT = 150;
 export const DEFAULT_WIDTH = 300;
+
+// Max file size in bytes (20MB - matches envoy proxy buffer limit)
+export const MAX_FILE_SIZE = 20971520;

--- a/app/web/service/constants.ts
+++ b/app/web/service/constants.ts
@@ -1,5 +1,5 @@
 export const FETCH_FAILED =
   "Couldn't connect to the server. Please check your Internet connection or try again later.";
-export const IMAGE_TOO_LARGE = "Image size was too large";
+export const IMAGE_TOO_LARGE = "Image size too large (max 20 MB)";
 export const INTERNAL_ERROR = "Internal error";
 export const SERVER_ERROR = "Server error";


### PR DESCRIPTION
Closes #4125 

Gives frontend user feedback if the image is too large. Previously only failed on the backend and user did not know why.

<img width="1163" height="463" alt="Screenshot 2026-02-17 at 14 19 50" src="https://github.com/user-attachments/assets/aef53268-e4b7-4ece-b100-c0151adebf0a" />


## Testing
* You can download a dummy 21MB image here to test: https://examplefile.com/image/jpg/21-mb-jpg
* Then try to upload in an event to see the error

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` and `yarn lint --fix` in app/web, and run tests locally. -->
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, you can merge it if you have write access.
--->
