### PR TITLE
Backend/notifs/i18n: Remove untranslatable strings from json

### DIFF
--- a/app/backend/src/couchers/notifications/locales/en.json
+++ b/app/backend/src/couchers/notifications/locales/en.json
@@ -61,7 +61,6 @@
     "discussion__create": {
       "title": "New discussion: {{title}}",
       "ios_title": "New Discussion",
-      "ios_subtitle": "{{title}}",
       "body": "{{user}} started the discussion in {{group_or_community}}."
     },
     "discussion__comment": {
@@ -80,59 +79,49 @@
     "event__create_any": {
       "title": "New event: {{title}}",
       "ios_title": "New Event",
-      "ios_subtitle": "{{title}}",
       "body": "{{user}} created the event on {{date_and_time}}."
     },
     "event__create_approved": {
       "title": "New event: {{title}}",
       "ios_title": "New Event",
-      "ios_subtitle": "{{title}}",
       "body": "{{user}} invited you to the event on {{date_and_time}}."
     },
     "event__update": {
       "title": "Event updated: {{title}}",
       "ios_title": "Event Updated",
-      "ios_subtitle": "{{title}}",
       "body": "{{user}} updated the event."
     },
     "event__invite_organizer": {
       "title": "Event updated: {{title}}",
       "ios_title": "Event Updated",
-      "ios_subtitle": "{{title}}",
       "body": "{{user}} added you as an event co-organizer."
     },
     "event__comment": {
       "title": "{{user}} • {{title}}",
-      "ios_title": "{{user}}",
       "ios_subtitle": "Commented on {{title}}"
     },
     "event__reminder": {
       "title": "Upcoming event: {{title}}",
       "ios_title": "Upcoming Event",
-      "ios_subtitle": "{{title}}",
       "body": "The event starts on {{date_and_time}}."
     },
     "event__cancel": {
       "title": "Event cancelled: {{title}}",
       "ios_title": "Event Cancelled",
-      "ios_subtitle": "{{title}}",
       "body": "{{user}} cancelled the event."
     },
     "event__delete": {
       "title": "Event deleted: {{title}}",
       "ios_title": "Event Deleted",
-      "ios_subtitle": "{{title}}",
       "body": "A moderator deleted the event."
     },
     "friend_request__create": {
       "title": "Friend request from {{from_user}}",
-      "ios_title": "{{from_user}}",
       "ios_subtitle": "Friend Request",
       "body": "{{from_user}} wants to be your friend."
     },
     "friend_request__accept": {
       "title": "{{friend}} accepted your friend request",
-      "ios_title": "{{friend}}",
       "ios_subtitle": "Accepted Your Friend Request",
       "body": "You are now friends with {{friend}}."
     },
@@ -143,49 +132,41 @@
     },
     "general__new_blog_post": {
       "title": "New blog post: {{title}}",
-      "ios_title": "New Blog Post",
-      "ios_subtitle": "{{title}}"
+      "ios_title": "New Blog Post"
     },
     "host_request__create": {
       "title": "New host request from {{user}}",
-      "ios_title": "{{user}}",
       "ios_subtitle": "New Host Request",
       "body_one": "{{user}} wants to stay from {{start_date}} for {{count}} day.",
       "body_other": "{{user}} wants to stay from {{start_date}} for {{count}} days."
     },
     "host_request__missed_messages": {
       "title": "New messages from {{user}}",
-      "ios_title": "{{user}}",
       "ios_subtitle": "Missed Messages",
       "body": "You have new unseen messages from {{user}}."
     },
     "host_request__reminder": {
       "title": "Pending request by {{user}}",
       "ios_title": "Host Request Pending",
-      "ios_subtitle": "{{user}}",
       "body": "{{user}} is waiting for your response, please accept or decline the request."
     },
     "host_request__accept": {
       "title": "{{user}} accepted your host request",
-      "ios_title": "{{user}}",
       "ios_subtitle": "Host Request Accepted",
       "body": "{{user}} accepted your host request for {{date}}."
     },
     "host_request__reject": {
       "title": "{{user}} declined your host request",
-      "ios_title": "{{user}}",
       "ios_subtitle": "Host Request Declined",
       "body": "{{user}} declined your host request for {{date}}."
     },
     "host_request__cancel": {
       "title": "{{user}} cancelled their host request",
-      "ios_title": "{{user}}",
       "ios_subtitle": "Host Request Cancelled",
       "body": "{{user}} cancelled their host request for {{date}}."
     },
     "host_request__confirm": {
       "title": "{{user}} confirmed their host request",
-      "ios_title": "{{user}}",
       "ios_subtitle": "Host Request Confirmed",
       "body": "{{user}} confirmed their host request for {{date}}."
     },
