### PR TITLE
Reduce stability threshold from 15 to 5 minutes

### DIFF
--- a/app/backend/src/couchers/constants.py
+++ b/app/backend/src/couchers/constants.py
@@ -113,4 +113,4 @@ GALLERY_MAX_PHOTOS_VERIFIED = 4
 COMPLETED_PROFILE_MINIMUM_CHAR_LENGTH = 150
 
 # How long a container must run uninterrupted before /status reports stable=true
-STABLE_THRESHOLD_SECONDS = 15 * 60
+STABLE_THRESHOLD_SECONDS = 5 * 60

--- a/app/web/pages/version.json.ts
+++ b/app/web/pages/version.json.ts
@@ -1,7 +1,7 @@
 import type { GetServerSideProps } from "next";
 
 const startTime = Date.now();
-const STABLE_THRESHOLD_MS = 15 * 60 * 1000;
+const STABLE_THRESHOLD_MS = 5 * 60 * 1000;
 
 export const getServerSideProps: GetServerSideProps = async ({ res }) => {
   res.setHeader("Content-Type", "application/json");


### PR DESCRIPTION
Reduces the stability threshold from 15 minutes to 5 minutes in both backend and frontend, so containers report `stable=true` sooner after startup.

## Testing
- Verified both constants are updated consistently (backend `STABLE_THRESHOLD_SECONDS` and frontend `STABLE_THRESHOLD_MS`)
- No tests to update as the threshold is a configuration value

**Backend checklist**
- [x] Run the backend locally and it works

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me