### PR TITLE
Backend/i18n: Fallback to en plural rules if not defined for language

### DIFF
--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from html import escape, unescape
 from typing import Any
 
-from babel import Locale
+from babel import Locale, UnknownLocaleError
 from markupsafe import Markup
 
 PLURALIZABLE_VARIABLE_NAME = "count"
@@ -103,7 +103,10 @@ class Translation:
         if substitutions:
             if count := substitutions.get(PLURALIZABLE_VARIABLE_NAME):
                 if isinstance(count, int):
-                    plural_form = Locale(self.locale).plural_form(count)
+                    try:
+                        plural_form = Locale(self.locale).plural_form(count)
+                    except UnknownLocaleError:
+                        plural_form = Locale("en").plural_form(count)
                     plural_key = key + "_" + plural_form
                     if string := self.strings_by_key.get(plural_key):
                         return string

--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -106,7 +106,8 @@ class Translation:
                     try:
                         plural_form = Locale(self.locale).plural_form(count)
                     except UnknownLocaleError:
-                        plural_form = Locale("en").plural_form(count)
+                        # Fallback to English-style plural rule.
+                        plural_form = "one" if 1 else "other"
                     plural_key = key + "_" + plural_form
                     if string := self.strings_by_key.get(plural_key):
                         return string

--- a/app/backend/src/tests/test_i18n.py
+++ b/app/backend/src/tests/test_i18n.py
@@ -1,5 +1,4 @@
 import pytest
-
 from babel import Locale, UnknownLocaleError
 
 from couchers.i18n.localize import get_main_i18next
@@ -38,6 +37,7 @@ def test_fallback_chain():
 
     assert i18next.default_translation == en
 
+
 def test_babel_locales():
     """Documents which locales are not supported/recognized by the Babel library's CLDR."""
     unknown_locales: set[str] = set()
@@ -47,4 +47,4 @@ def test_babel_locales():
             Locale(locale)
         except UnknownLocaleError:
             unknown_locales.add(locale)
-    assert unknown_locales == { "en_CORP", "es-419", "fr-CA", "nb-NO", "pt-BR", "zh-Hans", "zh-Hant" }
+    assert unknown_locales == {"en_CORP", "es-419", "fr-CA", "nb-NO", "pt-BR", "zh-Hans", "zh-Hant"}

--- a/app/backend/src/tests/test_i18n.py
+++ b/app/backend/src/tests/test_i18n.py
@@ -1,5 +1,7 @@
 import pytest
 
+from babel import Locale, UnknownLocaleError
+
 from couchers.i18n.localize import get_main_i18next
 
 
@@ -35,3 +37,14 @@ def test_fallback_chain():
     assert en.fallbacks == []
 
     assert i18next.default_translation == en
+
+def test_babel_locales():
+    """Documents which locales are not supported/recognized by the Babel library's CLDR."""
+    unknown_locales: set[str] = set()
+    i18next = get_main_i18next()
+    for locale in i18next.translations_by_locale.keys():
+        try:
+            Locale(locale)
+        except UnknownLocaleError:
+            unknown_locales.add(locale)
+    assert unknown_locales == { "en_CORP", "es-419", "fr-CA", "nb-NO", "pt-BR", "zh-Hans", "zh-Hant" }

--- a/app/backend/src/tests/test_i18next.py
+++ b/app/backend/src/tests/test_i18next.py
@@ -79,13 +79,14 @@ def test_plural_no_count():
     assert i18next.localize("apples", "en", {"count": 1}) == "apple"
     assert i18next.localize("apples", "en", {"count": 2}) == "apples"
 
+
 def test_missing_plural_rules():
     i18next = I18Next()
-    piglatin = i18next.add_translation("piglatin", json_dict={ "pigs": "igpays", "pigs_one": "igpay" })
-    en = i18next.add_translation("en", json_dict={ "pigs": "pigs", "pigs_one": "pig" })
+    piglatin = i18next.add_translation("piglatin", json_dict={"pigs": "igpays", "pigs_one": "igpay"})
+    en = i18next.add_translation("en", json_dict={"pigs": "pigs", "pigs_one": "pig"})
     piglatin.fallbacks.append(en)
     # Should resolve using the english plural rules since "piglatin" doesn't have its own.
-    assert i18next.localize("pigs", "piglatin", { "count": 1 }) == "igpay"
+    assert i18next.localize("pigs", "piglatin", {"count": 1}) == "igpay"
 
 
 def test_load_simple_json():

--- a/app/backend/src/tests/test_i18next.py
+++ b/app/backend/src/tests/test_i18next.py
@@ -79,6 +79,14 @@ def test_plural_no_count():
     assert i18next.localize("apples", "en", {"count": 1}) == "apple"
     assert i18next.localize("apples", "en", {"count": 2}) == "apples"
 
+def test_missing_plural_rules():
+    i18next = I18Next()
+    piglatin = i18next.add_translation("piglatin", json_dict={ "pigs": "igpays", "pigs_one": "igpay" })
+    en = i18next.add_translation("en", json_dict={ "pigs": "pigs", "pigs_one": "pig" })
+    piglatin.fallbacks.append(en)
+    # Should resolve using the english plural rules since "piglatin" doesn't have its own.
+    assert i18next.localize("pigs", "piglatin", { "count": 1 }) == "igpay"
+
 
 def test_load_simple_json():
     i18next = I18Next()


### PR DESCRIPTION
Fixes an issue where users of `es-419` would hit an exception because Babel doesn't have a locale with that name. For now fallback to the English plural rule as a short-term fix. I filed these follow-up tasks for investigation: #8028 #8029

## Testing
Added tests and ran it.

**Backend checklist**
<!-- To avoid CI failures, first run `make format` in app/backend and run tests locally. -->
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me