### PR TITLE
Backend/i18n: localize_with_markup

### DIFF
--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -165,7 +165,7 @@ class StringTemplate:
             if segment.is_variable:
                 if substitutions is not None and segment.text in substitutions:
                     value = substitutions[segment.text]
-                    if with_markup and not isinstance(value, Markup):
+                    if with_markup and not isinstance(value, Markup) and not isinstance(value, int):
                         # Auto-escape since we're producing markup
                         substrings.append(escape(value))
                     elif isinstance(value, Markup) and not with_markup:

--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -6,8 +6,9 @@ import re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from html import escape, unescape
-from markupsafe import Markup
 from typing import Any
+
+from markupsafe import Markup
 
 from couchers.i18n.plurals import PluralRule
 
@@ -30,16 +31,16 @@ class I18Next:
     default_translation: Translation | None = None
     """The translation used to look up strings in unsupported locales."""
 
-    def add_translation(self, locale: str, plural_rule: PluralRule, *, json_dict: dict[str, Any] | None = None) -> Translation:
+    def add_translation(
+        self, locale: str, plural_rule: PluralRule, *, json_dict: dict[str, Any] | None = None
+    ) -> Translation:
         translation = Translation(locale, plural_rule)
         self.translations_by_locale[locale] = translation
         if json_dict:
             translation.load_json_dict(json_dict)
         return translation
 
-    def find_string(
-        self, key: str, locale: str, substitutions: SubstitutionDict | None = None
-    ) -> String | None:
+    def find_string(self, key: str, locale: str, substitutions: SubstitutionDict | None = None) -> String | None:
         """Find the string that will be localized, applying fallbacks and variant selection."""
         translation = self.translations_by_locale.get(locale, self.default_translation)
         candidate_translations = [translation] + translation.fallbacks if translation else []
@@ -50,9 +51,7 @@ class I18Next:
 
         raise LocalizationError(locale, key)
 
-    def localize(
-        self, string_key: str, locale: str, substitutions: SubstitutionDict | None = None
-    ) -> str:
+    def localize(self, string_key: str, locale: str, substitutions: SubstitutionDict | None = None) -> str:
         """Finds a translated string in the best matching locale and performs substitutions."""
         if string := self.find_string(string_key, locale, substitutions):
             return string.render(substitutions)

--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -5,6 +5,8 @@ Implements localizing strings stored in the i18next json format.
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from html import escape, unescape
+from markupsafe import Markup
 from typing import Any
 
 from couchers.i18n.plurals import PluralRule
@@ -13,53 +15,73 @@ PLURALIZABLE_VARIABLE_NAME = "count"
 """Special variable name for which i18next supports pluralization forms."""
 
 
+# A dictionary of values to substitute placeholders with.
+# str: Default case, will be escaped if localizing with markup.
+# int: Supports plurals.
+# Markup: Will be unescaped if localizing without markup.
+SubstitutionDict = Mapping[str, str | int | Markup]
+
+
 @dataclass
 class I18Next:
     """Retrieves translated strings from their keys based on the i18next format."""
 
-    languages_by_code: dict[str, Language] = field(default_factory=dict)
-    default_language: Language | None = None
-    """The language used to look up strings in unsupported languages."""
+    translations_by_locale: dict[str, Translation] = field(default_factory=dict)
+    default_translation: Translation | None = None
+    """The translation used to look up strings in unsupported locales."""
 
-    def add_language(self, code: str, plural_rule: PluralRule, *, json_dict: dict[str, Any] | None = None) -> Language:
-        language = Language(code, plural_rule)
-        self.languages_by_code[code] = language
+    def add_translation(self, locale: str, plural_rule: PluralRule, *, json_dict: dict[str, Any] | None = None) -> Translation:
+        translation = Translation(locale, plural_rule)
+        self.translations_by_locale[locale] = translation
         if json_dict:
