### PR TITLE
Frontend/i18n: Apply best practices to invite codes strings

### DIFF
--- a/app/web/features/auth/InviteCodesPage.test.tsx
+++ b/app/web/features/auth/InviteCodesPage.test.tsx
@@ -67,7 +67,7 @@ describe("InviteCodesPage", () => {
 
     // Active codes have Disable action, disabled does not
     expect(
-      screen.getAllByRole("button", { name: t("global:disable") }),
+      screen.getAllByRole("button", { name: t("global:invites.disable_link") }),
     ).toHaveLength(2);
   });
 
@@ -107,10 +107,14 @@ describe("InviteCodesPage", () => {
     render(<InviteCodesPage />, { wrapper });
     const user = userEvent.setup();
 
-    await user.click(await screen.findByLabelText(t("global:copy")));
+    await user.click(
+      await screen.findByLabelText(t("global:copy_button.a11y")),
+    );
 
     // Feedback tooltip appears
-    expect(await screen.findByText(t("global:copied"))).toBeVisible();
+    expect(
+      await screen.findByText(t("global:copy_button.copied_tooltip")),
+    ).toBeVisible();
   });
 
   it("disables an active code when clicking Disable", async () => {
@@ -133,7 +137,9 @@ describe("InviteCodesPage", () => {
     const user = userEvent.setup();
 
     await user.click(
-      await screen.findByRole("button", { name: t("global:disable") }),
+      await screen.findByRole("button", {
+        name: t("global:invites.disable_link"),
+      }),
     );
 
     await waitFor(() => {

--- a/app/web/features/auth/InviteCodesPage.tsx
+++ b/app/web/features/auth/InviteCodesPage.tsx
@@ -73,11 +73,11 @@ export default function InviteCodesPage() {
   return (
     <Box sx={{ width: "100%", maxWidth: 800, mx: "auto", mt: 6, px: 2 }}>
       <Typography variant="h2" gutterBottom sx={{ mb: 1 }}>
-        {t("global:nav.invite_members")}
+        {t("global:invites.title")}
       </Typography>
 
       <Typography color="textSecondary" sx={{ mb: 3 }}>
-        {t("invites.instructions")}
+        {t("global:invites.instructions")}
       </Typography>
 
       <Box sx={{ display: "flex", gap: 1, mb: 2 }}>
@@ -124,13 +124,13 @@ export default function InviteCodesPage() {
                   <>
                     <Tooltip
                       open={copiedCode === c.code}
-                      title={t("global:copied")}
+                      title={t("global:copy_button.copied_tooltip")}
                       placement="top"
                       arrow
                     >
                       <IconButton
                         edge="end"
-                        aria-label={t("global:copy")}
+                        aria-label={t("global:copy_button.a11y")}
                         onClick={() => copy(shareUrl, c.code)}
                         disabled={!!c.disabled}
                       >
@@ -144,7 +144,7 @@ export default function InviteCodesPage() {
                         onClick={() => disableInviteCode(c.code)}
                         disabled={isDisablePending}
                       >
-                        {t("global:disable")}
+                        {t("global:invites.disable_link")}
                       </Button>
                     )}
                   </>
@@ -159,26 +159,29 @@ export default function InviteCodesPage() {
                     <>
                       {c.created?.seconds && (
                         <>
-                          {t("global:created")}:{" "}
-                          {dayjs(new Date(c.created.seconds * 1000)).format(
-                            "YYYY-MM-DD HH:mm",
-                          )}
+                          {t("global:invites.created_datetime", {
+                            datetime: dayjs(
+                              new Date(c.created.seconds * 1000),
+                            ).format("YYYY-MM-DD HH:mm"),
+                          })}
                         </>
                       )}
                       {c.disabled?.seconds && (
                         <>
                           {" • "}
-                          {t("global:disabled")}:{" "}
-                          {dayjs(new Date(c.disabled.seconds * 1000)).format(
-                            "YYYY-MM-DD HH:mm",
-                          )}
+                          {t("global:invites.disabled_datetime", {
+                            datetime: dayjs(
+                              new Date(c.disabled.seconds * 1000),
+                            ).format("YYYY-MM-DD HH:mm"),
+                          })}
                         </>
                       )}
                       {typeof c.uses === "number" && (
                         <>
                           {" • "}
-                          {t("global:uses")}: {c.uses}{" "}
-                          {t("invites.uses_suffix")}
+                          {t("global:invites.number_of_uses", {
+                            count: c.uses,
+                          })}
                         </>
                       )}
                     </>
@@ -189,7 +192,7 @@ export default function InviteCodesPage() {
           })}
           {!(data?.inviteCodesList?.length ?? 0) && (
             <Typography color="textSecondary">
-              {t("global:no_invite_codes")}
+              {t("global:invites.no_codes_message")}
             </Typography>
           )}
         </List>

--- a/app/web/features/auth/signup/Signup.test.tsx
+++ b/app/web/features/auth/signup/Signup.test.tsx
@@ -370,14 +370,18 @@ describe("Signup", () => {
     render(<View />, { wrapper });
 
     expect(
-      await screen.findByText(t("global:invited_you", { name: "Alice" })),
+      await screen.findByText(
+        t("global:invites.banner.invited_you", { name: "Alice" }),
+      ),
     ).toBeVisible();
   });
 
   it("does not show inviter banner if no inviteCode is present", async () => {
     render(<View />, { wrapper });
     expect(
-      screen.queryByText(t("global:invited_you", { name: expect.any(String) })),
+      screen.queryByText(
+        t("global:invites.banner.invited_you", { name: expect.any(String) }),
+      ),
     ).toBeNull();
   });
 

--- a/app/web/features/auth/signup/Signup.tsx
+++ b/app/web/features/auth/signup/Signup.tsx
@@ -140,7 +140,7 @@ export default function Signup() {
           )}
           {inviteError && (
             <Alert severity="error" sx={{ width: "100%" }}>
-              {t("global:error_loading_invite_codes")}
+              {t("global:invites.error.fetch_invite_info")}
             </Alert>
           )}
           {inviteCode && !inviteError && (
@@ -167,7 +167,9 @@ export default function Signup() {
                     highRes
                   />
                   <Typography>
-                    {t("global:invited_you", { name: inviter.name })}
+                    {t("global:invites.banner.invited_you", {
+                      name: inviter.name,
+                    })}
                   </Typography>
                 </>
               )}

--- a/app/web/resources/locales/en.json
+++ b/app/web/resources/locales/en.json
@@ -217,10 +217,10 @@
     "title": "Invite members",
     "instructions": "Create an invite link to share with friends and community. Disable codes you no longer use.",
     "no_codes_message": "No invite codes yet",
-    "created_datetime": "Created on {{datetime}}",
-    "disabled_datetime": "Disabled on {{datetime}}",
-    "number_of_uses": "{{count}} uses",
-    "number_of_uses_one": "{{count}} use",
+    "created_datetime": "Created: {{datetime}}",
+    "disabled_datetime": "Disabled: {{datetime}}",
+    "number_of_uses": "Uses: {{count}} completed signups",
+    "number_of_uses_one": "Uses: {{count}} completed signup",
     "disable_link": "Disable",
     "banner": {
       "invited_you": "{{name}} invited you to join Couchers!"

--- a/app/web/resources/locales/en.json
+++ b/app/web/resources/locales/en.json
@@ -12,16 +12,14 @@
   "join_us": "Join us",
   "update": "Update",
   "create": "Create",
-  "created": "Created",
   "terms_of_service": "Terms of Service",
   "required": "Required",
   "accept": "Accept",
   "continue": "Continue",
-  "disable": "Disable",
-  "disabled": "Disabled",
-  "uses": "Uses",
-  "no_invite_codes": "No invite codes yet",
-  "error_loading_invite_codes": "Couldn't get invite code details",
+  "copy_button": {
+    "a11y": "Copy",
+    "copied_tooltip": "Copied to clipboard"
+  },
   "thanks": "Thanks!",
   "donation_banner": {
     "message": "Couchers.org runs on kindness — just like couch surfing itself. This holiday season, help us keep it that way. We are raising {{goal}} to cover the cost of running Couchers.org.",
@@ -39,8 +37,6 @@
   "cancel": "Cancel",
   "submit": "Submit",
   "confirm": "Confirm",
-  "copy": "Copy",
-  "copied": "Copied to clipboard",
   "image_input": {
     "select_button_a11y": "Select an image",
     "replace_image_tooltip": "Click to replace image",
@@ -149,7 +145,6 @@
     "default_title": "Couchers.org",
     "default_description": "Share your world, discover theirs. Authentic local experiences, built on trust and genuine connection—not transactions."
   },
-  "invited_you": "{{name}} invited you to join Couchers!",
   "error": {
     "fatal_message": "This shouldn't have happened. Please contact us and tell us what you were doing to help us prevent this error in the future.",
     "unknown": "Unknown error",
@@ -220,14 +215,15 @@
   },
   "invites": {
     "title": "Invite members",
-    "create": "Create invite",
-    "disable": "Disable",
-    "share_link": "Copy share link",
     "instructions": "Create an invite link to share with friends and community. Disable codes you no longer use.",
-    "uses_suffix": "completed signups",
+    "no_codes_message": "No invite codes yet",
+    "created_datetime": "Created on {{datetime}}",
+    "disabled_datetime": "Disabled on {{datetime}}",
+    "number_of_uses": "{{count}} uses",
+    "number_of_uses_one": "{{count}} use",
+    "disable_link": "Disable",
     "banner": {
-      "invited_you": "{{name}} invited you to join Couchers!",
-      "inviter_fallback": "{{username}} invited you to join Couchers!"
+      "invited_you": "{{name}} invited you to join Couchers!"
     },
     "error": {
       "fetch_invite_info": "Couldn't get invite code details"


### PR DESCRIPTION
Translators were asking about pluralization of "completed signups", which lead to fixing a few issues with the invite codes strings:

- Replaced string concatenations with placeholders
- Consolidated duplicate strings (one copy of which was unused but still getting translated)
- Used more descriptive string keys (single words are generally not translatable without context)

This will cause some amount of relocalization, but since the original strings included little context, their translation quality might have been poor.

This will conflict with #8019, so please help review that PR!

## Testing
Ran local frontend against NEXT, created and disabled invite codes.

<img width="1641" height="657" alt="image" src="https://github.com/user-attachments/assets/d4f20dd2-4d70-46df-a772-312ee4c141f3" />

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` and `yarn lint --fix` in app/web, and run tests locally. -->
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me