### PR TITLE
Backend: Include gender in rate limit violation report emails

### DIFF
--- a/app/backend/src/couchers/rate_limits/definitions.py
+++ b/app/backend/src/couchers/rate_limits/definitions.py
@@ -40,6 +40,7 @@ def _get_user_host_requests_in_past_time_interval(session: Session, user_id: int
             select(
                 Conversation.created.label("created"),
                 HostRequest.recipient_user_id.label("host ID"),
+                User.gender.label("host gender"),
                 User.username.label("host username"),
                 User.city.label("host city"),
             )
@@ -59,6 +60,7 @@ def _get_user_friend_requests_in_past_time_interval(session: Session, user_id: i
             select(
                 FriendRelationship.time_sent,
                 User.id.label("recipient ID"),
+                User.gender.label("recipient gender"),
                 User.username.label("recipient username"),
                 FriendRelationship.status,
                 User.city.label("recipient city"),
@@ -81,6 +83,7 @@ def _get_user_initiated_chats_in_past_time_interval(session: Session, user_id: i
                 GroupChat.title,
                 GroupChat.is_dm,
                 func.array_agg(User.username).label("participants"),
+                func.array_agg(User.gender).label("participants genders"),
                 func.array_agg(User.city).label("participants cities"),
             )
             .join(Conversation, GroupChat.conversation_id == Conversation.id)

--- a/app/backend/templates/system/rate_limit_violation_report.md
+++ b/app/backend/templates/system/rate_limit_violation_report.md
@@ -14,6 +14,7 @@ Username: {{ user.username }}
 User ID: {{ user.id }}
 Joined: {{ user.joined }}
 City: {{ user.city }}
+Gender: {{ user.gender }}
 
 {% for action, entries in events.items() -%}
 **{{ action.value }}s (past {{ hours }} hours):**


### PR DESCRIPTION
## Summary

Adds the sender's gender to the user-info block and the recipient/host/participants genders to each per-action table in the moderation rate-limit violation email. The gender column is placed directly after the recipient/host ID so gender-targeting patterns are easy to spot.

Fixes #8302

## Test plan

- [ ] Trigger a friend-request rate-limit violation and verify the report email contains the sender's gender and a `recipient gender` column directly after `recipient ID`
- [ ] Trigger a host-request rate-limit violation and verify `host gender` column directly after `host ID`
- [ ] Trigger a chat-initiation rate-limit violation and verify `participants genders` column

Generated with [Claude Code](https://claude.ai/code)