-            language.load_json_dict(json_dict)
-        return language
+            translation.load_json_dict(json_dict)
+        return translation
 
     def find_string(
-        self, key: str, language_code: str, substitutions: Mapping[str, str | int] | None = None
+        self, key: str, locale: str, substitutions: SubstitutionDict | None = None
     ) -> String | None:
         """Find the string that will be localized, applying fallbacks and variant selection."""
-        language = self.languages_by_code.get(language_code, self.default_language)
-        candidate_languages = [language] + language.fallbacks if language else []
-        for candidate_language in candidate_languages:
-            if string := candidate_language.find_string(key, substitutions):
+        translation = self.translations_by_locale.get(locale, self.default_translation)
+        candidate_translations = [translation] + translation.fallbacks if translation else []
+        for candidate_translation in candidate_translations:
+            if string := candidate_translation.find_string(key, substitutions):
                 if string.template.can_render(substitutions):
                     return string
 
-        raise LocalizationError(language_code, key)
+        raise LocalizationError(locale, key)
 
     def localize(
-        self, string_key: str, language_code: str, substitutions: Mapping[str, str | int] | None = None
+        self, string_key: str, locale: str, substitutions: SubstitutionDict | None = None
     ) -> str:
-        if string := self.find_string(string_key, language_code, substitutions):
+        """Finds a translated string in the best matching locale and performs substitutions."""
+        if string := self.find_string(string_key, locale, substitutions):
             return string.render(substitutions)
         else:
-            raise LocalizationError(language_code, string_key)
+            raise LocalizationError(locale, string_key)
+
+    def localize_with_markup(
+        self, string_key: str, locale: str, substitutions: SubstitutionDict | None = None
+    ) -> Markup:
+        """
+        Finds a translated string that might contain markup in the best matching locale,
+        and performs substitutions in a way that results in a markup-safe string.
+        """
+        if string := self.find_string(string_key, locale, substitutions):
+            return string.render_with_markup(substitutions)
+        else:
+            raise LocalizationError(locale, string_key)
 
 
 @dataclass
-class Language:
-    """A set of translated strings for a language."""
+class Translation:
+    """A set of translated strings for a locale."""
 
-    code: str
-    """The language code, e.g. 'en'"""
+    locale: str
+    """The locale, e.g. 'en' or 'fr-CA'"""
     plural_rule: PluralRule
     """The rule for plurals in this language."""
     strings_by_key: dict[str, String] = field(default_factory=dict)
-    fallbacks: list[Language] = field(default_factory=list)
+    fallbacks: list[Translation] = field(default_factory=list)
 
     def load_json_dict(self, json_dict: Mapping[str, Any]) -> None:
         def add_strings(json_dict: Mapping[str, Any], key_prefix: str | None) -> None:
@@ -70,18 +92,18 @@ class Language:
                 elif isinstance(v, dict):
                     add_strings(v, key_prefix=full_key)
                 else:
-                    raise ValueError(f"Unexpected value type in language JSON: {type(v)}")
+                    raise ValueError(f"Unexpected value type in locale JSON: {type(v)}")
 
         add_strings(json_dict, key_prefix=None)
 
     def add_string(self, key: str, value: str) -> None:
         self.strings_by_key[key] = String(key, StringTemplate.parse(value))
 
-    def find_string(self, key: str, substitutions: Mapping[str, str | int] | None = None) -> String | None:
+    def find_string(self, key: str, substitutions: SubstitutionDict | None = None) -> String | None:
         # if we have a numerical "count" substitution,
         # i18next will first search for a key with a suffix
         # based on the plural category suggested by the count
-        # according to the current language's rules.
+        # according to the current locale's rules.
         if substitutions:
             if count := substitutions.get(PLURALIZABLE_VARIABLE_NAME):
                 if isinstance(count, int):
@@ -91,10 +113,10 @@ class Language:
                         return string
         return self.strings_by_key.get(key)
 
-    def localize(self, string_key: str, substitutions: Mapping[str, str | int] | None = None) -> str:
+    def localize(self, string_key: str, substitutions: SubstitutionDict | None = None) -> str:
         string = self.find_string(string_key, substitutions)
         if string is None:
