### PR TITLE
Fix Android deep link handling for email confirmation

### DIFF
--- a/app/mobile/app/login.tsx
+++ b/app/mobile/app/login.tsx
@@ -1,6 +1,7 @@
 import { useFocusEffect } from "@react-navigation/native";
+import * as Linking from "expo-linking";
 import { Href, useRouter } from "expo-router";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Appearance, BackHandler, useColorScheme } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { WebView } from "react-native-webview";
@@ -8,6 +9,21 @@ import { WebView } from "react-native-webview";
 import { useAuthContext } from "@/features/auth/AuthContext";
 import { loginRoute } from "@/routes";
 import { theme } from "@/theme";
+// Auth-related paths that should be forwarded to the WebView when opened via deep link
+const AUTH_DEEP_LINK_PATHS = ["/signup", "/confirm-email", "/complete-password-reset"];
+
+function getWebViewRoute(deepLinkUrl: string | null, webBaseUrl: string): string | null {
+  if (!deepLinkUrl) return null;
+  try {
+    const url = new URL(deepLinkUrl);
+    if (AUTH_DEEP_LINK_PATHS.some((path) => url.pathname.startsWith(path))) {
+      return url.pathname + url.search;
+    }
+  } catch {
+    // Invalid URL, fall through to default
+  }
+  return null;
+}
 
 export default function LoginScreen() {
   const WEB_BASE_URL = process.env.EXPO_PUBLIC_WEB_BASE_URL!;
@@ -16,6 +32,31 @@ export default function LoginScreen() {
   const router = useRouter();
   const colorScheme = useColorScheme();
   const [webViewKey, setWebViewKey] = useState<number>(0);
+  const [initialRoute, setInitialRoute] = useState<string | null>(null);
+  const [checkedDeepLink, setCheckedDeepLink] = useState(false);
+
+  // Check if the app was opened via a deep link (e.g. email confirmation)
+  useEffect(() => {
+    Linking.getInitialURL().then((url) => {
+      const route = getWebViewRoute(url, WEB_BASE_URL);
+      if (route) {
+        setInitialRoute(route);
+      }
+      setCheckedDeepLink(true);
+    });
+  }, [WEB_BASE_URL]);
+
+  // Listen for deep links while the login screen is mounted
+  useEffect(() => {
+    const subscription = Linking.addEventListener("url", (event) => {
+      const route = getWebViewRoute(event.url, WEB_BASE_URL);
+      if (route) {
+        setInitialRoute(route);
+        setWebViewKey((k) => k + 1);
+      }
+    });
+    return () => subscription.remove();
+  }, [WEB_BASE_URL]);
 
   // Prevent Android back button from navigating away from login screen
   // This fixes security bypass where users could press back to access authenticated screens
@@ -73,11 +114,15 @@ export default function LoginScreen() {
     }
   };
 
+  if (!checkedDeepLink) {
+    return <SafeAreaView style={{ flex: 1, backgroundColor }} />;
+  }
+
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor }}>
       <WebView
         key={webViewKey}
-        source={{ uri: WEB_BASE_URL + loginRoute }}
+        source={{ uri: WEB_BASE_URL + (initialRoute ?? loginRoute) }}
         sharedCookiesEnabled
         onMessage={handleMessage}
       />

--- a/app/mobile/app/login.tsx
+++ b/app/mobile/app/login.tsx
@@ -10,9 +10,16 @@ import { useAuthContext } from "@/features/auth/AuthContext";
 import { loginRoute } from "@/routes";
 import { theme } from "@/theme";
 // Auth-related paths that should be forwarded to the WebView when opened via deep link
-const AUTH_DEEP_LINK_PATHS = ["/signup", "/confirm-email", "/complete-password-reset"];
+const AUTH_DEEP_LINK_PATHS = [
+  "/signup",
+  "/confirm-email",
+  "/complete-password-reset",
+];
 
