### PR TITLE
Backend/i18n: Localize notification descriptions.

### DIFF
--- a/app/backend/src/couchers/notifications/locales.py
+++ b/app/backend/src/couchers/notifications/locales.py
@@ -1,0 +1,11 @@
+from functools import lru_cache
+from pathlib import Path
+
+from couchers.i18n.i18next import I18Next
+from couchers.i18n.locales import load_locales
+
+
+@lru_cache(maxsize=1)
+def get_notifs_i18next() -> I18Next:
+    """Gets the I18Next instance for notifications."""
+    return load_locales(Path(__file__).parent / "locales")

--- a/app/backend/src/couchers/notifications/locales/en.json
+++ b/app/backend/src/couchers/notifications/locales/en.json
@@ -64,6 +64,9 @@
       "complete": "Your account is deleted",
       "recovered": "Your account is recovered (undeleted)"
     },
+    "activeness": {
+      "probe": "You accept guests but haven't logged in a while",
+    },
     "api_key": {
       "create": "An API key is created for your account"
     },

--- a/app/backend/src/couchers/notifications/locales/en.json
+++ b/app/backend/src/couchers/notifications/locales/en.json
@@ -65,7 +65,7 @@
       "recovered": "Your account is recovered (undeleted)"
     },
     "activeness": {
-      "probe": "You accept guests but haven't logged in a while",
+      "probe": "You accept guests but haven't logged in a while"
     },
     "api_key": {
       "create": "An API key is created for your account"

--- a/app/backend/src/couchers/notifications/locales/en.json
+++ b/app/backend/src/couchers/notifications/locales/en.json
@@ -1,4 +1,90 @@
 {
+  "topic_action_descriptions": {
+    "host_request": {
+      "create": "Someone sends you a host request",
+      "accept": "Someone accepts your host request",
+      "confirm": "Someone confirms their host request",
+      "reject": "Someone declines your host request",
+      "cancel": "Someone cancels their host request",
+      "message": "Someone sends a message in a host request",
+      "missed_messages": "You miss messages in a host request",
+      "reminder": "You haven't responded to a pending host request"
+    },
+    "chat": {
+      "message": "Someone sends you a message",
+      "missed_messages": "You miss messages in a chat"
+    },
+    "general": {
+      "new_blog_post": "A new blog post is published"
+    },
+    "reference": {
+      "receive_hosted": "You receive a reference from someone who hosted you",
+      "receive_surfed": "You receive a reference from someone you hosted",
+      "receive_friend": "You received a reference from a friend",
+      "reminder_hosted": "Reminder to write a reference to someone you hosted",
+      "reminder_surfed": "Reminder to write a reference to someone you surfed with"
+    },
+    "friend_request": {
+      "create": "Someone sends you a friend request",
+      "accept": "Someone accepts your friend request"
+    },
+    "event": {
+      "create_approved": "An event that is approved by the moderators is created in your community",
+      "create_any": "A user creates any event in your community (not checked by an admin)",
+      "update": "An event you are attending is updated",
+      "cancel": "An event you are attending is cancelled",
+      "delete": "An event you are attending is deleted",
+      "invite_organizer": "Someone invites you to co-organize an event",
+      "comment": " A user comments on an event you are going to",
+      "reminder": "Reminder that an event you are going to is happening soon"
+    },
+    "onboarding": {
+      "reminder": "Reminder to complete your profile after signing up"
+    },
+    "badge": {
+      "add": "A badge is added to your account",
+      "remove": "A badge is removed from your account"
+    },
+    "donation": {
+      "received": "Your donation is received"
+    },
+    "password": {
+      "change": "Your password is changed"
+    },
+    "password_reset": {
+      "start": "Password reset is initiated",
+      "complete": "Password reset is completed"
+    },
+    "email_address": {
+      "change": "Email change is initiated",
+      "verify": "Your new email is verified"
+    },
+    "account_deletion": {
+      "start": "You initiate account deletion",
+      "complete": "Your account is deleted",
+      "recovered": "Your account is recovered (undeleted)"
+    },
+    "api_key": {
+      "create": "An API key is created for your account"
+    },
+    "phone_number": {
+      "change": "Your phone number is changed",
+      "verify": "Your phone number is verified"
+    },
+    "birthdate": {
+      "change": "Your birthdate is changed"
+    },
+    "gender": {
+      "change": "The gender displayed on your profile is changed"
+    },
+    "discussion": {
+      "create": "Someone creates a discussion in a community you are in",
+      "comment": "Someone comments on a discussion you are following"
+    },
+    "thread": {
+      "reply": "Someone responds to your comment"
+    }
+  },
   "push": {
     "account_deletion__start": {
       "title": "Account deletion requested",

--- a/app/backend/src/couchers/notifications/locales/en.json
+++ b/app/backend/src/couchers/notifications/locales/en.json
@@ -1,91 +1,103 @@
 {
   "topic_action_descriptions": {
-    "host_request": {
-      "create": "Someone sends you a host request",
-      "accept": "Someone accepts your host request",
-      "confirm": "Someone confirms their host request",
-      "reject": "Someone declines your host request",
-      "cancel": "Someone cancels their host request",
-      "message": "Someone sends a message in a host request",
-      "missed_messages": "You miss messages in a host request",
-      "reminder": "You haven't responded to a pending host request"
-    },
-    "chat": {
-      "message": "Someone sends you a message",
-      "missed_messages": "You miss messages in a chat"
-    },
-    "general": {
-      "new_blog_post": "A new blog post is published"
-    },
-    "reference": {
-      "receive_hosted": "You receive a reference from someone who hosted you",
-      "receive_surfed": "You receive a reference from someone you hosted",
-      "receive_friend": "You received a reference from a friend",
-      "reminder_hosted": "Reminder to write a reference to someone you hosted",
-      "reminder_surfed": "Reminder to write a reference to someone you surfed with"
-    },
-    "friend_request": {
-      "create": "Someone sends you a friend request",
-      "accept": "Someone accepts your friend request"
-    },
-    "event": {
-      "create_approved": "An event that is approved by the moderators is created in your community",
-      "create_any": "A user creates any event in your community (not checked by an admin)",
-      "update": "An event you are attending is updated",
-      "cancel": "An event you are attending is cancelled",
-      "delete": "An event you are attending is deleted",
-      "invite_organizer": "Someone invites you to co-organize an event",
-      "comment": " A user comments on an event you are going to",
-      "reminder": "Reminder that an event you are going to is happening soon"
-    },
-    "onboarding": {
-      "reminder": "Reminder to complete your profile after signing up"
-    },
-    "badge": {
-      "add": "A badge is added to your account",
-      "remove": "A badge is removed from your account"
-    },
-    "donation": {
-      "received": "Your donation is received"
-    },
-    "password": {
-      "change": "Your password is changed"
-    },
-    "password_reset": {
-      "start": "Password reset is initiated",
-      "complete": "Password reset is completed"
-    },
-    "email_address": {
-      "change": "Email change is initiated",
-      "verify": "Your new email is verified"
-    },
     "account_deletion": {
-      "start": "You initiate account deletion",
-      "complete": "Your account is deleted",
-      "recovered": "Your account is recovered (undeleted)"
+      "start": "You initiate account deletion.",
+      "complete": "Your account is deleted.",
+      "recovered": "Your account is recovered (undeleted)."
     },
     "activeness": {
-      "probe": "You accept guests but haven't logged in a while"
+      "probe": "You accept guests but haven't logged in a while."
     },
     "api_key": {
-      "create": "An API key is created for your account"
+      "create": "An API key is created for your account."
     },
-    "phone_number": {
-      "change": "Your phone number is changed",
-      "verify": "Your phone number is verified"
+    "badge": {
+      "add": "A badge is added to your account.",
+      "remove": "A badge is removed from your account."
     },
     "birthdate": {
-      "change": "Your birthdate is changed"
+      "change": "Your birthdate is changed."
     },
-    "gender": {
-      "change": "The gender displayed on your profile is changed"
+    "chat": {
+      "message": "Someone sends you a message.",
+      "missed_messages": "You miss messages in a chat."
     },
     "discussion": {
-      "create": "Someone creates a discussion in a community you are in",
-      "comment": "Someone comments on a discussion you are following"
+      "create": "Someone creates a discussion in a community you are in.",
+      "comment": "Someone comments on a discussion you are following."
+    },
+    "donation": {
+      "received": "Your donation is received."
+    },
+    "email_address": {
+      "change": "Email change is initiated.",
+      "verify": "Your new email is verified."
+    },
+    "event": {
+      "create_approved": "An event that is approved by the moderators is created in your community.",
+      "create_any": "A user creates any event in your community (not checked by an admin).",
+      "update": "An event you are attending is updated.",
+      "cancel": "An event you are attending is cancelled.",
+      "delete": "An event you are attending is deleted.",
+      "invite_organizer": "Someone invites you to co-organize an event.",
+      "comment": " A user comments on an event you are going to.",
+      "reminder": "Reminder that an event you are going to is happening soon."
+    },
+    "friend_request": {
+      "create": "Someone sends you a friend request.",
+      "accept": "Someone accepts your friend request."
+    },
+    "general": {
+      "new_blog_post": "A new blog post is published."
+    },
+    "gender": {
+      "change": "The gender displayed on your profile is changed."
+    },
+    "host_request": {
+      "create": "Someone sends you a host request.",
+      "accept": "Someone accepts your host request.",
+      "confirm": "Someone confirms their host request.",
+      "reject": "Someone declines your host request.",
+      "cancel": "Someone cancels their host request.",
+      "message": "Someone sends a message in a host request.",
+      "missed_messages": "You miss messages in a host request.",
+      "reminder": "You haven't responded to a pending host request."
+    },
+    "modnote": {
+      "create": "A moderator sends you a note."
+    },
+    "onboarding": {
+      "reminder": "Reminder to complete your profile after signing up."
+    },
+    "password": {
+      "change": "Your password is changed."
+    },
+    "password_reset": {
+      "start": "Password reset is initiated.",
+      "complete": "Password reset is completed."
+    },
+    "postal_verification": {
+      "postcard_sent": "Your verification postcard is sent.",
+      "success": "Your postal verification succeeds.",
+      "failed": "Your postal verification fails."
+    },
+    "phone_number": {
+      "change": "Your phone number is changed.",
+      "verify": "Your phone number is verified."
+    },
+    "reference": {
+      "receive_hosted": "You receive a reference from someone who hosted you.",
+      "receive_surfed": "You receive a reference from someone you hosted.",
+      "receive_friend": "You received a reference from a friend.",
+      "reminder_hosted": "Reminder to write a reference to someone you hosted.",
+      "reminder_surfed": "Reminder to write a reference to someone you surfed with."
     },
     "thread": {
-      "reply": "Someone responds to your comment"
+      "reply": "Someone responds to your comment."
+    },
+    "verification": {
+      "sv_fail": "Your strong verification fails.",
+      "sv_success": "Your strong verification succeeds."
     }
   },
   "push": {

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -4,16 +4,14 @@ Renders a Notification model into a localized push notification.
 
 import logging
 from datetime import date
-from functools import lru_cache
-from pathlib import Path
 from typing import Any, assert_never
 
 from couchers import urls
 from couchers.i18n import LocalizationContext
-from couchers.i18n.i18next import I18Next, LocalizationError
-from couchers.i18n.locales import load_locales
+from couchers.i18n.i18next import LocalizationError
 from couchers.i18n.localize import format_phone_number
 from couchers.models import Notification, NotificationTopicAction
+from couchers.notifications.locales import get_notifs_i18next
 from couchers.notifications.push import PushNotificationContent
 from couchers.proto import api_pb2, notification_data_pb2
 
@@ -194,7 +192,7 @@ def _get_string(
     if isinstance(string_group, NotificationTopicAction):
         string_group = string_group.display.replace(":", "__")
     key = f"push.{string_group}.{key}"
-    return _get_notifs_i18next().localize(key, loc_context.locale, substitutions)
+    return get_notifs_i18next().localize(key, loc_context.locale, substitutions)
 
 
 def _avatar_url_or_default(user: api_pb2.User) -> str:
@@ -857,9 +855,3 @@ def _render_verification__sv_fail(
         body=_get_string(NotificationTopicAction.verification__sv_fail, body_key, loc_context),
         action_url=urls.account_settings_link(),
     )
-
-
-@lru_cache(maxsize=1)
-def _get_notifs_i18next() -> I18Next:
-    """Gets the I18Next instance for notifications."""
-    return load_locales(Path(__file__).parent / "locales")

--- a/app/backend/src/couchers/notifications/settings.py
+++ b/app/backend/src/couchers/notifications/settings.py
@@ -11,7 +11,7 @@ from couchers.models import (
     NotificationPreference,
     NotificationTopicAction,
 )
-from couchers.notifications.locales import get_notifs_i18next
+from couchers.notifications.utils import get_topic_action_description
 from couchers.proto import notifications_pb2
 
 logger = logging.getLogger(__name__)
@@ -336,8 +336,7 @@ def get_user_setting_groups(user_id: int) -> list[notifications_pb2.Notification
                 actions = []
                 for topic_action in items:
                     delivery_types = get_preference(session, user_id, topic_action)
-                    description_key = f"topic_action_descriptions.{topic_action.topic}.{topic_action.action}"
-                    description = get_notifs_i18next().localize(description_key, loc_context.locale)
+                    description = get_topic_action_description(topic_action, locale=loc_context.locale)
                     actions.append(
                         notifications_pb2.NotificationItem(
                             action=topic_action.action,

--- a/app/backend/src/couchers/notifications/settings.py
+++ b/app/backend/src/couchers/notifications/settings.py
@@ -4,13 +4,14 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from couchers.db import session_scope
+from couchers.i18n import LocalizationContext
 from couchers.models import (
     NotificationDelivery,
     NotificationDeliveryType,
     NotificationPreference,
     NotificationTopicAction,
 )
-from couchers.notifications.utils import enum_from_topic_action
+from couchers.notifications.locales import get_notifs_i18next
 from couchers.proto import notifications_pb2
 
 logger = logging.getLogger(__name__)
@@ -113,40 +114,40 @@ settings_layout = [
                 "host_request",
                 "Host requests",
                 [
-                    ("create", "Someone sends you a host request"),
-                    ("accept", "Someone accepts your host request"),
-                    ("confirm", "Someone confirms their host request"),
-                    ("reject", "Someone declines your host request"),
-                    ("cancel", "Someone cancels their host request"),
-                    ("message", "Someone sends a message in a host request"),
-                    ("missed_messages", "You miss messages in a host request"),
-                    ("reminder", "You don't respond to a pending host request for a while"),
+                    NotificationTopicAction.host_request__create,
+                    NotificationTopicAction.host_request__accept,
+                    NotificationTopicAction.host_request__confirm,
+                    NotificationTopicAction.host_request__reject,
+                    NotificationTopicAction.host_request__cancel,
+                    NotificationTopicAction.host_request__message,
+                    NotificationTopicAction.host_request__missed_messages,
+                    NotificationTopicAction.host_request__reminder,
                 ],
             ),
             (
                 "activeness",
                 "Activity Check-in",
                 [
-                    ("probe", "Check in to see if you are still hosting after a long period of inactivity"),
+                    NotificationTopicAction.activeness__probe,
                 ],
             ),
             (
                 "chat",
                 "Messaging",
                 [
-                    ("message", "Someone sends you a message"),
-                    ("missed_messages", "You miss messages in a chat"),
+                    NotificationTopicAction.chat__message,
+                    NotificationTopicAction.chat__missed_messages,
                 ],
             ),
             (
                 "reference",
                 "References",
                 [
-                    ("receive_hosted", "You receive a reference from someone who hosted you"),
-                    ("receive_surfed", "You receive a reference from someone you hosted"),
-                    ("receive_friend", "You received a reference from a friend"),
-                    ("reminder_hosted", "Reminder to write a reference to someone you hosted"),
-                    ("reminder_surfed", "Reminder to write a reference to someone you surfed with"),
+                    NotificationTopicAction.reference__receive_hosted,
+                    NotificationTopicAction.reference__receive_surfed,
+                    NotificationTopicAction.reference__receive_friend,
+                    NotificationTopicAction.reference__reminder_hosted,
+                    NotificationTopicAction.reference__reminder_surfed,
                 ],
             ),
         ],
@@ -158,37 +159,37 @@ settings_layout = [
                 "friend_request",
                 "Friend requests",
                 [
-                    ("create", "Someone sends you a friend request"),
-                    ("accept", "Someone accepts your friend request"),
+                    NotificationTopicAction.friend_request__create,
+                    NotificationTopicAction.friend_request__accept,
                 ],
             ),
             (
                 "event",
                 "Events",
                 [
-                    ("create_approved", "An event that is approved by the moderators is created in your community"),
-                    ("create_any", "A user creates any event in your community (not checked by an admin)"),
-                    ("update", "An event you are attending is updated"),
-                    ("comment", "Someone comments on an event you are organizing or attending"),
-                    ("cancel", "An event you are attending is cancelled"),
-                    ("delete", "An event you are attending is deleted"),
-                    ("invite_organizer", "Someone invites you to co-organize an event"),
-                    ("reminder", "Reminder for an upcoming event"),
+                    NotificationTopicAction.event__create_approved,
+                    NotificationTopicAction.event__create_any,
+                    NotificationTopicAction.event__update,
+                    NotificationTopicAction.event__comment,
+                    NotificationTopicAction.event__cancel,
+                    NotificationTopicAction.event__delete,
+                    NotificationTopicAction.event__invite_organizer,
+                    NotificationTopicAction.event__reminder,
                 ],
             ),
             (
                 "discussion",
                 "Community discussions",
                 [
-                    ("create", "Someone creates a discussion in one of your communities"),
-                    ("comment", "Someone comments on a discussion you authored"),
+                    NotificationTopicAction.discussion__create,
+                    NotificationTopicAction.discussion__comment,
                 ],
             ),
             (
                 "thread",
                 "Threads, Comments, & Replies",
                 [
-                    ("reply", "Someone replies to your comment"),
+                    NotificationTopicAction.thread__reply,
                 ],
             ),
         ],
@@ -200,22 +201,22 @@ settings_layout = [
                 "onboarding",
                 "Onboarding",
                 [
-                    ("reminder", "Reminder to complete your profile after signing up"),
+                    NotificationTopicAction.onboarding__reminder,
                 ],
             ),
             (
                 "badge",
                 "Updates to Badges on your profile",
                 [
-                    ("add", "A badge is added to your account"),
-                    ("remove", "A badge is removed from your account"),
+                    NotificationTopicAction.badge__add,
+                    NotificationTopicAction.badge__remove,
                 ],
             ),
             (
                 "donation",
                 "Donations",
                 [
-                    ("received", "Your donation is received"),
+                    NotificationTopicAction.donation__received,
                 ],
             ),
         ],
@@ -227,85 +228,85 @@ settings_layout = [
                 "password",
                 "Password change",
                 [
-                    ("change", "Your password is changed"),
+                    NotificationTopicAction.password__change,
                 ],
             ),
             (
                 "password_reset",
                 "Password reset",
                 [
-                    ("start", "Password reset is initiated"),
-                    ("complete", "Password reset is completed"),
+                    NotificationTopicAction.password_reset__start,
+                    NotificationTopicAction.password_reset__complete,
                 ],
             ),
             (
                 "email_address",
                 "Email address change",
                 [
-                    ("change", "Email change is initiated"),
-                    ("verify", "Your new email is verified"),
+                    NotificationTopicAction.email_address__change,
+                    NotificationTopicAction.email_address__verify,
                 ],
             ),
             (
                 "account_deletion",
                 "Account deletion",
                 [
-                    ("start", "You initiate account deletion"),
-                    ("complete", "Your account is deleted"),
-                    ("recovered", "Your account is recovered (undeleted)"),
+                    NotificationTopicAction.account_deletion__start,
+                    NotificationTopicAction.account_deletion__complete,
+                    NotificationTopicAction.account_deletion__recovered,
                 ],
             ),
             (
                 "api_key",
                 "API keys",
                 [
-                    ("create", "An API key is created for your account"),
+                    NotificationTopicAction.api_key__create,
                 ],
             ),
             (
                 "phone_number",
                 "Phone number change",
                 [
-                    ("change", "Your phone number is changed"),
-                    ("verify", "Your phone number is verified"),
+                    NotificationTopicAction.phone_number__change,
+                    NotificationTopicAction.phone_number__verify,
                 ],
             ),
             (
                 "birthdate",
                 "Birthdate change",
                 [
-                    ("change", "Your birthdate is changed"),
+                    NotificationTopicAction.birthdate__change,
                 ],
             ),
             (
                 "gender",
                 "Displayed gender change",
                 [
-                    ("change", "The gender displayed on your profile is changed"),
+                    NotificationTopicAction.gender__change,
                 ],
             ),
             (
                 "modnote",
                 "Moderator notes",
                 [
-                    ("create", "You receive a moderator note"),
+                    NotificationTopicAction.modnote__create,
                 ],
             ),
             (
                 "verification",
                 "Verification",
                 [
-                    ("sv_fail", "Strong Verification fails"),
-                    ("sv_success", "Strong Verification succeeds"),
+                    NotificationTopicAction.verification__sv_fail,
+                    NotificationTopicAction.verification__sv_success,
                 ],
             ),
             (
                 "postal_verification",
                 "Postal Verification",
                 [
-                    ("postcard_sent", "Verification postcard is sent"),
-                    ("success", "Postal Verification succeeds"),
-                    ("failed", "Postal Verification fails"),
+                    NotificationTopicAction.postal_verification__postcard_sent,
+                    NotificationTopicAction.postal_verification__success,
+                    NotificationTopicAction.postal_verification__failed,
                 ],
             ),
         ],
@@ -317,7 +318,7 @@ settings_layout = [
                 "general",
                 "General",
                 [
-                    ("new_blog_post", "We published a new blog post"),
+                    NotificationTopicAction.general__new_blog_post,
                 ],
             ),
         ],
@@ -325,44 +326,21 @@ settings_layout = [
 ]
 
 
-def check_settings() -> None:
-    # check settings contain all actions+topics
-    actions_by_topic: dict[str, list[str]] = {}
-    for t in NotificationTopicAction:
-        actions_by_topic[t.topic] = actions_by_topic.get(t.topic, []) + [t.action]
-
-    actions_by_topic_check = {}
-
-    for heading, group in settings_layout:
-        for topic, name, items in group:
-            actions = []
-            for action, description in items:
-                actions.append(action)
-            actions_by_topic_check[topic] = actions
-
-    for topic, actions in actions_by_topic.items():
-        assert sorted(actions) == sorted(actions_by_topic_check[topic]), (
-            f"Expected {actions} == {actions_by_topic_check[topic]} for {topic}"
-        )
-    assert sorted(actions_by_topic.keys()) == sorted(actions_by_topic_check.keys())
-
-
-check_settings()
-
-
 def get_user_setting_groups(user_id: int) -> list[notifications_pb2.NotificationGroup]:
+    loc_context: LocalizationContext = LocalizationContext.en_utc()
     with session_scope() as session:
         groups = []
         for heading, group in settings_layout:
             topics = []
             for topic, name, items in group:
                 actions = []
-                for action, description in items:
-                    topic_action = enum_from_topic_action[topic, action]
+                for topic_action in items:
                     delivery_types = get_preference(session, user_id, topic_action)
+                    description_key = f"topic_action_descriptions.{topic_action.topic}.{topic_action.action}"
+                    description = get_notifs_i18next().localize(description_key, loc_context.locale)
                     actions.append(
                         notifications_pb2.NotificationItem(
-                            action=action,
+                            action=topic_action.action,
                             description=description,
                             user_editable=not topic_action.is_critical,
                             push=NotificationDeliveryType.push in delivery_types,

--- a/app/backend/src/couchers/notifications/utils.py
+++ b/app/backend/src/couchers/notifications/utils.py
@@ -1,4 +1,5 @@
 from couchers.models import NotificationTopicAction
+from couchers.notifications.locales import get_notifs_i18next
 
 enum_from_topic_action: dict[tuple[str, str], NotificationTopicAction] = {
     (item.topic, item.action): item for item in NotificationTopicAction
@@ -14,3 +15,8 @@ _DELETED_USER_NOTIFICATIONS = {
 
 def can_notify_deleted_user(topic_action: NotificationTopicAction) -> bool:
     return topic_action in _DELETED_USER_NOTIFICATIONS
+
+
+def get_topic_action_description(topic_action: NotificationTopicAction, locale: str) -> str:
+    description_key = f"topic_action_descriptions.{topic_action.topic}.{topic_action.action}"
+    return get_notifs_i18next().localize(description_key, locale)

--- a/app/backend/src/tests/test_notification_settings.py
+++ b/app/backend/src/tests/test_notification_settings.py
@@ -1,8 +1,10 @@
+from couchers.i18n.locales import DEFAULT_LOCALE
 from couchers.models.notifications import NotificationTopicAction
 from couchers.notifications.settings import settings_layout
+from couchers.notifications.utils import get_topic_action_description
 
 
-def test_all_notifications_have_descriptions() -> None:
+def test_all_notifications_appear_in_settings() -> None:
     # check settings contain all actions+topics
     actions_by_topic: dict[str, list[str]] = {}
     for t in NotificationTopicAction:
@@ -22,3 +24,9 @@ def test_all_notifications_have_descriptions() -> None:
             f"Expected {actions} == {actions_by_topic_check[topic]} for {topic}"
         )
     assert sorted(actions_by_topic.keys()) == sorted(actions_by_topic_check.keys())
+
+
+def test_all_notifications_have_descriptions() -> None:
+    for topic_action in NotificationTopicAction:
+        # Will throw if there's no string
+        assert get_topic_action_description(topic_action, locale=DEFAULT_LOCALE) != ""

--- a/app/backend/src/tests/test_notification_settings.py
+++ b/app/backend/src/tests/test_notification_settings.py
@@ -1,0 +1,24 @@
+from couchers.models.notifications import NotificationTopicAction
+from couchers.notifications.settings import settings_layout
+
+
+def test_all_notifications_have_descriptions() -> None:
+    # check settings contain all actions+topics
+    actions_by_topic: dict[str, list[str]] = {}
+    for t in NotificationTopicAction:
+        actions_by_topic[t.topic] = actions_by_topic.get(t.topic, []) + [t.action]
+
+    actions_by_topic_check = {}
+
+    for heading, group in settings_layout:
+        for topic, name, items in group:
+            actions = []
+            for topic_action in items:
+                actions.append(topic_action.action)
+            actions_by_topic_check[topic] = actions
+
+    for topic, actions in actions_by_topic.items():
+        assert sorted(actions) == sorted(actions_by_topic_check[topic]), (
+            f"Expected {actions} == {actions_by_topic_check[topic]} for {topic}"
+        )
+    assert sorted(actions_by_topic.keys()) == sorted(actions_by_topic_check.keys())


### PR DESCRIPTION
Our backend has an API to describe notifications but it is not localized, so the frontend ignores the descriptions and localizes it itself. This localizes the descriptions on the backend, opening the path to future frontends eventually switching over.

The backend should own this localization, since it is the source of truth for notifications. But also, emails can reuse these descriptions in their footer, for the link that says "do not notify when <topic-action-description>".

I copied the strings from the frontend with two changes: I filled in missing strings (non-editable notifications that the frontend won't show but the API reports), and punctuated each one with a period.

I ignored the category descriptions since the frontend ignores the backend's categories and reorganizes notifications according to its own categories.

## Testing
Added tests

**Backend checklist**
<!-- To avoid CI failures, first run `make format` in app/backend and run tests locally. -->
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me