### PR TITLE
Frontend: Remove RelativeTime plugin from dayjs configuration

### DIFF
--- a/app/web/utils/dayjs.ts
+++ b/app/web/utils/dayjs.ts
@@ -2,14 +2,12 @@ import dayjs, { Dayjs } from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import DurationPlugin from "dayjs/plugin/duration";
 import LocalizedFormat from "dayjs/plugin/localizedFormat";
-import RelativeTime from "dayjs/plugin/relativeTime";
 import Timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 
 dayjs.extend(utc);
 dayjs.extend(customParseFormat);
 dayjs.extend(DurationPlugin);
-dayjs.extend(RelativeTime);
 dayjs.extend(Timezone);
 dayjs.extend(LocalizedFormat);
 


### PR DESCRIPTION
We don't use dayjs' RelativeTime plugin (having our own logic in timeAgo.ts) and don't want to use it because it's not localized unless we import a bunch of locale plugins.

From the [docs](https://day.js.org/docs/en/plugin/relative-time), this plugin only exports 4 functions. Find in files didn't find uses of any of them, so this should be safe.

## Testing
N/A - dead code

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` and `yarn lint --fix` in app/web, and run tests locally. -->
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me