-            raise LocalizationError(language_code=self.code, string_key=string_key)
+            raise LocalizationError(locale=self.locale, string_key=string_key)
         return string.render(substitutions)
 
 
@@ -105,8 +127,11 @@ class String:
     key: str
     template: StringTemplate
 
-    def render(self, substitutions: Mapping[str, str | int] | None) -> str:
+    def render(self, substitutions: SubstitutionDict | None) -> str:
         return self.template.render(substitutions)
+
+    def render_with_markup(self, substitutions: SubstitutionDict | None) -> Markup:
+        return self.template.render_with_markup(substitutions)
 
 
 @dataclass(frozen=True, slots=True)
@@ -115,19 +140,34 @@ class StringTemplate:
 
     segments: list[StringSegment]
 
-    def can_render(self, substitutions: Mapping[str, str | int] | None) -> bool:
+    def can_render(self, substitutions: SubstitutionDict | None) -> bool:
         for segment in self.segments:
             if segment.is_variable:
                 if not substitutions or substitutions.get(segment.text) is None:
                     return False
         return True
 
-    def render(self, substitutions: Mapping[str, str | int] | None) -> str:
+    def render(self, substitutions: SubstitutionDict | None) -> str:
+        return self._render(substitutions, with_markup=False)
+
+    def render_with_markup(self, substitutions: SubstitutionDict | None) -> Markup:
+        return Markup(self._render(substitutions, with_markup=True))
+
+    def _render(self, substitutions: SubstitutionDict | None, with_markup: bool) -> str:
         substrings: list[str] = []
         for segment in self.segments:
             if segment.is_variable:
                 if substitutions is not None and segment.text in substitutions:
-                    substrings.append(str(substitutions[segment.text]))
+                    value = substitutions[segment.text]
+                    if with_markup and not isinstance(value, Markup):
+                        # Auto-escape since we're producing markup
+                        substrings.append(escape(value))
+                    elif isinstance(value, Markup) and not with_markup:
+                        # We're producing a string where markup is not evaluated
+                        # so resolve escape sequences like &quot;
+                        substrings.append(unescape(value))
+                    else:
+                        substrings.append(str(value))
                 else:
                     raise ValueError(f"Missing substitution for variable '{segment.text}'")
             else:
@@ -157,9 +197,9 @@ class StringSegment:
 
 
 class LocalizationError(Exception):
-    """Raised failing to localize a string, e.g. if it is not found in any fallback language."""
+    """Raised failing to localize a string, e.g. if it is not found in any fallback locale."""
 
-    def __init__(self, language_code: str, string_key: str):
-        self.language_code = language_code
+    def __init__(self, locale: str, string_key: str):
+        self.locale = locale
         self.string_key = string_key
-        super().__init__(f"Could not localize string {string_key} for language {language_code}")
+        super().__init__(f"Could not localize string {string_key} for locale {locale}")

--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -119,6 +119,12 @@ class Translation:
             raise LocalizationError(locale=self.locale, string_key=string_key)
         return string.render(substitutions)
 
+    def localize_with_markup(self, string_key: str, substitutions: SubstitutionDict | None = None) -> Markup:
+        string = self.find_string(string_key, substitutions)
+        if string is None:
+            raise LocalizationError(locale=self.locale, string_key=string_key)
+        return string.render_with_markup(substitutions)
+
 
 @dataclass(frozen=True, slots=True)
 class String:

--- a/app/backend/src/couchers/i18n/locales.py
+++ b/app/backend/src/couchers/i18n/locales.py
@@ -36,24 +36,24 @@ def load_locales(directory: Path) -> I18Next:
 
     # Load all locale JSON files from the locales directory
     for locale_file in directory.glob("*.json"):
-        lang_code = locale_file.stem  # e.g., "en" from "en.json"
+        locale = locale_file.stem  # e.g., "en" from "en.json"
 
         with open(locale_file, "r", encoding="utf-8") as f:
             translations = json.load(f)
 
