### PR TITLE
Backend/editor: allow reinstating former volunteers

### DIFF
--- a/app/backend/src/couchers/i18n/locales/en.json
+++ b/app/backend/src/couchers/i18n/locales/en.json
@@ -20,6 +20,7 @@
     "cannot_create_discussion": "You cannot create a discussion in this group or community.",
     "cannot_edit_that_notification_preference": "That notification preference is not user editable.",
     "cannot_leave_containing_community": "Your location on your profile is within this community, so you cannot leave it. However, you can adjust your notifications in your account settings.",
+    "cannot_reinstate_and_set_stopped_date": "Cannot reinstate a volunteer and set a stopped date at the same time.",
     "cant_add_self": "You can't add yourself to a group chat.",
     "cant_block_self": "You can't block yourself.",
     "cant_friend_self": "You can't befriend yourself!",

--- a/app/backend/src/couchers/servicers/editor.py
+++ b/app/backend/src/couchers/servicers/editor.py
@@ -276,8 +276,12 @@ class Editor(editor_pb2_grpc.EditorServicer):
                 context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_started_volunteering_date")
             volunteer.started_volunteering = started_volunteering
 
-        # Update stopped_volunteering if provided
-        if request.HasField("stopped_volunteering"):
+        # Reinstate (clear stopped_volunteering) or update stopped_volunteering
+        if request.reinstate_volunteer and request.HasField("stopped_volunteering"):
+            context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "cannot_reinstate_and_set_stopped_date")
+        if request.reinstate_volunteer:
+            volunteer.stopped_volunteering = None
+        elif request.HasField("stopped_volunteering"):
             stopped_volunteering = parse_date(request.stopped_volunteering.value)
             if not stopped_volunteering:
                 context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_stopped_volunteering_date")

--- a/app/backend/src/tests/test_editor.py
+++ b/app/backend/src/tests/test_editor.py
@@ -572,37 +572,37 @@ def test_UpdateVolunteer_reinstate(db):
     normal_user, normal_token = generate_user()
 
     refresh_materialized_views_rapid(empty_pb2.Empty())
