### PR TITLE
Allow importing your data from couchsurfing.com

### DIFF
--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "ua-parser>=1.0.1",
     "user-agents>=2.2.0",
     "statsig-python-core>=0.8.0",
+    "cattrs>=26.1.0",
 ]
 
 [project.scripts]

--- a/app/backend/src/couchers/couchsurfingcom_import.py
+++ b/app/backend/src/couchers/couchsurfingcom_import.py
@@ -1,0 +1,523 @@
+"""
+Helper for importing Couchsurfing™ data export into a Couchers user profile.
+
+This module provides functionality to update an existing Couchers user profile
+with data exported from Couchsurfing.com.
+
+Couchsurfing™ is a trademark of Couchsurfing International, Inc.
+"""
+
+import json
+import logging
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from typing import Any
+
+import cattrs
+from attrs import define, field
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import InstrumentedAttribute
+
+from couchers.i18n import LocalizationContext
+from couchers.models import (
+    CouchsurfingComImportAttempt,
+    LanguageAbility,
+    LanguageFluency,
+    SleepingArrangement,
+    SmokingLocation,
+    User,
+)
+from couchers.resources import language_is_allowed
+from couchers.utils import now
+
+# Maximum JSON size in bytes (20MB)
+MAX_JSON_SIZE = 20 * 1024 * 1024
+
+# Couchsurfing.com section titles (English-only, matching the CS website)
+# These are the exact titles users see when filling in their CS profile
+CS_SECTION_MY_FAVORITE_MUSIC_MOVIES_BOOKS = "My Favorite Music, Movies & Books"
+CS_SECTION_TEACH_LEARN_SHARE = "Teach, Learn, Share"
+CS_SECTION_ONE_AMAZING_THING_IVE_DONE = "One Amazing Thing I've Done"
+CS_SECTION_WHY_IM_ON_COUCHERS = "Why I'm on Couchers"
+CS_SECTION_WHAT_I_CAN_SHARE_WITH_HOSTS = "What I Can Share With Hosts"
+CS_SECTION_DESCRIPTION_OF_SLEEPING_ARRANGEMENT = "Description of Sleeping Arrangement"
+CS_SECTION_ROOMMATE_SITUATION = "Roommate Situation"
+CS_SECTION_PUBLIC_TRANSPORTATION_ACCESS = "Public Transportation Access"
+CS_SECTION_WHAT_I_CAN_SHARE_WITH_GUESTS = "What I Can Share With Guests"
+CS_SECTION_ADDITIONAL_INFORMATION = "Additional Information"
+
+
+def _serialize_value(value: Any) -> Any:
+    """Serialize a value for JSON storage in the import log."""
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (SleepingArrangement, SmokingLocation, LanguageFluency)):
+        return value.name
+    return str(value)
+
+
+logger = logging.getLogger(__name__)
+
+
+# --- Couchsurfing.com Data Schema (attrs classes for cattrs) ---
+
+
+@define
+class CouchsurfingComLanguages:
+    """Languages from Couchsurfing.com profile."""
+
+    fluent: list[str | None] = field(factory=list)
+    learning: list[str | None] = field(factory=list)
+
+
+@define
+class CouchsurfingComProfile:
+    """Profile data from Couchsurfing.com export."""
+
+    first_name: str | None = None
+    last_name: str | None = None
+    gender: str | None = None
+    occupation: str | None = None
+    about_me: str | None = None
+    interests: str | None = None
+    media: str | None = None
+    teach: str | None = None
+    amazing_thing: str | None = None
+    surf_reason: str | None = None
+    offer_hosts: str | None = None
+    languages: CouchsurfingComLanguages = field(factory=CouchsurfingComLanguages)
+    address: str | None = None
+    phone: str | None = None
+    birth_date: str | None = None
+    display_name: str | None = None
+    locale: str | None = None
+    emergency_contact: str | None = None
+    emergency_contact_name: str | None = None
+    emergency_contact_phone: str | None = None
+    emergency_contact_email: str | None = None
+    facebook_friends_number: int | None = None
+
+
+@define
+class CouchsurfingComAvailableDays:
+    """Available days of the week from Couchsurfing.com."""
+
+    mon: bool = True
+    tue: bool = True
+    wed: bool = True
+    thu: bool = True
+    fri: bool = True
+    sat: bool = True
+    sun: bool = True
+
+
+@define
+class CouchsurfingComCouch:
+    """Couch/hosting data from Couchsurfing.com export."""
+
+    id: int | None = None
+    max_guests: int | None = None
+    sleeping_arrangement: str | None = None
+    couch_description: str | None = None
+    offer_guests: str | None = None
+    sleeping_description: str | None = None
+    roommate: str | None = None
+    wheelchair_accessible: bool | None = None
+    public_transport_access: str | None = None
+    can_host_children: bool | None = None
+    smoking_ok: bool | None = None
+    smokes: bool | None = None
+    pets_ok: bool | None = None
+    preferred_gender: str | None = None
+    has_children: bool | None = None
+    has_pets: bool | None = None
+    allow_same_day_requests: bool | None = None
+    allow_multiple_parties: bool | None = None
+    available_days_of_week: CouchsurfingComAvailableDays = field(factory=CouchsurfingComAvailableDays)
+    directions: str | None = None
+
+
+@define
+class CouchsurfingComUserData:
+    """User data section from Couchsurfing.com export."""
+
+    id: int | None = None
+    email: str | None = None
+    username: str | None = None
+    current_sign_in_ip: str | None = None
+    last_sign_in_ip: str | None = None
+    profile: CouchsurfingComProfile = field(factory=CouchsurfingComProfile)
+    couch: CouchsurfingComCouch = field(factory=CouchsurfingComCouch)
+
+
+@define
+class CouchsurfingComFriend:
+    """Friend entry from Couchsurfing.com export."""
+
+    profile: str | None = None
+
+
+@define
+class CouchsurfingComFriends:
+    """Friends section from Couchsurfing.com export."""
+
+    friends: list[CouchsurfingComFriend] = field(factory=list)
+
+
+@define
+class CouchsurfingComExport:
+    """Root schema for Couchsurfing.com data export."""
+
+    user_data: CouchsurfingComUserData = field(factory=CouchsurfingComUserData)
+    friends: CouchsurfingComFriends = field(factory=CouchsurfingComFriends)
+    # We don't parse verifications, messages, etc. as they're not used for profile import
+
+
+def structure_couchsurfingcom_export(data: dict[str, Any]) -> CouchsurfingComExport:
+    return cattrs.structure(data, CouchsurfingComExport)
+
+
+COUCHSURFINGCOM_GENDER_MAP = {
+    "male": "Man",
+    "female": "Woman",
+    "other": "Other",
+}
+
+COUCHSURFINGCOM_SLEEPING_ARRANGEMENT_MAP = {
+    "private_room": SleepingArrangement.private,
+    "public_room": SleepingArrangement.common,
+    "shared_room": SleepingArrangement.shared_room,
+    # We explicitly don't support "shared bed".
+}
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class LanguageUpdate:
+    language_code: str
+    fluency: LanguageFluency
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CouchsurfingComProfileUpdates:
+    """Computed updates from Couchsurfing.com data, ready to be applied to a user."""
+
+    # Profile fields (field_name -> new_value)
+    field_updates: dict[str, Any]
+
+    # Language abilities to set (replaces existing)
+    language_updates: list[LanguageUpdate]
+
+    # Warnings generated during computation
+    warnings: list[str]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CouchsurfingComImportResult:
+    """Result of importing Couchsurfing.com data."""
+
+    success: bool
+    fields_updated: list[str] = dataclass_field(default_factory=list)
+    # Note: warnings are internal/debug strings (not localized), used for logging only
+    warnings: list[str] = dataclass_field(default_factory=list)
+    # errors are user-facing and must be localized
+    errors: list[str] = dataclass_field(default_factory=list)
+    # Old values before the import (for logging/rollback)
+    old_values: dict[str, Any] = dataclass_field(default_factory=dict)
+    # New values after the import (for logging)
+    new_values: dict[str, Any] = dataclass_field(default_factory=dict)
+
+    @classmethod
+    def from_error(cls, e: _ImportError, lctx: LocalizationContext) -> CouchsurfingComImportResult:
+        if isinstance(e, TooLarge):
+            return CouchsurfingComImportResult(
+                success=False,
+                errors=[lctx.localize_string("couchsurfingcom_import.errors.json_too_large")],
+            )
+        elif isinstance(e, InvalidJson):
+            return CouchsurfingComImportResult(
+                success=False,
+                errors=[lctx.localize_string("couchsurfingcom_import.errors.invalid_json")],
+            )
+        elif isinstance(e, ValidationError):
+            return CouchsurfingComImportResult(
+                success=False, errors=[lctx.localize_string("couchsurfingcom_import.errors.invalid_format")]
+            )
+        else:
+            raise RuntimeError("Unknown error") from e
+
+
+def _combine_text_sections(*sections: tuple[str, str | None]) -> str | None:
+    """
+    Combine multiple text sections with headers into one string.
+
+    Each section is a tuple of (header, content).
+    """
+    parts = []
+    for header, content in sections:
+        if content and content.strip():
+            parts.append(f"**{header}**\n\n{content.strip()}")
+    return "\n\n---\n\n".join(parts) if parts else None
+
+
+def compute_profile_updates(
+    couchsurfingcom_data: CouchsurfingComExport,
+) -> CouchsurfingComProfileUpdates:
+    field_updates: dict[InstrumentedAttribute[Any], Any] = {}
+    warnings = []
+    language_updates = []
+    profile = couchsurfingcom_data.user_data.profile
+    couch = couchsurfingcom_data.user_data.couch
+
+    # --- Profile Fields ---
+
+    # Name
+    first_name = profile.first_name or ""
+    last_name = profile.last_name or ""
+    if first_name or last_name:
+        full_name = f"{first_name} {last_name}".strip()
+        field_updates[User.name] = full_name
+
+    # Gender
+    if profile.gender:
+        couchers_gender = COUCHSURFINGCOM_GENDER_MAP.get(profile.gender.lower())
+        if couchers_gender:
+            field_updates[User.gender] = couchers_gender
+        else:
+            warnings.append(f"Unknown gender value: {profile.gender}")
+
+    # Simple profile fields
+    field_updates[User.occupation] = profile.occupation
+    field_updates[User.about_me] = profile.about_me
+    field_updates[User.things_i_like] = profile.interests
+
+    # Additional information (combine multiple CS fields)
+    additional_sections = [
+        (CS_SECTION_MY_FAVORITE_MUSIC_MOVIES_BOOKS, profile.media),
+        (CS_SECTION_TEACH_LEARN_SHARE, profile.teach),
+        (CS_SECTION_ONE_AMAZING_THING_IVE_DONE, profile.amazing_thing),
+        (CS_SECTION_WHY_IM_ON_COUCHERS, profile.surf_reason),
+        (CS_SECTION_WHAT_I_CAN_SHARE_WITH_HOSTS, profile.offer_hosts),
+    ]
+    combined_additional = _combine_text_sections(*additional_sections)
+    field_updates[User.additional_information] = combined_additional
+
+    # --- Couch/Hosting Fields ---
+
+    field_updates[User.max_guests] = couch.max_guests
+
+    # Sleeping arrangement
+    if couch.sleeping_arrangement:
+        sleeping = COUCHSURFINGCOM_SLEEPING_ARRANGEMENT_MAP.get(couch.sleeping_arrangement)
+        if sleeping:
+            field_updates[User.sleeping_arrangement] = sleeping
+        else:
+            warnings.append(f"Unknown sleeping arrangement: {couch.sleeping_arrangement}")
+
+    # Combine both sleeping description fields under one CS section header
+    sleeping_texts = [t for t in (couch.couch_description, couch.sleeping_description) if t and t.strip()]
+    combined_sleeping_content = "\n\n".join(sleeping_texts) if sleeping_texts else None
+    sleeping_sections = [(CS_SECTION_DESCRIPTION_OF_SLEEPING_ARRANGEMENT, combined_sleeping_content)]
+    combined_sleeping = _combine_text_sections(*sleeping_sections)
+    field_updates[User.sleeping_details] = combined_sleeping
+
+    # We can't update "has_housemates", because "roommate" is a text field
+    # and can contain anything, including "I live alone" or whatever.
+    field_updates[User.housemate_details] = couch.roommate
+
+    field_updates[User.area] = couch.public_transport_access
+    field_updates[User.other_host_info] = couch.directions
+    field_updates[User.about_place] = couch.offer_guests
+
+    # Hosting preferences
+    field_updates[User.wheelchair_accessible] = couch.wheelchair_accessible
+    field_updates[User.accepts_kids] = couch.can_host_children
+    field_updates[User.has_kids] = couch.has_children
+    field_updates[User.accepts_pets] = couch.pets_ok
+    field_updates[User.has_pets] = couch.has_pets
+    field_updates[User.last_minute] = couch.allow_same_day_requests
+    field_updates[User.smokes_at_home] = couch.smokes
+
+    if couch.smoking_ok is not None:
+        field_updates[User.smoking_allowed] = SmokingLocation.yes if couch.smoking_ok else SmokingLocation.no
+
+    # --- Language Abilities ---
+    added_languages = set[str]()
+
+    # Add fluent languages
+    for lang_code in profile.languages.fluent:
+        if lang_code and lang_code not in added_languages:
+            if language_is_allowed(lang_code):
+                language_updates.append(LanguageUpdate(language_code=lang_code, fluency=LanguageFluency.fluent))
+                added_languages.add(lang_code)
+            else:
+                warnings.append(f"Unknown language code: {lang_code}")
+
+    # Add learning languages (as beginner)
+    for lang_code in profile.languages.learning:
+        if lang_code and lang_code not in added_languages:
+            if language_is_allowed(lang_code):
+                language_updates.append(LanguageUpdate(language_code=lang_code, fluency=LanguageFluency.beginner))
+                added_languages.add(lang_code)
+            else:
+                warnings.append(f"Unknown language code: {lang_code}")
+
+    return CouchsurfingComProfileUpdates(
+        field_updates={col.name: v for col, v in field_updates.items() if v is not None},
+        warnings=warnings,
+        language_updates=language_updates,
+    )
+
+
+def apply_profile_updates(
+    session: Session,
+    user_id: int,
+    updates: CouchsurfingComProfileUpdates,
+    lctx: LocalizationContext,
+    *,
+    overwrite_existing: bool = False,
+) -> CouchsurfingComImportResult:
+    user = session.execute(select(User).where(User.id == user_id)).scalar_one_or_none()
+    if not user:
+        return CouchsurfingComImportResult(
+            success=False,
+            fields_updated=[],
+            warnings=updates.warnings,
+            errors=[lctx.localize_string("couchsurfingcom_import.errors.user_not_found")],
+        )
+
+    fields_updated: list[str] = []
+    old_values: dict[str, Any] = {}
+    new_values: dict[str, Any] = {}
+
+    # Capture old language abilities before any changes
+    old_languages = [{"code": la.language_code, "fluency": la.fluency.name} for la in user.language_abilities]
+
+    # Apply field updates
+    for field_name, new_value in updates.field_updates.items():
+        current_value = getattr(user, field_name)
+        should_update = overwrite_existing or current_value is None
+        if should_update:
+            old_values[field_name] = _serialize_value(current_value)
+            new_values[field_name] = _serialize_value(new_value)
+            fields_updated.append(field_name)
+            setattr(user, field_name, new_value)
+
+    # Apply language updates
+    has_existing_languages = bool(user.language_abilities)
+    if overwrite_existing or not has_existing_languages:
+        for ability in list(user.language_abilities):
+            session.delete(ability)
+        session.flush()
+
+        new_languages = []
+        for lang_update in updates.language_updates:
+            session.add(
+                LanguageAbility(
+                    user_id=user.id,
+                    language_code=lang_update.language_code,
+                    fluency=lang_update.fluency,
+                )
+            )
+            fluency_name = "fluent" if lang_update.fluency == LanguageFluency.fluent else "beginner"
+            fields_updated.append(f"language:{lang_update.language_code}:{fluency_name}")
+            new_languages.append({"code": lang_update.language_code, "fluency": fluency_name})
+
+        if new_languages:
+            old_values["languages"] = old_languages
+            new_values["languages"] = new_languages
+
+    if fields_updated:
+        user.profile_last_updated = now()
+
+    user.has_imported_from_couchsurfing_com = True
+
+    session.flush()
+
+    return CouchsurfingComImportResult(
+        success=True,
+        fields_updated=fields_updated,
+        warnings=updates.warnings,
+        errors=[],
+        old_values=old_values,
+        new_values=new_values,
+    )
+
+
+class _ImportError(Exception): ...
+
+
+class TooLarge(_ImportError):
+    pass
+
+
+class InvalidJson(_ImportError):
+    pass
+
+
+class ValidationError(_ImportError):
+    pass
+
+
+def parse_couchsurfingcom_data(json_data: str) -> CouchsurfingComExport:
+    if len(json_data) > MAX_JSON_SIZE:
+        raise TooLarge()
+
+    try:
+        data: dict[str, Any] = json.loads(json_data)
+    except json.JSONDecodeError as e:
+        raise InvalidJson() from e
+
+    relevant_data = {key: data[key] for key in ("user_data", "friends") if key in data}
+
+    try:
+        structured = structure_couchsurfingcom_export(relevant_data)
+    except Exception as e:
+        raise ValidationError() from e
+
+    return structured
+
+
+def import_couchsurfingcom_json(
+    session: Session,
+    user_id: int,
+    json_data: str,
+    lctx: LocalizationContext,
+    *,
+    overwrite_existing: bool = False,
+) -> CouchsurfingComImportResult:
+    """
+    Import Couchsurfing.com profile data from a JSON string.
+
+    Args:
+        session: Database session
+        user_id: ID of user to update
+        json_data: JSON string containing Couchsurfing.com export data
+        lctx: Localization context for generating localized errors
+        overwrite_existing: Whether to overwrite existing profile fields
+
+    Returns:
+        CouchsurfingComImportResult with success status, updated fields, warnings, and errors
+    """
+    try:
+        couchsurfingcom_data = parse_couchsurfingcom_data(json_data)
+        updates = compute_profile_updates(couchsurfingcom_data)
+        result = apply_profile_updates(session, user_id, updates, lctx, overwrite_existing=overwrite_existing)
+    except _ImportError as e:
+        result = CouchsurfingComImportResult.from_error(e, lctx)
+
+    session.add(
+        CouchsurfingComImportAttempt(
+            user_id=user_id,
+            success=result.success,
+            raw_json=json_data[:MAX_JSON_SIZE],
+            old_values=result.old_values,
+            new_values=result.new_values,
+            warnings=result.warnings,
+            errors=result.errors,
+        )
+    )
+
+    return result

