### PR TITLE
Implement basic repositories with common functionality

### DIFF
--- a/app/backend/copy_annotations.py
+++ b/app/backend/copy_annotations.py
@@ -156,7 +156,7 @@ def normalize_annotation(annotation: cst.BaseExpression) -> cst.BaseExpression:
     """
     Normalize type annotations:
     - google.X.*_pb2.Y -> *_pb2.Y (remove google.X prefix)
-    - orm.Session -> Session
+    - repositories.DB -> DB
     """
     # Handle google.X.something_pb2.Something -> something_pb2.Something
     if isinstance(annotation, cst.Attribute):
@@ -173,9 +173,9 @@ def normalize_annotation(annotation: cst.BaseExpression) -> cst.BaseExpression:
                         # Return *_pb2.Y
                         return cst.Attribute(value=cst.Name(pb2_module), attr=annotation.attr)
 
-    # Replace orm.Session with Session
-    if m.matches(annotation, m.Attribute(value=m.Name("orm"), attr=m.Name("Session"))):
-        return cst.Name("Session")
+    # Replace repositories.DB with DB
+    if m.matches(annotation, m.Attribute(value=m.Name("repositories"), attr=m.Name("DB"))):
+        return cst.Name("DB")
 
     return annotation
 
@@ -315,7 +315,7 @@ def ensure_imports(tree: cst.Module) -> cst.Module:
 
     # Map of type name to import statement
     import_map = {
-        "Session": "from sqlalchemy.orm import Session",
+        "DB": "from couchers.repositories import DB",
         "CouchersContext": "from couchers.context import CouchersContext",
         "Awaitable": "from collections.abc import Awaitable",
         "List": "from typing import List",

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -37,6 +37,7 @@ from couchers.metrics import observe_in_servicer_duration_histogram
 from couchers.models import APICall, User, UserActivity, UserSession
 from couchers.proto import annotations_pb2
 from couchers.proto.annotations_pb2 import AuthLevel
+from couchers.repositories import DB
 from couchers.utils import (
     create_lang_cookie,
     create_session_cookies,
@@ -313,8 +314,9 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             )
 
             with session_scope() as session:
+                db = DB(session)
                 try:
-                    _res = prev_function(req, couchers_context, session)  # type: ignore[call-arg, arg-type]
+                    _res = prev_function(req, couchers_context, db)  # type: ignore[call-arg, arg-type]
                     res = cast(Message, _res)
                     finished = perf_counter_ns()
                     duration = (finished - start) / 1e6  # ms
@@ -531,7 +533,8 @@ class MediaInterceptor(grpc.ServerInterceptor):
 
         def function_without_session(request: T, grpc_context: grpc.ServicerContext) -> R:
             with session_scope() as session:
-                return prev_func(request, make_media_context(grpc_context), session)  # type: ignore[call-arg, arg-type]
+                db = DB(session)
+                return prev_func(request, make_media_context(grpc_context), db)  # type: ignore[call-arg, arg-type]
 
         return grpc.unary_unary_rpc_method_handler(
             function_without_session,

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -106,6 +106,7 @@ from couchers.notifications.notify import notify
 from couchers.postal.my_postcard import get_order_ids, send_postcard
 from couchers.proto import moderation_pb2, notification_data_pb2
 from couchers.proto.internal import internal_pb2, jobs_pb2
+from couchers.repositories import DB
 from couchers.resources import get_badge_dict, get_static_badge_dict
 from couchers.sentry import report_message
 from couchers.servicers.api import user_model_to_pb
@@ -1513,7 +1514,7 @@ def auto_approve_moderation_queue(payload: empty_pb2.Empty) -> None:
                     created_before=Timestamp_from_datetime(now() - timedelta(seconds=deadline_seconds)),
                 ),
                 context=ctx,
-                session=session,
+                db=DB(session),
             )
             .queue_items
         )
@@ -1531,6 +1532,6 @@ def auto_approve_moderation_queue(payload: empty_pb2.Empty) -> None:
                     reason=f"Auto-approved: moderation deadline of {deadline_seconds} seconds exceeded.",
                 ),
                 context=ctx,
-                session=session,
+                db=DB(session),
             )
         moderation_auto_approved_counter.inc(len(items))

--- a/app/backend/src/couchers/notifications/quick_links.py
+++ b/app/backend/src/couchers/notifications/quick_links.py
@@ -29,6 +29,7 @@ from couchers.notifications import settings
 from couchers.notifications.utils import enum_from_topic_action
 from couchers.proto import auth_pb2, conversations_pb2, requests_pb2
 from couchers.proto.internal import unsubscribe_pb2
+from couchers.repositories import DB
 from couchers.servicers.requests import Requests
 from couchers.sql import where_moderated_content_visible
 from couchers.utils import now
@@ -158,7 +159,7 @@ def respond_quick_link(request: auth_pb2.UnsubscribeReq, context: CouchersContex
                 status=conversations_pb2.HOST_REQUEST_STATUS_REJECTED,
             ),
             context=make_one_off_interactive_user_context(couchers_context=context, user_id=payload.user_id),
-            session=session,
+            db=DB(session),
         )
         return context.localization.localize_string("quick_links.host_request_quick_decline")
     raise Exception("Unhandled quick link type")

--- a/app/backend/src/couchers/repositories/__init__.py
+++ b/app/backend/src/couchers/repositories/__init__.py
@@ -1,0 +1,178 @@
+from collections.abc import Sequence
+
+from sqlalchemy import ColumnElement, func, select
+from sqlalchemy.ext.hybrid import _HybridClassLevelAccessor
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.base import ExecutableOption
+
+from couchers.models import (
+    AdminTag,
+    Base,
+    Comment,
+    ContentReport,
+    Discussion,
+    ModerationUserList,
+    Node,
+    Page,
+    PhotoGallery,
+    Reference,
+    Reply,
+    Thread,
+    Upload,
+    User,
+)
+from couchers.sql import username_or_email_or_id, users_visible
+
+type WhereCondition = ColumnElement[bool] | _HybridClassLevelAccessor[bool]
+
+
+class BaseRepo[T: Base]:
+    model: type[T]
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def by_id(self, id_: int, options: Sequence[ExecutableOption] | None = None) -> T:
+        query = select(self.model).where(self.model.id == id_)  # type: ignore
+        if options:
+            query = query.options(*options)
+        return self.session.execute(query).scalar_one()
+
+    def get_by_id(self, id_: int, options: Sequence[ExecutableOption] | None = None) -> T | None:
+        query = select(self.model).where(self.model.id == id_)  # type: ignore
+        if options:
+            query = query.options(*options)
+        return self.session.execute(query).scalar_one_or_none()
+
+    def count(self, where: WhereCondition) -> int:
+        query = select(func.count()).select_from(self.model).where(where)
+        return self.session.execute(query).scalar_one()
+
+
+class UserRepo(BaseRepo[User]):
+    model = User
+
+    def get_by_username_or_email_or_id(self, val: str) -> User | None:
+        query = select(User).where(username_or_email_or_id(val))
+        return self.session.execute(query).scalar_one_or_none()
+
+    def get_by_id_if_visible(self, id_: int, visible_to: int) -> User | None:
+        query = select(User).where(User.id == id_).where(users_visible(visible_to))
+        return self.session.execute(query).scalar_one_or_none()
+
+
+class AdminTagRepo(BaseRepo[AdminTag]):
+    model = AdminTag
+
+    def get_by_tag(self, tag: str) -> AdminTag | None:
+        query = select(AdminTag).where(AdminTag.tag == tag)
+        return self.session.execute(query).scalar_one_or_none()
+
+
+class CommentRepo(BaseRepo[Comment]):
+    model = Comment
+
+
+class ThreadRepo(BaseRepo[Thread]):
+    model = Thread
+
+
+class ReplyRepo(BaseRepo[Reply]):
+    model = Reply
+
+
+class DiscussionRepo(BaseRepo[Discussion]):
+    model = Discussion
+
+
+class ReferenceRepo(BaseRepo[Reference]):
+    model = Reference
+
+
+class ModerationUserListRepo(BaseRepo[ModerationUserList]):
+    model = ModerationUserList
+
+
+class ContentReportRepo(BaseRepo[ContentReport]):
+    model = ContentReport
+
+
+class NodeRepo(BaseRepo[Node]):
+    model = Node
+
+
+class PhotoGalleryRepo(BaseRepo[PhotoGallery]):
+    model = PhotoGallery
+
+
+class PageRepo(BaseRepo[Page]):
+    model = Page
+
+
+class UploadRepo(BaseRepo[Upload]):
+    model = Upload
+
+    def get_by_key(self, key: str) -> Upload | None:
+        query = select(Upload).where(Upload.key == key)
+        return self.session.execute(query).scalar_one_or_none()
+
+
+class DB:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    @property
+    def session(self) -> Session:
+        return self._session
+
+    @property
+    def users(self) -> UserRepo:
+        return UserRepo(self.session)
+
+    @property
+    def admin_tags(self) -> AdminTagRepo:
+        return AdminTagRepo(self.session)
+
+    @property
+    def moderation_user_lists(self) -> ModerationUserListRepo:
+        return ModerationUserListRepo(self.session)
+
+    @property
+    def comments(self) -> CommentRepo:
+        return CommentRepo(self.session)
+
+    @property
+    def threads(self) -> ThreadRepo:
+        return ThreadRepo(self.session)
+
+    @property
+    def replies(self) -> ReplyRepo:
+        return ReplyRepo(self.session)
+
+    @property
+    def references(self) -> ReferenceRepo:
+        return ReferenceRepo(self.session)
+
+    @property
+    def discussions(self) -> DiscussionRepo:
+        return DiscussionRepo(self.session)
+
+    @property
+    def content_reports(self) -> ContentReportRepo:
+        return ContentReportRepo(self.session)
+
+    @property
+    def nodes(self) -> NodeRepo:
+        return NodeRepo(self.session)
+
+    @property
+    def photo_galleries(self) -> PhotoGalleryRepo:
+        return PhotoGalleryRepo(self.session)
+
+    @property
+    def pages(self) -> PageRepo:
+        return PageRepo(self.session)
+
+    @property
+    def uploads(self) -> UploadRepo:
+        return UploadRepo(self.session)

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -7,7 +7,6 @@ import grpc
 import requests
 from google.protobuf import empty_pb2
 from sqlalchemy import select
-from sqlalchemy.orm import Session
 from sqlalchemy.sql import func, update
 from user_agents import parse as user_agents_parse
 
@@ -63,6 +62,7 @@ from couchers.phone.check import is_e164_format, is_known_operator
 from couchers.proto import account_pb2, account_pb2_grpc, auth_pb2, iris_pb2_grpc, notification_data_pb2
 from couchers.proto.google.api import httpbody_pb2
 from couchers.proto.internal import internal_pb2, jobs_pb2
+from couchers.repositories import DB
 from couchers.servicers.api import lite_user_to_pb
 from couchers.servicers.public import format_volunteer_link
 from couchers.servicers.references import get_pending_references_to_write, reftype2api
@@ -160,9 +160,9 @@ def _volunteer_info_to_pb(volunteer: Volunteer, username: str) -> account_pb2.Ge
 
 class Account(account_pb2_grpc.AccountServicer):
     def GetAccountInfo(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+        self, request: empty_pb2.Empty, context: CouchersContext, db: DB
     ) -> account_pb2.GetAccountInfoRes:
