### PR TITLE
Backend: Add SetUserContentVisibility moderation RPC

### DIFF
--- a/app/backend/src/couchers/i18n/locales/en.json
+++ b/app/backend/src/couchers/i18n/locales/en.json
@@ -227,6 +227,7 @@
     "unrecognized_phone_number": "Your mobile phone number is not recognized. Please double-check it and contact support if this error persists.",
     "upload_not_found": "Upload not found.",
     "upload_not_found_or_not_owned": "Upload not found or you don't own it.",
+    "visibility_must_be_specified": "Visibility must be specified.",
     "user_already_admin": "That user is already an admin.",
     "user_already_blocked": "Target user has already been blocked.",
     "user_already_has_badge": "The user already has that badge.",

--- a/app/backend/src/couchers/migrations/versions/0144_add_bulk_set_visibility_to_moderationaction.py
+++ b/app/backend/src/couchers/migrations/versions/0144_add_bulk_set_visibility_to_moderationaction.py
@@ -1,0 +1,25 @@
+"""Add bulk_set_visibility to moderationaction enum
+
+Revision ID: 0144
+Revises: 0143
+Create Date: 2026-04-19 12:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0144"
+down_revision = "0143"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ALTER TYPE ... ADD VALUE cannot run inside a transaction in PostgreSQL
+    op.execute("COMMIT")
+    op.execute("ALTER TYPE moderationaction ADD VALUE IF NOT EXISTS 'bulk_set_visibility'")
+
+
+def downgrade() -> None:
+    raise Exception("Can't downgrade")

--- a/app/backend/src/couchers/models/moderation.py
+++ b/app/backend/src/couchers/models/moderation.py
@@ -55,6 +55,8 @@ class ModerationAction(enum.Enum):
     flag = enum.auto()
     # Remove flag
     unflag = enum.auto()
+    # Bulk visibility change applied to every item authored by a user
+    bulk_set_visibility = enum.auto()
 
 
 class ModerationObjectType(enum.Enum):

--- a/app/backend/src/couchers/servicers/moderation.py
+++ b/app/backend/src/couchers/servicers/moderation.py
@@ -15,7 +15,6 @@ from couchers.metrics import (
     observe_moderation_visibility_transition,
 )
 from couchers.models import (
-    AdminAction,
     AdminActionLevel,
     Event,
     EventOccurrence,
@@ -545,7 +544,6 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
         reason = request.reason or f"Bulk visibility update for user {user.id} to {new_visibility.name}"
-        action = ModerationAction.bulk_set_visibility
 
         author_exists_clauses = []
         for model in moderationobjecttype2model.values():
@@ -567,7 +565,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
 
             log_entry = ModerationLog(
                 moderation_state_id=moderation_state.id,
-                action=action,
+                action=ModerationAction.bulk_set_visibility,
                 moderator_user_id=context.user_id,
                 new_visibility=new_visibility,
                 reason=reason,
@@ -585,7 +583,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
                 queue_item.resolved_by_log_id = log_entry.id
                 session.flush()
 
-            observe_moderation_action(action, moderation_state.object_type)
+            observe_moderation_action(ModerationAction.bulk_set_visibility, moderation_state.object_type)
             observe_moderation_visibility_transition(old_visibility, new_visibility, moderation_state.object_type)
 
             if new_visibility in (ModerationVisibility.visible, ModerationVisibility.unlisted):
@@ -593,15 +591,17 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
 
             updated_count += 1
 
-        session.add(
-            AdminAction(
-                admin_user_id=context.user_id,
-                target_user_id=user.id,
-                action_type="set_user_content_visibility",
-                level=AdminActionLevel.high,
-                note=request.reason or None,
-                tag=new_visibility.name,
-            )
+        # Import here to avoid circular dependency
+        from couchers.servicers.admin import log_admin_action  # noqa: PLC0415
+
+        log_admin_action(
+            session,
+            context,
+            user,
+            "set_user_content_visibility",
+            note=request.reason or None,
+            tag=new_visibility.name,
+            level=AdminActionLevel.high,
         )
 
         return moderation_pb2.SetUserContentVisibilityRes(updated_count=updated_count)

--- a/app/backend/src/couchers/servicers/moderation.py
+++ b/app/backend/src/couchers/servicers/moderation.py
@@ -15,6 +15,8 @@ from couchers.metrics import (
     observe_moderation_visibility_transition,
 )
 from couchers.models import (
+    AdminAction,
+    AdminActionLevel,
     Event,
     EventOccurrence,
     FriendRelationship,
@@ -31,6 +33,7 @@ from couchers.models import (
     ModerationVisibility,
     Notification,
     NotificationDelivery,
+    User,
 )
 from couchers.proto import moderation_pb2, moderation_pb2_grpc
 from couchers.proto.internal import jobs_pb2
@@ -83,6 +86,7 @@ moderationaction2api = {
     ModerationAction.hide: moderation_pb2.MODERATION_ACTION_HIDE,
     ModerationAction.flag: moderation_pb2.MODERATION_ACTION_FLAG,
     ModerationAction.unflag: moderation_pb2.MODERATION_ACTION_UNFLAG,
+    ModerationAction.bulk_set_visibility: moderation_pb2.MODERATION_ACTION_BULK_SET_VISIBILITY,
 }
 
 moderationaction2sql = {
@@ -92,6 +96,7 @@ moderationaction2sql = {
     moderation_pb2.MODERATION_ACTION_HIDE: ModerationAction.hide,
     moderation_pb2.MODERATION_ACTION_FLAG: ModerationAction.flag,
     moderation_pb2.MODERATION_ACTION_UNFLAG: ModerationAction.unflag,
+    moderation_pb2.MODERATION_ACTION_BULK_SET_VISIBILITY: ModerationAction.bulk_set_visibility,
 }
 
 moderationobjecttype2api = {
@@ -117,6 +122,29 @@ moderationobjecttype2model: dict[ModerationObjectType, _ModeratedContent] = {
     ModerationObjectType.friend_request: FriendRelationship,
     ModerationObjectType.event_occurrence: EventOccurrence,
 }
+
+
+def _enqueue_pending_notifications(session: Session, moderation_state_id: int) -> None:
+    """Re-queue any pending notifications linked to the given moderation state whose deliveries were suppressed."""
+    pending_notifications = (
+        session.execute(
+            select(Notification)
+            .where(Notification.moderation_state_id == moderation_state_id)
+            .where(not_(exists().where(NotificationDelivery.notification_id == Notification.id)))
+        )
+        .scalars()
+        .all()
+    )
+
+    # Import here to avoid circular dependency
+    from couchers.notifications.background import handle_notification  # noqa: PLC0415
+
+    for notification in pending_notifications:
+        queue_job(
+            session,
+            job=handle_notification,
+            payload=jobs_pb2.HandleNotificationPayload(notification_id=notification.id),
+        )
 
 
 def moderation_state_to_pb(state: ModerationState, session: Session) -> moderation_pb2.ModerationStateInfo:
@@ -405,25 +433,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
 
         # If visibility becomes VISIBLE or UNLISTED, trigger pending notifications
         if new_visibility in (ModerationVisibility.visible, ModerationVisibility.unlisted):
-            pending_notifications = (
-                session.execute(
-                    select(Notification)
-                    .where(Notification.moderation_state_id == moderation_state.id)
-                    .where(not_(exists().where(NotificationDelivery.notification_id == Notification.id)))
-                )
-                .scalars()
-                .all()
-            )
-
-            # Import here to avoid circular dependency
-            from couchers.notifications.background import handle_notification  # noqa: PLC0415
-
-            for notification in pending_notifications:
-                queue_job(
-                    session,
-                    job=handle_notification,
-                    payload=jobs_pb2.HandleNotificationPayload(notification_id=notification.id),
-                )
+            _enqueue_pending_notifications(session, moderation_state.id)
 
         return moderation_pb2.ModerateContentRes(
             moderation_state=moderation_state_to_pb(moderation_state, session),
@@ -521,3 +531,77 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
         return moderation_pb2.UnflagContentRes(
             moderation_state=moderation_state_to_pb(moderation_state, session),
         )
+
+    def SetUserContentVisibility(
+        self, request: moderation_pb2.SetUserContentVisibilityReq, context: CouchersContext, session: Session
+    ) -> moderation_pb2.SetUserContentVisibilityRes:
+        """Bulk-set visibility on every UMS-governed object authored by the given user."""
+        new_visibility = moderationvisibility2sql[request.visibility]
+        if new_visibility is None:
+            context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "visibility_must_be_specified")
+
+        user = session.execute(select(User).where(User.id == request.user_id)).scalar_one_or_none()
+        if not user:
+            context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
+
+        reason = request.reason or f"Bulk visibility update for user {user.id} to {new_visibility.name}"
+        action = ModerationAction.bulk_set_visibility
+
+        author_exists_clauses = []
+        for model in moderationobjecttype2model.values():
+            author_col = getattr(model, model.__moderation_author_column__)
+            author_exists_clauses.append(
+                exists().where(and_(model.moderation_state_id == ModerationState.id, author_col == user.id))
+            )
+
+        states = session.execute(select(ModerationState).where(or_(*author_exists_clauses))).scalars().all()
+
+        updated_count = 0
+        for moderation_state in states:
+            if moderation_state.visibility == new_visibility:
+                continue
+
+            old_visibility = moderation_state.visibility
+            moderation_state.visibility = new_visibility
+            moderation_state.updated = now()
+
+            log_entry = ModerationLog(
+                moderation_state_id=moderation_state.id,
+                action=action,
+                moderator_user_id=context.user_id,
+                new_visibility=new_visibility,
+                reason=reason,
+            )
+            session.add(log_entry)
+            session.flush()
+
+            queue_item = session.execute(
+                select(ModerationQueueItem)
+                .where(ModerationQueueItem.moderation_state_id == moderation_state.id)
+                .where(ModerationQueueItem.resolved_by_log_id.is_(None))
+                .order_by(ModerationQueueItem.time_created.desc())
+            ).scalar_one_or_none()
+            if queue_item:
+                queue_item.resolved_by_log_id = log_entry.id
+                session.flush()
+
+            observe_moderation_action(action, moderation_state.object_type)
+            observe_moderation_visibility_transition(old_visibility, new_visibility, moderation_state.object_type)
+
+            if new_visibility in (ModerationVisibility.visible, ModerationVisibility.unlisted):
+                _enqueue_pending_notifications(session, moderation_state.id)
+
+            updated_count += 1
+
+        session.add(
+            AdminAction(
+                admin_user_id=context.user_id,
+                target_user_id=user.id,
+                action_type="set_user_content_visibility",
+                level=AdminActionLevel.high,
+                note=request.reason or None,
+                tag=new_visibility.name,
+            )
+        )
+
+        return moderation_pb2.SetUserContentVisibilityRes(updated_count=updated_count)

--- a/app/backend/src/tests/test_moderation.py
+++ b/app/backend/src/tests/test_moderation.py
@@ -14,7 +14,9 @@ from couchers.db import session_scope
 from couchers.jobs.handlers import auto_approve_moderation_queue
 from couchers.jobs.worker import process_job
 from couchers.models import (
+    AdminAction,
     EventOccurrence,
+    FriendRelationship,
     GroupChat,
     HostRequest,
     ModerationAction,
@@ -26,11 +28,12 @@ from couchers.models import (
     ModerationVisibility,
 )
 from couchers.moderation.utils import create_moderation
-from couchers.proto import conversations_pb2, events_pb2, moderation_pb2, notifications_pb2, requests_pb2
+from couchers.proto import api_pb2, conversations_pb2, events_pb2, moderation_pb2, notifications_pb2, requests_pb2
 from couchers.utils import Timestamp_from_datetime, now, today
 from tests.fixtures.db import generate_user, make_friends
 from tests.fixtures.misc import PushCollector, mock_notification_email, process_jobs
 from tests.fixtures.sessions import (
+    api_session,
     conversations_session,
     events_session,
     notifications_session,
@@ -2424,3 +2427,420 @@ def test_event_moderation_state_content(db):
         ]
         assert len(event_items) == 1
         assert event_items[0].moderation_state.content == "My Event Title\n\nMy event description."
+
+
+# ============================================================================
+# Tests for SetUserContentVisibility
+# ============================================================================
+
+
+def _get_moderation_state(session, object_type, object_id):
+    return session.execute(
+        select(ModerationState)
+        .where(ModerationState.object_type == object_type)
+        .where(ModerationState.object_id == object_id)
+    ).scalar_one()
+
+
+def test_SetUserContentVisibility_host_request(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    surfer, surfer_token = generate_user()
+    host, _ = generate_user()
+
+    today_plus_2 = (today() + timedelta(days=2)).isoformat()
+    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    with requests_session(surfer_token) as api:
+        hr_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=host.id,
+                from_date=today_plus_2,
+                to_date=today_plus_3,
+                text=valid_request_text(),
+            )
+        ).host_request_id
+
+    with real_moderation_session(super_token) as api:
+        res = api.SetUserContentVisibility(
+            moderation_pb2.SetUserContentVisibilityReq(
+                user_id=surfer.id,
+                visibility=moderation_pb2.MODERATION_VISIBILITY_SHADOWED,
+            )
+        )
+    # Already shadowed by default — no-op
+    assert res.updated_count == 0
+
+    with real_moderation_session(super_token) as api:
+        res = api.SetUserContentVisibility(
+            moderation_pb2.SetUserContentVisibilityReq(
+                user_id=surfer.id,
+                visibility=moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
+                reason="policy violation",
+            )
+        )
+    assert res.updated_count == 1
+
+    with session_scope() as session:
+        state = _get_moderation_state(session, ModerationObjectType.host_request, hr_id)
+        assert state.visibility == ModerationVisibility.hidden
+
+        log_entries = (
+            session.execute(
+                select(ModerationLog)
+                .where(ModerationLog.moderation_state_id == state.id)
+                .order_by(ModerationLog.time.asc(), ModerationLog.id.asc())
+            )
+            .scalars()
+            .all()
+        )
+        # create log + bulk update log
+        assert len(log_entries) == 2
+        assert log_entries[-1].new_visibility == ModerationVisibility.hidden
+        assert log_entries[-1].moderator_user_id == super_user.id
+        assert log_entries[-1].reason == "policy violation"
+
+
+def test_SetUserContentVisibility_group_chat(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    creator, creator_token = generate_user()
+    other, _ = generate_user()
+    make_friends(creator, other)
+
+    with conversations_session(creator_token) as api:
+        gc_id = api.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[other.id])).group_chat_id
+
+    with real_moderation_session(super_token) as api:
+        api.SetUserContentVisibility(
+            moderation_pb2.SetUserContentVisibilityReq(
+                user_id=creator.id,
+                visibility=moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
+            )
+        )
+
+    with session_scope() as session:
+        state = _get_moderation_state(session, ModerationObjectType.group_chat, gc_id)
+        assert state.visibility == ModerationVisibility.hidden
+
+
+def test_SetUserContentVisibility_event_occurrence(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    creator, creator_token = generate_user()
+
+    with session_scope() as session:
+        create_community(session, 0, 2, "Community", [creator], [], None)
+
+    start_time = now() + timedelta(hours=2)
+    end_time = start_time + timedelta(hours=3)
+    with events_session(creator_token) as api:
+        event_id = api.CreateEvent(
+            events_pb2.CreateEventReq(
+                title="Event",
+                content="Event description.",
+                photo_key=None,
+                offline_information=events_pb2.OfflineEventInformation(
+                    address="Near Null Island",
+                    lat=0.1,
+                    lng=0.2,
+                ),
+                start_time=Timestamp_from_datetime(start_time),
+                end_time=Timestamp_from_datetime(end_time),
+                timezone="UTC",
+            )
+        ).event_id
+
+    with real_moderation_session(super_token) as api:
+        res = api.SetUserContentVisibility(
+            moderation_pb2.SetUserContentVisibilityReq(
+                user_id=creator.id,
+                visibility=moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
+            )
+        )
+    assert res.updated_count == 1
+
+    with session_scope() as session:
+        state = _get_moderation_state(session, ModerationObjectType.event_occurrence, event_id)
+        assert state.visibility == ModerationVisibility.hidden
+
+
+def test_SetUserContentVisibility_friend_request(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    sender, sender_token = generate_user()
+    recipient, _ = generate_user()
+
+    with api_session(sender_token) as api:
+        api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=recipient.id))
+
+    with session_scope() as session:
+        fr_id = session.execute(
+            select(FriendRelationship.id).where(FriendRelationship.from_user_id == sender.id)
+        ).scalar_one()
+
+    with real_moderation_session(super_token) as api:
+        res = api.SetUserContentVisibility(
+            moderation_pb2.SetUserContentVisibilityReq(
+                user_id=sender.id,
+                visibility=moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
+            )
+        )
+    assert res.updated_count == 1
+
+    with session_scope() as session:
+        state = _get_moderation_state(session, ModerationObjectType.friend_request, fr_id)
+        assert state.visibility == ModerationVisibility.hidden
+
+
+def test_SetUserContentVisibility_round_trip(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    surfer, surfer_token = generate_user()
+    host, _ = generate_user()
+
+    today_plus_2 = (today() + timedelta(days=2)).isoformat()
+    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    with requests_session(surfer_token) as api:
+        hr_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=host.id,
+                from_date=today_plus_2,
+                to_date=today_plus_3,
+                text=valid_request_text(),
+            )
+        ).host_request_id
+
+    with real_moderation_session(super_token) as api:
+        api.SetUserContentVisibility(
+            moderation_pb2.SetUserContentVisibilityReq(
+                user_id=surfer.id,
+                visibility=moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
+                reason="first",
+            )
+        )
+        api.SetUserContentVisibility(
+            moderation_pb2.SetUserContentVisibilityReq(
+                user_id=surfer.id,
+                visibility=moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
+                reason="second",
+            )
+        )
+
+    with session_scope() as session:
+        state = _get_moderation_state(session, ModerationObjectType.host_request, hr_id)
+        assert state.visibility == ModerationVisibility.visible
+
+        bulk_log_entries = (
+            session.execute(
+                select(ModerationLog)
+                .where(ModerationLog.moderation_state_id == state.id)
+                .where(ModerationLog.reason.in_(("first", "second")))
+                .order_by(ModerationLog.time.asc(), ModerationLog.id.asc())
+            )
+            .scalars()
+            .all()
+        )
+        assert [entry.new_visibility for entry in bulk_log_entries] == [
+            ModerationVisibility.hidden,
+            ModerationVisibility.visible,
+        ]
+
+
+def test_SetUserContentVisibility_resolves_queue_items(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    surfer, surfer_token = generate_user()
+    host, _ = generate_user()
+
+    today_plus_2 = (today() + timedelta(days=2)).isoformat()
+    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    with requests_session(surfer_token) as api:
+        hr_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=host.id,
+                from_date=today_plus_2,
+                to_date=today_plus_3,
+                text=valid_request_text(),
+            )
+        ).host_request_id
+
+    with session_scope() as session:
+        state = _get_moderation_state(session, ModerationObjectType.host_request, hr_id)
+        queue_item = session.execute(
+            select(ModerationQueueItem).where(ModerationQueueItem.moderation_state_id == state.id)
+        ).scalar_one()
+        assert queue_item.resolved_by_log_id is None
+
+    with real_moderation_session(super_token) as api:
+        api.SetUserContentVisibility(
+            moderation_pb2.SetUserContentVisibilityReq(
+                user_id=surfer.id,
+                visibility=moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
+            )
+        )
+
+    with session_scope() as session:
+        state = _get_moderation_state(session, ModerationObjectType.host_request, hr_id)
+        queue_item = session.execute(
+            select(ModerationQueueItem).where(ModerationQueueItem.moderation_state_id == state.id)
+        ).scalar_one()
+        assert queue_item.resolved_by_log_id is not None
+
+
+def test_SetUserContentVisibility_noop_when_matches(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    surfer, surfer_token = generate_user()
+    host, _ = generate_user()
+
+    today_plus_2 = (today() + timedelta(days=2)).isoformat()
+    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    with requests_session(surfer_token) as api:
+        api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=host.id,
+                from_date=today_plus_2,
+                to_date=today_plus_3,
+                text=valid_request_text(),
+            )
+        )
+
+    with session_scope() as session:
+        log_count_before = len(session.execute(select(ModerationLog)).scalars().all())
+
+    with real_moderation_session(super_token) as api:
+        res = api.SetUserContentVisibility(
+            moderation_pb2.SetUserContentVisibilityReq(
+                user_id=surfer.id,
+                visibility=moderation_pb2.MODERATION_VISIBILITY_SHADOWED,
+            )
+        )
+    assert res.updated_count == 0
+
+    with session_scope() as session:
+        log_count_after = len(session.execute(select(ModerationLog)).scalars().all())
+    assert log_count_after == log_count_before
+
+
+def test_SetUserContentVisibility_unspecified_rejected(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    target, _ = generate_user()
+
+    with real_moderation_session(super_token) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.SetUserContentVisibility(
+                moderation_pb2.SetUserContentVisibilityReq(
+                    user_id=target.id,
+                    visibility=moderation_pb2.MODERATION_VISIBILITY_UNSPECIFIED,
+                )
+            )
+    assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+
+def test_SetUserContentVisibility_non_admin_rejected(db):
+    normal_user, normal_token = generate_user()
+    target, _ = generate_user()
+
+    with real_moderation_session(normal_token) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.SetUserContentVisibility(
+                moderation_pb2.SetUserContentVisibilityReq(
+                    user_id=target.id,
+                    visibility=moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
+                )
+            )
+    assert e.value.code() == grpc.StatusCode.PERMISSION_DENIED
+
+
+def test_SetUserContentVisibility_writes_admin_action(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    surfer, surfer_token = generate_user()
+    host, _ = generate_user()
+
+    today_plus_2 = (today() + timedelta(days=2)).isoformat()
+    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    with requests_session(surfer_token) as api:
+        api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=host.id,
+                from_date=today_plus_2,
+                to_date=today_plus_3,
+                text=valid_request_text(),
+            )
+        )
+
+    with real_moderation_session(super_token) as api:
+        api.SetUserContentVisibility(
+            moderation_pb2.SetUserContentVisibilityReq(
+                user_id=surfer.id,
+                visibility=moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
+                reason="bulk hide",
+            )
+        )
+
+    with session_scope() as session:
+        actions = (
+            session.execute(
+                select(AdminAction)
+                .where(AdminAction.target_user_id == surfer.id)
+                .where(AdminAction.action_type == "set_user_content_visibility")
+            )
+            .scalars()
+            .all()
+        )
+        assert len(actions) == 1
+        assert actions[0].admin_user_id == super_user.id
+        assert actions[0].tag == "hidden"
+        assert actions[0].note == "bulk hide"
+
+
+def test_SetUserContentVisibility_only_touches_target(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    target, target_token = generate_user()
+    other, other_token = generate_user()
+    host, _ = generate_user()
+
+    today_plus_2 = (today() + timedelta(days=2)).isoformat()
+    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+
+    with requests_session(target_token) as api:
+        target_hr_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=host.id,
+                from_date=today_plus_2,
+                to_date=today_plus_3,
+                text=valid_request_text(),
+            )
+        ).host_request_id
+
+    with requests_session(other_token) as api:
+        other_hr_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=host.id,
+                from_date=today_plus_2,
+                to_date=today_plus_3,
+                text=valid_request_text(),
+            )
+        ).host_request_id
+
+    with real_moderation_session(super_token) as api:
+        res = api.SetUserContentVisibility(
+            moderation_pb2.SetUserContentVisibilityReq(
+                user_id=target.id,
+                visibility=moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
+            )
+        )
+    assert res.updated_count == 1
+
+    with session_scope() as session:
+        target_state = _get_moderation_state(session, ModerationObjectType.host_request, target_hr_id)
+        other_state = _get_moderation_state(session, ModerationObjectType.host_request, other_hr_id)
+        assert target_state.visibility == ModerationVisibility.hidden
+        assert other_state.visibility == ModerationVisibility.shadowed
+
+
+def test_SetUserContentVisibility_user_not_found(db):
+    super_user, super_token = generate_user(is_superuser=True)
+
+    with real_moderation_session(super_token) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.SetUserContentVisibility(
+                moderation_pb2.SetUserContentVisibilityReq(
+                    user_id=999999,
+                    visibility=moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
+                )
+            )
+    assert e.value.code() == grpc.StatusCode.NOT_FOUND

--- a/app/proto/moderation.proto
+++ b/app/proto/moderation.proto
@@ -20,6 +20,8 @@ service Moderation {
   rpc FlagContentForReview(FlagContentForReviewReq) returns (FlagContentForReviewRes) {}
 
   rpc UnflagContent(UnflagContentReq) returns (UnflagContentRes) {}
+
+  rpc SetUserContentVisibility(SetUserContentVisibilityReq) returns (SetUserContentVisibilityRes) {}
 }
 
 
@@ -50,6 +52,7 @@ enum ModerationAction {
   MODERATION_ACTION_HIDE = 3;
   MODERATION_ACTION_FLAG = 4;
   MODERATION_ACTION_UNFLAG = 5;
+  MODERATION_ACTION_BULK_SET_VISIBILITY = 6;
 }
 
 enum ModerationObjectType {
@@ -166,4 +169,14 @@ message UnflagContentReq {
 
 message UnflagContentRes {
   ModerationStateInfo moderation_state = 1;
+}
+
+message SetUserContentVisibilityReq {
+  int64 user_id = 1;
+  ModerationVisibility visibility = 2;  // must be set
+  string reason = 3;  // optional; free-form admin note recorded in ModerationLog
+}
+
+message SetUserContentVisibilityRes {
+  int64 updated_count = 1;  // number of ModerationState rows whose visibility changed
 }


### PR DESCRIPTION
Adds a `SetUserContentVisibility` moderation RPC that bulk-sets `ModerationState.visibility` on every UMS-governed object authored by a given user.

Adds a new `ModerationAction.bulk_set_visibility` variant so these log entries are distinguishable from per-item moderation. Each changed state gets a `ModerationLog` entry, resolves any open `ModerationQueueItem`, re-enqueues suppressed notifications when flipping to visible/unlisted, and records an `AdminAction` for the whole operation.

## Testing
Added backend tests in `test_moderation.py` covering host requests, group chats, event occurrences, friend requests, round-trip visibility changes, queue-item resolution, no-op when visibility matches, rejection of unspecified visibility, non-admin rejection, admin action recording, scoping to the target user only, and user-not-found.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me