### PR TITLE
Fix desktop menu design

### DIFF
--- a/app/web/components/Navigation/LoggedInMenu.tsx
+++ b/app/web/components/Navigation/LoggedInMenu.tsx
@@ -393,10 +393,10 @@ export default function LoggedInMenu({
             flex: 1,
             display: "flex",
             flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: { xs: 1.5, md: 3 },
-            textAlign: "center",
+            alignItems: { xs: "center", md: "stretch" },
+            justifyContent: { xs: "center", md: "flex-start" },
+            gap: { xs: 1.5, md: 0 },
+            textAlign: { xs: "center", md: "left" },
           }}
         >
           {items.map((item) => (


### PR DESCRIPTION
Closes #8129 

Desktop menu design got a bit messed up when we changed the mobile menu design. This is fixing it by left-aligning and fixing the hover.

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

- View menu in desktop and make sure it looks okay. Main top left menu.
- View in mobile responsive mode and make sure it still looks okay

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

<img width="379" height="424" alt="Screenshot 2026-03-23 at 15 36 28" src="https://github.com/user-attachments/assets/d21ff7e2-11e9-49b5-84de-7dd674007dea" />

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` in app/web, and run tests locally. -->
- [ x ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ x ] Clicked around my changes running locally and it works
- [ x ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, you can merge it if you have write access.
--->
