### PR TITLE
Backend/i18n: Consider empty translations as missing

### DIFF
--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -75,7 +75,9 @@ class Language:
         add_strings(json_dict, key_prefix=None)
 
     def add_string(self, key: str, value: str) -> None:
-        self.strings_by_key[key] = String(key, StringTemplate.parse(value))
+        # Weblate and i18next consider an empty string as the absence of a translation.
+        if value:
+            self.strings_by_key[key] = String(key, StringTemplate.parse(value))
 
     def find_string(self, key: str, substitutions: Mapping[str, str | int] | None = None) -> String | None:
         # if we have a numerical "count" substitution,

--- a/app/backend/src/tests/test_i18next.py
+++ b/app/backend/src/tests/test_i18next.py
@@ -106,8 +106,8 @@ def test_fallback_locale():
 # since this is how Weblate/i18next interpret it.
 def test_fallback_on_empty_string():
     i18next = I18Next()
-    en = i18next.add_language("en", PluralRules.en, json_dict={ "greeting": "hello" })
-    fr = i18next.add_language("fr", PluralRules.fr, json_dict={ "greeting": "" })
+    en = i18next.add_language("en", PluralRules.en, json_dict={"greeting": "hello"})
+    fr = i18next.add_language("fr", PluralRules.fr, json_dict={"greeting": ""})
     fr.fallbacks.append(en)
     assert i18next.localize("greeting", "fr") == "hello"
 

--- a/app/backend/src/tests/test_i18next.py
+++ b/app/backend/src/tests/test_i18next.py
@@ -102,6 +102,16 @@ def test_fallback_locale():
     assert i18next.localize("greeting", "fr") == "hello"
 
 
+# An empty string in a translation should be considered as the lack of a string,
+# since this is how Weblate/i18next interpret it.
+def test_fallback_on_empty_string():
+    i18next = I18Next()
+    en = i18next.add_language("en", PluralRules.en, json_dict={ "greeting": "hello" })
+    fr = i18next.add_language("fr", PluralRules.fr, json_dict={ "greeting": "" })
+    fr.fallbacks.append(en)
+    assert i18next.localize("greeting", "fr") == "hello"
+
+
 def test_missing_locale():
     i18next = I18Next()
     with pytest.raises(LocalizationError) as raised:


### PR DESCRIPTION
Weblate can write empty strings to translation files and expects the code to treat them as missing translations rather than as valid empty string translations. This happens with missing plural forms, for example:

```json
  "attendees_count_one": "{{count}} participant",
  "attendees_count_many": "",
  "attendees_count_other": "{{count}} participants",
```

## Testing
Added a test

**Backend checklist**
<!-- To avoid CI failures, first run `make format` in app/backend and run tests locally. -->
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
