### PR TITLE
Frontend/i18n: Fix bad string reference in group chats

### DIFF
--- a/app/web/features/messages/groupchats/CreateGroupChat.tsx
+++ b/app/web/features/messages/groupchats/CreateGroupChat.tsx
@@ -166,7 +166,7 @@ export default function CreateGroupChat({ className }: { className?: string }) {
               <StyledTextField
                 {...register("title")}
                 id="group-chat-title"
-                label={t("messages:title_label")}
+                label={t("messages:create_chat.title_label")}
               />
             )}
             {createMessageToUserQuery.error && (


### PR DESCRIPTION
String is here: https://github.com/Couchers-org/couchers/blob/25635aa27656250150562c865320c02b0afb4ff2/app/web/features/messages/locales/en.json#L87

Fixes #8299 (see for pics)

## Testing
N/A

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
