### PR TITLE
Frontend: Fix off-by-one host request dates

### DIFF
--- a/app/web/features/messages/requests/HostRequestListItem.tsx
+++ b/app/web/features/messages/requests/HostRequestListItem.tsx
@@ -225,11 +225,11 @@ export default function HostRequestListItem({
               <StyledDateAndBadgeContainer>
                 <Typography component="div" display="inline" variant="h3">
                   {localizeDateTimeRange(
-                    dayjs(hostRequest.fromDate),
-                    dayjs(hostRequest.toDate),
+                    // Host request are plain dates (no time),
+                    // just make sure to parse and format them in the same timezone.
+                    dayjs.tz(hostRequest.fromDate, UTC_TIMEZONE),
+                    dayjs.tz(hostRequest.toDate, UTC_TIMEZONE),
                     {
-                      // Host request dates are plain dates (no time),
-                      // so it they can only be interpreted in UTC.
                       timezone: UTC_TIMEZONE,
                       locale,
                       includeTime: false,

--- a/app/web/features/messages/requests/HostRequestUserSummarySection.tsx
+++ b/app/web/features/messages/requests/HostRequestUserSummarySection.tsx
@@ -96,11 +96,11 @@ const HostRequestUserSummarySection = ({
             sx={{ paddingRight: theme.spacing(1) }}
           >
             {localizeDateTimeRange(
-              dayjs(hostRequest.fromDate),
-              dayjs(hostRequest.toDate),
+              // Host request are plain dates (no time),
+              // just make sure to parse and format them in the same timezone.
+              dayjs.tz(hostRequest.fromDate, UTC_TIMEZONE),
+              dayjs.tz(hostRequest.toDate, UTC_TIMEZONE),
               {
-                // Host request dates are plain dates (no time),
-                // so it they can only be interpreted in UTC.
                 timezone: UTC_TIMEZONE,
                 locale,
                 includeTime: false,

--- a/app/web/service/requests.ts
+++ b/app/web/service/requests.ts
@@ -97,6 +97,9 @@ export type CreateHostRequestWrapper = Omit<
 export async function createHostRequest(data: CreateHostRequestWrapper) {
   const req = new CreateHostRequestReq();
   req.setHostUserId(data.hostUserId);
+  // Dayjs.format() uses the browser timezone,
+  // which matches the timezone we used to create the
+  // Dayjs object from the year/month/date input fields.
   req.setFromDate(data.fromDate.format().split("T")[0]);
   req.setToDate(data.toDate.format().split("T")[0]);
   req.setText(data.text);


### PR DESCRIPTION
Host requests are date-only (no time), but we store them as Dayjs object in frontend logic. This is fraught because (year, month, day) -> Dayjs -> (year, month, day) is a timezone-dependent conversion, so we need to ensure both conversions use matching timezones (whichever it is). The mismatch resulted in off-by-one dates in some configurations.

Fixes https://github.com/Couchers-org/couchers/issues/8281

## Testing
Compared unix epochs in both cases.

Using `dayjs("2026-04-11")`:
<img width="1276" height="475" alt="image" src="https://github.com/user-attachments/assets/23611de1-40da-43e0-a3f7-516d2a696f88" />

Using `dayjs.tz("2026-04-11", "UTC")`:
<img width="1285" height="488" alt="image" src="https://github.com/user-attachments/assets/938e2071-e105-4155-b92f-f8230cc8df18" />

Since we were formatting as UTC, we needed also parse as UTC.

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
