### PR TITLE
Fix MyPostcard API crash on empty order date range

### DIFF
--- a/app/backend/src/couchers/postal/my_postcard.py
+++ b/app/backend/src/couchers/postal/my_postcard.py
@@ -185,6 +185,10 @@ def get_order_ids(date_from: date, date_to: date) -> list[int]:
         },
         timeout=30,
     )
+    # todo: remove this fix when upstream fixes API
+    # MyPostcard API returns 500 with empty body when there are no orders in the date range
+    if response.status_code == 500 and not response.content:
+        return []
     response.raise_for_status()
     return [int(order["job_id"]) for order in response.json()["orders"]]
 


### PR DESCRIPTION
The MyPostcard API returns HTTP 500 with an empty body when there are no orders in the requested date range, instead of returning an empty list. This caused `get_order_ids()` to raise an exception on `response.raise_for_status()`.

This adds a workaround to return an empty list when we receive a 500 with no response body, with a TODO to remove once the upstream API is fixed.

## Testing
- Verified that the fix correctly handles 500 responses with empty body by returning `[]`
- Existing behavior for successful responses and other error codes is unchanged

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me