### PR TITLE
[wip] Add user email history and allow email reuse after account deletion

### DIFF
--- a/app/backend/src/couchers/migrations/versions/0141_add_user_email_history.py
+++ b/app/backend/src/couchers/migrations/versions/0141_add_user_email_history.py
@@ -1,0 +1,55 @@
+"""Add user email history table and relax email uniqueness
+
+Revision ID: 0141
+Revises: 0140
+Create Date: 2026-03-28 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0141"
+down_revision = "0140"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create the user_email_history table
+    op.create_table(
+        "user_email_history",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.BigInteger(), sa.ForeignKey("users.id"), nullable=False, index=True),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("set_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("removed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    # Populate email history from existing users
+    op.execute(
+        """
+        INSERT INTO user_email_history (user_id, email, set_at)
+        SELECT id, email, joined
+        FROM users
+        """
+    )
+
+    # Drop the old unique constraint on users.email
+    op.drop_constraint("uq_users_email", "users", type_="unique")
+
+    # Add a partial unique index: email must be unique among active (non-deleted, non-banned) users
+    op.create_index(
+        "ix_users_unique_email_active",
+        "users",
+        ["email"],
+        unique=True,
+        postgresql_where=sa.text("banned_at IS NULL AND deleted_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_unique_email_active", table_name="users")
+    op.create_unique_constraint("uq_users_email", "users", ["email"])
+    op.drop_table("user_email_history")

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -106,7 +106,7 @@ class User(Base, kw_only=True):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     username: Mapped[str] = mapped_column(String, unique=True)
-    email: Mapped[str] = mapped_column(String, unique=True)
+    email: Mapped[str] = mapped_column(String)
     # stored in libsodium hash format, can be null for email login
     hashed_password: Mapped[bytes] = mapped_column(Binary)
     # phone number in E.164 format with leading +, for example "+46701740605"
@@ -359,6 +359,13 @@ class User(Base, kw_only=True):
     public_trips: Mapped[list[PublicTrip]] = relationship(init=False, back_populates="user")
 
     __table_args__ = (
+        # Email must be unique among active (non-deleted, non-banned) users
+        Index(
+            "ix_users_unique_email_active",
+            email,
+            unique=True,
+            postgresql_where=and_(banned_at.is_(None), deleted_at.is_(None)),
+        ),
         # Verified phone numbers should be unique
         Index(
             "ix_users_unique_phone",
@@ -578,3 +585,20 @@ class RegionLived(Base, kw_only=True):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
     region_code: Mapped[str] = mapped_column(ForeignKey("regions.code", deferrable=True))
+
+
+class UserEmailHistory(Base, kw_only=True):
+    """
+    Tracks the history of email addresses associated with a user account.
+    Each row records a period during which a user had a particular email address.
+    """
+
+    __tablename__ = "user_email_history"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    email: Mapped[str] = mapped_column(String)
+    set_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
+    removed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
+
+    user: Mapped[User] = relationship(init=False)

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -53,6 +53,7 @@ from couchers.models import (
     StrongVerificationAttemptStatus,
     StrongVerificationCallbackEvent,
     User,
+    UserEmailHistory,
     UserSession,
     Volunteer,
 )
@@ -244,8 +245,25 @@ class Account(account_pb2_grpc.AccountServicer):
         if not is_valid_email(request.new_email):
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_email")
 
-        # email already in use (possibly by this user)
-        if session.execute(select(User).where(User.email == request.new_email)).scalar_one_or_none():
+        # email already in use by an active user (possibly by this user)
+        if session.execute(
+            select(User).where(User.email == request.new_email).where(User.is_visible)
+        ).scalar_one_or_none():
+            context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_email")
+
+        # email was used by a banned user
+        if session.execute(
+            select(User).where(User.email == request.new_email).where(User.banned_at != None)
+        ).scalar_one_or_none():
+            context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_email")
+
+        # email was ever used by a banned user (check history)
+        if session.execute(
+            select(UserEmailHistory)
+            .join(User, User.id == UserEmailHistory.user_id)
+            .where(UserEmailHistory.email == request.new_email)
+            .where(User.banned_at != None)
+        ).first():
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_email")
 
         user.new_email = request.new_email

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -36,6 +36,7 @@ from couchers.models import (
     PhotoGallery,
     SignupFlow,
     User,
+    UserEmailHistory,
     UserSession,
 )
 from couchers.models.notifications import NotificationTopicAction
@@ -202,15 +203,25 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 if not request.HasField("basic"):
                     context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "signup_flow_basic_needed")
                 # TODO: unique across both tables
-                existing_user = session.execute(
-                    select(User).where(User.email == request.basic.email)
+                # Check if an active user already has this email
+                existing_active_user = session.execute(
+                    select(User).where(User.email == request.basic.email).where(User.is_visible)
                 ).scalar_one_or_none()
-                if existing_user:
-                    if not existing_user.is_visible:
-                        context.abort_with_error_code(
-                            grpc.StatusCode.FAILED_PRECONDITION, "signup_email_cannot_be_used"
-                        )
+                if existing_active_user:
                     context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "signup_flow_email_taken")
+
+                # Check if a banned user currently has or ever had this email
+                banned_user_has_email = session.execute(
+                    select(User).where(User.email == request.basic.email).where(User.banned_at != None)
+                ).scalar_one_or_none()
+                banned_user_had_email = session.execute(
+                    select(UserEmailHistory)
+                    .join(User, User.id == UserEmailHistory.user_id)
+                    .where(UserEmailHistory.email == request.basic.email)
+                    .where(User.banned_at != None)
+                ).first()
+                if banned_user_has_email or banned_user_had_email:
+                    context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "signup_email_cannot_be_used")
                 existing_flow = session.execute(
                     select(SignupFlow).where(SignupFlow.email == request.basic.email)
                 ).scalar_one_or_none()
@@ -360,6 +371,9 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
             session.add(user)
             session.flush()
+
+            # Record initial email in history
+            session.add(UserEmailHistory(user_id=user.id, email=user.email))
 
             # Create a profile gallery for the user
             profile_gallery = PhotoGallery(owner_user_id=user.id)
@@ -602,11 +616,26 @@ class Auth(auth_pb2_grpc.AuthServicer):
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "invalid_token")
 
+        old_email = user.email
+
+        # Close the old email history record
+        old_history = session.execute(
+            select(UserEmailHistory)
+            .where(UserEmailHistory.user_id == user.id)
+            .where(UserEmailHistory.email == old_email)
+            .where(UserEmailHistory.removed_at.is_(None))
+        ).scalar_one_or_none()
+        if old_history:
+            old_history.removed_at = now()
+
         user.email = not_none(user.new_email)
         user.new_email = None
         user.new_email_token = None
         user.new_email_token_created = None
         user.new_email_token_expiry = None
+
+        # Record the new email in history
+        session.add(UserEmailHistory(user_id=user.id, email=user.email))
 
         notify(
             session,

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -19,6 +19,7 @@ from couchers.models import (
     PhotoGalleryItem,
     Upload,
     User,
+    UserEmailHistory,
 )
 from couchers.proto import account_pb2, api_pb2, auth_pb2, conversations_pb2, requests_pb2
 from couchers.utils import now, today
@@ -576,6 +577,45 @@ def test_ChangeEmailV2(db, fast_passwords, push_collector: PushCollector):
     push = push_collector.pop_for_user(user_id, last=True)
     assert push.content.title == "Email verified"
     assert push.content.body == "Your new email address has been verified."
+
+
+def test_ChangeEmailV2_records_email_history(db, fast_passwords, push_collector: PushCollector):
+    password = random_hex()
+    new_email = f"{random_hex()}@couchers.org.invalid"
+    user, token = generate_user(hashed_password=hash_password(password))
+    user_id = user.id
+    old_email = user.email
+
+    with account_session(token) as account:
+        account.ChangeEmailV2(
+            account_pb2.ChangeEmailV2Req(
+                password=password,
+                new_email=new_email,
+            )
+        )
+
+    with session_scope() as session:
+        user_updated = session.execute(select(User).where(User.id == user_id)).scalar_one()
+        change_token = user_updated.new_email_token
+
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        auth_api.ConfirmChangeEmailV2(
+            auth_pb2.ConfirmChangeEmailV2Req(
+                change_email_token=change_token,
+            )
+        )
+
+    with session_scope() as session:
+        user_updated = session.execute(select(User).where(User.id == user_id)).scalar_one()
+        assert user_updated.email == new_email
+
+        # New email should be in history without removed_at
+        new_history = session.execute(
+            select(UserEmailHistory)
+            .where(UserEmailHistory.user_id == user_id)
+            .where(UserEmailHistory.email == new_email)
+        ).scalar_one()
+        assert new_history.removed_at is None
 
 
 def test_ChangeEmailV2_sends_proper_emails(db, fast_passwords, push_collector: PushCollector):

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -17,6 +17,7 @@ from couchers.models import (
     PasswordResetToken,
     SignupFlow,
     User,
+    UserEmailHistory,
     UserSession,
 )
 from couchers.proto import account_pb2, api_pb2, auth_pb2
@@ -712,14 +713,50 @@ def test_signup_banned_user_email(db):
 
 
 def test_signup_deleted_user_email(db):
+    """A deleted (non-banned) user's email can be reused for signup."""
     user, _ = generate_user()
