### PR TITLE
Frontend/i18n: Add a few datetime localization tests

### DIFF
--- a/app/web/utils/date.test.ts
+++ b/app/web/utils/date.test.ts
@@ -11,14 +11,14 @@ describe("localizeDateTime", () => {
       localizeDateTime(dayjs("2000-01-01"), {
         timezone: UTC_TIMEZONE,
         locale: "en",
-      }).toLowerCase(),
+      }),
     ).toContain("2000");
     expect(
       localizeDateTime(dayjs("2000-01-01"), {
         timezone: UTC_TIMEZONE,
         locale: "en",
         includeDate: false,
-      }).toLowerCase(),
+      }),
     ).not.toContain("2000");
   });
 
@@ -27,14 +27,14 @@ describe("localizeDateTime", () => {
       localizeDateTime(dayjs("2000-01-01"), {
         timezone: UTC_TIMEZONE,
         locale: "en",
-      }).toLowerCase(),
-    ).toContain("january");
+      }),
+    ).toContain("January");
     expect(
       localizeDateTime(dayjs("2000-01-01"), {
         timezone: UTC_TIMEZONE,
         locale: "en",
         abbreviate: true,
-      }).toLowerCase(),
+      }),
     ).not.toContain("uary");
   });
 
@@ -44,23 +44,23 @@ describe("localizeDateTime", () => {
         timezone: UTC_TIMEZONE,
         locale: "en",
         includeDayOfWeek: false,
-      }).toLowerCase(),
-    ).not.toContain("sat");
+      }),
+    ).not.toContain("Sat");
     expect(
       localizeDateTime(dayjs("2000-01-01"), {
         timezone: UTC_TIMEZONE,
         locale: "en",
         includeDayOfWeek: true,
-      }).toLowerCase(),
-    ).toContain("saturday");
+      }),
+    ).toContain("Saturday");
     expect(
       localizeDateTime(dayjs("2000-01-01"), {
         timezone: UTC_TIMEZONE,
         locale: "en",
         includeDayOfWeek: true,
         abbreviate: true,
-      }).toLowerCase(),
-    ).toContain("sat");
+      }),
+    ).toContain("Sat");
   });
 
   it("excludes times when specified", () => {
@@ -68,14 +68,14 @@ describe("localizeDateTime", () => {
       localizeDateTime(dayjs("2000-01-01").add(11, "hours"), {
         timezone: UTC_TIMEZONE,
         locale: "en",
-      }).toLowerCase(),
+      }),
     ).toContain("11");
     expect(
       localizeDateTime(dayjs("2000-01-01").add(11, "hours"), {
         timezone: UTC_TIMEZONE,
         locale: "en",
         includeTime: false,
-      }).toLowerCase(),
+      }),
     ).not.toContain("11");
   });
 
@@ -101,16 +101,26 @@ describe("localizeDateTime", () => {
       localizeDateTime(dayjs("2000-01-01"), {
         timezone: UTC_TIMEZONE,
         locale: "en",
-      }).toLowerCase(),
-    ).toContain("jan");
+      }),
+    ).toContain("January");
+    expect(
+      localizeDateTime(dayjs("2000-01-01"), {
+        timezone: UTC_TIMEZONE,
+        locale: "en-US",
+      }),
+    ).toContain("January");
     expect(
       localizeDateTime(dayjs("2000-01-01"), {
         timezone: UTC_TIMEZONE,
         locale: "es",
-      }).toLowerCase(),
-    ).toContain(
-      "ene", // enero = january
-    );
+      }),
+    ).toContain("enero");
+    expect(
+      localizeDateTime(dayjs("2000-01-01"), {
+        timezone: UTC_TIMEZONE,
+        locale: "de",
+      }),
+    ).toContain("Januar");
   });
 });
 


### PR DESCRIPTION
Following up to @nabramow 's comment in https://github.com/Couchers-org/couchers/pull/8019#discussion_r2939495186

I also removed the unneeded `toLowerCase()`. We can assume the casing of date words.

## Testing
Ran the test

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` in app/web, and run tests locally. -->
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me