@@ -250,26 +231,21 @@
     },
     "reference__receive_friend": {
       "title": "New friend reference from {{user}}",
-      "ios_title": "{{user}}",
       "ios_subtitle": "New Friend Reference"
     },
     "reference__receive": {
       "title": "New reference from {{user}}",
-      "ios_title": "{{user}}",
       "ios_subtitle": "New Reference",
       "body_must_write_yours": "{{user}} left you a reference, now it's your turn to write theirs!"
     },
     "reference__reminder": {
       "title": "Write your reference for {{user}}",
       "ios_title": "Write Your Reference",
-      "ios_subtitle": "{{user}}",
       "body_one": "You still have {{count}} day to write a reference for {{user}}.",
       "body_other": "You still have {{count}} days to write a reference for {{user}}."
     },
     "thread__reply": {
-      "title": "{{user}} • {{title}}",
-      "ios_title": "{{user}}",
-      "ios_subtitle": "{{title}}"
+      "title": "{{user}} • {{title}}"
     },
     "verification__sv_success": {
       "title": "Strong Verification completed",

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -306,6 +306,7 @@ def _render_discussion__create(
     return _get_content(
         NotificationTopicAction.discussion__create,
         loc_context,
+        ios_subtitle=data.discussion.title,
         substitutions={
             "title": data.discussion.title,
             "user": data.author.name,
@@ -356,6 +357,7 @@ def _render_event__create_any(
     return _get_content(
         NotificationTopicAction.event__create_any,
         loc_context,
+        ios_subtitle=data.event.title,
         substitutions={
             "title": data.event.title,
             "user": data.inviting_user.name,
@@ -371,6 +373,7 @@ def _render_event__create_approved(
     return _get_content(
         NotificationTopicAction.event__create_approved,
         loc_context,
+        ios_subtitle=data.event.title,
         substitutions={
             "title": data.event.title,
             "user": data.inviting_user.name,
@@ -388,6 +391,7 @@ def _render_event__update(
     return _get_content(
         NotificationTopicAction.event__update,
         loc_context,
+        ios_subtitle=data.event.title,
         substitutions={
             "title": data.event.title,
             "user": data.updating_user.name,
@@ -402,6 +406,7 @@ def _render_event__invite_organizer(
     return _get_content(
         NotificationTopicAction.event__invite_organizer,
         loc_context,
+        ios_subtitle=data.event.title,
         substitutions={
             "title": data.event.title,
             "user": data.inviting_user.name,
@@ -416,6 +421,7 @@ def _render_event__comment(
     return _get_content(
         NotificationTopicAction.event__comment,
         loc_context,
+        ios_title=data.event.title,
         substitutions={
             "title": data.event.title,
             "user": data.author.name,
@@ -432,6 +438,7 @@ def _render_event__reminder(
     return _get_content(
         NotificationTopicAction.event__reminder,
         loc_context,
+        ios_subtitle=data.event.title,
         substitutions={
             "title": data.event.title,
             "date_and_time": loc_context.localize_datetime(data.event.start_time),
@@ -446,6 +453,7 @@ def _render_event__cancel(
     return _get_content(
         NotificationTopicAction.event__cancel,
         loc_context,
+        ios_subtitle=data.event.title,
         substitutions={
             "title": data.event.title,
             "user": data.cancelling_user.name,
@@ -457,7 +465,12 @@ def _render_event__cancel(
 def _render_event__delete(
     data: notification_data_pb2.EventDelete, loc_context: LocalizationContext
 ) -> PushNotificationContent:
-    return _get_content(NotificationTopicAction.event__delete, loc_context, substitutions={"title": data.event.title})
+    return _get_content(
+        NotificationTopicAction.event__delete,
+        loc_context,
+        ios_subtitle=data.event.title,
+        substitutions={"title": data.event.title},
+    )
 
 
 def _render_friend_request__create(
@@ -466,6 +479,7 @@ def _render_friend_request__create(
     return _get_content(
         NotificationTopicAction.friend_request__create,
         loc_context,
+        ios_title=data.other_user.name,
         substitutions={"from_user": data.other_user.name},
         icon_user=data.other_user,
         action_url=urls.friend_requests_link(),
@@ -478,6 +492,7 @@ def _render_friend_request__accept(
     return _get_content(
         NotificationTopicAction.friend_request__accept,
         loc_context,
+        ios_title=data.other_user.name,
         substitutions={"friend": data.other_user.name},
         icon_user=data.other_user,
         action_url=urls.user_link(username=data.other_user.username),
@@ -501,6 +516,7 @@ def _render_general__new_blog_post(
     return _get_content(
         NotificationTopicAction.general__new_blog_post,
         loc_context,
+        ios_subtitle=data.title,
         body=data.blurb,
         substitutions={"title": data.title},
         action_url=data.url,
@@ -514,6 +530,7 @@ def _render_host_request__create(
     return _get_content(
         NotificationTopicAction.host_request__create,
         loc_context,
+        ios_title=data.surfer.name,
         substitutions={
             "user": data.surfer.name,
             "start_date": loc_context.localize_date_from_iso(data.host_request.from_date),
@@ -543,6 +560,7 @@ def _render_host_request__missed_messages(
     return _get_content(
         NotificationTopicAction.host_request__missed_messages,
         loc_context,
+        ios_title=data.user.name,
         substitutions={"user": data.user.name},
         icon_user=data.user,
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
@@ -555,6 +573,7 @@ def _render_host_request__reminder(
     return _get_content(
         NotificationTopicAction.host_request__reminder,
         loc_context,
+        ios_title=data.surfer.name,
         substitutions={"user": data.surfer.name},
         icon_user=data.surfer,
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
@@ -567,6 +586,7 @@ def _render_host_request__accept(
     return _get_content(
         NotificationTopicAction.host_request__accept,
         loc_context,
+        ios_title=data.surfer.name,
         substitutions={
             "user": data.host.name,
             "date": loc_context.localize_date_from_iso(data.host_request.from_date),
@@ -582,6 +602,7 @@ def _render_host_request__reject(
     return _get_content(
         NotificationTopicAction.host_request__reject,
         loc_context,
+        ios_title=data.host.name,
         substitutions={
             "user": data.host.name,
             "date": loc_context.localize_date_from_iso(data.host_request.from_date),
@@ -597,6 +618,7 @@ def _render_host_request__cancel(
     return _get_content(
         NotificationTopicAction.host_request__cancel,
         loc_context,
+        ios_title=data.surfer.name,
         substitutions={
             "user": data.surfer.name,
             "date": loc_context.localize_date_from_iso(data.host_request.from_date),
@@ -612,6 +634,7 @@ def _render_host_request__confirm(
     return _get_content(
         NotificationTopicAction.host_request__confirm,
         loc_context,
+        ios_title=data.surfer.name,
         substitutions={
             "user": data.surfer.name,
             "date": loc_context.localize_date_from_iso(data.host_request.from_date),
@@ -725,6 +748,7 @@ def _render_reference__receive_friend(
     return _get_content(
         NotificationTopicAction.reference__receive_friend,
         loc_context,
+        ios_title=data.from_user.name,
         body=data.text,
         substitutions={"user": data.from_user.name},
         icon_user=data.from_user,
@@ -754,6 +778,7 @@ def _render_reference__receive(
     return _get_content(
         string_group="reference__receive",
         loc_context=loc_context,
+        ios_title=data.from_user.name,
         body=body,
         substitutions={"user": data.from_user.name},
         icon_user=data.from_user,
@@ -785,6 +810,7 @@ def _render_reference__reminder(
     return _get_content(
         string_group="reference__reminder",
         loc_context=loc_context,
+        ios_subtitle=data.other_user.name,
         substitutions={"count": data.days_left, "user": data.other_user.name},
         icon_user=data.other_user,
         action_url=leave_reference_link,
@@ -823,6 +849,8 @@ def _render_thread__reply(
         NotificationTopicAction.thread__reply,
         loc_context=loc_context,
         body=data.reply.content,
+        ios_title=data.author.name,
+        ios_subtitle=parent_title,
         substitutions={"user": data.author.name, "title": parent_title},
         icon_user=data.author,
         action_url=view_link,


### PR DESCRIPTION
Translators commented that strings that only have a placeholders are useless to translate. Fair enough, we can lift them into the code. However there was a reason I did it that way: it made it obvious that all strings were accounted for by keeping them in the json file. Now in the code it's not obvious why sometimes ios_title is specified, and other times not, for example. Is this better?

## Testing
N/A

**Backend checklist**
<!-- To avoid CI failures, first run `make format` in app/backend and run tests locally. -->
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [ ] Maintainers can merge this PR for me