-        plural_rule = PluralRules.for_language(lang_code) or PluralRules.en
-        language = i18next.add_language(lang_code, plural_rule)
-        language.load_json_dict(translations)
+        plural_rule = PluralRules.for_language(locale) or PluralRules.en
+        translation = i18next.add_translation(locale, plural_rule)
+        translation.load_json_dict(translations)
 
     # English is our default for undefined languages
-    en = i18next.languages_by_code.get("en")
-    if en is None:
+    default_translation = i18next.translations_by_locale.get(DEFAULT_LOCALE)
+    if default_translation is None:
         raise RuntimeError("English translations must be loaded")
-    i18next.default_language = en
+    i18next.default_translation = default_translation
 
     # Apply fallbacks
-    for language in i18next.languages_by_code.values():
-        for fallback_code in get_locale_fallbacks(language.code):
-            language.fallbacks.append(i18next.languages_by_code[fallback_code])
+    for translation in i18next.translations_by_locale.values():
+        for fallback_locale in get_locale_fallbacks(translation.locale):
+            translation.fallbacks.append(i18next.translations_by_locale[fallback_locale])
 
     return i18next

--- a/app/backend/src/tests/test_i18n.py
+++ b/app/backend/src/tests/test_i18n.py
@@ -13,12 +13,12 @@ def test_translations_loaded():
     i18next = get_main_i18next()
 
     # Should have at least English errors loaded
-    en_lang = i18next.languages_by_code.get("en")
-    assert en_lang is not None
-    assert en_lang.strings_by_key.get("errors.account_not_found") is not None
+    en_translation = i18next.translations_by_locale.get("en")
+    assert en_translation is not None
+    assert en_translation.strings_by_key.get("errors.account_not_found") is not None
 
     # Other languages should also exist
-    assert len(i18next.languages_by_code) > 1
+    assert len(i18next.translations_by_locale) > 1
 
 
 def test_fallback_chain():
@@ -26,12 +26,12 @@ def test_fallback_chain():
     i18next = get_main_i18next()
 
     # Example: fr-CA should fallback to fr, which should fallback to en
-    fr_CA = i18next.languages_by_code["fr-CA"]
-    fr = i18next.languages_by_code["fr"]
-    en = i18next.languages_by_code["en"]
+    fr_CA = i18next.translations_by_locale["fr-CA"]
+    fr = i18next.translations_by_locale["fr"]
+    en = i18next.translations_by_locale["en"]
 
     assert fr_CA.fallbacks == [fr, en]
     assert fr.fallbacks == [en]
     assert en.fallbacks == []
 
-    assert i18next.default_language == en
+    assert i18next.default_translation == en

--- a/app/backend/src/tests/test_i18next.py
+++ b/app/backend/src/tests/test_i18next.py
@@ -1,5 +1,5 @@
-from markupsafe import Markup
 import pytest
+from markupsafe import Markup
 
 from couchers.i18n.i18next import I18Next, LocalizationError
 from couchers.i18n.plurals import PluralRules
@@ -158,7 +158,7 @@ def test_missing_substitution_fallback():
 
 def test_escaping():
     i18next = I18Next()
-    i18next.add_translation("en", PluralRules.en, json_dict= { "greeting": "hello {{name}}" })
+    i18next.add_translation("en", PluralRules.en, json_dict={"greeting": "hello {{name}}"})
 
     # localize returns an str, which is considered untrusted for markup,
     # so it can contain tags because the renderer is resposible for escaping them.
@@ -168,5 +168,9 @@ def test_escaping():
 
     # localize_with_markup returns a Markup object, which is considered trusted for markup,
     # so it can only interpolate tags if they are also trusted, and otherwise will escape them.
