### PR TITLE
Skip duplicate missed_messages notification for host request creation

### DIFF
--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -384,6 +384,33 @@ def send_request_notifications(payload: empty_pb2.Empty) -> None:
                 user.last_notified_request_message_id = max(user.last_notified_request_message_id, max_message_id)
                 session.flush()
 
+                # When a host request is created, the recipient immediately receives a
+                # host_request__create notification that includes the initial message text.
+                # A few minutes later, this background job sees that same message as "unseen"
+                # (the recipient hasn't opened the request yet) and would send a duplicate
+                # missed_messages notification.
+                #
+                # To prevent this, we check if the only unseen text message in this host
+                # request is the very first text message in the conversation (i.e. the
+                # creation message). If so, we skip sending missed_messages — the user was
+                # already notified via host_request__create.
+                #
+                # Advancing last_notified_request_message_id above is safe even when we skip
+                # the notification: this watermark is only ever advanced when we process all
+                # unseen messages for the user, so skipping one notification doesn't cause us
+                # to miss future messages in other host requests.
+                only_creation_message = not session.execute(
+                    select(
+                        select(func.count())
+                        .where(Message.conversation_id == host_request.conversation_id)
+                        .where(Message.message_type == MessageType.text)
+                        .scalar_subquery()
+                        > 1
+                    )
+                ).scalar_one()
+                if only_creation_message:
+                    continue
+
                 notify(
                     session,
                     user_id=user.id,

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -656,7 +656,6 @@ def test_send_request_notifications_host_request(db, moderator):
     with session_scope() as session:
         assert session.execute(select(func.count()).select_from(BackgroundJob)).scalar_one() == 0
 
-    # first test that sending host request creates email
     with requests_session(token1) as requests:
         host_request_id = requests.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
@@ -666,27 +665,13 @@ def test_send_request_notifications_host_request(db, moderator):
     moderator.approve_host_request(host_request_id)
 
     with session_scope() as session:
-        # delete send_email BackgroundJob created by CreateHostRequest
         session.execute(delete(BackgroundJob).execution_options(synchronize_session=False))
 
-        # check send_request_notifications successfully creates background job
+        # the only unseen message is the creation message, which the host was already
+        # notified about via host_request__create — no missed_messages email
         with patch("couchers.jobs.handlers.now", now_5_min_in_future):
             send_request_notifications(empty_pb2.Empty())
             process_jobs()
-        assert (
-            session.execute(
-                select(func.count()).select_from(BackgroundJob).where(BackgroundJob.job_type == "send_email")
-            ).scalar_one()
-            == 1
-        )
-
-        # delete all BackgroundJobs
-        session.execute(delete(BackgroundJob).execution_options(synchronize_session=False))
-
-        with patch("couchers.jobs.handlers.now", now_5_min_in_future):
-            send_request_notifications(empty_pb2.Empty())
-            process_jobs()
-        # should find no messages since host has already been notified
         assert (
             session.execute(
                 select(func.count()).select_from(BackgroundJob).where(BackgroundJob.job_type == "send_email")
@@ -694,7 +679,7 @@ def test_send_request_notifications_host_request(db, moderator):
             == 0
         )
 
-    # then test that responding to host request creates email
+    # test that responding to host request creates email
     with requests_session(token2) as requests:
         requests.RespondHostRequest(
             requests_pb2.RespondHostRequestReq(
@@ -731,6 +716,102 @@ def test_send_request_notifications_host_request(db, moderator):
                 select(func.count()).select_from(BackgroundJob).where(BackgroundJob.job_type == "send_email")
             ).scalar_one()
             == 0
+        )
+
+
+def test_send_request_notifications_host_request_with_followup(db, moderator):
+    """
+    When the surfer sends a follow-up message after creating the host request,
+    the host should get a missed_messages notification (even though the initial
+    creation message alone would be skipped).
+    """
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    today_plus_2 = (today() + timedelta(days=2)).isoformat()
+    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+
+    with requests_session(token1) as requests:
+        host_request_id = requests.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=user2.id, from_date=today_plus_2, to_date=today_plus_3, text=valid_request_text()
+            )
+        ).host_request_id
+    moderator.approve_host_request(host_request_id)
+
+    # surfer sends a follow-up message
+    with requests_session(token1) as requests:
+        requests.SendHostRequestMessage(
+            requests_pb2.SendHostRequestMessageReq(host_request_id=host_request_id, text="Following up on my request!")
+        )
+
+    with session_scope() as session:
+        session.execute(delete(BackgroundJob).execution_options(synchronize_session=False))
+
+        # now there are two unseen text messages for the host, so missed_messages should fire
+        with patch("couchers.jobs.handlers.now", now_5_min_in_future):
+            send_request_notifications(empty_pb2.Empty())
+            process_jobs()
+        assert (
+            session.execute(
+                select(func.count()).select_from(BackgroundJob).where(BackgroundJob.job_type == "send_email")
+            ).scalar_one()
+            == 1
+        )
+
+
+def test_send_request_notifications_two_requests_one_with_followup(db, moderator):
+    """
+    A host (user2) receives two requests: first from user1 (with a follow-up message),
+    then from user3 (creation only). Because request B is created after request A's
+    follow-up, it has a higher message ID. If the background job processes B first and
+    advances last_notified_request_message_id past A's messages, one might expect A's
+    notification to be lost — but it isn't, because the query results are already
+    materialized before the loop begins.
+    """
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
+
+    today_plus_2 = (today() + timedelta(days=2)).isoformat()
+    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+
+    # request A: user1 -> user2, with a follow-up
+    with requests_session(token1) as requests:
+        host_request_a = requests.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=user2.id, from_date=today_plus_2, to_date=today_plus_3, text=valid_request_text()
+            )
+        ).host_request_id
+    moderator.approve_host_request(host_request_a)
+
+    with requests_session(token1) as requests:
+        requests.SendHostRequestMessage(
+            requests_pb2.SendHostRequestMessageReq(host_request_id=host_request_a, text="Sorry, meant Tuesday night!")
+        )
+
+    # request B: user3 -> user2, creation only (higher message IDs than A's follow-up)
+    with requests_session(token3) as requests:
+        host_request_b = requests.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=user2.id, from_date=today_plus_2, to_date=today_plus_3, text=valid_request_text()
+            )
+        ).host_request_id
+    moderator.approve_host_request(host_request_b)
+
+    with session_scope() as session:
+        session.execute(delete(BackgroundJob).execution_options(synchronize_session=False))
+
+        # should get exactly 1 missed_messages email: for request A (has follow-up),
+        # not request B (creation only, skipped)
+        with patch("couchers.jobs.handlers.now", now_5_min_in_future):
+            send_request_notifications(empty_pb2.Empty())
+            process_jobs()
+        assert (
+            session.execute(
+                select(func.count()).select_from(BackgroundJob).where(BackgroundJob.job_type == "send_email")
+            ).scalar_one()
+            == 1
         )
 
 


### PR DESCRIPTION
When a host request is created, the recipient gets a `host_request__create` notification immediately. The background job `send_request_notifications` would then send a redundant `host_request__missed_messages` notification a few minutes later for the same message.

Fix: in the missed_messages loop, check if the host request conversation has more than one text message. If not, the only unseen message is the creation message which was already notified about, so skip. The `last_notified_request_message_id` watermark is still advanced, which is safe because it's only ever advanced when processing all unseen messages for the user.

Closes #5872

## Testing

- Added `test_send_request_notifications_host_request_with_followup`: verifies that a follow-up message still triggers missed_messages
- Added `test_send_request_notifications_two_requests_one_with_followup`: verifies correctness when a host receives two requests (one with follow-up, one without) and the creation-only request has a higher message ID
- Updated existing `test_send_request_notifications_host_request` to assert no missed_messages email for creation-only message

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me