### PR TITLE
Add spacing to remove photo icon

### DIFF
--- a/app/web/components/GalleryEditor/GalleryItem.tsx
+++ b/app/web/components/GalleryEditor/GalleryItem.tsx
@@ -107,6 +107,7 @@ const StyledImageListItemBar = styled(ImageListItemBar)(({ theme }) => ({
 const DeleteButton = styled(IconButton)(({ theme }) => ({
   color: theme.palette.common.white,
   backgroundColor: "rgba(255, 255, 255, 0.1)",
+  margin: theme.spacing(0.5),
   "&:hover": {
     backgroundColor: "rgba(255, 255, 255, 0.2)",
   },


### PR DESCRIPTION
The icon was touching the edges of the photo on hover, just adding a bit of margin for desktop view.