### PR TITLE
Include host request status in rate-limit violation email

### DIFF
--- a/app/backend/src/couchers/rate_limits/definitions.py
+++ b/app/backend/src/couchers/rate_limits/definitions.py
@@ -42,6 +42,7 @@ def _get_user_host_requests_in_past_time_interval(session: Session, user_id: int
                 HostRequest.recipient_user_id.label("host ID"),
                 User.gender.label("host gender"),
                 User.username.label("host username"),
+                HostRequest.status,
                 User.city.label("host city"),
             )
             .join(Conversation, HostRequest.conversation_id == Conversation.id)


### PR DESCRIPTION
Adds the `status` column (pending/accepted/rejected/confirmed/cancelled) to the `host_request` rate-limit report table sent to moderators, matching the style already used for `friend_request`.

Fixes #8305.

Generated with [Claude Code](https://claude.ai/code)