### PR TITLE
Frontend: Show notification body in feed menu

### DIFF
--- a/app/web/features/notifications/NotificationsFeed/NotificationItem.tsx
+++ b/app/web/features/notifications/NotificationsFeed/NotificationItem.tsx
@@ -142,10 +142,11 @@ const NotificationItem = ({
       <FlexColumn>
         <LinesEllipsis
           text={notification.title}
-          maxLine={2}
-          ellipsis="..."
+          maxLine={1}
+          ellipsis="…"
           style={{
             fontSize: theme.typography.body2.fontSize,
+            fontWeight: 600,
             whiteSpace: "normal",
             wordBreak: "break-word",
           }}
@@ -157,6 +158,16 @@ const NotificationItem = ({
             locale,
           })}
         </Typography>
+        <LinesEllipsis
+          text={notification.body}
+          maxLine={2}
+          ellipsis="…"
+          style={{
+            fontSize: theme.typography.body2.fontSize,
+            whiteSpace: "normal",
+            wordBreak: "break-word",
+          }}
+        />
       </FlexColumn>
       {!notification.isSeen && (
         <Circle


### PR DESCRIPTION
The notification feed menu only showed notification titles, but since their rewriting for push-notification friendliness, titles are now terse and don't contain enough information to make sense of. In any case, we need to show the body because it might be the only place where some info is displayed. For example, if the notification body says that it's the event's picture that changed, following the notification link to the event page wouldn't tell you that.

Note: I have no idea what I'm doing in terms of styling, so I plan to cross-post in our ux channel when this is approved.

Fixes #7977

## Testing
Ran local frontend against NEXT:

<img width="435" height="668" alt="image" src="https://github.com/user-attachments/assets/39b5fa6c-b9aa-4a4b-8b0f-2e4660284139" />

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` and `yarn lint --fix` in app/web, and run tests locally. -->
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