+    old_email = user.email
 
     with session_scope() as session:
         session.execute(update(User).where(User.id == user.id).values(deleted_at=func.now()))
 
     with auth_api_session() as (auth_api, _):
+        # Should succeed - deleted user's email can be reused
+        res = auth_api.SignupFlow(auth_pb2.SignupFlowReq(basic=auth_pb2.SignupBasic(name="NewName", email=old_email)))
+        assert res.flow_token
+
+
+def test_signup_deleted_and_banned_user_email(db):
+    """A deleted AND banned user's email cannot be reused for signup."""
+    user, _ = generate_user()
+
+    with session_scope() as session:
+        session.execute(update(User).where(User.id == user.id).values(deleted_at=func.now(), banned_at=func.now()))
+
+    with auth_api_session() as (auth_api, _):
         with pytest.raises(grpc.RpcError) as e:
             auth_api.SignupFlow(auth_pb2.SignupFlowReq(basic=auth_pb2.SignupBasic(name="NewName", email=user.email)))
+        assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+        assert e.value.details() == "You cannot sign up with that email address."
+
+
+def test_signup_banned_user_old_email(db):
+    """An email that a banned user previously had (but changed away from) cannot be reused."""
+    user, _ = generate_user()
+    old_email = user.email
+
+    with session_scope() as session:
+        # Record old email in history and change user's email
+        session.add(UserEmailHistory(user_id=user.id, email=old_email, removed_at=func.now()))
+        session.execute(
+            update(User)
+            .where(User.id == user.id)
+            .values(email=f"changed-{random_hex(12)}@couchers.org.invalid", banned_at=func.now())
+        )
+
+    with auth_api_session() as (auth_api, _):
+        with pytest.raises(grpc.RpcError) as e:
+            auth_api.SignupFlow(auth_pb2.SignupFlowReq(basic=auth_pb2.SignupBasic(name="NewName", email=old_email)))
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
         assert e.value.details() == "You cannot sign up with that email address."
 


### PR DESCRIPTION
Track all email addresses a user has ever had via a new user_email_history table. Relax email uniqueness so deleted (non-banned) users' emails can be reused for new signups or email changes. Banned users' emails (current and historical) remain blocked.

*Describe briefly what this PR is doing and why.*

<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, you can merge it if you have write access.
--->
