### PR TITLE
CI: generate protos before publishing client wheel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,10 +40,8 @@ jobs:
         run: uv python install 3.13
 
       - name: Generate protos
-        working-directory: app
-        run: |
-          docker pull -q registry.gitlab.com/couchers/grpc:latest
-          docker run --rm -w /app -v "$PWD":/app registry.gitlab.com/couchers/grpc:latest ./generate_protos.sh
+        working-directory: app/backend
+        run: make protos
 
       - name: Build
         working-directory: app/client

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Install Python 3.13
         run: uv python install 3.13
 
+      - name: Generate protos
+        working-directory: app
+        run: |
+          docker pull -q registry.gitlab.com/couchers/grpc:latest
+          docker run --rm -w /app -v "$PWD":/app registry.gitlab.com/couchers/grpc:latest ./generate_protos.sh
+
       - name: Build
         working-directory: app/client
         run: uv build


### PR DESCRIPTION
The "Publish client" GitHub Actions workflow was failing at the "Smoke test (wheel)" step with:

```
ModuleNotFoundError: No module named 'couchers.proto'
```

`app/client/src/couchers/proto/` is gitignored because the proto stubs are generated, but the publish workflow was running `uv build` without generating them first — so the wheel and sdist shipped without the `couchers.proto` module, and `import couchers` failed on a fresh install.

This adds a "Generate protos" step before "Build" that runs `./generate_protos.sh` inside the existing `registry.gitlab.com/couchers/grpc:latest` image, matching how `make protos` and the GitLab `protos` job work.

## Testing
- Verified locally that the grpc image is publicly pullable.
- Next push to `develop` touching `app/client/**` or `app/proto/**` will exercise the workflow; can also be triggered via `workflow_dispatch`.

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me