### PR TITLE
Fix crash when web push endpoint is permanently-removed.invalid

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ make mypy
 - gRPC for API (defined in `/app/proto`)
 - Background jobs in `couchers/jobs/handlers.py`
 - Notifications system in `couchers/notifications/`
-- Always run `make format` after changes
+- Always run `make format` and `make mypy` after modifying backend code
 - NEVER try-catch an exception and silently throw it away or just log it. By and large you don't need to wrap code in try-catch blocks, we already handle exceptions
 - Use `enum.auto()` for all enums (except in the rare case that they are inherently ordinal and we use that order in business logic)
 - Put relationships and constraints at the end of models

--- a/app/backend/src/couchers/i18n/locales/en.json
+++ b/app/backend/src/couchers/i18n/locales/en.json
@@ -107,6 +107,7 @@
     "invalid_started_volunteering_date": "Invalid start date for volunteering.",
     "invalid_stopped_volunteering_date": "Invalid end date for volunteering.",
     "invalid_email": "Invalid email.",
+    "invalid_endpoint": "Invalid push notification endpoint.",
     "invalid_guide_location": "You need to either supply an address and location or neither for a guide.",
     "invalid_host_request_status": "You can't set the host request status to that.",
     "invalid_invite_code": "Invite code is invalid or expired.",

--- a/app/backend/src/couchers/notifications/send_raw_push_notification.py
+++ b/app/backend/src/couchers/notifications/send_raw_push_notification.py
@@ -77,7 +77,7 @@ def _send_web_push(
     sub: PushNotificationSubscription, payload: jobs_pb2.SendRawPushNotificationPayloadV2
 ) -> PushDeliveryResult:
     """Send via Web Push API. Raises appropriate exceptions on failure."""
-    if is_known_invalid_endpoint(sub.endpoint):
+    if is_known_invalid_endpoint(not_none(sub.endpoint)):
         raise PermanentSubscriptionFailure("Endpoint is https://permanently-removed.invalid/")
 
     data = json.dumps(

--- a/app/backend/src/couchers/notifications/send_raw_push_notification.py
+++ b/app/backend/src/couchers/notifications/send_raw_push_notification.py
@@ -72,6 +72,9 @@ def _send_web_push(
     sub: PushNotificationSubscription, payload: jobs_pb2.SendRawPushNotificationPayloadV2
 ) -> PushDeliveryResult:
     """Send via Web Push API. Raises appropriate exceptions on failure."""
+    if sub.endpoint.startswith("https://permanently-removed.invalid/"):
+        raise PermanentSubscriptionFailure("Endpoint is https://permanently-removed.invalid/")
+
     data = json.dumps(
         {
             "title": payload.title,

--- a/app/backend/src/couchers/notifications/send_raw_push_notification.py
+++ b/app/backend/src/couchers/notifications/send_raw_push_notification.py
@@ -23,6 +23,11 @@ from couchers.utils import not_none, now
 logger = logging.getLogger(__name__)
 
 
+def is_known_invalid_endpoint(endpoint: str) -> bool:
+    # Edge on Android can generate this bad endpoint URL
+    return endpoint.startswith("https://permanently-removed.invalid/")
+
+
 class PushNotificationError(Exception):
     """Base exception for push notification errors.
 
@@ -72,7 +77,7 @@ def _send_web_push(
     sub: PushNotificationSubscription, payload: jobs_pb2.SendRawPushNotificationPayloadV2
 ) -> PushDeliveryResult:
     """Send via Web Push API. Raises appropriate exceptions on failure."""
-    if sub.endpoint.startswith("https://permanently-removed.invalid/"):
+    if is_known_invalid_endpoint(sub.endpoint):
         raise PermanentSubscriptionFailure("Endpoint is https://permanently-removed.invalid/")
 
     data = json.dumps(

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -24,6 +24,7 @@ from couchers.models import (
 )
 from couchers.notifications.push import PushNotificationContent, push_to_subscription, push_to_user
 from couchers.notifications.render_push import render_adhoc_push_notification, render_push_notification
+from couchers.notifications.send_raw_push_notification import is_known_invalid_endpoint
 from couchers.notifications.settings import (
     PreferenceNotUserEditableError,
     get_topic_actions_by_delivery_type,
@@ -173,6 +174,9 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         data = json.loads(request.full_subscription_json)
+        if is_known_invalid_endpoint(data["endpoint"]):
+            context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_endpoint")
+
         subscription = PushNotificationSubscription(
             user_id=context.user_id,
             platform=PushNotificationPlatform.web_push,

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -498,6 +498,28 @@ def test_RegisterPushNotificationSubscription(db):
         )
 
 
+def test_RegisterPushNotificationSubscription_invalid_endpoint(db):
+    _, token = generate_user()
+
+    subscription_info = {
+        "endpoint": "https://permanently-removed.invalid/some-id",
+        "expirationTime": None,
+        "keys": {
+            "auth": "TnuEJ1OdfEkf6HKcUovl0Q",
+            "p256dh": "BK7Rp8og3eFJPqm0ofR8F-l2mtNCCCWYo6f_5kSs8jPEFiKetnZHNOglvC6IrgU9vHmgFHlG7gHGtB1HM599sy0",
+        },
+    }
+
+    with notifications_session(token) as notifications:
+        with pytest.raises(grpc.RpcError) as e:
+            notifications.RegisterPushNotificationSubscription(
+                notifications_pb2.RegisterPushNotificationSubscriptionReq(
+                    full_subscription_json=json.dumps(subscription_info),
+                )
+            )
+        assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+
 def test_SendTestPushNotification(db, push_collector: PushCollector):
     user, token = generate_user()
 


### PR DESCRIPTION
Closes #8211 with duck tape.

Some browsers (observed on Edge on Android) register web push subscriptions with an endpoint of `https://permanently-removed.invalid/`. When we try to send a push notification to this endpoint, DNS resolution fails.

This adds a check before sending: if the endpoint starts with `https://permanently-removed.invalid/`, we immediately raise a `PermanentSubscriptionFailure`, which disables the subscription.

## Testing
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me