### PR TITLE
Backend/i18n: reword community_too_broad_for_public_trip

### DIFF
--- a/app/backend/src/couchers/i18n/locales/en.json
+++ b/app/backend/src/couchers/i18n/locales/en.json
@@ -44,7 +44,7 @@
     "chat_not_found": "Couldn't find that chat.",
     "city_required": "City is required.",
     "community_not_found": "Community not found.",
-    "community_too_broad_for_public_trip": "This community is too broad for a public trip — please post in a more specific community.",
+    "community_too_broad_for_public_trip": "This community is too broad for a public trip. Please post in a more local community.",
     "content_report_not_found": "Content report not found.",
     "country_required": "Country is required.",
     "date_from_after_one_year": "The start date must be within one year from today.",


### PR DESCRIPTION
Rewords the error shown when a user tries to post a public trip in a world- or macroregion-level community.

The previous wording — "please post in a more specific community" — was technically accurate (post further down the community hierarchy) but unclear to end users. Changed to "please post in a more local community", which conveys the same intent geographically without referring to the internal node-type hierarchy.

## Testing
*No functional change — locale string only.*

**Backend checklist**
- [x] Run the backend locally and it works

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me