-function getWebViewRoute(deepLinkUrl: string | null, webBaseUrl: string): string | null {
+function getWebViewRoute(
+  deepLinkUrl: string | null,
+  webBaseUrl: string,
+): string | null {
   if (!deepLinkUrl) return null;
   try {
     const url = new URL(deepLinkUrl);

--- a/app/mobile/tests/app/login.test.tsx
+++ b/app/mobile/tests/app/login.test.tsx
@@ -1,6 +1,8 @@
-import { act, render } from "@testing-library/react-native";
+import { render, waitFor } from "@testing-library/react-native";
 import { useFocusEffect } from "@react-navigation/native";
+import * as Linking from "expo-linking";
 import { useRouter } from "expo-router";
+import { act } from "react";
 
 import LoginScreen from "@/app/login";
 import { useAuthContext } from "@/features/auth/AuthContext";
@@ -19,6 +21,11 @@ jest.mock("@react-navigation/native", () => ({
 
 jest.mock("@/features/auth/AuthContext", () => ({
   useAuthContext: jest.fn(),
+}));
+
+jest.mock("expo-linking", () => ({
+  getInitialURL: jest.fn(),
+  addEventListener: jest.fn(() => ({ remove: jest.fn() })),
 }));
 
 let capturedWebViewProps: {
@@ -53,23 +60,113 @@ describe("LoginScreen", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    capturedWebViewProps = {};
     (useRouter as jest.Mock).mockReturnValue(mockRouter);
     (useAuthContext as jest.Mock).mockReturnValue(mockAuthContext);
     (useFocusEffect as jest.Mock).mockImplementation((callback) => callback());
+    (Linking.getInitialURL as jest.Mock).mockResolvedValue(null);
   });
 
   describe("rendering", () => {
-    it("renders WebView with login URL", () => {
+    it("renders WebView with login URL when no deep link", async () => {
       render(<LoginScreen />);
 
-      expect(capturedWebViewProps.source?.uri).toContain(mockWebBaseUrl);
-      expect(capturedWebViewProps.source?.uri).toContain("/login");
+      await waitFor(() => {
+        expect(capturedWebViewProps.source?.uri).toContain(mockWebBaseUrl);
+        expect(capturedWebViewProps.source?.uri).toContain("/login");
+      });
+    });
+
+    it("renders WebView with signup URL when opened via signup deep link", async () => {
+      (Linking.getInitialURL as jest.Mock).mockResolvedValue(
+        "https://couchers.org/signup?token=abc123",
+      );
+
+      render(<LoginScreen />);
+
+      await waitFor(() => {
+        expect(capturedWebViewProps.source?.uri).toBe(
+          mockWebBaseUrl + "/signup?token=abc123",
+        );
+      });
+    });
+
+    it("renders WebView with confirm-email URL when opened via confirm-email deep link", async () => {
+      (Linking.getInitialURL as jest.Mock).mockResolvedValue(
+        "https://couchers.org/confirm-email?token=xyz789",
+      );
+
+      render(<LoginScreen />);
+
+      await waitFor(() => {
+        expect(capturedWebViewProps.source?.uri).toBe(
+          mockWebBaseUrl + "/confirm-email?token=xyz789",
+        );
+      });
+    });
+
+    it("renders WebView with password reset URL when opened via password reset deep link", async () => {
+      (Linking.getInitialURL as jest.Mock).mockResolvedValue(
+        "https://couchers.org/complete-password-reset?token=reset456",
+      );
+
+      render(<LoginScreen />);
+
+      await waitFor(() => {
+        expect(capturedWebViewProps.source?.uri).toBe(
+          mockWebBaseUrl + "/complete-password-reset?token=reset456",
+        );
+      });
+    });
+
+    it("falls back to login URL for non-auth deep links", async () => {
+      (Linking.getInitialURL as jest.Mock).mockResolvedValue(
+        "https://couchers.org/profile/someuser",
+      );
+
+      render(<LoginScreen />);
+
+      await waitFor(() => {
+        expect(capturedWebViewProps.source?.uri).toContain("/login");
+      });
+    });
+  });
+
+  describe("runtime deep link handling", () => {
+    it("reloads WebView when a deep link arrives while mounted", async () => {
+      let urlListener: ((event: { url: string }) => void) | undefined;
+      (Linking.addEventListener as jest.Mock).mockImplementation(
+        (_event: string, callback: (event: { url: string }) => void) => {
+          urlListener = callback;
+          return { remove: jest.fn() };
+        },
+      );
+
+      render(<LoginScreen />);
+
+      await waitFor(() => {
+        expect(capturedWebViewProps.source?.uri).toContain("/login");
+      });
+
+      // Simulate deep link arriving
+      act(() => {
+        urlListener?.({ url: "https://couchers.org/signup?token=late123" });
+      });
+
+      await waitFor(() => {
+        expect(capturedWebViewProps.source?.uri).toBe(
+          mockWebBaseUrl + "/signup?token=late123",
+        );
+      });
     });
   });
 
   describe("LOGIN_SUCCESS handling", () => {
     it("updates auth state on successful login", async () => {
       render(<LoginScreen />);
+      await waitFor(() => {
+        expect(capturedWebViewProps.onMessage).toBeDefined();
+      });
 
       await sendMessage({ type: "LOGIN_SUCCESS", userId: 123, jailed: false });
 
@@ -80,6 +177,9 @@ describe("LoginScreen", () => {
 
     it("handles jailed user correctly", async () => {
       render(<LoginScreen />);
+      await waitFor(() => {
+        expect(capturedWebViewProps.onMessage).toBeDefined();
+      });
 
       await sendMessage({ type: "LOGIN_SUCCESS", userId: 456, jailed: true });
 
@@ -88,6 +188,9 @@ describe("LoginScreen", () => {
 
     it("navigates to dashboard after login", async () => {
       render(<LoginScreen />);
+      await waitFor(() => {
+        expect(capturedWebViewProps.onMessage).toBeDefined();
+      });
 
       await sendMessage({ type: "LOGIN_SUCCESS", userId: 1 });
 
@@ -98,6 +201,9 @@ describe("LoginScreen", () => {
   describe("LOGOUT handling", () => {
     it("clears auth state on logout", async () => {
       render(<LoginScreen />);
+      await waitFor(() => {
+        expect(capturedWebViewProps.onMessage).toBeDefined();
+      });
 
       await sendMessage({ type: "LOGOUT" });
 
@@ -106,10 +212,13 @@ describe("LoginScreen", () => {
   });
 
   describe("message handling", () => {
-    it("ignores non-JSON messages", () => {
+    it("ignores non-JSON messages", async () => {
       jest.spyOn(console, "debug").mockImplementation();
 
       render(<LoginScreen />);
+      await waitFor(() => {
+        expect(capturedWebViewProps.onMessage).toBeDefined();
+      });
 
       expect(() => {
         capturedWebViewProps.onMessage?.({
@@ -122,6 +231,9 @@ describe("LoginScreen", () => {
 
     it("ignores unknown message types", async () => {
       render(<LoginScreen />);
+      await waitFor(() => {
+        expect(capturedWebViewProps.onMessage).toBeDefined();
+      });
 
       await sendMessage({ type: "UNKNOWN" });
 


### PR DESCRIPTION
+ password reset + email change

*Describe briefly what this PR is doing and why.*

The login screen's WebView always loaded /login, ignoring the incoming deep link URL. Now captures the initial URL via Linking.getInitialURL() and listens for runtime deep links, forwarding auth-related paths (/signup, /confirm-email, /complete-password-reset) with their query parameters to the WebView.

Human: This should fix the signup issues we've been having.

<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Backend checklist**
<!-- To avoid CI failures, first run `make format` in app/backend and run tests locally. -->
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
<!-- To avoid CI failures, first run `yarn format` in app/web, and run tests locally. -->
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, you can merge it if you have write access.
--->
