### PR TITLE
Don't redirect to dashboard via web on mobile app

### DIFF
--- a/app/web/features/auth/password/CompleteResetPassword.tsx
+++ b/app/web/features/auth/password/CompleteResetPassword.tsx
@@ -14,6 +14,7 @@ import { useForm } from "react-hook-form";
 import { dashboardRoute } from "routes";
 import { service } from "service";
 import { theme } from "theme";
+import { useIsNativeEmbed } from "utils/nativeLink";
 import stringOrFirstString from "utils/stringOrFirstString";
 
 const StyledContainer = styled(Container)(() => ({
@@ -42,6 +43,7 @@ const StyledTextField = styled(TextField)(() => ({
 
 export default function CompleteResetPassword() {
   const { authState, authActions } = useAuthContext();
+  const isNativeEmbed = useIsNativeEmbed();
   const { t } = useTranslation([AUTH, GLOBAL]);
   const { handleSubmit, register } = useForm<{
     newPassword: string;
@@ -67,7 +69,10 @@ export default function CompleteResetPassword() {
     },
     onSuccess: (authRes) => {
       authActions.firstLogin(authRes.toObject());
-      router.push(dashboardRoute);
+      // In native embed, the mobile app handles navigation via LOGIN_SUCCESS message
+      if (!isNativeEmbed) {
+        router.push(dashboardRoute);
+      }
     },
   });
 

--- a/app/web/features/auth/signup/Signup.tsx
+++ b/app/web/features/auth/signup/Signup.tsx
@@ -27,6 +27,7 @@ import { dashboardRoute, loginRoute, signupRoute } from "routes";
 import { service } from "service";
 import isGrpcError from "service/utils/isGrpcError";
 import { theme } from "theme";
+import { useIsNativeEmbed } from "utils/nativeLink";
 import stringOrFirstString from "utils/stringOrFirstString";
 
 import { useAuthContext } from "../AuthProvider";
@@ -48,6 +49,7 @@ export default function Signup() {
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
   const { authState, authActions } = useAuthContext();
+  const isNativeEmbed = useIsNativeEmbed();
   const authenticated = authState.authenticated;
   const error = authState.error;
 
@@ -117,7 +119,7 @@ export default function Signup() {
 
   return (
     <>
-      {authenticated && <Redirect to={dashboardRoute} />}
+      {authenticated && !isNativeEmbed && <Redirect to={dashboardRoute} />}
       <HtmlMeta title={t("global:sign_up")} />
       <Container
         component="section"


### PR DESCRIPTION
The dashboard redirect messes up stuff on mobile as the communication about cookie status between web and mobile is async.

To simplify things for mobile, I'm disabling the automatic login after signup email confirm, etc. They will need to login again, but this is not so outlandish and it will fix issues with flashing screens between dashboard and login.

It's just a bit trickier with mobile since the mobile app wraps the web app.