### PR TITLE
Web changes to attempt to fix signup flow for mobile

### DIFF
--- a/app/web/components/AppRoute.tsx
+++ b/app/web/components/AppRoute.tsx
@@ -112,14 +112,22 @@ function AppRoute({
   useEffect(() => setIsMounted(true), []);
 
   useEffect(() => {
-    if (!isAuthenticated && isPrivate) {
+    if (!isAuthenticated && isPrivate && !isNativeEmbed) {
       authActions.authError("Please log in.");
       router.push({ pathname: loginRoute, query: { from: location.pathname } });
     }
     if (isAuthenticated && isJailed && isPrivate && pathname !== jailRoute) {
       router.push(jailRoute);
     }
-  }, [isAuthenticated, isJailed, isPrivate, authActions, router, pathname]);
+  }, [
+    isAuthenticated,
+    isJailed,
+    isPrivate,
+    authActions,
+    router,
+    pathname,
+    isNativeEmbed,
+  ]);
 
   return (
     <ErrorBoundary>

--- a/app/web/features/auth/AuthProvider.tsx
+++ b/app/web/features/auth/AuthProvider.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/router";
 import React, { Context, ReactNode, useContext, useEffect } from "react";
 import { jailRoute, loginRoute } from "routes";
 import { setUnauthenticatedErrorHandler } from "service/client";
+import { isNativeEmbed } from "utils/nativeLink";
 import useStablePush from "utils/useStablePush";
 
 import { JAILED_ERROR_MESSAGE } from "./constants";
@@ -39,8 +40,8 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
           // if the user is jailed, redirect them to the jail route
           push(jailRoute);
         }
-      } else {
-        // completely logged out
+      } else if (!isNativeEmbed()) {
+        // completely logged out — in native embed, the mobile app handles auth
         await store.authActions.logout();
         push(loginRoute);
       }

--- a/app/web/utils/nativeLink.ts
+++ b/app/web/utils/nativeLink.ts
@@ -6,7 +6,7 @@ function getReactNativeWebView(): typeof window.ReactNativeWebView {
   }
 }
 
-function isNativeEmbed(): boolean {
+export function isNativeEmbed(): boolean {
   const webview = getReactNativeWebView();
   if (!webview) return false;
 


### PR DESCRIPTION
Another attempt at web changes to help sync cookie state with mobile. Don't let web redirect to login when native app. It should let the mobile app handle it instead to avoid timing issues.