### PR TITLE
Check certs every 2 hours instead of every 5 days

### DIFF
--- a/app/nginx/scripts/run.sh
+++ b/app/nginx/scripts/run.sh
@@ -2,9 +2,9 @@
 
 /scripts/get-certs.sh
 
-# start cron to automatically renew certs every 5 days
+# start cron to automatically renew certs every 2 hours
 touch /var/log/get-certs.log
-echo "47 5 */5 * * root /scripts/get-certs.sh >> /var/log/get-certs.log 2>&1" > /etc/cron.d/get-certs
+echo "47 */2 * * * root /scripts/get-certs.sh >> /var/log/get-certs.log 2>&1" > /etc/cron.d/get-certs
 cron -f &
 # get output here
 tail -f /var/log/get-certs.log &


### PR DESCRIPTION
Increases the frequency of certificate renewal checks from every 5 days to every 2 hours, so that cert issues are caught and resolved more quickly.

## Testing
This is a cron schedule change in the nginx container startup script — no functional code changes.

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me