### PR TITLE
Frontend/perf: Cache Intl.DateTimeFormat objects.

### DIFF
--- a/app/web/utils/date.ts
+++ b/app/web/utils/date.ts
@@ -66,8 +66,28 @@ export function localizeDateTimeRange(
   return format.formatRange(start, end);
 }
 
-/// gets in an Intl.DateTimeFormat based on params.
+// Creating Intl.DateTimeFormat every time is 40x slower.
+const intlDateTimeFormatCache = new Map<string, Intl.DateTimeFormat>();
+
+/// Gets an Intl.DateTimeFormat based on params.
 function getIntlDateTimeFormat(
+  args: LocalizeDateTimeParams,
+): Intl.DateTimeFormat {
+  // We can't use args as the Map key as it uses reference equality.
+  // Convert it to a json string. The Symbol type requires special handling.
+  const cacheKey = JSON.stringify(args, (_, v) =>
+    typeof v === "symbol" ? v.toString() : v,
+  );
+  const cached = intlDateTimeFormatCache.get(cacheKey);
+  if (cached) return cached;
+
+  const format = createIntlDateTimeFormat(args);
+  intlDateTimeFormatCache.set(cacheKey, format);
+  return format;
+}
+
+/// Creates a new Intl.DateTimeFormat object based on params.
+function createIntlDateTimeFormat(
   args: LocalizeDateTimeParams,
 ): Intl.DateTimeFormat {
   const options: Intl.DateTimeFormatOptions = {};


### PR DESCRIPTION
Adds a cache for `Intl.DateTimeFormat` objects since I read around the internet that it's recommended and [this benchmark](https://www.measurethat.net/Benchmarks/Show/17387/0/new-intldatetimeformat-vs-cached-intldatetimeformat) confirms it's much faster on my machine.

Test case name | Result
-- | --
new Intl.DateTimeFormat.format() | new Intl.DateTimeFormat.format() x 23,943 ops/sec ±3.33% (56 runs sampled)
cached Intl.DateTimeFormat.format() | cached Intl.DateTimeFormat.format() x 976,681 ops/sec ±1.87% (62 runs sampled)

Unbounded cache size growth isn't a concern. This will clear on navigation and I expect the most different formats a given page will have will be in the low single digits.

## Testing
Verified two different date formats can still be shown.

<img width="1115" height="665" alt="image" src="https://github.com/user-attachments/assets/b3625ba2-0d71-4876-b93c-4e79cda06901" />

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` in app/web, and run tests locally. -->
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
