### PR TITLE
Frontend/protobuf: Fix typing of [u]int64 types

### DIFF
--- a/app/proto/account.proto
+++ b/app/proto/account.proto
@@ -230,7 +230,7 @@ message DeleteAccountReq {
 
 message ModNote {
   // used in ack
-  uint64 note_id = 1;
+  uint64 note_id = 1 [jstype = JS_STRING];
   string note_content = 2; // CommonMark without images
   google.protobuf.Timestamp created = 3;
   // will be empty if pending
@@ -312,12 +312,12 @@ message CompleteProfileReminder {}
 message CompleteVerificationReminder {}
 
 message RespondToHostRequestReminder {
-  int64 host_request_id = 1;
+  int64 host_request_id = 1 [jstype = JS_STRING];
   org.couchers.api.core.LiteUser surfer_user = 2;
 }
 
 message WriteReferenceReminder {
-  int64 host_request_id = 1;
+  int64 host_request_id = 1 [jstype = JS_STRING];
   org.couchers.api.core.LiteUser other_user = 2;
   org.couchers.api.references.ReferenceType reference_type = 3;
 }

--- a/app/proto/admin.proto
+++ b/app/proto/admin.proto
@@ -98,9 +98,9 @@ service Admin {
 }
 
 message AdminActionLog {
-  int64 admin_action_id = 1;
+  int64 admin_action_id = 1 [jstype = JS_STRING];
   google.protobuf.Timestamp created = 2;
-  int64 admin_user_id = 3;
+  int64 admin_user_id = 3 [jstype = JS_STRING];
   string admin_username = 4;
   string action_type = 5;
   string note = 6;   // optional note/details
@@ -109,12 +109,12 @@ message AdminActionLog {
 }
 
 message AdminTagInfo {
-  int64 admin_tag_id = 1;
+  int64 admin_tag_id = 1 [jstype = JS_STRING];
   string tag = 2;
 }
 
 message UserDetails {
-  int64 user_id = 1;
+  int64 user_id = 1 [jstype = JS_STRING];
   string username = 2;
   string name = 14;
   string email = 3;
@@ -133,8 +133,8 @@ message UserDetails {
   reserved 13;
   reserved "admin_note";
 
-  int64 pending_mod_notes_count = 16;
-  int64 acknowledged_mod_notes_count = 17;
+  int64 pending_mod_notes_count = 16 [jstype = JS_STRING];
+  int64 acknowledged_mod_notes_count = 17 [jstype = JS_STRING];
 
   repeated AdminActionLog admin_actions = 18;
   repeated string admin_tags = 19;
@@ -155,8 +155,8 @@ message SearchUsersReq {
   string name = 5;
   string admin_action_log = 6;
   string city = 7;
-  int64 min_user_id = 8;
-  int64 max_user_id = 9;
+  int64 min_user_id = 8 [jstype = JS_STRING];
+  int64 max_user_id = 9 [jstype = JS_STRING];
   string min_birthdate = 10; // in YYYY-MM-DD format
   string max_birthdate = 11; // in YYYY-MM-DD format
   string min_joined_date = 12; // in YYYY-MM-DD format
@@ -227,10 +227,10 @@ message AddAdminNoteReq {
 }
 
 message ContentReport {
-  int64 content_report_id = 1;
+  int64 content_report_id = 1 [jstype = JS_STRING];
   google.protobuf.Timestamp time = 2;
-  int64 reporting_user_id = 3;
-  int64 author_user_id = 4;
+  int64 reporting_user_id = 3 [jstype = JS_STRING];
+  int64 author_user_id = 4 [jstype = JS_STRING];
   string reason = 5;
   string description = 6;
   string content_ref = 7;
@@ -239,7 +239,7 @@ message ContentReport {
 }
 
 message GetContentReportReq {
-  int64 content_report_id = 1;
+  int64 content_report_id = 1 [jstype = JS_STRING];
 }
 
 message GetContentReportRes {
@@ -291,7 +291,7 @@ message GetChatsReq {
 }
 
 message ChatUserInfo {
-  int64 user_id = 1;
+  int64 user_id = 1 [jstype = JS_STRING];
   string username = 2;
   string name = 3;
   string birthdate = 4;
@@ -299,7 +299,7 @@ message ChatUserInfo {
 }
 
 message ChatMessage {
-  int64 message_id = 1;
+  int64 message_id = 1 [jstype = JS_STRING];
   ChatUserInfo author = 2;
   google.protobuf.Timestamp time = 3;
   string message_type = 4; // e.g. "text", "chat_created", "host_request_status_changed"
@@ -316,7 +316,7 @@ message GroupChatMember {
 }
 
 message AdminGroupChat {
-  int64 group_chat_id = 1;
+  int64 group_chat_id = 1 [jstype = JS_STRING];
   string title = 2;
   bool is_dm = 3;
   ChatUserInfo creator = 4;
@@ -325,7 +325,7 @@ message AdminGroupChat {
 }
 
 message AdminHostRequest {
-  int64 host_request_id = 1;
+  int64 host_request_id = 1 [jstype = JS_STRING];
   ChatUserInfo surfer = 2;
   ChatUserInfo host = 3;
   string status = 4;
@@ -342,7 +342,7 @@ message GetChatsRes {
 }
 
 message DeleteEventReq {
-  int64 event_id = 1;
+  int64 event_id = 1 [jstype = JS_STRING];
 }
 
 message ListUserIdsReq {
@@ -354,18 +354,18 @@ message ListUserIdsReq {
 }
 
 message ListUserIdsRes {
-  repeated int64 user_ids = 1;
+  repeated int64 user_ids = 1 [jstype = JS_STRING];
 
   string next_page_token = 2;
 }
 
 message EditReferenceTextReq {
-  int64 reference_id = 1;
+  int64 reference_id = 1 [jstype = JS_STRING];
   string new_text = 2;
 }
 
 message DeleteReferenceReq {
-  int64 reference_id = 1;
+  int64 reference_id = 1 [jstype = JS_STRING];
 }
 
 message GetUserReferencesReq {
@@ -374,14 +374,14 @@ message GetUserReferencesReq {
 }
 
 message AdminReference {
-  int64 reference_id = 1;
-  int64 from_user_id = 2;
-  int64 to_user_id = 3;
+  int64 reference_id = 1 [jstype = JS_STRING];
+  int64 from_user_id = 2 [jstype = JS_STRING];
+  int64 to_user_id = 3 [jstype = JS_STRING];
   string reference_type = 4;
   string text = 5;
   string private_text = 6;
   google.protobuf.Timestamp time = 7;
-  int64 host_request_id = 8;
+  int64 host_request_id = 8 [jstype = JS_STRING];
   double rating = 9;
   bool was_appropriate = 10;
   bool is_deleted = 11;
@@ -395,20 +395,20 @@ message GetUserReferencesRes {
 }
 
 message EditDiscussionReq {
-  int64 discussion_id = 1;
+  int64 discussion_id = 1 [jstype = JS_STRING];
   string new_title = 2;
   string new_content = 3;
 }
 
 message EditReplyReq {
-  int64 reply_id = 1;
+  int64 reply_id = 1 [jstype = JS_STRING];
   string new_content = 2;
 }
 
 message AddUsersToModerationUserListReq {
   // username, email, or user id
   repeated string users = 1;
-  int64 moderation_list_id = 2;
+  int64 moderation_list_id = 2 [jstype = JS_STRING];
 }
 
 message ListModerationUserListsReq {
@@ -417,8 +417,8 @@ message ListModerationUserListsReq {
 }
 
 message ModerationList {
-  int64 moderation_list_id = 1;
-  repeated int64 member_ids = 2;
+  int64 moderation_list_id = 1 [jstype = JS_STRING];
+  repeated int64 member_ids = 2 [jstype = JS_STRING];
 }
 
 message ListModerationUserListsRes {
@@ -426,19 +426,19 @@ message ListModerationUserListsRes {
 }
 
 message AddUsersToModerationUserListRes {
-  int64 moderation_list_id = 1;
+  int64 moderation_list_id = 1 [jstype = JS_STRING];
 }
 
 message RemoveUserFromModerationUserListReq {
   // username, email, or user id
   string user = 1;
-  int64 moderation_list_id = 2;
+  int64 moderation_list_id = 2 [jstype = JS_STRING];
 }
 
 message CreateAccountDeletionLinkReq {
   // username, email, or user id
   string user = 1;
-  int64 expiry_days = 2;
+  int64 expiry_days = 2 [jstype = JS_STRING];
 }
 
 message CreateAccountDeletionLinkRes {
@@ -462,8 +462,8 @@ message AccessStat {
   string browser = 7;
   string device = 8;
   string approximate_location = 9;
-  uint64 api_call_count = 10;
-  uint64 periods_count = 11;
+  uint64 api_call_count = 10 [jstype = JS_STRING];
+  uint64 periods_count = 11 [jstype = JS_STRING];
   google.protobuf.Timestamp first_seen = 12;
   google.protobuf.Timestamp last_seen = 13;
 }

--- a/app/proto/api.proto
+++ b/app/proto/api.proto
@@ -60,11 +60,11 @@ service API {
 }
 
 message SendFriendRequestReq {
-  int64 user_id = 1;
+  int64 user_id = 1 [jstype = JS_STRING];
 }
 
 message FriendRequest {
-  int64 friend_request_id = 1;
+  int64 friend_request_id = 1 [jstype = JS_STRING];
 
   enum FriendRequestStatus {
     // these are the only two states that a user will see
@@ -74,20 +74,20 @@ message FriendRequest {
 
   FriendRequestStatus state = 2;
 
-  int64 user_id = 3;
+  int64 user_id = 3 [jstype = JS_STRING];
 
   // we sent the request if true, received it if false
   bool sent = 4;
 }
 
 message RespondFriendRequestReq {
-  int64 friend_request_id = 1;
+  int64 friend_request_id = 1 [jstype = JS_STRING];
 
   bool accept = 2;
 }
 
 message CancelFriendRequestReq {
-  int64 friend_request_id = 1;
+  int64 friend_request_id = 1 [jstype = JS_STRING];
 }
 
 message ListFriendRequestsRes {
@@ -96,15 +96,15 @@ message ListFriendRequestsRes {
 }
 
 message ListFriendsRes {
-  repeated int64 user_ids = 1;
+  repeated int64 user_ids = 1 [jstype = JS_STRING];
 }
 
 message RemoveFriendReq {
-  int64 user_id = 1;
+  int64 user_id = 1 [jstype = JS_STRING];
 }
 
 message ListMutualFriendsReq {
-  int64 user_id = 1;
+  int64 user_id = 1 [jstype = JS_STRING];
 }
 
 message ListMutualFriendsRes {
@@ -124,7 +124,7 @@ message PingRes {
 }
 
 message MutualFriend {
-  int64 user_id = 1;
+  int64 user_id = 1 [jstype = JS_STRING];
   string username = 2;
   string name = 3;
 }
@@ -222,7 +222,7 @@ message User {
     NA = 3; // not applicable, e.g. user requesting is self
   }
 
-  int64 user_id = 1;
+  int64 user_id = 1 [jstype = JS_STRING];
   bool is_ghost = 56;
 
   string username = 2;
@@ -290,7 +290,7 @@ message User {
 
   string avatar_url = 32;
   string avatar_thumbnail_url = 44;
-  uint64 profile_gallery_id = 123;
+  uint64 profile_gallery_id = 123 [jstype = JS_STRING];
   repeated LanguageAbility language_abilities = 37;
 
   repeated string badges = 38;
@@ -320,7 +320,7 @@ message GetUserReq {
 }
 
 message LiteUser {
-  int64 user_id = 1;
+  int64 user_id = 1 [jstype = JS_STRING];
   bool is_ghost = 12;
 
   string username = 2;
@@ -448,7 +448,7 @@ message ListBadgeUsersReq {
 }
 
 message ListBadgeUsersRes {
-  repeated int64 user_ids = 1;
+  repeated int64 user_ids = 1 [jstype = JS_STRING];
 
   string next_page_token = 2;
 }

--- a/app/proto/auth.proto
+++ b/app/proto/auth.proto
@@ -196,7 +196,7 @@ message AuthReq {
 
 message AuthRes {
   // user_id of the user
-  int64 user_id = 1;
+  int64 user_id = 1 [jstype = JS_STRING];
   // whether the user has to complete some additional steps to continue to the
   // platform
   bool jailed = 2;

--- a/app/proto/bugs.proto
+++ b/app/proto/bugs.proto
@@ -77,7 +77,7 @@ message StatusReq {
 message StatusRes {
   string nonce = 1;
   string version = 2;
-  uint64 coucher_count = 3;
+  uint64 coucher_count = 3 [jstype = JS_STRING];
   bool stable = 4;
 }
 

--- a/app/proto/communities.proto
+++ b/app/proto/communities.proto
@@ -108,7 +108,7 @@ service Communities {
 }
 
 message Community {
-  int64 community_id = 1;
+  int64 community_id = 1 [jstype = JS_STRING];
   string name = 2;
   // a short URL fragment generated from the name, e.g. New York City: a guide to Phở might become
   // new-york-city-guide-to-pho
@@ -132,12 +132,12 @@ message Community {
 }
 
 message GetCommunityReq {
-  int64 community_id = 1;
+  int64 community_id = 1 [jstype = JS_STRING];
 }
 
 message ListCommunitiesReq {
   // leave blank (aka 0) to list all communities
-  int64 community_id = 1;
+  int64 community_id = 1 [jstype = JS_STRING];
 
   uint32 page_size = 2;
   string page_token = 3;
@@ -164,7 +164,7 @@ message ListUserCommunitiesRes {
 }
 
 message ListGroupsReq {
-  int64 community_id = 1;
+  int64 community_id = 1 [jstype = JS_STRING];
 
   uint32 page_size = 2;
   string page_token = 3;
@@ -177,56 +177,56 @@ message ListGroupsRes {
 }
 
 message ListAdminsReq {
-  int64 community_id = 1;
+  int64 community_id = 1 [jstype = JS_STRING];
 
   uint32 page_size = 2;
   string page_token = 3;
 }
 
 message ListAdminsRes {
-  repeated int64 admin_user_ids = 1;
+  repeated int64 admin_user_ids = 1 [jstype = JS_STRING];
 
   string next_page_token = 2;
 }
 
 message AddAdminReq {
-  int64 user_id = 1;
-  int64 community_id = 2;
+  int64 user_id = 1 [jstype = JS_STRING];
+  int64 community_id = 2 [jstype = JS_STRING];
 }
 
 message RemoveAdminReq {
-  int64 user_id = 1;
-  int64 community_id = 2;
+  int64 user_id = 1 [jstype = JS_STRING];
+  int64 community_id = 2 [jstype = JS_STRING];
 }
 
 message ListMembersReq {
-  int64 community_id = 1;
+  int64 community_id = 1 [jstype = JS_STRING];
 
   uint32 page_size = 2;
   string page_token = 3;
 }
 
 message ListMembersRes {
-  repeated int64 member_user_ids = 1;
+  repeated int64 member_user_ids = 1 [jstype = JS_STRING];
 
   string next_page_token = 2;
 }
 
 message ListNearbyUsersReq {
-  int64 community_id = 1;
+  int64 community_id = 1 [jstype = JS_STRING];
 
   uint32 page_size = 2;
   string page_token = 3;
 }
 
 message ListNearbyUsersRes {
-  repeated int64 nearby_user_ids = 1;
+  repeated int64 nearby_user_ids = 1 [jstype = JS_STRING];
 
   string next_page_token = 2;
 }
 
 message ListPlacesReq {
-  int64 community_id = 1;
+  int64 community_id = 1 [jstype = JS_STRING];
 
   uint32 page_size = 2;
   string page_token = 3;
@@ -239,7 +239,7 @@ message ListPlacesRes {
 }
 
 message ListGuidesReq {
-  int64 community_id = 1;
+  int64 community_id = 1 [jstype = JS_STRING];
 
   uint32 page_size = 2;
   string page_token = 3;
@@ -252,7 +252,7 @@ message ListGuidesRes {
 }
 
 message ListEventsReq {
-  int64 community_id = 1;
+  int64 community_id = 1 [jstype = JS_STRING];
   bool past = 4;
   // whether to include events in all parent communities as well
   bool include_parents = 5;
@@ -268,7 +268,7 @@ message ListEventsRes {
 }
 
 message ListDiscussionsReq {
-  int64 community_id = 1;
+  int64 community_id = 1 [jstype = JS_STRING];
 
   uint32 page_size = 2;
   string page_token = 3;
@@ -281,11 +281,11 @@ message ListDiscussionsRes {
 }
 
 message JoinCommunityReq {
-  int64 community_id = 1;
+  int64 community_id = 1 [jstype = JS_STRING];
 }
 
 message LeaveCommunityReq {
-  int64 community_id = 1;
+  int64 community_id = 1 [jstype = JS_STRING];
 }
 
 message SearchCommunitiesReq {
@@ -298,7 +298,7 @@ message SearchCommunitiesRes {
 }
 
 message CommunitySummary {
-  int64 community_id = 1;
+  int64 community_id = 1 [jstype = JS_STRING];
   string name = 2;
   string slug = 3;
   bool member = 4;

--- a/app/proto/conversations.proto
+++ b/app/proto/conversations.proto
@@ -98,22 +98,22 @@ message MessageContentChatCreated {}
 message MessageContentChatEdited {}
 
 message MessageContentUserInvited {
-  uint64 target_user_id = 1;
+  uint64 target_user_id = 1 [jstype = JS_STRING];
 }
 
 message MessageContentUserLeft {}
 
 message MessageContentUserMadeAdmin {
-  uint64 target_user_id = 1;
+  uint64 target_user_id = 1 [jstype = JS_STRING];
 }
 
 message MessageContentUserRemovedAdmin {
-  uint64 target_user_id = 1;
+  uint64 target_user_id = 1 [jstype = JS_STRING];
 }
 
 // field in Message, when a user is removed by admin
 message MessageContentUserRemoved {
-  uint64 target_user_id = 1;
+  uint64 target_user_id = 1 [jstype = JS_STRING];
 }
 
 enum HostRequestStatus {
@@ -130,8 +130,8 @@ message MessageContentHostRequestStatusChanged {
 }
 
 message Message {
-  uint64 message_id = 1;
-  uint64 author_user_id = 2;
+  uint64 message_id = 1 [jstype = JS_STRING];
+  uint64 author_user_id = 2 [jstype = JS_STRING];
   google.protobuf.Timestamp time = 3;
   oneof content {
     MessageContentText text = 4; // plain text
@@ -154,15 +154,15 @@ message MuteInfo {
 }
 
 message GroupChat {
-  uint64 group_chat_id = 1;
+  uint64 group_chat_id = 1 [jstype = JS_STRING];
   string title = 2;
-  repeated uint64 member_user_ids = 3; // inclusive of admins
-  repeated uint64 admin_user_ids = 4;
+  repeated uint64 member_user_ids = 3 [jstype = JS_STRING]; // inclusive of admins
+  repeated uint64 admin_user_ids = 4 [jstype = JS_STRING];
   bool only_admins_invite = 5;
   bool is_dm = 6;
   google.protobuf.Timestamp created = 7;
   uint32 unseen_message_count = 8;
-  uint64 last_seen_message_id = 9;
+  uint64 last_seen_message_id = 9 [jstype = JS_STRING];
   Message latest_message = 10;
   MuteInfo mute_info = 11;
   bool can_message = 12;
@@ -170,31 +170,31 @@ message GroupChat {
 }
 
 message GetGroupChatReq {
-  uint64 group_chat_id = 1;
+  uint64 group_chat_id = 1 [jstype = JS_STRING];
 }
 
 message ListGroupChatsReq {
-  uint64 last_message_id = 1;
+  uint64 last_message_id = 1 [jstype = JS_STRING];
   uint32 number = 2;
   optional bool only_archived = 3;
 }
 
 message ListGroupChatsRes {
   repeated GroupChat group_chats = 1;
-  uint64 last_message_id = 2;
+  uint64 last_message_id = 2 [jstype = JS_STRING];
   bool no_more = 3;
 }
 
 message GetUpdatesReq {
-  uint64 newest_message_id = 1;
+  uint64 newest_message_id = 1 [jstype = JS_STRING];
 }
 
 message GetDirectMessageReq {
-  uint64 user_id = 1;
+  uint64 user_id = 1 [jstype = JS_STRING];
 }
 
 message Update {
-  uint64 group_chat_id = 1;
+  uint64 group_chat_id = 1 [jstype = JS_STRING];
   Message message = 2;
 }
 
@@ -204,25 +204,25 @@ message GetUpdatesRes {
 }
 
 message GetGroupChatMessagesReq {
-  uint64 group_chat_id = 1;
-  uint64 last_message_id = 2;
+  uint64 group_chat_id = 1 [jstype = JS_STRING];
+  uint64 last_message_id = 2 [jstype = JS_STRING];
   uint32 number = 3;
   bool only_unseen = 4;
 }
 
 message GetGroupChatMessagesRes {
   repeated Message messages = 1;
-  uint64 last_message_id = 2;
+  uint64 last_message_id = 2 [jstype = JS_STRING];
   bool no_more = 3;
 }
 
 message MarkLastSeenGroupChatReq {
-  uint64 group_chat_id = 1;
-  uint64 last_seen_message_id = 2;
+  uint64 group_chat_id = 1 [jstype = JS_STRING];
+  uint64 last_seen_message_id = 2 [jstype = JS_STRING];
 }
 
 message MuteGroupChatReq {
-  uint64 group_chat_id = 1;
+  uint64 group_chat_id = 1 [jstype = JS_STRING];
   oneof duration {
     bool unmute = 2;
     bool forever = 3;
@@ -231,78 +231,78 @@ message MuteGroupChatReq {
 }
 
 message SetGroupChatArchiveStatusReq {
-  uint64 group_chat_id = 1;
+  uint64 group_chat_id = 1 [jstype = JS_STRING];
   bool is_archived = 2;
 }
 
 message SetGroupChatArchiveStatusRes {
-  uint64 group_chat_id = 1;
+  uint64 group_chat_id = 1 [jstype = JS_STRING];
   bool is_archived = 2;
 }
 
 message CreateGroupChatReq {
   google.protobuf.StringValue title = 1;
-  repeated uint64 recipient_user_ids = 2;
+  repeated uint64 recipient_user_ids = 2 [jstype = JS_STRING];
 }
 
 message EditGroupChatReq {
-  uint64 group_chat_id = 1;
+  uint64 group_chat_id = 1 [jstype = JS_STRING];
   google.protobuf.StringValue title = 2;
   google.protobuf.BoolValue only_admins_invite = 3;
 }
 
 message InviteToGroupChatReq {
-  uint64 group_chat_id = 1;
-  uint64 user_id = 2;
+  uint64 group_chat_id = 1 [jstype = JS_STRING];
+  uint64 user_id = 2 [jstype = JS_STRING];
 }
 
 message MakeGroupChatAdminReq {
-  uint64 group_chat_id = 1;
-  uint64 user_id = 2;
+  uint64 group_chat_id = 1 [jstype = JS_STRING];
+  uint64 user_id = 2 [jstype = JS_STRING];
 }
 
 // required fields and types
 message RemoveGroupChatUserReq {
-  uint64 group_chat_id = 1;
-  uint64 user_id = 2;
+  uint64 group_chat_id = 1 [jstype = JS_STRING];
+  uint64 user_id = 2 [jstype = JS_STRING];
 }
 
 message RemoveGroupChatAdminReq {
-  uint64 group_chat_id = 1;
-  uint64 user_id = 2;
+  uint64 group_chat_id = 1 [jstype = JS_STRING];
+  uint64 user_id = 2 [jstype = JS_STRING];
 }
 
 message SendMessageReq {
-  uint64 group_chat_id = 1;
+  uint64 group_chat_id = 1 [jstype = JS_STRING];
   string text = 2;
 }
 
 message SendDirectMessageReq {
-  uint64 recipient_user_id = 1;
+  uint64 recipient_user_id = 1 [jstype = JS_STRING];
   string text = 2;
 }
 
 message SendDirectMessageRes {
-  uint64 group_chat_id = 1;
+  uint64 group_chat_id = 1 [jstype = JS_STRING];
 }
 
 message LeaveGroupChatReq {
-  uint64 group_chat_id = 1;
+  uint64 group_chat_id = 1 [jstype = JS_STRING];
 }
 
 message SearchMessagesReq {
   string query = 1;
-  uint64 last_message_id = 2;
+  uint64 last_message_id = 2 [jstype = JS_STRING];
   uint32 number = 3;
 }
 
 message MessageSearchResult {
-  uint64 group_chat_id = 1;
+  uint64 group_chat_id = 1 [jstype = JS_STRING];
   Message message = 2;
 }
 
 message SearchMessagesRes {
   repeated MessageSearchResult results = 1;
-  uint64 last_message_id = 2;
+  uint64 last_message_id = 2 [jstype = JS_STRING];
   bool no_more = 3;
 }

--- a/app/proto/discussions.proto
+++ b/app/proto/discussions.proto
@@ -20,13 +20,13 @@ service Discussions {
 }
 
 message Discussion {
-  int64 discussion_id = 1;
+  int64 discussion_id = 1 [jstype = JS_STRING];
   string slug = 2;
   google.protobuf.Timestamp created = 3;
-  int64 creator_user_id = 4;
+  int64 creator_user_id = 4 [jstype = JS_STRING];
   oneof owner {
-    int64 owner_community_id = 5;
-    int64 owner_group_id = 6;
+    int64 owner_community_id = 5 [jstype = JS_STRING];
+    int64 owner_group_id = 6 [jstype = JS_STRING];
   }
   // name of community/group that this belongs in
   string owner_title = 12;
@@ -41,11 +41,11 @@ message CreateDiscussionReq {
   string title = 1;
   string content = 2;
   oneof owner {
-    int64 owner_community_id = 3;
-    int64 owner_group_id = 4;
+    int64 owner_community_id = 3 [jstype = JS_STRING];
+    int64 owner_group_id = 4 [jstype = JS_STRING];
   }
 }
 
 message GetDiscussionReq {
-  int64 discussion_id = 1;
+  int64 discussion_id = 1 [jstype = JS_STRING];
 }

--- a/app/proto/editor.proto
+++ b/app/proto/editor.proto
@@ -31,16 +31,16 @@ service Editor {
 message CreateCommunityReq {
   string name = 1;
   string description = 3;
-  int64 parent_node_id = 4;
-  repeated int64 admin_ids = 5;
+  int64 parent_node_id = 4 [jstype = JS_STRING];
+  repeated int64 admin_ids = 5 [jstype = JS_STRING];
   string geojson = 6;
 }
 
 message UpdateCommunityReq {
-  int64 community_id = 1;
+  int64 community_id = 1 [jstype = JS_STRING];
   string name = 2;
   string description = 3;
-  int64 parent_node_id = 4;
+  int64 parent_node_id = 4 [jstype = JS_STRING];
   string geojson = 5;
 }
 
@@ -50,14 +50,14 @@ message ListEventCommunityInviteRequestsReq {
 }
 
 message EventCommunityInviteRequest {
-  int64 event_community_invite_request_id = 1;
+  int64 event_community_invite_request_id = 1 [jstype = JS_STRING];
 
-  int64 user_id = 2;
+  int64 user_id = 2 [jstype = JS_STRING];
   string event_url = 3;
 
   // assuming they have notifs enabled
   uint32 approx_users_to_notify = 4;
-  int64 community_id = 5;
+  int64 community_id = 5 [jstype = JS_STRING];
 }
 
 message ListEventCommunityInviteRequestsRes {
@@ -67,7 +67,7 @@ message ListEventCommunityInviteRequestsRes {
 }
 
 message DecideEventCommunityInviteRequestReq {
-  int64 event_community_invite_request_id = 1;
+  int64 event_community_invite_request_id = 1 [jstype = JS_STRING];
 
   // whether to approve or deny it
   bool approve = 2;
@@ -82,7 +82,7 @@ message SendBlogPostNotificationReq {
 }
 
 message MakeUserVolunteerReq {
-  int64 user_id = 1;
+  int64 user_id = 1 [jstype = JS_STRING];
   string role = 2;
   // date as "yyyy-mm-dd", defaults to today if not provided
   string started_volunteering = 3;
@@ -91,7 +91,7 @@ message MakeUserVolunteerReq {
 }
 
 message UpdateVolunteerReq {
-  int64 user_id = 1;
+  int64 user_id = 1 [jstype = JS_STRING];
   google.protobuf.StringValue role = 2;
   google.protobuf.DoubleValue sort_key = 3;
   // dates as "yyyy-mm-dd"
@@ -106,7 +106,7 @@ message ListVolunteersReq {
 }
 
 message Volunteer {
-  int64 user_id = 1;
+  int64 user_id = 1 [jstype = JS_STRING];
   // display name
   string name = 2;
   // couchers username

--- a/app/proto/events.proto
+++ b/app/proto/events.proto
@@ -102,7 +102,7 @@ enum AttendanceState {
 }
 
 message Event {
-  int64 event_id = 1; // = occurrence_id
+  int64 event_id = 1 [jstype = JS_STRING]; // = occurrence_id
   // whether this is the next occurrence of this particular event
   // e.g. if this is a recurring event
   bool is_next = 2;
@@ -125,7 +125,7 @@ message Event {
 
   google.protobuf.Timestamp created = 13;
   google.protobuf.Timestamp last_edited = 14;
-  int64 creator_user_id = 15;
+  int64 creator_user_id = 15 [jstype = JS_STRING];
 
   // the UTC timestamps of start and end times
   google.protobuf.Timestamp start_time = 16;
@@ -151,9 +151,9 @@ message Event {
   uint32 subscriber_count = 27;
 
   oneof owner {
-    int64 owner_user_id = 28;
-    int64 owner_community_id = 29;
-    int64 owner_group_id = 30;
+    int64 owner_user_id = 28 [jstype = JS_STRING];
+    int64 owner_community_id = 29 [jstype = JS_STRING];
+    int64 owner_group_id = 30 [jstype = JS_STRING];
   }
   org.couchers.api.threads.Thread thread = 34;
 
@@ -171,7 +171,7 @@ message CreateEventReq {
     OfflineEventInformation offline_information = 5;
   }
   // must give this if online, otherwise optional as it can be auto-filled from the location
-  int64 parent_community_id = 8;
+  int64 parent_community_id = 8 [jstype = JS_STRING];
   // timestamps are in UTC
   google.protobuf.Timestamp start_time = 9;
   google.protobuf.Timestamp end_time = 10;
@@ -180,7 +180,7 @@ message CreateEventReq {
 }
 
 message ScheduleEventReq {
-  int64 event_id = 1;
+  int64 event_id = 1 [jstype = JS_STRING];
   string content = 2; // CommonMark without images
   // from media server
   string photo_key = 3;
@@ -196,7 +196,7 @@ message ScheduleEventReq {
 }
 
 message UpdateEventReq {
-  int64 event_id = 1;
+  int64 event_id = 1 [jstype = JS_STRING];
   // whether to update all future occurrences or just this one
   bool update_all_future = 2;
   google.protobuf.StringValue title = 3;
@@ -217,52 +217,52 @@ message UpdateEventReq {
 }
 
 message GetEventReq {
-  int64 event_id = 1;
+  int64 event_id = 1 [jstype = JS_STRING];
 }
 
 message CancelEventReq {
-  int64 event_id = 1;
+  int64 event_id = 1 [jstype = JS_STRING];
 }
 
 message RequestCommunityInviteReq {
-  int64 event_id = 1;
+  int64 event_id = 1 [jstype = JS_STRING];
 }
 
 message ListEventAttendeesReq {
-  int64 event_id = 1;
+  int64 event_id = 1 [jstype = JS_STRING];
 
   uint32 page_size = 2;
   string page_token = 3;
 }
 
 message ListEventAttendeesRes {
-  repeated int64 attendee_user_ids = 1;
+  repeated int64 attendee_user_ids = 1 [jstype = JS_STRING];
 
   string next_page_token = 2;
 }
 
 message ListEventSubscribersReq {
-  int64 event_id = 1;
+  int64 event_id = 1 [jstype = JS_STRING];
 
   uint32 page_size = 2;
   string page_token = 3;
 }
 
 message ListEventSubscribersRes {
-  repeated int64 subscriber_user_ids = 1;
+  repeated int64 subscriber_user_ids = 1 [jstype = JS_STRING];
 
   string next_page_token = 2;
 }
 
 message ListEventOrganizersReq {
-  int64 event_id = 1;
+  int64 event_id = 1 [jstype = JS_STRING];
 
   uint32 page_size = 2;
   string page_token = 3;
 }
 
 message ListEventOrganizersRes {
-  repeated int64 organizer_user_ids = 1;
+  repeated int64 organizer_user_ids = 1 [jstype = JS_STRING];
 
   string next_page_token = 2;
 }
@@ -313,7 +313,7 @@ message ListAllEventsRes {
 }
 
 message ListEventOccurrencesReq {
-  int64 event_id = 1;
+  int64 event_id = 1 [jstype = JS_STRING];
   // whether to paginate backwards
   bool past = 2;
 
@@ -330,29 +330,29 @@ message ListEventOccurrencesRes {
 }
 
 message TransferEventReq {
-  int64 event_id = 1;
+  int64 event_id = 1 [jstype = JS_STRING];
   oneof new_owner {
-    int64 new_owner_community_id = 3;
-    int64 new_owner_group_id = 2;
+    int64 new_owner_community_id = 3 [jstype = JS_STRING];
+    int64 new_owner_group_id = 2 [jstype = JS_STRING];
   }
 }
 
 message SetEventSubscriptionReq {
-  int64 event_id = 1;
+  int64 event_id = 1 [jstype = JS_STRING];
   bool subscribe = 2;
 }
 
 message SetEventAttendanceReq {
-  int64 event_id = 1;
+  int64 event_id = 1 [jstype = JS_STRING];
   AttendanceState attendance_state = 2;
 }
 
 message InviteEventOrganizerReq {
-  int64 event_id = 1;
-  int64 user_id = 2;
+  int64 event_id = 1 [jstype = JS_STRING];
+  int64 user_id = 2 [jstype = JS_STRING];
 }
 
 message RemoveEventOrganizerReq {
-  int64 event_id = 1;
+  int64 event_id = 1 [jstype = JS_STRING];
   google.protobuf.Int64Value user_id = 2;
 }

--- a/app/proto/galleries.proto
+++ b/app/proto/galleries.proto
@@ -33,7 +33,7 @@ service Galleries {
 }
 
 message PhotoGalleryItem {
-  int64 item_id = 1;
+  int64 item_id = 1 [jstype = JS_STRING];
   string full_url = 2;
   string thumbnail_url = 3;
   string caption = 4;
@@ -41,45 +41,45 @@ message PhotoGalleryItem {
 }
 
 message PhotoGallery {
-  int64 gallery_id = 1;
+  int64 gallery_id = 1 [jstype = JS_STRING];
   repeated PhotoGalleryItem photos = 2;
   bool can_edit = 3;
 }
 
 message GetGalleryReq {
-  int64 gallery_id = 1;
+  int64 gallery_id = 1 [jstype = JS_STRING];
 }
 
 message AddPhotoToGalleryReq {
-  int64 gallery_id = 1;
+  int64 gallery_id = 1 [jstype = JS_STRING];
   string upload_key = 2;
   string caption = 3;
 }
 
 message RemovePhotoFromGalleryReq {
-  int64 gallery_id = 1;
-  int64 item_id = 2;
+  int64 gallery_id = 1 [jstype = JS_STRING];
+  int64 item_id = 2 [jstype = JS_STRING];
 }
 
 message MovePhotoReq {
-  int64 gallery_id = 1;
-  int64 item_id = 2;
+  int64 gallery_id = 1 [jstype = JS_STRING];
+  int64 item_id = 2 [jstype = JS_STRING];
   // ID of photo to place this one after, or 0 to move to first position
-  int64 after_item_id = 3;
+  int64 after_item_id = 3 [jstype = JS_STRING];
 }
 
 message UpdatePhotoCaptionReq {
-  int64 gallery_id = 1;
-  int64 item_id = 2;
+  int64 gallery_id = 1 [jstype = JS_STRING];
+  int64 item_id = 2 [jstype = JS_STRING];
   string caption = 3;
 }
 
 message GetGalleryEditInfoReq {
-  int64 gallery_id = 1;
+  int64 gallery_id = 1 [jstype = JS_STRING];
 }
 
 message GetGalleryEditInfoRes {
-  int64 gallery_id = 1;
+  int64 gallery_id = 1 [jstype = JS_STRING];
   uint32 max_photos = 2;
   uint32 current_photo_count = 3;
 }

--- a/app/proto/groups.proto
+++ b/app/proto/groups.proto
@@ -59,7 +59,7 @@ service Groups {
 }
 
 message CommunityParent {
-  int64 community_id = 1;
+  int64 community_id = 1 [jstype = JS_STRING];
   string name = 2;
   // a short URL fragment generated from the name, e.g. New York City: a guide to Phở might become
   // new-york-city-guide-to-pho
@@ -68,7 +68,7 @@ message CommunityParent {
 }
 
 message GroupParent {
-  int64 group_id = 1;
+  int64 group_id = 1 [jstype = JS_STRING];
   string name = 2;
   // a short URL fragment generated from the name, e.g. New York City: a guide to Phở might become
   // new-york-city-guide-to-pho
@@ -84,7 +84,7 @@ message Parent {
 }
 
 message Group {
-  int64 group_id = 1;
+  int64 group_id = 1 [jstype = JS_STRING];
   string name = 2;
   // a short URL fragment generated from the name, e.g. New York City: a guide to Phở might become
   // new-york-city-guide-to-pho
@@ -102,37 +102,37 @@ message Group {
 }
 
 message GetGroupReq {
-  int64 group_id = 1;
+  int64 group_id = 1 [jstype = JS_STRING];
 }
 
 message ListAdminsReq {
-  int64 group_id = 1;
+  int64 group_id = 1 [jstype = JS_STRING];
 
   uint32 page_size = 2;
   string page_token = 3;
 }
 
 message ListAdminsRes {
-  repeated int64 admin_user_ids = 1;
+  repeated int64 admin_user_ids = 1 [jstype = JS_STRING];
 
   string next_page_token = 2;
 }
 
 message ListMembersReq {
-  int64 group_id = 1;
+  int64 group_id = 1 [jstype = JS_STRING];
 
   uint32 page_size = 2;
   string page_token = 3;
 }
 
 message ListMembersRes {
-  repeated int64 member_user_ids = 1;
+  repeated int64 member_user_ids = 1 [jstype = JS_STRING];
 
   string next_page_token = 2;
 }
 
 message ListPlacesReq {
-  int64 group_id = 1;
+  int64 group_id = 1 [jstype = JS_STRING];
 
   uint32 page_size = 2;
   string page_token = 3;
@@ -145,7 +145,7 @@ message ListPlacesRes {
 }
 
 message ListGuidesReq {
-  int64 group_id = 1;
+  int64 group_id = 1 [jstype = JS_STRING];
 
   uint32 page_size = 2;
   string page_token = 3;
@@ -158,7 +158,7 @@ message ListGuidesRes {
 }
 
 message ListEventsReq {
-  int64 group_id = 1;
+  int64 group_id = 1 [jstype = JS_STRING];
   bool past = 4;
 
   uint32 page_size = 2;
@@ -172,7 +172,7 @@ message ListEventsRes {
 }
 
 message ListDiscussionsReq {
-  int64 group_id = 1;
+  int64 group_id = 1 [jstype = JS_STRING];
 
   uint32 page_size = 2;
   string page_token = 3;
@@ -185,11 +185,11 @@ message ListDiscussionsRes {
 }
 
 message JoinGroupReq {
-  int64 group_id = 1;
+  int64 group_id = 1 [jstype = JS_STRING];
 }
 
 message LeaveGroupReq {
-  int64 group_id = 1;
+  int64 group_id = 1 [jstype = JS_STRING];
 }
 
 message ListUserGroupsReq {

--- a/app/proto/jail.proto
+++ b/app/proto/jail.proto
@@ -80,7 +80,7 @@ message AcceptCommunityGuidelinesReq {
 }
 
 message AcknowledgePendingModNoteReq {
-  uint64 note_id = 1;
+  uint64 note_id = 1 [jstype = JS_STRING];
   // whether the user acknowledges the note or not
   bool acknowledge = 2;
 }

--- a/app/proto/moderation.proto
+++ b/app/proto/moderation.proto
@@ -61,33 +61,33 @@ enum ModerationObjectType {
 }
 
 message ModerationStateInfo {
-  int64 moderation_state_id = 1;
+  int64 moderation_state_id = 1 [jstype = JS_STRING];
   ModerationObjectType object_type = 2;
-  int64 object_id = 3;
+  int64 object_id = 3 [jstype = JS_STRING];
   ModerationVisibility visibility = 4;
   google.protobuf.Timestamp created = 5;
   google.protobuf.Timestamp updated = 6;
-  int64 author_user_id = 7;
+  int64 author_user_id = 7 [jstype = JS_STRING];
   string content = 8;
 }
 
 message ModerationQueueItemInfo {
-  int64 queue_item_id = 1;
-  int64 moderation_state_id = 2;
+  int64 queue_item_id = 1 [jstype = JS_STRING];
+  int64 moderation_state_id = 2 [jstype = JS_STRING];
   google.protobuf.Timestamp time_created = 3;
   ModerationTrigger trigger = 4;
   string reason = 5;
   bool is_resolved = 6;
-  int64 resolved_by_log_id = 7;
+  int64 resolved_by_log_id = 7 [jstype = JS_STRING];
   ModerationStateInfo moderation_state = 8;
 }
 
 message ModerationLogEntryInfo {
-  int64 log_entry_id = 1;
-  int64 moderation_state_id = 2;
+  int64 log_entry_id = 1 [jstype = JS_STRING];
+  int64 moderation_state_id = 2 [jstype = JS_STRING];
   google.protobuf.Timestamp time = 3;
   ModerationAction action = 4;
-  int64 moderator_user_id = 5;
+  int64 moderator_user_id = 5 [jstype = JS_STRING];
   ModerationVisibility new_visibility = 6;
   string reason = 7;
 }
@@ -104,7 +104,7 @@ message GetModerationQueueReq {
   // Filter to items created after this time (optional)
   google.protobuf.Timestamp created_after = 8;
   // Filter by content author (optional)
-  int64 item_author_user_id = 9;
+  int64 item_author_user_id = 9 [jstype = JS_STRING];
 
   // Pagination
   uint32 page_size = 1;
@@ -120,7 +120,7 @@ message GetModerationQueueRes {
 
 message GetModerationStateReq {
   ModerationObjectType object_type = 1;
-  int64 object_id = 2;
+  int64 object_id = 2 [jstype = JS_STRING];
 }
 
 message GetModerationStateRes {
@@ -128,7 +128,7 @@ message GetModerationStateRes {
 }
 
 message GetModerationLogReq {
-  int64 moderation_state_id = 1;
+  int64 moderation_state_id = 1 [jstype = JS_STRING];
 }
 
 message GetModerationLogRes {
@@ -137,7 +137,7 @@ message GetModerationLogRes {
 }
 
 message ModerateContentReq {
-  int64 moderation_state_id = 1;
+  int64 moderation_state_id = 1 [jstype = JS_STRING];
   // Required
   ModerationAction action = 2;
   // Required
@@ -150,7 +150,7 @@ message ModerateContentRes {
 }
 
 message FlagContentForReviewReq {
-  int64 moderation_state_id = 1;
+  int64 moderation_state_id = 1 [jstype = JS_STRING];
   ModerationTrigger trigger = 2;
   string reason = 3;
 }
@@ -160,7 +160,7 @@ message FlagContentForReviewRes {
 }
 
 message UnflagContentReq {
-  int64 moderation_state_id = 1;
+  int64 moderation_state_id = 1 [jstype = JS_STRING];
   string reason = 2;
 }
 

--- a/app/proto/notification_data.proto
+++ b/app/proto/notification_data.proto
@@ -97,7 +97,7 @@ message EmailAddressChange {
 
 message DonationReceived {
   // whole dollar amount
-  int64 amount = 1;
+  int64 amount = 1 [jstype = JS_STRING];
   string receipt_url = 2;
 }
 
@@ -152,7 +152,7 @@ message ChatMessage {
   org.couchers.api.core.User author = 1;
   string message = 2;
   string text = 3;
-  uint64 group_chat_id = 4;
+  uint64 group_chat_id = 4 [jstype = JS_STRING];
 }
 
 message ChatMissedMessages {
@@ -165,14 +165,14 @@ message ReferenceReceiveFriend {
 }
 
 message ReferenceReceiveHostRequest {
-  int64 host_request_id = 1;
+  int64 host_request_id = 1 [jstype = JS_STRING];
   org.couchers.api.core.User from_user = 2;
   // this is non-empty iff both have written a reference, so they are unhidden
   string text = 3;
 }
 
 message ReferenceReminder {
-  int64 host_request_id = 1;
+  int64 host_request_id = 1 [jstype = JS_STRING];
   org.couchers.api.core.User other_user = 2;
   // time left to write the req in days
   uint32 days_left = 3;
@@ -244,7 +244,7 @@ message ThreadReply {
 
 message ActivenessProbe {
   // 1, 2, 3, etc
-  uint64 reminder_number = 1;
+  uint64 reminder_number = 1 [jstype = JS_STRING];
   google.protobuf.Timestamp deadline = 2;
 }
 

--- a/app/proto/notifications.proto
+++ b/app/proto/notifications.proto
@@ -92,7 +92,7 @@ message SetNotificationSettingsReq {
 }
 
 message Notification {
-  int64 notification_id = 1;
+  int64 notification_id = 1 [jstype = JS_STRING];
   google.protobuf.Timestamp created = 2;
   string topic = 3;
   string action = 4;
@@ -119,13 +119,13 @@ message ListNotificationsRes {
 }
 
 message MarkNotificationSeenReq {
-  int64 notification_id = 1;
+  int64 notification_id = 1 [jstype = JS_STRING];
   bool set_seen = 2;
 }
 
 message MarkAllNotificationsSeenReq {
   // mark all notifications up to and including this one as seen
-  int64 latest_notification_id = 1;
+  int64 latest_notification_id = 1 [jstype = JS_STRING];
 }
 
 message GetVapidPublicKeyRes {
@@ -174,5 +174,5 @@ message SendDevPushNotificationReq {
 
 message DebugRedeliverPushNotificationReq {
   // The notification to redeliver
-  int64 notification_id = 1;
+  int64 notification_id = 1 [jstype = JS_STRING];
 }

--- a/app/proto/pages.proto
+++ b/app/proto/pages.proto
@@ -55,19 +55,19 @@ enum PageType {
 }
 
 message Page {
-  int64 page_id = 1;
+  int64 page_id = 1 [jstype = JS_STRING];
   PageType type = 2;
   // a short URL fragment generated from the name, e.g. New York City: a guide to Phở might become
   // new-york-city-guide-to-pho
   string slug = 3;
   google.protobuf.Timestamp created = 4;
   google.protobuf.Timestamp last_edited = 5;
-  int64 last_editor_user_id = 6;
-  int64 creator_user_id = 7;
+  int64 last_editor_user_id = 6 [jstype = JS_STRING];
+  int64 creator_user_id = 7 [jstype = JS_STRING];
   oneof owner {
-    int64 owner_user_id = 8;
-    int64 owner_community_id = 17;
-    int64 owner_group_id = 9;
+    int64 owner_user_id = 8 [jstype = JS_STRING];
+    int64 owner_community_id = 17 [jstype = JS_STRING];
+    int64 owner_group_id = 9 [jstype = JS_STRING];
   }
   org.couchers.api.threads.Thread thread = 20;
 
@@ -77,7 +77,7 @@ message Page {
   string photo_url = 19;
   string address = 13;
   Coordinate location = 14;
-  repeated int64 editor_user_ids = 15;
+  repeated int64 editor_user_ids = 15 [jstype = JS_STRING];
   bool can_edit = 16;
   bool can_moderate = 18;
 }
@@ -96,17 +96,17 @@ message CreateGuideReq {
   string content = 2;
   // from media server
   string photo_key = 6;
-  int64 parent_community_id = 3;
+  int64 parent_community_id = 3 [jstype = JS_STRING];
   string address = 4; // optional
   Coordinate location = 5; // optional
 }
 
 message GetPageReq {
-  int64 page_id = 1;
+  int64 page_id = 1 [jstype = JS_STRING];
 }
 
 message UpdatePageReq {
-  int64 page_id = 1;
+  int64 page_id = 1 [jstype = JS_STRING];
 
   google.protobuf.StringValue title = 2;
   google.protobuf.StringValue content = 3;
@@ -119,10 +119,10 @@ message UpdatePageReq {
 }
 
 message TransferPageReq {
-  int64 page_id = 1;
+  int64 page_id = 1 [jstype = JS_STRING];
   oneof new_owner {
-    int64 new_owner_community_id = 3;
-    int64 new_owner_group_id = 2;
+    int64 new_owner_community_id = 3 [jstype = JS_STRING];
+    int64 new_owner_group_id = 2 [jstype = JS_STRING];
   }
 }
 

--- a/app/proto/postal_verification.proto
+++ b/app/proto/postal_verification.proto
@@ -84,7 +84,7 @@ message InitiatePostalVerificationReq {
 
 message InitiatePostalVerificationRes {
   // The ID of the created postal verification attempt
-  int64 postal_verification_attempt_id = 1;
+  int64 postal_verification_attempt_id = 1 [jstype = JS_STRING];
   // The validated/corrected address
   PostalAddress corrected_address = 2;
   // Whether the address needed correction
@@ -93,7 +93,7 @@ message InitiatePostalVerificationRes {
 
 // Step 2: Confirm the (possibly corrected) address and send postcard
 message ConfirmPostalAddressReq {
-  int64 postal_verification_attempt_id = 1;
+  int64 postal_verification_attempt_id = 1 [jstype = JS_STRING];
 }
 
 message ConfirmPostalAddressRes {
@@ -103,7 +103,7 @@ message ConfirmPostalAddressRes {
 // Get current postal verification status
 message GetPostalVerificationStatusReq {
   // Optional: if 0 or not provided, returns latest attempt
-  int64 postal_verification_attempt_id = 1;
+  int64 postal_verification_attempt_id = 1 [jstype = JS_STRING];
 }
 
 message GetPostalVerificationStatusRes {
@@ -112,7 +112,7 @@ message GetPostalVerificationStatusRes {
 
   // Current/latest attempt details (if any)
   bool has_active_attempt = 2;
-  int64 postal_verification_attempt_id = 3;
+  int64 postal_verification_attempt_id = 3 [jstype = JS_STRING];
   PostalVerificationStatus status = 4;
   PostalAddress address = 5;
   google.protobuf.Timestamp created = 6;
@@ -140,7 +140,7 @@ message VerifyPostalCodeRes {
 
 // Cancel an in-progress attempt
 message CancelPostalVerificationReq {
-  int64 postal_verification_attempt_id = 1;
+  int64 postal_verification_attempt_id = 1 [jstype = JS_STRING];
 }
 
 // List all postal verification attempts (history)
@@ -153,7 +153,7 @@ message ListPostalVerificationAttemptsRes {
 }
 
 message PostalVerificationAttemptSummary {
-  int64 postal_verification_attempt_id = 1;
+  int64 postal_verification_attempt_id = 1 [jstype = JS_STRING];
   PostalVerificationStatus status = 2;
   PostalAddress address = 3;
   google.protobuf.Timestamp created = 4;

--- a/app/proto/public.proto
+++ b/app/proto/public.proto
@@ -102,7 +102,7 @@ message GetSignupPageInfoRes {
   google.protobuf.Timestamp last_signup = 1;
   string last_location = 2;
 
-  uint64 user_count = 3;
+  uint64 user_count = 3 [jstype = JS_STRING];
 }
 
 message Volunteer {
@@ -134,7 +134,7 @@ message GetVolunteersRes {
 
 message GetDonationStatsRes {
   // Total donations received this year in USD (whole dollars)
-  uint64 total_donated_ytd = 1;
+  uint64 total_donated_ytd = 1 [jstype = JS_STRING];
   // The fundraising goal in USD (whole dollars)
-  uint64 goal = 2;
+  uint64 goal = 2 [jstype = JS_STRING];
 }

--- a/app/proto/references.proto
+++ b/app/proto/references.proto
@@ -48,23 +48,23 @@ enum ReferenceType {
 }
 
 message Reference {
-  int64 reference_id = 1;
+  int64 reference_id = 1 [jstype = JS_STRING];
 
-  int64 from_user_id = 2;
-  int64 to_user_id = 3;
+  int64 from_user_id = 2 [jstype = JS_STRING];
+  int64 to_user_id = 3 [jstype = JS_STRING];
 
   ReferenceType reference_type = 4;
   string text = 5; // plain text
   google.protobuf.Timestamp written_time = 6; // not exact
 
   // if the reference is about the current user, this tells which host request it's about
-  int64 host_request_id = 7;
+  int64 host_request_id = 7 [jstype = JS_STRING];
 }
 
 message ListReferencesReq {
   // at least one of these two must be set, zero means "any"
-  uint64 from_user_id = 1;
-  uint64 to_user_id = 2;
+  uint64 from_user_id = 1 [jstype = JS_STRING];
+  uint64 to_user_id = 2 [jstype = JS_STRING];
 
   // empty filter means include all, otherwise only those in the filter
   repeated ReferenceType reference_type_filter = 3;
@@ -80,7 +80,7 @@ message ListReferencesRes {
 }
 
 message WriteFriendReferenceReq {
-  int64 to_user_id = 1;
+  int64 to_user_id = 1 [jstype = JS_STRING];
   string text = 2; // plain text
   // private text to be send to moderation
   string private_text = 5; // plain text
@@ -90,7 +90,7 @@ message WriteFriendReferenceReq {
 }
 
 message WriteHostRequestReferenceReq {
-  int64 host_request_id = 1;
+  int64 host_request_id = 1 [jstype = JS_STRING];
   string text = 2; // plain text
   // private text to be send to moderation
   string private_text = 5; // plain text
@@ -100,17 +100,17 @@ message WriteHostRequestReferenceReq {
 }
 
 message HostRequestIndicateDidntMeetupReq {
-  int64 host_request_id = 1;
+  int64 host_request_id = 1 [jstype = JS_STRING];
   // reason why the host request didn't happen, can be blank
   string reason_didnt_meetup = 6; // plain text
 }
 
 message AvailableWriteReferencesReq {
-  int64 to_user_id = 1;
+  int64 to_user_id = 1 [jstype = JS_STRING];
 }
 
 message AvailableWriteReferenceType {
-  int64 host_request_id = 1;
+  int64 host_request_id = 1 [jstype = JS_STRING];
   // surfed or hosted
   ReferenceType reference_type = 2;
   google.protobuf.Timestamp time_expires = 3;
@@ -126,7 +126,7 @@ message ListPendingReferencesToWriteRes {
 }
 
 message GetHostRequestReferenceStatusReq {
-  int64 host_request_id = 1;
+  int64 host_request_id = 1 [jstype = JS_STRING];
 }
 
 message GetHostRequestReferenceStatusRes {

--- a/app/proto/requests.proto
+++ b/app/proto/requests.proto
@@ -50,7 +50,7 @@ service Requests {
 }
 
 message CreateHostRequestReq {
-  int64 host_user_id = 1;
+  int64 host_user_id = 1 [jstype = JS_STRING];
   // dates as "yyyy-mm-dd", in the timezone of the host
   string from_date = 2;
   string to_date = 3;
@@ -58,16 +58,16 @@ message CreateHostRequestReq {
 }
 
 message HostRequest {
-  int64 host_request_id = 1;
-  int64 surfer_user_id = 2;
-  int64 host_user_id = 3;
+  int64 host_request_id = 1 [jstype = JS_STRING];
+  int64 surfer_user_id = 2 [jstype = JS_STRING];
+  int64 host_user_id = 3 [jstype = JS_STRING];
   org.couchers.api.conversations.HostRequestStatus status = 4;
   google.protobuf.Timestamp created = 5;
 
   // dates as "yyyy-mm-dd", these are associated with a timezone, but that's not yet returned here TODO?
   string from_date = 6;
   string to_date = 7;
-  int64 last_seen_message_id = 8;
+  int64 last_seen_message_id = 8 [jstype = JS_STRING];
   org.couchers.api.conversations.Message latest_message = 9;
   string hosting_city = 10;
   double hosting_lat = 11;
@@ -78,31 +78,31 @@ message HostRequest {
 }
 
 message GetHostRequestReq {
-  int64 host_request_id = 1;
+  int64 host_request_id = 1 [jstype = JS_STRING];
 }
 
 message CreateHostRequestRes {
-  int64 host_request_id = 1;
+  int64 host_request_id = 1 [jstype = JS_STRING];
 }
 
 message RespondHostRequestReq {
-  int64 host_request_id = 1;
+  int64 host_request_id = 1 [jstype = JS_STRING];
   org.couchers.api.conversations.HostRequestStatus status = 2;
   string text = 3;
 }
 
 message SetHostRequestArchiveStatusReq {
-  int64 host_request_id = 1;
+  int64 host_request_id = 1 [jstype = JS_STRING];
   bool is_archived = 2;
 }
 
 message SetHostRequestArchiveStatusRes {
-  int64 host_request_id = 1;
+  int64 host_request_id = 1 [jstype = JS_STRING];
   bool is_archived = 2;
 }
 
 message ListHostRequestsReq {
-  int64 last_request_id = 1;
+  int64 last_request_id = 1 [jstype = JS_STRING];
   uint32 number = 2;
 
   // Whether to only show pending, accepted and
@@ -117,36 +117,36 @@ message ListHostRequestsReq {
 
 message ListHostRequestsRes {
   repeated HostRequest host_requests = 1;
-  int64 last_request_id = 2;
+  int64 last_request_id = 2 [jstype = JS_STRING];
   bool no_more = 3;
 }
 
 message GetHostRequestMessagesReq {
-  int64 host_request_id = 1;
-  int64 last_message_id = 2;
+  int64 host_request_id = 1 [jstype = JS_STRING];
+  int64 last_message_id = 2 [jstype = JS_STRING];
   uint32 number = 3;
 }
 
 message GetHostRequestMessagesRes {
   repeated org.couchers.api.conversations.Message messages = 1;
-  int64 last_message_id = 4;
+  int64 last_message_id = 4 [jstype = JS_STRING];
   bool no_more = 5;
 }
 
 message SendHostRequestMessageReq {
-  int64 host_request_id = 1;
+  int64 host_request_id = 1 [jstype = JS_STRING];
   string text = 2;
 }
 
 message GetHostRequestUpdatesReq {
-  int64 newest_message_id = 1;
+  int64 newest_message_id = 1 [jstype = JS_STRING];
   uint32 number = 2;
   bool only_sent = 3;
   bool only_received = 4;
 }
 
 message HostRequestUpdate {
-  int64 host_request_id = 1;
+  int64 host_request_id = 1 [jstype = JS_STRING];
   org.couchers.api.conversations.Message message = 2;
   // the current status of the host request, regardless of this update
   org.couchers.api.conversations.HostRequestStatus status = 3;
@@ -158,12 +158,12 @@ message GetHostRequestUpdatesRes {
 }
 
 message MarkLastSeenHostRequestReq {
-  int64 host_request_id = 1;
-  int64 last_seen_message_id = 2;
+  int64 host_request_id = 1 [jstype = JS_STRING];
+  int64 last_seen_message_id = 2 [jstype = JS_STRING];
 }
 
 message GetResponseRateReq {
-  int64 user_id = 1;
+  int64 user_id = 1 [jstype = JS_STRING];
 }
 
 message ResponseRateInsufficientData {}
@@ -214,7 +214,7 @@ enum HostRequestQuality {
 }
 
 message SendHostRequestFeedbackReq {
-  int64 host_request_id = 1;
+  int64 host_request_id = 1 [jstype = JS_STRING];
   HostRequestQuality host_request_quality = 2;
   string decline_reason = 3;
 }

--- a/app/proto/search.proto
+++ b/app/proto/search.proto
@@ -72,7 +72,7 @@ message SearchReq {
   //   // search in given area
   //   Area search_in_area = 11;
   //   // search inside the area defined by the community
-  //   int64 search_in_community_id = 12;
+  //   int64 search_in_community_id = 12 [jstype = JS_STRING];
   // }
 
   // whether to only perform a trigram based search on titles and not do full text search
@@ -109,7 +109,7 @@ message SearchRes {
 
 message UserSearchReq {
   // if this field is present, we filter to exactly these users (any invalid ids are ignored)
-  repeated int64 exactly_user_ids = 35;
+  repeated int64 exactly_user_ids = 35 [jstype = JS_STRING];
 
   google.protobuf.StringValue query = 3;
   // whether the query (if any) should only search through username and display name
@@ -123,7 +123,7 @@ message UserSearchReq {
     // search in given area
     Area search_in_area = 28;
     // search inside the area defined by the community
-    int64 search_in_community_id = 29;
+    int64 search_in_community_id = 29 [jstype = JS_STRING];
     RectArea search_in_rectangle = 33;
   }
 
@@ -173,7 +173,7 @@ message UserSearchRes {
 }
 
 message SearchUser {
-  int64 user_id = 1;
+  int64 user_id = 1 [jstype = JS_STRING];
   string username = 2;
   string name = 3;
   string city = 4;
@@ -249,7 +249,7 @@ message EventSearchReq {
     // search in given area
     Area search_in_area = 5;
     // search inside the area defined by the community
-    int64 search_in_community_id = 6;
+    int64 search_in_community_id = 6 [jstype = JS_STRING];
     RectArea search_in_rectangle = 7;
   }
 

--- a/app/proto/threads.proto
+++ b/app/proto/threads.proto
@@ -38,13 +38,13 @@ service Threads {
 // object returned by pages, discussions etc to refer to top level threads.
 message Thread {
   // top level thread id.
-  int64 thread_id = 1;
+  int64 thread_id = 1 [jstype = JS_STRING];
   // total number of comments and replies to comments.
-  int64 num_responses = 2;
+  int64 num_responses = 2 [jstype = JS_STRING];
 }
 
 message GetThreadReq {
-  int64 thread_id = 1;
+  int64 thread_id = 1 [jstype = JS_STRING];
 
   // Maximum number of replies to return. Defaults to 1000.
   uint32 page_size = 2;
@@ -67,9 +67,9 @@ message GetThreadRes {
 }
 
 message Reply {
-  int64 thread_id = 1; // id of this comment
+  int64 thread_id = 1 [jstype = JS_STRING]; // id of this comment
   string content = 2; // CommonMark without images
-  int64 author_user_id = 3;
+  int64 author_user_id = 3 [jstype = JS_STRING];
   google.protobuf.Timestamp created_time = 4;
 
   // number of replies to this comment
@@ -77,11 +77,11 @@ message Reply {
 }
 
 message PostReplyReq {
-  int64 thread_id = 1; // The comment to reply to
+  int64 thread_id = 1 [jstype = JS_STRING]; // The comment to reply to
   string content = 2; // CommonMark without images
 }
 
 message PostReplyRes {
   // The id of the just posted comment
-  int64 thread_id = 1;
+  int64 thread_id = 1 [jstype = JS_STRING];
 }

--- a/app/web/components/Comments/CommentBox.tsx
+++ b/app/web/components/Comments/CommentBox.tsx
@@ -10,7 +10,7 @@ import { service } from "service";
 import isGrpcError from "service/utils/isGrpcError";
 
 interface CommentBoxProps {
-  threadId: number;
+  threadId: string;
 }
 
 // Reply with more Reply objects as children
@@ -61,7 +61,7 @@ export default function CommentBox({ threadId }: CommentBoxProps) {
     })();
   }, [t, threadId]);
 
-  const handleComment = async (threadId: number, content: string) => {
+  const handleComment = async (threadId: string, content: string) => {
     await service.threads.postReply(threadId, content);
     setLoading(true);
     try {

--- a/app/web/components/UsersList.tsx
+++ b/app/web/components/UsersList.tsx
@@ -19,7 +19,7 @@ const StyledUsersDiv = styled("div")(({ theme }) => ({
 }));
 
 interface UsersListProps {
-  userIds: number[] | undefined;
+  userIds: string[] | undefined;
   emptyListChildren?: ReactNode;
   endChildren?: ReactNode;
   error?: RpcError | null;

--- a/app/web/features/auth/login/LoginForm.test.tsx
+++ b/app/web/features/auth/login/LoginForm.test.tsx
@@ -16,7 +16,7 @@ const passwordLoginMock = service.user.passwordLogin as MockedService<
 describe("LoginForm", () => {
   beforeEach(() => {
     passwordLoginMock.mockResolvedValue({
-      userId: 1,
+      userId: "1",
       jailed: false,
     });
   });

--- a/app/web/features/auth/signup/Signup.test.tsx
+++ b/app/web/features/auth/signup/Signup.test.tsx
@@ -282,7 +282,7 @@ describe("Signup", () => {
       );
       signupFlowMotivationsMock.mockResolvedValue({
         flowToken: "token",
-        authRes: { userId: 1, jailed: false },
+        authRes: { userId: "1", jailed: false },
         needBasic: false,
         needAccount: false,
         needAcceptCommunityGuidelines: false,

--- a/app/web/features/auth/useAuthStore.test.ts
+++ b/app/web/features/auth/useAuthStore.test.ts
@@ -219,7 +219,7 @@ describe("firstLogin action", () => {
     expect(result.current.authState.authenticated).toBe(false);
     await act(() =>
       result.current.authActions.firstLogin({
-        userId: 55,
+        userId: "55",
         jailed: false,
       }),
     );

--- a/app/web/features/auth/useAuthStore.ts
+++ b/app/web/features/auth/useAuthStore.ts
@@ -51,7 +51,7 @@ export default function useAuthStore() {
     false,
   );
   const [jailed, setJailed] = usePersistedState("auth.jailed", false);
-  const [userId, setUserId] = usePersistedState<number | null>(
+  const [userId, setUserId] = usePersistedState<string | null>(
     "auth.userId",
     null,
   );

--- a/app/web/features/communities/CommunitiesPage/CommunitySearch.test.tsx
+++ b/app/web/features/communities/CommunitiesPage/CommunitySearch.test.tsx
@@ -36,13 +36,13 @@ const mockListAllCommunities =
 
 const mockCommunities: CommunitySummary.AsObject[] = [
   {
-    communityId: 2,
+    communityId: "2",
     name: "Amsterdam",
     slug: "amsterdam",
     parentsList: [
       {
         community: {
-          communityId: 1,
+          communityId: "1",
           name: "Europe",
           slug: "europe",
           description: "European region",
@@ -55,13 +55,13 @@ const mockCommunities: CommunitySummary.AsObject[] = [
     nodeType: NodeType.NODE_TYPE_LOCALITY,
   },
   {
-    communityId: 3,
+    communityId: "3",
     name: "Rotterdam",
     slug: "rotterdam",
     parentsList: [
       {
         community: {
-          communityId: 1,
+          communityId: "1",
           name: "Europe",
           slug: "europe",
           description: "European region",
@@ -74,13 +74,13 @@ const mockCommunities: CommunitySummary.AsObject[] = [
     nodeType: NodeType.NODE_TYPE_LOCALITY,
   },
   {
-    communityId: 4,
+    communityId: "4",
     name: "Berlin",
     slug: "berlin",
     parentsList: [
       {
         community: {
-          communityId: 1,
+          communityId: "1",
           name: "Europe",
           slug: "europe",
           description: "European region",

--- a/app/web/features/communities/PagePage.tsx
+++ b/app/web/features/communities/PagePage.tsx
@@ -19,7 +19,7 @@ export default function PagePage({
   pageSlug,
 }: {
   pageType: PageType;
-  pageId: number;
+  pageId: string;
   pageSlug?: string;
 }) {
   const { t } = useTranslation(["communities", "global"]);

--- a/app/web/features/communities/events/CancelEventDialog.tsx
+++ b/app/web/features/communities/events/CancelEventDialog.tsx
@@ -20,7 +20,7 @@ import { service } from "service";
 export default function CancelEventDialog({
   eventId,
   ...props
-}: DialogProps & { eventId: number }) {
+}: DialogProps & { eventId: string }) {
   const { t } = useTranslation([GLOBAL, COMMUNITIES]);
   const queryClient = useQueryClient();
   const cancelEventMutation = useMutation<Empty, RpcError, void>({

--- a/app/web/features/communities/events/EditEventPage.tsx
+++ b/app/web/features/communities/events/EditEventPage.tsx
@@ -18,7 +18,7 @@ import { communityEventsBaseKey, eventKey } from "../../queryKeys";
 import EventForm, { CreateEventVariables } from "./EventForm";
 import { useEvent } from "./hooks";
 
-export default function EditEventPage({ eventId }: { eventId: number }) {
+export default function EditEventPage({ eventId }: { eventId: string }) {
   const { t } = useTranslation([GLOBAL, COMMUNITIES, PROFILE]);
   const router = useRouter();
 

--- a/app/web/features/communities/events/hooks.ts
+++ b/app/web/features/communities/events/hooks.ts
@@ -80,7 +80,7 @@ export function useEvent({
   eventId,
   enabled,
 }: {
-  eventId: number;
+  eventId: string;
   enabled?: boolean;
 }) {
   const isValidEventId = eventId > 0;

--- a/app/web/features/communities/hooks.ts
+++ b/app/web/features/communities/hooks.ts
@@ -107,7 +107,7 @@ export const useListDiscussions = (communityId: number) =>
       lastPage.nextPageToken ? lastPage.nextPageToken : undefined,
   });
 
-export const useListAdmins = (communityId: number, type: QueryType) => {
+export const useListAdmins = (communityId: string, type: QueryType) => {
   const query = useInfiniteQuery<ListAdminsRes.AsObject, RpcError>({
     queryKey: communityAdminsKey(communityId, type),
     queryFn: ({ pageParam }) =>

--- a/app/web/features/profile/hooks/useGallery.ts
+++ b/app/web/features/profile/hooks/useGallery.ts
@@ -3,7 +3,7 @@ import { galleryEditInfoKey, galleryKey, userKey } from "features/queryKeys";
 import { PhotoGallery } from "proto/galleries_pb";
 import { service } from "service";
 
-export function useGallery(galleryId: number | undefined) {
+export function useGallery(galleryId: string | undefined) {
   return useQuery({
     queryKey: galleryKey(galleryId || 0),
     queryFn: () => service.gallery.getGallery(galleryId!),
@@ -11,7 +11,7 @@ export function useGallery(galleryId: number | undefined) {
   });
 }
 
-export function useGalleryEditInfo(galleryId: number | undefined) {
+export function useGalleryEditInfo(galleryId: string | undefined) {
   return useQuery({
     queryKey: galleryEditInfoKey(galleryId || 0),
     queryFn: () => service.gallery.getGalleryEditInfo(galleryId!),
@@ -19,7 +19,7 @@ export function useGalleryEditInfo(galleryId: number | undefined) {
   });
 }
 
-export function useAddPhotoToGallery(galleryId: number, userId?: number) {
+export function useAddPhotoToGallery(galleryId: string, userId?: string) {
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/app/web/features/profile/view/leaveReference/LeaveReferencePage.tsx
+++ b/app/web/features/profile/view/leaveReference/LeaveReferencePage.tsx
@@ -53,8 +53,8 @@ export default function LeaveReferencePage({
   step = "did-stay",
 }: {
   referenceType: string;
-  userId: number;
-  hostRequestId?: number;
+  userId: string;
+  hostRequestId?: string;
   step?: ReferenceStep;
 }) {
   const { t } = useTranslation([GLOBAL, PROFILE]);

--- a/app/web/features/queryKeys.ts
+++ b/app/web/features/queryKeys.ts
@@ -16,7 +16,7 @@ export const pingQueryKey = "ping";
 export const username2Id = "username2Id";
 export const volunteerInfoQueryKey = "volunteerInfo";
 
-export function userKey(userId?: number) {
+export function userKey(userId?: string) {
   return userId === undefined ? ["user"] : ["user", userId];
 }
 
@@ -56,12 +56,12 @@ export const friendRequestKey = (type: FriendRequestType) => [
 
 // communities
 export const communityKey = (id: number) => ["community", id];
-export const subCommunitiesKey = (communityId: number) => [
+export const subCommunitiesKey = (communityId: string) => [
   "subCommunities",
   communityId,
 ];
 
-export const communityDiscussionsKey = (communityId: number) => [
+export const communityDiscussionsKey = (communityId: string) => [
   "communityDiscussions",
   communityId,
 ];
@@ -69,32 +69,32 @@ export const communityDiscussionsKey = (communityId: number) => [
 // Determines whether only some entities can be revealed or all can be revealed
 // with a fetch more button
 export type QueryType = "summary" | "all";
-export const communityAdminsKey = (communityId: number, type: QueryType) => [
+export const communityAdminsKey = (communityId: string, type: QueryType) => [
   "communityAdmins",
   { communityId, type },
 ];
 
-export const communityMembersKey = (communityId: number) => [
+export const communityMembersKey = (communityId: string) => [
   "communityMembers",
   communityId,
 ];
-export const communityNearbyUsersKey = (communityId: number) => [
+export const communityNearbyUsersKey = (communityId: string) => [
   "communityNearbyUsers",
   communityId,
 ];
 
 export const communityEventsBaseKey = "communityEvents";
-export const communityEventsKey = (communityId: number, type: QueryType) => [
+export const communityEventsKey = (communityId: string, type: QueryType) => [
   communityEventsBaseKey,
   communityId,
   { type },
 ];
 
 // events
-export const eventKey = (eventId: number) => ["event", eventId];
+export const eventKey = (eventId: string) => ["event", eventId];
 export type EventsType = "upcoming" | "past";
 interface EventUsersInput {
-  eventId: number;
+  eventId: string;
   type: QueryType;
 }
 

--- a/app/web/features/userQueries/useLiteUsers.ts
+++ b/app/web/features/userQueries/useLiteUsers.ts
@@ -9,7 +9,7 @@ import { userStaleTime } from "./constants";
 
 // React Query typically retains the last successful data until the next successful fetch
 // if ids is `[]`, then `data` is `undefined`
-function useLiteUsers(ids: (number | undefined)[] | undefined) {
+function useLiteUsers(ids: (string | undefined)[] | undefined) {
   const nonFalseyIds = ids?.filter((id) => id !== undefined);
   // remove duplicate IDs from this list
   const uniqueIds = Array.from(new Set(nonFalseyIds));
@@ -38,7 +38,7 @@ function useLiteUsers(ids: (number | undefined)[] | undefined) {
 }
 
 // Like above, but returns users in a list of the same size in same order
-function useLiteUsersList(ids: (number | undefined)[] | undefined) {
+function useLiteUsersList(ids: (string | undefined)[] | undefined) {
   const liteUsersMap = useLiteUsers(ids);
   const usersList = ids
     ?.map((id) => liteUsersMap.data?.get(id))
@@ -52,7 +52,7 @@ function useLiteUsersList(ids: (number | undefined)[] | undefined) {
 }
 
 // React Query typically retains the last successful data until the next successful fetch
-function useLiteUser(id: number | undefined) {
+function useLiteUser(id: string | undefined) {
   const query = useQuery<LiteUser.AsObject, RpcError>({
     queryKey: liteUserKey(id),
     queryFn: () => service.user.getLiteUser(id?.toString() || ""),

--- a/app/web/features/userQueries/useUsers.ts
+++ b/app/web/features/userQueries/useUsers.ts
@@ -73,7 +73,7 @@ export default function useUsers(
   };
 }
 
-export function useUser(id: number | undefined, invalidate = false) {
+export function useUser(id: string | undefined, invalidate = false) {
   const result = useUsers([id], invalidate);
   return {
     data: result.data?.get(id),

--- a/app/web/routes.ts
+++ b/app/web/routes.ts
@@ -138,30 +138,30 @@ export const jailRoute = "/restricted";
 export const tosRoute = "/terms";
 
 const placeBaseRoute = "/place";
-export const routeToPlace = (id: number, slug: string) =>
+export const routeToPlace = (id: string, slug: string) =>
   `${placeBaseRoute}/${id}/${slug}`;
 
 const guideBaseRoute = "/guide";
-export const routeToGuide = (id: number, slug: string) =>
+export const routeToGuide = (id: string, slug: string) =>
   `${guideBaseRoute}/${id}/${slug}`;
 
 const groupBaseRoute = "/group";
-export const routeToGroup = (id: number, slug: string) =>
+export const routeToGroup = (id: string, slug: string) =>
   `${groupBaseRoute}/${id}/${slug}`;
 
 export const discussionBaseRoute = "/discussion";
-export const routeToDiscussion = (id: number, slug: string) =>
+export const routeToDiscussion = (id: string, slug: string) =>
   `${discussionBaseRoute}/${id}/${slug}`;
 
 export const eventBaseRoute = "/event";
 export const newEventRoute = `${eventBaseRoute}/new`;
-export const routeToNewEvent = (communityId?: number) =>
+export const routeToNewEvent = (communityId?: string) =>
   `${newEventRoute}${communityId ? `?communityId=${communityId}` : ""}`;
-export const routeToDuplicateEvent = (eventId: number) =>
+export const routeToDuplicateEvent = (eventId: string) =>
   `${newEventRoute}?duplicateEventId=${eventId}`;
-export const routeToEvent = (id: number, slug: string) =>
+export const routeToEvent = (id: string, slug: string) =>
   `${eventBaseRoute}/${id}/${slug}`;
-export const routeToEditEvent = (id: number, slug: string) =>
+export const routeToEditEvent = (id: string, slug: string) =>
   `${routeToEvent(id, slug)}/edit`;
 
 const communityBaseRoute = "/community";
@@ -175,11 +175,11 @@ export const communityTabs = [
 export type CommunityTab = (typeof communityTabs)[number];
 
 export const routeToCommunity = (
-  id: number,
+  id: string,
   slug: string,
   page?: CommunityTab,
 ) => `${communityBaseRoute}/${id}/${slug}${page ? `/${page}` : ""}`;
-export const routeToEditCommunityPage = (id: number, slug: string) =>
+export const routeToEditCommunityPage = (id: string, slug: string) =>
   `${routeToCommunity(id, slug, "info")}/edit`;
 
 export const composingDiscussionHash = "new";

--- a/app/web/service/communities.ts
+++ b/app/web/service/communities.ts
@@ -17,7 +17,7 @@ import {
 
 import client from "./client";
 
-export async function getCommunity(communityId: number) {
+export async function getCommunity(communityId: string) {
   const req = new GetCommunityReq();
   req.setCommunityId(communityId);
   const response = await client.communities.getCommunity(req);
@@ -27,7 +27,7 @@ export async function getCommunity(communityId: number) {
 /**
  * List sub-communities of a given community
  */
-export async function listCommunities(communityId: number, pageToken?: string) {
+export async function listCommunities(communityId: string, pageToken?: string) {
   const req = new ListCommunitiesReq();
   req.setCommunityId(communityId);
   if (pageToken) {
@@ -37,7 +37,7 @@ export async function listCommunities(communityId: number, pageToken?: string) {
   return response.toObject();
 }
 
-export async function listGroups(communityId: number, pageToken?: string) {
+export async function listGroups(communityId: string, pageToken?: string) {
   const req = new ListGroupsReq();
   req.setCommunityId(communityId);
   if (pageToken) {
@@ -47,7 +47,7 @@ export async function listGroups(communityId: number, pageToken?: string) {
   return response.toObject();
 }
 
-export async function listAdmins(communityId: number, pageToken?: string) {
+export async function listAdmins(communityId: string, pageToken?: string) {
   const req = new ListAdminsReq();
   req.setCommunityId(communityId);
   if (pageToken) {
@@ -63,7 +63,7 @@ export async function listMembers({
   pageSize,
   pageToken,
 }: {
-  communityId: number;
+  communityId: string;
   pageSize?: number;
   pageToken?: string;
 }) {
@@ -83,7 +83,7 @@ export async function listMembers({
   return response.toObject();
 }
 
-export async function listNearbyUsers(communityId: number, pageToken?: string) {
+export async function listNearbyUsers(communityId: string, pageToken?: string) {
   const req = new ListNearbyUsersReq();
   req.setCommunityId(communityId);
   if (pageToken) {
@@ -93,7 +93,7 @@ export async function listNearbyUsers(communityId: number, pageToken?: string) {
   return response.toObject();
 }
 
-export async function listPlaces(communityId: number, pageToken?: string) {
+export async function listPlaces(communityId: string, pageToken?: string) {
   const req = new ListPlacesReq();
   req.setCommunityId(communityId);
   if (pageToken) {
@@ -103,7 +103,7 @@ export async function listPlaces(communityId: number, pageToken?: string) {
   return response.toObject();
 }
 
-export async function listGuides(communityId: number, pageToken?: string) {
+export async function listGuides(communityId: string, pageToken?: string) {
   const req = new ListGuidesReq();
   req.setCommunityId(communityId);
   if (pageToken) {
@@ -113,7 +113,7 @@ export async function listGuides(communityId: number, pageToken?: string) {
   return response.toObject();
 }
 
-export async function listDiscussions(communityId: number, pageToken?: string) {
+export async function listDiscussions(communityId: string, pageToken?: string) {
   const req = new ListDiscussionsReq();
   req.setCommunityId(communityId);
   if (pageToken) {
@@ -123,13 +123,13 @@ export async function listDiscussions(communityId: number, pageToken?: string) {
   return response.toObject();
 }
 
-export async function joinCommunity(communityId: number) {
+export async function joinCommunity(communityId: string) {
   const req = new JoinCommunityReq();
   req.setCommunityId(communityId);
   await client.communities.joinCommunity(req);
 }
 
-export async function leaveCommunity(communityId: number) {
+export async function leaveCommunity(communityId: string) {
   const req = new LeaveCommunityReq();
   req.setCommunityId(communityId);
   await client.communities.leaveCommunity(req);

--- a/app/web/service/conversations.ts
+++ b/app/web/service/conversations.ts
@@ -26,7 +26,7 @@ import { Duration, duration2pb } from "./utils/date";
 import isGrpcError from "./utils/isGrpcError";
 
 export async function listGroupChats(
-  lastMessageId = 0,
+  lastMessageId = "0",
   count = 10,
   onlyArchived?: boolean,
 ) {
@@ -42,7 +42,7 @@ export async function listGroupChats(
   return response.toObject();
 }
 
-export async function getGroupChat(id: number) {
+export async function getGroupChat(id: string) {
   const req = new GetGroupChatReq();
   req.setGroupChatId(id);
   const response = await client.conversations.getGroupChat(req);
@@ -50,8 +50,8 @@ export async function getGroupChat(id: number) {
 }
 
 export async function getGroupChatMessages(
-  groupChatId: number,
-  lastMessageId = 0,
+  groupChatId: string,
+  lastMessageId = "0",
   count = 20,
 ) {
   const req = new GetGroupChatMessagesReq();
@@ -67,7 +67,7 @@ export async function getGroupChatMessages(
 export async function createGroupChat(
   title: string,
   users: User.AsObject[],
-): Promise<number> {
+): Promise<string> {
   const req = new CreateGroupChatReq();
   req.setRecipientUserIdsList(users.map((user) => user.userId));
   req.setTitle(new StringValue().setValue(title));
@@ -77,20 +77,20 @@ export async function createGroupChat(
   return groupChatId;
 }
 
-export async function sendMessage(groupChatId: number, text: string) {
+export async function sendMessage(groupChatId: string, text: string) {
   const req = new SendMessageReq();
   req.setGroupChatId(groupChatId);
   req.setText(text);
   return await client.conversations.sendMessage(req);
 }
 
-export function leaveGroupChat(groupChatId: number) {
+export function leaveGroupChat(groupChatId: string) {
   const req = new LeaveGroupChatReq();
   req.setGroupChatId(groupChatId);
   return client.conversations.leaveGroupChat(req);
 }
 
-export function inviteToGroupChat(groupChatId: number, users: User.AsObject[]) {
+export function inviteToGroupChat(groupChatId: string, users: User.AsObject[]) {
   const promises = users.map((user) => {
     const req = new InviteToGroupChatReq();
     req.setGroupChatId(groupChatId);
@@ -101,7 +101,7 @@ export function inviteToGroupChat(groupChatId: number, users: User.AsObject[]) {
 }
 
 export function makeGroupChatAdmin(
-  groupChatId: number,
+  groupChatId: string,
   user: LiteUser.AsObject,
 ) {
   const req = new MakeGroupChatAdminReq();
@@ -111,7 +111,7 @@ export function makeGroupChatAdmin(
 }
 
 export function removeGroupChatAdmin(
-  groupChatId: number,
+  groupChatId: string,
   user: LiteUser.AsObject,
 ) {
   const req = new RemoveGroupChatAdminReq();
@@ -121,7 +121,7 @@ export function removeGroupChatAdmin(
 }
 
 export function editGroupChat(
-  groupChatId: number,
+  groupChatId: string,
   title?: string,
   onlyAdminsInvite?: boolean,
 ) {
@@ -134,8 +134,8 @@ export function editGroupChat(
 }
 
 export function markLastSeenGroupChat(
-  groupChatId: number,
-  lastSeenMessageId: number,
+  groupChatId: string,
+  lastSeenMessageId: string,
 ) {
   const req = new MarkLastSeenGroupChatReq();
   req.setGroupChatId(groupChatId);
@@ -143,7 +143,7 @@ export function markLastSeenGroupChat(
   return client.conversations.markLastSeenGroupChat(req);
 }
 
-export async function getDirectMessage(userId: number) {
+export async function getDirectMessage(userId: string) {
   const req = new GetDirectMessageReq();
   req.setUserId(userId);
   try {
@@ -172,7 +172,7 @@ export async function muteChat(options: MuteChatOptions) {
 }
 
 export async function setGroupChatArchiveStatus(
-  groupChatId: number,
+  groupChatId: string,
   isArchived: boolean,
 ) {
   const req = new SetGroupChatArchiveStatusReq();

--- a/app/web/service/discussions.ts
+++ b/app/web/service/discussions.ts
@@ -5,8 +5,8 @@ import client from "./client";
 export async function createDiscussion(
   title: string,
   content: string,
-  ownerCommunityId?: number,
-  ownerGroupId?: number,
+  ownerCommunityId?: string,
+  ownerGroupId?: string,
 ) {
   const req = new CreateDiscussionReq();
   req.setTitle(title);
@@ -23,7 +23,7 @@ export async function createDiscussion(
   return response.toObject();
 }
 
-export async function getDiscussion(discussionId: number) {
+export async function getDiscussion(discussionId: string) {
   const req = new GetDiscussionReq();
   req.setDiscussionId(discussionId);
   const response = await client.discussions.getDiscussion(req);

--- a/app/web/service/events.ts
+++ b/app/web/service/events.ts
@@ -25,7 +25,7 @@ import {
 import client from "./client";
 
 export async function listCommunityEvents(
-  communityId: number,
+  communityId: string,
   pageToken?: string,
   pageSize?: number,
 ) {
@@ -42,27 +42,27 @@ export async function listCommunityEvents(
   return res.toObject();
 }
 
-export async function getEvent(eventId: number) {
+export async function getEvent(eventId: string) {
   const req = new GetEventReq();
   req.setEventId(eventId);
   const res = await client.events.getEvent(req);
   return res.toObject();
 }
 
-export function cancelEvent(eventId: number) {
+export function cancelEvent(eventId: string) {
   const req = new CancelEventReq();
   req.setEventId(eventId);
   return client.events.cancelEvent(req);
 }
 
-export function RequestCommunityInvite(eventId: number) {
+export function RequestCommunityInvite(eventId: string) {
   const req = new RequestCommunityInviteReq();
   req.setEventId(eventId);
   return client.events.requestCommunityInvite(req);
 }
 
 interface ListEventUsersInput {
-  eventId: number;
+  eventId: string;
   pageSize?: number;
   pageToken?: string;
 }
@@ -106,7 +106,7 @@ export async function setEventAttendance({
   eventId,
 }: {
   attendanceState: AttendanceState;
-  eventId: number;
+  eventId: string;
 }) {
   const req = new SetEventAttendanceReq();
   req.setEventId(eventId);
@@ -125,7 +125,7 @@ interface EventInput {
 
 interface OnlineEventInput extends EventInput {
   isOnline: true;
-  parentCommunityId: number;
+  parentCommunityId: string;
   link: string;
 }
 
@@ -134,7 +134,7 @@ interface OfflineEventInput extends EventInput {
   address: string;
   lat: number;
   lng: number;
-  parentCommunityId?: number;
+  parentCommunityId?: string;
 }
 
 export type CreateEventInput = OnlineEventInput | OfflineEventInput;
@@ -182,7 +182,7 @@ export interface UpdateOfflineEventInput
 export type UpdateEventInput = (
   | UpdateOnlineEventInput
   | UpdateOfflineEventInput
-) & { eventId: number; shouldNotify: boolean };
+) & { eventId: string; shouldNotify: boolean };
 
 export async function updateEvent(input: UpdateEventInput) {
   const req = new UpdateEventReq();
@@ -309,7 +309,7 @@ export async function listMyEvents({
   return res.toObject();
 }
 
-export async function inviteEventOrganizer(eventId: number, userId: number) {
+export async function inviteEventOrganizer(eventId: string, userId: string) {
   const req = new InviteEventOrganizerReq();
   req.setEventId(eventId);
   req.setUserId(userId);
@@ -317,10 +317,10 @@ export async function inviteEventOrganizer(eventId: number, userId: number) {
   return res.toObject();
 }
 
-export async function removeEventOrganizer(eventId: number, userId: number) {
+export async function removeEventOrganizer(eventId: string, userId: string) {
   const req = new RemoveEventOrganizerReq();
   req.setEventId(eventId);
-  req.setUserId(new Int64Value().setValue(userId));
+  req.setUserId(new Int64Value().setValue(Number(userId)));
   const res = await client.events.removeEventOrganizer(req);
   return res.toObject();
 }

--- a/app/web/service/gallery.ts
+++ b/app/web/service/gallery.ts
@@ -12,7 +12,7 @@ import client from "./client";
 /**
  * Get a gallery by ID
  */
-export async function getGallery(galleryId: number) {
+export async function getGallery(galleryId: string) {
   const req = new GetGalleryReq();
   req.setGalleryId(galleryId);
 
@@ -23,7 +23,7 @@ export async function getGallery(galleryId: number) {
 /**
  * Get edit info for a gallery (only available to gallery owner)
  */
-export async function getGalleryEditInfo(galleryId: number) {
+export async function getGalleryEditInfo(galleryId: string) {
   const req = new GetGalleryEditInfoReq();
   req.setGalleryId(galleryId);
 
@@ -35,7 +35,7 @@ export async function getGalleryEditInfo(galleryId: number) {
  * Add a photo to a gallery
  */
 export async function addPhotoToGallery(
-  galleryId: number,
+  galleryId: string,
   uploadKey: string,
   caption?: string,
 ) {
@@ -55,8 +55,8 @@ export async function addPhotoToGallery(
  * Remove a photo from a gallery
  */
 export async function removePhotoFromGallery(
-  galleryId: number,
-  itemId: number,
+  galleryId: string,
+  itemId: string,
 ) {
   const req = new RemovePhotoFromGalleryReq();
   req.setGalleryId(galleryId);
@@ -71,9 +71,9 @@ export async function removePhotoFromGallery(
  * @param afterItemId - ID of the photo to place after, or 0 to move to first position
  */
 export async function movePhoto(
-  galleryId: number,
-  itemId: number,
-  afterItemId: number,
+  galleryId: string,
+  itemId: string,
+  afterItemId: string,
 ) {
   const req = new MovePhotoReq();
   req.setGalleryId(galleryId);
@@ -88,8 +88,8 @@ export async function movePhoto(
  * Update the caption of a photo
  */
 export async function updatePhotoCaption(
-  galleryId: number,
-  itemId: number,
+  galleryId: string,
+  itemId: string,
   caption: string,
 ) {
   const req = new UpdatePhotoCaptionReq();

--- a/app/web/service/groups.ts
+++ b/app/web/service/groups.ts
@@ -11,14 +11,14 @@ import {
 
 import client from "./client";
 
-export async function getGroup(groupId: number) {
+export async function getGroup(groupId: string) {
   const req = new GetGroupReq();
   req.setGroupId(groupId);
   const response = await client.groups.getGroup(req);
   return response.toObject();
 }
 
-export async function listAdmins(groupId: number, pageToken?: string) {
+export async function listAdmins(groupId: string, pageToken?: string) {
   const req = new ListAdminsReq();
   req.setGroupId(groupId);
   if (pageToken) {
@@ -28,7 +28,7 @@ export async function listAdmins(groupId: number, pageToken?: string) {
   return response.toObject();
 }
 
-export async function listMembers(groupId: number, pageToken?: string) {
+export async function listMembers(groupId: string, pageToken?: string) {
   const req = new ListMembersReq();
   req.setGroupId(groupId);
   if (pageToken) {
@@ -38,7 +38,7 @@ export async function listMembers(groupId: number, pageToken?: string) {
   return response.toObject();
 }
 
-export async function listPlaces(groupId: number, pageToken?: string) {
+export async function listPlaces(groupId: string, pageToken?: string) {
   const req = new ListPlacesReq();
   req.setGroupId(groupId);
   if (pageToken) {
@@ -48,7 +48,7 @@ export async function listPlaces(groupId: number, pageToken?: string) {
   return response.toObject();
 }
 
-export async function listGuides(groupId: number, pageToken?: string) {
+export async function listGuides(groupId: string, pageToken?: string) {
   const req = new ListGuidesReq();
   req.setGroupId(groupId);
   if (pageToken) {
@@ -58,7 +58,7 @@ export async function listGuides(groupId: number, pageToken?: string) {
   return response.toObject();
 }
 
-export async function listDiscussions(groupId: number, pageToken?: string) {
+export async function listDiscussions(groupId: string, pageToken?: string) {
   const req = new ListDiscussionsReq();
   req.setGroupId(groupId);
   if (pageToken) {
@@ -68,13 +68,13 @@ export async function listDiscussions(groupId: number, pageToken?: string) {
   return response.toObject();
 }
 
-export async function joinGroup(groupId: number) {
+export async function joinGroup(groupId: string) {
   const req = new JoinGroupReq();
   req.setGroupId(groupId);
   await client.groups.joinGroup(req);
 }
 
-export async function leaveGroup(groupId: number) {
+export async function leaveGroup(groupId: string) {
   const req = new LeaveGroupReq();
   req.setGroupId(groupId);
   await client.groups.leaveGroup(req);

--- a/app/web/service/jail.ts
+++ b/app/web/service/jail.ts
@@ -55,7 +55,7 @@ export async function setAcceptedCommunityGuidelines(accepted: boolean) {
 }
 
 export async function acknowledgePendingModNote(
-  modNoteId: number,
+  modNoteId: string,
   acknowledge: boolean,
 ) {
   const req = new AcknowledgePendingModNoteReq();

--- a/app/web/service/pages.ts
+++ b/app/web/service/pages.ts
@@ -35,7 +35,7 @@ export async function createPlace(
 export async function createGuide(
   title: string,
   content: string,
-  parentCommunityId: number,
+  parentCommunityId: string,
   address: string,
   lat?: number,
   lng?: number,
@@ -56,7 +56,7 @@ export async function createGuide(
   return response.toObject();
 }
 
-export async function getPage(pageId: number) {
+export async function getPage(pageId: string) {
   const req = new GetPageReq();
   req.setPageId(pageId);
   const response = await client.pages.getPage(req);
@@ -65,7 +65,7 @@ export async function getPage(pageId: number) {
 
 interface UpdatePageInput {
   content?: string;
-  pageId: number;
+  pageId: string;
   title?: string;
   photoKey?: string;
 }

--- a/app/web/service/references.ts
+++ b/app/web/service/references.ts
@@ -21,12 +21,12 @@ export enum ReferenceTypeStrings {
 }
 
 interface GetReferencesBaseInput {
-  userId: number;
+  userId: string;
   pageToken?: string;
 }
 
 interface GetAvailableReferencesInput {
-  userId: number;
+  userId: string;
 }
 
 interface WriteReferenceBaseInput {
@@ -38,11 +38,11 @@ interface WriteReferenceBaseInput {
 
 export interface WriteHostRequestReferenceInput
   extends WriteReferenceBaseInput {
-  hostRequestId: number;
+  hostRequestId: string;
 }
 
 export interface WriteFriendReferenceInput extends WriteReferenceBaseInput {
-  toUserId: number;
+  toUserId: string;
 }
 
 type GetReferencesGivenInput = GetReferencesBaseInput;
@@ -134,7 +134,7 @@ export async function listPendingReferencesToWrite() {
   return res.toObject();
 }
 
-export async function getHostRequestReferenceStatus(hostRequestId: number) {
+export async function getHostRequestReferenceStatus(hostRequestId: string) {
   const req = new GetHostRequestReferenceStatusReq();
   req.setHostRequestId(hostRequestId);
   const res = await client.references.getHostRequestReferenceStatus(req);

--- a/app/web/service/requests.ts
+++ b/app/web/service/requests.ts
@@ -15,13 +15,13 @@ import {
 import client from "./client";
 
 export async function listHostRequests({
-  lastRequestId = 0,
+  lastRequestId = "0",
   count = 10,
   type = "all",
   onlyActive,
   onlyArchived,
 }: {
-  lastRequestId?: number;
+  lastRequestId?: string;
   count?: number;
   type?: "all" | "hosting" | "surfing";
   onlyActive?: boolean;
@@ -44,14 +44,14 @@ export async function listHostRequests({
   return response.toObject();
 }
 
-export async function getHostRequest(id: number) {
+export async function getHostRequest(id: string) {
   const req = new GetHostRequestReq();
   req.setHostRequestId(id);
   const response = await client.requests.getHostRequest(req);
   return response.toObject();
 }
 
-export async function sendHostRequestMessage(id: number, text: string) {
+export async function sendHostRequestMessage(id: string, text: string) {
   const req = new SendHostRequestMessageReq();
   req.setHostRequestId(id);
   req.setText(text);
@@ -63,7 +63,7 @@ export async function sendHostRequestMessage(id: number, text: string) {
 }
 
 export async function respondHostRequest(
-  id: number,
+  id: string,
   status: HostRequestStatus,
   text: string,
 ) {
@@ -75,8 +75,8 @@ export async function respondHostRequest(
 }
 
 export async function getHostRequestMessages(
-  id: number,
-  lastMessageId = 0,
+  id: string,
+  lastMessageId = "0",
   count = 20,
 ) {
   const req = new GetHostRequestMessagesReq();
@@ -106,7 +106,7 @@ export async function createHostRequest(data: CreateHostRequestWrapper) {
   return response.getHostRequestId();
 }
 
-export function markLastRequestSeen(hostRequestId: number, messageId: number) {
+export function markLastRequestSeen(hostRequestId: string, messageId: string) {
   const req = new MarkLastSeenHostRequestReq();
   req.setHostRequestId(hostRequestId);
   req.setLastSeenMessageId(messageId);
@@ -114,14 +114,14 @@ export function markLastRequestSeen(hostRequestId: number, messageId: number) {
   return client.requests.markLastSeenHostRequest(req);
 }
 
-export async function getResponseRate(userId: number) {
+export async function getResponseRate(userId: string) {
   const req = new GetResponseRateReq();
   req.setUserId(userId);
   return (await client.requests.getResponseRate(req)).toObject();
 }
 
 export async function setHostRequestArchiveStatus(
-  hostRequestId: number,
+  hostRequestId: string,
   isArchived: boolean,
 ) {
   const req = new SetHostRequestArchiveStatusReq();

--- a/app/web/service/search.ts
+++ b/app/web/service/search.ts
@@ -38,7 +38,7 @@ export interface UserSearchFilters {
   showEmptyProfile?: boolean;
   pageNumber?: number;
   pageSize?: number;
-  selectedUserId?: number;
+  selectedUserId?: string;
   sleepingArrangement?: SleepingArrangementOptions[];
   sameGenderOnly?: boolean;
   smokesAtHome?: boolean | undefined;

--- a/app/web/service/threads.ts
+++ b/app/web/service/threads.ts
@@ -2,7 +2,7 @@ import { GetThreadReq, PostReplyReq } from "proto/threads_pb";
 
 import client from "./client";
 
-export async function getThread(threadId: number, pageToken?: string) {
+export async function getThread(threadId: string, pageToken?: string) {
   const req = new GetThreadReq();
   req.setThreadId(threadId);
   if (pageToken) {
@@ -12,7 +12,7 @@ export async function getThread(threadId: number, pageToken?: string) {
   return response.toObject();
 }
 
-export async function postReply(threadId: number, content: string) {
+export async function postReply(threadId: string, content: string) {
   const req = new PostReplyReq();
   req.setThreadId(threadId);
   req.setContent(content);

--- a/app/web/test/fixtures/community.json
+++ b/app/web/test/fixtures/community.json
@@ -1,5 +1,5 @@
 {
-  "communityId": 2,
+  "communityId": "2",
   "name": "Amsterdam",
   "slug": "amsterdam",
   "description": "This is amsterdam",
@@ -7,7 +7,7 @@
   "parentsList": [
     {
       "community": {
-        "communityId": 1,
+        "communityId": "1",
         "name": "Netherlands",
         "slug": "netherlands",
         "description": "Netherlands region"
@@ -21,7 +21,7 @@
     "lastEditorUserId": 3,
     "creatorUserId": 3,
     "ownerUserId": 0,
-    "ownerCommunityId": 1,
+    "ownerCommunityId": "1",
     "ownerGroupId": 0,
     "threadId": 5,
     "title": "Amsterdam community page",


### PR DESCRIPTION
Our protobuf typescript definitions used the `number` type for protobuf `[u]int64` fields, but at runtime they were actually javascript `strings` (because the javascript `number` type is a double-precision floating point that cannot represent all uint64's). 

Before:

```ts
export namespace GetSignupPageInfoRes {
  export type AsObject = {
    lastSignup?: google_protobuf_timestamp_pb.Timestamp.AsObject,
    lastLocation: string,
    userCount: number,
  }
} 
```

After:

```ts
export namespace GetSignupPageInfoRes {
  export type AsObject = {
    lastSignup?: google_protobuf_timestamp_pb.Timestamp.AsObject,
    lastLocation: string,
    userCount: string,
  }
}
```

Surprisingly, running `yarn lint` didn't find typing issues after this change. I suspect our code often coalesced values to `string`.

Fixes #8113

## Testing
Regenerated protos, ran the frontend and clicked around. Validated the member count still shows properly. I imagine this would crash very fast if it was wrong.

<img width="319" height="77" alt="image" src="https://github.com/user-attachments/assets/a9bde5f7-f869-421d-bfd2-30a39ea97d32" />

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` in app/web, and run tests locally. -->
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
