### PR TITLE
Sort admin GetChats by latest message time

### DIFF
--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -629,10 +629,17 @@ class Admin(admin_pb2_grpc.AdminServicer):
             session.execute(select(GroupChat).where(GroupChat.conversation_id.in_(group_chat_ids))).scalars().all()
         )
 
+        # Build protobuf objects, then sort by latest message time (most recent first)
+        host_request_pbs = [get_host_request_pb(hr) for hr in host_requests]
+        host_request_pbs.sort(key=lambda hr: hr.messages[-1].time.seconds if hr.messages else 0, reverse=True)
+
+        group_chat_pbs = [get_group_chat_pb(gc) for gc in group_chats]
+        group_chat_pbs.sort(key=lambda gc: gc.messages[-1].time.seconds if gc.messages else 0, reverse=True)
+
         return admin_pb2.GetChatsRes(
             user=get_chat_user_info(user.id),
-            host_requests=[get_host_request_pb(hr) for hr in host_requests],
-            group_chats=[get_group_chat_pb(gc) for gc in group_chats],
+            host_requests=host_request_pbs,
+            group_chats=group_chat_pbs,
         )
 
     def DeleteEvent(


### PR DESCRIPTION
Sort both host requests and group chats in the admin `GetChats` API by the timestamp of their last message (most recent first), so admins see the most recently active conversations at the top.

Previously host requests were sorted by conversation ID and group chats by join date, which didn't reflect actual activity.

## Testing
- Verified formatting passes (`make format`)
- Verified type checking passes (`make mypy`)
- Existing `test_GetChats` test still passes

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me