### PR TITLE
Devex: Remove formatting warning from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,13 +13,11 @@ Fill applicable checklists below, or remove those that don't apply.
 -->
 
 **Backend checklist**
-<!-- To avoid CI failures, first run `make format` in app/backend and run tests locally. -->
 - [ ] Added tests for any new code or added a regression test if fixing a bug
 - [ ] Run the backend locally and it works
 - [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history
 
 **Web frontend checklist**
-<!-- To avoid CI failures, first run `yarn format` in app/web, and run tests locally. -->
 - [ ] There are no console warnings when running the app
 - [ ] Added tests where relevant
 - [ ] Clicked around my changes running locally and it works


### PR DESCRIPTION
We're auto-formatting in CI since #7862

I think running tests locally to avoid CI failures should be self-obvious, so I removed that part too.

## Testing
N/A - text

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me