### PR TITLE
Add special native behavior to complete reset password

### DIFF
--- a/app/web/features/auth/password/CompleteResetPassword.tsx
+++ b/app/web/features/auth/password/CompleteResetPassword.tsx
@@ -11,9 +11,10 @@ import { AUTH, GLOBAL } from "i18n/namespaces";
 import { useRouter } from "next/router";
 import { AuthRes } from "proto/auth_pb";
 import { useForm } from "react-hook-form";
-import { dashboardRoute } from "routes";
+import { dashboardRoute, loginRoute } from "routes";
 import { service } from "service";
 import { theme } from "theme";
+import { useIsNativeEmbed } from "utils/nativeLink";
 import stringOrFirstString from "utils/stringOrFirstString";
 
 const StyledContainer = styled(Container)(() => ({
@@ -42,6 +43,7 @@ const StyledTextField = styled(TextField)(() => ({
 
 export default function CompleteResetPassword() {
   const { authState, authActions } = useAuthContext();
+  const isNativeEmbed = useIsNativeEmbed();
   const { t } = useTranslation([AUTH, GLOBAL]);
   const { handleSubmit, register } = useForm<{
     newPassword: string;
@@ -66,8 +68,14 @@ export default function CompleteResetPassword() {
       return res;
     },
     onSuccess: (authRes) => {
-      authActions.firstLogin(authRes.toObject());
-      router.push(dashboardRoute);
+      if (isNativeEmbed) {
+        // On mobile, redirect to login instead of auto-login to avoid
+        // iOS cookie sync issues between WebView instances
+        router.push(loginRoute);
+      } else {
+        authActions.firstLogin(authRes.toObject());
+        router.push(dashboardRoute);
+      }
     },
   });
 


### PR DESCRIPTION
Don't redirect to dashboard for complete reset password on native as it's causing cookie sync chaos.

Not ideal but for now it's good enough and is sorta standard after resetting password to log in again.

Right now it logs in but without the bottom tabs which means it got redirecting to the wrong mobile state.