-    assert i18next.localize_with_markup("greeting", "en", substitutions={"name": "<script/>"}) == "hello &lt;script/&gt;"
-    assert i18next.localize_with_markup("greeting", "en", substitutions={"name": Markup("<script/>")}) == "hello <script/>"
+    assert (
+        i18next.localize_with_markup("greeting", "en", substitutions={"name": "<script/>"}) == "hello &lt;script/&gt;"
+    )
+    assert (
+        i18next.localize_with_markup("greeting", "en", substitutions={"name": Markup("<script/>")}) == "hello <script/>"
+    )

--- a/app/backend/src/tests/test_i18next.py
+++ b/app/backend/src/tests/test_i18next.py
@@ -1,3 +1,4 @@
+from markupsafe import Markup
 import pytest
 
 from couchers.i18n.i18next import I18Next, LocalizationError
@@ -6,27 +7,27 @@ from couchers.i18n.plurals import PluralRules
 
 def test_lookup():
     i18next = I18Next()
-    i18next.add_language("en", PluralRules.en).add_string("greeting", "hello")
+    i18next.add_translation("en", PluralRules.en).add_string("greeting", "hello")
     assert i18next.localize("greeting", "en") == "hello"
 
 
 def test_substitution():
     i18next = I18Next()
-    i18next.add_language("en", PluralRules.en).add_string("greeting", "hello {{name}}!")
+    i18next.add_translation("en", PluralRules.en).add_string("greeting", "hello {{name}}!")
     assert i18next.localize("greeting", "en", {"name": "world"}) == "hello world!"
 
 
 def test_placeholder_with_spacing():
     i18next = I18Next()
-    i18next.add_language("en", PluralRules.en).add_string("greeting", "hello {{ name }}!")
+    i18next.add_translation("en", PluralRules.en).add_string("greeting", "hello {{ name }}!")
     assert i18next.localize("greeting", "en", {"name": "world"}) == "hello world!"
 
 
 def test_localized():
     i18next = I18Next()
-    en = i18next.add_language("en", PluralRules.en)
+    en = i18next.add_translation("en", PluralRules.en)
     en.add_string("greeting", "hello")
-    fr = i18next.add_language("fr", PluralRules.en)
+    fr = i18next.add_translation("fr", PluralRules.en)
     fr.add_string("greeting", "bonjour")
     fr.fallbacks.append(en)
     assert i18next.localize("greeting", "fr") == "bonjour"
@@ -34,18 +35,18 @@ def test_localized():
 
 def test_fallback():
     i18next = I18Next()
-    en = i18next.add_language("en", PluralRules.en)
+    en = i18next.add_translation("en", PluralRules.en)
     en.add_string("greeting", "hello")
-    fr = i18next.add_language("fr", PluralRules.en)
+    fr = i18next.add_translation("fr", PluralRules.en)
     fr.fallbacks.append(en)
     assert i18next.localize("greeting", "fr") == "hello"
 
 
 def test_mutual_fallback():
     i18next = I18Next()
-    pt_pt = i18next.add_language("pt-PT", PluralRules.en)
+    pt_pt = i18next.add_translation("pt-PT", PluralRules.en)
     pt_pt.add_string("greeting", "olá")
-    pt_br = i18next.add_language("pt-BR", PluralRules.en)
+    pt_br = i18next.add_translation("pt-BR", PluralRules.en)
     pt_br.add_string("farewell", "tchau")
     pt_pt.fallbacks.append(pt_br)
     pt_br.fallbacks.append(pt_pt)
@@ -55,7 +56,7 @@ def test_mutual_fallback():
 
 def test_plural_suffixes():
     i18next = I18Next()
-    en = i18next.add_language("en", PluralRules.en)
+    en = i18next.add_translation("en", PluralRules.en)
     en.add_string("apples_one", "{{count}} apple")
     en.add_string("apples_other", "{{count}} apples")
     assert i18next.localize("apples", "en", {"count": 1}) == "1 apple"
@@ -64,7 +65,7 @@ def test_plural_suffixes():
 
 def test_plural_suffix_fallback():
     i18next = I18Next()