--- a/app/backend/src/couchers/i18n/locales/en.json
+++ b/app/backend/src/couchers/i18n/locales/en.json
@@ -1,4 +1,12 @@
 {
+  "couchsurfingcom_import": {
+    "errors": {
+      "json_too_large": "The uploaded file is too large. Please ensure it is less than 20MB.",
+      "invalid_json": "The uploaded file is not valid JSON.",
+      "invalid_format": "The uploaded file does not match the expected Couchsurfing™ export format.",
+      "user_not_found": "User not found."
+    }
+  },
   "errors": {
     "account_not_found": "An account with that username or email was not found.",
     "account_suspended": "Your account is suspended.",

--- a/app/backend/src/couchers/migrations/versions/0150_add_couchsurfing_import_tracking.py
+++ b/app/backend/src/couchers/migrations/versions/0150_add_couchsurfing_import_tracking.py
@@ -1,0 +1,58 @@
+"""Add CouchSurfing import tracking
+
+Revision ID: 0150
+Revises: 0149
+Create Date: 2026-03-28 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "0150"
+down_revision = "0149"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "couchsurfingcom_import_attempts",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("created", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("success", sa.Boolean(), nullable=False),
+        sa.Column("raw_json", sa.String(), nullable=False),
+        sa.Column("old_values", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("new_values", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("warnings", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("errors", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["users.id"], name=op.f("fk_couchsurfingcom_import_attempts_user_id_users")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_couchsurfingcom_import_attempts")),
+    )
+    op.create_index(
+        "ix_couchsurfingcom_import_attempts_created",
+        "couchsurfingcom_import_attempts",
+        ["created"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_couchsurfingcom_import_attempts_user_id",
+        "couchsurfingcom_import_attempts",
+        ["user_id"],
+        unique=False,
+    )
+    op.add_column(
+        "users", sa.Column("has_imported_from_couchsurfing_com", sa.Boolean(), server_default="false", nullable=False)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "has_imported_from_couchsurfing_com")
+    op.drop_index("ix_couchsurfingcom_import_attempts_user_id", table_name="couchsurfingcom_import_attempts")
+    op.drop_index("ix_couchsurfingcom_import_attempts_created", table_name="couchsurfingcom_import_attempts")
+    op.drop_table("couchsurfingcom_import_attempts")

--- a/app/backend/src/couchers/models/__init__.py
+++ b/app/backend/src/couchers/models/__init__.py
@@ -5,6 +5,7 @@ from .background_jobs import *  # noqa: F401,F403
 from .base import *  # noqa: F401,F403
 from .clusters import *  # noqa: F401,F403
 from .conversations import *  # noqa: F401,F403
+from .couchsurfingcom_import import *  # noqa: F401,F403
 from .discussions import *  # noqa: F401,F403
 from .donations import *  # noqa: F401,F403
 from .events import *  # noqa: F401,F403

--- a/app/backend/src/couchers/models/couchsurfingcom_import.py
+++ b/app/backend/src/couchers/models/couchsurfingcom_import.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, Index, String, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from couchers.models.base import Base
+
+if TYPE_CHECKING:
+    from couchers.models.users import User
+
+
+class CouchsurfingComImportAttempt(Base, kw_only=True):
+    """
+    Records of Couchsurfing.com import attempts.
+
+    Each attempt is logged regardless of success/failure, allowing users to have
+    multiple import attempts over time.
+    """
+
+    __tablename__ = "couchsurfingcom_import_attempts"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id"))
+    success: Mapped[bool] = mapped_column(Boolean)
+
+    # the raw JSON string as uploaded by the user (stored as-is to preserve original data even if invalid)
+    raw_json: Mapped[str] = mapped_column(String)
+
+    # old values of fields before the import (field_name -> old_value). The keys are fields of the User model.
+    old_values: Mapped[dict[str, Any]] = mapped_column(JSONB)
+
+    # new values of fields after the import (field_name -> new_value). The keys are fields of the User model.
+    new_values: Mapped[dict[str, Any]] = mapped_column(JSONB)
+
+    # warnings generated during import (localized)
+    warnings: Mapped[list[str]] = mapped_column(JSONB)
+
+    # errors encountered, if any (localized)
+    errors: Mapped[list[str]] = mapped_column(JSONB)
+
+    user: Mapped[User] = relationship("User", back_populates="couchsurfingcom_import_attempts", init=False)
+
+    __table_args__ = (
+        Index("ix_couchsurfingcom_import_attempts_user_id", "user_id"),
+        Index("ix_couchsurfingcom_import_attempts_created", "created"),
+    )

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -47,6 +47,7 @@ from couchers.utils import get_coordinates, last_active_coarsen, now
 if TYPE_CHECKING:
     from couchers.models import UserBadge
     from couchers.models.admin import UserAdminTag
+    from couchers.models.couchsurfingcom_import import CouchsurfingComImportAttempt
     from couchers.models.public_trips import PublicTrip
     from couchers.models.rest import InviteCode, ModerationUserList
     from couchers.models.uploads import PhotoGallery
@@ -322,6 +323,11 @@ class User(Base, kw_only=True):
     # whether mods have marked this user has having to update their location
     needs_to_update_location: Mapped[bool] = mapped_column(Boolean, server_default=expression.false(), init=False)
 
+    # whether this user has successfully imported their profile from couchsurfing.com
+    has_imported_from_couchsurfing_com: Mapped[bool] = mapped_column(
+        Boolean, server_default=expression.false(), init=False
+    )
+
     last_antibot: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=text("to_timestamp(0)"), init=False
     )
@@ -361,6 +367,10 @@ class User(Base, kw_only=True):
     )
 
     public_trips: Mapped[list[PublicTrip]] = relationship(init=False, back_populates="user")
+
+    couchsurfingcom_import_attempts: Mapped[list[CouchsurfingComImportAttempt]] = relationship(
+        init=False, back_populates="user"
+    )
 
     __table_args__ = (
         # Verified phone numbers should be unique

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -15,6 +15,7 @@ from couchers import urls
 from couchers.config import config
 from couchers.constants import DONATION_DRIVE_START, PHONE_REVERIFICATION_INTERVAL, SMS_CODE_ATTEMPTS, SMS_CODE_LIFETIME
 from couchers.context import CouchersContext
+from couchers.couchsurfingcom_import import import_couchsurfingcom_json
 from couchers.crypto import (
     b64decode,
     b64encode,
@@ -190,6 +191,7 @@ class Account(account_pb2_grpc.AccountServicer):
             profile_public_visibility=profilepublicitysetting2api[user.public_visibility],
             is_volunteer=volunteer is not None,
             should_show_donation_banner=should_show_donation_banner,
+            has_imported_from_couchsurfing_com=user.has_imported_from_couchsurfing_com,
             **get_strong_verification_fields(session, user),
         )
 
@@ -841,6 +843,34 @@ class Account(account_pb2_grpc.AccountServicer):
 
         return _volunteer_info_to_pb(volunteer, user.username)
 
+    def ImportFromCouchsurfingCom(
+        self, request: account_pb2.ImportFromCouchsurfingComReq, context: CouchersContext, session: Session
+    ) -> account_pb2.ImportFromCouchsurfingComRes:
+        result = import_couchsurfingcom_json(
+            session,
+            context.user_id,
+            request.couchsurfingcom_json,
+            context.localization,
+            overwrite_existing=request.overwrite_existing,
+        )
+
+        session.commit()
+
+        logger.info(
+            "Couchsurfing.com import for user %s: success=%s, fields_updated=%s, warnings=%s, errors=%s",
+            context.user_id,
+            result.success,
+            result.fields_updated,
+            result.warnings,
+            result.errors,
+        )
+
+        return account_pb2.ImportFromCouchsurfingComRes(
+            success=result.success,
+            errors=result.errors,
+            fields_updated=result.fields_updated,
+        )
+
 
 class Iris(iris_pb2_grpc.IrisServicer):
     def Webhook(
@@ -856,8 +886,8 @@ class Iris(iris_pb2_grpc.IrisServicer):
 
         verification_attempt = session.execute(
             select(StrongVerificationAttempt)
-            .where(StrongVerificationAttempt.user_id == reference_payload.user_id)
-            .where(StrongVerificationAttempt.verification_attempt_token == reference_payload.verification_attempt_token)
+            .where(StrongVerificationAttempt.user_id == user_id)
+            .where(StrongVerificationAttempt.verification_attempt_token == verification_attempt_token)
             .where(StrongVerificationAttempt.iris_session_id == json_data["session_id"])
         ).scalar_one()
         iris_status = json_data["session_state"]

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -19,6 +19,7 @@ if "DATABASE_CONNECTION_STRING" not in os.environ:  # pragma: no cover
     )
 
 from couchers.config import config  # noqa: E402
+from couchers.metrics import create_prometheus_server  # noqa: E402
 from couchers.models import Base  # noqa: E402
 from tests.fixtures.db import (  # noqa: E402
     autocommit_engine,
@@ -295,3 +296,8 @@ def moderator():
     """
     user, token = generate_user(is_superuser=True)
     yield Moderator(user, token)
+
+
+@pytest.fixture(scope="session")
+def prometheus_server():
+    return create_prometheus_server(port=0)

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -1,3 +1,4 @@
+import json
 from datetime import UTC, date, datetime, timedelta
 from unittest.mock import patch
 
@@ -1259,3 +1260,67 @@ def test_volunteer_stuff(db):
         assert v.link_type == "email"
         assert v.link_text == "tester@vontester.com.invalid"
         assert v.link_url == "mailto:tester@vontester.com.invalid"
+
+
+def test_ImportFromCouchsurfing_success(db):
+    """Test successful import of Couchsurfing.com data via API endpoint."""
+    user, token = generate_user()
+
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {
+                "first_name": "Jane",
+                "last_name": "Smith",
+                "gender": "female",
+                "occupation": "Photographer",
+                "about_me": "I love traveling and meeting new people!",
+                "interests": "Photography, hiking, cooking",
+                "languages": {
+                    "fluent": ["eng", "fra"],
+                    "learning": ["deu"],
+                },
+            },
+            "couch": {
+                "max_guests": 2,
+                "wheelchair_accessible": True,
+                "smoking_ok": False,
+            },
+        },
+    }
+
+    with account_session(token) as account:
+        res = account.ImportFromCouchsurfingCom(
+            account_pb2.ImportFromCouchsurfingComReq(
+                couchsurfingcom_json=json.dumps(couchsurfingcom_data),
+                overwrite_existing=True,
+            )
+        )
+
+        assert res.success
+        assert len(res.errors) == 0
+
+    # Verify the data was actually saved
+    with session_scope() as session:
+        updated_user = session.execute(select(User).where(User.id == user.id)).scalar_one()
+        assert updated_user.name == "Jane Smith"
+        assert updated_user.gender == "Woman"
+        assert updated_user.occupation == "Photographer"
+        assert updated_user.about_me == "I love traveling and meeting new people!"
+        assert updated_user.max_guests == 2
+
+
+def test_ImportFromCouchsurfing_invalid_json(db):
+    """Test error handling for invalid JSON in Couchsurfing.com import."""
+    user, token = generate_user()
+
+    with account_session(token) as account:
+        res = account.ImportFromCouchsurfingCom(
+            account_pb2.ImportFromCouchsurfingComReq(
+                couchsurfingcom_json="this is not valid json {",
+                overwrite_existing=False,
+            )
+        )
+
+        assert not res.success
+        assert len(res.errors) == 1
+        assert "not valid JSON" in res.errors[0]

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -35,7 +35,6 @@ from couchers.jobs.handlers import (
 )
 from couchers.jobs.worker import _run_job_and_schedule, process_job, run_scheduler, service_jobs
 from couchers.materialized_views import refresh_materialized_views
