### PR TITLE
Include previous value in admin action log notes

### DIFF
--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -273,8 +273,11 @@ class Admin(admin_pb2_grpc.AdminServicer):
         user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
+        old_gender = user.gender
         user.gender = request.gender
-        log_admin_action(session, context, user, "change_gender", note=f"Changed to {request.gender}")
+        log_admin_action(
+            session, context, user, "change_gender", note=f"Changed from '{old_gender}' to '{request.gender}'"
+        )
         session.commit()
 
         notify(
@@ -298,8 +301,11 @@ class Admin(admin_pb2_grpc.AdminServicer):
         if not (birthdate := parse_date(request.birthdate)):
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_birthdate")
 
+        old_birthdate = user.birthdate
         user.birthdate = birthdate
-        log_admin_action(session, context, user, "change_birthdate", note=f"Changed to {request.birthdate}")
+        log_admin_action(
+            session, context, user, "change_birthdate", note=f"Changed from {old_birthdate} to {request.birthdate}"
+        )
         session.commit()
 
         notify(
@@ -367,8 +373,15 @@ class Admin(admin_pb2_grpc.AdminServicer):
         user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
+        old_exception = user.has_passport_sex_gender_exception
         user.has_passport_sex_gender_exception = request.passport_sex_gender_exception
-        log_admin_action(session, context, user, "set_passport_sex_gender_exception")
+        log_admin_action(
+            session,
+            context,
+            user,
+            "set_passport_sex_gender_exception",
+            note=f"Changed from {old_exception} to {request.passport_sex_gender_exception}",
+        )
         return _user_to_details(session, user)
 
     def BanUser(
@@ -451,7 +464,14 @@ class Admin(admin_pb2_grpc.AdminServicer):
             )
         )
         session.flush()
-        log_admin_action(session, context, user, "send_mod_note", note=request.content)
+        notify_user = "No" if request.do_not_notify else "Yes"
+        log_admin_action(
+            session,
+            context,
+            user,
+            "send_mod_note",
+            note=f"Notify user: {notify_user}\n\n{request.content}",
+        )
 
         if not request.do_not_notify:
             notify(
@@ -470,7 +490,9 @@ class Admin(admin_pb2_grpc.AdminServicer):
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         user.needs_to_update_location = True
-        log_admin_action(session, context, user, "mark_needs_location_update")
+        log_admin_action(
+            session, context, user, "mark_needs_location_update", note="Marked user as needing location update"
+        )
         return _user_to_details(session, user)
 
     def DeleteUser(

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -925,16 +925,58 @@ def test_admin_actions_on_mutations(db, push_collector: PushCollector):
     super_user, super_token = generate_user(is_superuser=True)
     normal_user, _ = generate_user()
 
+    original_gender = normal_user.gender
+    original_birthdate = normal_user.birthdate
+
     with real_admin_session(super_token) as api:
         # ChangeUserGender
         res = api.ChangeUserGender(admin_pb2.ChangeUserGenderReq(user=normal_user.username, gender="Machine"))
-        assert any(a.action_type == "change_gender" for a in res.admin_actions)
+        assert any(
+            a.action_type == "change_gender" and a.note == f"Changed from '{original_gender}' to 'Machine'"
+            for a in res.admin_actions
+        )
 
         # ChangeUserBirthdate
         res = api.ChangeUserBirthdate(
             admin_pb2.ChangeUserBirthdateReq(user=normal_user.username, birthdate="1990-01-01")
         )
-        assert any(a.action_type == "change_birthdate" for a in res.admin_actions)
+        assert any(
+            a.action_type == "change_birthdate" and a.note == f"Changed from {original_birthdate} to 1990-01-01"
+            for a in res.admin_actions
+        )
+
+        # SetPassportSexGenderException
+        res = api.SetPassportSexGenderException(
+            admin_pb2.SetPassportSexGenderExceptionReq(user=normal_user.username, passport_sex_gender_exception=True)
+        )
+        assert any(
+            a.action_type == "set_passport_sex_gender_exception" and a.note == "Changed from False to True"
+            for a in res.admin_actions
+        )
+
+        # SendModNote with notify
+        res = api.SendModNote(
+            admin_pb2.SendModNoteReq(
+                user=normal_user.username, content="Please update your profile", internal_id="test1"
+            )
+        )
+        assert any(
+            a.action_type == "send_mod_note" and a.note == "Notify user: Yes\n\nPlease update your profile"
+            for a in res.admin_actions
+        )
+
+        # SendModNote with do_not_notify
+        res = api.SendModNote(
+            admin_pb2.SendModNoteReq(
+                user=normal_user.username,
+                content="Silent note",
+                internal_id="test2",
+                do_not_notify=True,
+            )
+        )
+        assert any(
+            a.action_type == "send_mod_note" and a.note == "Notify user: No\n\nSilent note" for a in res.admin_actions
+        )
 
         # DeleteUser
         res = api.DeleteUser(admin_pb2.DeleteUserReq(user=normal_user.username))
@@ -949,7 +991,10 @@ def test_admin_actions_on_mutations(db, push_collector: PushCollector):
 
         # MarkUserNeedsLocationUpdate
         res = api.MarkUserNeedsLocationUpdate(admin_pb2.MarkUserNeedsLocationUpdateReq(user=normal_user.username))
-        assert any(a.action_type == "mark_needs_location_update" for a in res.admin_actions)
+        assert any(
+            a.action_type == "mark_needs_location_update" and a.note == "Marked user as needing location update"
+            for a in res.admin_actions
+        )
 
         # SetLastDonated
         res = api.SetLastDonated(


### PR DESCRIPTION
## Summary

Extends admin action log entries so the note records what changed, not just the new value:

- `change_gender`: `Changed from 'Woman' to 'Machine'`
- `change_birthdate`: `Changed from 2000-01-01 to 1990-01-01`
- `set_passport_sex_gender_exception`: `Changed from False to True`
- `send_mod_note`: note content prefixed with `Notify user: Yes/No`
- `mark_needs_location_update`: `Marked user as needing location update`

Fixes #8304.

## Test plan
- [ ] `test_admin_actions_on_mutations` passes with the new note assertions

🤖 Generated with [Claude Code](https://claude.ai/code)