### PR TITLE
Upgrade PostgreSQL from 17 to 18 (PostGIS 3.5 to 3.6)

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -164,7 +164,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgis/postgis:17-3.5
+        image: postgis/postgis:18-3.6
         env:
           POSTGRES_PASSWORD: testpassword
           POSTGRES_DB: postgres

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     services:
       postgres:
-        image: postgis/postgis:17-3.5
+        image: postgis/postgis:18-3.6
         env:
           POSTGRES_PASSWORD: "06b3890acd2c235c41be0bbfe22f1b386a04bf02eedf8c977486355616be2aa1"
           PGPORT: "6544"

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -295,7 +295,7 @@ test:backend:
     # no docker login
     default: false
   services:
-    - name: postgis/postgis:17-3.5
+    - name: postgis/postgis:18-3.6
       alias: postgres
       command: [
         "postgres",
@@ -348,7 +348,7 @@ test:backend-migrations:
     # no docker login
     default: false
   services:
-    - name: postgis/postgis:17-3.5
+    - name: postgis/postgis:18-3.6
       alias: postgres
       command: [
         "postgres",

--- a/app/deployment/psql.sh
+++ b/app/deployment/psql.sh
@@ -8,7 +8,7 @@ pushd ..
 # - DATABASE_CONNECTION_STRING
 source backup.prod.env
 
-docker_image=${DB_DOCKER_IMAGE:-"postgis/postgis:17-3.5"}
+docker_image=${DB_DOCKER_IMAGE:-"postgis/postgis:18-3.6"}
 
 # --net=host is required so we can hit localhost from inside the container
 docker run --log-driver none --net=host -it $docker_image psql $DATABASE_CONNECTION_STRING

--- a/app/docker-compose.prod.yml
+++ b/app/docker-compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgis/postgis:17-3.5
+    image: postgis/postgis:18-3.6
     command: ["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"]
     restart: always
     stop_grace_period: 30s

--- a/app/docker-compose.test.yml
+++ b/app/docker-compose.test.yml
@@ -1,6 +1,6 @@
 services:
   postgres_tests:
-    image: postgis/postgis:17-3.5
+    image: postgis/postgis:18-3.6
     env_file: postgres.test.env
     command: postgres
       -c shared_preload_libraries=pg_stat_statements

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - 9901:9901
     dns_search: ""
   postgres:
-    image: postgis/postgis:17-3.5
+    image: postgis/postgis:18-3.6
     env_file: postgres.dev.env
     command: ["postgres", "-c", "shared_preload_libraries=pg_stat_statements"]
     # to also log all queries, add: , "-c", "log_statement=all"

--- a/app/postgis/Dockerfile
+++ b/app/postgis/Dockerfile
@@ -2,14 +2,14 @@
 # NOTE: THIS DOCKERFILE IS GENERATED VIA "make update"! PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM postgres:17-bullseye
+FROM postgres:18-trixie
 
 LABEL maintainer="PostGIS Project - https://postgis.net" \
-      org.opencontainers.image.description="PostGIS 3.5.2+dfsg-1.pgdg110+1 spatial database extension with PostgreSQL 17 bullseye" \
+      org.opencontainers.image.description="PostGIS 3.6.3+dfsg-1.pgdg13+1 spatial database extension with PostgreSQL 18 trixie" \
       org.opencontainers.image.source="https://github.com/postgis/docker-postgis"
 
 ENV POSTGIS_MAJOR=3
-ENV POSTGIS_VERSION=3.5.2+dfsg-1.pgdg110+1
+ENV POSTGIS_VERSION=3.6.3+dfsg-1.pgdg13+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \

--- a/app/postgis/initdb-postgis.sh
+++ b/app/postgis/initdb-postgis.sh
@@ -19,7 +19,23 @@ for DB in template_postgis "$POSTGRES_DB"; do
 		-- Reconnect to update pg_setting.resetval
 		-- See https://github.com/postgis/docker-postgis/issues/288
 		\c
-		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
-		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
+		--
+		DO $$
+		DECLARE
+			postgis_major integer;
+			postgis_minor integer;
+		BEGIN
+			SELECT substring(postgis_lib_version() from '^([0-9]+)')::integer,
+				substring(postgis_lib_version() from '^[0-9]+\.([0-9]+)')::integer
+			INTO postgis_major, postgis_minor;
+
+			-- Install the legacy tiger geocoder stack only for PostGIS versions before 3.7.
+			-- fuzzystrmatch is required by postgis_tiger_geocoder, which PostGIS 3.7 and later no longer provide.
+			IF postgis_major < 3 OR (postgis_major = 3 AND postgis_minor < 7) THEN
+				CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+				CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
+			END IF;
+		END
+		$$;
 EOSQL
 done

--- a/app/postgis/readme.md
+++ b/app/postgis/readme.md
@@ -1,3 +1,3 @@
-Copied from https://github.com/postgis/docker-postgis/tree/master/17-3.5. 
+Copied from https://github.com/postgis/docker-postgis/tree/master/18-3.6. 
 
 See a note about `setup-db` command in [app/backend/Makefile](../backend/Makefile) for details.


### PR DESCRIPTION
Bumps our Docker image from `postgis/postgis:17-3.5` to `postgis/postgis:18-3.6` (PostgreSQL 18 on Debian trixie, PostGIS 3.6.3) across the local Dockerfile, all docker-compose files, GitLab CI, GitHub Actions workflows, and the deployment `psql.sh` helper.

PG 18 is not data-compatible with PG 17 on disk, so deploying this requires a `pg_dump` + restore against a fresh data volume. Local devs will need to wipe `data/postgres/pgdata` and let the new container re-initialize.

## Testing
- Verified all `postgis/postgis:17-3.5` and `postgres:17-bullseye` references are updated; only a historical blog post still mentions PG 17.
- CI will exercise the new image via the backend test job on this PR.

Locally:
1. Stop backend + postgres containers, `rm -rf app/data/postgres/pgdata`.
2. `make run-deps` to bring up the new postgres image.
3. Run backend tests via `make setup-db && uv run pytest`.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._