-from couchers.metrics import create_prometheus_server
 from couchers.models import (
     AccountDeletionToken,
     BackgroundJob,
@@ -71,8 +70,8 @@ def _(testconfig):
     pass
 
 
-def _check_job_counter(job, status, attempt, exception):
-    metrics_string = requests.get("http://localhost:8000").text
+def _check_job_counter(port, job, status, attempt, exception):
+    metrics_string = requests.get(f"http://localhost:{port}").text
     string_to_check = f'attempt="{attempt}",exception="{exception}",job="{job}",status="{status}"'
     assert string_to_check in metrics_string
 
@@ -336,7 +335,7 @@ def test_scheduler(db, monkeypatch):
     def send_message_notifications(payload: empty_pb2.Empty):
         return
 
-    MOCK_JOBS = {
+    mock_jobs = {
         "purge_login_tokens": Job(purge_login_tokens, timedelta(seconds=7)),
         "send_message_notifications": Job(send_message_notifications, timedelta(seconds=11)),
     }
@@ -363,7 +362,7 @@ def test_scheduler(db, monkeypatch):
         _run_job_and_schedule(sched, job, frequency)
 
     monkeypatch.setattr(couchers.jobs.worker, "_run_job_and_schedule", mock_run_job_and_schedule)
-    monkeypatch.setattr(couchers.jobs.worker, "JOBS", MOCK_JOBS)
+    monkeypatch.setattr(couchers.jobs.worker, "JOBS", mock_jobs)
     monkeypatch.setattr(couchers.jobs.worker, "monotonic", mock_monotonic)
     monkeypatch.setattr(couchers.jobs.worker, "sleep", mock_sleep)
 
@@ -410,7 +409,7 @@ def test_scheduler(db, monkeypatch):
         )
 
 
-def test_job_retry(db):
+def test_job_retry(db, prometheus_server):
     called_count = 0
 
     def mock_job(payload: empty_pb2.Empty) -> None:
@@ -424,7 +423,6 @@ def test_job_retry(db):
     MOCK_JOBS: dict[str, Job[Any]] = {
         "mock_job": Job(mock_job),
     }
-    create_prometheus_server(port=8000)
 
     # if IN_TEST is true, then the bg worker will raise on exceptions
     new_config = config.copy()
@@ -476,8 +474,9 @@ def test_job_retry(db):
             == 0
         )
 
