### PR TITLE
Adjust complete reset password redirect for mobile

### DIFF
--- a/app/web/features/auth/password/CompleteResetPassword.tsx
+++ b/app/web/features/auth/password/CompleteResetPassword.tsx
@@ -3,6 +3,7 @@ import { useMutation } from "@tanstack/react-query";
 import Alert from "components/Alert";
 import Button from "components/Button";
 import HtmlMeta from "components/HtmlMeta";
+import Redirect from "components/Redirect";
 import TextField from "components/TextField";
 import { useAuthContext } from "features/auth/AuthProvider";
 import { RpcError } from "grpc-web";
@@ -67,7 +68,6 @@ export default function CompleteResetPassword() {
     },
     onSuccess: (authRes) => {
       authActions.firstLogin(authRes.toObject());
-      router.push(dashboardRoute);
     },
   });
 
@@ -92,6 +92,7 @@ export default function CompleteResetPassword() {
 
   return (
     <StyledContainer>
+      {authState.authenticated && <Redirect to={dashboardRoute} />}
       <HtmlMeta title={t("auth:change_password_form.title")} />
 
       {!isResetTokenOk && (


### PR DESCRIPTION
Adjust the complete password reset redirect to work the same way the Login.tsx one does. This should fix an issue with timing between mobile and web as this waits until authentication is done.

I've tested this on desktop to make sure it's backwards compatible and all looks good to me.