-        user, volunteer = session.execute(
+        user, volunteer = db.session.execute(
             select(User, Volunteer).outerjoin(Volunteer, Volunteer.user_id == User.id).where(User.id == context.user_id)
         ).one()
 
@@ -181,7 +181,7 @@ class Account(account_pb2_grpc.AccountServicer):
             phone=user.phone if (user.phone_is_verified or not user.phone_code_expired) else None,
             has_donated=user.last_donated is not None,
             phone_verified=user.phone_is_verified,
-            profile_complete=has_completed_profile(session, user),
+            profile_complete=has_completed_profile(db.session, user),
             my_home_complete=user.has_completed_my_home,
             timezone=user.timezone,
             is_superuser=user.is_superuser,
@@ -189,18 +189,18 @@ class Account(account_pb2_grpc.AccountServicer):
             profile_public_visibility=profilepublicitysetting2api[user.public_visibility],
             is_volunteer=volunteer is not None,
             should_show_donation_banner=should_show_donation_banner,
-            **get_strong_verification_fields(session, user),
+            **get_strong_verification_fields(db.session, user),
         )
 
     def ChangePasswordV2(
-        self, request: account_pb2.ChangePasswordV2Req, context: CouchersContext, session: Session
+        self, request: account_pb2.ChangePasswordV2Req, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
         """
         Changes the user's password. They have to confirm their old password just in case.
 
         If they didn't have an old password previously, then we don't check that.
         """
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
 
         if not verify_password(user.hashed_password, request.old_password):
             # wrong password
@@ -209,21 +209,19 @@ class Account(account_pb2_grpc.AccountServicer):
         abort_on_invalid_password(request.new_password, context)
         user.hashed_password = hash_password(request.new_password)
 
-        session.commit()
+        db.session.commit()
 
         notify(
-            session,
+            db.session,
             user_id=user.id,
             topic_action=NotificationTopicAction.password__change,
             key="",
         )
-        log_event(context, session, "account.password_changed", {})
+        log_event(context, db.session, "account.password_changed", {})
 
         return empty_pb2.Empty()
 
-    def ChangeEmailV2(
-        self, request: account_pb2.ChangeEmailV2Req, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
+    def ChangeEmailV2(self, request: account_pb2.ChangeEmailV2Req, context: CouchersContext, db: DB) -> empty_pb2.Empty:
         """
         Change the user's email address.
 
@@ -233,7 +231,7 @@ class Account(account_pb2_grpc.AccountServicer):
 
         In all confirmation emails, the user must click on the confirmation link.
         """
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
 
         # check password first
         if not verify_password(user.hashed_password, request.password):
@@ -245,7 +243,7 @@ class Account(account_pb2_grpc.AccountServicer):
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_email")
 
         # email already in use (possibly by this user)
-        if session.execute(select(User).where(User.email == request.new_email)).scalar_one_or_none():
+        if db.session.execute(select(User).where(User.email == request.new_email)).scalar_one_or_none():
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_email")
 
         user.new_email = request.new_email
@@ -253,11 +251,11 @@ class Account(account_pb2_grpc.AccountServicer):
         user.new_email_token_created = now()
         user.new_email_token_expiry = now() + timedelta(hours=2)
 
-        send_email_changed_confirmation_to_new_email(session, user)
+        send_email_changed_confirmation_to_new_email(db.session, user)
 
         # will still go into old email
         notify(
-            session,
+            db.session,
             user_id=user.id,
             topic_action=NotificationTopicAction.email_address__change,
             key="",
@@ -266,16 +264,15 @@ class Account(account_pb2_grpc.AccountServicer):
             ),
         )
 
-        log_event(context, session, "account.email_change_initiated", {})
+        log_event(context, db.session, "account.email_change_initiated", {})
 
         # session autocommit
         return empty_pb2.Empty()
 
     def ChangeLanguagePreference(
-        self, request: account_pb2.ChangeLanguagePreferenceReq, context: CouchersContext, session: Session
+        self, request: account_pb2.ChangeLanguagePreferenceReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        # select the user from the db
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
 
         # update the user's preference
         user.ui_language_preference = request.ui_language_preference
@@ -284,9 +281,9 @@ class Account(account_pb2_grpc.AccountServicer):
         return empty_pb2.Empty()
 
     def FillContributorForm(
-        self, request: account_pb2.FillContributorFormReq, context: CouchersContext, session: Session
+        self, request: account_pb2.FillContributorFormReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
 
         form = request.contributor_form
 
@@ -300,33 +297,31 @@ class Account(account_pb2_grpc.AccountServicer):
             expertise=form.expertise or None,
         )
 
-        session.add(form)
-        session.flush()
-        maybe_send_contributor_form_email(session, form)
+        db.session.add(form)
+        db.session.flush()
+        maybe_send_contributor_form_email(db.session, form)
 
         user.filled_contributor_form = True
-        log_event(context, session, "contributor.form_submitted", {"is_filled": form.is_filled})
+        log_event(context, db.session, "contributor.form_submitted", {"is_filled": form.is_filled})
 
         return empty_pb2.Empty()
 
     def GetContributorFormInfo(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+        self, request: empty_pb2.Empty, context: CouchersContext, db: DB
     ) -> account_pb2.GetContributorFormInfoRes:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
 
         return account_pb2.GetContributorFormInfoRes(
             filled_contributor_form=user.filled_contributor_form,
         )
 
-    def ChangePhone(
-        self, request: account_pb2.ChangePhoneReq, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
+    def ChangePhone(self, request: account_pb2.ChangePhoneReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
         phone = request.phone
         # early quick validation
         if phone and not is_e164_format(phone):
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_phone")
 
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
         if user.last_donated is None:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "not_donated")
 
@@ -354,7 +349,7 @@ class Account(account_pb2_grpc.AccountServicer):
             user.phone_verification_attempts = 0
 
             notify(
-                session,
+                db.session,
                 user_id=user.id,
                 topic_action=NotificationTopicAction.phone_number__change,
                 key="",
@@ -367,13 +362,11 @@ class Account(account_pb2_grpc.AccountServicer):
 
         context.abort(grpc.StatusCode.UNIMPLEMENTED, result)
 
-    def VerifyPhone(
-        self, request: account_pb2.VerifyPhoneReq, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
+    def VerifyPhone(self, request: account_pb2.VerifyPhoneReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
         if not sms.looks_like_a_code(request.token):
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "wrong_sms_code")
 
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
         if user.phone_verification_token is None:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "no_pending_verification")
 
@@ -385,11 +378,11 @@ class Account(account_pb2_grpc.AccountServicer):
 
         if not verify_token(request.token, user.phone_verification_token):
             user.phone_verification_attempts += 1
-            session.commit()
+            db.session.commit()
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "wrong_sms_code")
 
         # Delete verifications from everyone else that has this number
-        session.execute(
+        db.session.execute(
             update(User)
             .where(User.phone == user.phone)
             .where(User.id != context.user_id)
@@ -409,7 +402,7 @@ class Account(account_pb2_grpc.AccountServicer):
         user.phone_verification_attempts = 0
 
         notify(
-            session,
+            db.session,
             user_id=user.id,
             topic_action=NotificationTopicAction.phone_number__verify,
             key="",
@@ -421,13 +414,13 @@ class Account(account_pb2_grpc.AccountServicer):
         return empty_pb2.Empty()
 
     def InitiateStrongVerification(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+        self, request: empty_pb2.Empty, context: CouchersContext, db: DB
     ) -> account_pb2.InitiateStrongVerificationRes:
         if not config["ENABLE_STRONG_VERIFICATION"]:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "strong_verification_disabled")
 
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
-        existing_verification = session.execute(
+        user = db.users.by_id(context.user_id)
+        existing_verification = db.session.execute(
             select(StrongVerificationAttempt)
             .where(StrongVerificationAttempt.user_id == user.id)
             .where(StrongVerificationAttempt.is_valid)
@@ -436,7 +429,7 @@ class Account(account_pb2_grpc.AccountServicer):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "strong_verification_already_verified")
 
         strong_verification_initiations_counter.labels(user.gender).inc()
-        log_event(context, session, "verification.strong_initiated", {"gender": user.gender})
+        log_event(context, db.session, "verification.strong_initiated", {"gender": user.gender})
 
         verification_attempt_token = urlsafe_secure_token()
         # this is the iris reference data, they will return this on every callback, it also doubles as webhook auth given lack of it otherwise
@@ -467,7 +460,7 @@ class Account(account_pb2_grpc.AccountServicer):
 
         iris_session_id = response.json()["id"]
         token = response.json()["token"]
-        session.add(
+        db.session.add(
             StrongVerificationAttempt(
                 user_id=user.id,
                 verification_attempt_token=verification_attempt_token,
@@ -490,9 +483,9 @@ class Account(account_pb2_grpc.AccountServicer):
         )
 
     def GetStrongVerificationAttemptStatus(
-        self, request: account_pb2.GetStrongVerificationAttemptStatusReq, context: CouchersContext, session: Session
+        self, request: account_pb2.GetStrongVerificationAttemptStatusReq, context: CouchersContext, db: DB
     ) -> account_pb2.GetStrongVerificationAttemptStatusRes:
-        verification_attempt = session.execute(
+        verification_attempt = db.session.execute(
             select(StrongVerificationAttempt)
             .where(StrongVerificationAttempt.user_id == context.user_id)
             .where(StrongVerificationAttempt.is_visible)
@@ -514,10 +507,10 @@ class Account(account_pb2_grpc.AccountServicer):
         )
 
     def DeleteStrongVerificationData(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+        self, request: empty_pb2.Empty, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
         verification_attempts = (
-            session.execute(
+            db.session.execute(
                 select(StrongVerificationAttempt)
                 .where(StrongVerificationAttempt.user_id == context.user_id)
                 .where(StrongVerificationAttempt.has_full_data)
@@ -531,10 +524,10 @@ class Account(account_pb2_grpc.AccountServicer):
             verification_attempt.passport_encrypted_data = None
             verification_attempt.passport_date_of_birth = None
             verification_attempt.passport_sex = None
-        session.flush()
+        db.session.flush()
         # double check:
         verification_attempts = (
-            session.execute(
+            db.session.execute(
                 select(StrongVerificationAttempt)
                 .where(StrongVerificationAttempt.user_id == context.user_id)
                 .where(StrongVerificationAttempt.has_full_data)
@@ -544,15 +537,13 @@ class Account(account_pb2_grpc.AccountServicer):
         )
         assert len(verification_attempts) == 0
 
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
         strong_verification_data_deletions_counter.labels(user.gender).inc()
-        log_event(context, session, "verification.strong_data_deleted", {"gender": user.gender})
+        log_event(context, db.session, "verification.strong_data_deleted", {"gender": user.gender})
 
         return empty_pb2.Empty()
 
-    def DeleteAccount(
-        self, request: account_pb2.DeleteAccountReq, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
+    def DeleteAccount(self, request: account_pb2.DeleteAccountReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
         """
         Triggers email with token to confirm deletion
 
@@ -561,19 +552,19 @@ class Account(account_pb2_grpc.AccountServicer):
         if not request.confirm:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "must_confirm_account_delete")
 
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
 
         reason = request.reason.strip()
         if reason:
             deletion_reason = AccountDeletionReason(user_id=user.id, reason=reason)
-            session.add(deletion_reason)
-            session.flush()
-            send_account_deletion_report_email(session, deletion_reason)
+            db.session.add(deletion_reason)
+            db.session.flush()
+            send_account_deletion_report_email(db.session, deletion_reason)
 
         token = AccountDeletionToken(token=urlsafe_secure_token(), user_id=user.id, expiry=now() + timedelta(hours=2))
 
         notify(
-            session,
+            db.session,
             user_id=user.id,
             topic_action=NotificationTopicAction.account_deletion__start,
             key="",
@@ -581,20 +572,20 @@ class Account(account_pb2_grpc.AccountServicer):
                 deletion_token=token.token,
             ),
         )
-        session.add(token)
+        db.session.add(token)
 
         account_deletion_initiations_counter.labels(user.gender).inc()
-        log_event(context, session, "account.deletion_initiated", {"gender": user.gender, "has_reason": bool(reason)})
+        log_event(
+            context, db.session, "account.deletion_initiated", {"gender": user.gender, "has_reason": bool(reason)}
+        )
 
         return empty_pb2.Empty()
 
-    def ListModNotes(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
-    ) -> account_pb2.ListModNotesRes:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+    def ListModNotes(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> account_pb2.ListModNotesRes:
+        user = db.users.by_id(context.user_id)
 
         notes = (
-            session.execute(select(ModNote).where(ModNote.user_id == user.id).order_by(ModNote.created.asc()))
+            db.session.execute(select(ModNote).where(ModNote.user_id == user.id).order_by(ModNote.created.asc()))
             .scalars()
             .all()
         )
@@ -602,13 +593,13 @@ class Account(account_pb2_grpc.AccountServicer):
         return account_pb2.ListModNotesRes(mod_notes=[mod_note_to_pb(note) for note in notes])
 
     def ListActiveSessions(
-        self, request: account_pb2.ListActiveSessionsReq, context: CouchersContext, session: Session
+        self, request: account_pb2.ListActiveSessionsReq, context: CouchersContext, db: DB
     ) -> account_pb2.ListActiveSessionsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         page_token = dt_from_page_token(request.page_token) if request.page_token else now()
 
         user_sessions = (
-            session.execute(
+            db.session.execute(
                 select(UserSession)
                 .where(UserSession.user_id == context.user_id)
                 .where(UserSession.is_valid)
@@ -639,10 +630,8 @@ class Account(account_pb2_grpc.AccountServicer):
             next_page_token=dt_to_page_token(user_sessions[-1].last_seen) if len(user_sessions) > page_size else None,
         )
 
-    def LogOutSession(
-        self, request: account_pb2.LogOutSessionReq, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
-        session.execute(
+    def LogOutSession(self, request: account_pb2.LogOutSessionReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
+        db.session.execute(
             update(UserSession)
             .where(UserSession.token != context.token)
             .where(UserSession.user_id == context.user_id)
@@ -655,12 +644,12 @@ class Account(account_pb2_grpc.AccountServicer):
         return empty_pb2.Empty()
 
     def LogOutOtherSessions(
-        self, request: account_pb2.LogOutOtherSessionsReq, context: CouchersContext, session: Session
+        self, request: account_pb2.LogOutOtherSessionsReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
         if not request.confirm:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "must_confirm_logout_other_sessions")
 
-        session.execute(
+        db.session.execute(
             update(UserSession)
             .where(UserSession.token != context.token)
             .where(UserSession.user_id == context.user_id)
@@ -672,18 +661,18 @@ class Account(account_pb2_grpc.AccountServicer):
         return empty_pb2.Empty()
 
     def SetProfilePublicVisibility(
-        self, request: account_pb2.SetProfilePublicVisibilityReq, context: CouchersContext, session: Session
+        self, request: account_pb2.SetProfilePublicVisibilityReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
         user.public_visibility = profilepublicitysetting2sql[request.profile_public_visibility]  # type: ignore[assignment]
         user.has_modified_public_visibility = True
         return empty_pb2.Empty()
 
     def CreateInviteCode(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+        self, request: empty_pb2.Empty, context: CouchersContext, db: DB
     ) -> account_pb2.CreateInviteCodeRes:
         code = generate_invite_code()
-        session.add(InviteCode(id=code, creator_user_id=context.user_id))
+        db.session.add(InviteCode(id=code, creator_user_id=context.user_id))
 
         return account_pb2.CreateInviteCodeRes(
             code=code,
@@ -691,9 +680,9 @@ class Account(account_pb2_grpc.AccountServicer):
         )
 
     def DisableInviteCode(
-        self, request: account_pb2.DisableInviteCodeReq, context: CouchersContext, session: Session
+        self, request: account_pb2.DisableInviteCodeReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        invite = session.execute(
+        invite = db.session.execute(
             select(InviteCode).where(InviteCode.id == request.code, InviteCode.creator_user_id == context.user_id)
         ).scalar_one_or_none()
 
@@ -701,14 +690,14 @@ class Account(account_pb2_grpc.AccountServicer):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "not_found")
 
         invite.disabled = func.now()
-        session.commit()
+        db.session.commit()
 
         return empty_pb2.Empty()
 
     def ListInviteCodes(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+        self, request: empty_pb2.Empty, context: CouchersContext, db: DB
     ) -> account_pb2.ListInviteCodesRes:
-        results = session.execute(
+        results = db.session.execute(
             select(
                 InviteCode.id,
                 InviteCode.created,
@@ -734,10 +723,8 @@ class Account(account_pb2_grpc.AccountServicer):
             ]
         )
 
-    def GetReminders(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
-    ) -> account_pb2.GetRemindersRes:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+    def GetReminders(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> account_pb2.GetRemindersRes:
+        user = db.users.by_id(context.user_id)
 
         # responding to reqs comes first in desc order of when they were received
         query = select(HostRequest.conversation_id, LiteUser).join(
@@ -745,7 +732,7 @@ class Account(account_pb2_grpc.AccountServicer):
         )
         query = where_users_column_visible(query, context, HostRequest.initiator_user_id)
         query = where_moderated_content_visible(query, context, HostRequest, is_list_operation=True)
-        pending_host_requests = session.execute(
+        pending_host_requests = db.session.execute(
             query.where(HostRequest.recipient_user_id == context.user_id)
             .where(HostRequest.status == HostRequestStatus.pending)
             .where(HostRequest.start_time > func.now())
@@ -755,7 +742,7 @@ class Account(account_pb2_grpc.AccountServicer):
             account_pb2.Reminder(
                 respond_to_host_request_reminder=account_pb2.RespondToHostRequestReminder(
                     host_request_id=host_request_id,
-                    surfer_user=lite_user_to_pb(session, lite_user, context),
+                    surfer_user=lite_user_to_pb(db.session, lite_user, context),
                 )
             )
             for host_request_id, lite_user in pending_host_requests
@@ -767,16 +754,16 @@ class Account(account_pb2_grpc.AccountServicer):
                 write_reference_reminder=account_pb2.WriteReferenceReminder(
                     host_request_id=host_request_id,
                     reference_type=reftype2api[reference_type],
-                    other_user=lite_user_to_pb(session, lite_user, context),
+                    other_user=lite_user_to_pb(db.session, lite_user, context),
                 )
             )
-            for host_request_id, reference_type, _, lite_user in get_pending_references_to_write(session, context)
+            for host_request_id, reference_type, _, lite_user in get_pending_references_to_write(db.session, context)
         ]
 
-        if not has_completed_profile(session, user):
+        if not has_completed_profile(db.session, user):
             reminders.append(account_pb2.Reminder(complete_profile_reminder=account_pb2.CompleteProfileReminder()))
 
-        if not has_strong_verification(session, user):
+        if not has_strong_verification(db.session, user):
             reminders.append(
                 account_pb2.Reminder(complete_verification_reminder=account_pb2.CompleteVerificationReminder())
             )
@@ -784,9 +771,9 @@ class Account(account_pb2_grpc.AccountServicer):
         return account_pb2.GetRemindersRes(reminders=reminders)
 
     def GetMyVolunteerInfo(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+        self, request: empty_pb2.Empty, context: CouchersContext, db: DB
     ) -> account_pb2.GetMyVolunteerInfoRes:
-        user, volunteer = session.execute(
+        user, volunteer = db.session.execute(
             select(User, Volunteer).outerjoin(Volunteer, Volunteer.user_id == User.id).where(User.id == context.user_id)
         ).one()
         if not volunteer:
@@ -794,9 +781,9 @@ class Account(account_pb2_grpc.AccountServicer):
         return _volunteer_info_to_pb(volunteer, user.username)
 
     def UpdateMyVolunteerInfo(
-        self, request: account_pb2.UpdateMyVolunteerInfoReq, context: CouchersContext, session: Session
+        self, request: account_pb2.UpdateMyVolunteerInfoReq, context: CouchersContext, db: DB
     ) -> account_pb2.GetMyVolunteerInfoRes:
-        user, volunteer = session.execute(
+        user, volunteer = db.session.execute(
             select(User, Volunteer).outerjoin(Volunteer, Volunteer.user_id == User.id).where(User.id == context.user_id)
         ).one()
         if not volunteer:
@@ -837,15 +824,13 @@ class Account(account_pb2_grpc.AccountServicer):
             volunteer.link_text = link_text
             volunteer.link_url = link_url
 
-        session.flush()
+        db.session.flush()
 
         return _volunteer_info_to_pb(volunteer, user.username)
 
 
 class Iris(iris_pb2_grpc.IrisServicer):
-    def Webhook(
-        self, request: httpbody_pb2.HttpBody, context: CouchersContext, session: Session
-    ) -> httpbody_pb2.HttpBody:
+    def Webhook(self, request: httpbody_pb2.HttpBody, context: CouchersContext, db: DB) -> httpbody_pb2.HttpBody:
         json_data = json.loads(request.data)
         reference_payload = internal_pb2.VerificationReferencePayload.FromString(
             simple_decrypt("iris_callback", b64decode(json_data["session_reference"]))
@@ -854,14 +839,14 @@ class Iris(iris_pb2_grpc.IrisServicer):
         verification_attempt_token = reference_payload.verification_attempt_token
         user_id = reference_payload.user_id
 
-        verification_attempt = session.execute(
+        verification_attempt = db.session.execute(
             select(StrongVerificationAttempt)
             .where(StrongVerificationAttempt.user_id == reference_payload.user_id)
             .where(StrongVerificationAttempt.verification_attempt_token == reference_payload.verification_attempt_token)
             .where(StrongVerificationAttempt.iris_session_id == json_data["session_id"])
         ).scalar_one()
         iris_status = json_data["session_state"]
-        session.add(
+        db.session.add(
             StrongVerificationCallbackEvent(
                 verification_attempt_id=verification_attempt.id,
                 iris_status=iris_status,
@@ -874,10 +859,10 @@ class Iris(iris_pb2_grpc.IrisServicer):
             verification_attempt.status = StrongVerificationAttemptStatus.in_progress_waiting_on_backend
         elif iris_status == "APPROVED":
             verification_attempt.status = StrongVerificationAttemptStatus.in_progress_waiting_on_backend
-            session.commit()
+            db.session.commit()
             # background worker will go and sort this one out
             queue_job(
-                session,
+                db.session,
                 job=finalize_strong_verification,
                 payload=jobs_pb2.FinalizeStrongVerificationPayload(verification_attempt_id=verification_attempt.id),
                 priority=8,

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -22,7 +22,6 @@ from couchers.models import (
     AdminTag,
     Comment,
     ContentReport,
-    Discussion,
     Event,
     EventOccurrence,
     GroupChat,
@@ -44,12 +43,13 @@ from couchers.models.uploads import has_avatar_photo_expression
 from couchers.notifications.notify import notify
 from couchers.proto import admin_pb2, admin_pb2_grpc, api_pb2, notification_data_pb2
 from couchers.proto.internal import jobs_pb2
+from couchers.repositories import DB
 from couchers.resources import get_badge_dict
 from couchers.servicers.api import user_model_to_pb
 from couchers.servicers.auth import create_session
 from couchers.servicers.events import generate_event_delete_notifications
 from couchers.servicers.threads import unpack_thread_id
-from couchers.sql import to_bool, username_or_email_or_id
+from couchers.sql import to_bool
 from couchers.utils import Timestamp_from_datetime, date_to_api, now, parse_date, to_aware_datetime
 
 logger = logging.getLogger(__name__)
@@ -180,21 +180,19 @@ def _reference_to_pb(reference: Reference) -> admin_pb2.AdminReference:
 
 class Admin(admin_pb2_grpc.AdminServicer):
     def GetUserDetails(
-        self, request: admin_pb2.GetUserDetailsReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.GetUserDetailsReq, context: CouchersContext, db: DB
     ) -> admin_pb2.UserDetails:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
-        return _user_to_details(session, user)
+        return _user_to_details(db.session, user)
 
-    def GetUser(self, request: admin_pb2.GetUserReq, context: CouchersContext, session: Session) -> api_pb2.User:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+    def GetUser(self, request: admin_pb2.GetUserReq, context: CouchersContext, db: DB) -> api_pb2.User:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
-        return user_model_to_pb(user, session, context, is_admin_see_ghosts=True)
+        return user_model_to_pb(user, db.session, context, is_admin_see_ghosts=True)
 
     def SearchUsers(
-        self, request: admin_pb2.SearchUsersReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.SearchUsersReq, context: CouchersContext, db: DB
     ) -> admin_pb2.SearchUsersRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_user_id = int(request.page_token) if request.page_token else 0
@@ -252,7 +250,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
                     )
                 )
         users = (
-            session.execute(
+            db.session.execute(
                 statement.where(User.id >= next_user_id)
                 .order_by(User.id)
                 .limit(page_size + 1)
@@ -263,22 +261,21 @@ class Admin(admin_pb2_grpc.AdminServicer):
         )
         logger.info(users)
         return admin_pb2.SearchUsersRes(
-            users=[_user_to_details(session, user) for user in users[:page_size]],
+            users=[_user_to_details(db.session, user) for user in users[:page_size]],
             next_page_token=str(users[-1].id) if len(users) > page_size else None,
         )
 
     def ChangeUserGender(
-        self, request: admin_pb2.ChangeUserGenderReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.ChangeUserGenderReq, context: CouchersContext, db: DB
     ) -> admin_pb2.UserDetails:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         user.gender = request.gender
-        log_admin_action(session, context, user, "change_gender", note=f"Changed to {request.gender}")
-        session.commit()
+        log_admin_action(db.session, context, user, "change_gender", note=f"Changed to {request.gender}")
+        db.session.commit()
 
         notify(
-            session,
+            db.session,
             user_id=user.id,
             topic_action=NotificationTopicAction.gender__change,
             key="",
@@ -287,23 +284,22 @@ class Admin(admin_pb2_grpc.AdminServicer):
             ),
         )
 
-        return _user_to_details(session, user)
+        return _user_to_details(db.session, user)
 
     def ChangeUserBirthdate(
-        self, request: admin_pb2.ChangeUserBirthdateReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.ChangeUserBirthdateReq, context: CouchersContext, db: DB
     ) -> admin_pb2.UserDetails:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         if not (birthdate := parse_date(request.birthdate)):
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_birthdate")
 
         user.birthdate = birthdate
-        log_admin_action(session, context, user, "change_birthdate", note=f"Changed to {request.birthdate}")
-        session.commit()
+        log_admin_action(db.session, context, user, "change_birthdate", note=f"Changed to {request.birthdate}")
+        db.session.commit()
 
         notify(
-            session,
+            db.session,
             user_id=user.id,
             topic_action=NotificationTopicAction.birthdate__change,
             key="",
@@ -312,17 +308,13 @@ class Admin(admin_pb2_grpc.AdminServicer):
             ),
         )
 
-        return _user_to_details(session, user)
+        return _user_to_details(db.session, user)
 
-    def AddBadge(
-        self, request: admin_pb2.AddBadgeReq, context: CouchersContext, session: Session
-    ) -> admin_pb2.UserDetails:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+    def AddBadge(self, request: admin_pb2.AddBadgeReq, context: CouchersContext, db: DB) -> admin_pb2.UserDetails:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
-        badge = get_badge_dict().get(request.badge_id)
-        if not badge:
+        if not (badge := get_badge_dict().get(request.badge_id)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "badge_not_found")
 
         if not badge.admin_editable:
@@ -331,102 +323,86 @@ class Admin(admin_pb2_grpc.AdminServicer):
         if badge.id in [b.badge_id for b in user.badges]:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "user_already_has_badge")
 
-        user_add_badge(session, user.id, request.badge_id)
-        log_admin_action(session, context, user, "add_badge", note=f"Added badge {request.badge_id}")
+        user_add_badge(db.session, user.id, request.badge_id)
+        log_admin_action(db.session, context, user, "add_badge", note=f"Added badge {request.badge_id}")
 
-        return _user_to_details(session, user)
+        return _user_to_details(db.session, user)
 
-    def RemoveBadge(
-        self, request: admin_pb2.RemoveBadgeReq, context: CouchersContext, session: Session
-    ) -> admin_pb2.UserDetails:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+    def RemoveBadge(self, request: admin_pb2.RemoveBadgeReq, context: CouchersContext, db: DB) -> admin_pb2.UserDetails:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
-        badge = get_badge_dict().get(request.badge_id)
-        if not badge:
+        if not (badge := get_badge_dict().get(request.badge_id)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "badge_not_found")
 
         if not badge.admin_editable:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "admin_cannot_edit_badge")
 
-        user_badge = session.execute(
+        user_badge = db.session.execute(
             select(UserBadge).where(UserBadge.user_id == user.id, UserBadge.badge_id == badge.id)
         ).scalar_one_or_none()
         if not user_badge:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "user_does_not_have_badge")
 
-        user_remove_badge(session, user.id, request.badge_id)
-        log_admin_action(session, context, user, "remove_badge", note=f"Removed badge {request.badge_id}")
+        user_remove_badge(db.session, user.id, request.badge_id)
+        log_admin_action(db.session, context, user, "remove_badge", note=f"Removed badge {request.badge_id}")
 
-        return _user_to_details(session, user)
+        return _user_to_details(db.session, user)
 
     def SetPassportSexGenderException(
-        self, request: admin_pb2.SetPassportSexGenderExceptionReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.SetPassportSexGenderExceptionReq, context: CouchersContext, db: DB
     ) -> admin_pb2.UserDetails:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         user.has_passport_sex_gender_exception = request.passport_sex_gender_exception
-        log_admin_action(session, context, user, "set_passport_sex_gender_exception")
-        return _user_to_details(session, user)
+        log_admin_action(db.session, context, user, "set_passport_sex_gender_exception")
+        return _user_to_details(db.session, user)
 
-    def BanUser(
-        self, request: admin_pb2.BanUserReq, context: CouchersContext, session: Session
-    ) -> admin_pb2.UserDetails:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+    def BanUser(self, request: admin_pb2.BanUserReq, context: CouchersContext, db: DB) -> admin_pb2.UserDetails:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         if not request.admin_note.strip():
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "admin_note_cant_be_empty")
-        log_admin_action(session, context, user, "ban", note=request.admin_note, level=AdminActionLevel.high)
+        log_admin_action(db.session, context, user, "ban", note=request.admin_note, level=AdminActionLevel.high)
         user.banned_at = now()
-        return _user_to_details(session, user)
+        return _user_to_details(db.session, user)
 
-    def UnbanUser(
-        self, request: admin_pb2.UnbanUserReq, context: CouchersContext, session: Session
-    ) -> admin_pb2.UserDetails:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+    def UnbanUser(self, request: admin_pb2.UnbanUserReq, context: CouchersContext, db: DB) -> admin_pb2.UserDetails:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         if not request.admin_note.strip():
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "admin_note_cant_be_empty")
-        log_admin_action(session, context, user, "unban", note=request.admin_note, level=AdminActionLevel.high)
+        log_admin_action(db.session, context, user, "unban", note=request.admin_note, level=AdminActionLevel.high)
         user.banned_at = None
-        return _user_to_details(session, user)
+        return _user_to_details(db.session, user)
 
     def AddAdminNote(
-        self, request: admin_pb2.AddAdminNoteReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.AddAdminNoteReq, context: CouchersContext, db: DB
     ) -> admin_pb2.UserDetails:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         if not request.admin_note.strip():
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "admin_note_cant_be_empty")
         level = api2adminactionlevel.get(request.level, AdminActionLevel.normal)
-        log_admin_action(session, context, user, "note", note=request.admin_note, level=level)
-        return _user_to_details(session, user)
+        log_admin_action(db.session, context, user, "note", note=request.admin_note, level=level)
+        return _user_to_details(db.session, user)
 
     def GetContentReport(
-        self, request: admin_pb2.GetContentReportReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.GetContentReportReq, context: CouchersContext, db: DB
     ) -> admin_pb2.GetContentReportRes:
-        content_report = session.execute(
-            select(ContentReport).where(ContentReport.id == request.content_report_id)
-        ).scalar_one_or_none()
-        if not content_report:
+        if not (content_report := db.content_reports.get_by_id(request.content_report_id)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "content_report_not_found")
         return admin_pb2.GetContentReportRes(
             content_report=_content_report_to_pb(content_report),
         )
 
     def GetContentReportsForAuthor(
-        self, request: admin_pb2.GetContentReportsForAuthorReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.GetContentReportsForAuthorReq, context: CouchersContext, db: DB
     ) -> admin_pb2.GetContentReportsForAuthorRes:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         content_reports = (
-            session.execute(
+            db.session.execute(
                 select(ContentReport).where(ContentReport.author_user_id == user.id).order_by(ContentReport.id.desc())
             )
             .scalars()
@@ -436,13 +412,10 @@ class Admin(admin_pb2_grpc.AdminServicer):
             content_reports=[_content_report_to_pb(content_report) for content_report in content_reports],
         )
 
-    def SendModNote(
-        self, request: admin_pb2.SendModNoteReq, context: CouchersContext, session: Session
-    ) -> admin_pb2.UserDetails:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+    def SendModNote(self, request: admin_pb2.SendModNoteReq, context: CouchersContext, db: DB) -> admin_pb2.UserDetails:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
-        session.add(
+        db.session.add(
             ModNote(
                 user_id=user.id,
                 internal_id=request.internal_id,
@@ -450,64 +423,58 @@ class Admin(admin_pb2_grpc.AdminServicer):
                 note_content=request.content,
             )
         )
-        session.flush()
-        log_admin_action(session, context, user, "send_mod_note", note=request.content)
+        db.session.flush()
+        log_admin_action(db.session, context, user, "send_mod_note", note=request.content)
 
         if not request.do_not_notify:
             notify(
-                session,
+                db.session,
                 user_id=user.id,
                 topic_action=NotificationTopicAction.modnote__create,
                 key="",
             )
 
-        return _user_to_details(session, user)
+        return _user_to_details(db.session, user)
 
     def MarkUserNeedsLocationUpdate(
-        self, request: admin_pb2.MarkUserNeedsLocationUpdateReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.MarkUserNeedsLocationUpdateReq, context: CouchersContext, db: DB
     ) -> admin_pb2.UserDetails:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         user.needs_to_update_location = True
-        log_admin_action(session, context, user, "mark_needs_location_update")
-        return _user_to_details(session, user)
+        log_admin_action(db.session, context, user, "mark_needs_location_update")
+        return _user_to_details(db.session, user)
 
-    def DeleteUser(
-        self, request: admin_pb2.DeleteUserReq, context: CouchersContext, session: Session
-    ) -> admin_pb2.UserDetails:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+    def DeleteUser(self, request: admin_pb2.DeleteUserReq, context: CouchersContext, db: DB) -> admin_pb2.UserDetails:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         user.deleted_at = now()
-        log_admin_action(session, context, user, "delete_user", level=AdminActionLevel.high)
-        return _user_to_details(session, user)
+        log_admin_action(db.session, context, user, "delete_user", level=AdminActionLevel.high)
+        return _user_to_details(db.session, user)
 
     def RecoverDeletedUser(
-        self, request: admin_pb2.RecoverDeletedUserReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.RecoverDeletedUserReq, context: CouchersContext, db: DB
     ) -> admin_pb2.UserDetails:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         user.deleted_at = None
         user.undelete_token = None
         user.undelete_until = None
-        log_admin_action(session, context, user, "recover_user", level=AdminActionLevel.high)
-        return _user_to_details(session, user)
+        log_admin_action(db.session, context, user, "recover_user", level=AdminActionLevel.high)
+        return _user_to_details(db.session, user)
 
     def CreateApiKey(
-        self, request: admin_pb2.CreateApiKeyReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.CreateApiKeyReq, context: CouchersContext, db: DB
     ) -> admin_pb2.CreateApiKeyRes:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         token, expiry = create_session(
-            context, session, user, long_lived=True, is_api_key=True, duration=timedelta(days=365), set_cookie=False
+            context, db.session, user, long_lived=True, is_api_key=True, duration=timedelta(days=365), set_cookie=False
         )
-        log_admin_action(session, context, user, "create_api_key")
+        log_admin_action(db.session, context, user, "create_api_key")
 
         notify(
-            session,
+            db.session,
             user_id=user.id,
             topic_action=NotificationTopicAction.api_key__create,
             key="",
@@ -519,11 +486,8 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         return admin_pb2.CreateApiKeyRes()
 
-    def GetChats(
-        self, request: admin_pb2.GetChatsReq, context: CouchersContext, session: Session
-    ) -> admin_pb2.GetChatsRes:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+    def GetChats(self, request: admin_pb2.GetChatsReq, context: CouchersContext, db: DB) -> admin_pb2.GetChatsRes:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
         # Cache for ChatUserInfo to avoid recomputing for the same user
@@ -531,7 +495,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         def get_chat_user_info(user_id: int) -> admin_pb2.ChatUserInfo:
             if user_id not in user_info_cache:
-                u = session.execute(select(User).where(User.id == user_id)).scalar_one()
+                u = db.users.by_id(user_id)
                 user_info_cache[user_id] = admin_pb2.ChatUserInfo(
                     user_id=u.id,
                     username=u.username,
@@ -556,7 +520,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         def get_messages_for_conversation(conversation_id: int) -> list[admin_pb2.ChatMessage]:
             messages = (
-                session.execute(
+                db.session.execute(
                     select(Message).where(Message.conversation_id == conversation_id).order_by(Message.id.asc())
                 )
                 .scalars()
@@ -578,7 +542,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         def get_group_chat_pb(group_chat: GroupChat) -> admin_pb2.AdminGroupChat:
             subs = (
-                session.execute(
+                db.session.execute(
                     select(GroupChatSubscription)
                     .where(GroupChatSubscription.group_chat_id == group_chat.conversation_id)
                     .order_by(GroupChatSubscription.joined.asc())
@@ -606,7 +570,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         # Get all host requests for the user
         host_requests = (
-            session.execute(
+            db.session.execute(
                 select(HostRequest)
                 .where(or_(HostRequest.recipient_user_id == user.id, HostRequest.initiator_user_id == user.id))
                 .order_by(HostRequest.conversation_id.desc())
@@ -617,7 +581,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         # Get all group chats for the user
         group_chat_ids = (
-            session.execute(
+            db.session.execute(
                 select(GroupChatSubscription.group_chat_id)
                 .where(GroupChatSubscription.user_id == user.id)
                 .order_by(GroupChatSubscription.joined.desc())
@@ -626,7 +590,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
             .all()
         )
         group_chats = (
-            session.execute(select(GroupChat).where(GroupChat.conversation_id.in_(group_chat_ids))).scalars().all()
+            db.session.execute(select(GroupChat).where(GroupChat.conversation_id.in_(group_chat_ids))).scalars().all()
         )
 
         return admin_pb2.GetChatsRes(
@@ -635,10 +599,8 @@ class Admin(admin_pb2_grpc.AdminServicer):
             group_chats=[get_group_chat_pb(gc) for gc in group_chats],
         )
 
-    def DeleteEvent(
-        self, request: admin_pb2.DeleteEventReq, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
-        res = session.execute(
+    def DeleteEvent(self, request: admin_pb2.DeleteEventReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
+        res = db.session.execute(
             select(Event, EventOccurrence)
             .where(EventOccurrence.id == request.event_id)
             .where(EventOccurrence.event_id == Event.id)
@@ -653,7 +615,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
         occurrence.is_deleted = True
 
         queue_job(
-            session,
+            db.session,
             job=generate_event_delete_notifications,
             payload=jobs_pb2.GenerateEventDeleteNotificationsPayload(
                 occurrence_id=occurrence.id,
@@ -663,7 +625,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
         return empty_pb2.Empty()
 
     def ListUserIds(
-        self, request: admin_pb2.ListUserIdsReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.ListUserIdsReq, context: CouchersContext, db: DB
     ) -> admin_pb2.ListUserIdsRes:
         start_date = to_aware_datetime(request.start_time)
         end_date = to_aware_datetime(request.end_time)
@@ -672,7 +634,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
         next_user_id = int(request.page_token) if request.page_token else 0
 
         user_ids = (
-            session.execute(
+            db.session.execute(
                 select(User.id)
                 .where(or_(User.id <= next_user_id, to_bool(next_user_id == 0)))
                 .where(User.joined >= start_date)
@@ -690,11 +652,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
         )
 
     def EditReferenceText(
-        self, request: admin_pb2.EditReferenceTextReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.EditReferenceTextReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        reference = session.execute(select(Reference).where(Reference.id == request.reference_id)).scalar_one_or_none()
-
-        if reference is None:
+        if not (reference := db.references.get_by_id(request.reference_id)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "reference_not_found")
 
         if not request.new_text.strip():
@@ -702,39 +662,36 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         reference.text = request.new_text.strip()
         # Log action against the reference author
-        author = session.execute(select(User).where(User.id == reference.from_user_id)).scalar_one()
-        log_admin_action(session, context, author, "edit_reference", note=f"Edited reference {reference.id}")
+        author = db.users.by_id(reference.from_user_id)
+        log_admin_action(db.session, context, author, "edit_reference", note=f"Edited reference {reference.id}")
         return empty_pb2.Empty()
 
     def DeleteReference(
-        self, request: admin_pb2.DeleteReferenceReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.DeleteReferenceReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        reference = session.execute(select(Reference).where(Reference.id == request.reference_id)).scalar_one_or_none()
-
-        if reference is None:
+        if not (reference := db.references.get_by_id(request.reference_id)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "reference_not_found")
 
         reference.is_deleted = True
         # Log action against the reference author
-        author = session.execute(select(User).where(User.id == reference.from_user_id)).scalar_one()
-        log_admin_action(session, context, author, "delete_reference", note=f"Deleted reference {reference.id}")
+        author = db.users.by_id(reference.from_user_id)
+        log_admin_action(db.session, context, author, "delete_reference", note=f"Deleted reference {reference.id}")
         return empty_pb2.Empty()
 
     def GetUserReferences(
-        self, request: admin_pb2.GetUserReferencesReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.GetUserReferencesReq, context: CouchersContext, db: DB
     ) -> admin_pb2.GetUserReferencesRes:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
         references_from = (
-            session.execute(select(Reference).where(Reference.from_user_id == user.id).order_by(Reference.id.desc()))
+            db.session.execute(select(Reference).where(Reference.from_user_id == user.id).order_by(Reference.id.desc()))
             .scalars()
             .all()
         )
 
         references_to = (
-            session.execute(select(Reference).where(Reference.to_user_id == user.id).order_by(Reference.id.desc()))
+            db.session.execute(select(Reference).where(Reference.to_user_id == user.id).order_by(Reference.id.desc()))
             .scalars()
             .all()
         )
@@ -744,13 +701,8 @@ class Admin(admin_pb2_grpc.AdminServicer):
             references_to=[_reference_to_pb(ref) for ref in references_to],
         )
 
-    def EditDiscussion(
-        self, request: admin_pb2.EditDiscussionReq, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
-        discussion = session.execute(
-            select(Discussion).where(Discussion.id == request.discussion_id)
-        ).scalar_one_or_none()
-        if not discussion:
+    def EditDiscussion(self, request: admin_pb2.EditDiscussionReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
+        if not (discussion := db.discussions.get_by_id(request.discussion_id)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "discussion_not_found")
         if request.new_title:
             discussion.title = request.new_title.strip()
@@ -758,14 +710,12 @@ class Admin(admin_pb2_grpc.AdminServicer):
             discussion.content = request.new_content.strip()
         return empty_pb2.Empty()
 
-    def EditReply(self, request: admin_pb2.EditReplyReq, context: CouchersContext, session: Session) -> empty_pb2.Empty:
+    def EditReply(self, request: admin_pb2.EditReplyReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
         database_id, depth = unpack_thread_id(request.reply_id)
         if depth == 1:
-            obj: Comment | Reply | None = session.execute(
-                select(Comment).where(Comment.id == database_id)
-            ).scalar_one_or_none()
+            obj: Comment | Reply | None = db.comments.get_by_id(database_id)
         elif depth == 2:
-            obj = session.execute(select(Reply).where(Reply.id == database_id)).scalar_one_or_none()
+            obj = db.replies.get_by_id(database_id)
         else:
             obj = None
 
@@ -775,7 +725,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
         return empty_pb2.Empty()
 
     def AddUsersToModerationUserList(
-        self, request: admin_pb2.AddUsersToModerationUserListReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.AddUsersToModerationUserListReq, context: CouchersContext, db: DB
     ) -> admin_pb2.AddUsersToModerationUserListRes:
         """Add multiple users to a moderation user list. If no moderation list is provided, a new one is created.
         Id of the moderation list is returned."""
@@ -783,35 +733,33 @@ class Admin(admin_pb2_grpc.AdminServicer):
         users = []
 
         for req_user in req_users:
-            user = session.execute(select(User).where(username_or_email_or_id(req_user))).scalar_one_or_none()
-            if not user:
+            if not (user := db.users.get_by_username_or_email_or_id(req_user)):
                 context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
             users.append(user)
 
         if request.moderation_list_id:
-            moderation_user_list = session.get(ModerationUserList, request.moderation_list_id)
+            moderation_user_list = db.moderation_user_lists.get_by_id(request.moderation_list_id)
             if not moderation_user_list:
                 context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "moderation_user_list_not_found")
         # Create a new moderation user list if no one is provided
         else:
             moderation_user_list = ModerationUserList()
-            session.add(moderation_user_list)
-            session.flush()
+            db.session.add(moderation_user_list)
+            db.session.flush()
 
         # Add users to the moderation list only if not already in it
         for user in users:
             if user not in moderation_user_list.users:
                 moderation_user_list.users.append(user)
-            log_admin_action(session, context, user, "add_to_moderation_list")
+            log_admin_action(db.session, context, user, "add_to_moderation_list")
 
         return admin_pb2.AddUsersToModerationUserListRes(moderation_list_id=moderation_user_list.id)
 
     def ListModerationUserLists(
-        self, request: admin_pb2.ListModerationUserListsReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.ListModerationUserListsReq, context: CouchersContext, db: DB
     ) -> admin_pb2.ListModerationUserListsRes:
         """Lists all moderation user lists for a user."""
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
         moderation_lists = [
@@ -821,53 +769,50 @@ class Admin(admin_pb2_grpc.AdminServicer):
         return admin_pb2.ListModerationUserListsRes(moderation_lists=moderation_lists)
 
     def RemoveUserFromModerationUserList(
-        self, request: admin_pb2.RemoveUserFromModerationUserListReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.RemoveUserFromModerationUserListReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
         """Removes a user from a provided moderation user list."""
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         if not request.moderation_list_id:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "missing_moderation_user_list_id")
 
-        moderation_user_list = session.get(ModerationUserList, request.moderation_list_id)
+        moderation_user_list = db.moderation_user_lists.get_by_id(request.moderation_list_id)
         if not moderation_user_list:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "moderation_user_list_not_found")
         if user not in moderation_user_list.users:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "user_not_in_the_moderation_user_list")
 
         moderation_user_list.users.remove(user)
-        log_admin_action(session, context, user, "remove_from_moderation_list")
+        log_admin_action(db.session, context, user, "remove_from_moderation_list")
 
         if len(moderation_user_list.users) == 0:
-            session.delete(moderation_user_list)
+            db.session.delete(moderation_user_list)
 
         return empty_pb2.Empty()
 
     def CreateAccountDeletionLink(
-        self, request: admin_pb2.CreateAccountDeletionLinkReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.CreateAccountDeletionLinkReq, context: CouchersContext, db: DB
     ) -> admin_pb2.CreateAccountDeletionLinkRes:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         token = AccountDeletionToken(token=urlsafe_secure_token(), user_id=user.id, expiry=now() + timedelta(hours=2))
-        session.add(token)
-        log_admin_action(session, context, user, "create_account_deletion_link", level=AdminActionLevel.high)
+        db.session.add(token)
+        log_admin_action(db.session, context, user, "create_account_deletion_link", level=AdminActionLevel.high)
         return admin_pb2.CreateAccountDeletionLinkRes(
             account_deletion_confirm_url=urls.delete_account_link(account_deletion_token=token.token)
         )
 
     def AccessStats(
-        self, request: admin_pb2.AccessStatsReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.AccessStatsReq, context: CouchersContext, db: DB
     ) -> admin_pb2.AccessStatsRes:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
         start_time = to_aware_datetime(request.start_time) if request.start_time else now() - timedelta(days=90)
         end_time = to_aware_datetime(request.end_time) if request.end_time else now()
 
-        user_activity = session.execute(
+        user_activity = db.session.execute(
             select(
                 UserActivity.ip_address,
                 UserActivity.user_agent,
@@ -909,10 +854,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
         return out
 
     def SetLastDonated(
-        self, request: admin_pb2.SetLastDonatedReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.SetLastDonatedReq, context: CouchersContext, db: DB
     ) -> admin_pb2.UserDetails:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
         if request.HasField("last_donated"):
@@ -920,64 +864,59 @@ class Admin(admin_pb2_grpc.AdminServicer):
         else:
             user.last_donated = None
 
-        log_admin_action(session, context, user, "set_last_donated")
-        return _user_to_details(session, user)
+        log_admin_action(db.session, context, user, "set_last_donated")
+        return _user_to_details(db.session, user)
 
     def CreateAdminTag(
-        self, request: admin_pb2.CreateAdminTagReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.CreateAdminTagReq, context: CouchersContext, db: DB
     ) -> admin_pb2.AdminTagInfo:
-        if not request.tag.strip():
+        if not (tag := request.tag.strip()):
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "admin_tag_cant_be_empty")
-        existing = session.execute(select(AdminTag).where(AdminTag.tag == request.tag.strip())).scalar_one_or_none()
-        if existing:
+        if db.admin_tags.get_by_tag(tag):
             context.abort_with_error_code(grpc.StatusCode.ALREADY_EXISTS, "admin_tag_already_exists")
         admin_tag = AdminTag(tag=request.tag.strip())
-        session.add(admin_tag)
-        session.flush()
+        db.session.add(admin_tag)
+        db.session.flush()
         return admin_pb2.AdminTagInfo(admin_tag_id=admin_tag.id, tag=admin_tag.tag)
 
     def ListAdminTags(
-        self, request: admin_pb2.ListAdminTagsReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.ListAdminTagsReq, context: CouchersContext, db: DB
     ) -> admin_pb2.ListAdminTagsRes:
-        tags = session.execute(select(AdminTag).order_by(AdminTag.tag)).scalars().all()
+        tags = db.session.execute(select(AdminTag).order_by(AdminTag.tag)).scalars().all()
         return admin_pb2.ListAdminTagsRes(
             tags=[admin_pb2.AdminTagInfo(admin_tag_id=tag.id, tag=tag.tag) for tag in tags]
         )
 
     def AddAdminTagToUser(
-        self, request: admin_pb2.AddAdminTagToUserReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.AddAdminTagToUserReq, context: CouchersContext, db: DB
     ) -> admin_pb2.UserDetails:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
-        admin_tag = session.execute(select(AdminTag).where(AdminTag.tag == request.tag)).scalar_one_or_none()
-        if not admin_tag:
+        if not (admin_tag := db.admin_tags.get_by_tag(request.tag)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "admin_tag_not_found")
-        existing = session.execute(
+        existing = db.session.execute(
             select(UserAdminTag).where(UserAdminTag.user_id == user.id, UserAdminTag.admin_tag_id == admin_tag.id)
         ).scalar_one_or_none()
         if existing:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "user_already_has_admin_tag")
-        session.add(UserAdminTag(user_id=user.id, admin_tag_id=admin_tag.id))
-        session.flush()
-        log_admin_action(session, context, user, "add_tag", tag=request.tag)
-        return _user_to_details(session, user)
+        db.session.add(UserAdminTag(user_id=user.id, admin_tag_id=admin_tag.id))
+        db.session.flush()
+        log_admin_action(db.session, context, user, "add_tag", tag=request.tag)
+        return _user_to_details(db.session, user)
 
     def RemoveAdminTagFromUser(
-        self, request: admin_pb2.RemoveAdminTagFromUserReq, context: CouchersContext, session: Session
+        self, request: admin_pb2.RemoveAdminTagFromUserReq, context: CouchersContext, db: DB
     ) -> admin_pb2.UserDetails:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
+        if not (user := db.users.get_by_username_or_email_or_id(request.user)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
-        admin_tag = session.execute(select(AdminTag).where(AdminTag.tag == request.tag)).scalar_one_or_none()
-        if not admin_tag:
+        if not (admin_tag := db.admin_tags.get_by_tag(request.tag)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "admin_tag_not_found")
-        user_admin_tag = session.execute(
+        user_admin_tag = db.session.execute(
             select(UserAdminTag).where(UserAdminTag.user_id == user.id, UserAdminTag.admin_tag_id == admin_tag.id)
         ).scalar_one_or_none()
         if not user_admin_tag:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "user_does_not_have_admin_tag")
-        session.delete(user_admin_tag)
-        session.flush()
-        log_admin_action(session, context, user, "remove_tag", tag=request.tag)
-        return _user_to_details(session, user)
+        db.session.delete(user_admin_tag)
+        db.session.flush()
+        log_admin_action(db.session, context, user, "remove_tag", tag=request.tag)
+        return _user_to_details(db.session, user)

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -51,6 +51,7 @@ from couchers.notifications.settings import get_topic_actions_by_delivery_type
 from couchers.proto import api_pb2, api_pb2_grpc, media_pb2, notification_data_pb2, requests_pb2
 from couchers.rate_limits.check import process_rate_limits_and_check_abort
 from couchers.rate_limits.definitions import RATE_LIMIT_HOURS
+from couchers.repositories import DB
 from couchers.resources import get_badge_dict, language_is_allowed, region_is_allowed
 from couchers.servicers.blocking import is_not_visible
 from couchers.sql import username_or_id, users_visible, where_moderated_content_visible, where_users_column_visible
@@ -168,9 +169,10 @@ fluency2api = {
 
 
 class API(api_pb2_grpc.APIServicer):
-    def Ping(self, request: api_pb2.PingReq, context: CouchersContext, session: Session) -> api_pb2.PingRes:
+    def Ping(self, request: api_pb2.PingReq, context: CouchersContext, db: DB) -> api_pb2.PingRes:
+
         # auth ought to make sure the user exists
-        user = session.execute(
+        user = db.session.execute(
             select(User)
             .where(User.id == context.user_id)
             .options(
@@ -187,7 +189,7 @@ class API(api_pb2_grpc.APIServicer):
         sent_reqs_query = where_moderated_content_visible(sent_reqs_query, context, HostRequest, is_list_operation=True)
         sent_reqs_last_seen_message_ids = sent_reqs_query.subquery()
 
-        unseen_sent_host_request_count = session.execute(
+        unseen_sent_host_request_count = db.session.execute(
             select(func.count())
             .select_from(sent_reqs_last_seen_message_ids)
             .where(
@@ -208,7 +210,7 @@ class API(api_pb2_grpc.APIServicer):
         )
         received_reqs_last_seen_message_ids = received_reqs_query.subquery()
 
-        unseen_received_host_request_count = session.execute(
+        unseen_received_host_request_count = db.session.execute(
             select(func.count())
             .select_from(received_reqs_last_seen_message_ids)
             .where(
@@ -234,7 +236,7 @@ class API(api_pb2_grpc.APIServicer):
             .where(or_(Message.time <= GroupChatSubscription.left, GroupChatSubscription.left == None))
             .where(Message.id > GroupChatSubscription.last_seen_message_id)
         )
-        unseen_message_count = session.execute(unseen_message_query).scalar_one()
+        unseen_message_count = db.session.execute(unseen_message_query).scalar_one()
 
         pending_friend_request_query = select(func.count(FriendRelationship.id)).where(
             FriendRelationship.to_user_id == context.user_id
@@ -248,22 +250,22 @@ class API(api_pb2_grpc.APIServicer):
         pending_friend_request_query = where_moderated_content_visible(
             pending_friend_request_query, context, FriendRelationship, is_list_operation=True
         )
-        pending_friend_request_count = session.execute(pending_friend_request_query).scalar_one()
+        pending_friend_request_count = db.session.execute(pending_friend_request_query).scalar_one()
 
-        unseen_notification_count = session.execute(
+        unseen_notification_count = db.session.execute(
             select(func.count())
             .select_from(Notification)
             .where(Notification.user_id == context.user_id)
             .where(Notification.is_seen == False)
             .where(
                 Notification.topic_action.in_(
-                    get_topic_actions_by_delivery_type(session, user.id, NotificationDeliveryType.push)
+                    get_topic_actions_by_delivery_type(db.session, user.id, NotificationDeliveryType.push)
                 )
             )
         ).scalar_one()
 
         return api_pb2.PingRes(
-            user=user_model_to_pb(user, session, context),
+            user=user_model_to_pb(user, db.session, context),
             unseen_message_count=unseen_message_count,
             unseen_sent_host_request_count=unseen_sent_host_request_count,
             unseen_received_host_request_count=unseen_received_host_request_count,
@@ -271,8 +273,8 @@ class API(api_pb2_grpc.APIServicer):
             unseen_notification_count=unseen_notification_count,
         )
 
-    def GetUser(self, request: api_pb2.GetUserReq, context: CouchersContext, session: Session) -> api_pb2.User:
-        user = session.execute(
+    def GetUser(self, request: api_pb2.GetUserReq, context: CouchersContext, db: DB) -> api_pb2.User:
+        user = db.session.execute(
             select(User)
             .where(username_or_id(request.user))
             .options(
@@ -285,22 +287,20 @@ class API(api_pb2_grpc.APIServicer):
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
-        return user_model_to_pb(user, session, context, is_get_user_return_ghosts=True)
+        return user_model_to_pb(user, db.session, context, is_get_user_return_ghosts=True)
 
-    def GetLiteUser(
-        self, request: api_pb2.GetLiteUserReq, context: CouchersContext, session: Session
-    ) -> api_pb2.LiteUser:
-        lite_user = session.execute(
+    def GetLiteUser(self, request: api_pb2.GetLiteUserReq, context: CouchersContext, db: DB) -> api_pb2.LiteUser:
+        lite_user = db.session.execute(
             select(LiteUser).where(username_or_id(request.user, table=LiteUser))
         ).scalar_one_or_none()
 
         if not lite_user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
-        return lite_user_to_pb(session, lite_user, context, is_get_user_return_ghosts=True)
+        return lite_user_to_pb(db.session, lite_user, context, is_get_user_return_ghosts=True)
 
     def GetLiteUsers(
-        self, request: api_pb2.GetLiteUsersReq, context: CouchersContext, session: Session
+        self, request: api_pb2.GetLiteUsersReq, context: CouchersContext, db: DB
     ) -> api_pb2.GetLiteUsersRes:
         if len(request.users) > MAX_USERS_PER_QUERY:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "requested_too_many_users")
@@ -310,7 +310,7 @@ class API(api_pb2_grpc.APIServicer):
 
         # decomposed where_username_or_id...
         users = (
-            session.execute(select(LiteUser).where(or_(LiteUser.username.in_(usernames), LiteUser.id.in_(ids))))
+            db.session.execute(select(LiteUser).where(or_(LiteUser.username.in_(usernames), LiteUser.id.in_(ids))))
             .scalars()
             .all()
         )
@@ -331,7 +331,7 @@ class API(api_pb2_grpc.APIServicer):
                 api_pb2.LiteUserRes(
                     query=user,
                     not_found=lite_user is None,
-                    user=lite_user_to_pb(session, lite_user, context, is_get_user_return_ghosts=True)
+                    user=lite_user_to_pb(db.session, lite_user, context, is_get_user_return_ghosts=True)
                     if lite_user
                     else None,
                 )
@@ -339,10 +339,8 @@ class API(api_pb2_grpc.APIServicer):
 
         return res
 
-    def UpdateProfile(
-        self, request: api_pb2.UpdateProfileReq, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
-        user: User = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+    def UpdateProfile(self, request: api_pb2.UpdateProfileReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
+        user = db.users.by_id(context.user_id)
 
         if request.HasField("name"):
             if not is_valid_name(request.name.value):
@@ -419,14 +417,14 @@ class API(api_pb2_grpc.APIServicer):
         if request.HasField("language_abilities"):
             # delete all existing abilities
             for ability in user.language_abilities:
-                session.delete(ability)
-            session.flush()
+                db.session.delete(ability)
+            db.session.flush()
 
             # add the new ones
             for language_ability in request.language_abilities.value:
                 if not language_is_allowed(language_ability.code):
                     context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_language")
-                session.add(
+                db.session.add(
                     LanguageAbility(
                         user_id=user.id,
                         language_code=language_ability.code,
@@ -435,12 +433,12 @@ class API(api_pb2_grpc.APIServicer):
                 )
 
         if request.HasField("regions_visited"):
-            session.execute(delete(RegionVisited).where(RegionVisited.user_id == context.user_id))
+            db.session.execute(delete(RegionVisited).where(RegionVisited.user_id == context.user_id))
 
             for region in request.regions_visited.value:
                 if not region_is_allowed(region):
                     context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_region")
-                session.add(
+                db.session.add(
                     RegionVisited(
                         user_id=user.id,
                         region_code=region,
@@ -448,12 +446,12 @@ class API(api_pb2_grpc.APIServicer):
                 )
 
         if request.HasField("regions_lived"):
-            session.execute(delete(RegionLived).where(RegionLived.user_id == context.user_id))
+            db.session.execute(delete(RegionLived).where(RegionLived.user_id == context.user_id))
 
             for region in request.regions_lived.value:
                 if not region_is_allowed(region):
                     context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_region")
-                session.add(
+                db.session.add(
                     RegionLived(
                         user_id=user.id,
                         region_code=region,
@@ -599,9 +597,7 @@ class API(api_pb2_grpc.APIServicer):
 
         return empty_pb2.Empty()
 
-    def ListFriends(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
-    ) -> api_pb2.ListFriendsRes:
+    def ListFriends(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> api_pb2.ListFriendsRes:
         rels_query = select(FriendRelationship)
         rels_query = where_users_column_visible(rels_query, context, FriendRelationship.from_user_id)
         rels_query = where_users_column_visible(rels_query, context, FriendRelationship.to_user_id)
@@ -612,14 +608,12 @@ class API(api_pb2_grpc.APIServicer):
             )
         ).where(FriendRelationship.status == FriendStatus.accepted)
         rels_query = where_moderated_content_visible(rels_query, context, FriendRelationship, is_list_operation=True)
-        rels = session.execute(rels_query).scalars().all()
+        rels = db.session.execute(rels_query).scalars().all()
         return api_pb2.ListFriendsRes(
             user_ids=[rel.from_user.id if rel.from_user.id != context.user_id else rel.to_user.id for rel in rels],
         )
 
-    def RemoveFriend(
-        self, request: api_pb2.RemoveFriendReq, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
+    def RemoveFriend(self, request: api_pb2.RemoveFriendReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
         rel_query = select(FriendRelationship)
         rel_query = where_users_column_visible(rel_query, context, FriendRelationship.from_user_id)
         rel_query = where_users_column_visible(rel_query, context, FriendRelationship.to_user_id)
@@ -636,25 +630,23 @@ class API(api_pb2_grpc.APIServicer):
             )
         ).where(FriendRelationship.status == FriendStatus.accepted)
         rel_query = where_moderated_content_visible(rel_query, context, FriendRelationship)
-        rel = session.execute(rel_query).scalar_one_or_none()
+        rel = db.session.execute(rel_query).scalar_one_or_none()
 
         if not rel:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "not_friends")
 
-        session.delete(rel)
-        log_event(context, session, "friendship.removed", {"other_user_id": request.user_id})
+        db.session.delete(rel)
+        log_event(context, db.session, "friendship.removed", {"other_user_id": request.user_id})
 
         return empty_pb2.Empty()
 
     def ListMutualFriends(
-        self, request: api_pb2.ListMutualFriendsReq, context: CouchersContext, session: Session
+        self, request: api_pb2.ListMutualFriendsReq, context: CouchersContext, db: DB
     ) -> api_pb2.ListMutualFriendsRes:
         if context.user_id == request.user_id:
             return api_pb2.ListMutualFriendsRes(mutual_friends=[])
 
-        user = session.execute(
-            select(User).where(users_visible(context)).where(User.id == request.user_id)
-        ).scalar_one_or_none()
+        user = db.users.get_by_id_if_visible(request.user_id, visible_to=context.user_id)
 
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -698,7 +690,7 @@ class API(api_pb2_grpc.APIServicer):
         mutual = select(intersect(union(q1, q2), union(q3, q4)).subquery())
 
         mutual_friends = (
-            session.execute(select(User).where(users_visible(context)).where(User.id.in_(mutual))).scalars().all()
+            db.session.execute(select(User).where(users_visible(context)).where(User.id.in_(mutual))).scalars().all()
         )
 
         return api_pb2.ListMutualFriendsRes(
@@ -709,21 +701,19 @@ class API(api_pb2_grpc.APIServicer):
         )
 
     def SendFriendRequest(
-        self, request: api_pb2.SendFriendRequestReq, context: CouchersContext, session: Session
+        self, request: api_pb2.SendFriendRequestReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
         if context.user_id == request.user_id:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "cant_friend_self")
 
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
-        to_user = session.execute(
-            select(User).where(users_visible(context)).where(User.id == request.user_id)
-        ).scalar_one_or_none()
+        user = db.users.by_id(context.user_id)
+        to_user = db.users.get_by_id_if_visible(request.user_id, visible_to=context.user_id)
 
         if not to_user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
         if (
-            session.execute(
+            db.session.execute(
                 select(FriendRelationship)
                 .where(
                     or_(
@@ -750,7 +740,7 @@ class API(api_pb2_grpc.APIServicer):
 
         # Check if user has been sending friend requests excessively
         if process_rate_limits_and_check_abort(
-            session=session, user_id=context.user_id, action=RateLimitAction.friend_request
+            db.session, user_id=context.user_id, action=RateLimitAction.friend_request
         ):
             context.abort_with_error_code(
                 grpc.StatusCode.RESOURCE_EXHAUSTED,
@@ -771,32 +761,32 @@ class API(api_pb2_grpc.APIServicer):
                 status=FriendStatus.pending,
                 moderation_state_id=moderation_state_id,
             )
-            session.add(friend_relationship)
-            session.flush()
+            db.session.add(friend_relationship)
+            db.session.flush()
             return friend_relationship.id
 
         moderation_state = create_moderation(
-            session, ModerationObjectType.friend_request, create_friend_relationship, context.user_id
+            db.session, ModerationObjectType.friend_request, create_friend_relationship, context.user_id
         )
 
         assert friend_relationship is not None  # set by create_friend_relationship callback
 
         notify(
-            session,
+            db.session,
             user_id=friend_relationship.to_user_id,
             topic_action=NotificationTopicAction.friend_request__create,
             key=str(friend_relationship.from_user_id),
             data=notification_data_pb2.FriendRequestCreate(
-                other_user=user_model_to_pb(friend_relationship.from_user, session, context),
+                other_user=user_model_to_pb(friend_relationship.from_user, db.session, context),
             ),
             moderation_state_id=moderation_state.id,
         )
-        log_event(context, session, "friendship.request_sent", {"to_user_id": to_user.id})
+        log_event(context, db.session, "friendship.request_sent", {"to_user_id": to_user.id})
 
         return empty_pb2.Empty()
 
     def ListFriendRequests(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+        self, request: empty_pb2.Empty, context: CouchersContext, db: DB
     ) -> api_pb2.ListFriendRequestsRes:
         # both sent and received
         sent_requests_query = select(FriendRelationship)
@@ -807,7 +797,7 @@ class API(api_pb2_grpc.APIServicer):
         sent_requests_query = where_moderated_content_visible(
             sent_requests_query, context, FriendRelationship, is_list_operation=True
         )
-        sent_requests = session.execute(sent_requests_query).scalars().all()
+        sent_requests = db.session.execute(sent_requests_query).scalars().all()
 
         received_requests_query = select(FriendRelationship)
         received_requests_query = where_users_column_visible(
@@ -819,7 +809,7 @@ class API(api_pb2_grpc.APIServicer):
         received_requests_query = where_moderated_content_visible(
             received_requests_query, context, FriendRelationship, is_list_operation=True
         )
-        received_requests = session.execute(received_requests_query).scalars().all()
+        received_requests = db.session.execute(received_requests_query).scalars().all()
 
         return api_pb2.ListFriendRequestsRes(
             sent=[
@@ -843,7 +833,7 @@ class API(api_pb2_grpc.APIServicer):
         )
 
     def RespondFriendRequest(
-        self, request: api_pb2.RespondFriendRequestReq, context: CouchersContext, session: Session
+        self, request: api_pb2.RespondFriendRequestReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
         friend_request_query = select(FriendRelationship)
         friend_request_query = where_users_column_visible(
@@ -855,7 +845,7 @@ class API(api_pb2_grpc.APIServicer):
             .where(FriendRelationship.id == request.friend_request_id)
         )
         friend_request_query = where_moderated_content_visible(friend_request_query, context, FriendRelationship)
-        friend_request = session.execute(friend_request_query).scalar_one_or_none()
+        friend_request = db.session.execute(friend_request_query).scalar_one_or_none()
 
         if not friend_request:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "friend_request_not_found")
@@ -863,22 +853,22 @@ class API(api_pb2_grpc.APIServicer):
         friend_request.status = FriendStatus.accepted if request.accept else FriendStatus.rejected
         friend_request.time_responded = func.now()
 
-        session.flush()
+        db.session.flush()
 
         if friend_request.status == FriendStatus.accepted:
             notify(
-                session,
+                db.session,
                 user_id=friend_request.from_user_id,
                 topic_action=NotificationTopicAction.friend_request__accept,
                 key=str(friend_request.to_user_id),
                 data=notification_data_pb2.FriendRequestAccept(
-                    other_user=user_model_to_pb(friend_request.to_user, session, context),
+                    other_user=user_model_to_pb(friend_request.to_user, db.session, context),
                 ),
             )
 
         log_event(
             context,
-            session,
+            db.session,
             "friendship.request_responded",
             {"from_user_id": friend_request.from_user_id, "accepted": request.accept},
         )
@@ -886,7 +876,7 @@ class API(api_pb2_grpc.APIServicer):
         return empty_pb2.Empty()
 
     def CancelFriendRequest(
-        self, request: api_pb2.CancelFriendRequestReq, context: CouchersContext, session: Session
+        self, request: api_pb2.CancelFriendRequestReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
         friend_request_query = select(FriendRelationship)
         friend_request_query = where_users_column_visible(friend_request_query, context, FriendRelationship.to_user_id)
@@ -896,7 +886,7 @@ class API(api_pb2_grpc.APIServicer):
             .where(FriendRelationship.id == request.friend_request_id)
         )
         friend_request_query = where_moderated_content_visible(friend_request_query, context, FriendRelationship)
-        friend_request = session.execute(friend_request_query).scalar_one_or_none()
+        friend_request = db.session.execute(friend_request_query).scalar_one_or_none()
 
         if not friend_request:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "friend_request_not_found")
@@ -905,14 +895,14 @@ class API(api_pb2_grpc.APIServicer):
         friend_request.time_responded = func.now()
 
         # note no notifications
-        log_event(context, session, "friendship.request_cancelled", {"to_user_id": friend_request.to_user_id})
+        log_event(context, db.session, "friendship.request_cancelled", {"to_user_id": friend_request.to_user_id})
 
-        session.commit()
+        db.session.commit()
 
         return empty_pb2.Empty()
 
     def InitiateMediaUpload(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+        self, request: empty_pb2.Empty, context: CouchersContext, db: DB
     ) -> api_pb2.InitiateMediaUploadRes:
         key = random_hex()
 
@@ -920,8 +910,8 @@ class API(api_pb2_grpc.APIServicer):
         expiry = created + timedelta(minutes=20)
 
         upload = InitiatedUpload(key=key, created=created, expiry=expiry, initiator_user_id=context.user_id)
-        session.add(upload)
-        session.commit()
+        db.session.add(upload)
+        db.session.commit()
 
         req = media_pb2.UploadRequest(
             key=upload.key,
@@ -943,7 +933,7 @@ class API(api_pb2_grpc.APIServicer):
         )
 
     def ListBadgeUsers(
-        self, request: api_pb2.ListBadgeUsersReq, context: CouchersContext, session: Session
+        self, request: api_pb2.ListBadgeUsersReq, context: CouchersContext, db: DB
     ) -> api_pb2.ListBadgeUsersRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_user_id = int(request.page_token) if request.page_token else 0
@@ -956,7 +946,7 @@ class API(api_pb2_grpc.APIServicer):
         )
         badge_user_ids_query = where_users_column_visible(badge_user_ids_query, context, UserBadge.user_id)
         badge_user_ids_query = badge_user_ids_query.order_by(UserBadge.user_id).limit(page_size + 1)
-        badge_user_ids = session.execute(badge_user_ids_query).scalars().all()
+        badge_user_ids = db.session.execute(badge_user_ids_query).scalars().all()
 
         return api_pb2.ListBadgeUsersRes(
             user_ids=badge_user_ids[:page_size],

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -43,6 +43,7 @@ from couchers.models.uploads import get_avatar_upload
 from couchers.notifications.notify import notify
 from couchers.notifications.quick_links import respond_quick_link
 from couchers.proto import auth_pb2, auth_pb2_grpc, notification_data_pb2
+from couchers.repositories import DB
 from couchers.servicers.account import abort_on_invalid_password, contributeoption2sql
 from couchers.servicers.api import hostingstatus2sql
 from couchers.sql import username_or_email
@@ -171,12 +172,10 @@ class Auth(auth_pb2_grpc.AuthServicer):
     This class services the Auth service/API.
     """
 
-    def SignupFlow(
-        self, request: auth_pb2.SignupFlowReq, context: CouchersContext, session: Session
-    ) -> auth_pb2.SignupFlowRes:
+    def SignupFlow(self, request: auth_pb2.SignupFlowReq, context: CouchersContext, db: DB) -> auth_pb2.SignupFlowRes:
         if request.email_token:
             # the email token can either be for verification or just to find an existing signup
-            flow = session.execute(
+            flow = db.session.execute(
                 select(SignupFlow)
                 .where(SignupFlow.email_verified == False)
                 .where(SignupFlow.email_token == request.email_token)
@@ -188,10 +187,10 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 flow.email_token = None
                 flow.email_token_expiry = None
 
-                session.flush()
+                db.session.flush()
             else:
                 # just try to find the flow by flow token, no verification is done
-                flow = session.execute(
+                flow = db.session.execute(
                     select(SignupFlow).where(SignupFlow.flow_token == request.email_token)
                 ).scalar_one_or_none()
                 if not flow:
@@ -202,7 +201,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 if not request.HasField("basic"):
                     context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "signup_flow_basic_needed")
                 # TODO: unique across both tables
-                existing_user = session.execute(
+                existing_user = db.session.execute(
                     select(User).where(User.email == request.basic.email)
                 ).scalar_one_or_none()
                 if existing_user:
@@ -211,12 +210,12 @@ class Auth(auth_pb2_grpc.AuthServicer):
                             grpc.StatusCode.FAILED_PRECONDITION, "signup_email_cannot_be_used"
                         )
                     context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "signup_flow_email_taken")
-                existing_flow = session.execute(
+                existing_flow = db.session.execute(
                     select(SignupFlow).where(SignupFlow.email == request.basic.email)
                 ).scalar_one_or_none()
                 if existing_flow:
-                    send_signup_email(session, existing_flow)
-                    session.commit()
+                    send_signup_email(db.session, existing_flow)
+                    db.session.commit()
                     context.abort_with_error_code(
                         grpc.StatusCode.FAILED_PRECONDITION, "signup_flow_email_started_signup"
                     )
@@ -230,7 +229,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
                 invite_id = None
                 if request.basic.invite_code:
-                    invite_id = session.execute(
+                    invite_id = db.session.execute(
                         select(InviteCode.id).where(
                             InviteCode.id == request.basic.invite_code,
                             or_(InviteCode.disabled == None, InviteCode.disabled > func.now()),
@@ -245,13 +244,13 @@ class Auth(auth_pb2_grpc.AuthServicer):
                     email=request.basic.email,
                     invite_code_id=invite_id,
                 )
-                session.add(flow)
-                session.flush()
+                db.session.add(flow)
+                db.session.flush()
                 signup_initiations_counter.inc()
-                log_event(context, session, "account.signup_initiated", {"has_invite_code": invite_id is not None})
+                log_event(context, db.session, "account.signup_initiated", {"has_invite_code": invite_id is not None})
             else:
                 # not fresh signup
-                flow = session.execute(
+                flow = db.session.execute(
                     select(SignupFlow).where(SignupFlow.flow_token == request.flow_token)
                 ).scalar_one_or_none()
                 if not flow:
@@ -268,7 +267,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 if not is_valid_username(request.account.username):
                     context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_username")
 
-                if not _username_available(session, request.account.username):
+                if not _username_available(db.session, request.account.username):
                     context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "username_not_available")
 
                 abort_on_invalid_password(request.account.password, context)
@@ -297,7 +296,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 flow.geom_radius = request.account.radius
                 flow.accepted_tos = TOS_VERSION
                 flow.opt_out_of_newsletter = request.account.opt_out_of_newsletter
-                session.flush()
+                db.session.flush()
 
             if request.HasField("feedback"):
                 if flow.filled_feedback:
@@ -311,7 +310,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 flow.contribute = contributeoption2sql[form.contribute]
                 flow.contribute_ways = form.contribute_ways  # type: ignore[assignment]
                 flow.expertise = form.expertise
-                session.flush()
+                db.session.flush()
 
             if request.HasField("motivations"):
                 if flow.filled_motivations:
@@ -320,19 +319,19 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 flow.filled_motivations = True
                 flow.heard_about_couchers = request.motivations.heard_about_couchers or None
                 flow.signup_motivations = list(request.motivations.motivations)
-                session.flush()
+                db.session.flush()
 
             if request.HasField("accept_community_guidelines"):
                 if not request.accept_community_guidelines.value:
                     context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "must_accept_community_guidelines")
                 flow.accepted_community_guidelines = GUIDELINES_VERSION
-                session.flush()
+                db.session.flush()
 
             # send verification email if needed
             if not flow.email_sent or request.resend_verification_email:
-                send_signup_email(session, flow)
+                send_signup_email(db.session, flow)
 
-            session.flush()
+            db.session.flush()
 
         # finish the signup if done
         if flow.is_completed:
@@ -358,13 +357,13 @@ class Auth(auth_pb2_grpc.AuthServicer):
             user.onboarding_emails_sent = 1
             user.opt_out_of_newsletter = not_none(flow.opt_out_of_newsletter)
 
-            session.add(user)
-            session.flush()
+            db.session.add(user)
+            db.session.flush()
 
             # Create a profile gallery for the user
             profile_gallery = PhotoGallery(owner_user_id=user.id)
-            session.add(profile_gallery)
-            session.flush()
+            db.session.add(profile_gallery)
+            db.session.flush()
             user.profile_gallery_id = profile_gallery.id
 
             if flow.filled_feedback:
@@ -378,22 +377,22 @@ class Auth(auth_pb2_grpc.AuthServicer):
                     expertise=flow.expertise or None,
                 )
 
-                session.add(form_)
+                db.session.add(form_)
 
                 user.filled_contributor_form = form_.is_filled
 
-                maybe_send_contributor_form_email(session, form_)
+                maybe_send_contributor_form_email(db.session, form_)
 
             signup_duration_s = (now() - flow.created).total_seconds()
 
-            session.delete(flow)
-            session.commit()
+            db.session.delete(flow)
+            db.session.commit()
 
-            enforce_community_memberships_for_user(session, user)
+            enforce_community_memberships_for_user(db.session, user)
 
             # sends onboarding email
             notify(
-                session,
+                db.session,
                 user_id=user.id,
                 topic_action=NotificationTopicAction.onboarding__reminder,
                 key="1",
@@ -403,7 +402,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
             signup_time_histogram.labels(flow.gender).observe(signup_duration_s)
             log_event(
                 context,
-                session,
+                db.session,
                 "account.signup_completed",
                 {
                     "gender": flow.gender,
@@ -416,7 +415,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 _override_user_id=user.id,
             )
 
-            create_session(context, session, user, False)
+            create_session(context, db.session, user, False)
             return auth_pb2.SignupFlowRes(
                 auth_res=_auth_res(user),
             )
@@ -431,21 +430,21 @@ class Auth(auth_pb2_grpc.AuthServicer):
             )
 
     def UsernameValid(
-        self, request: auth_pb2.UsernameValidReq, context: CouchersContext, session: Session
+        self, request: auth_pb2.UsernameValidReq, context: CouchersContext, db: DB
     ) -> auth_pb2.UsernameValidRes:
         """
         Runs a username availability and validity check.
         """
-        return auth_pb2.UsernameValidRes(valid=_username_available(session, request.username.lower()))
+        return auth_pb2.UsernameValidRes(valid=_username_available(db.session, request.username.lower()))
 
-    def Authenticate(self, request: auth_pb2.AuthReq, context: CouchersContext, session: Session) -> auth_pb2.AuthRes:
+    def Authenticate(self, request: auth_pb2.AuthReq, context: CouchersContext, db: DB) -> auth_pb2.AuthRes:
         """
         Authenticates a classic password-based login request.
 
         request.user can be any of id/username/email
         """
         logger.debug(f"Logging in with {request.user=}, password=*******")
-        user = session.execute(
+        user = db.session.execute(
             select(User).where(username_or_email(request.user)).where(User.deleted_at.is_(None))
         ).scalar_one_or_none()
         if user:
@@ -453,10 +452,10 @@ class Auth(auth_pb2_grpc.AuthServicer):
             if verify_password(user.hashed_password, request.password):
                 logger.debug("Right password")
                 # correct password
-                create_session(context, session, user, request.remember_device)
+                create_session(context, db.session, user, request.remember_device)
                 log_event(
                     context,
-                    session,
+                    db.session,
                     "account.login",
                     {"gender": user.gender, "remember_device": request.remember_device},
                     _override_user_id=user.id,
@@ -468,26 +467,24 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "invalid_password")
         else:  # user not found
             # check if this is an email and they tried to sign up but didn't complete
-            signup_flow = session.execute(
+            signup_flow = db.session.execute(
                 select(SignupFlow).where(username_or_email(request.user, table=SignupFlow))
             ).scalar_one_or_none()
             if signup_flow:
-                send_signup_email(session, signup_flow)
-                session.commit()
+                send_signup_email(db.session, signup_flow)
+                db.session.commit()
                 context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "signup_flow_email_started_signup")
             logger.debug("Didn't find user")
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "account_not_found")
 
-    def GetAuthState(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
-    ) -> auth_pb2.GetAuthStateRes:
+    def GetAuthState(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> auth_pb2.GetAuthStateRes:
         if not context.is_logged_in():
             return auth_pb2.GetAuthStateRes(logged_in=False)
         else:
-            user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+            user = db.users.by_id(context.user_id)
             return auth_pb2.GetAuthStateRes(logged_in=True, auth_res=_auth_res(user))
 
-    def Deauthenticate(self, request: empty_pb2.Empty, context: CouchersContext, session: Session) -> empty_pb2.Empty:
+    def Deauthenticate(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> empty_pb2.Empty:
         """
         Removes an active cookie session.
         """
@@ -496,18 +493,16 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
         # if we had a token, try to remove the session
         if token:
-            delete_session(session, token)
+            delete_session(db.session, token)
 
-        log_event(context, session, "account.logout", {})
+        log_event(context, db.session, "account.logout", {})
 
         # set the cookie to an empty string and expire immediately, should remove it from the browser
         context.set_cookies(create_session_cookies("", "", now()))
 
         return empty_pb2.Empty()
 
-    def ResetPassword(
-        self, request: auth_pb2.ResetPasswordReq, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
+    def ResetPassword(self, request: auth_pb2.ResetPasswordReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
         """
         If the user does not exist, do nothing.
 
@@ -516,18 +511,18 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
         Note that as long as emails are send synchronously, this is far from constant time regardless of output.
         """
-        user = session.execute(
+        user = db.session.execute(
             select(User).where(username_or_email(request.user)).where(User.deleted_at.is_(None))
         ).scalar_one_or_none()
         if user:
             password_reset_token = PasswordResetToken(
                 token=urlsafe_secure_token(), user_id=user.id, expiry=now() + timedelta(hours=2)
             )
-            session.add(password_reset_token)
-            session.flush()
+            db.session.add(password_reset_token)
+            db.session.flush()
 
             notify(
-                session,
+                db.session,
                 user_id=user.id,
                 topic_action=NotificationTopicAction.password_reset__start,
                 key="",
@@ -539,7 +534,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
             password_reset_initiations_counter.inc()
             log_event(
                 context,
-                session,
+                db.session,
                 "account.password_reset_initiated",
                 {},
                 _override_user_id=user.id,
@@ -550,12 +545,12 @@ class Auth(auth_pb2_grpc.AuthServicer):
         return empty_pb2.Empty()
 
     def CompletePasswordResetV2(
-        self, request: auth_pb2.CompletePasswordResetV2Req, context: CouchersContext, session: Session
+        self, request: auth_pb2.CompletePasswordResetV2Req, context: CouchersContext, db: DB
     ) -> auth_pb2.AuthRes:
         """
         Completes the password reset: just clears the user's password
         """
-        res = session.execute(
+        res = db.session.execute(
             select(PasswordResetToken, User)
             .join(User, User.id == PasswordResetToken.user_id)
             .where(PasswordResetToken.token == request.password_reset_token)
@@ -565,22 +560,22 @@ class Auth(auth_pb2_grpc.AuthServicer):
             password_reset_token, user = res
             abort_on_invalid_password(request.new_password, context)
             user.hashed_password = hash_password(request.new_password)
-            session.delete(password_reset_token)
+            db.session.delete(password_reset_token)
 
-            session.flush()
+            db.session.flush()
 
             notify(
-                session,
+                db.session,
                 user_id=user.id,
                 topic_action=NotificationTopicAction.password_reset__complete,
                 key="",
             )
 
-            create_session(context, session, user, False)
+            create_session(context, db.session, user, False)
             password_reset_completions_counter.inc()
             log_event(
                 context,
-                session,
+                db.session,
                 "account.password_reset_completed",
                 {},
                 _override_user_id=user.id,
@@ -590,9 +585,9 @@ class Auth(auth_pb2_grpc.AuthServicer):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "invalid_token")
 
     def ConfirmChangeEmailV2(
-        self, request: auth_pb2.ConfirmChangeEmailV2Req, context: CouchersContext, session: Session
+        self, request: auth_pb2.ConfirmChangeEmailV2Req, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        user = session.execute(
+        user = db.session.execute(
             select(User)
             .where(User.new_email_token == request.change_email_token)
             .where(User.new_email_token_created <= now())
@@ -609,23 +604,23 @@ class Auth(auth_pb2_grpc.AuthServicer):
         user.new_email_token_expiry = None
 
         notify(
-            session,
+            db.session,
             user_id=user.id,
             topic_action=NotificationTopicAction.email_address__verify,
             key="",
         )
 
-        log_event(context, session, "account.email_confirmed", {}, _override_user_id=user.id)
+        log_event(context, db.session, "account.email_confirmed", {}, _override_user_id=user.id)
 
         return empty_pb2.Empty()
 
     def ConfirmDeleteAccount(
-        self, request: auth_pb2.ConfirmDeleteAccountReq, context: CouchersContext, session: Session
+        self, request: auth_pb2.ConfirmDeleteAccountReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
         """
         Confirm account deletion using account delete token
         """
-        res = session.execute(
+        res = db.session.execute(
             select(User, AccountDeletionToken)
             .join(AccountDeletionToken, AccountDeletionToken.user_id == User.id)
             .where(AccountDeletionToken.token == request.token)
@@ -637,16 +632,16 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
         user, account_deletion_token = res
 
-        session.execute(delete(AccountDeletionToken).where(AccountDeletionToken.user_id == user.id))
+        db.session.execute(delete(AccountDeletionToken).where(AccountDeletionToken.user_id == user.id))
 
         user.deleted_at = now()
         user.undelete_until = now() + timedelta(days=UNDELETE_DAYS)
         user.undelete_token = urlsafe_secure_token()
 
-        session.flush()
+        db.session.flush()
 
         notify(
-            session,
+            db.session,
             user_id=user.id,
             topic_action=NotificationTopicAction.account_deletion__complete,
             key="",
@@ -659,7 +654,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
         account_deletion_completions_counter.labels(user.gender).inc()
         log_event(
             context,
-            session,
+            db.session,
             "account.deletion_completed",
             {"gender": user.gender},
             _override_user_id=user.id,
@@ -667,13 +662,11 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
         return empty_pb2.Empty()
 
-    def RecoverAccount(
-        self, request: auth_pb2.RecoverAccountReq, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
+    def RecoverAccount(self, request: auth_pb2.RecoverAccountReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
         """
         Recovers a recently deleted account
         """
-        user = session.execute(
+        user = db.session.execute(
             select(User).where(User.undelete_token == request.token).where(User.undelete_until > now())
         ).scalar_one_or_none()
 
@@ -685,7 +678,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
         user.undelete_until = None
 
         notify(
-            session,
+            db.session,
             user_id=user.id,
             topic_action=NotificationTopicAction.account_deletion__recovered,
             key="",
@@ -694,7 +687,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
         account_recoveries_counter.labels(user.gender).inc()
         log_event(
             context,
-            session,
+            db.session,
             "account.recovered",
             {"gender": user.gender},
             _override_user_id=user.id,
@@ -703,11 +696,11 @@ class Auth(auth_pb2_grpc.AuthServicer):
         return empty_pb2.Empty()
 
     def Unsubscribe(
-        self, request: auth_pb2.UnsubscribeReq, context: CouchersContext, session: Session
+        self, request: auth_pb2.UnsubscribeReq, context: CouchersContext, db: DB
     ) -> auth_pb2.UnsubscribeRes:
-        return auth_pb2.UnsubscribeRes(response=respond_quick_link(request, context, session))
+        return auth_pb2.UnsubscribeRes(response=respond_quick_link(request, context, db.session))
 
-    def AntiBot(self, request: auth_pb2.AntiBotReq, context: CouchersContext, session: Session) -> auth_pb2.AntiBotRes:
+    def AntiBot(self, request: auth_pb2.AntiBotReq, context: CouchersContext, db: DB) -> auth_pb2.AntiBotRes:
         if not config["RECAPTHCA_ENABLED"]:
             return auth_pb2.AntiBotRes()
 
@@ -741,33 +734,33 @@ class Auth(auth_pb2_grpc.AuthServicer):
             provider_data=resp.json(),
         )
 
-        session.add(log)
-        session.flush()
+        db.session.add(log)
+        db.session.flush()
 
         recaptchas_assessed_counter.labels(log.action).inc()
         recaptcha_score_histogram.labels(log.action).observe(log.score)
 
         if context.is_logged_in():
-            user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+            user = db.session.execute(select(User).where(User.id == context.user_id)).scalar_one()
             user.last_antibot = now()
 
         return auth_pb2.AntiBotRes()
 
     def AntiBotPolicy(
-        self, request: auth_pb2.AntiBotPolicyReq, context: CouchersContext, session: Session
+        self, request: auth_pb2.AntiBotPolicyReq, context: CouchersContext, db: DB
     ) -> auth_pb2.AntiBotPolicyRes:
         if config["RECAPTHCA_ENABLED"]:
             if context.is_logged_in():
-                user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+                user = db.session.execute(select(User).where(User.id == context.user_id)).scalar_one()
                 if now() - user.last_antibot > ANTIBOT_FREQ:
                     return auth_pb2.AntiBotPolicyRes(should_antibot=True)
 
         return auth_pb2.AntiBotPolicyRes(should_antibot=False)
 
     def GetInviteCodeInfo(
-        self, request: auth_pb2.GetInviteCodeInfoReq, context: CouchersContext, session: Session
+        self, request: auth_pb2.GetInviteCodeInfoReq, context: CouchersContext, db: DB
     ) -> auth_pb2.GetInviteCodeInfoRes:
-        invite = session.execute(
+        invite = db.session.execute(
             select(InviteCode).where(
                 InviteCode.id == request.code, or_(InviteCode.disabled == None, InviteCode.disabled > func.now())
             )
@@ -776,9 +769,9 @@ class Auth(auth_pb2_grpc.AuthServicer):
         if not invite:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "invite_code_not_found")
 
-        user = session.execute(select(User).where(User.id == invite.creator_user_id)).scalar_one()
+        user = db.users.by_id(invite.creator_user_id)
 
-        avatar_upload = get_avatar_upload(session, user)
+        avatar_upload = get_avatar_upload(db.session, user)
 
         return auth_pb2.GetInviteCodeInfoRes(
             name=user.name,

--- a/app/backend/src/couchers/servicers/blocking.py
+++ b/app/backend/src/couchers/servicers/blocking.py
@@ -9,6 +9,7 @@ from couchers.context import CouchersContext
 from couchers.models import Upload, User, UserBlock
 from couchers.models.uploads import get_avatar_photo_subquery
 from couchers.proto import blocking_pb2, blocking_pb2_grpc
+from couchers.repositories import DB
 
 
 def is_not_visible(session: Session, user1_id: int | None, user2_id: int | None) -> bool:
@@ -39,10 +40,8 @@ def is_not_visible(session: Session, user1_id: int | None, user2_id: int | None)
 
 
 class Blocking(blocking_pb2_grpc.BlockingServicer):
-    def BlockUser(
-        self, request: blocking_pb2.BlockUserReq, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
-        blockee = session.execute(
+    def BlockUser(self, request: blocking_pb2.BlockUserReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
+        blockee = db.session.execute(
             select(User).where(User.is_visible).where(User.username == request.username)
         ).scalar_one_or_none()
 
@@ -52,7 +51,7 @@ class Blocking(blocking_pb2_grpc.BlockingServicer):
         if context.user_id == blockee.id:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "cant_block_self")
 
-        if session.execute(
+        if db.session.execute(
             select(
                 exists()
                 .where(UserBlock.blocking_user_id == context.user_id)
@@ -65,22 +64,20 @@ class Blocking(blocking_pb2_grpc.BlockingServicer):
                 blocking_user_id=context.user_id,
                 blocked_user_id=blockee.id,
             )
-            session.add(user_block)
-            session.commit()
+            db.session.add(user_block)
+            db.session.commit()
 
         return empty_pb2.Empty()
 
-    def UnblockUser(
-        self, request: blocking_pb2.UnblockUserReq, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
-        blockee = session.execute(
+    def UnblockUser(self, request: blocking_pb2.UnblockUserReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
+        blockee = db.session.execute(
             select(User).where(User.is_visible).where(User.username == request.username)
         ).scalar_one_or_none()
 
         if not blockee:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
-        user_block = session.execute(
+        user_block = db.session.execute(
             select(UserBlock)
             .where(UserBlock.blocking_user_id == context.user_id)
             .where(UserBlock.blocked_user_id == blockee.id)
@@ -88,17 +85,17 @@ class Blocking(blocking_pb2_grpc.BlockingServicer):
         if not user_block:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "user_not_blocked")
 
-        session.delete(user_block)
-        session.commit()
+        db.session.delete(user_block)
+        db.session.commit()
 
         return empty_pb2.Empty()
 
     def GetBlockedUsers(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+        self, request: empty_pb2.Empty, context: CouchersContext, db: DB
     ) -> blocking_pb2.GetBlockedUsersRes:
         avatar_photo_subquery = get_avatar_photo_subquery()
 
-        blocked_users = session.execute(
+        blocked_users = db.session.execute(
             select(User.username, User.name, Upload.filename)
             .join(UserBlock, UserBlock.blocked_user_id == User.id)
             .outerjoin(

--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -7,8 +7,6 @@ import grpc
 import requests
 from google.protobuf import empty_pb2
 from sqlalchemy import insert, select
-from sqlalchemy.orm import Session
-from sqlalchemy.sql import func
 
 from couchers import urls
 from couchers.config import config
@@ -19,6 +17,7 @@ from couchers.models import User
 from couchers.models.logging import EventLog, EventSource
 from couchers.proto import bugs_pb2, bugs_pb2_grpc
 from couchers.proto.google.api import httpbody_pb2
+from couchers.repositories import DB
 
 _start_time = time.monotonic()
 
@@ -27,12 +26,10 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
     def _version(self) -> str:
         return cast(str, config["VERSION"])
 
-    def Version(self, request: empty_pb2.Empty, context: CouchersContext, session: Session) -> bugs_pb2.VersionInfo:
+    def Version(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> bugs_pb2.VersionInfo:
         return bugs_pb2.VersionInfo(version=self._version())
 
-    def ReportBug(
-        self, request: bugs_pb2.ReportBugReq, context: CouchersContext, session: Session
-    ) -> bugs_pb2.ReportBugRes:
+    def ReportBug(self, request: bugs_pb2.ReportBugReq, context: CouchersContext, db: DB) -> bugs_pb2.ReportBugRes:
         if not config["BUG_TOOL_ENABLED"]:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "bug_tool_disabled")
 
@@ -40,7 +37,7 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
         auth = (config["BUG_TOOL_GITHUB_USERNAME"], config["BUG_TOOL_GITHUB_TOKEN"])
 
         if context.is_logged_in():
-            username = session.execute(select(User.username).where(User.id == context.user_id)).scalar_one()
+            username = db.session.execute(select(User.username).where(User.id == context.user_id)).scalar_one()
             user_details = f"[@{username}]({urls.user_link(username=username)}) ({context.user_id})"
         else:
             user_details = "<not logged in>"
@@ -75,8 +72,8 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
             bug_id=f"#{issue_number}", bug_url=f"https://github.com/{repo}/issues/{issue_number}"
         )
 
-    def Status(self, request: bugs_pb2.StatusReq, context: CouchersContext, session: Session) -> bugs_pb2.StatusRes:
-        coucher_count = session.execute(select(func.count()).select_from(User).where(User.is_visible)).scalar_one()
+    def Status(self, request: bugs_pb2.StatusReq, context: CouchersContext, db: DB) -> bugs_pb2.StatusRes:
+        coucher_count = db.users.count(where=User.is_visible)
 
         return bugs_pb2.StatusRes(
             nonce=request.nonce,
@@ -85,16 +82,14 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
             stable=time.monotonic() - _start_time >= STABLE_THRESHOLD_SECONDS,
         )
 
-    def GetDescriptors(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
-    ) -> httpbody_pb2.HttpBody:
+    def GetDescriptors(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> httpbody_pb2.HttpBody:
         return httpbody_pb2.HttpBody(
             content_type="application/octet-stream",
             data=get_descriptors_pb(),
         )
 
     def ReportDiagnostics(
-        self, request: bugs_pb2.ReportDiagnosticsReq, context: CouchersContext, session: Session
+        self, request: bugs_pb2.ReportDiagnosticsReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
         if len(request.infos) > 100:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "too_many_diagnostic_infos")
@@ -122,16 +117,16 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
             )
 
         if events:
-            session.execute(insert(EventLog), events)
+            db.session.execute(insert(EventLog), events)
 
         return empty_pb2.Empty()
 
     def GeolocationSearchInfo(
-        self, request: bugs_pb2.GeolocationSearchInfoReq, context: CouchersContext, session: Session
+        self, request: bugs_pb2.GeolocationSearchInfoReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
         return empty_pb2.Empty()
 
     def GeolocationClickInfo(
-        self, request: bugs_pb2.GeolocationClickInfoReq, context: CouchersContext, session: Session
+        self, request: bugs_pb2.GeolocationClickInfoReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
         return empty_pb2.Empty()

--- a/app/backend/src/couchers/servicers/communities.py
+++ b/app/backend/src/couchers/servicers/communities.py
@@ -28,6 +28,7 @@ from couchers.models import (
     User,
 )
 from couchers.proto import communities_pb2, communities_pb2_grpc, groups_pb2
+from couchers.repositories import DB
 from couchers.servicers.discussions import discussion_to_pb
 from couchers.servicers.events import event_to_pb
 from couchers.servicers.groups import group_to_pb
@@ -135,23 +136,23 @@ def community_to_pb(session: Session, node: Node, context: CouchersContext) -> c
 
 class Communities(communities_pb2_grpc.CommunitiesServicer):
     def GetCommunity(
-        self, request: communities_pb2.GetCommunityReq, context: CouchersContext, session: Session
+        self, request: communities_pb2.GetCommunityReq, context: CouchersContext, db: DB
     ) -> communities_pb2.Community:
-        node = session.execute(
+        node = db.session.execute(
             select(Node).where(Node.id == request.community_id).options(selectinload(Node.official_cluster))
         ).scalar_one_or_none()
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
 
-        return community_to_pb(session, node, context)
+        return community_to_pb(db.session, node, context)
 
     def ListCommunities(
-        self, request: communities_pb2.ListCommunitiesReq, context: CouchersContext, session: Session
+        self, request: communities_pb2.ListCommunitiesReq, context: CouchersContext, db: DB
     ) -> communities_pb2.ListCommunitiesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         offset = int(decrypt_page_token(request.page_token)) if request.page_token else 0
         nodes = (
-            session.execute(
+            db.session.execute(
                 select(Node)
                 .join(Cluster, Cluster.parent_node_id == Node.id)
                 .where(or_(Node.parent_node_id == request.community_id, to_bool(request.community_id == 0)))
@@ -165,12 +166,12 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             .all()
         )
         return communities_pb2.ListCommunitiesRes(
-            communities=communities_to_pb(session, nodes[:page_size], context),
+            communities=communities_to_pb(db.session, nodes[:page_size], context),
             next_page_token=encrypt_page_token(str(offset + page_size)) if len(nodes) > page_size else None,
         )
 
     def SearchCommunities(
-        self, request: communities_pb2.SearchCommunitiesReq, context: CouchersContext, session: Session
+        self, request: communities_pb2.SearchCommunitiesReq, context: CouchersContext, db: DB
     ) -> communities_pb2.SearchCommunitiesRes:
         raw_query = request.query.strip()
         if len(raw_query) < 3:
@@ -189,17 +190,17 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             .limit(page_size)
         )
 
-        rows = session.execute(query.options(selectinload(Node.official_cluster))).scalars().all()
+        rows = db.session.execute(query.options(selectinload(Node.official_cluster))).scalars().all()
 
-        return communities_pb2.SearchCommunitiesRes(communities=communities_to_pb(session, rows, context))
+        return communities_pb2.SearchCommunitiesRes(communities=communities_to_pb(db.session, rows, context))
 
     def ListGroups(
-        self, request: communities_pb2.ListGroupsReq, context: CouchersContext, session: Session
+        self, request: communities_pb2.ListGroupsReq, context: CouchersContext, db: DB
     ) -> communities_pb2.ListGroupsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_cluster_id = int(request.page_token) if request.page_token else 0
         clusters = (
-            session.execute(
+            db.session.execute(
                 select(Cluster)
                 .where(~Cluster.is_official_cluster)  # not an official group
                 .where(Cluster.parent_node_id == request.community_id)
@@ -211,20 +212,20 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             .all()
         )
         return communities_pb2.ListGroupsRes(
-            groups=[group_to_pb(session, cluster, context) for cluster in clusters[:page_size]],
+            groups=[group_to_pb(db.session, cluster, context) for cluster in clusters[:page_size]],
             next_page_token=str(clusters[-1].id) if len(clusters) > page_size else None,
         )
 
     def ListAdmins(
-        self, request: communities_pb2.ListAdminsReq, context: CouchersContext, session: Session
+        self, request: communities_pb2.ListAdminsReq, context: CouchersContext, db: DB
     ) -> communities_pb2.ListAdminsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_admin_id = int(request.page_token) if request.page_token else 0
-        node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
+        node = db.nodes.get_by_id(request.community_id)
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
         admins = (
-            session.execute(
+            db.session.execute(
                 select(User)
                 .join(ClusterSubscription, ClusterSubscription.user_id == User.id)
                 .where(users_visible(context))
@@ -242,22 +243,20 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             next_page_token=str(admins[-1].id) if len(admins) > page_size else None,
         )
 
-    def AddAdmin(
-        self, request: communities_pb2.AddAdminReq, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
-        node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
+    def AddAdmin(self, request: communities_pb2.AddAdminReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
+        node = db.nodes.get_by_id(request.community_id)
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
-        if not can_moderate_node(session, context.user_id, node.id):
+        if not can_moderate_node(db.session, context.user_id, node.id):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "node_moderate_permission_denied")
 
-        user = session.execute(
+        user = db.session.execute(
             select(User).where(users_visible(context)).where(User.id == request.user_id)
         ).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
-        subscription = session.execute(
+        subscription = db.session.execute(
             select(ClusterSubscription)
             .where(ClusterSubscription.user_id == user.id)
             .where(ClusterSubscription.cluster_id == node.official_cluster.id)
@@ -272,22 +271,20 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
 
         return empty_pb2.Empty()
 
-    def RemoveAdmin(
-        self, request: communities_pb2.RemoveAdminReq, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
-        node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
+    def RemoveAdmin(self, request: communities_pb2.RemoveAdminReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
+        node = db.nodes.get_by_id(request.community_id)
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
-        if not can_moderate_node(session, context.user_id, node.id):
+        if not can_moderate_node(db.session, context.user_id, node.id):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "node_moderate_permission_denied")
 
-        user = session.execute(
+        user = db.session.execute(
             select(User).where(users_visible(context)).where(User.id == request.user_id)
         ).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
-        subscription = session.execute(
+        subscription = db.session.execute(
             select(ClusterSubscription)
             .where(ClusterSubscription.user_id == user.id)
             .where(ClusterSubscription.cluster_id == node.official_cluster.id)
@@ -302,12 +299,12 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         return empty_pb2.Empty()
 
     def ListMembers(
-        self, request: communities_pb2.ListMembersReq, context: CouchersContext, session: Session
+        self, request: communities_pb2.ListMembersReq, context: CouchersContext, db: DB
     ) -> communities_pb2.ListMembersRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_member_id = int(request.page_token) if request.page_token else None
 
-        node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
+        node = db.nodes.get_by_id(request.community_id)
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
 
@@ -319,7 +316,7 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         )
         if next_member_id is not None:
             query = query.where(User.id <= next_member_id)
-        members = session.execute(query.order_by(User.id.desc()).limit(page_size + 1)).scalars().all()
+        members = db.session.execute(query.order_by(User.id.desc()).limit(page_size + 1)).scalars().all()
 
         return communities_pb2.ListMembersRes(
             member_user_ids=[member.id for member in members[:page_size]],
@@ -327,15 +324,15 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         )
 
     def ListNearbyUsers(
-        self, request: communities_pb2.ListNearbyUsersReq, context: CouchersContext, session: Session
+        self, request: communities_pb2.ListNearbyUsersReq, context: CouchersContext, db: DB
     ) -> communities_pb2.ListNearbyUsersRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_nearby_id = int(request.page_token) if request.page_token else 0
-        node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
+        node = db.nodes.get_by_id(request.community_id)
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
         nearbys = (
-            session.execute(
+            db.session.execute(
                 select(User)
                 .where(users_visible(context))
                 .where(func.ST_Contains(node.geom, User.geom))
@@ -352,11 +349,11 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         )
 
     def ListPlaces(
-        self, request: communities_pb2.ListPlacesReq, context: CouchersContext, session: Session
+        self, request: communities_pb2.ListPlacesReq, context: CouchersContext, db: DB
     ) -> communities_pb2.ListPlacesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_page_id = int(request.page_token) if request.page_token else 0
-        node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
+        node = db.nodes.get_by_id(request.community_id)
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
         places = (
@@ -367,16 +364,16 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             .all()
         )
         return communities_pb2.ListPlacesRes(
-            places=[page_to_pb(session, page, context) for page in places[:page_size]],
+            places=[page_to_pb(db.session, page, context) for page in places[:page_size]],
             next_page_token=str(places[-1].id) if len(places) > page_size else None,
         )
 
     def ListGuides(
-        self, request: communities_pb2.ListGuidesReq, context: CouchersContext, session: Session
+        self, request: communities_pb2.ListGuidesReq, context: CouchersContext, db: DB
     ) -> communities_pb2.ListGuidesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_page_id = int(request.page_token) if request.page_token else 0
-        node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
+        node = db.nodes.get_by_id(request.community_id)
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
         guides = (
@@ -387,18 +384,18 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             .all()
         )
         return communities_pb2.ListGuidesRes(
-            guides=[page_to_pb(session, page, context) for page in guides[:page_size]],
+            guides=[page_to_pb(db.session, page, context) for page in guides[:page_size]],
             next_page_token=str(guides[-1].id) if len(guides) > page_size else None,
         )
 
     def ListEvents(
-        self, request: communities_pb2.ListEventsReq, context: CouchersContext, session: Session
+        self, request: communities_pb2.ListEventsReq, context: CouchersContext, db: DB
     ) -> communities_pb2.ListEventsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         # the page token is a unix timestamp of where we left off
         page_token = dt_from_millis(int(request.page_token)) if request.page_token else now()
 
-        node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
+        node = db.nodes.get_by_id(request.community_id)
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
         if not node.official_cluster.events_enabled:
@@ -409,7 +406,7 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         else:
             # the first value is the node_id, the last is the cluster (object)
             nodes_clusters_to_search = [
-                (parent[0], parent[3]) for parent in get_node_parents_recursively(session, node.id)
+                (parent[0], parent[3]) for parent in get_node_parents_recursively(db.session, node.id)
             ]
 
         membership_clauses = []
@@ -431,19 +428,19 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             query = query.where(EventOccurrence.end_time > cutoff).order_by(EventOccurrence.start_time.asc())
 
         query = query.limit(page_size + 1)
-        occurrences = session.execute(query).scalars().all()
+        occurrences = db.session.execute(query).scalars().all()
 
         return communities_pb2.ListEventsRes(
-            events=[event_to_pb(session, occurrence, context) for occurrence in occurrences[:page_size]],
+            events=[event_to_pb(db.session, occurrence, context) for occurrence in occurrences[:page_size]],
             next_page_token=str(millis_from_dt(occurrences[-1].end_time)) if len(occurrences) > page_size else None,
         )
 
     def ListDiscussions(
-        self, request: communities_pb2.ListDiscussionsReq, context: CouchersContext, session: Session
+        self, request: communities_pb2.ListDiscussionsReq, context: CouchersContext, db: DB
     ) -> communities_pb2.ListDiscussionsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_page_id = int(request.page_token) if request.page_token else 0
-        node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
+        node = db.nodes.get_by_id(request.community_id)
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
         if not node.official_cluster.discussions_enabled:
@@ -457,14 +454,14 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
             .all()
         )
         return communities_pb2.ListDiscussionsRes(
-            discussions=[discussion_to_pb(session, discussion, context) for discussion in discussions[:page_size]],
+            discussions=[discussion_to_pb(db.session, discussion, context) for discussion in discussions[:page_size]],
             next_page_token=str(discussions[-1].id) if len(discussions) > page_size else None,
         )
 
     def JoinCommunity(
-        self, request: communities_pb2.JoinCommunityReq, context: CouchersContext, session: Session
+        self, request: communities_pb2.JoinCommunityReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
+        node = db.nodes.get_by_id(request.community_id)
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
 
@@ -482,7 +479,7 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
 
         log_event(
             context,
-            session,
+            db.session,
             "community.joined",
             {"community_id": node.id, "community_name": node.official_cluster.name},
         )
@@ -490,9 +487,9 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         return empty_pb2.Empty()
 
     def LeaveCommunity(
-        self, request: communities_pb2.LeaveCommunityReq, context: CouchersContext, session: Session
+        self, request: communities_pb2.LeaveCommunityReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
+        node = db.nodes.get_by_id(request.community_id)
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
 
@@ -501,29 +498,32 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         if not current_membership:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "not_in_community")
 
-        if is_user_in_node_geography(session, context.user_id, node.id):
+        if is_user_in_node_geography(db.session, context.user_id, node.id):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "cannot_leave_containing_community")
 
-        session.execute(
+        db.session.execute(
             delete(ClusterSubscription)
             .where(ClusterSubscription.cluster_id == node.official_cluster.id)
             .where(ClusterSubscription.user_id == context.user_id)
         )
 
         log_event(
-            context, session, "community.left", {"community_id": node.id, "community_name": node.official_cluster.name}
+            context,
+            db.session,
+            "community.left",
+            {"community_id": node.id, "community_name": node.official_cluster.name},
         )
 
         return empty_pb2.Empty()
 
     def ListUserCommunities(
-        self, request: communities_pb2.ListUserCommunitiesReq, context: CouchersContext, session: Session
+        self, request: communities_pb2.ListUserCommunitiesReq, context: CouchersContext, db: DB
     ) -> communities_pb2.ListUserCommunitiesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_node_id = int(request.page_token) if request.page_token else 0
         user_id = request.user_id or context.user_id
         nodes = (
-            session.execute(
+            db.session.execute(
                 select(Node)
                 .join(Cluster, Cluster.parent_node_id == Node.id)
                 .join(ClusterSubscription, ClusterSubscription.cluster_id == Cluster.id)
@@ -539,16 +539,16 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         )
 
         return communities_pb2.ListUserCommunitiesRes(
-            communities=communities_to_pb(session, nodes[:page_size], context),
+            communities=communities_to_pb(db.session, nodes[:page_size], context),
             next_page_token=str(nodes[-1].id) if len(nodes) > page_size else None,
         )
 
     def ListAllCommunities(
-        self, request: communities_pb2.ListAllCommunitiesReq, context: CouchersContext, session: Session
+        self, request: communities_pb2.ListAllCommunitiesReq, context: CouchersContext, db: DB
     ) -> communities_pb2.ListAllCommunitiesRes:
         """List all communities ordered hierarchically by parent-child relationships"""
         # Get all nodes with their clusters, member counts, and user membership in a single query
-        results = session.execute(
+        results = db.session.execute(
             select(
                 Node,
                 Cluster,
@@ -576,7 +576,7 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
                     slug=cluster.slug,
                     member=user_subscription is not None,
                     member_count=member_count or 1,
-                    parents=_parents_to_pb(session, node.id),
+                    parents=_parents_to_pb(db.session, node.id),
                     created=Timestamp_from_datetime(node.created),
                     node_type=nodetype2api[node.node_type],
                 )

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -34,6 +34,7 @@ from couchers.proto import conversations_pb2, conversations_pb2_grpc, notificati
 from couchers.proto.internal import jobs_pb2
 from couchers.rate_limits.check import process_rate_limits_and_check_abort
 from couchers.rate_limits.definitions import RATE_LIMIT_HOURS
+from couchers.repositories import DB
 from couchers.servicers.api import user_model_to_pb
 from couchers.sql import to_bool, users_visible, where_moderated_content_visible, where_users_column_visible
 from couchers.utils import Timestamp_from_datetime, now
@@ -294,15 +295,13 @@ def _create_chat(
     return chat
 
 
-def _get_message_subscription(session: Session, user_id: int, conversation_id: int) -> GroupChatSubscription:
-    subscription = session.execute(
+def _get_message_subscription(session: Session, user_id: int, conversation_id: int) -> GroupChatSubscription | None:
+    return session.execute(
         select(GroupChatSubscription)
         .where(GroupChatSubscription.group_chat_id == conversation_id)
         .where(GroupChatSubscription.user_id == user_id)
         .where(GroupChatSubscription.left == None)
     ).scalar_one_or_none()
-
-    return cast(GroupChatSubscription, subscription)
 
 
 def _get_visible_message_subscription(
@@ -346,7 +345,7 @@ def _mute_info(subscription: GroupChatSubscription) -> conversations_pb2.MuteInf
 
 class Conversations(conversations_pb2_grpc.ConversationsServicer):
     def ListGroupChats(
-        self, request: conversations_pb2.ListGroupChatsReq, context: CouchersContext, session: Session
+        self, request: conversations_pb2.ListGroupChatsReq, context: CouchersContext, db: DB
     ) -> conversations_pb2.ListGroupChatsRes:
         page_size = request.number if request.number != 0 else DEFAULT_PAGINATION_LENGTH
         page_size = min(page_size, MAX_PAGE_SIZE)
@@ -375,7 +374,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             .subquery()
         )
 
-        results = session.execute(
+        results = db.session.execute(
             where_moderated_content_visible(
                 select(t, GroupChat, GroupChatSubscription, Message)
                 .join(Message, Message.id == t.c.message_id)
@@ -395,7 +394,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         # Batch: unseen message counts in one query instead of N individual queries
         subscription_ids = [r.GroupChatSubscription.id for r in results[:page_size]]
         unseen_counts: dict[int, int] = dict(
-            session.execute(  # type: ignore[arg-type]
+            db.session.execute(  # type: ignore[arg-type]
                 select(GroupChatSubscription.id, func.count(Message.id))
                 .join(Message, Message.conversation_id == GroupChatSubscription.group_chat_id)
                 .where(GroupChatSubscription.id.in_(subscription_ids))
@@ -418,7 +417,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
                     last_seen_message_id=result.GroupChatSubscription.last_seen_message_id,
                     latest_message=_message_to_pb(result.Message) if result.Message else None,
                     mute_info=_mute_info(result.GroupChatSubscription),
-                    can_message=_user_can_message(session, context, result.GroupChat),
+                    can_message=_user_can_message(db.session, context, result.GroupChat),
                     is_archived=result.GroupChatSubscription.is_archived,
                 )
                 for result in results[:page_size]
@@ -430,9 +429,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         )
 
     def GetGroupChat(
-        self, request: conversations_pb2.GetGroupChatReq, context: CouchersContext, session: Session
+        self, request: conversations_pb2.GetGroupChatReq, context: CouchersContext, db: DB
     ) -> conversations_pb2.GroupChat:
-        result = session.execute(
+        result = db.session.execute(
             where_moderated_content_visible(
                 select(GroupChat, GroupChatSubscription, Message)
                 .join(Message, Message.conversation_id == GroupChatSubscription.group_chat_id)
@@ -462,16 +461,16 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             only_admins_invite=result.GroupChat.only_admins_invite,
             is_dm=result.GroupChat.is_dm,
             created=Timestamp_from_datetime(result.GroupChat.conversation.created),
-            unseen_message_count=_unseen_message_count(session, result.GroupChatSubscription.id),
+            unseen_message_count=_unseen_message_count(db.session, result.GroupChatSubscription.id),
             last_seen_message_id=result.GroupChatSubscription.last_seen_message_id,
             latest_message=_message_to_pb(result.Message) if result.Message else None,
             mute_info=_mute_info(result.GroupChatSubscription),
-            can_message=_user_can_message(session, context, result.GroupChat),
+            can_message=_user_can_message(db.session, context, result.GroupChat),
             is_archived=result.GroupChatSubscription.is_archived,
         )
 
     def GetDirectMessage(
-        self, request: conversations_pb2.GetDirectMessageReq, context: CouchersContext, session: Session
+        self, request: conversations_pb2.GetDirectMessageReq, context: CouchersContext, db: DB
     ) -> conversations_pb2.GroupChat:
         count = func.count(GroupChatSubscription.id).label("count")
         subquery = (
@@ -490,7 +489,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             .subquery()
         )
 
-        result = session.execute(
+        result = db.session.execute(
             where_moderated_content_visible(
                 select(subquery, GroupChat, GroupChatSubscription, Message)
                 .join(subquery, subquery.c.group_chat_id == GroupChat.conversation_id)
@@ -520,19 +519,19 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             only_admins_invite=result.GroupChat.only_admins_invite,
             is_dm=result.GroupChat.is_dm,
             created=Timestamp_from_datetime(result.GroupChat.conversation.created),
-            unseen_message_count=_unseen_message_count(session, result.GroupChatSubscription.id),
+            unseen_message_count=_unseen_message_count(db.session, result.GroupChatSubscription.id),
             last_seen_message_id=result.GroupChatSubscription.last_seen_message_id,
             latest_message=_message_to_pb(result.Message) if result.Message else None,
             mute_info=_mute_info(result.GroupChatSubscription),
-            can_message=_user_can_message(session, context, result.GroupChat),
+            can_message=_user_can_message(db.session, context, result.GroupChat),
             is_archived=result.GroupChatSubscription.is_archived,
         )
 
     def GetUpdates(
-        self, request: conversations_pb2.GetUpdatesReq, context: CouchersContext, session: Session
+        self, request: conversations_pb2.GetUpdatesReq, context: CouchersContext, db: DB
     ) -> conversations_pb2.GetUpdatesRes:
         results = (
-            session.execute(
+            db.session.execute(
                 where_moderated_content_visible(
                     select(Message)
                     .join(GroupChatSubscription, GroupChatSubscription.group_chat_id == Message.conversation_id)
@@ -564,13 +563,13 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         )
 
     def GetGroupChatMessages(
-        self, request: conversations_pb2.GetGroupChatMessagesReq, context: CouchersContext, session: Session
+        self, request: conversations_pb2.GetGroupChatMessagesReq, context: CouchersContext, db: DB
     ) -> conversations_pb2.GetGroupChatMessagesRes:
         page_size = request.number if request.number != 0 else DEFAULT_PAGINATION_LENGTH
         page_size = min(page_size, MAX_PAGE_SIZE)
 
         results = (
-            session.execute(
+            db.session.execute(
                 where_moderated_content_visible(
                     select(Message)
                     .join(GroupChatSubscription, GroupChatSubscription.group_chat_id == Message.conversation_id)
@@ -601,9 +600,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         )
 
     def MarkLastSeenGroupChat(
-        self, request: conversations_pb2.MarkLastSeenGroupChatReq, context: CouchersContext, session: Session
+        self, request: conversations_pb2.MarkLastSeenGroupChatReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        subscription = _get_visible_message_subscription(session, context, request.group_chat_id)
+        subscription = _get_visible_message_subscription(db.session, context, request.group_chat_id)
 
         if not subscription:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "chat_not_found")
@@ -616,9 +615,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         return empty_pb2.Empty()
 
     def MuteGroupChat(
-        self, request: conversations_pb2.MuteGroupChatReq, context: CouchersContext, session: Session
+        self, request: conversations_pb2.MuteGroupChatReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        subscription = _get_visible_message_subscription(session, context, request.group_chat_id)
+        subscription = _get_visible_message_subscription(db.session, context, request.group_chat_id)
 
         if not subscription:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "chat_not_found")
@@ -636,9 +635,9 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         return empty_pb2.Empty()
 
     def SetGroupChatArchiveStatus(
-        self, request: conversations_pb2.SetGroupChatArchiveStatusReq, context: CouchersContext, session: Session
+        self, request: conversations_pb2.SetGroupChatArchiveStatusReq, context: CouchersContext, db: DB
     ) -> conversations_pb2.SetGroupChatArchiveStatusRes:
-        subscription = _get_visible_message_subscription(session, context, request.group_chat_id)
+        subscription = _get_visible_message_subscription(db.session, context, request.group_chat_id)
 
         if not subscription:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "chat_not_found")
@@ -651,13 +650,13 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         )
 
     def SearchMessages(
-        self, request: conversations_pb2.SearchMessagesReq, context: CouchersContext, session: Session
+        self, request: conversations_pb2.SearchMessagesReq, context: CouchersContext, db: DB
     ) -> conversations_pb2.SearchMessagesRes:
         page_size = request.number if request.number != 0 else DEFAULT_PAGINATION_LENGTH
         page_size = min(page_size, MAX_PAGE_SIZE)
 
         results = (
-            session.execute(
+            db.session.execute(
                 where_moderated_content_visible(
                     select(Message)
                     .join(GroupChatSubscription, GroupChatSubscription.group_chat_id == Message.conversation_id)
@@ -691,14 +690,14 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         )
 
     def CreateGroupChat(
-        self, request: conversations_pb2.CreateGroupChatReq, context: CouchersContext, session: Session
+        self, request: conversations_pb2.CreateGroupChatReq, context: CouchersContext, db: DB
     ) -> conversations_pb2.GroupChat:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
-        if not has_completed_profile(session, user):
+        user = db.users.by_id(context.user_id)
+        if not has_completed_profile(db.session, user):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "incomplete_profile_send_message")
 
         recipient_user_ids = list(
-            session.execute(
+            db.session.execute(
                 select(User.id).where(users_visible(context)).where(User.id.in_(request.recipient_user_ids))
             )
             .scalars()
@@ -727,7 +726,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             # user_id either this user or the recipient user. If you find two subscriptions to the same DM group
             # chat, you know they already have a shared group chat
             count = func.count(GroupChatSubscription.id).label("count")
-            if session.execute(
+            if db.session.execute(
                 where_moderated_content_visible(
                     select(count)
                     .where(
@@ -750,7 +749,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
 
         # Check if user has been initiating chats excessively
         if process_rate_limits_and_check_abort(
-            session=session, user_id=context.user_id, action=RateLimitAction.chat_initiation
+            session=db.session, user_id=context.user_id, action=RateLimitAction.chat_initiation
         ):
             context.abort_with_error_code(
                 grpc.StatusCode.RESOURCE_EXHAUSTED,
@@ -759,21 +758,22 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             )
 
         group_chat = _create_chat(
-            session,
+            db.session,
             creator_id=context.user_id,
             recipient_ids=request.recipient_user_ids,
             title=request.title.value,
         )
 
-        your_subscription = _get_message_subscription(session, context.user_id, group_chat.conversation_id)
+        your_subscription = _get_message_subscription(db.session, context.user_id, group_chat.conversation_id)
+        assert your_subscription is not None
 
-        _add_message_to_subscription(session, your_subscription, message_type=MessageType.chat_created)
+        _add_message_to_subscription(db.session, your_subscription, message_type=MessageType.chat_created)
 
-        session.flush()
+        db.session.flush()
 
         log_event(
             context,
-            session,
+            db.session,
             "group_chat.created",
             {
                 "group_chat_id": group_chat.conversation_id,
@@ -795,12 +795,12 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         )
 
     def SendMessage(
-        self, request: conversations_pb2.SendMessageReq, context: CouchersContext, session: Session
+        self, request: conversations_pb2.SendMessageReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
         if request.text == "":
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_message")
 
-        result = session.execute(
+        result = db.session.execute(
             where_moderated_content_visible(
                 select(GroupChatSubscription, GroupChat)
                 .join(GroupChat, GroupChat.conversation_id == GroupChatSubscription.group_chat_id)
@@ -816,18 +816,18 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "chat_not_found")
 
         subscription, group_chat = result._tuple()
-        if not _user_can_message(session, context, group_chat):
+        if not _user_can_message(db.session, context, group_chat):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "cant_message_in_chat")
 
-        _add_message_to_subscription(session, subscription, message_type=MessageType.text, text=request.text)
+        _add_message_to_subscription(db.session, subscription, message_type=MessageType.text, text=request.text)
 
-        user_gender = session.execute(select(User.gender).where(User.id == context.user_id)).scalar_one()
+        user_gender = db.session.execute(select(User.gender).where(User.id == context.user_id)).scalar_one()
         sent_messages_counter.labels(
             user_gender, "direct message" if subscription.group_chat.is_dm else "group chat"
         ).inc()
         log_event(
             context,
-            session,
+            db.session,
             "message.sent",
             {"group_chat_id": request.group_chat_id, "is_dm": subscription.group_chat.is_dm},
         )
@@ -835,20 +835,20 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         return empty_pb2.Empty()
 
     def SendDirectMessage(
-        self, request: conversations_pb2.SendDirectMessageReq, context: CouchersContext, session: Session
+        self, request: conversations_pb2.SendDirectMessageReq, context: CouchersContext, db: DB
     ) -> conversations_pb2.SendDirectMessageRes:
         user_id = context.user_id
-        user = session.execute(select(User).where(User.id == user_id)).scalar_one()
+        user = db.users.by_id(user_id)
 
         recipient_id = request.recipient_user_id
 
-        if not has_completed_profile(session, user):
+        if not has_completed_profile(db.session, user):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "incomplete_profile_send_message")
 
         if not recipient_id:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "no_recipients")
 
-        recipient_user_id = session.execute(
+        recipient_user_id = db.session.execute(
             select(User.id).where(users_visible(context)).where(User.id == recipient_id)
         ).scalar_one_or_none()
 
@@ -869,7 +869,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             .having(func.count(GroupChatSubscription.user_id) == 2)
         )
 
-        chat = session.execute(
+        chat = db.session.execute(
             where_moderated_content_visible(
                 select(GroupChat)
                 .where(GroupChat.is_dm == True)
@@ -882,31 +882,32 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         ).scalar_one_or_none()
 
         if not chat:
-            chat = _create_chat(session, user_id, [recipient_id])
+            chat = _create_chat(db.session, user_id, [recipient_id])
 
         # Retrieve the sender's active subscription to the chat
-        subscription = _get_message_subscription(session, user_id, chat.conversation_id)
+        subscription = _get_message_subscription(db.session, user_id, chat.conversation_id)
+        assert subscription is not None
 
         # Add the message to the conversation
-        _add_message_to_subscription(session, subscription, message_type=MessageType.text, text=request.text)
+        _add_message_to_subscription(db.session, subscription, message_type=MessageType.text, text=request.text)
 
-        user_gender = session.execute(select(User.gender).where(User.id == user_id)).scalar_one()
+        user_gender = db.session.execute(select(User.gender).where(User.id == user_id)).scalar_one()
         sent_messages_counter.labels(user_gender, "direct message").inc()
         log_event(
             context,
-            session,
+            db.session,
             "message.sent",
             {"group_chat_id": chat.conversation_id, "is_dm": True, "recipient_id": recipient_id},
         )
 
-        session.flush()
+        db.session.flush()
 
         return conversations_pb2.SendDirectMessageRes(group_chat_id=chat.conversation_id)
 
     def EditGroupChat(
-        self, request: conversations_pb2.EditGroupChatReq, context: CouchersContext, session: Session
+        self, request: conversations_pb2.EditGroupChatReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        subscription = _get_visible_message_subscription(session, context, request.group_chat_id)
+        subscription = _get_visible_message_subscription(db.session, context, request.group_chat_id)
 
         if not subscription:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "chat_not_found")
@@ -920,19 +921,17 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         if request.HasField("only_admins_invite"):
             subscription.group_chat.only_admins_invite = request.only_admins_invite.value
 
-        _add_message_to_subscription(session, subscription, message_type=MessageType.chat_edited)
+        _add_message_to_subscription(db.session, subscription, message_type=MessageType.chat_edited)
 
         return empty_pb2.Empty()
 
     def MakeGroupChatAdmin(
-        self, request: conversations_pb2.MakeGroupChatAdminReq, context: CouchersContext, session: Session
+        self, request: conversations_pb2.MakeGroupChatAdminReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        if not session.execute(
-            select(User).where(users_visible(context)).where(User.id == request.user_id)
-        ).scalar_one_or_none():
+        if not db.users.get_by_id_if_visible(request.user_id, visible_to=context.user_id):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
-        your_subscription = _get_visible_message_subscription(session, context, request.group_chat_id)
+        your_subscription = _get_visible_message_subscription(db.session, context, request.group_chat_id)
 
         if not your_subscription:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "chat_not_found")
@@ -943,7 +942,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         if request.user_id == context.user_id:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "cant_make_self_admin")
 
-        their_subscription = _get_message_subscription(session, request.user_id, request.group_chat_id)
+        their_subscription = _get_message_subscription(db.session, request.user_id, request.group_chat_id)
 
         if not their_subscription:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "user_not_in_chat")
@@ -954,27 +953,25 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         their_subscription.role = GroupChatRole.admin
 
         _add_message_to_subscription(
-            session, your_subscription, message_type=MessageType.user_made_admin, target_id=request.user_id
+            db.session, your_subscription, message_type=MessageType.user_made_admin, target_id=request.user_id
         )
 
         return empty_pb2.Empty()
 
     def RemoveGroupChatAdmin(
-        self, request: conversations_pb2.RemoveGroupChatAdminReq, context: CouchersContext, session: Session
+        self, request: conversations_pb2.RemoveGroupChatAdminReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        if not session.execute(
-            select(User).where(users_visible(context)).where(User.id == request.user_id)
-        ).scalar_one_or_none():
+        if not db.users.get_by_id_if_visible(request.user_id, visible_to=context.user_id):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
-        your_subscription = _get_visible_message_subscription(session, context, request.group_chat_id)
+        your_subscription = _get_visible_message_subscription(db.session, context, request.group_chat_id)
 
         if not your_subscription:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "chat_not_found")
 
         if request.user_id == context.user_id:
             # Race condition!
-            other_admins_count = session.execute(
+            other_admins_count = db.session.execute(
                 select(func.count())
                 .select_from(GroupChatSubscription)
                 .where(GroupChatSubscription.group_chat_id == request.group_chat_id)
@@ -988,7 +985,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         if your_subscription.role != GroupChatRole.admin:
             context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "only_admin_can_remove_admin")
 
-        their_subscription = session.execute(
+        their_subscription = db.session.execute(
             select(GroupChatSubscription)
             .where(GroupChatSubscription.group_chat_id == request.group_chat_id)
             .where(GroupChatSubscription.user_id == request.user_id)
@@ -1002,20 +999,18 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         their_subscription.role = GroupChatRole.participant
 
         _add_message_to_subscription(
-            session, your_subscription, message_type=MessageType.user_removed_admin, target_id=request.user_id
+            db.session, your_subscription, message_type=MessageType.user_removed_admin, target_id=request.user_id
         )
 
         return empty_pb2.Empty()
 
     def InviteToGroupChat(
-        self, request: conversations_pb2.InviteToGroupChatReq, context: CouchersContext, session: Session
+        self, request: conversations_pb2.InviteToGroupChatReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        if not session.execute(
-            select(User).where(users_visible(context)).where(User.id == request.user_id)
-        ).scalar_one_or_none():
+        if not db.users.get_by_id_if_visible(request.user_id, visible_to=context.user_id):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
-        result = session.execute(
+        result = db.session.execute(
             where_moderated_content_visible(
                 select(GroupChatSubscription, GroupChat)
                 .join(GroupChat, GroupChat.conversation_id == GroupChatSubscription.group_chat_id)
@@ -1042,7 +1037,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         if group_chat.is_dm:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "cant_invite_to_dm")
 
-        their_subscription = _get_message_subscription(session, request.user_id, request.group_chat_id)
+        their_subscription = _get_message_subscription(db.session, request.user_id, request.group_chat_id)
 
         if their_subscription:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "already_in_chat")
@@ -1054,23 +1049,23 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             group_chat_id=your_subscription.group_chat.conversation_id,
             role=GroupChatRole.participant,
         )
-        session.add(subscription)
+        db.session.add(subscription)
 
         _add_message_to_subscription(
-            session, your_subscription, message_type=MessageType.user_invited, target_id=request.user_id
+            db.session, your_subscription, message_type=MessageType.user_invited, target_id=request.user_id
         )
 
         return empty_pb2.Empty()
 
     def RemoveGroupChatUser(
-        self, request: conversations_pb2.RemoveGroupChatUserReq, context: CouchersContext, session: Session
+        self, request: conversations_pb2.RemoveGroupChatUserReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
         """
         1. Get admin info and check it's correct
         2. Get user data, check it's correct and remove user
         """
         # Admin info
-        your_subscription = _get_visible_message_subscription(session, context, request.group_chat_id)
+        your_subscription = _get_visible_message_subscription(db.session, context, request.group_chat_id)
 
         # if user info is missing
         if not your_subscription:
@@ -1085,14 +1080,14 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "cant_remove_self")
 
         # get user info
-        their_subscription = _get_message_subscription(session, request.user_id, request.group_chat_id)
+        their_subscription = _get_message_subscription(db.session, request.user_id, request.group_chat_id)
 
         # user not found
         if not their_subscription:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "user_not_in_chat")
 
         _add_message_to_subscription(
-            session, your_subscription, message_type=MessageType.user_removed, target_id=request.user_id
+            db.session, your_subscription, message_type=MessageType.user_removed, target_id=request.user_id
         )
 
         their_subscription.left = func.now()
@@ -1100,15 +1095,15 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         return empty_pb2.Empty()
 
     def LeaveGroupChat(
-        self, request: conversations_pb2.LeaveGroupChatReq, context: CouchersContext, session: Session
+        self, request: conversations_pb2.LeaveGroupChatReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        subscription = _get_visible_message_subscription(session, context, request.group_chat_id)
+        subscription = _get_visible_message_subscription(db.session, context, request.group_chat_id)
 
         if not subscription:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "chat_not_found")
 
         if subscription.role == GroupChatRole.admin:
-            other_admins_count = session.execute(
+            other_admins_count = db.session.execute(
                 select(func.count())
                 .select_from(GroupChatSubscription)
                 .where(GroupChatSubscription.group_chat_id == request.group_chat_id)
@@ -1116,7 +1111,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
                 .where(GroupChatSubscription.role == GroupChatRole.admin)
                 .where(GroupChatSubscription.left == None)
             ).scalar_one()
-            participants_count = session.execute(
+            participants_count = db.session.execute(
                 select(func.count())
                 .select_from(GroupChatSubscription)
                 .where(GroupChatSubscription.group_chat_id == request.group_chat_id)
@@ -1127,7 +1122,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             if not (other_admins_count > 0 or participants_count == 0):
                 context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "last_admin_cant_leave")
 
-        _add_message_to_subscription(session, subscription, message_type=MessageType.user_left)
+        _add_message_to_subscription(db.session, subscription, message_type=MessageType.user_left)
 
         subscription.left = func.now()
 

--- a/app/backend/src/couchers/servicers/discussions.py
+++ b/app/backend/src/couchers/servicers/discussions.py
@@ -13,6 +13,7 @@ from couchers.models.notifications import NotificationTopicAction
 from couchers.notifications.notify import notify
 from couchers.proto import discussions_pb2, discussions_pb2_grpc, notification_data_pb2
 from couchers.proto.internal import jobs_pb2
+from couchers.repositories import DB
 from couchers.servicers.api import user_model_to_pb
 from couchers.servicers.blocking import is_not_visible
 from couchers.servicers.threads import thread_to_pb
@@ -73,7 +74,7 @@ def generate_create_discussion_notifications(payload: jobs_pb2.GenerateCreateDis
 
 class Discussions(discussions_pb2_grpc.DiscussionsServicer):
     def CreateDiscussion(
-        self, request: discussions_pb2.CreateDiscussionReq, context: CouchersContext, session: Session
+        self, request: discussions_pb2.CreateDiscussionReq, context: CouchersContext, db: DB
     ) -> discussions_pb2.Discussion:
         if not request.title:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "missing_discussion_title")
@@ -83,11 +84,11 @@ class Discussions(discussions_pb2_grpc.DiscussionsServicer):
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "group_or_community_not_found")
 
         if request.WhichOneof("owner") == "owner_group_id":
-            cluster = session.execute(
+            cluster = db.session.execute(
                 select(Cluster).where(~Cluster.is_official_cluster).where(Cluster.id == request.owner_group_id)
             ).scalar_one_or_none()
         elif request.WhichOneof("owner") == "owner_community_id":
-            cluster = session.execute(
+            cluster = db.session.execute(
                 select(Cluster)
                 .where(Cluster.parent_node_id == request.owner_community_id)
                 .where(Cluster.is_official_cluster)
@@ -100,8 +101,8 @@ class Discussions(discussions_pb2_grpc.DiscussionsServicer):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "cannot_create_discussion")
 
         thread = Thread()
-        session.add(thread)
-        session.flush()
+        db.session.add(thread)
+        db.session.flush()
 
         discussion = Discussion(
             title=request.title,
@@ -110,12 +111,12 @@ class Discussions(discussions_pb2_grpc.DiscussionsServicer):
             owner_cluster_id=cluster.id,
             thread_id=thread.id,
         )
-        session.add(discussion)
-        session.flush()
+        db.session.add(discussion)
+        db.session.flush()
 
         log_event(
             context,
-            session,
+            db.session,
             "discussion.created",
             {
                 "discussion_id": discussion.id,
@@ -126,22 +127,19 @@ class Discussions(discussions_pb2_grpc.DiscussionsServicer):
         )
 
         queue_job(
-            session,
+            db.session,
             job=generate_create_discussion_notifications,
             payload=jobs_pb2.GenerateCreateDiscussionNotificationsPayload(
                 discussion_id=discussion.id,
             ),
         )
 
-        return discussion_to_pb(session, discussion, context)
+        return discussion_to_pb(db.session, discussion, context)
 
     def GetDiscussion(
-        self, request: discussions_pb2.GetDiscussionReq, context: CouchersContext, session: Session
+        self, request: discussions_pb2.GetDiscussionReq, context: CouchersContext, db: DB
     ) -> discussions_pb2.Discussion:
-        discussion = session.execute(
-            select(Discussion).where(Discussion.id == request.discussion_id)
-        ).scalar_one_or_none()
-        if not discussion:
+        if not (discussion := db.discussions.get_by_id(request.discussion_id)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "discussion_not_found")
 
-        return discussion_to_pb(session, discussion, context)
+        return discussion_to_pb(db.session, discussion, context)

--- a/app/backend/src/couchers/servicers/donations.py
+++ b/app/backend/src/couchers/servicers/donations.py
@@ -17,6 +17,7 @@ from couchers.models.notifications import NotificationTopicAction
 from couchers.notifications.notify import notify
 from couchers.proto import donations_pb2, donations_pb2_grpc, notification_data_pb2, stripe_pb2_grpc
 from couchers.proto.google.api import httpbody_pb2
+from couchers.repositories import DB
 from couchers.sentry import report_error
 from couchers.slack import send_slack_message
 from couchers.utils import not_none
@@ -39,19 +40,19 @@ def _create_stripe_customer(session: Session, user: User) -> None:
 
 class Donations(donations_pb2_grpc.DonationsServicer):
     def InitiateDonation(
-        self, request: donations_pb2.InitiateDonationReq, context: CouchersContext, session: Session
+        self, request: donations_pb2.InitiateDonationReq, context: CouchersContext, db: DB
     ) -> donations_pb2.InitiateDonationRes:
         if not config["ENABLE_DONATIONS"]:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "donations_disabled")
 
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
 
         if request.amount < 2:
             # we don't want to waste *all* of the donation on processing fees
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "donation_too_small")
 
         if not user.stripe_customer_id:
-            _create_stripe_customer(session, user)
+            _create_stripe_customer(db.session, user)
 
         if request.recurring:
             item = {
@@ -84,7 +85,7 @@ class Donations(donations_pb2_grpc.DonationsServicer):
             api_key=config["STRIPE_API_KEY"],
         )
 
-        session.add(
+        db.session.add(
             DonationInitiation(
                 user_id=user.id,
                 amount=request.amount,
@@ -96,7 +97,7 @@ class Donations(donations_pb2_grpc.DonationsServicer):
 
         log_event(
             context,
-            session,
+            db.session,
             "donation.initiated",
             {"amount": request.amount, "recurring": request.recurring, "source": request.source or None},
         )
@@ -106,15 +107,15 @@ class Donations(donations_pb2_grpc.DonationsServicer):
         )
 
     def GetDonationPortalLink(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+        self, request: empty_pb2.Empty, context: CouchersContext, db: DB
     ) -> donations_pb2.GetDonationPortalLinkRes:
         if not config["ENABLE_DONATIONS"]:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "donations_disabled")
 
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
 
         if not user.stripe_customer_id:
-            _create_stripe_customer(session, user)
+            _create_stripe_customer(db.session, user)
 
         stripe_session = stripe.billing_portal.Session.create(
             customer=not_none(user.stripe_customer_id),
@@ -126,9 +127,7 @@ class Donations(donations_pb2_grpc.DonationsServicer):
 
 
 class Stripe(stripe_pb2_grpc.StripeServicer):
-    def Webhook(
-        self, request: httpbody_pb2.HttpBody, context: CouchersContext, session: Session
-    ) -> httpbody_pb2.HttpBody:
+    def Webhook(self, request: httpbody_pb2.HttpBody, context: CouchersContext, db: DB) -> httpbody_pb2.HttpBody:
         # We're set up to receive the following webhook events (with explanations from stripe docs):
         # For both recurring and one-off donations, we get a `charge.succeeded` event and we then send the user an
         # invoice. There are other events too, but we don't handle them right now.
@@ -152,9 +151,9 @@ class Stripe(stripe_pb2_grpc.StripeServicer):
                 # merch shop. look up this email and give them the swagster badge
                 customer_email = metadata["customer_email"]
                 amount = int(data_object["amount"]) // 100
-                user = session.execute(select(User).where(User.email == customer_email)).scalar_one_or_none()
+                user = db.session.execute(select(User).where(User.email == customer_email)).scalar_one_or_none()
                 if user:
-                    user_add_badge(session, user.id, "swagster")
+                    user_add_badge(db.session, user.id, "swagster")
                     user_link = urls.user_link(username=user.username)
                     customer_info = f"<{user_link}|{user.name}>"
                 else:
@@ -168,7 +167,7 @@ class Stripe(stripe_pb2_grpc.StripeServicer):
                     report_error(e)
             else:
                 customer_id = data_object["customer"]
-                user = session.execute(select(User).where(User.stripe_customer_id == customer_id)).scalar_one()
+                user = db.session.execute(select(User).where(User.stripe_customer_id == customer_id)).scalar_one()
                 # amount comes in cents
                 amount = int(data_object["amount"]) // 100
                 receipt_url = data_object["receipt_url"]
@@ -181,12 +180,12 @@ class Stripe(stripe_pb2_grpc.StripeServicer):
                     stripe_receipt_url=receipt_url,
                     invoice_type=InvoiceType.on_platform,
                 )
-                session.add(invoice)
-                session.flush()
+                db.session.add(invoice)
+                db.session.flush()
                 user.last_donated = invoice.created
 
                 notify(
-                    session,
+                    db.session,
                     user_id=user.id,
                     topic_action=NotificationTopicAction.donation__received,
                     key="",

--- a/app/backend/src/couchers/servicers/editor.py
+++ b/app/backend/src/couchers/servicers/editor.py
@@ -16,13 +16,14 @@ from couchers.db import session_scope
 from couchers.helpers.clusters import CHILD_NODE_TYPE, create_cluster, create_node
 from couchers.jobs.enqueue import queue_job
 from couchers.materialized_views import LiteUser
-from couchers.models import EventCommunityInviteRequest, Node, User, Volunteer
+from couchers.models import EventCommunityInviteRequest, User, Volunteer
 from couchers.models.notifications import NotificationTopicAction
 from couchers.models.postal_verification import PostalVerificationAttempt
 from couchers.notifications.notify import notify
 from couchers.postal.my_postcard import download_pdf
 from couchers.proto import communities_pb2, editor_pb2, editor_pb2_grpc, notification_data_pb2, postal_verification_pb2
 from couchers.proto.internal import jobs_pb2
+from couchers.repositories import DB
 from couchers.resources import get_static_badge_dict
 from couchers.servicers.communities import community_to_pb
 from couchers.servicers.events import generate_event_create_notifications, get_users_to_notify_for_new_event
@@ -84,28 +85,28 @@ def generate_new_blog_post_notifications(payload: jobs_pb2.GenerateNewBlogPostNo
 
 class Editor(editor_pb2_grpc.EditorServicer):
     def CreateCommunity(
-        self, request: editor_pb2.CreateCommunityReq, context: CouchersContext, session: Session
+        self, request: editor_pb2.CreateCommunityReq, context: CouchersContext, db: DB
     ) -> communities_pb2.Community:
         geom = load_community_geom(request.geojson, context)
 
         parent_node_id = request.parent_node_id if request.parent_node_id != 0 else None
         if parent_node_id is not None:
-            parent_node = session.execute(select(Node).where(Node.id == parent_node_id)).scalar_one_or_none()
+            parent_node = db.nodes.get_by_id(parent_node_id)
             if not parent_node:
                 context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "parent_node_not_found")
             parent_type = parent_node.node_type
         else:
             parent_type = None
         node_type = CHILD_NODE_TYPE[parent_type]
-        node = create_node(session, geom, parent_node_id, node_type)
-        create_cluster(session, node.id, request.name, request.description, context.user_id, request.admin_ids, True)
+        node = create_node(db.session, geom, parent_node_id, node_type)
+        create_cluster(db.session, node.id, request.name, request.description, context.user_id, request.admin_ids, True)
 
-        return community_to_pb(session, node, context)
+        return community_to_pb(db.session, node, context)
 
     def UpdateCommunity(
-        self, request: editor_pb2.UpdateCommunityReq, context: CouchersContext, session: Session
+        self, request: editor_pb2.UpdateCommunityReq, context: CouchersContext, db: DB
     ) -> communities_pb2.Community:
-        node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
+        node = db.nodes.get_by_id(request.community_id)
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
         cluster = node.official_cluster
@@ -124,17 +125,17 @@ class Editor(editor_pb2_grpc.EditorServicer):
         if request.parent_node_id != 0:
             node.parent_node_id = request.parent_node_id
 
-        session.flush()
+        db.session.flush()
 
-        return community_to_pb(session, cluster.parent_node, context)
+        return community_to_pb(db.session, cluster.parent_node, context)
 
     def ListEventCommunityInviteRequests(
-        self, request: editor_pb2.ListEventCommunityInviteRequestsReq, context: CouchersContext, session: Session
+        self, request: editor_pb2.ListEventCommunityInviteRequestsReq, context: CouchersContext, db: DB
     ) -> editor_pb2.ListEventCommunityInviteRequestsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_request_id = int(request.page_token) if request.page_token else 0
         requests = (
-            session.execute(
+            db.session.execute(
                 select(EventCommunityInviteRequest)
                 .where(EventCommunityInviteRequest.approved.is_(None))
                 .where(EventCommunityInviteRequest.id >= next_request_id)
@@ -146,7 +147,7 @@ class Editor(editor_pb2_grpc.EditorServicer):
         )
 
         def _request_to_pb(request: EventCommunityInviteRequest) -> editor_pb2.EventCommunityInviteRequest:
-            users_to_notify, node_id = get_users_to_notify_for_new_event(session, request.occurrence)
+            users_to_notify, node_id = get_users_to_notify_for_new_event(db.session, request.occurrence)
             return editor_pb2.EventCommunityInviteRequest(
                 event_community_invite_request_id=request.id,
                 user_id=request.user_id,
@@ -161,9 +162,9 @@ class Editor(editor_pb2_grpc.EditorServicer):
         )
 
     def DecideEventCommunityInviteRequest(
-        self, request: editor_pb2.DecideEventCommunityInviteRequestReq, context: CouchersContext, session: Session
+        self, request: editor_pb2.DecideEventCommunityInviteRequestReq, context: CouchersContext, db: DB
     ) -> editor_pb2.DecideEventCommunityInviteRequestRes:
-        req = session.execute(
+        req = db.session.execute(
             select(EventCommunityInviteRequest).where(
                 EventCommunityInviteRequest.id == request.event_community_invite_request_id
             )
@@ -182,18 +183,18 @@ class Editor(editor_pb2_grpc.EditorServicer):
 
         # deny other reqs for the same event
         if request.approve:
-            session.execute(
+            db.session.execute(
                 update(EventCommunityInviteRequest)
                 .where(EventCommunityInviteRequest.occurrence_id == req.occurrence_id)
                 .where(EventCommunityInviteRequest.decided.is_(None))
                 .values(decided=decided, decided_by_user_id=context.user_id, approved=False)
             )
 
-        session.flush()
+        db.session.flush()
 
         if request.approve:
             queue_job(
-                session,
+                db.session,
                 job=generate_event_create_notifications,
                 payload=jobs_pb2.GenerateEventCreateNotificationsPayload(
                     inviting_user_id=req.user_id,
@@ -205,14 +206,14 @@ class Editor(editor_pb2_grpc.EditorServicer):
         return editor_pb2.DecideEventCommunityInviteRequestRes()
 
     def SendBlogPostNotification(
-        self, request: editor_pb2.SendBlogPostNotificationReq, context: CouchersContext, session: Session
+        self, request: editor_pb2.SendBlogPostNotificationReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
         if len(request.title) > 50:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "admin_blog_title_too_long")
         if len(request.blurb) > 100:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "admin_blog_blurb_too_long")
         queue_job(
-            session,
+            db.session,
             job=generate_new_blog_post_notifications,
             payload=jobs_pb2.GenerateNewBlogPostNotificationsPayload(
                 url=request.url,
@@ -223,14 +224,14 @@ class Editor(editor_pb2_grpc.EditorServicer):
         return empty_pb2.Empty()
 
     def MakeUserVolunteer(
-        self, request: editor_pb2.MakeUserVolunteerReq, context: CouchersContext, session: Session
+        self, request: editor_pb2.MakeUserVolunteerReq, context: CouchersContext, db: DB
     ) -> editor_pb2.Volunteer:
         # Check if user exists
-        if not session.execute(select(exists().where(User.id == request.user_id))).scalar():
+        if not db.session.execute(select(exists().where(User.id == request.user_id))).scalar():
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
         # Check if user is already a volunteer
-        if session.execute(select(exists().where(Volunteer.user_id == request.user_id))).scalar():
+        if db.session.execute(select(exists().where(Volunteer.user_id == request.user_id))).scalar():
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "user_already_volunteer")
 
         # Parse started_volunteering date
@@ -248,16 +249,18 @@ class Editor(editor_pb2_grpc.EditorServicer):
         )
         if started_volunteering:
             volunteer.started_volunteering = started_volunteering
-        session.add(volunteer)
-        session.flush()
+        db.session.add(volunteer)
+        db.session.flush()
 
-        return volunteer_to_pb(session, volunteer)
+        return volunteer_to_pb(db.session, volunteer)
 
     def UpdateVolunteer(
-        self, request: editor_pb2.UpdateVolunteerReq, context: CouchersContext, session: Session
+        self, request: editor_pb2.UpdateVolunteerReq, context: CouchersContext, db: DB
     ) -> editor_pb2.Volunteer:
         # Check if volunteer exists
-        volunteer = session.execute(select(Volunteer).where(Volunteer.user_id == request.user_id)).scalar_one_or_none()
+        volunteer = db.session.execute(
+            select(Volunteer).where(Volunteer.user_id == request.user_id)
+        ).scalar_one_or_none()
         if not volunteer:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "volunteer_not_found")
 
@@ -287,12 +290,12 @@ class Editor(editor_pb2_grpc.EditorServicer):
         if request.HasField("show_on_team_page"):
             volunteer.show_on_team_page = request.show_on_team_page.value
 
-        session.flush()
+        db.session.flush()
 
-        return volunteer_to_pb(session, volunteer)
+        return volunteer_to_pb(db.session, volunteer)
 
     def ListVolunteers(
-        self, request: editor_pb2.ListVolunteersReq, context: CouchersContext, session: Session
+        self, request: editor_pb2.ListVolunteersReq, context: CouchersContext, db: DB
     ) -> editor_pb2.ListVolunteersRes:
         # Query volunteers
         query = select(Volunteer).join(LiteUser, LiteUser.id == Volunteer.user_id).where(LiteUser.is_visible)
@@ -308,14 +311,14 @@ class Editor(editor_pb2_grpc.EditorServicer):
             Volunteer.started_volunteering.asc(),
         )
 
-        volunteers = session.execute(query).scalars().all()
+        volunteers = db.session.execute(query).scalars().all()
 
         return editor_pb2.ListVolunteersRes(
-            volunteers=[volunteer_to_pb(session, volunteer) for volunteer in volunteers]
+            volunteers=[volunteer_to_pb(db.session, volunteer) for volunteer in volunteers]
         )
 
     def ListPostcards(
-        self, request: editor_pb2.ListPostcardsReq, context: CouchersContext, session: Session
+        self, request: editor_pb2.ListPostcardsReq, context: CouchersContext, db: DB
     ) -> editor_pb2.ListPostcardsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_id = int(request.page_token) if request.page_token else None
@@ -329,7 +332,7 @@ class Editor(editor_pb2_grpc.EditorServicer):
         if next_id is not None:
             query = query.where(PostalVerificationAttempt.id <= next_id)
 
-        results = session.execute(query).all()
+        results = db.session.execute(query).all()
 
         def _attempt_to_pb(attempt: PostalVerificationAttempt, user: User) -> editor_pb2.PostcardInfo:
             return editor_pb2.PostcardInfo(
@@ -361,9 +364,9 @@ class Editor(editor_pb2_grpc.EditorServicer):
         )
 
     def DownloadPostcardPdf(
-        self, request: editor_pb2.DownloadPostcardPdfReq, context: CouchersContext, session: Session
+        self, request: editor_pb2.DownloadPostcardPdfReq, context: CouchersContext, db: DB
     ) -> editor_pb2.DownloadPostcardPdfRes:
-        attempt = session.execute(
+        attempt = db.session.execute(
             select(PostalVerificationAttempt).where(
                 PostalVerificationAttempt.id == request.postal_verification_attempt_id
             )

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -28,7 +28,6 @@ from couchers.models import (
     Node,
     NodeType,
     Thread,
-    Upload,
     User,
 )
 from couchers.models.notifications import NotificationTopicAction
@@ -36,10 +35,11 @@ from couchers.moderation.utils import create_moderation
 from couchers.notifications.notify import notify
 from couchers.proto import events_pb2, events_pb2_grpc, notification_data_pb2
 from couchers.proto.internal import jobs_pb2
+from couchers.repositories import DB
 from couchers.servicers.api import user_model_to_pb
 from couchers.servicers.blocking import is_not_visible
 from couchers.servicers.threads import thread_to_pb
-from couchers.sql import users_visible, where_moderated_content_visible, where_users_column_visible
+from couchers.sql import where_moderated_content_visible, where_users_column_visible
 from couchers.tasks import send_event_community_invite_request_email
 from couchers.utils import (
     Timestamp_from_datetime,
@@ -407,11 +407,9 @@ def generate_event_delete_notifications(payload: jobs_pb2.GenerateEventDeleteNot
 
 
 class Events(events_pb2_grpc.EventsServicer):
-    def CreateEvent(
-        self, request: events_pb2.CreateEventReq, context: CouchersContext, session: Session
-    ) -> events_pb2.Event:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
-        if not has_completed_profile(session, user):
+    def CreateEvent(self, request: events_pb2.CreateEventReq, context: CouchersContext, db: DB) -> events_pb2.Event:
+        user = db.users.by_id(context.user_id)
+        if not has_completed_profile(db.session, user):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "incomplete_profile_create_event")
         if not request.title:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "missing_event_title")
@@ -447,9 +445,7 @@ class Events(events_pb2_grpc.EventsServicer):
         _check_occurrence_time_validity(start_time, end_time, context)
 
         if request.parent_community_id:
-            parent_node = session.execute(
-                select(Node).where(Node.id == request.parent_community_id)
-            ).scalar_one_or_none()
+            parent_node = db.nodes.get_by_id(request.parent_community_id)
 
             if not parent_node or not parent_node.official_cluster.events_enabled:
                 context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "events_not_enabled")
@@ -457,20 +453,17 @@ class Events(events_pb2_grpc.EventsServicer):
             if online:
                 context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "online_event_missing_parent_community")
             # parent community computed from geom
-            parent_node = get_parent_node_at_location(session, not_none(geom))
+            parent_node = get_parent_node_at_location(db.session, not_none(geom))
 
         if not parent_node:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "community_not_found")
 
-        if (
-            request.photo_key
-            and not session.execute(select(Upload).where(Upload.key == request.photo_key)).scalar_one_or_none()
-        ):
+        if request.photo_key and not db.uploads.get_by_key(request.photo_key):
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "photo_not_found")
 
         thread = Thread()
-        session.add(thread)
-        session.flush()
+        db.session.add(thread)
+        db.session.flush()
 
         event = Event(
             title=request.title,
@@ -479,8 +472,8 @@ class Events(events_pb2_grpc.EventsServicer):
             thread_id=thread.id,
             creator_user_id=context.user_id,
         )
-        session.add(event)
-        session.flush()
+        db.session.add(event)
+        db.session.flush()
 
         occurrence: EventOccurrence | None = None
 
@@ -498,12 +491,12 @@ class Events(events_pb2_grpc.EventsServicer):
                 creator_user_id=context.user_id,
                 moderation_state_id=moderation_state_id,
             )
-            session.add(occurrence)
-            session.flush()
+            db.session.add(occurrence)
+            db.session.flush()
             return occurrence.id
 
         create_moderation(
-            session=session,
+            session=db.session,
             object_type=ModerationObjectType.event_occurrence,
             object_id=create_occurrence,
             creator_user_id=context.user_id,
@@ -511,21 +504,21 @@ class Events(events_pb2_grpc.EventsServicer):
 
         assert occurrence is not None
 
-        session.add(
+        db.session.add(
             EventOrganizer(
                 user_id=context.user_id,
                 event_id=event.id,
             )
         )
 
-        session.add(
+        db.session.add(
             EventSubscription(
                 user_id=context.user_id,
                 event_id=event.id,
             )
         )
 
-        session.add(
+        db.session.add(
             EventOccurrenceAttendee(
                 user_id=context.user_id,
                 occurrence_id=occurrence.id,
@@ -533,11 +526,11 @@ class Events(events_pb2_grpc.EventsServicer):
             )
         )
 
-        session.commit()
+        db.session.commit()
 
         log_event(
             context,
-            session,
+            db.session,
             "event.created",
             {
                 "event_id": event.id,
@@ -548,9 +541,9 @@ class Events(events_pb2_grpc.EventsServicer):
             },
         )
 
-        if has_completed_profile(session, user):
+        if has_completed_profile(db.session, user):
             queue_job(
-                session,
+                db.session,
                 job=generate_event_create_notifications,
                 payload=jobs_pb2.GenerateEventCreateNotificationsPayload(
                     inviting_user_id=user.id,
@@ -559,11 +552,9 @@ class Events(events_pb2_grpc.EventsServicer):
                 ),
             )
 
-        return event_to_pb(session, occurrence, context)
+        return event_to_pb(db.session, occurrence, context)
 
-    def ScheduleEvent(
-        self, request: events_pb2.ScheduleEventReq, context: CouchersContext, session: Session
-    ) -> events_pb2.Event:
+    def ScheduleEvent(self, request: events_pb2.ScheduleEventReq, context: CouchersContext, db: DB) -> events_pb2.Event:
         if not request.content:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "missing_event_content")
         if request.HasField("online_information"):
@@ -590,29 +581,26 @@ class Events(events_pb2_grpc.EventsServicer):
 
         _check_occurrence_time_validity(start_time, end_time, context)
 
-        res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id, context=context)
+        res = _get_event_and_occurrence_one_or_none(db.session, occurrence_id=request.event_id, context=context)
         if not res:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
 
         event, occurrence = res
 
-        if not _can_edit_event(session, event, context.user_id):
+        if not _can_edit_event(db.session, event, context.user_id):
             context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "event_edit_permission_denied")
 
         if occurrence.is_cancelled:
             context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "event_cant_update_cancelled_event")
 
-        if (
-            request.photo_key
-            and not session.execute(select(Upload).where(Upload.key == request.photo_key)).scalar_one_or_none()
-        ):
+        if request.photo_key and not db.uploads.get_by_key(request.photo_key):
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "photo_not_found")
 
         during = DateTimeTZRange(start_time, end_time)
 
         # && is the overlap operator for ranges
         if (
-            session.execute(
+            db.session.execute(
                 select(EventOccurrence.id)
                 .where(EventOccurrence.event_id == event.id)
                 .where(EventOccurrence.during.op("&&")(during))
@@ -640,12 +628,12 @@ class Events(events_pb2_grpc.EventsServicer):
                 creator_user_id=context.user_id,
                 moderation_state_id=moderation_state_id,
             )
-            session.add(new_occurrence)
-            session.flush()
+            db.session.add(new_occurrence)
+            db.session.flush()
             return new_occurrence.id
 
         create_moderation(
-            session=session,
+            session=db.session,
             object_type=ModerationObjectType.event_occurrence,
             object_id=create_occurrence,
             creator_user_id=context.user_id,
@@ -653,7 +641,7 @@ class Events(events_pb2_grpc.EventsServicer):
 
         assert new_occurrence is not None
 
-        session.add(
+        db.session.add(
             EventOccurrenceAttendee(
                 user_id=context.user_id,
                 occurrence_id=new_occurrence.id,
@@ -661,23 +649,22 @@ class Events(events_pb2_grpc.EventsServicer):
             )
         )
 
-        session.flush()
+        db.session.flush()
 
         # TODO: notify
 
-        return event_to_pb(session, new_occurrence, context)
+        return event_to_pb(db.session, new_occurrence, context)
 
-    def UpdateEvent(
-        self, request: events_pb2.UpdateEventReq, context: CouchersContext, session: Session
-    ) -> events_pb2.Event:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
-        res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id, context=context)
+    def UpdateEvent(self, request: events_pb2.UpdateEventReq, context: CouchersContext, db: DB) -> events_pb2.Event:
+
+        user = db.users.by_id(context.user_id)
+        res = _get_event_and_occurrence_one_or_none(db.session, occurrence_id=request.event_id, context=context)
         if not res:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
 
         event, occurrence = res
 
-        if not _can_edit_event(session, event, context.user_id):
+        if not _can_edit_event(db.session, event, context.user_id):
             context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "event_edit_permission_denied")
 
         # the things that were updated and need to be notified about
@@ -736,7 +723,7 @@ class Events(events_pb2_grpc.EventsServicer):
 
             # && is the overlap operator for ranges
             if (
-                session.execute(
+                db.session.execute(
                     select(EventOccurrence.id)
                     .where(EventOccurrence.event_id == event.id)
                     .where(EventOccurrence.id != occurrence.id)
@@ -760,7 +747,7 @@ class Events(events_pb2_grpc.EventsServicer):
 
         cutoff_time = now() - timedelta(hours=24)
         if request.update_all_future:
-            session.execute(
+            db.session.execute(
                 update(EventOccurrence)
                 .where(EventOccurrence.end_time >= cutoff_time)
                 .where(EventOccurrence.start_time >= occurrence.start_time)
@@ -770,7 +757,7 @@ class Events(events_pb2_grpc.EventsServicer):
         else:
             if occurrence.end_time < cutoff_time:
                 context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "event_cant_update_old_event")
-            session.execute(
+            db.session.execute(
                 update(EventOccurrence)
                 .where(EventOccurrence.end_time >= cutoff_time)
                 .where(EventOccurrence.id == occurrence.id)
@@ -778,14 +765,14 @@ class Events(events_pb2_grpc.EventsServicer):
                 .execution_options(synchronize_session=False)
             )
 
-        session.flush()
+        db.session.flush()
 
         if notify_updated:
             if request.should_notify:
                 logger.info(f"Fields {','.join(notify_updated)} updated in event {event.id=}, notifying")
 
                 queue_job(
-                    session,
+                    db.session,
                     job=generate_event_update_notifications,
                     payload=jobs_pb2.GenerateEventUpdateNotificationsPayload(
                         updating_user_id=user.id,
@@ -799,30 +786,28 @@ class Events(events_pb2_grpc.EventsServicer):
                 )
 
         # since we have synchronize_session=False, we have to refresh the object
-        session.refresh(occurrence)
+        db.session.refresh(occurrence)
 
-        return event_to_pb(session, occurrence, context)
+        return event_to_pb(db.session, occurrence, context)
 
-    def GetEvent(self, request: events_pb2.GetEventReq, context: CouchersContext, session: Session) -> events_pb2.Event:
+    def GetEvent(self, request: events_pb2.GetEventReq, context: CouchersContext, db: DB) -> events_pb2.Event:
         query = select(EventOccurrence).where(EventOccurrence.id == request.event_id).where(~EventOccurrence.is_deleted)
         query = where_moderated_content_visible(query, context, EventOccurrence, is_list_operation=False)
-        occurrence = session.execute(query).scalar_one_or_none()
+        occurrence = db.session.execute(query).scalar_one_or_none()
 
         if not occurrence:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
 
-        return event_to_pb(session, occurrence, context)
+        return event_to_pb(db.session, occurrence, context)
 
-    def CancelEvent(
-        self, request: events_pb2.CancelEventReq, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
-        res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id, context=context)
+    def CancelEvent(self, request: events_pb2.CancelEventReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
+        res = _get_event_and_occurrence_one_or_none(db.session, occurrence_id=request.event_id, context=context)
         if not res:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
 
         event, occurrence = res
 
-        if not _can_edit_event(session, event, context.user_id):
+        if not _can_edit_event(db.session, event, context.user_id):
             context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "event_edit_permission_denied")
 
         if occurrence.end_time < now() - timedelta(hours=24):
@@ -830,10 +815,10 @@ class Events(events_pb2_grpc.EventsServicer):
 
         occurrence.is_cancelled = True
 
-        log_event(context, session, "event.cancelled", {"event_id": event.id, "occurrence_id": occurrence.id})
+        log_event(context, db.session, "event.cancelled", {"event_id": event.id, "occurrence_id": occurrence.id})
 
         queue_job(
-            session,
+            db.session,
             job=generate_event_cancel_notifications,
             payload=jobs_pb2.GenerateEventCancelNotificationsPayload(
                 cancelling_user_id=context.user_id,
@@ -844,16 +829,17 @@ class Events(events_pb2_grpc.EventsServicer):
         return empty_pb2.Empty()
 
     def RequestCommunityInvite(
-        self, request: events_pb2.RequestCommunityInviteReq, context: CouchersContext, session: Session
+        self, request: events_pb2.RequestCommunityInviteReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
-        res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id, context=context)
+        db.users.by_id(context.user_id)
+
+        res = _get_event_and_occurrence_one_or_none(db.session, occurrence_id=request.event_id, context=context)
         if not res:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
 
         event, occurrence = res
 
-        if not _can_edit_event(session, event, context.user_id):
+        if not _can_edit_event(db.session, event, context.user_id):
             context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "event_edit_permission_denied")
 
         if occurrence.is_cancelled:
@@ -880,15 +866,15 @@ class Events(events_pb2_grpc.EventsServicer):
             occurrence_id=request.event_id,
             user_id=context.user_id,
         )
-        session.add(req)
-        session.flush()
+        db.session.add(req)
+        db.session.flush()
 
-        send_event_community_invite_request_email(session, req)
+        send_event_community_invite_request_email(db.session, req)
 
         return empty_pb2.Empty()
 
     def ListEventOccurrences(
-        self, request: events_pb2.ListEventOccurrencesReq, context: CouchersContext, session: Session
+        self, request: events_pb2.ListEventOccurrencesReq, context: CouchersContext, db: DB
     ) -> events_pb2.ListEventOccurrencesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         # the page token is a unix timestamp of where we left off
@@ -899,7 +885,7 @@ class Events(events_pb2_grpc.EventsServicer):
         initial_query = where_moderated_content_visible(
             initial_query, context, EventOccurrence, is_list_operation=False
         )
-        occurrence = session.execute(initial_query).scalar_one_or_none()
+        occurrence = db.session.execute(initial_query).scalar_one_or_none()
         if not occurrence:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
 
@@ -921,19 +907,19 @@ class Events(events_pb2_grpc.EventsServicer):
             query = query.where(EventOccurrence.end_time < cutoff).order_by(EventOccurrence.start_time.desc())
 
         query = query.limit(page_size + 1)
-        occurrences = session.execute(query).scalars().all()
+        occurrences = db.session.execute(query).scalars().all()
 
         return events_pb2.ListEventOccurrencesRes(
-            events=[event_to_pb(session, occurrence, context) for occurrence in occurrences[:page_size]],
+            events=[event_to_pb(db.session, occurrence, context) for occurrence in occurrences[:page_size]],
             next_page_token=str(millis_from_dt(occurrences[-1].end_time)) if len(occurrences) > page_size else None,
         )
 
     def ListEventAttendees(
-        self, request: events_pb2.ListEventAttendeesReq, context: CouchersContext, session: Session
+        self, request: events_pb2.ListEventAttendeesReq, context: CouchersContext, db: DB
     ) -> events_pb2.ListEventAttendeesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_user_id = int(request.page_token) if request.page_token else 0
-        occurrence = session.execute(
+        occurrence = db.session.execute(
             where_moderated_content_visible(
                 select(EventOccurrence)
                 .where(EventOccurrence.id == request.event_id)
@@ -946,7 +932,7 @@ class Events(events_pb2_grpc.EventsServicer):
         if not occurrence:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
         attendees = (
-            session.execute(
+            db.session.execute(
                 where_users_column_visible(
                     select(EventOccurrenceAttendee)
                     .where(EventOccurrenceAttendee.occurrence_id == occurrence.id)
@@ -966,16 +952,17 @@ class Events(events_pb2_grpc.EventsServicer):
         )
 
     def ListEventSubscribers(
-        self, request: events_pb2.ListEventSubscribersReq, context: CouchersContext, session: Session
+        self, request: events_pb2.ListEventSubscribersReq, context: CouchersContext, db: DB
     ) -> events_pb2.ListEventSubscribersRes:
+
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_user_id = int(request.page_token) if request.page_token else 0
-        res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id, context=context)
+        res = _get_event_and_occurrence_one_or_none(db.session, occurrence_id=request.event_id, context=context)
         if not res:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
         event, occurrence = res
         subscribers = (
-            session.execute(
+            db.session.execute(
                 where_users_column_visible(
                     select(EventSubscription)
                     .where(EventSubscription.event_id == event.id)
@@ -995,16 +982,17 @@ class Events(events_pb2_grpc.EventsServicer):
         )
 
     def ListEventOrganizers(
-        self, request: events_pb2.ListEventOrganizersReq, context: CouchersContext, session: Session
+        self, request: events_pb2.ListEventOrganizersReq, context: CouchersContext, db: DB
     ) -> events_pb2.ListEventOrganizersRes:
+
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_user_id = int(request.page_token) if request.page_token else 0
-        res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id, context=context)
+        res = _get_event_and_occurrence_one_or_none(db.session, occurrence_id=request.event_id, context=context)
         if not res:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
         event, occurrence = res
         organizers = (
-            session.execute(
+            db.session.execute(
                 where_users_column_visible(
                     select(EventOrganizer)
                     .where(EventOrganizer.event_id == event.id)
@@ -1023,16 +1011,14 @@ class Events(events_pb2_grpc.EventsServicer):
             next_page_token=str(organizers[-1].user_id) if len(organizers) > page_size else None,
         )
 
-    def TransferEvent(
-        self, request: events_pb2.TransferEventReq, context: CouchersContext, session: Session
-    ) -> events_pb2.Event:
-        res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id, context=context)
+    def TransferEvent(self, request: events_pb2.TransferEventReq, context: CouchersContext, db: DB) -> events_pb2.Event:
+        res = _get_event_and_occurrence_one_or_none(db.session, occurrence_id=request.event_id, context=context)
         if not res:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
 
         event, occurrence = res
 
-        if not _can_edit_event(session, event, context.user_id):
+        if not _can_edit_event(db.session, event, context.user_id):
             context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "event_transfer_permission_denied")
 
         if occurrence.is_cancelled:
@@ -1042,11 +1028,11 @@ class Events(events_pb2_grpc.EventsServicer):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "event_cant_update_old_event")
 
         if request.WhichOneof("new_owner") == "new_owner_group_id":
-            cluster = session.execute(
+            cluster = db.session.execute(
                 select(Cluster).where(~Cluster.is_official_cluster).where(Cluster.id == request.new_owner_group_id)
             ).scalar_one_or_none()
         elif request.WhichOneof("new_owner") == "new_owner_community_id":
-            cluster = session.execute(
+            cluster = db.session.execute(
                 select(Cluster)
                 .where(Cluster.parent_node_id == request.new_owner_community_id)
                 .where(Cluster.is_official_cluster)
@@ -1058,13 +1044,13 @@ class Events(events_pb2_grpc.EventsServicer):
         event.owner_user = None
         event.owner_cluster = cluster
 
-        session.commit()
-        return event_to_pb(session, occurrence, context)
+        db.session.commit()
+        return event_to_pb(db.session, occurrence, context)
 
     def SetEventSubscription(
-        self, request: events_pb2.SetEventSubscriptionReq, context: CouchersContext, session: Session
+        self, request: events_pb2.SetEventSubscriptionReq, context: CouchersContext, db: DB
     ) -> events_pb2.Event:
-        res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id, context=context)
+        res = _get_event_and_occurrence_one_or_none(db.session, occurrence_id=request.event_id, context=context)
         if not res:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
 
@@ -1076,7 +1062,7 @@ class Events(events_pb2_grpc.EventsServicer):
         if occurrence.end_time < now() - timedelta(hours=24):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "event_cant_update_old_event")
 
-        current_subscription = session.execute(
+        current_subscription = db.session.execute(
             select(EventSubscription)
             .where(EventSubscription.user_id == context.user_id)
             .where(EventSubscription.event_id == event.id)
@@ -1084,27 +1070,27 @@ class Events(events_pb2_grpc.EventsServicer):
 
         # if not subscribed, subscribe
         if request.subscribe and not current_subscription:
-            session.add(EventSubscription(user_id=context.user_id, event_id=event.id))
+            db.session.add(EventSubscription(user_id=context.user_id, event_id=event.id))
 
         # if subscribed but unsubbing, remove subscription
         if not request.subscribe and current_subscription:
-            session.delete(current_subscription)
+            db.session.delete(current_subscription)
 
-        session.flush()
+        db.session.flush()
 
         log_event(
             context,
-            session,
+            db.session,
             "event.subscription_set",
             {"event_id": event.id, "occurrence_id": occurrence.id, "subscribed": request.subscribe},
         )
 
-        return event_to_pb(session, occurrence, context)
+        return event_to_pb(db.session, occurrence, context)
 
     def SetEventAttendance(
-        self, request: events_pb2.SetEventAttendanceReq, context: CouchersContext, session: Session
+        self, request: events_pb2.SetEventAttendanceReq, context: CouchersContext, db: DB
     ) -> events_pb2.Event:
-        occurrence = session.execute(
+        occurrence = db.session.execute(
             where_moderated_content_visible(
                 select(EventOccurrence)
                 .where(EventOccurrence.id == request.event_id)
@@ -1124,7 +1110,7 @@ class Events(events_pb2_grpc.EventsServicer):
         if occurrence.end_time < now() - timedelta(hours=24):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "event_cant_update_old_event")
 
-        current_attendance = session.execute(
+        current_attendance = db.session.execute(
             select(EventOccurrenceAttendee)
             .where(EventOccurrenceAttendee.user_id == context.user_id)
             .where(EventOccurrenceAttendee.occurrence_id == occurrence.id)
@@ -1132,7 +1118,7 @@ class Events(events_pb2_grpc.EventsServicer):
 
         if request.attendance_state == events_pb2.ATTENDANCE_STATE_NOT_GOING:
             if current_attendance:
-                session.delete(current_attendance)
+                db.session.delete(current_attendance)
             # if unset/not going, nothing to do!
         else:
             if current_attendance:
@@ -1144,21 +1130,21 @@ class Events(events_pb2_grpc.EventsServicer):
                     occurrence_id=occurrence.id,
                     attendee_status=not_none(attendancestate2sql[request.attendance_state]),
                 )
-                session.add(attendance)
+                db.session.add(attendance)
 
-        session.flush()
+        db.session.flush()
 
         log_event(
             context,
-            session,
+            db.session,
             "event.attendance_set",
             {"occurrence_id": occurrence.id, "attendance_state": request.attendance_state},
         )
 
-        return event_to_pb(session, occurrence, context)
+        return event_to_pb(db.session, occurrence, context)
 
     def ListMyEvents(
-        self, request: events_pb2.ListMyEventsReq, context: CouchersContext, session: Session
+        self, request: events_pb2.ListMyEventsReq, context: CouchersContext, db: DB
     ) -> events_pb2.ListMyEventsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         # the page token is a unix timestamp of where we left off
@@ -1204,7 +1190,7 @@ class Events(events_pb2_grpc.EventsServicer):
             where_.append(EventOccurrenceAttendee.user_id != None)
         if include_my_communities:
             my_communities = (
-                session.execute(
+                db.session.execute(
                     select(Node.id)
                     .join(Cluster, Cluster.parent_node_id == Node.id)
                     .join(ClusterSubscription, ClusterSubscription.cluster_id == Cluster.id)
@@ -1233,19 +1219,19 @@ class Events(events_pb2_grpc.EventsServicer):
             cutoff = page_token + timedelta(seconds=1)
             query = query.where(EventOccurrence.end_time < cutoff).order_by(EventOccurrence.start_time.desc())
         # Count the total number of items for pagination
-        total_items = session.execute(select(func.count()).select_from(query.subquery())).scalar()
+        total_items = db.session.execute(select(func.count()).select_from(query.subquery())).scalar()
         # Apply pagination by page number
         query = query.offset(offset).limit(page_size) if request.page_number else query.limit(page_size + 1)
-        occurrences = session.execute(query).scalars().all()
+        occurrences = db.session.execute(query).scalars().all()
 
         return events_pb2.ListMyEventsRes(
-            events=[event_to_pb(session, occurrence, context) for occurrence in occurrences[:page_size]],
+            events=[event_to_pb(db.session, occurrence, context) for occurrence in occurrences[:page_size]],
             next_page_token=str(millis_from_dt(occurrences[-1].end_time)) if len(occurrences) > page_size else None,
             total_items=total_items,
         )
 
     def ListAllEvents(
-        self, request: events_pb2.ListAllEventsReq, context: CouchersContext, session: Session
+        self, request: events_pb2.ListAllEventsReq, context: CouchersContext, db: DB
     ) -> events_pb2.ListAllEventsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         # the page token is a unix timestamp of where we left off
@@ -1265,24 +1251,25 @@ class Events(events_pb2_grpc.EventsServicer):
             query = query.where(EventOccurrence.end_time < cutoff).order_by(EventOccurrence.start_time.desc())
 
         query = query.limit(page_size + 1)
-        occurrences = session.execute(query).scalars().all()
+        occurrences = db.session.execute(query).scalars().all()
 
         return events_pb2.ListAllEventsRes(
-            events=[event_to_pb(session, occurrence, context) for occurrence in occurrences[:page_size]],
+            events=[event_to_pb(db.session, occurrence, context) for occurrence in occurrences[:page_size]],
             next_page_token=str(millis_from_dt(occurrences[-1].end_time)) if len(occurrences) > page_size else None,
         )
 
     def InviteEventOrganizer(
-        self, request: events_pb2.InviteEventOrganizerReq, context: CouchersContext, session: Session
+        self, request: events_pb2.InviteEventOrganizerReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
-        res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id, context=context)
+
+        user = db.users.by_id(context.user_id)
+        res = _get_event_and_occurrence_one_or_none(db.session, occurrence_id=request.event_id, context=context)
         if not res:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
 
         event, occurrence = res
 
-        if not _can_edit_event(session, event, context.user_id):
+        if not _can_edit_event(db.session, event, context.user_id):
             context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "event_edit_permission_denied")
 
         if occurrence.is_cancelled:
@@ -1291,38 +1278,36 @@ class Events(events_pb2_grpc.EventsServicer):
         if occurrence.end_time < now() - timedelta(hours=24):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "event_cant_update_old_event")
 
-        if not session.execute(
-            select(User).where(users_visible(context)).where(User.id == request.user_id)
-        ).scalar_one_or_none():
+        if not db.users.get_by_id_if_visible(request.user_id, visible_to=context.user_id):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
-        session.add(
+        db.session.add(
             EventOrganizer(
                 user_id=request.user_id,
                 event_id=event.id,
             )
         )
-        session.flush()
+        db.session.flush()
 
         other_user_context = make_background_user_context(user_id=request.user_id)
 
         notify(
-            session,
+            db.session,
             user_id=request.user_id,
             topic_action=NotificationTopicAction.event__invite_organizer,
             key=str(event.id),
             data=notification_data_pb2.EventInviteOrganizer(
-                event=event_to_pb(session, occurrence, other_user_context),
-                inviting_user=user_model_to_pb(user, session, other_user_context),
+                event=event_to_pb(db.session, occurrence, other_user_context),
+                inviting_user=user_model_to_pb(user, db.session, other_user_context),
             ),
         )
 
         return empty_pb2.Empty()
 
     def RemoveEventOrganizer(
-        self, request: events_pb2.RemoveEventOrganizerReq, context: CouchersContext, session: Session
+        self, request: events_pb2.RemoveEventOrganizerReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id, context=context)
+        res = _get_event_and_occurrence_one_or_none(db.session, occurrence_id=request.event_id, context=context)
         if not res:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
 
@@ -1342,11 +1327,11 @@ class Events(events_pb2_grpc.EventsServicer):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "event_cant_remove_owner_as_organizer")
 
         # Check permissions: either an organizer removing an organizer OR you're the event owner
-        if not _can_edit_event(session, event, context.user_id):
+        if not _can_edit_event(db.session, event, context.user_id):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "event_edit_permission_denied")
 
         # Find the organizer to remove
-        organizer_to_remove = session.execute(
+        organizer_to_remove = db.session.execute(
             select(EventOrganizer)
             .where(EventOrganizer.user_id == user_id_to_remove)
             .where(EventOrganizer.event_id == event.id)
@@ -1355,6 +1340,6 @@ class Events(events_pb2_grpc.EventsServicer):
         if not organizer_to_remove:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "event_not_an_organizer")
 
-        session.delete(organizer_to_remove)
+        db.session.delete(organizer_to_remove)
 
         return empty_pb2.Empty()

--- a/app/backend/src/couchers/servicers/galleries.py
+++ b/app/backend/src/couchers/servicers/galleries.py
@@ -1,13 +1,13 @@
 import grpc
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.orm import Session
-from sqlalchemy.sql import func
 
 from couchers.constants import GALLERY_MAX_PHOTOS_NOT_VERIFIED, GALLERY_MAX_PHOTOS_VERIFIED
 from couchers.context import CouchersContext
 from couchers.helpers.strong_verification import has_strong_verification
 from couchers.models import PhotoGallery, PhotoGalleryItem, Upload, User
 from couchers.proto import galleries_pb2, galleries_pb2_grpc
+from couchers.repositories import DB
 
 
 def _get_max_photos_for_user(session: Session, user: User) -> int:
@@ -36,33 +36,25 @@ def _gallery_to_pb(gallery: PhotoGallery, context: CouchersContext) -> galleries
 
 class Galleries(galleries_pb2_grpc.GalleriesServicer):
     def GetGallery(
-        self, request: galleries_pb2.GetGalleryReq, context: CouchersContext, session: Session
+        self, request: galleries_pb2.GetGalleryReq, context: CouchersContext, db: DB
     ) -> galleries_pb2.PhotoGallery:
-        gallery = session.execute(
-            select(PhotoGallery).where(PhotoGallery.id == request.gallery_id)
-        ).scalar_one_or_none()
-
-        if not gallery:
+        if not (gallery := db.photo_galleries.get_by_id(request.gallery_id)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "gallery_not_found")
 
         return _gallery_to_pb(gallery, context)
 
     def AddPhotoToGallery(
-        self, request: galleries_pb2.AddPhotoToGalleryReq, context: CouchersContext, session: Session
+        self, request: galleries_pb2.AddPhotoToGalleryReq, context: CouchersContext, db: DB
     ) -> galleries_pb2.PhotoGallery:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
 
-        gallery = session.execute(
-            select(PhotoGallery).where(PhotoGallery.id == request.gallery_id)
-        ).scalar_one_or_none()
-
-        if not gallery:
+        if not (gallery := db.photo_galleries.get_by_id(request.gallery_id)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "gallery_not_found")
 
         if not _can_edit_gallery(gallery, context):
             context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "permission_denied_to_edit_gallery")
 
-        upload_exists = session.execute(
+        upload_exists = db.session.execute(
             select(Upload.key).where(Upload.key == request.upload_key).where(Upload.creator_user_id == user.id)
         ).scalar_one_or_none()
 
@@ -70,7 +62,7 @@ class Galleries(galleries_pb2_grpc.GalleriesServicer):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "upload_not_found_or_not_owned")
 
         # Get all gallery items' upload keys and positions in one query
-        gallery_items = session.execute(
+        gallery_items = db.session.execute(
             select(PhotoGalleryItem.upload_key, PhotoGalleryItem.position).where(
                 PhotoGalleryItem.gallery_id == gallery.id
             )
@@ -81,7 +73,7 @@ class Galleries(galleries_pb2_grpc.GalleriesServicer):
         if request.upload_key in existing_upload_keys:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "photo_already_in_gallery")
 
-        max_photos = _get_max_photos_for_user(session, user)
+        max_photos = _get_max_photos_for_user(db.session, user)
 
         if len(gallery_items) >= max_photos:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "gallery_at_max_capacity")
@@ -95,26 +87,22 @@ class Galleries(galleries_pb2_grpc.GalleriesServicer):
             position=0.0 if max_position is None else max_position + 1.0,
             caption=request.caption or None,
         )
-        session.add(item)
-        session.flush()
-        session.refresh(gallery)
+        db.session.add(item)
+        db.session.flush()
+        db.session.refresh(gallery)
 
         return _gallery_to_pb(gallery, context)
 
     def RemovePhotoFromGallery(
-        self, request: galleries_pb2.RemovePhotoFromGalleryReq, context: CouchersContext, session: Session
+        self, request: galleries_pb2.RemovePhotoFromGalleryReq, context: CouchersContext, db: DB
     ) -> galleries_pb2.PhotoGallery:
-        gallery = session.execute(
-            select(PhotoGallery).where(PhotoGallery.id == request.gallery_id)
-        ).scalar_one_or_none()
-
-        if not gallery:
+        if not (gallery := db.photo_galleries.get_by_id(request.gallery_id)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "gallery_not_found")
 
         if not _can_edit_gallery(gallery, context):
             context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "permission_denied_to_edit_gallery")
 
-        item = session.execute(
+        item = db.session.execute(
             select(PhotoGalleryItem)
             .where(PhotoGalleryItem.gallery_id == gallery.id)
             .where(PhotoGalleryItem.id == request.item_id)
@@ -123,27 +111,23 @@ class Galleries(galleries_pb2_grpc.GalleriesServicer):
         if not item:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "gallery_item_not_found")
 
-        session.delete(item)
-        session.flush()
-        session.refresh(gallery)
+        db.session.delete(item)
+        db.session.flush()
+        db.session.refresh(gallery)
 
         return _gallery_to_pb(gallery, context)
 
     def MovePhoto(
-        self, request: galleries_pb2.MovePhotoReq, context: CouchersContext, session: Session
+        self, request: galleries_pb2.MovePhotoReq, context: CouchersContext, db: DB
     ) -> galleries_pb2.PhotoGallery:
-        gallery = session.execute(
-            select(PhotoGallery).where(PhotoGallery.id == request.gallery_id)
-        ).scalar_one_or_none()
-
-        if not gallery:
+        if not (gallery := db.photo_galleries.get_by_id(request.gallery_id)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "gallery_not_found")
 
         if not _can_edit_gallery(gallery, context):
             context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "permission_denied_to_edit_gallery")
 
         # Get all items' (id, position) sorted by position
-        items = session.execute(
+        items = db.session.execute(
             select(PhotoGalleryItem.id, PhotoGalleryItem.position)
             .where(PhotoGalleryItem.gallery_id == gallery.id)
             .order_by(PhotoGalleryItem.position)
@@ -181,29 +165,25 @@ class Galleries(galleries_pb2_grpc.GalleriesServicer):
                 new_position = (positions[request.after_item_id] + positions[sorted_ids[next_idx]]) / 2.0
 
         if new_position is not None:
-            session.execute(
+            db.session.execute(
                 update(PhotoGalleryItem).where(PhotoGalleryItem.id == request.item_id).values(position=new_position)
             )
 
-        session.flush()
-        session.refresh(gallery)
+        db.session.flush()
+        db.session.refresh(gallery)
 
         return _gallery_to_pb(gallery, context)
 
     def UpdatePhotoCaption(
-        self, request: galleries_pb2.UpdatePhotoCaptionReq, context: CouchersContext, session: Session
+        self, request: galleries_pb2.UpdatePhotoCaptionReq, context: CouchersContext, db: DB
     ) -> galleries_pb2.PhotoGallery:
-        gallery = session.execute(
-            select(PhotoGallery).where(PhotoGallery.id == request.gallery_id)
-        ).scalar_one_or_none()
-
-        if not gallery:
+        if not (gallery := db.photo_galleries.get_by_id(request.gallery_id)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "gallery_not_found")
 
         if not _can_edit_gallery(gallery, context):
             context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "permission_denied_to_edit_gallery")
 
-        item = session.execute(
+        item = db.session.execute(
             select(PhotoGalleryItem)
             .where(PhotoGalleryItem.gallery_id == gallery.id)
             .where(PhotoGalleryItem.id == request.item_id)
@@ -213,32 +193,28 @@ class Galleries(galleries_pb2_grpc.GalleriesServicer):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "gallery_item_not_found")
 
         item.caption = request.caption or None
-        session.flush()
-        session.refresh(gallery)
+        db.session.flush()
+        db.session.refresh(gallery)
 
         return _gallery_to_pb(gallery, context)
 
     def GetGalleryEditInfo(
-        self, request: galleries_pb2.GetGalleryEditInfoReq, context: CouchersContext, session: Session
+        self, request: galleries_pb2.GetGalleryEditInfoReq, context: CouchersContext, db: DB
     ) -> galleries_pb2.GetGalleryEditInfoRes:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
 
-        gallery = session.execute(
-            select(PhotoGallery).where(PhotoGallery.id == request.gallery_id)
-        ).scalar_one_or_none()
-
-        if not gallery:
+        if not (gallery := db.photo_galleries.get_by_id(request.gallery_id)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "gallery_not_found")
 
         if not _can_edit_gallery(gallery, context):
             context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "permission_denied_to_edit_gallery")
 
-        current_photo_count = session.execute(
-            select(func.count()).where(PhotoGalleryItem.gallery_id == gallery.id)
+        current_photo_count = db.session.execute(
+            select(func.count()).select_from(PhotoGalleryItem).where(PhotoGalleryItem.gallery_id == gallery.id)
         ).scalar_one()
 
         return galleries_pb2.GetGalleryEditInfoRes(
             gallery_id=gallery.id,
-            max_photos=_get_max_photos_for_user(session, user),
+            max_photos=_get_max_photos_for_user(db.session, user),
             current_photo_count=current_photo_count,
         )

--- a/app/backend/src/couchers/servicers/gis.py
+++ b/app/backend/src/couchers/servicers/gis.py
@@ -14,6 +14,7 @@ from couchers.materialized_views import ClusteredUser, LiteUser
 from couchers.models import Node, Page, PageType, PageVersion
 from couchers.proto import gis_pb2_grpc
 from couchers.proto.google.api import httpbody_pb2
+from couchers.repositories import DB
 from couchers.sql import users_visible
 
 logger = logging.getLogger(__name__)
@@ -42,10 +43,10 @@ def _statement_to_geojson_response(session: Session, statement: GenerativeSelect
 
 
 class GIS(gis_pb2_grpc.GISServicer):
-    def GetUsers(self, request: empty_pb2.Empty, context: CouchersContext, session: Session) -> httpbody_pb2.HttpBody:
+    def GetUsers(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> httpbody_pb2.HttpBody:
         # Build FeatureCollection from precomputed per-row GeoJSON in the materialized view,
         # assembling with string_agg in Postgres
-        result = session.execute(
+        result = db.session.execute(
             select(
                 func.concat(
                     '{"type":"FeatureCollection","features":[',
@@ -59,17 +60,13 @@ class GIS(gis_pb2_grpc.GISServicer):
             data=result.encode("ascii"),
         )
 
-    def GetClusteredUsers(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
-    ) -> httpbody_pb2.HttpBody:
-        return _statement_to_geojson_response(session, select(ClusteredUser.geom, ClusteredUser.count))
+    def GetClusteredUsers(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> httpbody_pb2.HttpBody:
+        return _statement_to_geojson_response(db.session, select(ClusteredUser.geom, ClusteredUser.count))
 
-    def GetCommunities(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
-    ) -> httpbody_pb2.HttpBody:
-        return _statement_to_geojson_response(session, select(Node).where(Node.geom != None))
+    def GetCommunities(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> httpbody_pb2.HttpBody:
+        return _statement_to_geojson_response(db.session, select(Node).where(Node.geom != None))
 
-    def GetPlaces(self, request: empty_pb2.Empty, context: CouchersContext, session: Session) -> httpbody_pb2.HttpBody:
+    def GetPlaces(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> httpbody_pb2.HttpBody:
         # need to do a subquery here so we get pages without a geom, not just versions without geom
         latest_pages = (
             select(func.max(PageVersion.id).label("id"))
@@ -85,9 +82,9 @@ class GIS(gis_pb2_grpc.GISServicer):
             .where(PageVersion.geom != None)
         )
 
-        return _statement_to_geojson_response(session, statement)
+        return _statement_to_geojson_response(db.session, statement)
 
-    def GetGuides(self, request: empty_pb2.Empty, context: CouchersContext, session: Session) -> httpbody_pb2.HttpBody:
+    def GetGuides(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> httpbody_pb2.HttpBody:
         latest_pages = (
             select(func.max(PageVersion.id).label("id"))
             .join(Page, Page.id == PageVersion.page_id)
@@ -102,4 +99,4 @@ class GIS(gis_pb2_grpc.GISServicer):
             .where(PageVersion.geom != None)
         )
 
-        return _statement_to_geojson_response(session, statement)
+        return _statement_to_geojson_response(db.session, statement)

--- a/app/backend/src/couchers/servicers/groups.py
+++ b/app/backend/src/couchers/servicers/groups.py
@@ -22,6 +22,7 @@ from couchers.models import (
     User,
 )
 from couchers.proto import groups_pb2, groups_pb2_grpc
+from couchers.repositories import DB
 from couchers.servicers.discussions import discussion_to_pb
 from couchers.servicers.events import event_to_pb
 from couchers.servicers.pages import page_to_pb
@@ -113,8 +114,8 @@ def group_to_pb(session: Session, cluster: Cluster, context: CouchersContext) ->
 
 
 class Groups(groups_pb2_grpc.GroupsServicer):
-    def GetGroup(self, request: groups_pb2.GetGroupReq, context: CouchersContext, session: Session) -> groups_pb2.Group:
-        cluster = session.execute(
+    def GetGroup(self, request: groups_pb2.GetGroupReq, context: CouchersContext, db: DB) -> groups_pb2.Group:
+        cluster = db.session.execute(
             select(Cluster)
             .where(~Cluster.is_official_cluster)  # not an official group
             .where(Cluster.id == request.group_id)
@@ -122,21 +123,21 @@ class Groups(groups_pb2_grpc.GroupsServicer):
         if not cluster:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "group_not_found")
 
-        return group_to_pb(session, cluster, context)
+        return group_to_pb(db.session, cluster, context)
 
     def ListAdmins(
-        self, request: groups_pb2.ListAdminsReq, context: CouchersContext, session: Session
+        self, request: groups_pb2.ListAdminsReq, context: CouchersContext, db: DB
     ) -> groups_pb2.ListAdminsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_admin_id = int(request.page_token) if request.page_token else 0
-        cluster = session.execute(
+        cluster = db.session.execute(
             select(Cluster).where(~Cluster.is_official_cluster).where(Cluster.id == request.group_id)
         ).scalar_one_or_none()
         if not cluster:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "group_not_found")
 
         admins = (
-            session.execute(
+            db.session.execute(
                 select(User)
                 .where(users_visible(context))
                 .join(ClusterSubscription, ClusterSubscription.user_id == User.id)
@@ -155,18 +156,18 @@ class Groups(groups_pb2_grpc.GroupsServicer):
         )
 
     def ListMembers(
-        self, request: groups_pb2.ListMembersReq, context: CouchersContext, session: Session
+        self, request: groups_pb2.ListMembersReq, context: CouchersContext, db: DB
     ) -> groups_pb2.ListMembersRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_member_id = int(request.page_token) if request.page_token else 0
-        cluster = session.execute(
+        cluster = db.session.execute(
             select(Cluster).where(~Cluster.is_official_cluster).where(Cluster.id == request.group_id)
         ).scalar_one_or_none()
         if not cluster:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "group_not_found")
 
         members = (
-            session.execute(
+            db.session.execute(
                 select(User)
                 .join(ClusterSubscription, ClusterSubscription.user_id == User.id)
                 .where(users_visible(context))
@@ -184,11 +185,11 @@ class Groups(groups_pb2_grpc.GroupsServicer):
         )
 
     def ListPlaces(
-        self, request: groups_pb2.ListPlacesReq, context: CouchersContext, session: Session
+        self, request: groups_pb2.ListPlacesReq, context: CouchersContext, db: DB
     ) -> groups_pb2.ListPlacesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_page_id = int(request.page_token) if request.page_token else 0
-        cluster = session.execute(
+        cluster = db.session.execute(
             select(Cluster).where(~Cluster.is_official_cluster).where(Cluster.id == request.group_id)
         ).scalar_one_or_none()
         if not cluster:
@@ -201,16 +202,16 @@ class Groups(groups_pb2_grpc.GroupsServicer):
             .all()
         )
         return groups_pb2.ListPlacesRes(
-            places=[page_to_pb(session, page, context) for page in places[:page_size]],
+            places=[page_to_pb(db.session, page, context) for page in places[:page_size]],
             next_page_token=str(places[-1].id) if len(places) > page_size else None,
         )
 
     def ListGuides(
-        self, request: groups_pb2.ListGuidesReq, context: CouchersContext, session: Session
+        self, request: groups_pb2.ListGuidesReq, context: CouchersContext, db: DB
     ) -> groups_pb2.ListGuidesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_page_id = int(request.page_token) if request.page_token else 0
-        cluster = session.execute(
+        cluster = db.session.execute(
             select(Cluster).where(~Cluster.is_official_cluster).where(Cluster.id == request.group_id)
         ).scalar_one_or_none()
         if not cluster:
@@ -223,18 +224,18 @@ class Groups(groups_pb2_grpc.GroupsServicer):
             .all()
         )
         return groups_pb2.ListGuidesRes(
-            guides=[page_to_pb(session, page, context) for page in guides[:page_size]],
+            guides=[page_to_pb(db.session, page, context) for page in guides[:page_size]],
             next_page_token=str(guides[-1].id) if len(guides) > page_size else None,
         )
 
     def ListEvents(
-        self, request: groups_pb2.ListEventsReq, context: CouchersContext, session: Session
+        self, request: groups_pb2.ListEventsReq, context: CouchersContext, db: DB
     ) -> groups_pb2.ListEventsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         # the page token is a unix timestamp of where we left off
         page_token = dt_from_millis(int(request.page_token)) if request.page_token else now()
 
-        cluster = session.execute(
+        cluster = db.session.execute(
             select(Cluster).where(~Cluster.is_official_cluster).where(Cluster.id == request.group_id)
         ).scalar_one_or_none()
         if not cluster:
@@ -255,19 +256,19 @@ class Groups(groups_pb2_grpc.GroupsServicer):
             query = query.where(EventOccurrence.end_time < cutoff).order_by(EventOccurrence.start_time.desc())
 
         query = query.limit(page_size + 1)
-        occurrences = session.execute(query).scalars().all()
+        occurrences = db.session.execute(query).scalars().all()
 
         return groups_pb2.ListEventsRes(
-            events=[event_to_pb(session, occurrence, context) for occurrence in occurrences[:page_size]],
+            events=[event_to_pb(db.session, occurrence, context) for occurrence in occurrences[:page_size]],
             next_page_token=str(millis_from_dt(occurrences[-1].end_time)) if len(occurrences) > page_size else None,
         )
 
     def ListDiscussions(
-        self, request: groups_pb2.ListDiscussionsReq, context: CouchersContext, session: Session
+        self, request: groups_pb2.ListDiscussionsReq, context: CouchersContext, db: DB
     ) -> groups_pb2.ListDiscussionsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_page_id = int(request.page_token) if request.page_token else 0
-        cluster = session.execute(
+        cluster = db.session.execute(
             select(Cluster).where(~Cluster.is_official_cluster).where(Cluster.id == request.group_id)
         ).scalar_one_or_none()
         if not cluster:
@@ -279,14 +280,12 @@ class Groups(groups_pb2_grpc.GroupsServicer):
             .all()
         )
         return groups_pb2.ListDiscussionsRes(
-            discussions=[discussion_to_pb(session, discussion, context) for discussion in discussions[:page_size]],
+            discussions=[discussion_to_pb(db.session, discussion, context) for discussion in discussions[:page_size]],
             next_page_token=str(discussions[-1].id) if len(discussions) > page_size else None,
         )
 
-    def JoinGroup(
-        self, request: groups_pb2.JoinGroupReq, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
-        cluster = session.execute(
+    def JoinGroup(self, request: groups_pb2.JoinGroupReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
+        cluster = db.session.execute(
             select(Cluster).where(~Cluster.is_official_cluster).where(Cluster.id == request.group_id)
         ).scalar_one_or_none()
         if not cluster:
@@ -304,14 +303,12 @@ class Groups(groups_pb2_grpc.GroupsServicer):
             )
         )
 
-        log_event(context, session, "group.joined", {"group_id": cluster.id, "group_name": cluster.name})
+        log_event(context, db.session, "group.joined", {"group_id": cluster.id, "group_name": cluster.name})
 
         return empty_pb2.Empty()
 
-    def LeaveGroup(
-        self, request: groups_pb2.LeaveGroupReq, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
-        cluster = session.execute(
+    def LeaveGroup(self, request: groups_pb2.LeaveGroupReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
+        cluster = db.session.execute(
             select(Cluster).where(~Cluster.is_official_cluster).where(Cluster.id == request.group_id)
         ).scalar_one_or_none()
         if not cluster:
@@ -321,24 +318,24 @@ class Groups(groups_pb2_grpc.GroupsServicer):
         if not user_in_group:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "not_in_group")
 
-        session.execute(
+        db.session.execute(
             delete(ClusterSubscription)
             .where(ClusterSubscription.cluster_id == request.group_id)
             .where(ClusterSubscription.user_id == context.user_id)
         )
 
-        log_event(context, session, "group.left", {"group_id": cluster.id, "group_name": cluster.name})
+        log_event(context, db.session, "group.left", {"group_id": cluster.id, "group_name": cluster.name})
 
         return empty_pb2.Empty()
 
     def ListUserGroups(
-        self, request: groups_pb2.ListUserGroupsReq, context: CouchersContext, session: Session
+        self, request: groups_pb2.ListUserGroupsReq, context: CouchersContext, db: DB
     ) -> groups_pb2.ListUserGroupsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_cluster_id = int(request.page_token) if request.page_token else 0
         user_id = request.user_id or context.user_id
         clusters = (
-            session.execute(
+            db.session.execute(
                 select(Cluster)
                 .join(ClusterSubscription, ClusterSubscription.cluster_id == Cluster.id)
                 .where(ClusterSubscription.user_id == user_id)
@@ -351,6 +348,6 @@ class Groups(groups_pb2_grpc.GroupsServicer):
             .all()
         )
         return groups_pb2.ListUserGroupsRes(
-            groups=[group_to_pb(session, cluster, context) for cluster in clusters[:page_size]],
+            groups=[group_to_pb(db.session, cluster, context) for cluster in clusters[:page_size]],
             next_page_token=str(clusters[-1].id) if len(clusters) > page_size else None,
         )

--- a/app/backend/src/couchers/servicers/jail.py
+++ b/app/backend/src/couchers/servicers/jail.py
@@ -3,12 +3,12 @@ import logging
 import grpc
 from google.protobuf import empty_pb2
 from sqlalchemy import select
-from sqlalchemy.orm import Session
 
 from couchers.constants import GUIDELINES_VERSION, TOS_VERSION
 from couchers.context import CouchersContext
 from couchers.models import ActivenessProbe, ActivenessProbeStatus, HostingStatus, ModNote, User
 from couchers.proto import jail_pb2, jail_pb2_grpc
+from couchers.repositories import DB
 from couchers.servicers.account import mod_note_to_pb
 from couchers.utils import create_coordinate, now
 
@@ -46,14 +46,14 @@ class Jail(jail_pb2_grpc.JailServicer):
     fully active
     """
 
-    def JailInfo(self, request: empty_pb2.Empty, context: CouchersContext, session: Session) -> jail_pb2.JailInfoRes:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+    def JailInfo(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> jail_pb2.JailInfoRes:
+
+        user = db.users.by_id(context.user_id)
         return _get_jail_info(user)
 
-    def AcceptTOS(
-        self, request: jail_pb2.AcceptTOSReq, context: CouchersContext, session: Session
-    ) -> jail_pb2.JailInfoRes:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+    def AcceptTOS(self, request: jail_pb2.AcceptTOSReq, context: CouchersContext, db: DB) -> jail_pb2.JailInfoRes:
+
+        user = db.users.by_id(context.user_id)
 
         if not request.accept:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "cant_unaccept_tos")
@@ -62,10 +62,9 @@ class Jail(jail_pb2_grpc.JailServicer):
 
         return _get_jail_info(user)
 
-    def SetLocation(
-        self, request: jail_pb2.SetLocationReq, context: CouchersContext, session: Session
-    ) -> jail_pb2.JailInfoRes:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+    def SetLocation(self, request: jail_pb2.SetLocationReq, context: CouchersContext, db: DB) -> jail_pb2.JailInfoRes:
+
+        user = db.users.by_id(context.user_id)
 
         if request.lat == 0 and request.lng == 0:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_coordinate")
@@ -79,9 +78,9 @@ class Jail(jail_pb2_grpc.JailServicer):
         return _get_jail_info(user)
 
     def AcceptCommunityGuidelines(
-        self, request: jail_pb2.AcceptCommunityGuidelinesReq, context: CouchersContext, session: Session
+        self, request: jail_pb2.AcceptCommunityGuidelinesReq, context: CouchersContext, db: DB
     ) -> jail_pb2.JailInfoRes:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
 
         if not request.accept:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "cant_unaccept_community_guidelines")
@@ -91,11 +90,11 @@ class Jail(jail_pb2_grpc.JailServicer):
         return _get_jail_info(user)
 
     def AcknowledgePendingModNote(
-        self, request: jail_pb2.AcknowledgePendingModNoteReq, context: CouchersContext, session: Session
+        self, request: jail_pb2.AcknowledgePendingModNoteReq, context: CouchersContext, db: DB
     ) -> jail_pb2.JailInfoRes:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
 
-        note = session.execute(
+        note = db.session.execute(
             select(ModNote)
             .where(ModNote.user_id == user.id)
             .where(ModNote.is_pending)
@@ -113,11 +112,11 @@ class Jail(jail_pb2_grpc.JailServicer):
         return _get_jail_info(user)
 
     def RespondToActivenessProbe(
-        self, request: jail_pb2.RespondToActivenessProbeReq, context: CouchersContext, session: Session
+        self, request: jail_pb2.RespondToActivenessProbeReq, context: CouchersContext, db: DB
     ) -> jail_pb2.JailInfoRes:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
 
-        probe = session.execute(
+        probe = db.session.execute(
             select(ActivenessProbe).where(ActivenessProbe.user_id == user.id).where(ActivenessProbe.is_pending)
         ).scalar_one_or_none()
 

--- a/app/backend/src/couchers/servicers/media.py
+++ b/app/backend/src/couchers/servicers/media.py
@@ -3,13 +3,13 @@ import logging
 import grpc
 from google.protobuf import empty_pb2
 from sqlalchemy import select
-from sqlalchemy.orm import Session
 
 from couchers.context import CouchersContext
 from couchers.crypto import secure_compare
 from couchers.interceptors import MediaInterceptor
 from couchers.models import InitiatedUpload, Upload
 from couchers.proto import media_pb2, media_pb2_grpc
+from couchers.repositories import DB
 
 logger = logging.getLogger(__name__)
 
@@ -23,9 +23,9 @@ def get_media_auth_interceptor(secret_token: str) -> MediaInterceptor:
 
 class Media(media_pb2_grpc.MediaServicer):
     def UploadConfirmation(
-        self, request: media_pb2.UploadConfirmationReq, context: CouchersContext, session: Session
+        self, request: media_pb2.UploadConfirmationReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        initiated_upload = session.execute(
+        initiated_upload = db.session.execute(
             select(InitiatedUpload).where(InitiatedUpload.key == request.key).where(InitiatedUpload.is_valid)
         ).scalar_one_or_none()
 
@@ -38,9 +38,9 @@ class Media(media_pb2_grpc.MediaServicer):
             filename=request.filename,
             creator_user_id=initiated_upload.initiator_user_id,
         )
-        session.add(upload)
+        db.session.add(upload)
 
         # delete the old upload
-        session.delete(initiated_upload)
+        db.session.delete(initiated_upload)
 
         return empty_pb2.Empty()

--- a/app/backend/src/couchers/servicers/moderation.py
+++ b/app/backend/src/couchers/servicers/moderation.py
@@ -34,6 +34,7 @@ from couchers.models import (
 )
 from couchers.proto import moderation_pb2, moderation_pb2_grpc
 from couchers.proto.internal import jobs_pb2
+from couchers.repositories import DB
 from couchers.utils import Timestamp_from_datetime, now
 
 if TYPE_CHECKING:
@@ -181,10 +182,9 @@ def moderation_state_to_pb(state: ModerationState, session: Session) -> moderati
 
 class Moderation(moderation_pb2_grpc.ModerationServicer):
     def GetModerationQueue(
-        self, request: moderation_pb2.GetModerationQueueReq, context: CouchersContext, session: Session
+        self, request: moderation_pb2.GetModerationQueueReq, context: CouchersContext, db: DB
     ) -> moderation_pb2.GetModerationQueueRes:
         """Get moderation queue items with optional filtering"""
-
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
 
         # Build query
@@ -244,13 +244,13 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
         else:
             statement = statement.order_by(ModerationQueueItem.time_created.asc(), ModerationQueueItem.id.asc())
 
-        queue_items = session.execute(statement.limit(page_size + 1)).scalars().all()
+        queue_items = db.session.execute(statement.limit(page_size + 1)).scalars().all()
 
         # Convert to proto
         queue_items_pb = []
         for item in queue_items[:page_size]:
             # Fetch the moderation state for this queue item
-            mod_state = session.execute(
+            mod_state = db.session.execute(
                 select(ModerationState).where(ModerationState.id == item.moderation_state_id)
             ).scalar_one()
 
@@ -262,7 +262,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
                 reason=item.reason,
                 is_resolved=item.resolved_by_log_id is not None,
                 resolved_by_log_id=item.resolved_by_log_id or 0,
-                moderation_state=moderation_state_to_pb(mod_state, session),
+                moderation_state=moderation_state_to_pb(mod_state, db.session),
             )
 
             queue_items_pb.append(queue_item_pb)
@@ -274,14 +274,14 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
         )
 
     def GetModerationState(
-        self, request: moderation_pb2.GetModerationStateReq, context: CouchersContext, session: Session
+        self, request: moderation_pb2.GetModerationStateReq, context: CouchersContext, db: DB
     ) -> moderation_pb2.GetModerationStateRes:
         """Get moderation state by object type and object ID"""
         object_type = moderationobjecttype2sql[request.object_type]
         if object_type is None:
             context.abort(grpc.StatusCode.INVALID_ARGUMENT, "Object type must be specified.")
 
-        moderation_state = session.execute(
+        moderation_state = db.session.execute(
             select(ModerationState)
             .where(ModerationState.object_type == object_type)
             .where(ModerationState.object_id == request.object_id)
@@ -290,15 +290,15 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
             context.abort(grpc.StatusCode.NOT_FOUND, "Moderation state not found.")
 
         return moderation_pb2.GetModerationStateRes(
-            moderation_state=moderation_state_to_pb(moderation_state, session),
+            moderation_state=moderation_state_to_pb(moderation_state, db.session),
         )
 
     def GetModerationLog(
-        self, request: moderation_pb2.GetModerationLogReq, context: CouchersContext, session: Session
+        self, request: moderation_pb2.GetModerationLogReq, context: CouchersContext, db: DB
     ) -> moderation_pb2.GetModerationLogRes:
         """Get moderation log for a specific moderation state"""
         # Get the moderation state
-        moderation_state = session.execute(
+        moderation_state = db.session.execute(
             select(ModerationState).where(ModerationState.id == request.moderation_state_id)
         ).scalar_one_or_none()
         if moderation_state is None:
@@ -306,7 +306,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
 
         # Get all log entries for this state, ordered by time (most recent first)
         log_entries = (
-            session.execute(
+            db.session.execute(
                 select(ModerationLog)
                 .where(ModerationLog.moderation_state_id == request.moderation_state_id)
                 .order_by(ModerationLog.time.desc(), ModerationLog.id.desc())
@@ -316,7 +316,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
         )
 
         # Convert moderation state to proto first (while still in session)
-        moderation_state_pb = moderation_state_to_pb(moderation_state, session)
+        moderation_state_pb = moderation_state_to_pb(moderation_state, db.session)
 
         # Convert to proto
         log_entries_pb = []
@@ -342,11 +342,10 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
         )
 
     def ModerateContent(
-        self, request: moderation_pb2.ModerateContentReq, context: CouchersContext, session: Session
+        self, request: moderation_pb2.ModerateContentReq, context: CouchersContext, db: DB
     ) -> moderation_pb2.ModerateContentRes:
         """Unified moderation action - takes both action and visibility explicitly"""
-
-        moderation_state = session.execute(
+        moderation_state = db.session.execute(
             select(ModerationState).where(ModerationState.id == request.moderation_state_id)
         ).scalar_one_or_none()
         if moderation_state is None:
@@ -378,11 +377,11 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
             new_visibility=new_visibility,
             reason=reason,
         )
-        session.add(log_entry)
-        session.flush()
+        db.session.add(log_entry)
+        db.session.flush()
 
         # Resolve any pending queue items
-        queue_item = session.execute(
+        queue_item = db.session.execute(
             select(ModerationQueueItem)
             .where(ModerationQueueItem.moderation_state_id == moderation_state.id)
             .where(ModerationQueueItem.resolved_by_log_id.is_(None))
@@ -391,7 +390,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
 
         if queue_item:
             queue_item.resolved_by_log_id = log_entry.id
-            session.flush()
+            db.session.flush()
             observe_moderation_queue_item_resolved(queue_item.trigger, action, moderation_state.object_type)
             observe_moderation_queue_resolution_time(
                 queue_item.trigger,
@@ -406,7 +405,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
         # If visibility becomes VISIBLE or UNLISTED, trigger pending notifications
         if new_visibility in (ModerationVisibility.visible, ModerationVisibility.unlisted):
             pending_notifications = (
-                session.execute(
+                db.session.execute(
                     select(Notification)
                     .where(Notification.moderation_state_id == moderation_state.id)
                     .where(not_(exists().where(NotificationDelivery.notification_id == Notification.id)))
@@ -420,21 +419,20 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
 
             for notification in pending_notifications:
                 queue_job(
-                    session,
+                    db.session,
                     job=handle_notification,
                     payload=jobs_pb2.HandleNotificationPayload(notification_id=notification.id),
                 )
 
         return moderation_pb2.ModerateContentRes(
-            moderation_state=moderation_state_to_pb(moderation_state, session),
+            moderation_state=moderation_state_to_pb(moderation_state, db.session),
         )
 
     def FlagContentForReview(
-        self, request: moderation_pb2.FlagContentForReviewReq, context: CouchersContext, session: Session
+        self, request: moderation_pb2.FlagContentForReviewReq, context: CouchersContext, db: DB
     ) -> moderation_pb2.FlagContentForReviewRes:
         """Flag content for review by adding it to the moderation queue"""
-
-        moderation_state = session.execute(
+        moderation_state = db.session.execute(
             select(ModerationState).where(ModerationState.id == request.moderation_state_id)
         ).scalar_one_or_none()
         if not moderation_state:
@@ -449,8 +447,8 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
             trigger=trigger,
             reason=reason,
         )
-        session.add(queue_item)
-        session.flush()
+        db.session.add(queue_item)
+        db.session.flush()
 
         observe_moderation_action(ModerationAction.flag, moderation_state.object_type)
         observe_moderation_queue_item_created(trigger, moderation_state.object_type)
@@ -463,17 +461,16 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
             reason=queue_item.reason,
             is_resolved=False,
             resolved_by_log_id=0,
-            moderation_state=moderation_state_to_pb(moderation_state, session),
+            moderation_state=moderation_state_to_pb(moderation_state, db.session),
         )
 
         return moderation_pb2.FlagContentForReviewRes(queue_item=queue_item_pb)
 
     def UnflagContent(
-        self, request: moderation_pb2.UnflagContentReq, context: CouchersContext, session: Session
+        self, request: moderation_pb2.UnflagContentReq, context: CouchersContext, db: DB
     ) -> moderation_pb2.UnflagContentRes:
         """Unflag content by resolving pending queue items"""
-
-        moderation_state = session.execute(
+        moderation_state = db.session.execute(
             select(ModerationState).where(ModerationState.id == request.moderation_state_id)
         ).scalar_one_or_none()
         if not moderation_state:
@@ -492,11 +489,11 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
             new_visibility=None,
             reason=reason,
         )
-        session.add(log_entry)
-        session.flush()
+        db.session.add(log_entry)
+        db.session.flush()
 
         # Resolve any pending queue items (inline resolve_queue_item logic)
-        queue_item = session.execute(
+        queue_item = db.session.execute(
             select(ModerationQueueItem)
             .where(ModerationQueueItem.moderation_state_id == moderation_state.id)
             .where(ModerationQueueItem.resolved_by_log_id.is_(None))
@@ -505,7 +502,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
 
         if queue_item:
             queue_item.resolved_by_log_id = log_entry.id
-            session.flush()
+            db.session.flush()
             observe_moderation_queue_item_resolved(
                 queue_item.trigger, ModerationAction.unflag, moderation_state.object_type
             )
@@ -519,5 +516,5 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
         observe_moderation_action(ModerationAction.unflag, moderation_state.object_type)
 
         return moderation_pb2.UnflagContentRes(
-            moderation_state=moderation_state_to_pb(moderation_state, session),
+            moderation_state=moderation_state_to_pb(moderation_state, db.session),
         )

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -5,7 +5,6 @@ import logging
 import grpc
 from google.protobuf import empty_pb2
 from sqlalchemy import select, update
-from sqlalchemy.orm import Session
 from sqlalchemy.sql import or_
 
 from couchers.config import config
@@ -34,6 +33,7 @@ from couchers.notifications.settings import (
 from couchers.notifications.utils import enum_from_topic_action
 from couchers.notifications.web_push_api import decode_key, get_vapid_public_key_from_private_key
 from couchers.proto import notifications_pb2, notifications_pb2_grpc
+from couchers.repositories import DB
 from couchers.sql import moderation_state_column_visible, to_bool
 from couchers.utils import Timestamp_from_datetime, now
 
@@ -64,18 +64,18 @@ def notification_to_pb(user: User, notification: Notification) -> notifications_
 
 class Notifications(notifications_pb2_grpc.NotificationsServicer):
     def GetNotificationSettings(
-        self, request: notifications_pb2.GetNotificationSettingsReq, context: CouchersContext, session: Session
+        self, request: notifications_pb2.GetNotificationSettingsReq, context: CouchersContext, db: DB
     ) -> notifications_pb2.GetNotificationSettingsRes:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
         return notifications_pb2.GetNotificationSettingsRes(
             do_not_email_enabled=user.do_not_email,
             groups=get_user_setting_groups(user.id, context.localization),
         )
 
     def SetNotificationSettings(
-        self, request: notifications_pb2.SetNotificationSettingsReq, context: CouchersContext, session: Session
+        self, request: notifications_pb2.SetNotificationSettingsReq, context: CouchersContext, db: DB
     ) -> notifications_pb2.GetNotificationSettingsRes:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
         user.do_not_email = request.enable_do_not_email
         if request.enable_do_not_email:
             user.hosting_status = HostingStatus.cant_host
@@ -89,7 +89,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
                 context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "invalid_delivery_method")
             delivery_type = NotificationDeliveryType[preference.delivery_method]
             try:
-                set_preference(session, user.id, topic_action, delivery_type, preference.enabled)
+                set_preference(db.session, user.id, topic_action, delivery_type, preference.enabled)
             except PreferenceNotUserEditableError:
                 context.abort_with_error_code(
                     grpc.StatusCode.FAILED_PRECONDITION, "cannot_edit_that_notification_preference"
@@ -100,20 +100,20 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         )
 
     def ListNotifications(
-        self, request: notifications_pb2.ListNotificationsReq, context: CouchersContext, session: Session
+        self, request: notifications_pb2.ListNotificationsReq, context: CouchersContext, db: DB
     ) -> notifications_pb2.ListNotificationsRes:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_notification_id = int(request.page_token) if request.page_token else 2**50
         notifications = (
-            session.execute(
+            db.session.execute(
                 select(Notification)
                 .where(Notification.user_id == context.user_id)
                 .where(Notification.id <= next_notification_id)
                 .where(or_(to_bool(request.only_unread == False), Notification.is_seen == False))
                 .where(
                     Notification.topic_action.in_(
-                        get_topic_actions_by_delivery_type(session, user.id, NotificationDeliveryType.push)
+                        get_topic_actions_by_delivery_type(db.session, user.id, NotificationDeliveryType.push)
                     )
                 )
                 .where(moderation_state_column_visible(context, Notification.moderation_state_id))
@@ -129,10 +129,10 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         )
 
     def MarkNotificationSeen(
-        self, request: notifications_pb2.MarkNotificationSeenReq, context: CouchersContext, session: Session
+        self, request: notifications_pb2.MarkNotificationSeenReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
         notification = (
-            session.execute(
+            db.session.execute(
                 select(Notification)
                 .where(Notification.user_id == context.user_id)
                 .where(Notification.id == request.notification_id)
@@ -146,9 +146,9 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         return empty_pb2.Empty()
 
     def MarkAllNotificationsSeen(
-        self, request: notifications_pb2.MarkAllNotificationsSeenReq, context: CouchersContext, session: Session
+        self, request: notifications_pb2.MarkAllNotificationsSeenReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        session.execute(
+        db.session.execute(
             update(Notification)
             .values(is_seen=True)
             .where(Notification.user_id == context.user_id)
@@ -157,7 +157,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         return empty_pb2.Empty()
 
     def GetVapidPublicKey(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+        self, request: empty_pb2.Empty, context: CouchersContext, db: DB
     ) -> notifications_pb2.GetVapidPublicKeyRes:
         if not config["PUSH_NOTIFICATIONS_ENABLED"]:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
@@ -168,7 +168,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         self,
         request: notifications_pb2.RegisterPushNotificationSubscriptionReq,
         context: CouchersContext,
-        session: Session,
+        db: DB,
     ) -> empty_pb2.Empty:
         if not config["PUSH_NOTIFICATIONS_ENABLED"]:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
@@ -186,10 +186,10 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             full_subscription_info=request.full_subscription_json,
             user_agent=request.user_agent,
         )
-        session.add(subscription)
-        session.flush()
+        db.session.add(subscription)
+        db.session.flush()
         push_to_subscription(
-            session,
+            db.session,
             push_notification_subscription_id=subscription.id,
             user_id=context.user_id,
             topic_action="adhoc:setup",
@@ -202,14 +202,12 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
 
         return empty_pb2.Empty()
 
-    def SendTestPushNotification(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
-    ) -> empty_pb2.Empty:
+    def SendTestPushNotification(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> empty_pb2.Empty:
         if not config["PUSH_NOTIFICATIONS_ENABLED"]:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         push_to_user(
-            session,
+            db.session,
             user_id=context.user_id,
             topic_action="adhoc:testing",
             content=PushNotificationContent(
@@ -225,13 +223,13 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         self,
         request: notifications_pb2.RegisterMobilePushNotificationSubscriptionReq,
         context: CouchersContext,
-        session: Session,
+        db: DB,
     ) -> empty_pb2.Empty:
         if not config["PUSH_NOTIFICATIONS_ENABLED"]:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         # Check for existing subscription with this token
-        existing = session.execute(
+        existing = db.session.execute(
             select(PushNotificationSubscription).where(PushNotificationSubscription.token == request.token)
         ).scalar_one_or_none()
 
@@ -255,12 +253,12 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             device_name=request.device_name if request.device_name else None,
             device_type=device_type,
         )
-        session.add(subscription)
-        session.flush()
+        db.session.add(subscription)
+        db.session.flush()
 
         push_content = render_adhoc_push_notification("push_enabled", context.localization)
         push_to_subscription(
-            session,
+            db.session,
             push_notification_subscription_id=subscription.id,
             user_id=context.user_id,
             topic_action="adhoc:push_enabled",
@@ -270,13 +268,13 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         return empty_pb2.Empty()
 
     def SendTestMobilePushNotification(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+        self, request: empty_pb2.Empty, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
         if not config["PUSH_NOTIFICATIONS_ENABLED"]:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         push_to_user(
-            session,
+            db.session,
             user_id=context.user_id,
             topic_action="adhoc:testing",
             content=PushNotificationContent(
@@ -289,7 +287,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         return empty_pb2.Empty()
 
     def SendDevPushNotification(
-        self, request: notifications_pb2.SendDevPushNotificationReq, context: CouchersContext, session: Session
+        self, request: notifications_pb2.SendDevPushNotificationReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
         if not config["ENABLE_DEV_APIS"]:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "dev_apis_disabled")
@@ -298,7 +296,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         push_to_user(
-            session,
+            db.session,
             user_id=context.user_id,
             topic_action="adhoc:testing",
             content=PushNotificationContent(
@@ -318,7 +316,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         self,
         request: notifications_pb2.DebugRedeliverPushNotificationReq,
         context: CouchersContext,
-        session: Session,
+        db: DB,
     ) -> empty_pb2.Empty:
         if not config["ENABLE_DEV_APIS"]:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "dev_apis_disabled")
@@ -326,9 +324,9 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         if not config["PUSH_NOTIFICATIONS_ENABLED"]:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
 
-        notification = session.execute(
+        notification = db.session.execute(
             select(Notification)
             .where(Notification.id == request.notification_id)
             .where(Notification.user_id == context.user_id)
@@ -338,7 +336,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "notification_not_found")
 
         push_to_user(
-            session,
+            db.session,
             user_id=context.user_id,
             topic_action=notification.topic_action.display,
             content=render_push_notification(notification, LocalizationContext.from_user(user)),

--- a/app/backend/src/couchers/servicers/pages.py
+++ b/app/backend/src/couchers/servicers/pages.py
@@ -4,8 +4,9 @@ from sqlalchemy.orm import Session, selectinload
 
 from couchers.context import CouchersContext
 from couchers.db import can_moderate_at, can_moderate_node, get_parent_node_at_location
-from couchers.models import Cluster, Node, Page, PageType, PageVersion, Thread, Upload, User
+from couchers.models import Cluster, Page, PageType, PageVersion, Thread, User
 from couchers.proto import pages_pb2, pages_pb2_grpc
+from couchers.repositories import DB
 from couchers.servicers.threads import thread_to_pb
 from couchers.utils import Timestamp_from_datetime, create_coordinate, not_none, remove_duplicates_retain_order
 
@@ -98,9 +99,7 @@ def page_to_pb(session: Session, page: Page, context: CouchersContext) -> pages_
 
 
 class Pages(pages_pb2_grpc.PagesServicer):
-    def CreatePlace(
-        self, request: pages_pb2.CreatePlaceReq, context: CouchersContext, session: Session
-    ) -> pages_pb2.Page:
+    def CreatePlace(self, request: pages_pb2.CreatePlaceReq, context: CouchersContext, db: DB) -> pages_pb2.Page:
         if not request.title:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "missing_page_title")
         if not request.content:
@@ -114,18 +113,15 @@ class Pages(pages_pb2_grpc.PagesServicer):
 
         geom = create_coordinate(request.location.lat, request.location.lng)
 
-        if (
-            request.photo_key
-            and not session.execute(select(Upload).where(Upload.key == request.photo_key)).scalar_one_or_none()
-        ):
+        if request.photo_key and not db.uploads.get_by_key(request.photo_key):
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "photo_not_found")
 
-        parent_node = get_parent_node_at_location(session, geom)
+        parent_node = get_parent_node_at_location(db.session, geom)
         if not parent_node:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "location_not_in_any_community")
         thread = Thread()
-        session.add(thread)
-        session.flush()
+        db.session.add(thread)
+        db.session.flush()
         page = Page(
             parent_node_id=parent_node.id,
             type=PageType.place,
@@ -133,8 +129,8 @@ class Pages(pages_pb2_grpc.PagesServicer):
             owner_user_id=context.user_id,
             thread_id=thread.id,
         )
-        session.add(page)
-        session.flush()
+        db.session.add(page)
+        db.session.flush()
         page_version = PageVersion(
             page_id=page.id,
             editor_user_id=context.user_id,
@@ -144,13 +140,11 @@ class Pages(pages_pb2_grpc.PagesServicer):
             address=request.address,
             geom=geom,
         )
-        session.add(page_version)
-        session.commit()
-        return page_to_pb(session, page, context)
+        db.session.add(page_version)
+        db.session.commit()
+        return page_to_pb(db.session, page, context)
 
-    def CreateGuide(
-        self, request: pages_pb2.CreateGuideReq, context: CouchersContext, session: Session
-    ) -> pages_pb2.Page:
+    def CreateGuide(self, request: pages_pb2.CreateGuideReq, context: CouchersContext, db: DB) -> pages_pb2.Page:
         if not request.title:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "missing_page_title")
         if not request.content:
@@ -170,20 +164,17 @@ class Pages(pages_pb2_grpc.PagesServicer):
         if not request.parent_community_id:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "missing_page_parent")
 
-        parent_node = session.execute(select(Node).where(Node.id == request.parent_community_id)).scalar_one_or_none()
+        parent_node = db.nodes.get_by_id(request.parent_community_id)
 
         if not parent_node:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "community_not_found")
 
-        if (
-            request.photo_key
-            and not session.execute(select(Upload).where(Upload.key == request.photo_key)).scalar_one_or_none()
-        ):
+        if request.photo_key and not db.uploads.get_by_key(request.photo_key):
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "photo_not_found")
 
         thread = Thread()
-        session.add(thread)
-        session.flush()
+        db.session.add(thread)
+        db.session.flush()
         page = Page(
             parent_node_id=parent_node.id,
             type=PageType.guide,
@@ -191,8 +182,8 @@ class Pages(pages_pb2_grpc.PagesServicer):
             owner_user_id=context.user_id,
             thread_id=thread.id,
         )
-        session.add(page)
-        session.flush()
+        db.session.add(page)
+        db.session.flush()
         page_version = PageVersion(
             page_id=page.id,
             editor_user_id=context.user_id,
@@ -202,29 +193,25 @@ class Pages(pages_pb2_grpc.PagesServicer):
             address=address,
             geom=geom,
         )
-        session.add(page_version)
-        session.commit()
-        return page_to_pb(session, page, context)
+        db.session.add(page_version)
+        db.session.commit()
+        return page_to_pb(db.session, page, context)
 
-    def GetPage(self, request: pages_pb2.GetPageReq, context: CouchersContext, session: Session) -> pages_pb2.Page:
-        page = session.execute(
-            select(Page)
-            .where(Page.id == request.page_id)
-            .options(selectinload(Page.versions), selectinload(Page.owner_cluster))
-        ).scalar_one_or_none()
+    def GetPage(self, request: pages_pb2.GetPageReq, context: CouchersContext, db: DB) -> pages_pb2.Page:
+        page = db.pages.get_by_id(
+            request.page_id,
+            options=[selectinload(Page.versions), selectinload(Page.owner_cluster)],
+        )
         if not page:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "page_not_found")
 
-        return page_to_pb(session, page, context)
+        return page_to_pb(db.session, page, context)
 
-    def UpdatePage(
-        self, request: pages_pb2.UpdatePageReq, context: CouchersContext, session: Session
-    ) -> pages_pb2.Page:
-        page = session.execute(select(Page).where(Page.id == request.page_id)).scalar_one_or_none()
-        if not page:
+    def UpdatePage(self, request: pages_pb2.UpdatePageReq, context: CouchersContext, db: DB) -> pages_pb2.Page:
+        if not (page := db.pages.get_by_id(request.page_id)):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "page_not_found")
 
-        if not _is_page_owner(page, context.user_id) and not _can_moderate_page(session, page, context.user_id):
+        if not _is_page_owner(page, context.user_id) and not _can_moderate_page(db.session, page, context.user_id):
             context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "page_update_permission_denied")
 
         current_version = page.versions[-1]
@@ -253,9 +240,7 @@ class Pages(pages_pb2_grpc.PagesServicer):
             if not request.photo_key.value:
                 page_version.photo_key = None
             else:
-                if not session.execute(
-                    select(Upload).where(Upload.key == request.photo_key.value)
-                ).scalar_one_or_none():
+                if not db.uploads.get_by_key(request.photo_key.value):
                     context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "photo_not_found")
                 page_version.photo_key = request.photo_key.value
 
@@ -267,35 +252,33 @@ class Pages(pages_pb2_grpc.PagesServicer):
         if request.HasField("location"):
             page_version.geom = create_coordinate(request.location.lat, request.location.lng)
 
-        session.add(page_version)
-        session.commit()
-        return page_to_pb(session, page, context)
+        db.session.add(page_version)
+        db.session.commit()
+        return page_to_pb(db.session, page, context)
 
-    def TransferPage(
-        self, request: pages_pb2.TransferPageReq, context: CouchersContext, session: Session
-    ) -> pages_pb2.Page:
-        page = session.execute(
+    def TransferPage(self, request: pages_pb2.TransferPageReq, context: CouchersContext, db: DB) -> pages_pb2.Page:
+        page = db.session.execute(
             select(Page).where(Page.id == request.page_id).where(Page.type != PageType.main_page)
         ).scalar_one_or_none()
 
         if not page:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "page_not_found")
 
-        if not _is_page_owner(page, context.user_id) and not _can_moderate_page(session, page, context.user_id):
+        if not _is_page_owner(page, context.user_id) and not _can_moderate_page(db.session, page, context.user_id):
             context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "page_transfer_permission_denied")
 
         if request.WhichOneof("new_owner") == "new_owner_group_id":
-            cluster = session.execute(
+            cluster = db.session.execute(
                 select(Cluster).where(~Cluster.is_official_cluster).where(Cluster.id == request.new_owner_group_id)
             ).scalar_one_or_none()
         elif request.WhichOneof("new_owner") == "new_owner_community_id":
-            cluster = session.execute(
+            cluster = db.session.execute(
                 select(Cluster)
                 .where(Cluster.parent_node_id == request.new_owner_community_id)
                 .where(Cluster.is_official_cluster)
             ).scalar_one_or_none()
         else:
-            # i'm not sure if this needs to be checked
+            # I'm not sure if this needs to be checked
             context.abort_with_error_code(grpc.StatusCode.UNKNOWN, "unknown_error")
 
         if not cluster:
@@ -304,17 +287,17 @@ class Pages(pages_pb2_grpc.PagesServicer):
         page.owner_user = None
         page.owner_cluster = cluster
 
-        session.commit()
-        return page_to_pb(session, page, context)
+        db.session.commit()
+        return page_to_pb(db.session, page, context)
 
     def ListUserPlaces(
-        self, request: pages_pb2.ListUserPlacesReq, context: CouchersContext, session: Session
+        self, request: pages_pb2.ListUserPlacesReq, context: CouchersContext, db: DB
     ) -> pages_pb2.ListUserPlacesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_page_id = int(request.page_token) if request.page_token else 0
         user_id = request.user_id or context.user_id
         places = (
-            session.execute(
+            db.session.execute(
                 select(Page)
                 .where(Page.owner_user_id == user_id)
                 .where(Page.type == PageType.place)
@@ -327,18 +310,18 @@ class Pages(pages_pb2_grpc.PagesServicer):
             .all()
         )
         return pages_pb2.ListUserPlacesRes(
-            places=[page_to_pb(session, page, context) for page in places[:page_size]],
+            places=[page_to_pb(db.session, page, context) for page in places[:page_size]],
             next_page_token=str(places[-1].id) if len(places) > page_size else None,
         )
 
     def ListUserGuides(
-        self, request: pages_pb2.ListUserGuidesReq, context: CouchersContext, session: Session
+        self, request: pages_pb2.ListUserGuidesReq, context: CouchersContext, db: DB
     ) -> pages_pb2.ListUserGuidesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_page_id = int(request.page_token) if request.page_token else 0
         user_id = request.user_id or context.user_id
         guides = (
-            session.execute(
+            db.session.execute(
                 select(Page)
                 .where(Page.owner_user_id == user_id)
                 .where(Page.type == PageType.guide)
@@ -351,6 +334,6 @@ class Pages(pages_pb2_grpc.PagesServicer):
             .all()
         )
         return pages_pb2.ListUserGuidesRes(
-            guides=[page_to_pb(session, page, context) for page in guides[:page_size]],
+            guides=[page_to_pb(db.session, page, context) for page in guides[:page_size]],
             next_page_token=str(guides[-1].id) if len(guides) > page_size else None,
         )

--- a/app/backend/src/couchers/servicers/postal_verification.py
+++ b/app/backend/src/couchers/servicers/postal_verification.py
@@ -4,7 +4,6 @@ import logging
 import grpc
 from google.protobuf import empty_pb2
 from sqlalchemy import exists, select
-from sqlalchemy.orm import Session
 
 from couchers.config import config
 from couchers.constants import (
@@ -16,13 +15,13 @@ from couchers.context import CouchersContext
 from couchers.helpers.postal_verification import generate_postal_verification_code, has_postal_verification
 from couchers.jobs.enqueue import queue_job
 from couchers.jobs.handlers import send_postal_verification_postcard
-from couchers.models import User
 from couchers.models.notifications import NotificationTopicAction
 from couchers.models.postal_verification import PostalVerificationAttempt, PostalVerificationStatus
 from couchers.notifications.notify import notify
 from couchers.postal.address_validation import AddressValidationError, validate_address
 from couchers.proto import notification_data_pb2, postal_verification_pb2, postal_verification_pb2_grpc
 from couchers.proto.internal import jobs_pb2
+from couchers.repositories import DB
 from couchers.utils import Timestamp_from_datetime, now
 
 logger = logging.getLogger(__name__)
@@ -53,7 +52,7 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
         self,
         request: postal_verification_pb2.InitiatePostalVerificationReq,
         context: CouchersContext,
-        session: Session,
+        db: DB,
     ) -> postal_verification_pb2.InitiatePostalVerificationRes:
         """
         Step 1: User submits address for validation.
@@ -62,7 +61,7 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "postal_verification_disabled")
 
         # Check if there's an active attempt
-        has_active_attempt = session.execute(
+        has_active_attempt = db.session.execute(
             select(
                 exists(
                     select(PostalVerificationAttempt)
@@ -86,7 +85,7 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
             )
 
         # Check rate limit: one initiation per 30 days
-        has_recent_attempt = session.execute(
+        has_recent_attempt = db.session.execute(
             select(
                 exists(
                     select(PostalVerificationAttempt)
@@ -144,8 +143,8 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
                 }
             ),
         )
-        session.add(attempt)
-        session.flush()
+        db.session.add(attempt)
+        db.session.flush()
 
         return postal_verification_pb2.InitiatePostalVerificationRes(
             postal_verification_attempt_id=attempt.id,
@@ -164,12 +163,12 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
         self,
         request: postal_verification_pb2.ConfirmPostalAddressReq,
         context: CouchersContext,
-        session: Session,
+        db: DB,
     ) -> postal_verification_pb2.ConfirmPostalAddressRes:
         """
         Step 2: User confirms address, we generate code and send postcard.
         """
-        attempt = session.execute(
+        attempt = db.session.execute(
             select(PostalVerificationAttempt)
             .where(PostalVerificationAttempt.id == request.postal_verification_attempt_id)
             .where(PostalVerificationAttempt.user_id == context.user_id)
@@ -187,7 +186,7 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
 
         # Queue background job to send postcard
         queue_job(
-            session,
+            db.session,
             job=send_postal_verification_postcard,
             payload=jobs_pb2.SendPostalVerificationPostcardPayload(
                 postal_verification_attempt_id=attempt.id,
@@ -200,17 +199,17 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
         self,
         request: postal_verification_pb2.GetPostalVerificationStatusReq,
         context: CouchersContext,
-        session: Session,
+        db: DB,
     ) -> postal_verification_pb2.GetPostalVerificationStatusRes:
         """
         Returns the user's postal verification status and current/latest attempt details.
         """
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
 
-        has_verification = has_postal_verification(session, user)
+        has_verification = has_postal_verification(db.session, user)
 
         # Always get the latest attempt for determining can_initiate and has_active_attempt
-        latest_attempt = session.execute(
+        latest_attempt = db.session.execute(
             select(PostalVerificationAttempt)
             .where(PostalVerificationAttempt.user_id == user.id)
             .order_by(PostalVerificationAttempt.created.desc())
@@ -249,7 +248,7 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
 
         # Get specific attempt if requested, otherwise use latest
         if request.postal_verification_attempt_id:
-            attempt = session.execute(
+            attempt = db.session.execute(
                 select(PostalVerificationAttempt)
                 .where(PostalVerificationAttempt.id == request.postal_verification_attempt_id)
                 .where(PostalVerificationAttempt.user_id == context.user_id)
@@ -273,13 +272,13 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
         self,
         request: postal_verification_pb2.VerifyPostalCodeReq,
         context: CouchersContext,
-        session: Session,
+        db: DB,
     ) -> postal_verification_pb2.VerifyPostalCodeRes:
         """
         User submits the code from the postcard.
         Looks up the user's active attempt (awaiting_verification status).
         """
-        attempt = session.execute(
+        attempt = db.session.execute(
             select(PostalVerificationAttempt)
             .where(PostalVerificationAttempt.user_id == context.user_id)
             .where(PostalVerificationAttempt.status == PostalVerificationStatus.awaiting_verification)
@@ -292,7 +291,7 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
         if attempt.postcard_sent_at and (now() - attempt.postcard_sent_at) > POSTAL_VERIFICATION_CODE_LIFETIME:
             attempt.status = PostalVerificationStatus.failed
             notify(
-                session,
+                db.session,
                 user_id=context.user_id,
                 topic_action=NotificationTopicAction.postal_verification__failed,
                 key="",
@@ -300,7 +299,7 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
                     reason=notification_data_pb2.POSTAL_VERIFICATION_FAIL_REASON_CODE_EXPIRED
                 ),
             )
-            session.commit()
+            db.session.commit()
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "postal_verification_code_expired")
 
         # Normalize submitted code
@@ -313,7 +312,7 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
             if remaining <= 0:
                 attempt.status = PostalVerificationStatus.failed
                 notify(
-                    session,
+                    db.session,
                     user_id=context.user_id,
                     topic_action=NotificationTopicAction.postal_verification__failed,
                     key="",
@@ -336,7 +335,7 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
         attempt.verified_at = now()
 
         notify(
-            session,
+            db.session,
             user_id=context.user_id,
             topic_action=NotificationTopicAction.postal_verification__success,
             key="",
@@ -351,12 +350,12 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
         self,
         request: postal_verification_pb2.CancelPostalVerificationReq,
         context: CouchersContext,
-        session: Session,
+        db: DB,
     ) -> empty_pb2.Empty:
         """
         Cancels an active postal verification attempt.
         """
-        attempt = session.execute(
+        attempt = db.session.execute(
             select(PostalVerificationAttempt)
             .where(PostalVerificationAttempt.id == request.postal_verification_attempt_id)
             .where(PostalVerificationAttempt.user_id == context.user_id)
@@ -383,12 +382,12 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
         self,
         request: postal_verification_pb2.ListPostalVerificationAttemptsReq,
         context: CouchersContext,
-        session: Session,
+        db: DB,
     ) -> postal_verification_pb2.ListPostalVerificationAttemptsRes:
         """
         Returns all postal verification attempts for the user.
         """
-        attempts = session.execute(
+        attempts = db.session.execute(
             select(PostalVerificationAttempt)
             .where(PostalVerificationAttempt.user_id == context.user_id)
             .order_by(PostalVerificationAttempt.created.desc())

--- a/app/backend/src/couchers/servicers/public.py
+++ b/app/backend/src/couchers/servicers/public.py
@@ -25,6 +25,7 @@ from couchers.models import (
 from couchers.models.uploads import get_avatar_upload
 from couchers.proto import api_pb2, public_pb2, public_pb2_grpc
 from couchers.proto.google.api import httpbody_pb2
+from couchers.repositories import DB
 from couchers.resources import get_static_badge_dict
 from couchers.servicers.api import fluency2api, hostingstatus2api, meetupstatus2api, user_model_to_pb
 from couchers.servicers.gis import _statement_to_geojson_response
@@ -170,15 +171,13 @@ class Public(public_pb2_grpc.PublicServicer):
     Public (logged-out) APIs for getting public info
     """
 
-    def GetPublicUsers(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
-    ) -> httpbody_pb2.HttpBody:
-        return _get_public_users(session)
+    def GetPublicUsers(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> httpbody_pb2.HttpBody:
+        return _get_public_users(db.session)
 
     def GetPublicUser(
-        self, request: public_pb2.GetPublicUserReq, context: CouchersContext, session: Session
+        self, request: public_pb2.GetPublicUserReq, context: CouchersContext, db: DB
     ) -> public_pb2.GetPublicUserRes:
-        user = session.execute(
+        user = db.session.execute(
             select(User)
             .where(User.is_visible)
             .where(User.username == request.user)
@@ -200,10 +199,10 @@ class Public(public_pb2_grpc.PublicServicer):
 
         if user.public_visibility == ProfilePublicVisibility.full:
             return public_pb2.GetPublicUserRes(
-                full_user=user_model_to_pb(user, session, make_logged_out_context(localization=context.localization))
+                full_user=user_model_to_pb(user, db.session, make_logged_out_context(localization=context.localization))
             )
 
-        num_references = session.execute(
+        num_references = db.session.execute(
             select(func.count())
             .select_from(Reference)
             .join(User, User.id == Reference.from_user_id)
@@ -227,7 +226,7 @@ class Public(public_pb2_grpc.PublicServicer):
             )
 
         if user.public_visibility == ProfilePublicVisibility.most:
-            avatar_upload = get_avatar_upload(session, user)
+            avatar_upload = get_avatar_upload(db.session, user)
 
             return public_pb2.GetPublicUserRes(
                 most_user=public_pb2.MostUser(
@@ -262,16 +261,14 @@ class Public(public_pb2_grpc.PublicServicer):
         raise RuntimeError(user.public_visibility)
 
     def GetSignupPageInfo(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+        self, request: empty_pb2.Empty, context: CouchersContext, db: DB
     ) -> public_pb2.GetSignupPageInfoRes:
-        return _get_signup_page_info(session)
+        return _get_signup_page_info(db.session)
 
-    def GetVolunteers(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
-    ) -> public_pb2.GetVolunteersRes:
-        return _get_volunteers(session)
+    def GetVolunteers(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> public_pb2.GetVolunteersRes:
+        return _get_volunteers(db.session)
 
     def GetDonationStats(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+        self, request: empty_pb2.Empty, context: CouchersContext, db: DB
     ) -> public_pb2.GetDonationStatsRes:
-        return _get_donation_stats(session)
+        return _get_donation_stats(db.session)

--- a/app/backend/src/couchers/servicers/references.py
+++ b/app/backend/src/couchers/servicers/references.py
@@ -21,8 +21,9 @@ from couchers.models import HostRequest, Reference, ReferenceType, User
 from couchers.models.notifications import NotificationTopicAction
 from couchers.notifications.notify import notify
 from couchers.proto import notification_data_pb2, references_pb2, references_pb2_grpc
+from couchers.repositories import DB
 from couchers.servicers.api import user_model_to_pb
-from couchers.sql import users_visible, where_moderated_content_visible, where_users_column_visible
+from couchers.sql import where_moderated_content_visible, where_users_column_visible
 from couchers.tasks import maybe_send_reference_report_email
 from couchers.utils import Timestamp_from_datetime, now
 
@@ -168,7 +169,7 @@ def get_pending_references_to_write(
 
 class References(references_pb2_grpc.ReferencesServicer):
     def ListReferences(
-        self, request: references_pb2.ListReferencesReq, context: CouchersContext, session: Session
+        self, request: references_pb2.ListReferencesReq, context: CouchersContext, db: DB
     ) -> references_pb2.ListReferencesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         next_reference_id = int(request.page_token) if request.page_token else 0
@@ -234,7 +235,7 @@ class References(references_pb2_grpc.ReferencesServicer):
         )
 
         statement = statement.order_by(Reference.id.desc()).limit(page_size + 1)
-        references = session.execute(statement).scalars().all()
+        references = db.session.execute(statement).scalars().all()
 
         return references_pb2.ListReferencesRes(
             references=[reference_to_pb(reference, context) for reference in references[:page_size]],
@@ -242,24 +243,22 @@ class References(references_pb2_grpc.ReferencesServicer):
         )
 
     def WriteFriendReference(
-        self, request: references_pb2.WriteFriendReferenceReq, context: CouchersContext, session: Session
+        self, request: references_pb2.WriteFriendReferenceReq, context: CouchersContext, db: DB
     ) -> references_pb2.Reference:
         if context.user_id == request.to_user_id:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "cant_refer_self")
 
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
 
         check_valid_reference(request, context)
 
-        if not session.execute(
-            select(User).where(users_visible(context)).where(User.id == request.to_user_id)
-        ).scalar_one_or_none():
+        if not db.users.get_by_id_if_visible(request.to_user_id, visible_to=context.user_id):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
-        if not are_friends(session, context, request.to_user_id):
+        if not are_friends(db.session, context, request.to_user_id):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "can_only_refer_friends")
 
-        if session.execute(
+        if db.session.execute(
             select(Reference)
             .where(Reference.from_user_id == context.user_id)
             .where(Reference.to_user_id == request.to_user_id)
@@ -278,27 +277,27 @@ class References(references_pb2_grpc.ReferencesServicer):
             rating=request.rating,
             was_appropriate=request.was_appropriate,
         )
-        session.add(reference)
-        session.commit()
+        db.session.add(reference)
+        db.session.commit()
 
         # send the recipient of the reference a reminder
         notify(
-            session,
+            db.session,
             user_id=request.to_user_id,
             topic_action=NotificationTopicAction.reference__receive_friend,
             key=str(reference.id),
             data=notification_data_pb2.ReferenceReceiveFriend(
-                from_user=user_model_to_pb(user, session, make_background_user_context(user_id=request.to_user_id)),
+                from_user=user_model_to_pb(user, db.session, make_background_user_context(user_id=request.to_user_id)),
                 text=reference_text,
             ),
         )
 
         # possibly send out an alert to the mod team if the reference was bad
-        maybe_send_reference_report_email(session, reference)
+        maybe_send_reference_report_email(db.session, reference)
 
         log_event(
             context,
-            session,
+            db.session,
             "reference.friend_written",
             {
                 "to_user_id": request.to_user_id,
@@ -310,13 +309,13 @@ class References(references_pb2_grpc.ReferencesServicer):
         return reference_to_pb(reference, context)
 
     def WriteHostRequestReference(
-        self, request: references_pb2.WriteHostRequestReferenceReq, context: CouchersContext, session: Session
+        self, request: references_pb2.WriteHostRequestReferenceReq, context: CouchersContext, db: DB
     ) -> references_pb2.Reference:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
+        user = db.users.by_id(context.user_id)
 
         check_valid_reference(request, context)
 
-        host_request, surfed = get_host_req_and_check_can_write_ref(session, context, request.host_request_id)
+        host_request, surfed = get_host_req_and_check_can_write_ref(db.session, context, request.host_request_id)
 
         reference_text = request.text.strip()
 
@@ -342,10 +341,10 @@ class References(references_pb2_grpc.ReferencesServicer):
             reference_type=reference_type,
         )
 
-        session.add(reference)
-        session.commit()
+        db.session.add(reference)
+        db.session.commit()
 
-        other_reference = session.execute(
+        other_reference = db.session.execute(
             select(Reference)
             .where(Reference.host_request_id == host_request.conversation_id)
             .where(Reference.to_user_id == context.user_id)
@@ -358,23 +357,25 @@ class References(references_pb2_grpc.ReferencesServicer):
             else NotificationTopicAction.reference__receive_hosted
         )
         notify(
-            session,
+            db.session,
             user_id=reference.to_user_id,
             topic_action=topic_action,
             key=str(host_request.conversation_id),
             data=notification_data_pb2.ReferenceReceiveHostRequest(
                 host_request_id=host_request.conversation_id,
-                from_user=user_model_to_pb(user, session, make_background_user_context(user_id=reference.to_user_id)),
+                from_user=user_model_to_pb(
+                    user, db.session, make_background_user_context(user_id=reference.to_user_id)
+                ),
                 text=reference_text if other_reference is not None else None,
             ),
         )
 
         # possibly send out an alert to the mod team if the reference was bad
-        maybe_send_reference_report_email(session, reference)
+        maybe_send_reference_report_email(db.session, reference)
 
         log_event(
             context,
-            session,
+            db.session,
             "reference.host_request_written",
             {
                 "to_user_id": to_user_id,
@@ -388,9 +389,9 @@ class References(references_pb2_grpc.ReferencesServicer):
         return reference_to_pb(reference, context)
 
     def HostRequestIndicateDidntMeetup(
-        self, request: references_pb2.HostRequestIndicateDidntMeetupReq, context: CouchersContext, session: Session
+        self, request: references_pb2.HostRequestIndicateDidntMeetupReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        host_request, surfed = get_host_req_and_check_can_write_ref(session, context, request.host_request_id)
+        host_request, surfed = get_host_req_and_check_can_write_ref(db.session, context, request.host_request_id)
 
         reason = request.reason_didnt_meetup.strip()
 
@@ -402,19 +403,17 @@ class References(references_pb2_grpc.ReferencesServicer):
         return empty_pb2.Empty()
 
     def AvailableWriteReferences(
-        self, request: references_pb2.AvailableWriteReferencesReq, context: CouchersContext, session: Session
+        self, request: references_pb2.AvailableWriteReferencesReq, context: CouchersContext, db: DB
     ) -> references_pb2.AvailableWriteReferencesRes:
         # can't write anything for ourselves, but let's return empty so this can be used generically on profile page
         if request.to_user_id == context.user_id:
             return references_pb2.AvailableWriteReferencesRes()
 
-        if not session.execute(
-            select(User).where(users_visible(context)).where(User.id == request.to_user_id)
-        ).scalar_one_or_none():
+        if not db.users.get_by_id_if_visible(request.to_user_id, visible_to=context.user_id):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
         can_write_friend_reference = (
-            session.execute(
+            db.session.execute(
                 select(Reference)
                 .where(Reference.from_user_id == context.user_id)
                 .where(Reference.to_user_id == request.to_user_id)
@@ -456,7 +455,7 @@ class References(references_pb2_grpc.ReferencesServicer):
 
         union = union_all(q1, q2).order_by(HostRequest.end_time_to_write_reference.asc()).subquery()
         query = select(union.c[0].label("surfed"), aliased(HostRequest, union))
-        host_request_references = session.execute(query).all()
+        host_request_references = db.session.execute(query).all()
 
         return references_pb2.AvailableWriteReferencesRes(
             can_write_friend_reference=can_write_friend_reference,
@@ -471,7 +470,7 @@ class References(references_pb2_grpc.ReferencesServicer):
         )
 
     def ListPendingReferencesToWrite(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+        self, request: empty_pb2.Empty, context: CouchersContext, db: DB
     ) -> references_pb2.ListPendingReferencesToWriteRes:
         return references_pb2.ListPendingReferencesToWriteRes(
             pending_references=[
@@ -481,17 +480,17 @@ class References(references_pb2_grpc.ReferencesServicer):
                     time_expires=Timestamp_from_datetime(end_time_to_write_reference),
                 )
                 for host_request_id, reference_type, end_time_to_write_reference, other_user in get_pending_references_to_write(
-                    session, context
+                    db.session, context
                 )
             ],
         )
 
     def GetHostRequestReferenceStatus(
-        self, request: references_pb2.GetHostRequestReferenceStatusReq, context: CouchersContext, session: Session
+        self, request: references_pb2.GetHostRequestReferenceStatusReq, context: CouchersContext, db: DB
     ) -> references_pb2.GetHostRequestReferenceStatusRes:
         # Compute has_given (whether current user already wrote a reference for this host request)
         has_given = (
-            session.execute(
+            db.session.execute(
                 select(Reference)
                 .where(Reference.host_request_id == request.host_request_id)
                 .where(Reference.from_user_id == context.user_id)
@@ -505,7 +504,7 @@ class References(references_pb2_grpc.ReferencesServicer):
         query = query.where(
             or_(HostRequest.initiator_user_id == context.user_id, HostRequest.recipient_user_id == context.user_id)
         )
-        host_request = session.execute(query).scalar_one_or_none()
+        host_request = db.session.execute(query).scalar_one_or_none()
 
         can_write = False
         is_expired = False

--- a/app/backend/src/couchers/servicers/reporting.py
+++ b/app/backend/src/couchers/servicers/reporting.py
@@ -1,20 +1,20 @@
 import grpc
 from google.protobuf import empty_pb2
 from sqlalchemy import select
-from sqlalchemy.orm import Session
 
 from couchers.context import CouchersContext
 from couchers.event_log import log_event
 from couchers.models import ContentReport, User
 from couchers.proto import reporting_pb2, reporting_pb2_grpc
+from couchers.repositories import DB
 from couchers.sql import username_or_id
 from couchers.tasks import send_content_report_email
 
 
 class Reporting(reporting_pb2_grpc.ReportingServicer):
-    def Report(self, request: reporting_pb2.ReportReq, context: CouchersContext, session: Session) -> empty_pb2.Empty:
+    def Report(self, request: reporting_pb2.ReportReq, context: CouchersContext, db: DB) -> empty_pb2.Empty:
         # note no filtering on visibility
-        author_user = session.execute(select(User).where(username_or_id(request.author_user))).scalar_one_or_none()
+        author_user = db.session.execute(select(User).where(username_or_id(request.author_user))).scalar_one_or_none()
 
         if not author_user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -29,14 +29,14 @@ class Reporting(reporting_pb2_grpc.ReportingServicer):
             page=request.page,
         )
 
-        session.add(content_report)
-        session.flush()
+        db.session.add(content_report)
+        db.session.flush()
 
-        send_content_report_email(session, content_report)
+        send_content_report_email(db.session, content_report)
 
         log_event(
             context,
-            session,
+            db.session,
             "content.reported",
             {
                 "author_user_id": author_user.id,

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -37,6 +37,7 @@ from couchers.notifications.notify import notify
 from couchers.proto import conversations_pb2, notification_data_pb2, requests_pb2, requests_pb2_grpc
 from couchers.rate_limits.check import process_rate_limits_and_check_abort
 from couchers.rate_limits.definitions import RATE_LIMIT_HOURS
+from couchers.repositories import DB
 from couchers.servicers.api import response_rate_to_pb, user_model_to_pb
 from couchers.sql import to_bool, users_visible, where_moderated_content_visible, where_users_column_visible
 from couchers.utils import (
@@ -189,17 +190,17 @@ def _is_host_request_long_enough(text: str) -> bool:
 
 class Requests(requests_pb2_grpc.RequestsServicer):
     def CreateHostRequest(
-        self, request: requests_pb2.CreateHostRequestReq, context: CouchersContext, session: Session
+        self, request: requests_pb2.CreateHostRequestReq, context: CouchersContext, db: DB
     ) -> requests_pb2.CreateHostRequestRes:
-        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
-        if not has_completed_profile(session, user):
+        user = db.users.by_id(context.user_id)
+        if not has_completed_profile(db.session, user):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "incomplete_profile_send_request")
 
         if request.host_user_id == context.user_id:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "cant_request_self")
 
         # just to check recipient exists and is visible
-        recipient = session.execute(
+        recipient = db.session.execute(
             select(User).where(users_visible(context, User)).where(User.id == request.host_user_id)
         ).scalar_one_or_none()
         if not recipient:
@@ -239,7 +240,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
 
         # Check if user has been sending host requests excessively
         if process_rate_limits_and_check_abort(
-            session=session, user_id=context.user_id, action=RateLimitAction.host_request
+            session=db.session, user_id=context.user_id, action=RateLimitAction.host_request
         ):
             context.abort_with_error_code(
                 grpc.StatusCode.RESOURCE_EXHAUSTED,
@@ -248,10 +249,10 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             )
 
         conversation = Conversation()
-        session.add(conversation)
-        session.flush()
+        db.session.add(conversation)
+        db.session.flush()
 
-        session.add(
+        db.session.add(
             Message(
                 conversation_id=conversation.id,
                 author_id=context.user_id,
@@ -265,12 +266,12 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             text=request.text,
             message_type=MessageType.text,
         )
-        session.add(message)
-        session.flush()
+        db.session.add(message)
+        db.session.flush()
 
         # Create moderation state for UMS (starts as SHADOWED)
         moderation_state = create_moderation(
-            session=session,
+            session=db.session,
             object_type=ModerationObjectType.host_request,
             object_id=conversation.id,
             creator_user_id=context.user_id,
@@ -291,17 +292,17 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             hosting_location=recipient.geom,
             hosting_radius=recipient.geom_radius,
         )
-        session.add(host_request)
-        session.flush()
+        db.session.add(host_request)
+        db.session.flush()
 
         notify(
-            session,
+            db.session,
             user_id=host_request.recipient_user_id,
             topic_action=NotificationTopicAction.host_request__create,
             key=str(host_request.conversation_id),
             data=notification_data_pb2.HostRequestCreate(
-                host_request=host_request_to_pb(host_request, session, context),
-                surfer=user_model_to_pb(host_request.initiator, session, context),
+                host_request=host_request_to_pb(host_request, db.session, context),
+                surfer=user_model_to_pb(host_request.initiator, db.session, context),
                 text=request.text,
             ),
             moderation_state_id=moderation_state.id,
@@ -314,7 +315,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         )
         log_event(
             context,
-            session,
+            db.session,
             "host_request.created",
             {
                 "host_request_id": host_request.conversation_id,
@@ -331,9 +332,9 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         return requests_pb2.CreateHostRequestRes(host_request_id=host_request.conversation_id)
 
     def GetHostRequest(
-        self, request: requests_pb2.GetHostRequestReq, context: CouchersContext, session: Session
+        self, request: requests_pb2.GetHostRequestReq, context: CouchersContext, db: DB
     ) -> requests_pb2.HostRequest:
-        host_request = session.execute(
+        host_request = db.session.execute(
             where_moderated_content_visible(
                 where_users_column_visible(
                     where_users_column_visible(
@@ -357,10 +358,10 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         if not host_request:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "host_request_not_found")
 
-        return host_request_to_pb(host_request, session, context)
+        return host_request_to_pb(host_request, db.session, context)
 
     def ListHostRequests(
-        self, request: requests_pb2.ListHostRequestsReq, context: CouchersContext, session: Session
+        self, request: requests_pb2.ListHostRequestsReq, context: CouchersContext, db: DB
     ) -> requests_pb2.ListHostRequestsRes:
         if request.only_sent and request.only_received:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "host_request_sent_or_received")
@@ -430,7 +431,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             statement = statement.where(HostRequest.end_time <= func.now())
 
         statement = statement.order_by(Message.id.desc()).limit(pagination + 1)
-        results = session.execute(statement).all()
+        results = db.session.execute(statement).all()
 
         host_requests = []
         for result in results[:pagination]:
@@ -465,15 +466,16 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         )
 
     def RespondHostRequest(
-        self, request: requests_pb2.RespondHostRequestReq, context: CouchersContext, session: Session
+        self, request: requests_pb2.RespondHostRequestReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
+
         def count_host_response(other_user_id: int, response_type: str) -> None:
-            user_gender = session.execute(select(User.gender).where(User.id == context.user_id)).scalar_one()
-            other_gender = session.execute(select(User.gender).where(User.id == other_user_id)).scalar_one()
+            user_gender = db.session.execute(select(User.gender).where(User.id == context.user_id)).scalar_one()
+            other_gender = db.session.execute(select(User.gender).where(User.id == other_user_id)).scalar_one()
             host_request_responses_counter.labels(user_gender, other_gender, response_type).inc()
             sent_messages_counter.labels(user_gender, "host request response").inc()
 
-        host_request = session.execute(
+        host_request = db.session.execute(
             where_moderated_content_visible(
                 where_users_column_visible(
                     where_users_column_visible(
@@ -519,19 +521,19 @@ class Requests(requests_pb2_grpc.RequestsServicer):
                 or host_request.status == HostRequestStatus.accepted
             ):
                 context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "invalid_host_request_status")
-            _possibly_observe_first_response_time(session, host_request, context.user_id, "accepted")
+            _possibly_observe_first_response_time(db.session, host_request, context.user_id, "accepted")
             control_message.host_request_status_target = HostRequestStatus.accepted
             host_request.status = HostRequestStatus.accepted
-            session.flush()
+            db.session.flush()
 
             notify(
-                session,
+                db.session,
                 user_id=host_request.initiator_user_id,
                 topic_action=NotificationTopicAction.host_request__accept,
                 key=str(host_request.conversation_id),
                 data=notification_data_pb2.HostRequestAccept(
-                    host_request=host_request_to_pb(host_request, session, context),
-                    host=user_model_to_pb(host_request.recipient, session, context),
+                    host_request=host_request_to_pb(host_request, db.session, context),
+                    host=user_model_to_pb(host_request.recipient, db.session, context),
                 ),
                 moderation_state_id=host_request.moderation_state_id,
             )
@@ -539,7 +541,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             count_host_response(host_request.initiator_user_id, "accepted")
             log_event(
                 context,
-                session,
+                db.session,
                 "host_request.accepted",
                 {
                     "host_request_id": host_request.conversation_id,
@@ -560,19 +562,19 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             # can't reject a cancelled or already rejected request
             if host_request.status == HostRequestStatus.cancelled or host_request.status == HostRequestStatus.rejected:
                 context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "invalid_host_request_status")
-            _possibly_observe_first_response_time(session, host_request, context.user_id, "rejected")
+            _possibly_observe_first_response_time(db.session, host_request, context.user_id, "rejected")
             control_message.host_request_status_target = HostRequestStatus.rejected
             host_request.status = HostRequestStatus.rejected
-            session.flush()
+            db.session.flush()
 
             notify(
-                session,
+                db.session,
                 user_id=host_request.initiator_user_id,
                 topic_action=NotificationTopicAction.host_request__reject,
                 key=str(host_request.conversation_id),
                 data=notification_data_pb2.HostRequestReject(
-                    host_request=host_request_to_pb(host_request, session, context),
-                    host=user_model_to_pb(host_request.recipient, session, context),
+                    host_request=host_request_to_pb(host_request, db.session, context),
+                    host=user_model_to_pb(host_request.recipient, db.session, context),
                 ),
                 moderation_state_id=host_request.moderation_state_id,
             )
@@ -581,7 +583,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
 
             log_event(
                 context,
-                session,
+                db.session,
                 "host_request.rejected",
                 {
                     "host_request_id": host_request.conversation_id,
@@ -604,16 +606,16 @@ class Requests(requests_pb2_grpc.RequestsServicer):
                 context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "invalid_host_request_status")
             control_message.host_request_status_target = HostRequestStatus.confirmed
             host_request.status = HostRequestStatus.confirmed
-            session.flush()
+            db.session.flush()
 
             notify(
-                session,
+                db.session,
                 user_id=host_request.recipient_user_id,
                 topic_action=NotificationTopicAction.host_request__confirm,
                 key=str(host_request.conversation_id),
                 data=notification_data_pb2.HostRequestConfirm(
-                    host_request=host_request_to_pb(host_request, session, context),
-                    surfer=user_model_to_pb(host_request.initiator, session, context),
+                    host_request=host_request_to_pb(host_request, db.session, context),
+                    surfer=user_model_to_pb(host_request.initiator, db.session, context),
                 ),
                 moderation_state_id=host_request.moderation_state_id,
             )
@@ -621,7 +623,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             count_host_response(host_request.recipient_user_id, "confirmed")
             log_event(
                 context,
-                session,
+                db.session,
                 "host_request.confirmed",
                 {
                     "host_request_id": host_request.conversation_id,
@@ -644,16 +646,16 @@ class Requests(requests_pb2_grpc.RequestsServicer):
                 context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "invalid_host_request_status")
             control_message.host_request_status_target = HostRequestStatus.cancelled
             host_request.status = HostRequestStatus.cancelled
-            session.flush()
+            db.session.flush()
 
             notify(
-                session,
+                db.session,
                 user_id=host_request.recipient_user_id,
                 topic_action=NotificationTopicAction.host_request__cancel,
                 key=str(host_request.conversation_id),
                 data=notification_data_pb2.HostRequestCancel(
-                    host_request=host_request_to_pb(host_request, session, context),
-                    surfer=user_model_to_pb(host_request.initiator, session, context),
+                    host_request=host_request_to_pb(host_request, db.session, context),
+                    surfer=user_model_to_pb(host_request.initiator, db.session, context),
                 ),
                 moderation_state_id=host_request.moderation_state_id,
             )
@@ -661,7 +663,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             count_host_response(host_request.recipient_user_id, "cancelled")
             log_event(
                 context,
-                session,
+                db.session,
                 "host_request.cancelled",
                 {
                     "host_request_id": host_request.conversation_id,
@@ -675,7 +677,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
                 },
             )
 
-        session.add(control_message)
+        db.session.add(control_message)
 
         if request.text:
             latest_message = Message(
@@ -685,24 +687,25 @@ class Requests(requests_pb2_grpc.RequestsServicer):
                 message_type=MessageType.text,
             )
 
-            session.add(latest_message)
+            db.session.add(latest_message)
         else:
             latest_message = control_message
 
-        session.flush()
+        db.session.flush()
 
         if host_request.initiator_user_id == context.user_id:
             host_request.initiator_last_seen_message_id = latest_message.id
         else:
             host_request.recipient_last_seen_message_id = latest_message.id
-        session.commit()
+        db.session.commit()
 
         return empty_pb2.Empty()
 
     def GetHostRequestMessages(
-        self, request: requests_pb2.GetHostRequestMessagesReq, context: CouchersContext, session: Session
+        self, request: requests_pb2.GetHostRequestMessagesReq, context: CouchersContext, db: DB
     ) -> requests_pb2.GetHostRequestMessagesRes:
-        host_request = session.execute(
+
+        host_request = db.session.execute(
             where_moderated_content_visible(select(HostRequest), context, HostRequest, is_list_operation=False).where(
                 HostRequest.conversation_id == request.host_request_id
             )
@@ -718,7 +721,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         pagination = min(pagination, MAX_PAGE_SIZE)
 
         messages = (
-            session.execute(
+            db.session.execute(
                 select(Message)
                 .where(Message.conversation_id == host_request.conversation_id)
                 .where(or_(Message.id < request.last_message_id, to_bool(request.last_message_id == 0)))
@@ -740,11 +743,12 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         )
 
     def SendHostRequestMessage(
-        self, request: requests_pb2.SendHostRequestMessageReq, context: CouchersContext, session: Session
+        self, request: requests_pb2.SendHostRequestMessageReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
+
         if request.text == "":
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_message")
-        host_request = session.execute(
+        host_request = db.session.execute(
             where_moderated_content_visible(select(HostRequest), context, HostRequest, is_list_operation=False).where(
                 HostRequest.conversation_id == request.host_request_id
             )
@@ -757,7 +761,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "host_request_not_found")
 
         if host_request.recipient_user_id == context.user_id:
-            _possibly_observe_first_response_time(session, host_request, context.user_id, "message")
+            _possibly_observe_first_response_time(db.session, host_request, context.user_id, "message")
 
         message = Message(
             conversation_id=host_request.conversation_id,
@@ -766,20 +770,20 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             text=request.text,
         )
 
-        session.add(message)
-        session.flush()
+        db.session.add(message)
+        db.session.flush()
 
         if host_request.initiator_user_id == context.user_id:
             host_request.initiator_last_seen_message_id = message.id
 
             notify(
-                session,
+                db.session,
                 user_id=host_request.recipient_user_id,
                 topic_action=NotificationTopicAction.host_request__message,
                 key=str(host_request.conversation_id),
                 data=notification_data_pb2.HostRequestMessage(
-                    host_request=host_request_to_pb(host_request, session, context),
-                    user=user_model_to_pb(host_request.initiator, session, context),
+                    host_request=host_request_to_pb(host_request, db.session, context),
+                    user=user_model_to_pb(host_request.initiator, db.session, context),
                     text=request.text,
                     am_host=True,
                 ),
@@ -790,26 +794,26 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             host_request.recipient_last_seen_message_id = message.id
 
             notify(
-                session,
+                db.session,
                 user_id=host_request.initiator_user_id,
                 topic_action=NotificationTopicAction.host_request__message,
                 key=str(host_request.conversation_id),
                 data=notification_data_pb2.HostRequestMessage(
-                    host_request=host_request_to_pb(host_request, session, context),
-                    user=user_model_to_pb(host_request.recipient, session, context),
+                    host_request=host_request_to_pb(host_request, db.session, context),
+                    user=user_model_to_pb(host_request.recipient, db.session, context),
                     text=request.text,
                     am_host=False,
                 ),
                 moderation_state_id=host_request.moderation_state_id,
             )
 
-        session.commit()
+        db.session.commit()
 
-        user_gender = session.execute(select(User.gender).where(User.id == context.user_id)).scalar_one()
+        user_gender = db.session.execute(select(User.gender).where(User.id == context.user_id)).scalar_one()
         sent_messages_counter.labels(user_gender, "host request").inc()
         log_event(
             context,
-            session,
+            db.session,
             "host_request.message_sent",
             {
                 "host_request_id": host_request.conversation_id,
@@ -823,7 +827,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         return empty_pb2.Empty()
 
     def GetHostRequestUpdates(
-        self, request: requests_pb2.GetHostRequestUpdatesReq, context: CouchersContext, session: Session
+        self, request: requests_pb2.GetHostRequestUpdatesReq, context: CouchersContext, db: DB
     ) -> requests_pb2.GetHostRequestUpdatesRes:
         if request.only_sent and request.only_received:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "host_request_sent_or_received")
@@ -831,7 +835,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         if request.newest_message_id == 0:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_message")
 
-        if not session.execute(select(Message).where(Message.id == request.newest_message_id)).scalar_one_or_none():
+        if not db.session.execute(select(Message).where(Message.id == request.newest_message_id)).scalar_one_or_none():
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_message")
 
         pagination = request.number if request.number > 0 else DEFAULT_PAGINATION_LENGTH
@@ -860,7 +864,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             )
 
         statement = statement.order_by(Message.id.asc()).limit(pagination + 1)
-        res = session.execute(statement).all()
+        res = db.session.execute(statement).all()
 
         no_more = len(res) <= pagination
 
@@ -879,9 +883,9 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         )
 
     def MarkLastSeenHostRequest(
-        self, request: requests_pb2.MarkLastSeenHostRequestReq, context: CouchersContext, session: Session
+        self, request: requests_pb2.MarkLastSeenHostRequestReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        host_request = session.execute(
+        host_request = db.session.execute(
             where_moderated_content_visible(select(HostRequest), context, HostRequest, is_list_operation=False).where(
                 HostRequest.conversation_id == request.host_request_id
             )
@@ -902,13 +906,13 @@ class Requests(requests_pb2_grpc.RequestsServicer):
                 context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "cant_unsee_messages")
             host_request.recipient_last_seen_message_id = request.last_seen_message_id
 
-        session.commit()
+        db.session.commit()
         return empty_pb2.Empty()
 
     def SetHostRequestArchiveStatus(
-        self, request: requests_pb2.SetHostRequestArchiveStatusReq, context: CouchersContext, session: Session
+        self, request: requests_pb2.SetHostRequestArchiveStatusReq, context: CouchersContext, db: DB
     ) -> requests_pb2.SetHostRequestArchiveStatusRes:
-        host_request = session.execute(
+        host_request = db.session.execute(
             where_moderated_content_visible(select(HostRequest), context, HostRequest, is_list_operation=False)
             .where(HostRequest.conversation_id == request.host_request_id)
             .where(
@@ -930,9 +934,9 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         )
 
     def GetResponseRate(
-        self, request: requests_pb2.GetResponseRateReq, context: CouchersContext, session: Session
+        self, request: requests_pb2.GetResponseRateReq, context: CouchersContext, db: DB
     ) -> requests_pb2.GetResponseRateRes:
-        user_res = session.execute(
+        user_res = db.session.execute(
             select(User.id, UserResponseRate)
             .outerjoin(UserResponseRate, UserResponseRate.user_id == User.id)
             .where(users_visible(context, User))
@@ -947,9 +951,9 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         return requests_pb2.GetResponseRateRes(**response_rate_to_pb(response_rates))  # type: ignore[arg-type]
 
     def SendHostRequestFeedback(
-        self, request: requests_pb2.SendHostRequestFeedbackReq, context: CouchersContext, session: Session
+        self, request: requests_pb2.SendHostRequestFeedbackReq, context: CouchersContext, db: DB
     ) -> empty_pb2.Empty:
-        host_request = session.execute(
+        host_request = db.session.execute(
             where_moderated_content_visible(select(HostRequest), context, HostRequest, is_list_operation=False)
             .where(HostRequest.conversation_id == request.host_request_id)
             .where(HostRequest.recipient_user_id == context.user_id)
@@ -958,7 +962,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         if not host_request:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "host_request_not_found")
 
-        feedback = session.execute(
+        feedback = db.session.execute(
             select(HostRequestFeedback)
             .where(HostRequestFeedback.host_request_id == host_request.conversation_id)
             .where(HostRequestFeedback.from_user_id == context.user_id)
@@ -967,7 +971,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         if feedback:
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "already_left_host_request_feedback")
 
-        session.add(
+        db.session.add(
             HostRequestFeedback(
                 host_request_id=host_request.conversation_id,
                 from_user_id=host_request.recipient_user_id,
@@ -979,7 +983,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         quality = hostrequestquality2sql.get(request.host_request_quality)
         log_event(
             context,
-            session,
+            db.session,
             "host_request.feedback_submitted",
             {
                 "host_request_id": host_request.conversation_id,

--- a/app/backend/src/couchers/servicers/resources.py
+++ b/app/backend/src/couchers/servicers/resources.py
@@ -1,10 +1,10 @@
 import logging
 
 from google.protobuf import empty_pb2
-from sqlalchemy.orm import Session
 
 from couchers.context import CouchersContext
 from couchers.proto import resources_pb2, resources_pb2_grpc
+from couchers.repositories import DB
 from couchers.resources import (
     get_badge_dict,
     get_icon,
@@ -25,13 +25,15 @@ COMMUNITY_GUIDELINES = [
 
 class Resources(resources_pb2_grpc.ResourcesServicer):
     def GetTermsOfService(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+        self, request: empty_pb2.Empty, context: CouchersContext, db: DB
     ) -> resources_pb2.GetTermsOfServiceRes:
+
         return resources_pb2.GetTermsOfServiceRes(terms_of_service=get_terms_of_service())
 
     def GetCommunityGuidelines(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
+        self, request: empty_pb2.Empty, context: CouchersContext, db: DB
     ) -> resources_pb2.GetCommunityGuidelinesRes:
+
         return resources_pb2.GetCommunityGuidelinesRes(
             community_guidelines=[
                 resources_pb2.CommunityGuideline(
@@ -43,27 +45,24 @@ class Resources(resources_pb2_grpc.ResourcesServicer):
             ]
         )
 
-    def GetRegions(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
-    ) -> resources_pb2.GetRegionsRes:
+    def GetRegions(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> resources_pb2.GetRegionsRes:
+
         return resources_pb2.GetRegionsRes(
             regions=[
                 resources_pb2.Region(alpha3=alpha3, name=name) for alpha3, name in sorted(get_region_dict().items())
             ]
         )
 
-    def GetLanguages(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
-    ) -> resources_pb2.GetLanguagesRes:
+    def GetLanguages(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> resources_pb2.GetLanguagesRes:
+
         return resources_pb2.GetLanguagesRes(
             languages=[
                 resources_pb2.Language(code=code, name=name) for code, name in sorted(get_language_dict().items())
             ]
         )
 
-    def GetBadges(
-        self, request: empty_pb2.Empty, context: CouchersContext, session: Session
-    ) -> resources_pb2.GetBadgesRes:
+    def GetBadges(self, request: empty_pb2.Empty, context: CouchersContext, db: DB) -> resources_pb2.GetBadgesRes:
+
         return resources_pb2.GetBadgesRes(
             badges=[
                 resources_pb2.Badge(

--- a/app/backend/src/couchers/servicers/search.py
+++ b/app/backend/src/couchers/servicers/search.py
@@ -35,6 +35,7 @@ from couchers.models import (
     User,
 )
 from couchers.proto import search_pb2, search_pb2_grpc
+from couchers.repositories import DB
 from couchers.reranker import reranker
 from couchers.servicers.api import (
     fluency2sql,
@@ -597,14 +598,14 @@ def _user_search_inner(
 
 
 class Search(search_pb2_grpc.SearchServicer):
-    def Search(self, request: search_pb2.SearchReq, context: CouchersContext, session: Session) -> search_pb2.SearchRes:
+    def Search(self, request: search_pb2.SearchReq, context: CouchersContext, db: DB) -> search_pb2.SearchRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
         # this is not an ideal page token, some results have equal rank (unlikely)
         next_rank = float(request.page_token) if request.page_token else None
 
         all_results = (
             _search_users(
-                session,
+                db.session,
                 request.query,
                 request.title_only,
                 next_rank,
@@ -613,7 +614,7 @@ class Search(search_pb2_grpc.SearchServicer):
                 request.include_users,
             )
             + _search_pages(
-                session,
+                db.session,
                 request.query,
                 request.title_only,
                 next_rank,
@@ -623,7 +624,7 @@ class Search(search_pb2_grpc.SearchServicer):
                 request.include_guides,
             )
             + _search_events(
-                session,
+                db.session,
                 request.query,
                 request.title_only,
                 next_rank,
@@ -631,7 +632,7 @@ class Search(search_pb2_grpc.SearchServicer):
                 context,
             )
             + _search_clusters(
-                session,
+                db.session,
                 request.query,
                 request.title_only,
                 next_rank,
@@ -648,13 +649,13 @@ class Search(search_pb2_grpc.SearchServicer):
         )
 
     def UserSearch(
-        self, request: search_pb2.UserSearchReq, context: CouchersContext, session: Session
+        self, request: search_pb2.UserSearchReq, context: CouchersContext, db: DB
     ) -> search_pb2.UserSearchRes:
-        user_ids_to_return, next_page_token, total_items = _user_search_inner(request, context, session)
+        user_ids_to_return, next_page_token, total_items = _user_search_inner(request, context, db.session)
 
         log_event(
             context,
-            session,
+            db.session,
             "search.performed",
             {
                 "search_in": request.WhichOneof("search_in"),
@@ -674,7 +675,7 @@ class Search(search_pb2_grpc.SearchServicer):
         )
 
         user_ids_to_users: dict[int, User] = dict(
-            session.execute(  # type: ignore[arg-type]
+            db.session.execute(  # type: ignore[arg-type]
                 select(User.id, User).where(User.id.in_(user_ids_to_return))
             ).all()
         )
@@ -683,7 +684,7 @@ class Search(search_pb2_grpc.SearchServicer):
             results=[
                 search_pb2.Result(
                     rank=1,
-                    user=user_model_to_pb(user_ids_to_users[user_id], session, context),
+                    user=user_model_to_pb(user_ids_to_users[user_id], db.session, context),
                 )
                 for user_id in user_ids_to_return
             ],
@@ -692,20 +693,20 @@ class Search(search_pb2_grpc.SearchServicer):
         )
 
     def UserSearchV2(
-        self, request: search_pb2.UserSearchReq, context: CouchersContext, session: Session
+        self, request: search_pb2.UserSearchReq, context: CouchersContext, db: DB
     ) -> search_pb2.UserSearchV2Res:
-        user_ids_to_return, next_page_token, total_items = _user_search_inner(request, context, session)
+        user_ids_to_return, next_page_token, total_items = _user_search_inner(request, context, db.session)
 
         LiteUser_by_id = {
             lite_user.id: lite_user
-            for lite_user in session.execute(select(LiteUser).where(LiteUser.id.in_(user_ids_to_return)))
+            for lite_user in db.session.execute(select(LiteUser).where(LiteUser.id.in_(user_ids_to_return)))
             .scalars()
             .all()
         }
 
         response_rate_by_id = {
             resp_rate.user_id: resp_rate
-            for resp_rate in session.execute(
+            for resp_rate in db.session.execute(
                 select(UserResponseRate).where(UserResponseRate.user_id.in_(user_ids_to_return))
             )
             .scalars()
@@ -714,7 +715,7 @@ class Search(search_pb2_grpc.SearchServicer):
 
         db_user_data_by_id = {
             user_id: (about_me, gender, last_active, hosting_status, meetup_status, joined)
-            for user_id, about_me, gender, last_active, hosting_status, meetup_status, joined in session.execute(
+            for user_id, about_me, gender, last_active, hosting_status, meetup_status, joined in db.session.execute(
                 select(
                     User.id,
                     User.about_me,
@@ -727,7 +728,7 @@ class Search(search_pb2_grpc.SearchServicer):
             ).all()
         }
 
-        ref_counts_by_user_id = get_num_references(session, user_ids_to_return)
+        ref_counts_by_user_id = get_num_references(db.session, user_ids_to_return)
 
         def _user_to_search_user(user_id: int) -> search_pb2.SearchUser:
             lite_user = LiteUser_by_id[user_id]
@@ -771,7 +772,7 @@ class Search(search_pb2_grpc.SearchServicer):
         )
 
     def EventSearch(
-        self, request: search_pb2.EventSearchReq, context: CouchersContext, session: Session
+        self, request: search_pb2.EventSearchReq, context: CouchersContext, db: DB
     ) -> search_pb2.EventSearchRes:
         statement = (
             select(EventOccurrence).join(Event, Event.id == EventOccurrence.event_id).where(~EventOccurrence.is_deleted)
@@ -821,7 +822,7 @@ class Search(search_pb2_grpc.SearchServicer):
                 where_.append(EventOccurrenceAttendee.user_id != None)
             if request.my_communities:
                 my_communities = (
-                    session.execute(
+                    db.session.execute(
                         select(Node.id)
                         .join(Cluster, Cluster.parent_node_id == Node.id)
                         .join(ClusterSubscription, ClusterSubscription.cluster_id == Cluster.id)
@@ -870,7 +871,7 @@ class Search(search_pb2_grpc.SearchServicer):
             )
         if request.HasField("search_in_community_id"):
             # could do a join here as well, but this is just simpler
-            node = session.execute(select(Node).where(Node.id == request.search_in_community_id)).scalar_one_or_none()
+            node = db.nodes.get_by_id(request.search_in_community_id)
             if not node:
                 context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
             statement = statement.where(func.ST_Contains(node.geom, EventOccurrence.geom))
@@ -898,13 +899,13 @@ class Search(search_pb2_grpc.SearchServicer):
             cutoff = page_token + timedelta(seconds=1)
             statement = statement.where(EventOccurrence.end_time < cutoff).order_by(EventOccurrence.start_time.desc())
 
-        total_items = session.execute(select(func.count()).select_from(statement.subquery())).scalar()
+        total_items = db.session.execute(select(func.count()).select_from(statement.subquery())).scalar()
         # Apply pagination by page number
         statement = statement.offset(offset).limit(page_size) if request.page_number else statement.limit(page_size + 1)
-        occurrences = session.execute(statement).scalars().all()
+        occurrences = db.session.execute(statement).scalars().all()
 
         return search_pb2.EventSearchRes(
-            events=[event_to_pb(session, occurrence, context) for occurrence in occurrences[:page_size]],
+            events=[event_to_pb(db.session, occurrence, context) for occurrence in occurrences[:page_size]],
             next_page_token=(str(millis_from_dt(occurrences[-1].end_time)) if len(occurrences) > page_size else None),
             total_items=total_items,
         )

--- a/app/backend/src/couchers/servicers/threads.py
+++ b/app/backend/src/couchers/servicers/threads.py
@@ -14,6 +14,7 @@ from couchers.models.notifications import NotificationTopicAction
 from couchers.notifications.notify import notify
 from couchers.proto import notification_data_pb2, threads_pb2, threads_pb2_grpc
 from couchers.proto.internal import jobs_pb2
+from couchers.repositories import DB
 from couchers.servicers.api import user_model_to_pb
 from couchers.servicers.blocking import is_not_visible
 from couchers.sql import where_users_column_visible
@@ -210,17 +211,17 @@ def generate_reply_notifications(payload: jobs_pb2.GenerateReplyNotificationsPay
 
 class Threads(threads_pb2_grpc.ThreadsServicer):
     def GetThread(
-        self, request: threads_pb2.GetThreadReq, context: CouchersContext, session: Session
+        self, request: threads_pb2.GetThreadReq, context: CouchersContext, db: DB
     ) -> threads_pb2.GetThreadRes:
         database_id, depth = unpack_thread_id(request.thread_id)
         page_size = request.page_size if 0 < request.page_size < 100000 else 1000
         page_start = unpack_thread_id(int(request.page_token))[0] if request.page_token else 2**50
 
         if depth == 0:
-            if not session.execute(select(Thread).where(Thread.id == database_id)).scalar_one_or_none():
+            if not db.threads.get_by_id(database_id):
                 context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "thread_not_found")
 
-            res = session.execute(
+            res = db.session.execute(
                 select(Comment, func.count(Reply.id))
                 .outerjoin(Reply, Reply.comment_id == Comment.id)
                 .where(Comment.thread_id == database_id)
@@ -241,11 +242,11 @@ class Threads(threads_pb2_grpc.ThreadsServicer):
             ]
 
         elif depth == 1:
-            if not session.execute(select(Comment).where(Comment.id == database_id)).scalar_one_or_none():
+            if not db.comments.get_by_id(database_id):
                 context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "thread_not_found")
 
             res = (
-                session.execute(  # type: ignore[assignment]
+                db.session.execute(  # type: ignore[assignment]
                     select(Reply)
                     .where(Reply.comment_id == database_id)
                     .where(Reply.id < page_start)
@@ -278,7 +279,7 @@ class Threads(threads_pb2_grpc.ThreadsServicer):
         return threads_pb2.GetThreadRes(replies=replies, next_page_token=next_page_token)
 
     def PostReply(
-        self, request: threads_pb2.PostReplyReq, context: CouchersContext, session: Session
+        self, request: threads_pb2.PostReplyReq, context: CouchersContext, db: DB
     ) -> threads_pb2.PostReplyRes:
         content = request.content.strip()
 
@@ -294,16 +295,16 @@ class Threads(threads_pb2_grpc.ThreadsServicer):
             object_to_add = Reply(comment_id=database_id, author_user_id=context.user_id, content=content)
         else:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "thread_not_found")
-        session.add(object_to_add)
+        db.session.add(object_to_add)
         try:
-            session.flush()
+            db.session.flush()
         except sqlalchemy.exc.IntegrityError:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "thread_not_found")
 
         thread_id = pack_thread_id(object_to_add.id, depth + 1)
 
         queue_job(
-            session,
+            db.session,
             job=generate_reply_notifications,
             payload=jobs_pb2.GenerateReplyNotificationsPayload(
                 thread_id=thread_id,

--- a/app/backend/src/couchers/sql.py
+++ b/app/backend/src/couchers/sql.py
@@ -57,13 +57,14 @@ def username_or_email_or_id(value: str) -> ColumnElement[bool]:
     return false()
 
 
-def users_visible(context: CouchersContext, table: _User = User) -> ColumnElement[bool]:
+def users_visible(context: CouchersContext | int, table: _User = User) -> ColumnElement[bool]:
     """
     Filters out users that should not be visible: blocked, deleted, or banned
 
     Filters the given table, assuming it's already joined/selected from
     """
-    hidden_users = _relevant_user_blocks(context.user_id)
+    user_id = context if isinstance(context, int) else context.user_id
+    hidden_users = _relevant_user_blocks(user_id)
     return and_(table.is_visible, ~table.id.in_(hidden_users))
 
 

--- a/app/backend/src/tests/fixtures/sessions.py
+++ b/app/backend/src/tests/fixtures/sessions.py
@@ -50,6 +50,7 @@ from couchers.proto import (
     stripe_pb2_grpc,
     threads_pb2_grpc,
 )
+from couchers.repositories import DB
 from couchers.servicers.account import Account, Iris
 from couchers.servicers.admin import Admin
 from couchers.servicers.api import API
@@ -172,6 +173,7 @@ class FakeChannel:
             request = handler.request_deserializer(request_serializer(request))
 
             with session_scope() as session:
+                db = DB(session)
                 context = make_interactive_context(
                     grpc_context=MockGrpcContext(),
                     user_id=auth_info.user_id if auth_info else None,
@@ -183,7 +185,7 @@ class FakeChannel:
                     ),
                 )
 
-                response = handler.unary_unary(request, context, session)
+                response = handler.unary_unary(request, context, db)
 
             return response_deserializer(handler.response_serializer(response))
 

--- a/app/postprocess_grpc_stubs.py
+++ b/app/postprocess_grpc_stubs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Modifies method arguments in GRPC stubs: we change them in our middleware. ServicerContext becomes
-CouchersContext, and a third parameter, "session: sqlalchemy.orm.Session", is added.
+CouchersContext, and a third parameter, "db: DB", is added.
 """
 
 import sys
@@ -21,12 +21,12 @@ def add_imports(lines: list[str]) -> list[str]:
 
     # Check if imports already exist
     imports_text = ''.join(lines)
-    has_orm_import = 'from sqlalchemy import orm' in imports_text
+    has_db_import = 'from couchers.repositories import DB' in imports_text
     has_context_import = 'from couchers.context import CouchersContext' in imports_text
 
     new_imports = []
-    if not has_orm_import:
-        new_imports.append('from sqlalchemy import orm\n')
+    if not has_db_import:
+        new_imports.append('from couchers.repositories import DB\n')
     if not has_context_import:
         new_imports.append('from couchers.context import CouchersContext\n')
 
@@ -37,7 +37,7 @@ def add_imports(lines: list[str]) -> list[str]:
 
 
 def replace_context_parameter(lines: list[str]) -> list[str]:
-    """Replace 'context: grpc.ServicerContext,' with 'context: CouchersContext,\nsession: orm.Session'."""
+    """Replace 'context: grpc.ServicerContext,' with 'context: CouchersContext,\ndb: DB'."""
     new_lines = []
     for line in lines:
         if 'context: grpc.ServicerContext,' in line:
@@ -45,7 +45,7 @@ def replace_context_parameter(lines: list[str]) -> list[str]:
             indent = len(line) - len(line.lstrip())
             # Replace the line
             new_lines.append(' ' * indent + 'context: CouchersContext,\n')
-            new_lines.append(' ' * indent + 'session: orm.Session,\n')
+            new_lines.append(' ' * indent + 'db: DB,\n')
         else:
             new_lines.append(line)
     return new_lines


### PR DESCRIPTION
## Basic idea

Database-related code should be separated from business logic. It makes code easier to read, and it allows for simpler migrations (e.g., from GRPC to any HTTP web framework). Consider:

```python
user = db.users.by_id(context.user_id)
```

vs

```python
user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
```

Or another common example:

```python
user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
if not user:
    context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
```

vs

```python
user = db.users.get_by_username_or_email_or_id(request.user)
if not user:
    context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
```

## Details

This PR is a POC with a few basic methods implemented. Ideally we'd want to move all SQL into repositories, with the services calling methods with names, instead of constructing ad-hoc queries.

Instead of `Session`, servicers now receive a `DB`, a wrapper around repositores and Session (for now). 