-    _check_job_counter("mock_job", "error", "4", "Exception")
-    _check_job_counter("mock_job", "failed", "5", "Exception")
+    port = prometheus_server.server_address[1]
+    _check_job_counter(port, "mock_job", "error", "4", "Exception")
+    _check_job_counter(port, "mock_job", "failed", "5", "Exception")
 
 
 def test_no_jobs_no_problem(db):

--- a/app/backend/src/tests/test_cs_import.py
+++ b/app/backend/src/tests/test_cs_import.py
@@ -1,0 +1,893 @@
+import json
+
+import pytest
+from sqlalchemy import select
+
+from couchers.couchsurfingcom_import import (
+    MAX_JSON_SIZE,
+    CouchsurfingComExport,
+    InvalidJson,
+    TooLarge,
+    ValidationError,
+    _serialize_value,
+    apply_profile_updates,
+    compute_profile_updates,
+    import_couchsurfingcom_json,
+    parse_couchsurfingcom_data,
+    structure_couchsurfingcom_export,
+)
+from couchers.db import session_scope
+from couchers.i18n import LocalizationContext
+from couchers.models import CouchsurfingComImportAttempt, LanguageFluency, SleepingArrangement, SmokingLocation, User
+from tests.fixtures.db import generate_user
+
+
+@pytest.fixture
+def lctx():
+    """Localization context for tests."""
+    return LocalizationContext.en_utc()
+
+
+@pytest.fixture(autouse=True)
+def _(testconfig):
+    pass
+
+
+# --- Pure function tests (no database needed) ---
+
+
+def test_compute_profile_updates_basic():
+    """Test basic profile field computation from Couchsurfing.com data."""
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {
+                "first_name": "John",
+                "last_name": "Doe",
+                "gender": "male",
+                "occupation": "Software Developer",
+                "about_me": "Hello, I love traveling!",
+                "interests": "Hiking, coding, music",
+            },
+            "couch": {},
+        }
+    }
+
+    couchsurfingcom_export = structure_couchsurfingcom_export(couchsurfingcom_data)
+    updates = compute_profile_updates(couchsurfingcom_export)
+
+    assert updates.field_updates["name"] == "John Doe"
+    assert updates.field_updates["gender"] == "Man"
+    assert updates.field_updates["occupation"] == "Software Developer"
+    assert updates.field_updates["about_me"] == "Hello, I love traveling!"
+    assert updates.field_updates["things_i_like"] == "Hiking, coding, music"
+    assert len(updates.warnings) == 0
+
+
+def test_compute_profile_updates_couch_settings():
+    """Test couch/hosting preferences computation."""
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {},
+            "couch": {
+                "max_guests": 3,
+                "sleeping_arrangement": "shared_room",
+                "wheelchair_accessible": True,
+                "can_host_children": True,
+                "smoking_ok": False,
+                "smokes": False,
+                "pets_ok": True,
+                "has_pets": True,
+                "has_children": False,
+                "allow_same_day_requests": True,
+                "public_transport_access": "5 min walk to metro",
+                "couch_description": "Comfy couch",
+                "sleeping_description": "You get your own room",
+            },
+        }
+    }
+
+    couchsurfingcom_export = structure_couchsurfingcom_export(couchsurfingcom_data)
+    updates = compute_profile_updates(couchsurfingcom_export)
+
+    assert updates.field_updates["max_guests"] == 3
+    assert updates.field_updates["sleeping_arrangement"] == SleepingArrangement.shared_room
+    assert updates.field_updates["wheelchair_accessible"] is True
+    assert updates.field_updates["accepts_kids"] is True
+    assert updates.field_updates["smoking_allowed"] == SmokingLocation.no
+    assert updates.field_updates["smokes_at_home"] is False
+    assert updates.field_updates["accepts_pets"] is True
+    assert updates.field_updates["has_pets"] is True
+    assert updates.field_updates["has_kids"] is False
+    assert updates.field_updates["last_minute"] is True
+    assert updates.field_updates["area"] == "5 min walk to metro"
+    assert "Comfy couch" in updates.field_updates["sleeping_details"]
+    assert "You get your own room" in updates.field_updates["sleeping_details"]
+
+
+def test_compute_profile_updates_languages():
+    """Test language abilities computation."""
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {
+                "languages": {
+                    "fluent": ["eng", "fra"],
+                    "learning": ["deu"],
+                }
+            },
+            "couch": {},
+        }
+    }
+
+    couchsurfingcom_export = structure_couchsurfingcom_export(couchsurfingcom_data)
+    updates = compute_profile_updates(couchsurfingcom_export)
+
+    lang_updates = {lu.language_code: lu.fluency for lu in updates.language_updates}
+    assert lang_updates["eng"] == LanguageFluency.fluent
+    assert lang_updates["fra"] == LanguageFluency.fluent
+    assert lang_updates["deu"] == LanguageFluency.beginner
+
+
+def test_compute_profile_updates_unknown_language():
+    """Test that unknown language codes are reported as warnings."""
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {
+                "languages": {
+                    "fluent": ["unknown_lang_code"],
+                }
+            },
+            "couch": {},
+        }
+    }
+
+    couchsurfingcom_export = structure_couchsurfingcom_export(couchsurfingcom_data)
+    updates = compute_profile_updates(couchsurfingcom_export)
+
+    assert any("unknown_lang_code" in w for w in updates.warnings)
+    # Unknown language should not be in language_updates
+    assert not any(lu.language_code == "unknown_lang_code" for lu in updates.language_updates)
+
+
+def test_compute_profile_updates_gender_mapping():
+    """Test gender mapping from Couchsurfing.com format to Couchers format."""
+    for cs_gender, couchers_gender in [("male", "Man"), ("female", "Woman"), ("other", "Other")]:
+        couchsurfingcom_data = {
+            "user_data": {
+                "profile": {"gender": cs_gender},
+                "couch": {},
+            }
+        }
+
+        couchsurfingcom_export = structure_couchsurfingcom_export(couchsurfingcom_data)
+        updates = compute_profile_updates(couchsurfingcom_export)
+
+        assert updates.field_updates["gender"] == couchers_gender
+
+
+def test_compute_profile_updates_additional_info_combined():
+    """Test that additional info sections are combined properly."""
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {
+                "media": "I love jazz",
+                "teach": "Python programming",
+                "amazing_thing": "Climbed a mountain",
+            },
+            "couch": {},
+        }
+    }
+
+    couchsurfingcom_export = structure_couchsurfingcom_export(couchsurfingcom_data)
+    updates = compute_profile_updates(couchsurfingcom_export)
+
+    additional_info = updates.field_updates["additional_information"]
+    assert "I love jazz" in additional_info
+    assert "Python programming" in additional_info
+    assert "Climbed a mountain" in additional_info
+
+
+def test_compute_profile_updates_roommate_details():
+    """Test that roommate text is computed as housemate_details."""
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {},
+            "couch": {"roommate": "I live alone with my cat"},
+        }
+    }
+
+    couchsurfingcom_export = structure_couchsurfingcom_export(couchsurfingcom_data)
+    updates = compute_profile_updates(couchsurfingcom_export)
+
+    assert updates.field_updates["housemate_details"] == "I live alone with my cat"
+
+
+def test_parse_couchsurfingcom_data_invalid_json():
+    """Test that invalid JSON raises InvalidJson."""
+    with pytest.raises(InvalidJson):
+        parse_couchsurfingcom_data("not valid json {")
+
+
+def test_parse_couchsurfingcom_data_too_large():
+    """Test that JSON over 20MB raises TooLarge."""
+    large_json = "x" * (MAX_JSON_SIZE + 1)
+
+    with pytest.raises(TooLarge):
+        parse_couchsurfingcom_data(large_json)
+
+
+def test_structure_couchsurfingcom_export_full():
+    """Test cattrs schema parsing with a complete CS export structure."""
+    raw_data = {
+        "user_data": {
+            "id": 12345,
+            "email": "test@example.com",
+            "username": "testuser",
+            "profile": {
+                "first_name": "Test",
+                "last_name": "User",
+                "gender": "male",
+                "occupation": "Developer",
+                "about_me": "About me text",
+                "interests": "Coding",
+                "media": "Music",
+                "teach": "Programming",
+                "amazing_thing": "Built something",
+                "surf_reason": "Travel",
+                "offer_hosts": "Conversation",
+                "languages": {
+                    "fluent": ["eng", "fra"],
+                    "learning": ["deu", None],
+                },
+                "birth_date": "1990-01-15T00:00:00.000Z",
+            },
+            "couch": {
+                "id": 12345,
+                "max_guests": 2,
+                "sleeping_arrangement": "shared_room",
+                "couch_description": "Comfy couch",
+                "wheelchair_accessible": False,
+                "smoking_ok": True,
+                "has_pets": True,
+                "available_days_of_week": {
+                    "mon": True,
+                    "tue": True,
+                    "wed": False,
+                },
+            },
+        },
+        "friends": {
+            "friends": [
+                {"profile": "https://example.com/user/1"},
+                {"profile": "https://example.com/user/2"},
+            ]
+        },
+    }
+
+    couchsurfingcom_export = structure_couchsurfingcom_export(raw_data)
+
+    # Verify it's the correct type
+    assert isinstance(couchsurfingcom_export, CouchsurfingComExport)
+
+    # Verify user_data
+    assert couchsurfingcom_export.user_data.id == 12345
+    assert couchsurfingcom_export.user_data.email == "test@example.com"
+    assert couchsurfingcom_export.user_data.username == "testuser"
+
+    # Verify profile
+    profile = couchsurfingcom_export.user_data.profile
+    assert profile.first_name == "Test"
+    assert profile.last_name == "User"
+    assert profile.gender == "male"
+    assert profile.occupation == "Developer"
+    assert profile.about_me == "About me text"
+    assert profile.languages.fluent == ["eng", "fra"]
+    assert profile.languages.learning == ["deu", None]
+
+    # Verify couch
+    couch = couchsurfingcom_export.user_data.couch
+    assert couch.max_guests == 2
+    assert couch.sleeping_arrangement == "shared_room"
+    assert couch.smoking_ok is True
+    assert couch.has_pets is True
+    assert couch.available_days_of_week.mon is True
+    assert couch.available_days_of_week.wed is False
+
+    # Verify friends
+    assert len(couchsurfingcom_export.friends.friends) == 2
+    assert couchsurfingcom_export.friends.friends[0].profile == "https://example.com/user/1"
+
+
+def test_structure_couchsurfingcom_export_minimal():
+    """Test cattrs schema parsing with minimal data."""
+    raw_data: dict[str, object] = {}
+
+    couchsurfingcom_export = structure_couchsurfingcom_export(raw_data)
+
+    assert isinstance(couchsurfingcom_export, CouchsurfingComExport)
+    # Should have default empty values
+    assert couchsurfingcom_export.user_data.profile.first_name is None
+    assert couchsurfingcom_export.user_data.couch.max_guests is None
+    assert couchsurfingcom_export.friends.friends == []
+
+
+def test_structure_couchsurfingcom_export_ignores_unknown_fields():
+    """Test that cattrs schema ignores unknown fields in the input."""
+    raw_data = {
+        "user_data": {
+            "profile": {
+                "first_name": "Test",
+                "unknown_field": "should be ignored",
+                "another_unknown": 12345,
+            },
+            "couch": {},
+        },
+        "unknown_top_level": "ignored",
+    }
+
+    # Should not raise an exception
+    couchsurfingcom_export = structure_couchsurfingcom_export(raw_data)
+
+    assert couchsurfingcom_export.user_data.profile.first_name == "Test"
+
+
+# --- Database-dependent tests ---
+
+
+def test_apply_profile_updates_no_overwrite(db, lctx):
+    """Test that existing fields are not overwritten when overwrite_existing=False."""
+    user, token = generate_user()
+
+    # Set initial value
+    with session_scope() as session:
+        db_user = session.get(User, user.id)
+        assert db_user is not None
+        db_user.about_me = "My original about me"
+        session.commit()
+
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {
+                "about_me": "New about me from Couchsurfing.com",
+            },
+            "couch": {},
+        }
+    }
+
+    couchsurfingcom_export = structure_couchsurfingcom_export(couchsurfingcom_data)
+    updates = compute_profile_updates(couchsurfingcom_export)
+
+    with session_scope() as session:
+        result = apply_profile_updates(session, user.id, updates, lctx, overwrite_existing=False)
+
+        assert result.success
+        assert User.about_me.key not in result.fields_updated
+
+        updated_user = session.get(User, user.id)
+        assert updated_user is not None
+        assert updated_user.about_me == "My original about me"
+
+
+def test_apply_profile_updates_with_overwrite(db, lctx):
+    """Test that existing fields are overwritten when overwrite_existing=True."""
+    user, token = generate_user()
+
+    # Set initial value
+    with session_scope() as session:
+        db_user = session.get(User, user.id)
+        assert db_user is not None
+        db_user.about_me = "My original about me"
+        session.commit()
+
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {
+                "about_me": "New about me from Couchsurfing.com",
+            },
+            "couch": {},
+        }
+    }
+
+    couchsurfingcom_export = structure_couchsurfingcom_export(couchsurfingcom_data)
+    updates = compute_profile_updates(couchsurfingcom_export)
+
+    with session_scope() as session:
+        result = apply_profile_updates(session, user.id, updates, lctx, overwrite_existing=True)
+
+        assert result.success
+        assert User.about_me.key in result.fields_updated
+
+        updated_user = session.get(User, user.id)
+        assert updated_user is not None
+        assert updated_user.about_me == "New about me from Couchsurfing.com"
+
+
+def test_apply_profile_updates_user_not_found(db, lctx):
+    """Test error handling when user is not found."""
+    couchsurfingcom_data: dict[str, dict[str, dict[str, str]]] = {"user_data": {"profile": {}, "couch": {}}}
+    couchsurfingcom_export = structure_couchsurfingcom_export(couchsurfingcom_data)
+    updates = compute_profile_updates(couchsurfingcom_export)
+
+    with session_scope() as session:
+        result = apply_profile_updates(session, 999999, updates, lctx)
+
+        assert not result.success
+        assert len(result.errors) == 1
+        assert "not found" in result.errors[0]
+
+
+def test_import_couchsurfingcom_json_invalid_json(db, lctx):
+    """Test error handling for invalid JSON."""
+    user, token = generate_user()
+
+    with session_scope() as session:
+        result = import_couchsurfingcom_json(session, user.id, "not valid json {", lctx)
+
+        assert not result.success
+        assert any("not valid JSON" in e for e in result.errors)
+
+
+def test_import_couchsurfingcom_json_success(db, lctx):
+    """Test successful import from JSON string."""
+    user, token = generate_user()
+
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {
+                "first_name": "Test",
+                "last_name": "User",
+                "about_me": "Test about me",
+            },
+            "couch": {},
+        }
+    }
+
+    with session_scope() as session:
+        # Use overwrite_existing=True since generate_user() populates default values
+        result = import_couchsurfingcom_json(
+            session, user.id, json.dumps(couchsurfingcom_data), lctx, overwrite_existing=True
+        )
+
+        assert result.success
+        assert User.name.key in result.fields_updated
+        assert User.about_me.key in result.fields_updated
+
+        updated_user = session.get(User, user.id)
+        assert updated_user is not None
+        assert updated_user.name == "Test User"
+        assert updated_user.about_me == "Test about me"
+
+
+def test_apply_profile_updates_with_structured_data(db, lctx):
+    """Test apply_profile_updates with structured CouchsurfingComExport data."""
+    user, token = generate_user()
+
+    raw_data = {
+        "user_data": {
+            "profile": {
+                "first_name": "Direct",
+                "last_name": "Object",
+                "about_me": "Testing CouchsurfingComExport object",
+            },
+            "couch": {
+                "max_guests": 5,
+            },
+        },
+    }
+
+    couchsurfingcom_export = structure_couchsurfingcom_export(raw_data)
+    updates = compute_profile_updates(couchsurfingcom_export)
+
+    with session_scope() as session:
+        result = apply_profile_updates(session, user.id, updates, lctx, overwrite_existing=True)
+
+        assert result.success
+        assert User.name.key in result.fields_updated
+        assert User.max_guests.key in result.fields_updated
+
+        updated_user = session.get(User, user.id)
+        assert updated_user is not None
+        assert updated_user.name == "Direct Object"
+        assert updated_user.max_guests == 5
+
+
+def test_import_couchsurfingcom_json_sets_flag(db, lctx):
+    """Test that successful import creates a CouchsurfingImportLog entry."""
+    user, token = generate_user()
+
+    # Verify no successful import log exists initially
+    with session_scope() as session:
+        log_entry = session.execute(
+            select(CouchsurfingComImportAttempt)
+            .where(CouchsurfingComImportAttempt.user_id == user.id)
+            .where(CouchsurfingComImportAttempt.success == True)
+        ).scalar_one_or_none()
+        assert log_entry is None
+
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {
+                "first_name": "Test",
+                "about_me": "Test about me",
+            },
+            "couch": {},
+        }
+    }
+
+    with session_scope() as session:
+        result = import_couchsurfingcom_json(
+            session, user.id, json.dumps(couchsurfingcom_data), lctx, overwrite_existing=True
+        )
+        assert result.success
+
+    # Verify successful import log now exists
+    with session_scope() as session:
+        log_entry = session.execute(
+            select(CouchsurfingComImportAttempt)
+            .where(CouchsurfingComImportAttempt.user_id == user.id)
+            .where(CouchsurfingComImportAttempt.success == True)
+        ).scalar_one_or_none()
+        assert log_entry is not None
+
+
+def test_import_couchsurfingcom_json_creates_log(db, lctx):
+    """Test that import creates a log entry in CouchsurfingImportLog."""
+    user, token = generate_user()
+
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {
+                "first_name": "LogTest",
+                "about_me": "Testing log entry",
+            },
+            "couch": {"max_guests": 3},
+        }
+    }
+
+    json_str = json.dumps(couchsurfingcom_data)
+
+    with session_scope() as session:
+        result = import_couchsurfingcom_json(session, user.id, json_str, lctx, overwrite_existing=True)
+        assert result.success
+
+    # Verify log entry was created
+    with session_scope() as session:
+        log_entry = session.execute(
+            select(CouchsurfingComImportAttempt).where(CouchsurfingComImportAttempt.user_id == user.id)
+        ).scalar_one()
+
+        assert log_entry.success is True
+        # Old values should be captured
+        assert "name" in log_entry.old_values
+        # New values should be captured
+        assert log_entry.new_values.get("name") == "LogTest"
+        assert log_entry.new_values.get("about_me") == "Testing log entry"
+        assert log_entry.new_values.get("max_guests") == 3
+
+
+def test_import_couchsurfingcom_json_logs_invalid_json(db, lctx):
+    """Test that invalid JSON imports create a failed log entry."""
+    user, token = generate_user()
+
+    invalid_json = "not valid json {"
+
+    with session_scope() as session:
+        result = import_couchsurfingcom_json(session, user.id, invalid_json, lctx)
+        assert not result.success
+
+    # Verify a failed log entry was created
+    with session_scope() as session:
+        log_entry = session.execute(
+            select(CouchsurfingComImportAttempt).where(CouchsurfingComImportAttempt.user_id == user.id)
+        ).scalar_one()
+
+        assert log_entry.success is False
+        assert len(log_entry.errors) > 0
+        assert any("not valid JSON" in e for e in log_entry.errors)
+        # Raw JSON is stored as the original string
+        assert log_entry.raw_json == invalid_json
+
+
+def test_import_couchsurfingcom_json_captures_old_values(db, lctx):
+    """Test that old values are correctly captured before import."""
+    user, token = generate_user()
+
+    # Set initial values
+    with session_scope() as session:
+        db_user = session.get(User, user.id)
+        assert db_user is not None
+        db_user.about_me = "Original about me"
+        db_user.occupation = "Original occupation"
+        session.commit()
+
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {
+                "about_me": "New about me",
+                "occupation": "New occupation",
+            },
+            "couch": {},
+        }
+    }
+
+    with session_scope() as session:
+        result = import_couchsurfingcom_json(
+            session, user.id, json.dumps(couchsurfingcom_data), lctx, overwrite_existing=True
+        )
+        assert result.success
+
+    # Verify old values were captured in log
+    with session_scope() as session:
+        log_entry = session.execute(
+            select(CouchsurfingComImportAttempt).where(CouchsurfingComImportAttempt.user_id == user.id)
+        ).scalar_one()
+
+        assert log_entry.old_values.get("about_me") == "Original about me"
+        assert log_entry.old_values.get("occupation") == "Original occupation"
+        assert log_entry.new_values.get("about_me") == "New about me"
+        assert log_entry.new_values.get("occupation") == "New occupation"
+
+
+def test_import_couchsurfingcom_json_stores_raw_json(db, lctx):
+    """Test that the raw JSON is stored in the log entry."""
+    user, token = generate_user()
+
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {
+                "first_name": "Test",
+                "about_me": "Test about me",
+            },
+            "couch": {},
+        },
+        "friends": {"friends": [{"profile": "https://example.com/user/1"}]},
+    }
+
+    json_str = json.dumps(couchsurfingcom_data)
+
+    with session_scope() as session:
+        result = import_couchsurfingcom_json(session, user.id, json_str, lctx, overwrite_existing=True)
+        assert result.success
+
+    # Verify raw_json is stored as the original string
+    with session_scope() as session:
+        log_entry = session.execute(
+            select(CouchsurfingComImportAttempt).where(CouchsurfingComImportAttempt.user_id == user.id)
+        ).scalar_one()
+
+        assert log_entry.raw_json == json_str
+
+
+def test_import_couchsurfingcom_json_too_large(db, lctx):
+    """Test that JSON over 20MB is rejected."""
+    user, token = generate_user()
+
+    # Create a JSON string that's over 20MB
+    large_json = "x" * (MAX_JSON_SIZE + 1)
+
+    with session_scope() as session:
+        result = import_couchsurfingcom_json(session, user.id, large_json, lctx)
+        assert not result.success
+        assert len(result.errors) > 0
+
+    # Verify a failed log entry was created
+    with session_scope() as session:
+        log_entry = session.execute(
+            select(CouchsurfingComImportAttempt).where(CouchsurfingComImportAttempt.user_id == user.id)
+        ).scalar_one()
+
+        assert log_entry.success is False
+        # Raw JSON is truncated to MAX_JSON_SIZE
+        assert log_entry.raw_json == large_json[:MAX_JSON_SIZE]
+
+
+def test_compute_profile_updates_unknown_gender():
+    """Test that unknown gender values are reported as warnings."""
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {
+                "gender": "unknown_gender_value",
+            },
+            "couch": {},
+        }
+    }
+
+    couchsurfingcom_export = structure_couchsurfingcom_export(couchsurfingcom_data)
+    updates = compute_profile_updates(couchsurfingcom_export)
+
+    assert any("Unknown gender value" in w for w in updates.warnings)
+    assert "gender" not in updates.field_updates
+
+
+def test_compute_profile_updates_unknown_sleeping_arrangement():
+    """Test that unknown sleeping arrangement values are reported as warnings."""
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {},
+            "couch": {
+                "sleeping_arrangement": "shared_bed",  # Not supported
+            },
+        }
+    }
+
+    couchsurfingcom_export = structure_couchsurfingcom_export(couchsurfingcom_data)
+    updates = compute_profile_updates(couchsurfingcom_export)
+
+    assert any("Unknown sleeping arrangement" in w for w in updates.warnings)
+    assert "sleeping_arrangement" not in updates.field_updates
+
+
+def test_compute_profile_updates_unknown_learning_language():
+    """Test that unknown language codes in learning list are reported as warnings."""
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {
+                "languages": {
+                    "fluent": ["eng"],
+                    "learning": ["unknown_learning_lang"],
+                }
+            },
+            "couch": {},
+        }
+    }
+
+    couchsurfingcom_export = structure_couchsurfingcom_export(couchsurfingcom_data)
+    updates = compute_profile_updates(couchsurfingcom_export)
+
+    assert any("unknown_learning_lang" in w for w in updates.warnings)
+    # Unknown language should not be in language_updates
+    assert not any(lu.language_code == "unknown_learning_lang" for lu in updates.language_updates)
+    # Valid language should still be added
+    assert any(lu.language_code == "eng" for lu in updates.language_updates)
+
+
+def test_compute_profile_updates_null_language_codes():
+    """Test that None language codes in lists are skipped without error."""
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {
+                "languages": {
+                    "fluent": [None, "eng", None],
+                    "learning": [None, "fra"],
+                }
+            },
+            "couch": {},
+        }
+    }
+
+    couchsurfingcom_export = structure_couchsurfingcom_export(couchsurfingcom_data)
+    updates = compute_profile_updates(couchsurfingcom_export)
+
+    # Should only include valid languages
+    lang_codes = [lu.language_code for lu in updates.language_updates]
+    assert "eng" in lang_codes
+    assert "fra" in lang_codes
+    assert len(lang_codes) == 2
+    # No warnings about None values
+    assert not any("None" in w for w in updates.warnings)
+
+
+def test_apply_profile_updates_preserves_languages_when_not_overwriting(db, lctx):
+    """Test that existing languages are preserved when overwrite_existing=False."""
+    user, token = generate_user(
+        language_abilities=[
+            ("fin", LanguageFluency.fluent),
+        ]
+    )
+
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {
+                "languages": {
+                    "fluent": ["eng"],
+                }
+            },
+            "couch": {},
+        }
+    }
+
+    couchsurfingcom_export = structure_couchsurfingcom_export(couchsurfingcom_data)
+    updates = compute_profile_updates(couchsurfingcom_export)
+
+    with session_scope() as session:
+        result = apply_profile_updates(session, user.id, updates, lctx, overwrite_existing=False)
+
+        assert result.success
+        # Languages should NOT be updated since user has existing languages
+        assert not any("language:" in f for f in result.fields_updated)
+
+        # Verify existing language is preserved
+        db_user = session.get(User, user.id)
+        assert db_user is not None
+        lang_codes = [la.language_code for la in db_user.language_abilities]
+        assert "fin" in lang_codes
+        assert "eng" not in lang_codes
+
+
+def test_apply_profile_updates_replaces_languages_when_overwriting(db, lctx):
+    """Test that existing languages are replaced when overwrite_existing=True."""
+    user, token = generate_user(
+        language_abilities=[
+            ("fin", LanguageFluency.fluent),
+        ]
+    )
+
+    couchsurfingcom_data = {
+        "user_data": {
+            "profile": {
+                "languages": {
+                    "fluent": ["eng"],
+                }
+            },
+            "couch": {},
+        }
+    }
+
+    couchsurfingcom_export = structure_couchsurfingcom_export(couchsurfingcom_data)
+    updates = compute_profile_updates(couchsurfingcom_export)
+
+    with session_scope() as session:
+        result = apply_profile_updates(session, user.id, updates, lctx, overwrite_existing=True)
+
+        assert result.success
+        # Languages should be updated
+        assert any("language:eng:fluent" in f for f in result.fields_updated)
+
+    # Verify old language was replaced in a fresh session
+    with session_scope() as session:
+        db_user = session.get(User, user.id)
+        assert db_user is not None
+        lang_codes = [la.language_code for la in db_user.language_abilities]
+        assert "eng" in lang_codes
+        assert "fin" not in lang_codes
+
+
+def test_import_couchsurfingcom_json_validation_error(db, lctx):
+    """Test that invalid JSON structure (valid JSON but wrong schema) returns validation error."""
+    user, token = generate_user()
+
+    # Valid JSON but with wrong types that cause cattrs to fail
+    # max_guests should be an int, not a string
+    invalid_structure = {"user_data": {"couch": {"max_guests": "not an int"}}}
+
+    with session_scope() as session:
+        result = import_couchsurfingcom_json(session, user.id, json.dumps(invalid_structure), lctx)
+
+        assert not result.success
+        assert any("does not match" in e for e in result.errors)
+
+    # Verify a failed log entry was created
+    with session_scope() as session:
+        log_entry = session.execute(
+            select(CouchsurfingComImportAttempt).where(CouchsurfingComImportAttempt.user_id == user.id)
+        ).scalar_one()
+
+        assert log_entry.success is False
+
+
+def test_parse_couchsurfingcom_data_validation_error():
+    """Test that invalid structure raises ValidationError."""
+    # Valid JSON but with wrong types that cause cattrs to fail
+    # max_guests should be an int, not a string
+    invalid_structure = {"user_data": {"couch": {"max_guests": "not an int"}}}
+
+    with pytest.raises(ValidationError):
+        parse_couchsurfingcom_data(json.dumps(invalid_structure))
+
+
+def test_serialize_value_fallback():
+    """Test _serialize_value fallback for non-standard types."""
+    # Test with types that aren't explicitly handled
+    assert _serialize_value([1, 2, 3]) == "[1, 2, 3]"
+    assert _serialize_value({"key": "value"}) == "{'key': 'value'}"
+
+    # Standard types should pass through
+    assert _serialize_value("string") == "string"
+    assert _serialize_value(42) == 42
+    assert _serialize_value(3.14) == 3.14
+    assert _serialize_value(True) is True
+    assert _serialize_value(None) is None
+
+    # Enum types should return their name
+    assert _serialize_value(SleepingArrangement.private) == "private"
+    assert _serialize_value(SmokingLocation.yes) == "yes"
+    assert _serialize_value(LanguageFluency.fluent) == "fluent"

