### PR TITLE
Make reference list item pill flexible for long text

### DIFF
--- a/app/web/features/profile/view/ReferenceListItem.tsx
+++ b/app/web/features/profile/view/ReferenceListItem.tsx
@@ -24,7 +24,7 @@ const StyledBadgesContainer = styled("div")(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
   marginInlineEnd: theme.spacing(2),
-  minWidth: theme.spacing(9),
+  flexShrink: 0,
 }));
 
 const StyledListItem = styled(ListItem)(({ theme }) => ({


### PR DESCRIPTION
Closes #8149 

Fixes the pill in ReferenceListItem so long text doesn't overflow it. This is how it looked before:

<img width="658" height="432" alt="Screenshot 2026-03-23 at 13 54 50" src="https://github.com/user-attachments/assets/146a1ed8-7797-4e9d-8bdf-5eb711d39462" />


## Testing
- Check ReferenceListItem and change the language to Russian, French, etc. The host surfer and date pills text should not overflow anymore.

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` in app/web, and run tests locally. -->
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, you can merge it if you have write access.
--->
