### PR TITLE
CI: Fix auto-formatting's "git add"

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Commit and push backend formatting changes
         run: |
-          git add app/backend/**/*.py
+          git add "app/backend/**/*.py"
           git diff --staged --quiet || (git commit -m "Format backend" && git push)
 
   format-frontend:
@@ -215,7 +215,7 @@ jobs:
 
       - name: Commit and push migration if created
         run: |
-          git add app/backend/src/couchers/migrations/versions/*.py
+          git add "app/backend/src/couchers/migrations/versions/*.py"
           git diff --staged --quiet || (git commit -m "Generate migrations" && git push)
 
   regenerate-html-templates:
@@ -251,5 +251,5 @@ jobs:
 
       - name: Commit and push HTML template changes
         run: |
-          git add app/backend/templates/v2/generated_html/*.html
+          git add "app/backend/templates/v2/generated_html/*.html"
           git diff --staged --quiet || (git commit -m "Regenerate HTML templates" && git push)


### PR DESCRIPTION
Unquoted wildcards will be expanded by the shell, but it doesn't process recursive wildcards by default, so `app/backend/**/*.py` expanded to nothing. By quoting wildcards, we let git do the dirty job, and it'll process recursive globs.

## Testing
```
tristan@blueqing:~/code/couchers$ git status
HEAD detached from origin/develop
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   app/backend/src/couchers/i18n/i18next.py

no changes added to commit (use "git add" and/or "git commit -a")
tristan@blueqing:~/code/couchers$ git add app/backend/**/*.py
tristan@blueqing:~/code/couchers$ git status
HEAD detached from origin/develop
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   app/backend/src/couchers/i18n/i18next.py

no changes added to commit (use "git add" and/or "git commit -a")
tristan@blueqing:~/code/couchers$ git add "app/backend/**/*.py"
tristan@blueqing:~/code/couchers$ git status
HEAD detached from origin/develop
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   app/backend/src/couchers/i18n/i18next.py

tristan@blueqing:~/code/couchers$
```

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