--- a/app/backend/src/tests/test_templating.py
+++ b/app/backend/src/tests/test_templating.py
@@ -56,14 +56,6 @@ def _greeting_i18next(value: str) -> I18Next:
     return i18next
 
 
-def _i18next_from_dict(value: dict[str, dict[str, str]]) -> I18Next:
-    i18next = I18Next()
-    for lang_code, strings in value.items():
-        language = i18next.add_translation(lang_code)
-        language.load_json_dict(strings)
-    return i18next
-
-
 def test_translate_no_substitutions() -> None:
     template = Jinja2Template(source='{{ "greeting"|translate }}', html=False)
     i18next = _greeting_i18next("Hello!")

--- a/app/backend/uv.lock
+++ b/app/backend/uv.lock
@@ -169,6 +169,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cattrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096", size = 73054, upload-time = "2026-02-18T22:15:17.958Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.10.5"
 source = { registry = "https://pypi.org/simple" }
@@ -262,6 +275,7 @@ dependencies = [
     { name = "babel" },
     { name = "boto3" },
     { name = "cachetools" },
+    { name = "cattrs" },
     { name = "cryptography" },
     { name = "geoalchemy2" },
     { name = "geoip2" },
@@ -323,6 +337,7 @@ requires-dist = [
     { name = "babel", specifier = ">=2.18.0" },
     { name = "boto3", specifier = ">=1.43.1" },
     { name = "cachetools", specifier = ">=6.2.1" },
+    { name = "cattrs", specifier = ">=26.1.0" },
     { name = "cryptography", specifier = ">=46.0.3" },
     { name = "geoalchemy2", specifier = ">=0.18.0" },
     { name = "geoip2", specifier = ">=5.1.0" },

--- a/app/docker-compose.local-backend.yml
+++ b/app/docker-compose.local-backend.yml
@@ -27,7 +27,7 @@ services:
       service: proxy
     # Tell it how to find the local backend
     extra_hosts:
-      backend: ${BACKEND_HOST:-172.17.0.1}
+      - "backend:host-gateway"
   # Not extending, because we want to build image locally, so that it buids the correct
   # image on Macs. Dockerhub has images only for x86, and they are very slow on ARM Macs.
   postgres:
@@ -37,7 +37,7 @@ services:
     command: ["postgres", "-c", "shared_preload_libraries=pg_stat_statements"]
     # to also log all queries, add: , "-c", "log_statement=all"
     volumes:
-      - "./data/postgres/pgdata:/var/lib/postgresql/data"
+      - "./data/postgres/pgdata:/var/lib/postgresql"
     restart: unless-stopped
     ports:
       - 6545:6545

--- a/app/proto/account.proto
+++ b/app/proto/account.proto
@@ -119,6 +119,10 @@ service Account {
   rpc UpdateMyVolunteerInfo(UpdateMyVolunteerInfoReq) returns (GetMyVolunteerInfoRes) {
     // Updates the current user's volunteer status if they are volunteer
   }
+
+  rpc ImportFromCouchsurfingCom(ImportFromCouchsurfingComReq) returns (ImportFromCouchsurfingComRes) {
+    // Import user profile data from a couchsurfing.com JSON export
+  }
 }
 
 message GetAccountInfoRes {
@@ -162,6 +166,9 @@ message GetAccountInfoRes {
   bool is_volunteer = 18;
 
   bool should_show_donation_banner = 20;
+
+  // whether the user has already imported their profile from couchsurfing.com
+  bool has_imported_from_couchsurfing_com = 21;
 }
 
 message ChangePasswordV2Req {
@@ -370,4 +377,20 @@ message UpdateMyVolunteerInfoReq {
   google.protobuf.StringValue link_text = 5;
   // the URL the link should take you to
   google.protobuf.StringValue link_url = 6;
+}
+
+message ImportFromCouchsurfingComReq {
+  // JSON data from couchsurfing.com export
+  string couchsurfingcom_json = 1;
+  // Whether to overwrite existing profile fields
+  bool overwrite_existing = 2;
+}
+
+message ImportFromCouchsurfingComRes {
+  // Whether the import was successful
+  bool success = 1;
+  // Localized errors encountered (fatal issues)
+  repeated string errors = 2;
+  // List of field names that were updated (empty if nothing imported)
+  repeated string fields_updated = 3;
 }


### PR DESCRIPTION
## How it works

A user presses the import button, upload the archive from couchsufring. We extract the JSON with the data right in the browser (to avoid having to deal with zip bombs etc on the backend), send it to `ImportFromCouchsurfing` endpoint, which validates the JSON and updates the database.

<img width="2446" height="710" alt="Screenshot 2026-03-28 at 10 15 00" src="https://github.com/user-attachments/assets/468a8894-c682-47fe-864f-bc16d857cf79" />

<img width="614" height="471" alt="image" src="https://github.com/user-attachments/assets/3edb2e6a-3e2b-4588-b4fd-583942988c5a" />

