### PR TITLE
Backend/i18n: Fix plural forms for compound locales

### DIFF
--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -105,7 +105,7 @@ class Translation:
                 if isinstance(count, int):
                     try:
                         # Babel resolves the locale name into a filename that uses underscores
-                        babel_locale_name = self.locale.replace('-', '_')
+                        babel_locale_name = self.locale.replace("-", "_")
                         plural_form = Locale(babel_locale_name).plural_form(count)
                     except UnknownLocaleError:
                         # Fallback to English-style plural rule.

--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -104,7 +104,9 @@ class Translation:
             if count := substitutions.get(PLURALIZABLE_VARIABLE_NAME):
                 if isinstance(count, int):
                     try:
-                        plural_form = Locale(self.locale).plural_form(count)
+                        # Babel resolves the locale name into a filename that uses underscores
+                        babel_locale_name = self.locale.replace('-', '_')
+                        plural_form = Locale(babel_locale_name).plural_form(count)
                     except UnknownLocaleError:
                         # Fallback to English-style plural rule.
                         plural_form = "one" if 1 else "other"

--- a/app/backend/src/tests/test_i18n.py
+++ b/app/backend/src/tests/test_i18n.py
@@ -44,7 +44,7 @@ def test_babel_locales():
     i18next = get_main_i18next()
     for locale in i18next.translations_by_locale.keys():
         try:
-            Locale(locale.replace('-', '_'))
+            Locale(locale.replace("-", "_"))
         except UnknownLocaleError:
             unknown_locales.add(locale)
     assert unknown_locales == {"en_CORP"}

--- a/app/backend/src/tests/test_i18n.py
+++ b/app/backend/src/tests/test_i18n.py
@@ -44,7 +44,7 @@ def test_babel_locales():
     i18next = get_main_i18next()
     for locale in i18next.translations_by_locale.keys():
         try:
-            Locale(locale)
+            Locale(locale.replace('-', '_'))
         except UnknownLocaleError:
             unknown_locales.add(locale)
-    assert unknown_locales == {"en_CORP", "es-419", "fr-CA", "nb-NO", "pt-BR", "zh-Hans", "zh-Hant"}
+    assert unknown_locales == {"en_CORP"}


### PR DESCRIPTION
Babel requires underscore delimiting locales like `pt-BR` instead of the standard dash.

Fixes #8029

## Testing
Updated code and test together

**Backend checklist**
<!-- To avoid CI failures, first run `make format` in app/backend and run tests locally. -->
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
