### PR TITLE
Move logout outside of try catch so always runs on mobile

### DIFF
--- a/app/web/features/auth/useAuthStore.ts
+++ b/app/web/features/auth/useAuthStore.ts
@@ -79,16 +79,6 @@ export default function useAuthStore() {
         setLoading(true);
         try {
           await service.user.logout();
-          setAuthenticated(false);
-          setUserId(null);
-          Sentry.setUser({ id: undefined });
-
-          // Notify mobile app if running in embed
-          if (window.ReactNativeWebView) {
-            window.ReactNativeWebView.postMessage(
-              JSON.stringify({ type: "LOGOUT" }),
-            );
-          }
         } catch (e) {
           Sentry.captureException(e, {
             tags: {
@@ -97,6 +87,16 @@ export default function useAuthStore() {
             },
           });
           setError(isGrpcError(e) ? e.message : fatalErrorMessage.current);
+        }
+        // Always clear local auth state even if the backend call failed
+        // (e.g. session cookie not yet available in a new WebView context)
+        setAuthenticated(false);
+        setUserId(null);
+        Sentry.setUser({ id: undefined });
+        if (window.ReactNativeWebView) {
+          window.ReactNativeWebView.postMessage(
+            JSON.stringify({ type: "LOGOUT" }),
+          );
         }
         clearStorage();
         setLoading(false);


### PR DESCRIPTION
There is a delay with cookie syncing between web and mobile app. This causes a delay sometimes where the logout api call fails because it can't find the cookie, then the rest of the logout code doesn't run and the logout state isn't cleared.

This is just moving the rest of the code outside the try/catch so even if the api call throws it will clear the logout state. I think this should be a better practice anyway and shouldn't effect desktop. It prevents us from getting stuck in and in-between state.