### PR TITLE
Don't show cookie banner on mobile app

### DIFF
--- a/app/web/components/CookieBanner.tsx
+++ b/app/web/components/CookieBanner.tsx
@@ -7,6 +7,7 @@ import { Trans, useTranslation } from "i18n";
 import { usePersistedState } from "platform/usePersistedState";
 import { tosRoute } from "routes";
 import { useIsMounted } from "utils/hooks";
+import { useIsNativeEmbed } from "utils/nativeLink";
 
 const StyledWrapper = styled("div")(({ theme }) => ({
   position: "fixed",
@@ -39,8 +40,12 @@ export default function CookieBanner() {
   const isMounted = useIsMounted().current;
   const auth = useAuthContext();
   const [hasSeen, setHasSeen] = usePersistedState("hasSeenCookieBanner", false);
+  const isNativeEmbed = useIsNativeEmbed();
 
-  if (auth.authState.authenticated) return null;
+  // Don't show cookie banner in native mobile app
+  // Mobile apps use app store privacy mechanisms, not cookie banners
+  // Only essential cookies are used (session/auth), which don't require consent
+  if (auth.authState.authenticated || isNativeEmbed) return null;
 
   //specifically not using our snackbar, which is designed for alerts
   return isMounted && !hasSeen ? (


### PR DESCRIPTION
We got feedback from Apple about the cookie banner, etc. I am removing it on the mobile app as the process is a bit different for mobile since we enter all the privacy info via Apple Connect and Google Play.

Apple defines tracking as, "Tracking is linking data collected from the app with third-party data for advertising purposes, or sharing the collected data with a data broker. Learn more about [tracking](https://developer.apple.com/app-store/app-privacy-details/#user-tracking)."

Since we don't do any of this, they suggested we remove the cookie banner.