### PR TITLE
Backend: Exclude UMS-hidden notifications from unseen count

### DIFF
--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -53,7 +53,13 @@ from couchers.rate_limits.check import process_rate_limits_and_check_abort
 from couchers.rate_limits.definitions import RATE_LIMIT_HOURS
 from couchers.resources import get_badge_dict, language_is_allowed, region_is_allowed
 from couchers.servicers.blocking import is_not_visible
-from couchers.sql import username_or_id, users_visible, where_moderated_content_visible, where_users_column_visible
+from couchers.sql import (
+    moderation_state_column_visible,
+    username_or_id,
+    users_visible,
+    where_moderated_content_visible,
+    where_users_column_visible,
+)
 from couchers.utils import (
     Duration_from_timedelta,
     Timestamp_from_datetime,
@@ -260,6 +266,7 @@ class API(api_pb2_grpc.APIServicer):
                     get_topic_actions_by_delivery_type(session, user.id, NotificationDeliveryType.push)
                 )
             )
+            .where(moderation_state_column_visible(context, Notification.moderation_state_id))
         ).scalar_one()
 
         return api_pb2.PingRes(

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -468,6 +468,26 @@ def test_notifications_seen(db, push_collector: PushCollector, moderator):
         assert api.Ping(api_pb2.PingReq()).unseen_notification_count == 1
 
 
+def test_unseen_notification_count_excludes_ums_hidden(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    with api_session(token2) as api:
+        api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user1.id))
+        res = api.ListFriendRequests(empty_pb2.Empty())
+        fr_id = res.sent[0].friend_request_id
+
+    # Before moderation the friend request is shadowed, so the resulting notification
+    # is not visible to the recipient and must not contribute to their unseen count.
+    with api_session(token1) as api:
+        assert api.Ping(api_pb2.PingReq()).unseen_notification_count == 0
+
+    moderator.approve_friend_request(fr_id)
+
+    with api_session(token1) as api:
+        assert api.Ping(api_pb2.PingReq()).unseen_notification_count == 1
+
+
 def test_GetVapidPublicKey(db):
     _, token = generate_user()
 


### PR DESCRIPTION
The unseen notification count returned by `Ping` (used to render the notification badge) did not exclude notifications hidden by the user moderation system. As a result, users could see a non-zero badge but find no corresponding notification in `ListNotifications`, which already filters by `moderation_state_column_visible`.

Apply the same `moderation_state_column_visible(context, Notification.moderation_state_id)` filter to the `unseen_notification_count` query so the two endpoints stay in sync.

## Testing
- `make format` passes
- Existing mypy errors on `develop` are unrelated to this change

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me