-    en = i18next.add_language("en", PluralRules.en)
+    en = i18next.add_translation("en", PluralRules.en)
     en.add_string("apples", "{{count}} apples")
     en.add_string("apples_one", "{{count}} apple")
     assert i18next.localize("apples", "en", {"count": 1}) == "1 apple"
@@ -73,7 +74,7 @@ def test_plural_suffix_fallback():
 
 def test_plural_no_count():
     i18next = I18Next()
-    en = i18next.add_language("en", PluralRules.en)
+    en = i18next.add_translation("en", PluralRules.en)
     en.add_string("apples_one", "apple")
     en.add_string("apples_other", "apples")
     assert i18next.localize("apples", "en", {"count": 1}) == "apple"
@@ -82,23 +83,23 @@ def test_plural_no_count():
 
 def test_load_simple_json():
     i18next = I18Next()
-    en = i18next.add_language("en", PluralRules.en)
+    en = i18next.add_translation("en", PluralRules.en)
     en.load_json_dict({"greeting": "hello"})
     assert i18next.localize("greeting", "en") == "hello"
 
 
 def test_load_nested_json():
     i18next = I18Next()
-    en = i18next.add_language("en", PluralRules.en)
+    en = i18next.add_translation("en", PluralRules.en)
     en.load_json_dict({"greeting": {"short": "hi"}})
     assert i18next.localize("greeting.short", "en") == "hi"
 
 
 def test_fallback_locale():
     i18next = I18Next()
-    en = i18next.add_language("en", PluralRules.en)
+    en = i18next.add_translation("en", PluralRules.en)
     en.add_string("greeting", "hello")
-    i18next.default_language = en
+    i18next.default_translation = en
     assert i18next.localize("greeting", "fr") == "hello"
 
 
@@ -106,50 +107,66 @@ def test_missing_locale():
     i18next = I18Next()
     with pytest.raises(LocalizationError) as raised:
         i18next.localize("greeting", "en")
-    assert raised.value.language_code == "en"
+    assert raised.value.locale == "en"
     assert raised.value.string_key == "greeting"
 
 
 def test_missing_string():
     i18next = I18Next()
-    i18next.add_language("en", PluralRules.en)
+    i18next.add_translation("en", PluralRules.en)
     with pytest.raises(LocalizationError) as raised:
         i18next.localize("greeting", "en")
-    assert raised.value.language_code == "en"
+    assert raised.value.locale == "en"
     assert raised.value.string_key == "greeting"
 
 
 def test_missing_plural_form():
     i18next = I18Next()
-    en = i18next.add_language("en", PluralRules.en)
+    en = i18next.add_translation("en", PluralRules.en)
     en.add_string("apples_one", "{{count}} apple")
     assert i18next.localize("apples", "en", {"count": 1}) == "1 apple"
     with pytest.raises(LocalizationError) as raised:
         i18next.localize("apples", "en", {"count": 2})
-    assert raised.value.language_code == "en"
+    assert raised.value.locale == "en"
     assert raised.value.string_key == "apples"
 
 
 def test_extra_substitution():
     i18next = I18Next()
-    i18next.add_language("en", PluralRules.en).add_string("greeting", "hello")
+    i18next.add_translation("en", PluralRules.en).add_string("greeting", "hello")
     assert i18next.localize("greeting", "en", substitutions={"e": "mc2"})
 
 
 def test_missing_substitution():
     i18next = I18Next()
-    i18next.add_language("en", PluralRules.en).add_string("greeting", "hello {{name}}")
+    i18next.add_translation("en", PluralRules.en).add_string("greeting", "hello {{name}}")
     with pytest.raises(LocalizationError) as raised:
         i18next.localize("greeting", "en")
-    assert raised.value.language_code == "en"
+    assert raised.value.locale == "en"
     assert raised.value.string_key == "greeting"
 
 
 def test_missing_substitution_fallback():
     i18next = I18Next()
-    en = i18next.add_language("en", PluralRules.en)
+    en = i18next.add_translation("en", PluralRules.en)
     en.add_string("greeting", "hello {{name}}")
