### PR TITLE
Add ListRecentCommunities RPC and use it on dashboard

### DIFF
--- a/app/backend/src/couchers/servicers/communities.py
+++ b/app/backend/src/couchers/servicers/communities.py
@@ -193,6 +193,24 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
 
         return communities_pb2.SearchCommunitiesRes(communities=communities_to_pb(session, rows, context))
 
+    def ListRecentCommunities(
+        self, request: communities_pb2.ListRecentCommunitiesReq, context: CouchersContext, session: Session
+    ) -> communities_pb2.ListRecentCommunitiesRes:
+        page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
+        nodes = (
+            session.execute(
+                select(Node)
+                .join(Cluster, Cluster.parent_node_id == Node.id)
+                .where(Cluster.is_official_cluster)
+                .order_by(Node.created.desc(), Node.id.desc())
+                .limit(page_size)
+                .options(selectinload(Node.official_cluster))
+            )
+            .scalars()
+            .all()
+        )
+        return communities_pb2.ListRecentCommunitiesRes(communities=communities_to_pb(session, nodes, context))
+
     def ListGroups(
         self, request: communities_pb2.ListGroupsReq, context: CouchersContext, session: Session
     ) -> communities_pb2.ListGroupsRes:

--- a/app/backend/src/couchers/servicers/communities.py
+++ b/app/backend/src/couchers/servicers/communities.py
@@ -197,19 +197,25 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         self, request: communities_pb2.ListRecentCommunitiesReq, context: CouchersContext, session: Session
     ) -> communities_pb2.ListRecentCommunitiesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
