### PR TITLE
Backend/i18n: Give CouchersContext a LocalizationContext

### DIFF
--- a/app/backend/src/couchers/context.py
+++ b/app/backend/src/couchers/context.py
@@ -195,10 +195,7 @@ def make_interactive_context(
     )
 
 
-def make_one_off_interactive_user_context(
-    couchers_context: CouchersContext,
-    user_id: int
-) -> CouchersContext:
+def make_one_off_interactive_user_context(couchers_context: CouchersContext, user_id: int) -> CouchersContext:
     return CouchersContext(
         is_interactive=True,
         grpc_context=couchers_context._grpc_context,

--- a/app/backend/src/couchers/context.py
+++ b/app/backend/src/couchers/context.py
@@ -2,7 +2,7 @@ from typing import NoReturn, cast
 
 import grpc
 
-from couchers.i18n.localize import localize_string
+from couchers.i18n import LocalizationContext
 
 
 class NonInteractiveContextException(Exception):
@@ -66,7 +66,7 @@ class CouchersContext:
         user_id: int | None,
         is_api_key: bool | None,
         token: str | None,
-        ui_language_preference: str | None,
+        localization: LocalizationContext,
         sofa: str | None = None,
     ):
         """Don't ever construct directly, always use the `make_*_context_` functions!"""
@@ -74,7 +74,7 @@ class CouchersContext:
         self._user_id = user_id
         self._is_api_key = is_api_key
         self.__token = token
-        self.__ui_language_preference = ui_language_preference
+        self.__localization = localization
         self._sofa = sofa
         self.__is_interactive = is_interactive
         self.__logged_in = self._user_id is not None
@@ -103,20 +103,6 @@ class CouchersContext:
     def is_logged_out(self) -> bool:
         return not self.__logged_in
 
