### PR TITLE
Fix background worker startup log level

### DIFF
--- a/app/backend/src/couchers/jobs/worker.py
+++ b/app/backend/src/couchers/jobs/worker.py
@@ -180,7 +180,7 @@ def _run_forever(func: Callable[[], None]) -> None:
 
     while True:
         try:
-            logger.critical("Background worker starting")
+            logger.info("Background worker starting")
             func()
         except Exception as e:
             logger.critical("Unhandled exception in background worker", exc_info=e)


### PR DESCRIPTION
Change the background worker startup log message from `critical` to `info` level. This is a routine startup message, not an error condition.

Closes #7547

## Testing
Straightforward log level change, no behavioral impact.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me