### PR TITLE
Group mobile dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,10 @@ updates:
     labels:
       - "mobile app"
       - "dependencies"
+    groups:
+      mobile-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directories:

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -560,6 +560,24 @@ test:mobile-typecheck:
       changes:
         - app/mobile/**/*
 
+test:mobile-expo-doctor:
+  needs: ["protos"]
+  stage: test
+  image: node:22
+  inherit:
+    default: false
+  script:
+    - cd app/mobile
+    - npm ci
+    - npm run build:protos
+    - npx expo-doctor
+  rules:
+    - if: ($BUILD_MOBILE == "true") && ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
+    - if: ($BUILD_MOBILE == "true") && ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
+      changes:
+        - app/mobile/package.json
+        - app/mobile/package-lock.json
+
 test:proxy:
   needs: ["build:proxy"]
   stage: test
@@ -861,6 +879,9 @@ wait:before-release:
       artifacts: false
       optional: true
     - job: test:mobile-typecheck
+      artifacts: false
+      optional: true
+    - job: test:mobile-expo-doctor
       artifacts: false
       optional: true
 

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -560,24 +560,6 @@ test:mobile-typecheck:
       changes:
         - app/mobile/**/*
 
-test:mobile-expo-doctor:
-  needs: ["protos"]
-  stage: test
-  image: node:22
-  inherit:
-    default: false
-  script:
-    - cd app/mobile
-    - npm ci
-    - npm run build:protos
-    - npx expo-doctor
-  rules:
-    - if: ($BUILD_MOBILE == "true") && ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
-    - if: ($BUILD_MOBILE == "true") && ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
-      changes:
-        - app/mobile/package.json
-        - app/mobile/package-lock.json
-
 test:proxy:
   needs: ["build:proxy"]
   stage: test
@@ -879,9 +861,6 @@ wait:before-release:
       artifacts: false
       optional: true
     - job: test:mobile-typecheck
-      artifacts: false
-      optional: true
-    - job: test:mobile-expo-doctor
       artifacts: false
       optional: true
 


### PR DESCRIPTION
Configure Dependabot to group mobile dependencies

- Add grouped updates for mobile app dependencies
- All mobile dependencies will be updated together in a single PR
- This matches React Native/Expo best practices where packages are
  tightly coupled and should be upgraded together
- Also fixes current package-lock.json sync issue