### PR TITLE
Backend: Use node's timezone for public trip date validation

### DIFF
--- a/app/backend/src/couchers/materialized_views.py
+++ b/app/backend/src/couchers/materialized_views.py
@@ -15,9 +15,9 @@ from sqlalchemy.sql import (
     func,
     literal,
     literal_column,
+    select,
     union_all,
 )
-from sqlalchemy.sql import select as sa_select
 from sqlalchemy.sql.functions import percentile_disc
 from sqlalchemy_utils.view import (
     CreateView,
@@ -78,7 +78,7 @@ def create_materialized_view_with_different_ddl(
 
 
 cluster_subscription_counts_selectable = (
-    sa_select(
+    select(
         ClusterSubscription.cluster_id.label("cluster_id"),
         func.count().label("count"),
     )
@@ -110,7 +110,7 @@ class ClusterSubscriptionCount(MatViewBase):
 
 
 cluster_admin_counts_selectable = (
-    sa_select(
+    select(
         ClusterSubscription.cluster_id.label("cluster_id"),
         func.count().label("count"),
     )
@@ -151,7 +151,7 @@ def make_lite_users_selectable(create: bool = False) -> Select[Any]:
         geom_column = User.geom
 
     strong_verification_subquery = (
-        sa_select(User.id, literal(True).label("true"))
+        select(User.id, literal(True).label("true"))
         .select_from(StrongVerificationAttempt)
         .where(StrongVerificationAttempt.has_strong_verification(User))
         .distinct()
@@ -175,7 +175,7 @@ def make_lite_users_selectable(create: bool = False) -> Select[Any]:
 
     # Be sure to modify the LiteUser type if you add/remove columns!
     return (
-        sa_select(
+        select(
             User.id.label("id"),
             User.username.label("username"),
             User.name.label("name"),
@@ -259,7 +259,7 @@ def make_clustered_users_selectable(create: bool = False) -> CompoundSelect[Any]
     # )
 
     cluster_cte = (
-        sa_select(
+        select(
             User.id,
             User.geom,
             # DBSCAN clustering with epsilon=.15 deg (~17 km), minpoints=5, cluster will be NULL for not in any cluster
@@ -277,14 +277,14 @@ def make_clustered_users_selectable(create: bool = False) -> CompoundSelect[Any]
         cluster_geom = cluster_cte.c.geom
 
     clustered_users = (
-        sa_select(centroid_geom.label("geom"), func.count().label("count"))
+        select(centroid_geom.label("geom"), func.count().label("count"))
         .select_from(cluster_cte)
         .where(cluster_cte.c.cluster_id != None)
         .group_by(cluster_cte.c.cluster_id)
     )
 
     isolated_users = (
-        sa_select(cluster_geom.label("geom"), literal(1, type_=Integer).label("count"))
+        select(cluster_geom.label("geom"), literal(1, type_=Integer).label("count"))
         .select_from(cluster_cte)
         .where(cluster_cte.c.cluster_id == None)
     )
@@ -312,16 +312,16 @@ def float_(stmt: Any) -> Any:
 
 
 # this subquery gets the time that the request was sent
-t = sa_select(Message.conversation_id, Message.time).where(Message.message_type == MessageType.chat_created).subquery()
+t = select(Message.conversation_id, Message.time).where(Message.message_type == MessageType.chat_created).subquery()
 # this subquery gets the time that the user responded to the request
 s = (
-    sa_select(Message.conversation_id, Message.author_id, func.min(Message.time).label("time"))
+    select(Message.conversation_id, Message.author_id, func.min(Message.time).label("time"))
     .group_by(Message.conversation_id, Message.author_id)
     .subquery()
 )
 all_responses = union_all(
     # host request responses
-    sa_select(
+    select(
         HostRequest.recipient_user_id.label("user_id"),
         (s.c.time - t.c.time).label("response_time"),
     )
@@ -330,7 +330,7 @@ all_responses = union_all(
         s, and_(s.c.conversation_id == HostRequest.conversation_id, s.c.author_id == HostRequest.recipient_user_id)
     ),
     # activeness probes
-    sa_select(
+    select(
         ActivenessProbe.user_id,
         (
             # expired probes have a responded time for when they were marked responded
@@ -345,7 +345,7 @@ all_responses = union_all(
     ),
 ).subquery()
 
-user_response_rates_selectable = sa_select(
+user_response_rates_selectable = select(
     all_responses.c.user_id.label("user_id"),
     # number of requests received
     func.count().label("requests"),

--- a/app/backend/src/couchers/models/clusters.py
+++ b/app/backend/src/couchers/models/clusters.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
     func,
     text,
 )
+from sqlalchemy import select as sa_select
 from sqlalchemy.orm import (
     DynamicMapped,
     Mapped,
@@ -27,6 +28,7 @@ from sqlalchemy.orm import (
 from sqlalchemy.sql import expression
 
 from couchers.models.base import Base, Geom, communities_seq
+from couchers.models.static import TimezoneArea
 from couchers.utils import get_coordinates
 
 if TYPE_CHECKING:
@@ -67,6 +69,14 @@ class Node(Base, kw_only=True):
     parent_node_id: Mapped[int | None] = mapped_column(ForeignKey("nodes.id"), default=None, index=True)
     geom: Mapped[Geom] = deferred(mapped_column(Geometry(geometry_type="MULTIPOLYGON", srid=4326), nullable=False))
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
+
+    timezone = column_property(
+        sa_select(TimezoneArea.tzid)
+        .where(func.ST_Contains(TimezoneArea.geom, func.ST_PointOnSurface(geom)))
+        .limit(1)
+        .scalar_subquery(),
+        deferred=True,
+    )
 
     parent_node: Mapped[Node] = relationship(init=False, back_populates="child_nodes", remote_side="Node.id")
     child_nodes: Mapped[list[Node]] = relationship(init=False)

--- a/app/backend/src/couchers/models/clusters.py
+++ b/app/backend/src/couchers/models/clusters.py
@@ -14,9 +14,9 @@ from sqlalchemy import (
     String,
     UniqueConstraint,
     func,
+    select,
     text,
 )
-from sqlalchemy import select as sa_select
 from sqlalchemy.orm import (
     DynamicMapped,
     Mapped,
@@ -71,7 +71,7 @@ class Node(Base, kw_only=True):
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     timezone = column_property(
-        sa_select(TimezoneArea.tzid)
+        select(TimezoneArea.tzid)
         .where(func.ST_Contains(TimezoneArea.geom, func.ST_PointOnSurface(geom)))
         .limit(1)
         .scalar_subquery(),

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -21,10 +21,10 @@ from sqlalchemy import (
     and_,
     func,
     or_,
+    select,
     text,
 )
 from sqlalchemy import LargeBinary as Binary
-from sqlalchemy import select as sa_select
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import DynamicMapped, Mapped, column_property, mapped_column, relationship
 from sqlalchemy.sql import expression
@@ -135,7 +135,7 @@ class User(Base, kw_only=True):
     regions_lived: Mapped[list[Region]] = relationship(init=False, secondary="regions_lived", order_by="Region.name")
 
     timezone = column_property(
-        sa_select(TimezoneArea.tzid).where(func.ST_Contains(TimezoneArea.geom, geom)).limit(1).scalar_subquery(),
+        select(TimezoneArea.tzid).where(func.ST_Contains(TimezoneArea.geom, geom)).limit(1).scalar_subquery(),
         deferred=True,
     )
 

--- a/app/backend/src/couchers/servicers/public_trips.py
+++ b/app/backend/src/couchers/servicers/public_trips.py
@@ -77,7 +77,7 @@ class PublicTrips(public_trips_pb2_grpc.PublicTripsServicer):
         if not from_date or not to_date:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_date")
 
-        today = today_in_timezone(user.timezone)
+        today = today_in_timezone(node.timezone)
 
         if from_date < today:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "date_from_before_today")
@@ -222,8 +222,7 @@ class PublicTrips(public_trips_pb2_grpc.PublicTripsServicer):
         )
 
         if editing_content:
-            user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
-            today_local = today_in_timezone(user.timezone)
+            today_local = today_in_timezone(public_trip.node.timezone)
 
             if public_trip.to_date < today_local:
                 context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "public_trip_in_past")

--- a/app/backend/src/tests/test_public_trips.py
+++ b/app/backend/src/tests/test_public_trips.py
@@ -1,4 +1,5 @@
-from datetime import timedelta
+from datetime import date, timedelta
+from unittest.mock import patch
 
 import grpc
 import pytest
@@ -160,22 +161,30 @@ def test_create_public_trip_allows_region_and_narrower(db, node_type):
 
 
 def test_create_public_trip_in_past_uses_node_timezone(db):
-    # Default user geom resolves to America/New_York, but the node geom is in Europe/Helsinki.
-    # The past-date check must use the node's timezone (the destination), not the user's home.
+    # Default user geom resolves to America/New_York; the node's geom is in Europe/Helsinki.
+    # Simulate a moment where Helsinki has already rolled into the next day (2026-01-16)
+    # while NYC is still on 2026-01-15. A from_date of 2026-01-15 is "today" in NYC but
+    # "yesterday" in Helsinki, and must be rejected because the check uses the node's tz.
     _, token = generate_user()
     node_id = _make_node()
 
-    with public_trips_session(token) as api:
-        with pytest.raises(grpc.RpcError) as e:
-            api.CreatePublicTrip(
-                public_trips_pb2.CreatePublicTripReq(
-                    node_id=node_id,
-                    from_date=(today() - timedelta(days=2)).isoformat(),
-                    to_date=(today() + timedelta(days=1)).isoformat(),
-                    description=VALID_DESCRIPTION,
+    fake_today_by_tz = {"America/New_York": date(2026, 1, 15), "Europe/Helsinki": date(2026, 1, 16)}
+
+    with patch(
+        "couchers.servicers.public_trips.today_in_timezone",
+        side_effect=lambda tz: fake_today_by_tz[tz],
+    ):
+        with public_trips_session(token) as api:
+            with pytest.raises(grpc.RpcError) as e:
+                api.CreatePublicTrip(
+                    public_trips_pb2.CreatePublicTripReq(
+                        node_id=node_id,
+                        from_date="2026-01-15",
+                        to_date="2026-01-20",
+                        description=VALID_DESCRIPTION,
+                    )
                 )
-            )
-        assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+            assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
 
 
 def test_create_public_trip_date_errors(db):

--- a/app/backend/src/tests/test_public_trips.py
+++ b/app/backend/src/tests/test_public_trips.py
@@ -26,9 +26,10 @@ VALID_DESCRIPTION = (
 
 
 def _make_node(node_type: NodeType = NodeType.locality) -> int:
+    # Polygon inside the fake Europe/Helsinki timezone area so node.timezone resolves.
     with session_scope() as session:
         node = Node(
-            geom=to_multi(create_polygon_lat_lng([[0, 0], [0, 2], [2, 2], [2, 0], [0, 0]])),
+            geom=to_multi(create_polygon_lat_lng([[60, 24], [60, 26], [62, 26], [62, 24], [60, 24]])),
             node_type=node_type,
         )
         session.add(node)
@@ -158,6 +159,25 @@ def test_create_public_trip_allows_region_and_narrower(db, node_type):
         assert res.trip_id > 0
 
 
+def test_create_public_trip_in_past_uses_node_timezone(db):
+    # Default user geom resolves to America/New_York, but the node geom is in Europe/Helsinki.
+    # The past-date check must use the node's timezone (the destination), not the user's home.
+    _, token = generate_user()
+    node_id = _make_node()
+
+    with public_trips_session(token) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.CreatePublicTrip(
+                public_trips_pb2.CreatePublicTripReq(
+                    node_id=node_id,
+                    from_date=(today() - timedelta(days=2)).isoformat(),
+                    to_date=(today() + timedelta(days=1)).isoformat(),
+                    description=VALID_DESCRIPTION,
+                )
+            )
+        assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+
 def test_create_public_trip_date_errors(db):
     _, token = generate_user()
     node_id = _make_node()
@@ -168,7 +188,7 @@ def test_create_public_trip_date_errors(db):
             api.CreatePublicTrip(
                 public_trips_pb2.CreatePublicTripReq(
                     node_id=node_id,
-                    from_date=(today() - timedelta(days=1)).isoformat(),
+                    from_date=(today() - timedelta(days=2)).isoformat(),
                     to_date=(today() + timedelta(days=1)).isoformat(),
                     description="Visiting town!",
                 )
@@ -564,7 +584,7 @@ def test_update_public_trip_not_owner(db):
 def test_update_public_trip_in_past(db):
     user, token = generate_user()
     node_id = _make_node()
-    trip_id = _create_trip_directly(user.id, node_id, today() - timedelta(days=10), today() - timedelta(days=1))
+    trip_id = _create_trip_directly(user.id, node_id, today() - timedelta(days=10), today() - timedelta(days=2))
 
     with public_trips_session(token) as api:
         with pytest.raises(grpc.RpcError) as e:


### PR DESCRIPTION
Public trip date validation (`CreatePublicTrip` / `UpdatePublicTrip`) previously used the **creator's** home timezone to decide what "today" meant. This is wrong — a user in NYC can create a public trip in Helsinki, and the correctness of the past-date check should depend on where the trip is, not where the user lives. This also caused a flaky test (`test_update_public_trip_in_past`) that failed during the ~00:00–05:00 UTC window because UTC `today() - 1` could equal NYC's "today".

This PR adds a `timezone` column_property on `Node` (mirroring the pattern on `User`, but wrapping the MULTIPOLYGON geom in `ST_PointOnSurface` so we always get an interior point) and switches the `CreatePublicTrip`/`UpdatePublicTrip` past-date checks to use the node's timezone. `ListPublicTrips*` still uses UTC `today()` — it spans many nodes and ~1 day of slack there is fine.

No migration — the column is computed at query time and `deferred=True` so default `SELECT Node` queries pay zero cost.

## Testing
- Updated `_make_node` test helper to use a Helsinki polygon so `node.timezone` resolves to something non-UTC in tests.
- Added `test_create_public_trip_in_past_uses_node_timezone` — user in NYC (default), node in Helsinki, past `from_date` → rejected with `INVALID_ARGUMENT`.
- Padded `test_update_public_trip_in_past` from `today() - 1` to `today() - 2` to be robust against any UTC/local boundary.
- All 31 tests in `test_public_trips.py` pass; `make format` and `make mypy` clean.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._