-        nodes = (
-            session.execute(
-                select(Node)
-                .join(Cluster, Cluster.parent_node_id == Node.id)
-                .where(Cluster.is_official_cluster)
-                .order_by(Node.created.desc(), Node.id.desc())
-                .limit(page_size)
-                .options(selectinload(Node.official_cluster))
-            )
-            .scalars()
-            .all()
+        rows = session.execute(
+            select(Node, Cluster)
+            .join(Cluster, Cluster.parent_node_id == Node.id)
+            .where(Cluster.is_official_cluster)
+            .order_by(Node.created.desc(), Node.id.desc())
+            .limit(page_size)
+        ).all()
+        return communities_pb2.ListRecentCommunitiesRes(
+            communities=[
+                communities_pb2.CommunitySummary(
+                    community_id=node.id,
+                    name=cluster.name,
+                    slug=cluster.slug,
+                    created=Timestamp_from_datetime(node.created),
+                    node_type=nodetype2api[node.node_type],
+                )
+                for node, cluster in rows
+            ],
         )
-        return communities_pb2.ListRecentCommunitiesRes(communities=communities_to_pb(session, nodes, context))
 
     def ListGroups(
         self, request: communities_pb2.ListGroupsReq, context: CouchersContext, session: Session

--- a/app/backend/src/tests/test_communities.py
+++ b/app/backend/src/tests/test_communities.py
@@ -1057,6 +1057,55 @@ class TestCommunities:
             global_community = next(c for c in res.communities if c.community_id == w_id)
             assert global_community.member  # user6 is a member
 
+    @staticmethod
+    def test_ListRecentCommunities(testing_communities):
+        """
+        ListRecentCommunities returns newest-first communities across the whole tree,
+        honouring page_size.
+        """
+        with session_scope() as session:
+            _, token = get_user_id_and_token(session, "user1")
+            # communities are created in this order in the fixture, so creation
+            # time ascends down the list
+            w_id = get_community_id(session, "Global")
+            c2_id = get_community_id(session, "Country 2")
+            c2r1_id = get_community_id(session, "Country 2, Region 1")
+            c2r1c1_id = get_community_id(session, "Country 2, Region 1, City 1")
+            c1_id = get_community_id(session, "Country 1")
+            c1r1_id = get_community_id(session, "Country 1, Region 1")
+            c1r1c1_id = get_community_id(session, "Country 1, Region 1, City 1")
+            c1r1c2_id = get_community_id(session, "Country 1, Region 1, City 2")
+            c1r2_id = get_community_id(session, "Country 1, Region 2")
+            c1r2c1_id = get_community_id(session, "Country 1, Region 2, City 1")
+
+        newest_first = [
+            c1r2c1_id,
+            c1r2_id,
+            c1r1c2_id,
+            c1r1c1_id,
+            c1r1_id,
+            c1_id,
+            c2r1c1_id,
+            c2r1_id,
+            c2_id,
+            w_id,
+        ]
+
+        with communities_session(token) as api:
+            res = api.ListRecentCommunities(communities_pb2.ListRecentCommunitiesReq(page_size=3))
+            assert [c.community_id for c in res.communities] == newest_first[:3]
+            for community in res.communities:
+                assert community.HasField("created")
+                assert community.created.seconds > 0
+
+            # default page size returns all 10 for this fixture
+            res = api.ListRecentCommunities(communities_pb2.ListRecentCommunitiesReq())
+            assert [c.community_id for c in res.communities] == newest_first
+
+            # page_size is clamped to MAX_PAGINATION_LENGTH (25)
+            res = api.ListRecentCommunities(communities_pb2.ListRecentCommunitiesReq(page_size=1000))
+            assert len(res.communities) == 10
+
 
 def test_JoinCommunity_and_LeaveCommunity(testing_communities):
     # these are separate as they mutate the database

--- a/app/backend/src/tests/test_communities.py
+++ b/app/backend/src/tests/test_communities.py
@@ -1058,7 +1058,7 @@ class TestCommunities:
             assert global_community.member  # user6 is a member
 
     @staticmethod
-    def test_ListRecentCommunities(testing_communities):
+    def test_ListRecentCommunities(testing_communities, monkeypatch):
         """
         ListRecentCommunities returns newest-first communities across the whole tree,
         honouring page_size.
@@ -1098,13 +1098,17 @@ class TestCommunities:
                 assert community.HasField("created")
                 assert community.created.seconds > 0
 
-            # default page size returns all 10 for this fixture
+            # default page size returns all communities for this fixture
             res = api.ListRecentCommunities(communities_pb2.ListRecentCommunitiesReq())
             assert [c.community_id for c in res.communities] == newest_first
 
-            # page_size is clamped to MAX_PAGINATION_LENGTH (25)
+            # page_size is clamped to MAX_PAGINATION_LENGTH on the server
+            monkeypatch.setattr("couchers.servicers.communities.MAX_PAGINATION_LENGTH", 4)
             res = api.ListRecentCommunities(communities_pb2.ListRecentCommunitiesReq(page_size=1000))
-            assert len(res.communities) == 10
+            assert [c.community_id for c in res.communities] == newest_first[:4]
+            # and also applies to the default when the request omits page_size
+            res = api.ListRecentCommunities(communities_pb2.ListRecentCommunitiesReq())
+            assert [c.community_id for c in res.communities] == newest_first[:4]
 
 
 def test_JoinCommunity_and_LeaveCommunity(testing_communities):

--- a/app/proto/communities.proto
+++ b/app/proto/communities.proto
@@ -327,5 +327,5 @@ message ListRecentCommunitiesReq {
 }
 
 message ListRecentCommunitiesRes {
-  repeated Community communities = 1;
+  repeated CommunitySummary communities = 1;
 }

--- a/app/proto/communities.proto
+++ b/app/proto/communities.proto
@@ -105,6 +105,10 @@ service Communities {
   rpc ListAllCommunities(ListAllCommunitiesReq) returns (ListAllCommunitiesRes) {
     // Gets a list of all communities, ordered hierarchically
   }
+
+  rpc ListRecentCommunities(ListRecentCommunitiesReq) returns (ListRecentCommunitiesRes) {
+    // Gets the most recently created communities across the whole tree, ordered newest-first
+  }
 }
 
 message Community {
@@ -315,4 +319,13 @@ message ListAllCommunitiesReq {
 
 message ListAllCommunitiesRes {
   repeated CommunitySummary communities = 1;
+}
+
+message ListRecentCommunitiesReq {
+  // number of communities to return; server caps this to a sensible maximum
+  uint32 page_size = 1;
+}
+
+message ListRecentCommunitiesRes {
+  repeated Community communities = 1;
 }

--- a/app/web/features/communities/NewCommunities.tsx
+++ b/app/web/features/communities/NewCommunities.tsx
@@ -1,13 +1,15 @@
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import { Chip, Skeleton, styled, Typography } from "@mui/material";
+import { useQuery } from "@tanstack/react-query";
+import { RpcError } from "grpc-web";
 import { useTranslation } from "i18n";
 import { DASHBOARD } from "i18n/namespaces";
 import { useRouter } from "next/router";
-import Sentry from "platform/sentry";
-import { Community } from "proto/communities_pb";
-import { useEffect, useState } from "react";
+import { ListRecentCommunitiesRes } from "proto/communities_pb";
 import { routeToCommunity } from "routes";
-import { listCommunities } from "service/communities";
+import { listRecentCommunities } from "service/communities";
+
+const NEW_COMMUNITIES_LIMIT = 5;
 
 const Container = styled("div")(({ theme }) => ({
   marginBottom: theme.spacing(3),
@@ -20,14 +22,14 @@ const ChipsContainer = styled("div")(({ theme }) => ({
   marginTop: theme.spacing(1),
 }));
 
-const StyledChip = styled(Chip)(({ theme }) => ({
+const StyledChip = styled(Chip)({
   fontSize: "0.875rem",
   fontWeight: 500,
   height: 36,
   "& .MuiChip-icon": {
     fontSize: "1rem",
   },
-}));
+});
 
 const Label = styled(Typography)(({ theme }) => ({
   display: "flex",
@@ -41,81 +43,11 @@ const Label = styled(Typography)(({ theme }) => ({
 export default function NewCommunities() {
   const { t } = useTranslation(DASHBOARD);
   const router = useRouter();
-  const [newCommunities, setNewCommunities] = useState<Community.AsObject[]>(
-    [],
-  );
-  const [isLoading, setIsLoading] = useState(true);
 
-  useEffect(() => {
-    // Fetch all communities from all regions, then filter to cities and sort by date
-    const fetchNewCities = async () => {
-      try {
-        setIsLoading(true);
-
-        // First, fetch all top-level regions
-        const regionsResponse = await listCommunities(0);
-        const regions = regionsResponse.communitiesList || [];
-
-        if (regions.length === 0) {
-          setNewCommunities([]);
-          return;
-        }
-
-        // Then fetch subcommunities (cities) for each region
-        const citiesPromises = regions.map((region) =>
-          listCommunities(region.communityId).catch((err) => {
-            Sentry.captureException(err, {
-              tags: {
-                component: "NewCommunities",
-                action: "listCommunities",
-                regionId: region.communityId.toString(),
-              },
-            });
-            return { communitiesList: [], nextPageToken: "" };
-          }),
-        );
-        const citiesResponses = await Promise.all(citiesPromises);
-
-        // Flatten all cities and deduplicate
-        const allCities = citiesResponses.flatMap(
-          (response) => response.communitiesList || [],
-        );
-        const citiesMap = new Map<number, Community.AsObject>();
-        allCities.forEach((community) => {
-          if (
-            community &&
-            community.communityId &&
-            !citiesMap.has(community.communityId)
-          ) {
-            citiesMap.set(community.communityId, community);
-          }
-        });
-
-        // Sort by creation date (newest first) and take top 5
-        const newestCities = Array.from(citiesMap.values())
-          .sort((a, b) => {
-            const aTime = a.created?.seconds || 0;
-            const bTime = b.created?.seconds || 0;
-            return bTime - aTime;
-          })
-          .slice(0, 5);
-
-        setNewCommunities(newestCities);
-      } catch (error) {
-        Sentry.captureException(error, {
-          tags: {
-            component: "NewCommunities",
-            action: "fetchNewCities",
-          },
-        });
-        setNewCommunities([]);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchNewCities();
-  }, []);
+  const { data, isLoading } = useQuery<ListRecentCommunitiesRes.AsObject, RpcError>({
+    queryKey: ["recentCommunities", NEW_COMMUNITIES_LIMIT],
+    queryFn: () => listRecentCommunities(NEW_COMMUNITIES_LIMIT),
+  });
 
   if (isLoading) {
     return (
@@ -125,7 +57,7 @@ export default function NewCommunities() {
           {t("dashboard:new_pill")}
         </Label>
         <ChipsContainer>
-          {[1, 2, 3, 4, 5].map((i) => (
+          {Array.from({ length: NEW_COMMUNITIES_LIMIT }).map((_, i) => (
             <Skeleton
               key={i}
               variant="rectangular"
@@ -139,7 +71,8 @@ export default function NewCommunities() {
     );
   }
 
-  if (newCommunities.length === 0) {
+  const communities = data?.communitiesList ?? [];
+  if (communities.length === 0) {
     return null;
   }
 
@@ -150,7 +83,7 @@ export default function NewCommunities() {
         {t("dashboard:new_pill")}
       </Label>
       <ChipsContainer>
-        {newCommunities.map((community) => (
+        {communities.map((community) => (
           <StyledChip
             key={community.communityId}
             label={community.name}

--- a/app/web/features/communities/NewCommunities.tsx
+++ b/app/web/features/communities/NewCommunities.tsx
@@ -44,7 +44,10 @@ export default function NewCommunities() {
   const { t } = useTranslation(DASHBOARD);
   const router = useRouter();
 
-  const { data, isLoading } = useQuery<ListRecentCommunitiesRes.AsObject, RpcError>({
+  const { data, isLoading } = useQuery<
+    ListRecentCommunitiesRes.AsObject,
+    RpcError
+  >({
     queryKey: ["recentCommunities", NEW_COMMUNITIES_LIMIT],
     queryFn: () => listRecentCommunities(NEW_COMMUNITIES_LIMIT),
   });

--- a/app/web/service/communities.ts
+++ b/app/web/service/communities.ts
@@ -11,6 +11,7 @@ import {
   ListMembersReq,
   ListNearbyUsersReq,
   ListPlacesReq,
+  ListRecentCommunitiesReq,
   ListUserCommunitiesReq,
   SearchCommunitiesReq,
 } from "proto/communities_pb";
@@ -154,5 +155,14 @@ export async function searchCommunities(query: string, pageSize?: number) {
 export async function listAllCommunities() {
   const req = new ListAllCommunitiesReq();
   const response = await client.communities.listAllCommunities(req);
+  return response.toObject();
+}
+
+export async function listRecentCommunities(pageSize?: number) {
+  const req = new ListRecentCommunitiesReq();
+  if (pageSize) {
+    req.setPageSize(pageSize);
+  }
+  const response = await client.communities.listRecentCommunities(req);
   return response.toObject();
 }


### PR DESCRIPTION
The dashboard's "new communities" widget was fanning out one `ListCommunities` RPC per top-level region and then sorting client-side by creation time. It was also slightly incorrect: each sub-RPC only returned the first alphabetical page (max 25), so any region with more children silently dropped communities, and nothing deeper than one level was ever considered.

This replaces that logic with a dedicated `ListRecentCommunities` RPC that orders across the whole community tree by `Node.created DESC` (ties broken by `Node.id`) and returns up to `page_size` results, capped at the existing `MAX_PAGINATION_LENGTH`. The dashboard component now makes a single call via `useQuery`.

## Testing
- `uv run pytest src/tests/test_communities.py` — all 25 tests pass, including new `test_ListRecentCommunities` covering ordering, default page size, and clamping.
- `make mypy` clean.
- `yarn tsc --noEmit` and `yarn lint:fix` clean on the web side.
- Manually verified the dashboard widget with the new RPC is pending reviewer replication.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me