### PR TITLE
Revert "Remove RelativeTime plugin from dayjs configuration (#8016)"

### DIFF
--- a/app/web/utils/dayjs.ts
+++ b/app/web/utils/dayjs.ts
@@ -2,12 +2,14 @@ import dayjs, { Dayjs } from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import DurationPlugin from "dayjs/plugin/duration";
 import LocalizedFormat from "dayjs/plugin/localizedFormat";
+import RelativeTime from "dayjs/plugin/relativeTime";
 import Timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 
 dayjs.extend(utc);
 dayjs.extend(customParseFormat);
 dayjs.extend(DurationPlugin);
+dayjs.extend(RelativeTime);
 dayjs.extend(Timezone);
 dayjs.extend(LocalizedFormat);
 


### PR DESCRIPTION
It looks like this is causing Sentry issues like https://couchers.sentry.io/issues/7311432064 .

The dayjs documentation says that the plugin only adds `fromNow` and related functions but it doesn't mention `humanize()` which also requires this plugin and which we call.

```
TypeError: t(...).add(...).locale(...).fromNow is not a function
    at p.humanize (8529-212a40c3c81a7dbb.js:1:109477)
```

Called at https://github.com/Couchers-org/couchers/blob/87a384ede69a40d65aa369d00f641bb32f3d9561/app/web/features/profile/view/userLabels.tsx#L91

This reverts commit ba9858c16933a7c243f88a1268a5a78054d1c167.

## Testing
N/A

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` in app/web, and run tests locally. -->
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me