### PR TITLE
Frontend/build: Don't emit code while typechecking

### DIFF
--- a/app/web/package.json
+++ b/app/web/package.json
@@ -20,7 +20,7 @@
     "serve": "next start",
     "test-ci": "tsc && cross-env NEXT_PUBLIC_API_BASE_URL=http://localhost:8888 CI=true TZ=UTC jest --runInBand --coverageReporters=\"cobertura\" --coverageReporters=\"lcov\" --reporters=\"default\" --reporters=\"jest-junit\" --coverage",
     "test": "cross-env NEXT_PUBLIC_API_BASE_URL=http://localhost:8888 TZ=UTC jest --watch",
-    "typecheck": "tsc",
+    "typecheck": "tsc --noEmit",
     "knip": "knip"
   },
   "dependencies": {


### PR DESCRIPTION
Type-checking doesn't require emitting code. It might make the operation faster, or at least it won't write files we don't need to the disk.

## Testing
Introduced a type error locally and ran `yarn typecheck`.

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` in app/web, and run tests locally. -->
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
