### PR TITLE
Frontend/i18n: Fix string pluralization format

### DIFF
--- a/app/web/resources/locales/en.json
+++ b/app/web/resources/locales/en.json
@@ -219,8 +219,8 @@
     "no_codes_message": "No invite codes yet",
     "created_datetime": "Created: {{datetime}}",
     "disabled_datetime": "Disabled: {{datetime}}",
-    "number_of_uses": "Uses: {{count}} completed signups",
     "number_of_uses_one": "Uses: {{count}} completed signup",
+    "number_of_uses_other": "Uses: {{count}} completed signups",
     "disable_link": "Disable",
     "banner": {
       "invited_you": "{{name}} invited you to join Couchers!"


### PR DESCRIPTION
Weblate doesn't understand the current string keys as it expects English to specify its two suffixed pluralization forms. This fix should make the string appear correctly pluralizable to translators.

> The component contains several duplicated translation strings.

<img width="635" height="708" alt="image" src="https://github.com/user-attachments/assets/4fc2c656-08e9-4ed3-9c6a-7d22405b6326" />

## Testing
N/A - There's no problem code-wise, only Weblate confusion.

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` in app/web, and run tests locally. -->
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me