### PR TITLE
Add commit_sha and pipeline_id to /version.json

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -222,7 +222,7 @@ build:web:
   script:
     - - *common_functions
     # Add "--load" so that the image is saved locally for "docker create"
-    - build "$WEB_TAG" "$WEB_RELEASE_TAG" "web" "$SLUG" --build-arg environment=production -f app/web/Dockerfile.prod --load
+    - build "$WEB_TAG" "$WEB_RELEASE_TAG" "web" "$SLUG" --build-arg environment=production --build-arg pipeline_id=$CI_PIPELINE_ID -f app/web/Dockerfile.prod --load
     # creates a new docker container (docker create returns the container name), and copies the static folder to the host
     - mkdir -p artifacts && docker cp $(docker create $WEB_TAG):/app/.next/static/ static
     - ./app/web/generate_static_manifest.sh static > static/manifest.txt
@@ -250,7 +250,7 @@ build:web-next:
   script:
     - *common_functions
     # Add "--load" so that the image is saved locally for "docker create"
-    - build "$WEB_NEXT_TAG" "$WEB_NEXT_RELEASE_TAG" "web" "$SLUG-next" --build-arg environment=next -f app/web/Dockerfile.prod --load
+    - build "$WEB_NEXT_TAG" "$WEB_NEXT_RELEASE_TAG" "web" "$SLUG-next" --build-arg environment=next --build-arg pipeline_id=$CI_PIPELINE_ID -f app/web/Dockerfile.prod --load
     # creates a new docker container (docker create returns the container name), and copies the static folder to the host
     - mkdir -p artifacts && docker cp $(docker create $WEB_NEXT_TAG):/app/.next/static/ static
     - ./app/web/generate_static_manifest.sh static > static/manifest.txt

--- a/app/web/Dockerfile.prod
+++ b/app/web/Dockerfile.prod
@@ -54,4 +54,7 @@ EXPOSE 3000
 
 ENV HOSTNAME="::"
 
+ARG pipeline_id
+ENV PIPELINE_ID=$pipeline_id
+
 CMD ["node", "server.js"]

--- a/app/web/pages/version.json.ts
+++ b/app/web/pages/version.json.ts
@@ -9,6 +9,8 @@ export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     JSON.stringify({
       version: process.env.NEXT_PUBLIC_VERSION || "unknown",
       display_version: process.env.NEXT_PUBLIC_DISPLAY_VERSION || "dev",
+      commit_sha: process.env.NEXT_PUBLIC_COMMIT_SHA || "unknown",
+      pipeline_id: process.env.PIPELINE_ID || "unknown",
       stable: Date.now() - startTime >= STABLE_THRESHOLD_MS,
     }),
   );


### PR DESCRIPTION
Adds `commit_sha` and `pipeline_id` fields to the `/version.json` endpoint so we can identify exactly which build is running.

The `pipeline_id` Docker build arg is in the runner stage so it doesn't invalidate the expensive `yarn build` cache in the builder stage.

## Testing
- Deploy and check `/version.json` returns the new fields

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

🤖 Generated with [Claude Code](https://claude.com/claude-code)