-    def get_localized_string(self, key: str, *, substitutions: dict[str, str | int] | None = None) -> str:
-        """
-        Get a localized string using the user's language preference.
-        Falls back to the default language if no preference is set.
-
-        Args:
-            key: The key for the specific string
-            substitutions: Dictionary of variable substitutions for the string (optional)
-
-        Returns:
-            The translated string with substitutions applied
-        """
-        return localize_string(self.__ui_language_preference, key, substitutions=substitutions)
-
     def abort(self, status_code: grpc.StatusCode, error_message: str) -> NoReturn:
         """
         Raises an error that's returned to the user
@@ -138,7 +124,7 @@ class CouchersContext:
         else:
             context = cast(grpc.ServicerContext, self._grpc_context)
             # Get the translated error message using the user's language preference
-            error_message = self.get_localized_string(f"errors.{error_message_id}", substitutions=substitutions)
+            error_message = self.localization.localize_string(f"errors.{error_message_id}", substitutions=substitutions)
             context.abort(status_code, error_message)
 
     def set_cookies(self, cookies: list[str]) -> None:
@@ -186,8 +172,8 @@ class CouchersContext:
         return cast(str, self.__token)
 
     @property
-    def ui_language_preference(self) -> str | None:
-        return self.__ui_language_preference
+    def localization(self) -> LocalizationContext:
+        return self.__localization
 
 
 def make_interactive_context(
@@ -195,7 +181,7 @@ def make_interactive_context(
     user_id: int | None,
     is_api_key: bool,
     token: str | None,
-    ui_language_preference: str | None,
+    localization: LocalizationContext | None,
     sofa: str | None = None,
 ) -> CouchersContext:
     return CouchersContext(
@@ -204,14 +190,14 @@ def make_interactive_context(
         user_id=user_id,
         is_api_key=is_api_key,
         token=token,
-        ui_language_preference=ui_language_preference,
+        localization=localization or LocalizationContext.en_utc(),
         sofa=sofa,
     )
 
 
 def make_one_off_interactive_user_context(
     couchers_context: CouchersContext,
-    user_id: int,
+    user_id: int
 ) -> CouchersContext:
     return CouchersContext(
         is_interactive=True,
@@ -219,7 +205,7 @@ def make_one_off_interactive_user_context(
         user_id=user_id,
         is_api_key=None,
         token=None,
-        ui_language_preference=None,
+        localization=couchers_context.localization,
     )
 
 
@@ -230,27 +216,27 @@ def make_media_context(grpc_context: grpc.ServicerContext) -> CouchersContext:
         is_api_key=False,
         grpc_context=grpc_context,
         token=None,
-        ui_language_preference=None,
+        localization=LocalizationContext.en_utc(),
     )
 
 
-def make_background_user_context(user_id: int) -> CouchersContext:
+def make_background_user_context(user_id: int, localization: LocalizationContext | None = None) -> CouchersContext:
     return CouchersContext(
         is_interactive=False,
         user_id=user_id,
         is_api_key=None,
         grpc_context=None,
         token=None,
-        ui_language_preference=None,
+        localization=localization or LocalizationContext.en_utc(),
     )
 
 
-def make_logged_out_context() -> CouchersContext:
+def make_logged_out_context(localization: LocalizationContext | None = None) -> CouchersContext:
     return CouchersContext(
         user_id=None,
         is_interactive=False,
         is_api_key=None,
         grpc_context=None,
         token=None,
-        ui_language_preference=None,
+        localization=localization or LocalizationContext.en_utc(),
     )

--- a/app/backend/src/couchers/context.py
+++ b/app/backend/src/couchers/context.py
@@ -181,7 +181,7 @@ def make_interactive_context(
     user_id: int | None,
     is_api_key: bool,
     token: str | None,
-    localization: LocalizationContext | None,
+    localization: LocalizationContext,
     sofa: str | None = None,
 ) -> CouchersContext:
     return CouchersContext(
@@ -190,7 +190,7 @@ def make_interactive_context(
         user_id=user_id,
         is_api_key=is_api_key,
         token=token,
-        localization=localization or LocalizationContext.en_utc(),
+        localization=localization,
         sofa=sofa,
     )
 
@@ -228,12 +228,12 @@ def make_background_user_context(user_id: int, localization: LocalizationContext
     )
 
 
-def make_logged_out_context(localization: LocalizationContext | None = None) -> CouchersContext:
+def make_logged_out_context(localization: LocalizationContext) -> CouchersContext:
     return CouchersContext(
         user_id=None,
         is_interactive=False,
         is_api_key=None,
         grpc_context=None,
         token=None,
-        localization=localization or LocalizationContext.en_utc(),
+        localization=localization,
     )

--- a/app/backend/src/couchers/helpers/badges.py
+++ b/app/backend/src/couchers/helpers/badges.py
@@ -22,8 +22,8 @@ def user_add_badge(session: Session, user_id: int, badge_id: str, do_notify: boo
             key=badge.id,
             data=notification_data_pb2.BadgeAdd(
                 badge_id=badge.id,
-                badge_name=context.get_localized_string(f"badges.{badge.id}_name"),
-                badge_description=context.get_localized_string(f"badges.{badge.id}_description"),
+                badge_name=context.localization.localize_string(f"badges.{badge.id}_name"),
+                badge_description=context.localization.localize_string(f"badges.{badge.id}_description"),
             ),
         )
     session.commit()
@@ -41,8 +41,8 @@ def user_remove_badge(session: Session, user_id: int, badge_id: str) -> None:
         key=badge.id,
         data=notification_data_pb2.BadgeRemove(
             badge_id=badge.id,
-            badge_name=context.get_localized_string(f"badges.{badge.id}_name"),
-            badge_description=context.get_localized_string(f"badges.{badge.id}_description"),
+            badge_name=context.localization.localize_string(f"badges.{badge.id}_name"),
+            badge_description=context.localization.localize_string(f"badges.{badge.id}_description"),
         ),
     )
     session.commit()

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -298,8 +298,8 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             sofa, new_sofa_cookie = generate_sofa_cookie()
 
         loc_context = LocalizationContext(
-            locale=auth_info.ui_language_preference if auth_info else (headers.ui_lang or DEFAULT_LOCALE),
-            timezone=ZoneInfo(auth_info.timezone if auth_info else "Etc/UTC"),
+            locale=(auth_info.ui_language_preference if auth_info else headers.ui_lang) or DEFAULT_LOCALE,
+            timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
         )
 
         def function_without_couchers_stuff(req: Message, grpc_context: grpc.ServicerContext) -> Message | None:

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -132,8 +132,7 @@ def _try_get_and_update_user_details(
         session.commit()
 
         loc_context = LocalizationContext(
-            locale=user.ui_language_preference or DEFAULT_LOCALE,
-            timezone=ZoneInfo(user.timezone or "Etc/UTC")
+            locale=user.ui_language_preference or DEFAULT_LOCALE, timezone=ZoneInfo(user.timezone or "Etc/UTC")
         )
 
         return UserAuthInfo(

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -138,7 +138,7 @@ def _try_get_and_update_user_details(
             is_editor=user.is_editor,
             is_superuser=user.is_superuser,
             token_expiry=user_session.expiry,
-            locale=user.ui_language_preference,
+            ui_language_preference=user.ui_language_preference,
             timezone=user.timezone,
             token=token,
             is_api_key=is_api_key,
@@ -298,8 +298,9 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             sofa, new_sofa_cookie = generate_sofa_cookie()
 
         loc_context = LocalizationContext(
-            locale=auth_info.ui_language_preference or headers.ui_lang or DEFAULT_LOCALE,
-            timezone=ZoneInfo(auth_info.timezone or "Etc/UTC"))
+            locale=(auth_info and auth_info.ui_language_preference) or headers.ui_lang or DEFAULT_LOCALE,
+            timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
+        )
 
         def function_without_couchers_stuff(req: Message, grpc_context: grpc.ServicerContext) -> Message | None:
             couchers_context = make_interactive_context(

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -303,7 +303,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
         if auth_info:
             loc_context = auth_info.loc_context
         else:
-            loc_context = LocalizationContext(locale=headers.ui_lang or DEFAULT_LOCALE, timezone=ZoneInfo("Utc/ETC"))
+            loc_context = LocalizationContext(locale=headers.ui_lang or DEFAULT_LOCALE, timezone=ZoneInfo("Etc/UTC"))
 
         def function_without_couchers_stuff(req: Message, grpc_context: grpc.ServicerContext) -> Message | None:
             couchers_context = make_interactive_context(

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -61,7 +61,8 @@ class UserAuthInfo:
     is_editor: bool
     is_superuser: bool
     token_expiry: datetime
-    loc_context: LocalizationContext
+    ui_language_preference: str | None
+    timezone: str | None
     token: str = field(repr=False)
     is_api_key: bool
 
@@ -131,17 +132,14 @@ def _try_get_and_update_user_details(
 
         session.commit()
 
-        loc_context = LocalizationContext(
-            locale=user.ui_language_preference or DEFAULT_LOCALE, timezone=ZoneInfo(user.timezone or "Etc/UTC")
-        )
-
         return UserAuthInfo(
             user_id=user.id,
             is_jailed=user.is_jailed,
             is_editor=user.is_editor,
             is_superuser=user.is_superuser,
             token_expiry=user_session.expiry,
-            loc_context=loc_context,
+            locale=user.ui_language_preference,
+            timezone=user.timezone,
             token=token,
             is_api_key=is_api_key,
         )
@@ -299,10 +297,9 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
         else:
             sofa, new_sofa_cookie = generate_sofa_cookie()
 
-        if auth_info:
-            loc_context = auth_info.loc_context
-        else:
-            loc_context = LocalizationContext(locale=headers.ui_lang or DEFAULT_LOCALE, timezone=ZoneInfo("Etc/UTC"))
+        loc_context = LocalizationContext(
+            locale=auth_info.ui_language_preference or headers.ui_lang or DEFAULT_LOCALE,
+            timezone=ZoneInfo(auth_info.timezone or "Etc/UTC"))
 
         def function_without_couchers_stuff(req: Message, grpc_context: grpc.ServicerContext) -> Message | None:
             couchers_context = make_interactive_context(
@@ -373,8 +370,8 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                     couchers_context.set_cookies(
                         create_session_cookies(auth_info.token, auth_info.user_id, auth_info.token_expiry)
                     )
-                if auth_info.loc_context.locale != headers.ui_lang:
-                    couchers_context.set_cookies(create_lang_cookie(auth_info.loc_context.locale))
+                if auth_info.ui_language_preference and auth_info.ui_language_preference != headers.ui_lang:
+                    couchers_context.set_cookies(create_lang_cookie(auth_info.ui_language_preference))
 
             if new_sofa_cookie:
                 couchers_context.set_cookies([new_sofa_cookie])

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -8,6 +8,7 @@ from threading import get_ident
 from time import perf_counter_ns
 from traceback import format_exception
 from typing import Any, NoReturn, cast, overload
+from zoneinfo import ZoneInfo
 
 import grpc
 import sentry_sdk
@@ -30,6 +31,8 @@ from couchers.constants import (
 from couchers.context import CouchersContext, make_interactive_context, make_media_context
 from couchers.db import session_scope
 from couchers.descriptor_pool import get_descriptor_pool
+from couchers.i18n import LocalizationContext
+from couchers.i18n.locales import DEFAULT_LOCALE
 from couchers.metrics import observe_in_servicer_duration_histogram
 from couchers.models import APICall, User, UserActivity, UserSession
 from couchers.proto import annotations_pb2
@@ -58,7 +61,7 @@ class UserAuthInfo:
     is_editor: bool
     is_superuser: bool
     token_expiry: datetime
-    ui_language_preference: str | None
+    loc_context: LocalizationContext
     token: str = field(repr=False)
     is_api_key: bool
 
@@ -128,13 +131,18 @@ def _try_get_and_update_user_details(
 
         session.commit()
 
+        loc_context = LocalizationContext(
+            locale=user.ui_language_preference or DEFAULT_LOCALE,
+            timezone=ZoneInfo(user.timezone or "Etc/UTC")
+        )
+
         return UserAuthInfo(
             user_id=user.id,
             is_jailed=user.is_jailed,
             is_editor=user.is_editor,
             is_superuser=user.is_superuser,
             token_expiry=user_session.expiry,
-            ui_language_preference=user.ui_language_preference,
+            loc_context=loc_context,
             token=token,
             is_api_key=is_api_key,
         )
@@ -292,13 +300,18 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
         else:
             sofa, new_sofa_cookie = generate_sofa_cookie()
 
+        if auth_info:
+            loc_context = auth_info.loc_context
+        else:
+            loc_context = LocalizationContext(locale=headers.ui_lang or DEFAULT_LOCALE, timezone=ZoneInfo("Utc/ETC"))
+
         def function_without_couchers_stuff(req: Message, grpc_context: grpc.ServicerContext) -> Message | None:
             couchers_context = make_interactive_context(
                 grpc_context=grpc_context,
                 user_id=auth_info.user_id if auth_info else None,
                 is_api_key=auth_info.is_api_key if auth_info else False,
                 token=auth_info.token if auth_info else None,
-                ui_language_preference=(auth_info.ui_language_preference if auth_info else None) or headers.ui_lang,
+                localization=loc_context,
                 sofa=sofa,
             )
 
@@ -361,8 +374,8 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                     couchers_context.set_cookies(
                         create_session_cookies(auth_info.token, auth_info.user_id, auth_info.token_expiry)
                     )
-                if auth_info.ui_language_preference and auth_info.ui_language_preference != headers.ui_lang:
-                    couchers_context.set_cookies(create_lang_cookie(auth_info.ui_language_preference))
+                if auth_info.loc_context.locale != headers.ui_lang:
+                    couchers_context.set_cookies(create_lang_cookie(auth_info.loc_context.locale))
 
             if new_sofa_cookie:
                 couchers_context.set_cookies([new_sofa_cookie])

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -298,8 +298,8 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             sofa, new_sofa_cookie = generate_sofa_cookie()
 
         loc_context = LocalizationContext(
-            locale=(auth_info and auth_info.ui_language_preference) or headers.ui_lang or DEFAULT_LOCALE,
-            timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
+            locale=auth_info.ui_language_preference if auth_info else (headers.ui_lang or DEFAULT_LOCALE),
+            timezone=ZoneInfo(auth_info.timezone if auth_info else "Etc/UTC"),
         )
 
         def function_without_couchers_stuff(req: Message, grpc_context: grpc.ServicerContext) -> Message | None:

--- a/app/backend/src/couchers/notifications/quick_links.py
+++ b/app/backend/src/couchers/notifications/quick_links.py
@@ -111,7 +111,7 @@ def respond_quick_link(request: auth_pb2.UnsubscribeReq, context: CouchersContex
         user.do_not_email = True
         user.hosting_status = HostingStatus.cant_host
         user.meetup_status = MeetupStatus.does_not_want_to_meetup
-        return context.get_localized_string("quick_links.do_not_email")
+        return context.localization.localize_string("quick_links.do_not_email")
     if payload.HasField("topic_action"):
         logger.info(f"User {user.name} unsubscribing from topic_action")
         topic = payload.topic_action.topic
@@ -119,7 +119,7 @@ def respond_quick_link(request: auth_pb2.UnsubscribeReq, context: CouchersContex
         topic_action = enum_from_topic_action[topic, action]
         # disable emails for this type
         settings.set_preference(session, user.id, topic_action, NotificationDeliveryType.email, False)
-        return context.get_localized_string("quick_links.topic_action")
+        return context.localization.localize_string("quick_links.topic_action")
     if payload.HasField("topic_key"):
         logger.info(f"User {user.name} unsubscribing from topic_key")
         topic = payload.topic_key.topic
@@ -145,7 +145,7 @@ def respond_quick_link(request: auth_pb2.UnsubscribeReq, context: CouchersContex
                 context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "chat_not_found")
 
             subscription.muted_until = DATETIME_INFINITY
-            return context.get_localized_string("quick_links.chat_unsub")
+            return context.localization.localize_string("quick_links.chat_unsub")
         else:
             context.abort_with_error_code(grpc.StatusCode.UNIMPLEMENTED, "cant_unsub_topic")
     if payload.HasField("host_request_quick_decline"):
@@ -157,5 +157,5 @@ def respond_quick_link(request: auth_pb2.UnsubscribeReq, context: CouchersContex
             context=make_one_off_interactive_user_context(couchers_context=context, user_id=payload.user_id),
             session=session,
         )
-        return context.get_localized_string("quick_links.host_request_quick_decline")
+        return context.localization.localize_string("quick_links.host_request_quick_decline")
     raise Exception("Unhandled quick link type")

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -1012,8 +1012,8 @@ def user_model_to_pb(
                 user_id=db_user.id,
                 is_ghost=True,
                 username=GHOST_USERNAME,
-                name=context.get_localized_string("ghost_users.display_name"),
-                about_me=context.get_localized_string("ghost_users.about_me"),
+                name=context.localization.localize_string("ghost_users.display_name"),
+                about_me=context.localization.localize_string("ghost_users.about_me"),
             )
         raise GhostUserSerializationError(
             f"Tried to serialize ghost profile in user_model_to_pb without appropriate flags. "
@@ -1213,7 +1213,7 @@ def lite_user_to_pb(
                 user_id=lite_user.id,
                 is_ghost=True,
                 username=GHOST_USERNAME,
-                name=context.get_localized_string("ghost_users.display_name"),
+                name=context.localization.localize_string("ghost_users.display_name"),
             )
         raise GhostUserSerializationError(
             f"Tried to serialize ghost profile in lite_user_to_pb without appropriate flags. "

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -255,8 +255,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         session.add(subscription)
         session.flush()
 
-        loc_context = LocalizationContext(locale=context.ui_language_preference or "en", timezone=ZoneInfo("Etc/UTC"))
-        push_content = render_adhoc_push_notification("push_enabled", loc_context)
+        push_content = render_adhoc_push_notification("push_enabled", context.localization)
         push_to_subscription(
             session,
             push_notification_subscription_id=subscription.id,

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -1,7 +1,6 @@
 import functools
 import json
 import logging
-from zoneinfo import ZoneInfo
 
 import grpc
 from google.protobuf import empty_pb2

--- a/app/backend/src/couchers/servicers/public.py
+++ b/app/backend/src/couchers/servicers/public.py
@@ -193,7 +193,9 @@ class Public(public_pb2_grpc.PublicServicer):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
         if user.public_visibility == ProfilePublicVisibility.full:
-            return public_pb2.GetPublicUserRes(full_user=user_model_to_pb(user, session, make_logged_out_context(localization=context.localization)))
+            return public_pb2.GetPublicUserRes(
+                full_user=user_model_to_pb(user, session, make_logged_out_context(localization=context.localization))
+            )
 
         num_references = session.execute(
             select(func.count())

--- a/app/backend/src/couchers/servicers/public.py
+++ b/app/backend/src/couchers/servicers/public.py
@@ -193,7 +193,7 @@ class Public(public_pb2_grpc.PublicServicer):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
         if user.public_visibility == ProfilePublicVisibility.full:
-            return public_pb2.GetPublicUserRes(full_user=user_model_to_pb(user, session, make_logged_out_context()))
+            return public_pb2.GetPublicUserRes(full_user=user_model_to_pb(user, session, make_logged_out_context(localization=context.localization)))
 
         num_references = session.execute(
             select(func.count())

--- a/app/backend/src/couchers/servicers/resources.py
+++ b/app/backend/src/couchers/servicers/resources.py
@@ -35,8 +35,8 @@ class Resources(resources_pb2_grpc.ResourcesServicer):
         return resources_pb2.GetCommunityGuidelinesRes(
             community_guidelines=[
                 resources_pb2.CommunityGuideline(
-                    title=context.get_localized_string(f"community_guidelines.{cg['key']}_title"),
-                    guideline=context.get_localized_string(f"community_guidelines.{cg['key']}_guideline"),
+                    title=context.localization.localize_string(f"community_guidelines.{cg['key']}_title"),
+                    guideline=context.localization.localize_string(f"community_guidelines.{cg['key']}_guideline"),
                     icon_svg=get_icon(cg["icon"]),
                 )
                 for cg in COMMUNITY_GUIDELINES
@@ -68,8 +68,8 @@ class Resources(resources_pb2_grpc.ResourcesServicer):
             badges=[
                 resources_pb2.Badge(
                     id=badge.id,
-                    name=context.get_localized_string(f"badges.{badge.id}_name"),
-                    description=context.get_localized_string(f"badges.{badge.id}_description"),
+                    name=context.localization.localize_string(f"badges.{badge.id}_name"),
+                    description=context.localization.localize_string(f"badges.{badge.id}_description"),
                     color=badge.color,
                 )
                 for badge in get_badge_dict().values()

--- a/app/backend/src/tests/fixtures/sessions.py
+++ b/app/backend/src/tests/fixtures/sessions.py
@@ -178,8 +178,9 @@ class FakeChannel:
                     is_api_key=False,
                     token=self._token if auth_info else None,
                     localization=LocalizationContext(
-                        locale=auth_info.ui_language_preference or DEFAULT_LOCALE,
-                        timezone=ZoneInfo(auth_info.timezone or "Etc/UTC"),
+                        locale=(auth_info and auth_info.ui_language_preference) or DEFAULT_LOCALE,
+                        timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
+                    ),
                 )
 
                 response = handler.unary_unary(request, context, session)

--- a/app/backend/src/tests/fixtures/sessions.py
+++ b/app/backend/src/tests/fixtures/sessions.py
@@ -178,8 +178,8 @@ class FakeChannel:
                     is_api_key=False,
                     token=self._token if auth_info else None,
                     localization=LocalizationContext(
-                        locale=(auth_info and auth_info.ui_language_preference) or DEFAULT_LOCALE,
-                        timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
+                        locale=auth_info.ui_language_preference if auth_info else DEFAULT_LOCALE,
+                        timezone=ZoneInfo(auth_info.timezone if auth_info else "Etc/UTC"),
                     ),
                 )
 

--- a/app/backend/src/tests/fixtures/sessions.py
+++ b/app/backend/src/tests/fixtures/sessions.py
@@ -178,8 +178,8 @@ class FakeChannel:
                     is_api_key=False,
                     token=self._token if auth_info else None,
                     localization=LocalizationContext(
-                        locale=auth_info.ui_language_preference if auth_info else DEFAULT_LOCALE,
-                        timezone=ZoneInfo(auth_info.timezone if auth_info else "Etc/UTC"),
+                        locale=(auth_info and auth_info.ui_language_preference) or DEFAULT_LOCALE,
+                        timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
                     ),
                 )
 

--- a/app/backend/src/tests/fixtures/sessions.py
+++ b/app/backend/src/tests/fixtures/sessions.py
@@ -174,7 +174,7 @@ class FakeChannel:
                     user_id=auth_info.user_id if auth_info else None,
                     is_api_key=False,
                     token=self._token if auth_info else None,
-                    ui_language_preference=auth_info.ui_language_preference if auth_info else None,
+                    localization=auth_info.loc_context if auth_info else None,
                 )
 
                 response = handler.unary_unary(request, context, session)

--- a/app/backend/src/tests/fixtures/sessions.py
+++ b/app/backend/src/tests/fixtures/sessions.py
@@ -2,6 +2,7 @@ from collections.abc import Generator
 from concurrent import futures
 from contextlib import contextmanager
 from typing import Any, NoReturn
+from zoneinfo import ZoneInfo
 
 import grpc
 from grpc._server import _validate_generic_rpc_handlers
@@ -9,6 +10,8 @@ from grpc._server import _validate_generic_rpc_handlers
 from couchers.context import make_interactive_context
 from couchers.db import session_scope
 from couchers.descriptor_pool import get_descriptor_pool
+from couchers.i18n import LocalizationContext
+from couchers.i18n.locales import DEFAULT_LOCALE
 from couchers.interceptors import (
     CouchersMiddlewareInterceptor,
     _try_get_and_update_user_details,
@@ -174,7 +177,9 @@ class FakeChannel:
                     user_id=auth_info.user_id if auth_info else None,
                     is_api_key=False,
                     token=self._token if auth_info else None,
-                    localization=auth_info.loc_context if auth_info else None,
+                    localization=LocalizationContext(
+                        locale=auth_info.ui_language_preference or DEFAULT_LOCALE,
+                        timezone=ZoneInfo(auth_info.timezone or "Etc/UTC"),
                 )
 
                 response = handler.unary_unary(request, context, session)

--- a/app/backend/src/tests/test_event_log.py
+++ b/app/backend/src/tests/test_event_log.py
@@ -61,7 +61,7 @@ def test_log_event_authenticated_context(db):
             user_id=user.id,
             is_api_key=False,
             token=token,
-            ui_language_preference=None,
+            loc_context=None,
             sofa="test-sofa-123",
         )
         log_event(context, session, "test.event", {"key": "value"})
@@ -86,7 +86,7 @@ def test_log_event_with_override_user_id(db):
             user_id=None,
             is_api_key=False,
             token=None,
-            ui_language_preference=None,
+            loc_context=None,
             sofa="sofa-456",
         )
         log_event(context, session, "account.signup_completed", {"gender": "Woman"}, _override_user_id=user.id)
@@ -107,7 +107,7 @@ def test_log_event_anonymous(db):
             user_id=None,
             is_api_key=False,
             token=None,
-            ui_language_preference=None,
+            loc_context=None,
         )
         log_event(context, session, "account.signup_initiated", {"has_invite_code": False})
 
@@ -138,7 +138,7 @@ def test_log_event_complex_properties(db):
             user_id=user.id,
             is_api_key=False,
             token=token,
-            ui_language_preference=None,
+            loc_context=None,
         )
         log_event(context, session, "test.complex", props)
 
@@ -158,7 +158,7 @@ def test_log_event_empty_properties(db):
             user_id=user.id,
             is_api_key=False,
             token=token,
-            ui_language_preference=None,
+            loc_context=None,
         )
         log_event(context, session, "account.logout", {})
 
@@ -178,7 +178,7 @@ def test_log_event_multiple_events(db):
             user_id=user.id,
             is_api_key=False,
             token=token,
-            ui_language_preference=None,
+            loc_context=None,
         )
         log_event(context, session, "test.first", {"n": 1})
         log_event(context, session, "test.second", {"n": 2})

--- a/app/backend/src/tests/test_event_log.py
+++ b/app/backend/src/tests/test_event_log.py
@@ -8,6 +8,7 @@ from couchers.context import make_interactive_context
 from couchers.crypto import hash_password
 from couchers.db import session_scope
 from couchers.event_log import log_event
+from couchers.i18n import LocalizationContext
 from couchers.models.logging import EventLog
 from couchers.proto import (
     api_pb2,
@@ -61,7 +62,7 @@ def test_log_event_authenticated_context(db):
             user_id=user.id,
             is_api_key=False,
             token=token,
-            localization=None,
+            localization=LocalizationContext.en_utc(),
             sofa="test-sofa-123",
         )
         log_event(context, session, "test.event", {"key": "value"})
@@ -86,7 +87,7 @@ def test_log_event_with_override_user_id(db):
             user_id=None,
             is_api_key=False,
             token=None,
-            localization=None,
+            localization=LocalizationContext.en_utc(),
             sofa="sofa-456",
         )
         log_event(context, session, "account.signup_completed", {"gender": "Woman"}, _override_user_id=user.id)
@@ -107,7 +108,7 @@ def test_log_event_anonymous(db):
             user_id=None,
             is_api_key=False,
             token=None,
-            localization=None,
+            localization=LocalizationContext.en_utc(),
         )
         log_event(context, session, "account.signup_initiated", {"has_invite_code": False})
 
@@ -138,7 +139,7 @@ def test_log_event_complex_properties(db):
             user_id=user.id,
             is_api_key=False,
             token=token,
-            localization=None,
+            localization=LocalizationContext.en_utc(),
         )
         log_event(context, session, "test.complex", props)
 
@@ -158,7 +159,7 @@ def test_log_event_empty_properties(db):
             user_id=user.id,
             is_api_key=False,
             token=token,
-            localization=None,
+            localization=LocalizationContext.en_utc(),
         )
         log_event(context, session, "account.logout", {})
 
@@ -178,7 +179,7 @@ def test_log_event_multiple_events(db):
             user_id=user.id,
             is_api_key=False,
             token=token,
-            localization=None,
+            localization=LocalizationContext.en_utc(),
         )
         log_event(context, session, "test.first", {"n": 1})
         log_event(context, session, "test.second", {"n": 2})

--- a/app/backend/src/tests/test_event_log.py
+++ b/app/backend/src/tests/test_event_log.py
@@ -61,7 +61,7 @@ def test_log_event_authenticated_context(db):
             user_id=user.id,
             is_api_key=False,
             token=token,
-            loc_context=None,
+            localization=None,
             sofa="test-sofa-123",
         )
         log_event(context, session, "test.event", {"key": "value"})
@@ -86,7 +86,7 @@ def test_log_event_with_override_user_id(db):
             user_id=None,
             is_api_key=False,
             token=None,
-            loc_context=None,
+            localization=None,
             sofa="sofa-456",
         )
         log_event(context, session, "account.signup_completed", {"gender": "Woman"}, _override_user_id=user.id)
@@ -107,7 +107,7 @@ def test_log_event_anonymous(db):
             user_id=None,
             is_api_key=False,
             token=None,
-            loc_context=None,
+            localization=None,
         )
         log_event(context, session, "account.signup_initiated", {"has_invite_code": False})
 
@@ -138,7 +138,7 @@ def test_log_event_complex_properties(db):
             user_id=user.id,
             is_api_key=False,
             token=token,
-            loc_context=None,
+            localization=None,
         )
         log_event(context, session, "test.complex", props)
 
@@ -158,7 +158,7 @@ def test_log_event_empty_properties(db):
             user_id=user.id,
             is_api_key=False,
             token=token,
-            loc_context=None,
+            localization=None,
         )
         log_event(context, session, "account.logout", {})
 
@@ -178,7 +178,7 @@ def test_log_event_multiple_events(db):
             user_id=user.id,
             is_api_key=False,
             token=token,
-            loc_context=None,
+            localization=None,
         )
         log_event(context, session, "test.first", {"n": 1})
         log_event(context, session, "test.second", {"n": 2})

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -19,6 +19,7 @@ from couchers.constants import (
 from couchers.crypto import b64encode, random_hex, simple_encrypt
 from couchers.db import session_scope
 from couchers.descriptor_pool import get_descriptor_pool
+from couchers.i18n import LocalizationContext
 from couchers.interceptors import (
     AbortError,
     BadHeaders,
@@ -810,7 +811,7 @@ def test_check_auth_open_service_with_auth():
         is_editor=False,
         is_superuser=False,
         token_expiry=now(),
-        ui_language_preference="en",
+        loc_context=LocalizationContext.en_utc(),
         token="abc123",
         is_api_key=False,
     )
@@ -829,7 +830,7 @@ def test_check_auth_secure_service_with_normal_auth():
         is_editor=False,
         is_superuser=False,
         token_expiry=now(),
-        ui_language_preference="en",
+        loc_context=LocalizationContext.en_utc(),
         token="abc123",
         is_api_key=False,
     )
@@ -843,7 +844,7 @@ def test_check_auth_secure_service_with_jailed_user():
         is_editor=False,
         is_superuser=False,
         token_expiry=now(),
-        ui_language_preference="en",
+        loc_context=LocalizationContext.en_utc(),
         token="abc123",
         is_api_key=False,
     )
@@ -858,7 +859,7 @@ def test_check_auth_jailed_service_with_jailed_user():
         is_editor=False,
         is_superuser=False,
         token_expiry=now(),
-        ui_language_preference="en",
+        loc_context=LocalizationContext.en_utc(),
         token="abc123",
         is_api_key=False,
     )
@@ -877,7 +878,7 @@ def test_check_auth_editor_service_without_editor():
         is_editor=False,
         is_superuser=False,
         token_expiry=now(),
-        ui_language_preference="en",
+        loc_context=LocalizationContext.en_utc(),
         token="abc123",
         is_api_key=False,
     )
@@ -892,7 +893,7 @@ def test_check_auth_editor_service_with_editor():
         is_editor=True,
         is_superuser=False,
         token_expiry=now(),
-        ui_language_preference="en",
+        loc_context=LocalizationContext.en_utc(),
         token="abc123",
         is_api_key=False,
     )
@@ -906,7 +907,7 @@ def test_check_auth_admin_service_without_superuser():
         is_editor=True,
         is_superuser=False,
         token_expiry=now(),
-        ui_language_preference="en",
+        loc_context=LocalizationContext.en_utc(),
         token="abc123",
         is_api_key=False,
     )
@@ -921,7 +922,7 @@ def test_check_auth_admin_service_with_superuser():
         is_editor=True,
         is_superuser=True,
         token_expiry=now(),
-        ui_language_preference="en",
+        loc_context=LocalizationContext.en_utc(),
         token="abc123",
         is_api_key=False,
     )

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -19,7 +19,6 @@ from couchers.constants import (
 from couchers.crypto import b64encode, random_hex, simple_encrypt
 from couchers.db import session_scope
 from couchers.descriptor_pool import get_descriptor_pool
-from couchers.i18n import LocalizationContext
 from couchers.interceptors import (
     AbortError,
     BadHeaders,
@@ -811,7 +810,8 @@ def test_check_auth_open_service_with_auth():
         is_editor=False,
         is_superuser=False,
         token_expiry=now(),
-        loc_context=LocalizationContext.en_utc(),
+        ui_language_preference="en",
+        timezone="Etc/UTC",
         token="abc123",
         is_api_key=False,
     )
@@ -830,7 +830,8 @@ def test_check_auth_secure_service_with_normal_auth():
         is_editor=False,
         is_superuser=False,
         token_expiry=now(),
-        loc_context=LocalizationContext.en_utc(),
+        ui_language_preference="en",
+        timezone="Etc/UTC",
         token="abc123",
         is_api_key=False,
     )
@@ -844,7 +845,8 @@ def test_check_auth_secure_service_with_jailed_user():
         is_editor=False,
         is_superuser=False,
         token_expiry=now(),
-        loc_context=LocalizationContext.en_utc(),
+        ui_language_preference="en",
+        timezone="Etc/UTC",
         token="abc123",
         is_api_key=False,
     )
@@ -859,7 +861,8 @@ def test_check_auth_jailed_service_with_jailed_user():
         is_editor=False,
         is_superuser=False,
         token_expiry=now(),
-        loc_context=LocalizationContext.en_utc(),
+        ui_language_preference="en",
+        timezone="Etc/UTC",
         token="abc123",
         is_api_key=False,
     )
@@ -878,7 +881,8 @@ def test_check_auth_editor_service_without_editor():
         is_editor=False,
         is_superuser=False,
         token_expiry=now(),
-        loc_context=LocalizationContext.en_utc(),
+        ui_language_preference="en",
+        timezone="Etc/UTC",
         token="abc123",
         is_api_key=False,
     )
@@ -893,7 +897,8 @@ def test_check_auth_editor_service_with_editor():
         is_editor=True,
         is_superuser=False,
         token_expiry=now(),
-        loc_context=LocalizationContext.en_utc(),
+        ui_language_preference="en",
+        timezone="Etc/UTC",
         token="abc123",
         is_api_key=False,
     )
@@ -907,7 +912,8 @@ def test_check_auth_admin_service_without_superuser():
         is_editor=True,
         is_superuser=False,
         token_expiry=now(),
-        loc_context=LocalizationContext.en_utc(),
+        ui_language_preference="en",
+        timezone="Etc/UTC",
         token="abc123",
         is_api_key=False,
     )
@@ -922,7 +928,8 @@ def test_check_auth_admin_service_with_superuser():
         is_editor=True,
         is_superuser=True,
         token_expiry=now(),
-        loc_context=LocalizationContext.en_utc(),
+        ui_language_preference="en",
+        timezone="Etc/UTC",
         token="abc123",
         is_api_key=False,
     )


### PR DESCRIPTION
Instead of `CouchersContext.ui_language_preference`, expose a `LocalizationContext`, which also includes the time zone, so all code can appropriately localize dates. Also avoid having to deal with nulls everywhere: if we don't have a value (e.g. media server), fallback to `LocalizationContext.en_utc()`. Finally, remove `get_localized_string`, letting code use LocalizationContext's methods directly.

## Testing
Ran backend locally, created a new account, navigated around.

**Backend checklist**
<!-- To avoid CI failures, first run `make format` in app/backend and run tests locally. -->
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me