### PR TITLE
Add a make command to auth-generate migrations

### DIFF
--- a/app/backend/Makefile
+++ b/app/backend/Makefile
@@ -31,6 +31,13 @@ fmt: format
 mypy:
 	uv run mypy src
 
+# Generate a new database migration by comparing models to an empty database
+# Usage:
+# make revision                     → generates migration with default message
+# make revision m='Add users table' → generates migration with custom message
+revision:
+	uv run --with 'docker,psycopg[binary]' python revision.py $(if $(m),-m '$(m)',)
+
 # Downgrade the local database to the previous migration. Good if you ran a migration on a branch and will run the backend on another branch after.
 # Usage:
 # make downgrade

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -79,13 +79,14 @@ exclude = [
 
 [tool.ruff.lint]
 select = [
-    "E",   # pycodestyle
-    "F",   # pyflakes
-    "UP",  # pyupgrade
-    "B",   # flake8-bugbear
-    "C4",  # flake8-comprehensions
-    "A",   # flake8-builtins
-    "I",   # isort
+    "E",       # pycodestyle
+    "F",       # pyflakes
+    "UP",      # pyupgrade
+    "B",       # flake8-bugbear
+    "C4",      # flake8-comprehensions
+    "A",       # flake8-builtins
+    "I",       # isort
+    "PLC0415", # import-outside-toplevel
 ]
 ignore = [
     "A003",   # SQLAlchemy model columns like `id` and `type` legitimately shadow builtins
@@ -162,6 +163,8 @@ branch = true
 [tool.coverage.report]
 exclude_also = [
     "def __repr__",
+    "pass",
+    "...",
     "raise AssertionError",
     "raise NotImplementedError",
     "if __name__ == .__main__.:",

--- a/app/backend/revision.py
+++ b/app/backend/revision.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+# ruff: noqa: T201
+"""
+Script to create a PostgreSQL/PostGIS container, run Alembic migrations, and autogenerate a new migration.
+
+Usage:
+    uv run --with 'docker,psycopg[binary]' python revision.py [-m MESSAGE] [--alembic-ini PATH]
+
+Arguments:
+    -m, --message           Revision message for the generated migration (optional)
+    --alembic-ini           Path to alembic.ini file (default: alembic.ini)
+"""
+
+import argparse
+import os
+import sys
+import time
+import traceback
+from pathlib import Path
+from typing import Any
+
+import docker
+import docker.errors
+from alembic import command
+from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
+from alembic.script import Script
+from sqlalchemy import create_engine
+
+# Configuration
+CONTAINER_NAME = "alembic_test_db"
+POSTGRES_USER = "postgres"
+POSTGRES_PASSWORD = "postgres"
+POSTGRES_DB = "testdb"
+POSTGRES_PORT = 5432
+HOST_PORT = 25432
+
+# Database URL for Alembic (using psycopg driver)
+DATABASE_URL = f"postgresql+psycopg://{POSTGRES_USER}:{POSTGRES_PASSWORD}@localhost:{HOST_PORT}/{POSTGRES_DB}"
+
+# PostGIS image configuration
+POSTGIS_IMAGE_NAME = "couchers-postgis"
+POSTGIS_DOCKERFILE_PATH = Path(__file__).parent.parent / "postgis"
+
+
+def build_postgis_image_if_needed() -> str:
+    """Build the PostGIS image from ../postgis if it doesn't exist locally."""
+    client = docker.from_env()
+
+    # Check if image already exists
+    try:
+        client.images.get(POSTGIS_IMAGE_NAME)
+        print(f"Using existing PostGIS image '{POSTGIS_IMAGE_NAME}'")
+        return POSTGIS_IMAGE_NAME
+    except docker.errors.ImageNotFound:
+        pass
+
+    # Build the image
+    print(f"Building PostGIS image '{POSTGIS_IMAGE_NAME}' from {POSTGIS_DOCKERFILE_PATH}...")
+    client.images.build(
+        path=str(POSTGIS_DOCKERFILE_PATH),
+        tag=POSTGIS_IMAGE_NAME,
+        rm=True,
+    )
+    print(f"PostGIS image '{POSTGIS_IMAGE_NAME}' built successfully!")
+    return POSTGIS_IMAGE_NAME
+
+
+def create_postgres_container() -> Any:
+    """Create and start a PostGIS container."""
+    postgis_image = build_postgis_image_if_needed()
+    print(f"Creating PostGIS container '{CONTAINER_NAME}' with {postgis_image}...")
+
+    client = docker.from_env()
+
+    # Remove existing container if it exists
+    try:
+        existing_container = client.containers.get(CONTAINER_NAME)
+        print(f"Stopping and removing existing container '{CONTAINER_NAME}'...")
+        existing_container.stop()
+        existing_container.remove()
+    except docker.errors.NotFound:
+        pass
+
+    # Create and start new container
+    container = client.containers.run(
+        postgis_image,
+        name=CONTAINER_NAME,
+        environment={
+            "POSTGRES_USER": POSTGRES_USER,
+            "POSTGRES_PASSWORD": POSTGRES_PASSWORD,
+            "POSTGRES_DB": POSTGRES_DB,
+        },
+        ports={f"{POSTGRES_PORT}/tcp": HOST_PORT},
+        detach=True,
+        remove=False,
+    )
+
+    print(f"Container '{CONTAINER_NAME}' started. Waiting for PostGIS to be ready...")
+
+    # Wait for PostgreSQL to be ready by actually connecting
+    # Note: pg_isready is not sufficient because PostGIS init scripts
+    # start postgres, do setup, shut down, and restart
+    max_attempts = 60
+    for attempt in range(max_attempts):
+        try:
+            # Try to actually connect and run a simple query
+            result = container.exec_run(
+                f'psql -U {POSTGRES_USER} -d {POSTGRES_DB} -c "SELECT 1"',
+                environment={"PGPASSWORD": POSTGRES_PASSWORD},
+            )
+            if result.exit_code == 0:
+                # Small delay for connection stability
+                time.sleep(1)
+                print("PostGIS is ready!")
+                return container
+        except Exception:
+            pass
+
+        time.sleep(1)
+        if (attempt + 1) % 5 == 0:
+            print(f"Waiting... ({attempt + 1}/{max_attempts})")
+
+    raise Exception("PostGIS failed to start within the timeout period")
+
+
+def get_alembic_config(database_url: str, alembic_ini_path: str = "alembic.ini") -> Config:
+    """Create and configure Alembic Config object."""
+    alembic_cfg = Config(alembic_ini_path)
+    alembic_cfg.set_main_option("sqlalchemy.url", database_url)
+    return alembic_cfg
+
+
+def get_current_revision(database_url: str) -> str | None:
+    """Get current database revision using sync engine."""
+    engine = create_engine(database_url)
+    try:
+        max_retries = 2
+        for attempt in range(max_retries + 1):
+            try:
+                with engine.connect() as conn:
+                    context = MigrationContext.configure(conn)
+                    return context.get_current_revision()
+            except OSError as e:
+                if attempt < max_retries:
+                    print(f"OSError encountered: {e}. Retrying in 1 second... (attempt {attempt + 1}/{max_retries})")
+                    time.sleep(1)
+                else:
+                    print(f"OSError encountered after {max_retries} retries. Failing.")
+                    raise
+    finally:
+        engine.dispose()
+    return None
+
+
+def run_alembic_upgrade(alembic_cfg: Config) -> None:
+    """Run alembic upgrade to apply all migrations using Python API."""
+    print("\nRunning Alembic upgrade (applying migrations)...")
+
+    # Get current revision before upgrade
+    database_url = alembic_cfg.get_main_option("sqlalchemy.url")
+    if not database_url:
+        raise RuntimeError("sqlalchemy.url is not set in alembic.ini")
+
+    current_rev = get_current_revision(database_url)
+    print(f"Current revision: {current_rev or 'None (empty database)'}")
+
+    # Run upgrade
+    command.upgrade(alembic_cfg, "head")
+
+    # Get revision after upgrade
+    new_rev = get_current_revision(database_url)
+    print(f"New revision: {new_rev}")
+
+    print("Migrations applied successfully!")
+
+
+def run_alembic_autogenerate(alembic_cfg: Config, message: str = "Auto-generated migration") -> None:
+    """Run alembic revision --autogenerate using Python API."""
+    print(f"\nGenerating new migration: '{message}'...")
+
+    revision = command.revision(alembic_cfg, message=message, autogenerate=True)
+
+    if revision and isinstance(revision, Script):
+        print(f"New migration generated: {revision.revision}")
+        print(f"Migration file: {revision.path}")
+    else:
+        print("No changes detected - no migration generated.")
+
+
+def cleanup_container(container: Any) -> None:
+    """Stop and remove the PostGIS container."""
+    if not container:
+        return
+
+    print(f"\nCleaning up container '{CONTAINER_NAME}'...")
+    try:
+        container.stop()
+        container.remove()
+        print("Container removed.")
+    except Exception as e:
+        print(f"Error during cleanup: {e}", file=sys.stderr)
+
+
+def main(revision_message: str, alembic_ini_path: str) -> None:
+    """Main execution flow."""
+    container: Any = None
+
+    try:
+        # Step 1: Create PostGIS container
+        container = create_postgres_container()
+
+        # Step 2: Configure environment and Alembic
+        # Set minimal environment variables required by couchers.config and migrations
+        os.environ["DATABASE_CONNECTION_STRING"] = DATABASE_URL
+        os.environ.setdefault("DEV", "1")
+        os.environ.setdefault("SECRET", "0" * 64)  # 32-byte hex string
+        alembic_cfg = get_alembic_config(DATABASE_URL, alembic_ini_path)
+
+        # Step 3: Apply existing migrations
+        run_alembic_upgrade(alembic_cfg)
+
+        # Step 4: Generate new migration
+        run_alembic_autogenerate(alembic_cfg, revision_message)
+    except Exception as e:
+        print(f"\n❌ Error: {e}", file=sys.stderr)
+        traceback.print_exc()
+        sys.exit(1)
+    finally:
+        cleanup_container(container)
+
+
+def cli() -> None:
+    """CLI entry point for the script."""
+    parser = argparse.ArgumentParser(description="Create PostGIS container and run Alembic migrations")
+    parser.add_argument(
+        "-m",
+        "--message",
+        type=str,
+        default="New autogenerated migration",
+        help="Revision message for the generated migration",
+    )
+    parser.add_argument(
+        "--alembic-ini", type=str, default="alembic.ini", help="Path to alembic.ini file (default: alembic.ini)"
+    )
+
+    args = parser.parse_args()
+
+    if not Path(args.alembic_ini).exists():
+        print(f"Error: {args.alembic_ini} not found.", file=sys.stderr)
+        print("Please run 'alembic init alembic' first to set up Alembic.", file=sys.stderr)
+        sys.exit(1)
+
+    main(revision_message=args.message, alembic_ini_path=args.alembic_ini)
+
+
+if __name__ == "__main__":
+    cli()

--- a/app/backend/src/couchers/email/queuing.py
+++ b/app/backend/src/couchers/email/queuing.py
@@ -29,7 +29,7 @@ def _queue_email(
     """
 
     # Import here to avoid circular dependency
-    from couchers.jobs.handlers import send_email
+    from couchers.jobs.handlers import send_email  # noqa: PLC0415
 
     payload = jobs_pb2.SendEmailPayload(
         sender_name=sender_name,

--- a/app/backend/src/couchers/notifications/notify.py
+++ b/app/backend/src/couchers/notifications/notify.py
@@ -43,7 +43,7 @@ def notify(
     """
     logger.info(f"Generating notification of type {topic_action.display} for user {user_id}")
     # Import here to avoid circular dependency
-    from couchers.notifications.background import handle_notification
+    from couchers.notifications.background import handle_notification  # noqa: PLC0415
 
     notification = Notification(
         user_id=user_id,

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -290,7 +290,8 @@ def generate_event_create_notifications(payload: jobs_pb2.GenerateEventCreateNot
     """
     Background job to generated/fan out event notifications
     """
-    from couchers.servicers.communities import community_to_pb
+    # Import here to avoid circular dependency
+    from couchers.servicers.communities import community_to_pb  # noqa: PLC0415
 
     logger.info(f"Fanning out notifications for event occurrence id = {payload.occurrence_id}")
 

--- a/app/backend/src/couchers/servicers/moderation.py
+++ b/app/backend/src/couchers/servicers/moderation.py
@@ -416,7 +416,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
             )
 
             # Import here to avoid circular dependency
-            from couchers.notifications.background import handle_notification
+            from couchers.notifications.background import handle_notification  # noqa: PLC0415
 
             for notification in pending_notifications:
                 queue_job(

--- a/app/backend/src/couchers/servicers/threads.py
+++ b/app/backend/src/couchers/servicers/threads.py
@@ -57,8 +57,9 @@ def thread_to_pb(session: Session, database_id: int) -> threads_pb2.Thread:
 
 
 def generate_reply_notifications(payload: jobs_pb2.GenerateReplyNotificationsPayload) -> None:
-    from couchers.servicers.discussions import discussion_to_pb
-    from couchers.servicers.events import event_to_pb
+    # Import here to avoid circular dependency
+    from couchers.servicers.discussions import discussion_to_pb  # noqa: PLC0415
+    from couchers.servicers.events import event_to_pb  # noqa: PLC0415
 
     with session_scope() as session:
         database_id, depth = unpack_thread_id(payload.thread_id)

--- a/app/backend/src/run_locally.py
+++ b/app/backend/src/run_locally.py
@@ -44,7 +44,7 @@ def main() -> None:
         os.environ["PROMETHEUS_MULTIPROC_DIR"] = prometheus_multiproc_dir.name
 
     # Only import it here because it has side effects.
-    import app
+    import app  # noqa: PLC0415
 
     if __name__ == "__main__":
         app.common_init()

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -6,6 +6,7 @@ from google.protobuf import empty_pb2, wrappers_pb2
 from sqlalchemy import func, select, update
 
 from couchers.db import session_scope
+from couchers.helpers.badges import user_add_badge
 from couchers.jobs.handlers import update_badges
 from couchers.materialized_views import refresh_materialized_views_rapid
 from couchers.models import (
@@ -19,6 +20,7 @@ from couchers.models import (
     User,
     UserBadge,
 )
+from couchers.models.notifications import Notification
 from couchers.proto import admin_pb2, api_pb2, blocking_pb2, jail_pb2, notifications_pb2
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_HOURS
 from couchers.resources import get_badge_dict
@@ -1558,9 +1560,6 @@ def test_badges(db):
 
 def test_user_add_badge_is_idempotent(db):
     """Test that adding a badge a user already has is a no-op and doesn't send a duplicate notification."""
-    from couchers.helpers.badges import user_add_badge
-    from couchers.models.notifications import Notification
-
     user, _ = generate_user()
 
     with session_scope() as session:
@@ -1600,8 +1599,6 @@ def test_user_add_badge_is_idempotent(db):
 @pytest.mark.parametrize("flag", ["deleted_at", "banned_at"])
 def test_ListBadgeUsers_excludes_ghost_users(db, flag):
     """Test that ListBadgeUsers does not return deleted/banned users."""
-    from couchers.helpers.badges import user_add_badge
-
     user1, token1 = generate_user()
     user2, _ = generate_user()
     user3, _ = generate_user()

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -47,6 +47,7 @@ from couchers.models import (
     Message,
     MessageType,
     PasswordResetToken,
+    User,
     UserBadge,
     UserBlock,
     Volunteer,
@@ -1500,8 +1501,6 @@ def test_send_message_notifications_blocked_users_no_notification(db, moderator)
 
     # Reset the notification state so user2 will receive notifications for old messages again
     with session_scope() as session:
-        from couchers.models import User
-
         u2 = session.execute(select(User).where(User.id == user2.id)).scalar_one()
         u2.last_notified_message_id = 0
 

--- a/app/backend/src/tests/test_bugs.py
+++ b/app/backend/src/tests/test_bugs.py
@@ -1,4 +1,4 @@
-from datetime import UTC
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import grpc
@@ -272,8 +272,6 @@ def test_report_diagnostics_with_value(db):
 
 
 def test_report_diagnostics_with_occurred(db):
-    from datetime import datetime
-
     ts = timestamp_pb2.Timestamp()
     ts.FromDatetime(datetime(2026, 1, 15, 10, 30, 0, tzinfo=UTC))
 

--- a/app/backend/src/tests/test_event_log.py
+++ b/app/backend/src/tests/test_event_log.py
@@ -11,8 +11,10 @@ from couchers.crypto import hash_password
 from couchers.db import session_scope
 from couchers.event_log import log_event
 from couchers.i18n import LocalizationContext
+from couchers.models import FriendRelationship, SignupFlow
 from couchers.models.logging import EventLog
 from couchers.proto import (
+    account_pb2,
     api_pb2,
     auth_pb2,
     conversations_pb2,
@@ -26,6 +28,7 @@ from couchers.utils import Timestamp_from_datetime, create_coordinate, now, toda
 from tests.fixtures.db import generate_user, make_friends
 from tests.fixtures.sessions import (
     MockGrpcContext,
+    account_session,
     api_session,
     auth_api_session,
     conversations_session,
@@ -221,8 +224,6 @@ def test_signup_flow_creates_events(db):
         assert events[0].properties["has_invite_code"] is False
 
     # complete signup: get email token, verify, fill account, etc.
-    from couchers.models import SignupFlow
-
     with session_scope() as session:
         flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
         email_token = flow.email_token
@@ -633,8 +634,6 @@ def test_friendship_request_events(db, moderator):
         assert events[0].properties["to_user_id"] == user2.id
 
     # Approve and accept friend request
-    from couchers.models import FriendRelationship
-
     with session_scope() as session:
         fr = session.execute(select(FriendRelationship)).scalar_one()
         fr_id = fr.id
@@ -670,8 +669,6 @@ def test_friendship_cancel_event(db, moderator):
 
     with api_session(token1) as api:
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user2.id))
-
-    from couchers.models import FriendRelationship
 
     with session_scope() as session:
         fr = session.execute(select(FriendRelationship)).scalar_one()
@@ -815,9 +812,6 @@ def test_event_created_event(db):
 def test_password_change_event(db):
     """Changing password creates account.password_changed event."""
     user, token = generate_user(hashed_password=hash_password("oldpassword"))
-
-    from couchers.proto import account_pb2
-    from tests.fixtures.sessions import account_session
 
     with account_session(token) as api:
         api.ChangePasswordV2(

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -13,6 +13,8 @@ from couchers.models import (
     BackgroundJob,
     BackgroundJobState,
     EventOccurrence,
+    ModerationState,
+    ModerationVisibility,
     Notification,
     NotificationDelivery,
     Upload,
@@ -2609,8 +2611,6 @@ def test_event_photo_key(db):
 
 def test_event_created_with_shadowed_visibility(db):
     """Events start in SHADOWED state when created."""
-    from couchers.models import ModerationState, ModerationVisibility
-
     user, token = generate_user()
 
     with session_scope() as session:

--- a/app/backend/src/tests/test_galleries.py
+++ b/app/backend/src/tests/test_galleries.py
@@ -5,9 +5,10 @@ from sqlalchemy.exc import IntegrityError
 
 from couchers.db import session_scope
 from couchers.models import PhotoGallery, PhotoGalleryItem, Upload, User
-from couchers.proto import galleries_pb2
+from couchers.models.uploads import get_avatar_upload, has_avatar_photo_expression
+from couchers.proto import api_pb2, galleries_pb2
 from tests.fixtures.db import generate_user
-from tests.fixtures.sessions import galleries_session
+from tests.fixtures.sessions import api_session, galleries_session
 
 
 @pytest.fixture(autouse=True)
@@ -718,8 +719,6 @@ def test_database_constraints_upload_uniqueness(db):
 
 def test_get_avatar_upload_returns_first_by_position(db):
     """get_avatar_upload should return the upload with the lowest position value"""
-    from couchers.models.uploads import get_avatar_upload
-
     user1, token1 = generate_user(complete_profile=False, strong_verification=True)
 
     with session_scope() as session:
@@ -754,8 +753,6 @@ def test_get_avatar_upload_returns_first_by_position(db):
 
 def test_get_avatar_upload_no_photos(db):
     """get_avatar_upload should return None when user has no photos"""
-    from couchers.models.uploads import get_avatar_upload
-
     user1, token1 = generate_user(complete_profile=False)
 
     with session_scope() as session:
@@ -767,8 +764,6 @@ def test_get_avatar_upload_no_photos(db):
 
 def test_has_avatar_photo_expression_with_photos(db):
     """has_avatar_photo_expression should return True when user has photos"""
-    from couchers.models.uploads import has_avatar_photo_expression
-
     user1, token1 = generate_user(complete_profile=False)
 
     with session_scope() as session:
@@ -794,8 +789,6 @@ def test_has_avatar_photo_expression_with_photos(db):
 
 def test_has_avatar_photo_expression_no_photos(db):
     """has_avatar_photo_expression should return False when user has no photos"""
-    from couchers.models.uploads import has_avatar_photo_expression
-
     user1, token1 = generate_user(complete_profile=False)
 
     with session_scope() as session:
@@ -813,9 +806,6 @@ def test_has_avatar_photo_expression_no_photos(db):
 
 def test_avatar_url_via_api_reflects_first_photo(db):
     """GetUser should return avatar URL matching the first photo by position"""
-    from couchers.proto import api_pb2
-    from tests.fixtures.sessions import api_session
-
     user1, token1 = generate_user(complete_profile=False, strong_verification=True)
     user2, token2 = generate_user()
 
@@ -848,9 +838,6 @@ def test_avatar_url_via_api_reflects_first_photo(db):
 
 def test_avatar_changes_after_reordering(db):
     """Moving a photo to first position should make it the new avatar"""
-    from couchers.proto import api_pb2
-    from tests.fixtures.sessions import api_session
-
     user1, token1 = generate_user(complete_profile=False, strong_verification=True)
     user2, token2 = generate_user()
 
@@ -889,8 +876,6 @@ def test_avatar_changes_after_reordering(db):
 
 def test_avatar_with_negative_positions(db):
     """Avatar selection should work correctly with negative position values"""
-    from couchers.models.uploads import get_avatar_upload
-
     user1, token1 = generate_user(complete_profile=False, strong_verification=True)
 
     with session_scope() as session:
@@ -923,8 +908,6 @@ def test_avatar_with_negative_positions(db):
 
 def test_avatar_with_fractional_positions(db):
     """Avatar selection should work correctly with fractional position values"""
-    from couchers.models.uploads import get_avatar_upload
-
     user1, token1 = generate_user(complete_profile=False, strong_verification=True)
 
     with session_scope() as session:

--- a/app/backend/src/tests/test_moderation.py
+++ b/app/backend/src/tests/test_moderation.py
@@ -12,6 +12,7 @@ from sqlalchemy.sql import select
 from couchers.config import config
 from couchers.db import session_scope
 from couchers.jobs.handlers import auto_approve_moderation_queue
+from couchers.jobs.worker import process_job
 from couchers.models import (
     EventOccurrence,
     GroupChat,
@@ -2311,9 +2312,6 @@ def test_group_chat_message_notifications_suppressed_before_approval(db, push_co
     Test that notifications are NOT sent for messages in group chats
     that haven't been approved yet.
     """
-    from couchers.jobs.worker import process_job
-    from couchers.models import GroupChat
-
     user1, token1 = generate_user(complete_profile=True)
     user2, token2 = generate_user(complete_profile=True)
 

--- a/app/backend/src/tests/test_public_trips.py
+++ b/app/backend/src/tests/test_public_trips.py
@@ -5,10 +5,10 @@ import pytest
 from sqlalchemy import select
 
 from couchers.db import session_scope
-from couchers.models import Node, NodeType
+from couchers.models import Node, NodeType, User
 from couchers.models.public_trips import PublicTrip, PublicTripStatus
 from couchers.proto import public_trips_pb2
-from couchers.utils import create_polygon_lat_lng, to_multi, today
+from couchers.utils import create_polygon_lat_lng, now, to_multi, today
 from tests.fixtures.db import generate_user
 from tests.fixtures.sessions import public_trips_session
 
@@ -337,9 +337,6 @@ def test_list_public_trips_hides_invisible_user(db):
 
     # soft-delete the traveler
     with session_scope() as session:
-        from couchers.models import User
-        from couchers.utils import now
-
         t = session.execute(select(User).where(User.id == traveler.id)).scalar_one()
         t.deleted_at = now()
 
@@ -431,9 +428,6 @@ def test_list_public_trips_by_user_invisible_user(db):
 
     # soft-delete the traveler
     with session_scope() as session:
-        from couchers.models import User
-        from couchers.utils import now
-
         t = session.execute(select(User).where(User.id == traveler.id)).scalar_one()
         t.deleted_at = now()
 

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -15,8 +15,11 @@ from couchers.i18n import LocalizationContext
 from couchers.models import (
     Message,
     MessageType,
+    Node,
+    NodeType,
     RateLimitAction,
 )
+from couchers.models.public_trips import PublicTrip, PublicTripStatus
 from couchers.proto import (
     api_pb2,
     auth_pb2,
@@ -25,7 +28,7 @@ from couchers.proto import (
 )
 from couchers.proto.internal import unsubscribe_pb2
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_HOURS
-from couchers.utils import create_coordinate, now, today
+from couchers.utils import create_coordinate, create_polygon_lat_lng, now, to_multi, today
 from tests.fixtures.db import generate_user
 from tests.fixtures.misc import PushCollector, email_fields, mock_notification_email
 from tests.fixtures.sessions import api_session, auth_api_session, requests_session
@@ -1571,10 +1574,6 @@ def test_host_req_feedback(db, moderator):
 
 
 def _create_public_trip(user_id: int, from_date, to_date, status=None):
-    from couchers.models import Node, NodeType
-    from couchers.models.public_trips import PublicTrip, PublicTripStatus
-    from couchers.utils import create_polygon_lat_lng, to_multi
-
     with session_scope() as session:
         node = session.execute(select(Node).limit(1)).scalar_one_or_none()
         if node is None:
@@ -1689,8 +1688,6 @@ def test_create_request_with_public_trip_user_mismatch(db):
 
 def test_create_request_with_closed_public_trip(db):
     """Cannot offer to host a trip that's been closed."""
-    from couchers.models.public_trips import PublicTripStatus
-
     surfer, _ = generate_user()
     host, host_token = generate_user()
 


### PR DESCRIPTION
Adds `make revision` command that doesn't require a locally running database. The command starts a fresh docker container from our Postgis image, applies existing migrations, then runs alembic auto-generation command. At the end, the Postgis container is cleaned up. This way it doesn't interfere with one's local database.

Also adds `ruff` rule to disallow local imports - something claude is guilty of a lot...

