### PR TITLE
Devex: Prevent html generation from running unconditionally

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -38,7 +38,6 @@ jobs:
               - 'app/backend/src/couchers/migrations/versions/**'
             templates:
               - 'app/backend/templates/v2/**'
-              - '!app/backend/templates/v2/generated_html/**'
 
   format-backend:
     needs: detect-changes


### PR DESCRIPTION
Matching both 'app/backend/templates/v2/**' and '!app/backend/templates/v2/generated_html/**' means matching the union of those two filters, not its intersection, so the check was running unconditionally.

I think we should run if you modify the generated_html since you could manually get one of those files out of sync with its base mjml files.

## Testing
N/A - This PR should not run the html generation step.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me