-    with session_scope() as session:
-        with real_editor_session(editor_token) as api:
-            api.MakeUserVolunteer(
-                editor_pb2.MakeUserVolunteerReq(
-                    user_id=normal_user.id,
-                    role="Test Volunteer",
-                )
+    with real_editor_session(editor_token) as api:
+        api.MakeUserVolunteer(
+            editor_pb2.MakeUserVolunteerReq(
+                user_id=normal_user.id,
+                role="Test Volunteer",
             )
+        )
 
-            # Set a stopped date first (make them a former volunteer)
-            api.UpdateVolunteer(
-                editor_pb2.UpdateVolunteerReq(
-                    user_id=normal_user.id,
-                    stopped_volunteering=StringValue(value="2024-12-31"),
-                )
+        # Set a stopped date first (make them a former volunteer)
+        api.UpdateVolunteer(
+            editor_pb2.UpdateVolunteerReq(
+                user_id=normal_user.id,
+                stopped_volunteering=StringValue(value="2024-12-31"),
             )
+        )
+        with session_scope() as session:
             volunteer_before = session.execute(
                 select(Volunteer).where(Volunteer.user_id == normal_user.id)
             ).scalar_one()
             assert volunteer_before.stopped_volunteering is not None
 
-            # Reinstate them
-            res = api.UpdateVolunteer(
-                editor_pb2.UpdateVolunteerReq(
-                    user_id=normal_user.id,
-                    reinstate_volunteer=True,
-                )
+        # Reinstate them
+        res = api.UpdateVolunteer(
+            editor_pb2.UpdateVolunteerReq(
+                user_id=normal_user.id,
+                reinstate_volunteer=True,
             )
-            assert not res.HasField("stopped_volunteering")
+        )
+        assert not res.HasField("stopped_volunteering")
 
-            session.expire_all()
+        with session_scope() as session:
             volunteer_after = session.execute(select(Volunteer).where(Volunteer.user_id == normal_user.id)).scalar_one()
             assert volunteer_after.stopped_volunteering is None
 
@@ -613,23 +613,23 @@ def test_UpdateVolunteer_reinstate_already_current(db):
     normal_user, normal_token = generate_user()
 
     refresh_materialized_views_rapid(empty_pb2.Empty())
-    with session_scope() as session:
-        with real_editor_session(editor_token) as api:
-            api.MakeUserVolunteer(
-                editor_pb2.MakeUserVolunteerReq(
-                    user_id=normal_user.id,
-                    role="Test Volunteer",
-                )
+    with real_editor_session(editor_token) as api:
+        api.MakeUserVolunteer(
+            editor_pb2.MakeUserVolunteerReq(
+                user_id=normal_user.id,
+                role="Test Volunteer",
             )
+        )
 
-            res = api.UpdateVolunteer(
-                editor_pb2.UpdateVolunteerReq(
-                    user_id=normal_user.id,
-                    reinstate_volunteer=True,
-                )
+        res = api.UpdateVolunteer(
+            editor_pb2.UpdateVolunteerReq(
+                user_id=normal_user.id,
+                reinstate_volunteer=True,
             )
-            assert not res.HasField("stopped_volunteering")
+        )
+        assert not res.HasField("stopped_volunteering")
 
+        with session_scope() as session:
             volunteer = session.execute(select(Volunteer).where(Volunteer.user_id == normal_user.id)).scalar_one()
             assert volunteer.stopped_volunteering is None
 

--- a/app/backend/src/tests/test_editor.py
+++ b/app/backend/src/tests/test_editor.py
@@ -566,6 +566,100 @@ def test_UpdateVolunteer_invalid_stopped_date(db):
         assert e.value.details() == "Invalid end date for volunteering."
 
 
+def test_UpdateVolunteer_reinstate(db):
+    """UpdateVolunteer should clear stopped_volunteering when reinstate_volunteer=True"""
+    editor_user, editor_token = generate_user(is_editor=True)
+    normal_user, normal_token = generate_user()
+
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+    with session_scope() as session:
+        with real_editor_session(editor_token) as api:
+            api.MakeUserVolunteer(
+                editor_pb2.MakeUserVolunteerReq(
+                    user_id=normal_user.id,
+                    role="Test Volunteer",
+                )
+            )
+
+            # Set a stopped date first (make them a former volunteer)
+            api.UpdateVolunteer(
+                editor_pb2.UpdateVolunteerReq(
+                    user_id=normal_user.id,
+                    stopped_volunteering=StringValue(value="2024-12-31"),
+                )
+            )
+            volunteer_before = session.execute(
+                select(Volunteer).where(Volunteer.user_id == normal_user.id)
+            ).scalar_one()
+            assert volunteer_before.stopped_volunteering is not None
+
+            # Reinstate them
+            res = api.UpdateVolunteer(
+                editor_pb2.UpdateVolunteerReq(
+                    user_id=normal_user.id,
+                    reinstate_volunteer=True,
+                )
+            )
+            assert not res.HasField("stopped_volunteering")
+
+            session.expire_all()
+            volunteer_after = session.execute(select(Volunteer).where(Volunteer.user_id == normal_user.id)).scalar_one()
+            assert volunteer_after.stopped_volunteering is None
+
+
+def test_UpdateVolunteer_reinstate_already_current(db):
+    """UpdateVolunteer with reinstate_volunteer=True on a current volunteer is a no-op"""
+    editor_user, editor_token = generate_user(is_editor=True)
+    normal_user, normal_token = generate_user()
+
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+    with session_scope() as session:
+        with real_editor_session(editor_token) as api:
+            api.MakeUserVolunteer(
+                editor_pb2.MakeUserVolunteerReq(
+                    user_id=normal_user.id,
+                    role="Test Volunteer",
+                )
+            )
+
+            res = api.UpdateVolunteer(
+                editor_pb2.UpdateVolunteerReq(
+                    user_id=normal_user.id,
+                    reinstate_volunteer=True,
+                )
+            )
+            assert not res.HasField("stopped_volunteering")
+
+            volunteer = session.execute(select(Volunteer).where(Volunteer.user_id == normal_user.id)).scalar_one()
+            assert volunteer.stopped_volunteering is None
+
+
+def test_UpdateVolunteer_reinstate_conflict_with_stopped(db):
+    """UpdateVolunteer should fail if reinstate_volunteer=True and stopped_volunteering is also set"""
+    editor_user, editor_token = generate_user(is_editor=True)
+    normal_user, normal_token = generate_user()
+
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+    with real_editor_session(editor_token) as api:
+        api.MakeUserVolunteer(
+            editor_pb2.MakeUserVolunteerReq(
+                user_id=normal_user.id,
+                role="Test Volunteer",
+            )
+        )
+
+        with pytest.raises(grpc.RpcError) as e:
+            api.UpdateVolunteer(
+                editor_pb2.UpdateVolunteerReq(
+                    user_id=normal_user.id,
+                    reinstate_volunteer=True,
+                    stopped_volunteering=StringValue(value="2024-12-31"),
+                )
+            )
+        assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+        assert e.value.details() == "Cannot reinstate a volunteer and set a stopped date at the same time."
+
+
 def test_ListVolunteers(db):
     """ListVolunteers should return all current volunteers"""
     editor_user, editor_token = generate_user(is_editor=True)

--- a/app/proto/editor.proto
+++ b/app/proto/editor.proto
@@ -104,6 +104,8 @@ message UpdateVolunteerReq {
   google.protobuf.StringValue started_volunteering = 4;
   google.protobuf.StringValue stopped_volunteering = 5;
   google.protobuf.BoolValue show_on_team_page = 6;
+  // if true, clears stopped_volunteering (reinstates a former volunteer as current); cannot be combined with setting stopped_volunteering
+  bool reinstate_volunteer = 7;
 }
 
 message ListVolunteersReq {


### PR DESCRIPTION
Adds a `reinstate_volunteer` flag to the `UpdateVolunteer` editor RPC. The existing `UpdateVolunteer` uses `HasField()`-style partial updates on wrapped fields, which lets you set or change `stopped_volunteering`, but gives no way to clear it back to NULL. This flag explicitly clears `stopped_volunteering`, making a former volunteer current again. Setting both `reinstate_volunteer=true` and `stopped_volunteering` in the same request is rejected as `INVALID_ARGUMENT`.

## Testing
- New tests in `test_editor.py`:
  - `test_UpdateVolunteer_reinstate` — reinstate a former volunteer, confirm `stopped_volunteering` is cleared in the DB and the returned proto.
  - `test_UpdateVolunteer_reinstate_already_current` — no-op on a volunteer who is already current.
  - `test_UpdateVolunteer_reinstate_conflict_with_stopped` — conflict with `stopped_volunteering` returns `INVALID_ARGUMENT`.
- `uv run pytest src/tests/test_editor.py` — all 27 tests pass.
- `make format` and `make mypy` clean.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me