### PR TITLE
Remove expo doctor from wait:before-release dependencies

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -942,9 +942,6 @@ wait:before-release:
     - job: test:mobile-typecheck
       artifacts: false
       optional: true
-    - job: test:mobile-expo-doctor
-      artifacts: false
-      optional: true
 
 release:proxy:
   needs: ["wait:before-release"]


### PR DESCRIPTION
Because the job is broken and shouldn't block platform releases.