### PR TITLE
Backend/strings: remove full stop from notification settings strings

### DIFF
--- a/app/backend/src/couchers/notifications/locales/en.json
+++ b/app/backend/src/couchers/notifications/locales/en.json
@@ -1,103 +1,103 @@
 {
   "topic_action_descriptions": {
     "account_deletion": {
-      "start": "You initiate account deletion.",
-      "complete": "Your account is deleted.",
-      "recovered": "Your account is recovered (undeleted)."
+      "start": "You initiate account deletion",
+      "complete": "Your account is deleted",
+      "recovered": "Your account is recovered (undeleted)"
     },
     "activeness": {
-      "probe": "You accept guests but haven't logged in a while."
+      "probe": "You accept guests but haven't logged in a while"
     },
     "api_key": {
-      "create": "An API key is created for your account."
+      "create": "An API key is created for your account"
     },
     "badge": {
-      "add": "A badge is added to your account.",
-      "remove": "A badge is removed from your account."
+      "add": "A badge is added to your account",
+      "remove": "A badge is removed from your account"
     },
     "birthdate": {
-      "change": "Your birthdate is changed."
+      "change": "Your birthdate is changed"
     },
     "chat": {
-      "message": "Someone sends you a message.",
-      "missed_messages": "You miss messages in a chat."
+      "message": "Someone sends you a message",
+      "missed_messages": "You miss messages in a chat"
     },
     "discussion": {
-      "create": "Someone creates a discussion in a community you are in.",
-      "comment": "Someone comments on a discussion you are following."
+      "create": "Someone creates a discussion in a community you are in",
+      "comment": "Someone comments on a discussion you are following"
     },
     "donation": {
-      "received": "Your donation is received."
+      "received": "Your donation is received"
     },
     "email_address": {
-      "change": "Email change is initiated.",
-      "verify": "Your new email is verified."
+      "change": "Email change is initiated",
+      "verify": "Your new email is verified"
     },
     "event": {
-      "create_approved": "An event that is approved by the moderators is created in your community.",
-      "create_any": "A user creates any event in your community (not checked by an admin).",
-      "update": "An event you are attending is updated.",
-      "cancel": "An event you are attending is cancelled.",
-      "delete": "An event you are attending is deleted.",
-      "invite_organizer": "Someone invites you to co-organize an event.",
-      "comment": "A user comments on an event you are going to.",
-      "reminder": "Reminder that an event you are going to is happening soon."
+      "create_approved": "An event that is approved by the moderators is created in your community",
+      "create_any": "A user creates any event in your community (not checked by an admin)",
+      "update": "An event you are attending is updated",
+      "cancel": "An event you are attending is cancelled",
+      "delete": "An event you are attending is deleted",
+      "invite_organizer": "Someone invites you to co-organize an event",
+      "comment": "A user comments on an event you are going to",
+      "reminder": "Reminder that an event you are going to is happening soon"
     },
     "friend_request": {
-      "create": "Someone sends you a friend request.",
-      "accept": "Someone accepts your friend request."
+      "create": "Someone sends you a friend request",
+      "accept": "Someone accepts your friend request"
     },
     "general": {
-      "new_blog_post": "A new blog post is published."
+      "new_blog_post": "A new blog post is published"
     },
     "gender": {
-      "change": "The gender displayed on your profile is changed."
+      "change": "The gender displayed on your profile is changed"
     },
     "host_request": {
-      "create": "Someone sends you a host request.",
-      "accept": "Someone accepts your host request.",
-      "confirm": "Someone confirms their host request.",
-      "reject": "Someone declines your host request.",
-      "cancel": "Someone cancels their host request.",
-      "message": "Someone sends a message in a host request.",
-      "missed_messages": "You miss messages in a host request.",
-      "reminder": "You haven't responded to a pending host request."
+      "create": "Someone sends you a host request",
+      "accept": "Someone accepts your host request",
+      "confirm": "Someone confirms their host request",
+      "reject": "Someone declines your host request",
+      "cancel": "Someone cancels their host request",
+      "message": "Someone sends a message in a host request",
+      "missed_messages": "You miss messages in a host request",
+      "reminder": "You haven't responded to a pending host request"
     },
     "modnote": {
-      "create": "A moderator sends you a note."
+      "create": "A moderator sends you a note"
     },
     "onboarding": {
-      "reminder": "Reminder to complete your profile after signing up."
+      "reminder": "Reminder to complete your profile after signing up"
     },
     "password": {
-      "change": "Your password is changed."
+      "change": "Your password is changed"
     },
     "password_reset": {
-      "start": "Password reset is initiated.",
-      "complete": "Password reset is completed."
+      "start": "Password reset is initiated",
+      "complete": "Password reset is completed"
     },
     "postal_verification": {
-      "postcard_sent": "Your verification postcard is sent.",
-      "success": "Your postal verification succeeds.",
-      "failed": "Your postal verification fails."
+      "postcard_sent": "Your verification postcard is sent",
+      "success": "Your postal verification succeeds",
+      "failed": "Your postal verification fails"
     },
     "phone_number": {
-      "change": "Your phone number is changed.",
-      "verify": "Your phone number is verified."
+      "change": "Your phone number is changed",
+      "verify": "Your phone number is verified"
     },
     "reference": {
-      "receive_hosted": "You receive a reference from someone who hosted you.",
-      "receive_surfed": "You receive a reference from someone you hosted.",
-      "receive_friend": "You received a reference from a friend.",
-      "reminder_hosted": "Reminder to write a reference to someone you hosted.",
-      "reminder_surfed": "Reminder to write a reference to someone you surfed with."
+      "receive_hosted": "You receive a reference from someone who hosted you",
+      "receive_surfed": "You receive a reference from someone you hosted",
+      "receive_friend": "You received a reference from a friend",
+      "reminder_hosted": "Reminder to write a reference to someone you hosted",
+      "reminder_surfed": "Reminder to write a reference to someone you surfed with"
     },
     "thread": {
-      "reply": "Someone responds to your comment."
+      "reply": "Someone responds to your comment"
     },
     "verification": {
-      "sv_fail": "Your strong verification fails.",
-      "sv_success": "Your strong verification succeeds."
+      "sv_fail": "Your strong verification fails",
+      "sv_success": "Your strong verification succeeds"
     }
   },
   "push": {


### PR DESCRIPTION
I added the full stops when moving these strings from the frontend. Per translator feedback, they're not needed. I asked AI and came up with this rule for it: if by construction the string is going to be a single sentence, like these settings descriptions, skip punctuation.

## Testing
N/A - text only

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
