### PR TITLE
i18n: Remove bogus space in string

### DIFF
--- a/app/backend/src/couchers/notifications/locales/en.json
+++ b/app/backend/src/couchers/notifications/locales/en.json
@@ -40,7 +40,7 @@
       "cancel": "An event you are attending is cancelled.",
       "delete": "An event you are attending is deleted.",
       "invite_organizer": "Someone invites you to co-organize an event.",
-      "comment": " A user comments on an event you are going to.",
+      "comment": "A user comments on an event you are going to.",
       "reminder": "Reminder that an event you are going to is happening soon."
     },
     "friend_request": {

--- a/app/web/features/notifications/locales/en.json
+++ b/app/web/features/notifications/locales/en.json
@@ -65,7 +65,7 @@
                     "cancel": "An event you are attending is cancelled",
                     "delete": "An event you are attending is deleted",
                     "invite_organizer": "Someone invites you to co-organize an event",
-                    "comment": " A user comments on an event you are going to",
+                    "comment": "A user comments on an event you are going to",
                     "reminder": "Reminder that an event you are going to is happening soon"
                 },
                 "onboarding": {


### PR DESCRIPTION
As reported by @c-kreuz .

This string exists in two instances because I'm migrating them from the frontend to the backend. I'll follow-up soon with removing the frontend copies so the backend has the source of truth.

## Testing
N/A

**Backend checklist**
<!-- To avoid CI failures, first run `make format` in app/backend and run tests locally. -->
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` in app/web, and run tests locally. -->
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
