### PR TITLE
Fix ReferencesView scroll on load more

### DIFF
--- a/app/web/features/profile/view/ReferencesView.tsx
+++ b/app/web/features/profile/view/ReferencesView.tsx
@@ -9,6 +9,7 @@ import { RpcError } from "grpc-web";
 import { useTranslation } from "i18n";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
 import { ListReferencesRes } from "proto/references_pb";
+import { useEffect, useRef } from "react";
 import { theme } from "theme";
 import hasAtLeastOnePage from "utils/hasAtLeastOnePage";
 
@@ -49,6 +50,22 @@ export default function ReferencesView({
   referenceUsers,
 }: ReferencesViewProps) {
   const { t } = useTranslation([GLOBAL, PROFILE]);
+  const scrollPositionRef = useRef<number | null>(null);
+
+  // Restore scroll position after loading more references
+  useEffect(() => {
+    if (!isFetchingNextPage && scrollPositionRef.current !== null) {
+      // Restore the scroll position
+      window.scrollTo(0, scrollPositionRef.current);
+      scrollPositionRef.current = null;
+    }
+  }, [isFetchingNextPage]);
+
+  const handleFetchMore = () => {
+    // Store current scroll position before fetching
+    scrollPositionRef.current = window.scrollY;
+    fetchNextPage();
+  };
 
   return (
     <>
@@ -66,10 +83,7 @@ export default function ReferencesView({
           />
           {hasNextPage && (
             <SeeMoreReferencesButtonContainer>
-              <Button
-                loading={isFetchingNextPage}
-                onClick={() => fetchNextPage()}
-              >
+              <Button loading={isFetchingNextPage} onClick={handleFetchMore}>
                 {t("profile:see_more_references")}
               </Button>
             </SeeMoreReferencesButtonContainer>


### PR DESCRIPTION
Closes #4397 

Previously if a user was browsing a profile with many references and clicked "load more" it scrolled back to the top, which was annoying. Now it should stay in place.


## Testing
* Change REFERENCES_PAGE_SIZE to something smaller in app/web/service/references.ts
* Go to a profile with more than that references, like Aapeli, me or Jesse on stage
* Load more and see it doesn't jump all the way to the top.

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` and `yarn lint --fix` in app/web, and run tests locally. -->
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, you can merge it if you have write access.
--->