-    fr = i18next.add_language("fr", PluralRules.fr)
+    fr = i18next.add_translation("fr", PluralRules.fr)
     fr.add_string("greeting", "bonjour {{nom}}")
     fr.fallbacks.append(en)
     assert i18next.localize("greeting", "fr", substitutions={"name": "world"}) == "hello world"
+
+
+def test_escaping():
+    i18next = I18Next()
+    i18next.add_translation("en", PluralRules.en, json_dict= { "greeting": "hello {{name}}" })
+
+    # localize returns an str, which is considered untrusted for markup,
+    # so it can contain tags because the renderer is resposible for escaping them.
+    # Markup in this context is unescaped back into plaintext to avoid double-escaping.
+    assert i18next.localize("greeting", "en", substitutions={"name": "<script/>"}) == "hello <script/>"
+    assert i18next.localize("greeting", "en", substitutions={"name": Markup("&lt;script/&gt;")}) == "hello <script/>"
+
+    # localize_with_markup returns a Markup object, which is considered trusted for markup,
+    # so it can only interpolate tags if they are also trusted, and otherwise will escape them.
+    assert i18next.localize_with_markup("greeting", "en", substitutions={"name": "<script/>"}) == "hello &lt;script/&gt;"
+    assert i18next.localize_with_markup("greeting", "en", substitutions={"name": Markup("<script/>")}) == "hello <script/>"

--- a/app/backend/src/tests/test_templating.py
+++ b/app/backend/src/tests/test_templating.py
@@ -53,7 +53,7 @@ def test_date_formatting() -> None:
 
 def _greeting_i18next(value: str) -> I18Next:
     i18next = I18Next()
-    language = i18next.add_language("en", PluralRules.en)
+    language = i18next.add_translation("en", PluralRules.en)
     language.add_string("greeting", value)
     return i18next
 
@@ -61,7 +61,7 @@ def _greeting_i18next(value: str) -> I18Next:
 def _i18next_from_dict(value: dict[str, dict[str, str]]) -> I18Next:
     i18next = I18Next()
     for lang_code, strings in value.items():
-        language = i18next.add_language(lang_code, PluralRules.en)
+        language = i18next.add_translation(lang_code, PluralRules.en)
         language.load_json_dict(strings)
     return i18next
 
@@ -76,8 +76,8 @@ def test_translate_no_substitutions() -> None:
 def test_translate_multiple_languages() -> None:
     template = Jinja2Template(source='{{ "greeting"|translate }}', html=False)
     i18next = I18Next()
-    i18next.add_language("en", PluralRules.en).add_string("greeting", "Hello!")
-    i18next.add_language("fr", PluralRules.en).add_string("greeting", "Bonjour!")
+    i18next.add_translation("en", PluralRules.en).add_string("greeting", "Hello!")
+    i18next.add_translation("fr", PluralRules.en).add_string("greeting", "Bonjour!")
     fr_loc_context = LocalizationContext(locale="fr", timezone=ZoneInfo("Etc/UTC"))
     rendered = template.render({}, fr_loc_context, i18next)
     assert rendered == "Bonjour!"


### PR DESCRIPTION
Some of our localizable strings for emails will contain simple markup like `<b>` tags. When dealing with markup, it's important to know what is trusted and what is untrusted markup. Markup in translations is always trusted, but interpolated placeholder values are typically not.

To safely support this distinction, this introduces two modes for localizing strings. The default returns a string, which is inherently untrusted, so it can contain markup because rendering code will be responsible for escaping it. `localize_with_markup` returns a `markupsafe.Markup` object, which is trusted markup, so any untrusted placeholders should be escaped during substitution.

Also renames i18n's `Language` to `Translation` and `language_code` to `locale` to follow the rest of the code.

## Testing
Added a test.

**Backend checklist**
<!-- To avoid CI failures, first run `make format` in app/backend and run tests locally. -->
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
