### PR TITLE
Rename stale NOT NULL constraints after PG 18 upgrade

### DIFF
--- a/app/backend/src/couchers/migrations/versions/0143_rename_stale_not_null_constraints.py
+++ b/app/backend/src/couchers/migrations/versions/0143_rename_stale_not_null_constraints.py
@@ -1,0 +1,66 @@
+"""Rename stale NOT NULL constraints left over from renamed columns
+
+Revision ID: 0143
+Revises: 0142
+Create Date: 2026-04-19 12:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0143"
+down_revision = "0142"
+branch_labels = None
+depends_on = None
+
+
+# (table, old_constraint_name, new_constraint_name)
+RENAMES = [
+    (
+        "host_requests",
+        "host_requests_from_last_seen_message_id_not_null",
+        "host_requests_initiator_last_seen_message_id_not_null",
+    ),
+    (
+        "host_requests",
+        "host_requests_from_sent_reference_reminders_not_null",
+        "host_requests_initiator_sent_reference_reminders_not_null",
+    ),
+    ("host_requests", "host_requests_from_user_id_not_null", "host_requests_initiator_user_id_not_null"),
+    ("host_requests", "host_requests_is_surfer_archived_not_null", "host_requests_is_initiator_archived_not_null"),
+    ("host_requests", "host_requests_is_host_archived_not_null", "host_requests_is_recipient_archived_not_null"),
+    (
+        "host_requests",
+        "host_requests_to_last_seen_message_id_not_null",
+        "host_requests_recipient_last_seen_message_id_not_null",
+    ),
+    (
+        "host_requests",
+        "host_requests_to_sent_reference_reminders_not_null",
+        "host_requests_recipient_sent_reference_reminders_not_null",
+    ),
+    (
+        "host_requests",
+        "host_requests_host_sent_request_reminders_not_null",
+        "host_requests_recipient_sent_request_reminders_not_null",
+    ),
+    ("host_requests", "host_requests_to_user_id_not_null", "host_requests_recipient_user_id_not_null"),
+    (
+        "postal_verification_attempts",
+        "postal_verification_attempts_country_not_null",
+        "postal_verification_attempts_country_code_not_null",
+    ),
+    ("users", "users_added_to_mailing_list_not_null", "users_in_sync_with_newsletter_not_null"),
+    ("users", "users_daily_order_key_not_null", "users_recommendation_score_not_null"),
+]
+
+
+def upgrade() -> None:
+    for table, old, new in RENAMES:
+        op.execute(f"ALTER TABLE {table} RENAME CONSTRAINT {old} TO {new}")
+
+
+def downgrade() -> None:
+    for table, old, new in RENAMES:
+        op.execute(f"ALTER TABLE {table} RENAME CONSTRAINT {new} TO {old}")

--- a/app/backend/src/couchers/migrations/versions/0143_rename_stale_not_null_constraints.py
+++ b/app/backend/src/couchers/migrations/versions/0143_rename_stale_not_null_constraints.py
@@ -15,52 +15,79 @@ branch_labels = None
 depends_on = None
 
 
-# (table, old_constraint_name, new_constraint_name)
-RENAMES = [
-    (
-        "host_requests",
-        "host_requests_from_last_seen_message_id_not_null",
-        "host_requests_initiator_last_seen_message_id_not_null",
-    ),
-    (
-        "host_requests",
-        "host_requests_from_sent_reference_reminders_not_null",
-        "host_requests_initiator_sent_reference_reminders_not_null",
-    ),
-    ("host_requests", "host_requests_from_user_id_not_null", "host_requests_initiator_user_id_not_null"),
-    ("host_requests", "host_requests_is_surfer_archived_not_null", "host_requests_is_initiator_archived_not_null"),
-    ("host_requests", "host_requests_is_host_archived_not_null", "host_requests_is_recipient_archived_not_null"),
-    (
-        "host_requests",
-        "host_requests_to_last_seen_message_id_not_null",
-        "host_requests_recipient_last_seen_message_id_not_null",
-    ),
-    (
-        "host_requests",
-        "host_requests_to_sent_reference_reminders_not_null",
-        "host_requests_recipient_sent_reference_reminders_not_null",
-    ),
-    (
-        "host_requests",
-        "host_requests_host_sent_request_reminders_not_null",
-        "host_requests_recipient_sent_request_reminders_not_null",
-    ),
-    ("host_requests", "host_requests_to_user_id_not_null", "host_requests_recipient_user_id_not_null"),
-    (
-        "postal_verification_attempts",
-        "postal_verification_attempts_country_not_null",
-        "postal_verification_attempts_country_code_not_null",
-    ),
-    ("users", "users_added_to_mailing_list_not_null", "users_in_sync_with_newsletter_not_null"),
-    ("users", "users_daily_order_key_not_null", "users_recommendation_score_not_null"),
-]
-
-
 def upgrade() -> None:
-    for table, old, new in RENAMES:
-        op.execute(f"ALTER TABLE {table} RENAME CONSTRAINT {old} TO {new}")
+    op.execute(
+        "ALTER TABLE host_requests RENAME CONSTRAINT host_requests_from_last_seen_message_id_not_null TO host_requests_initiator_last_seen_message_id_not_null"
+    )
+    op.execute(
+        "ALTER TABLE host_requests RENAME CONSTRAINT host_requests_from_sent_reference_reminders_not_null TO host_requests_initiator_sent_reference_reminders_not_null"
+    )
+    op.execute(
+        "ALTER TABLE host_requests RENAME CONSTRAINT host_requests_from_user_id_not_null TO host_requests_initiator_user_id_not_null"
+    )
+    op.execute(
+        "ALTER TABLE host_requests RENAME CONSTRAINT host_requests_is_surfer_archived_not_null TO host_requests_is_initiator_archived_not_null"
+    )
+    op.execute(
+        "ALTER TABLE host_requests RENAME CONSTRAINT host_requests_is_host_archived_not_null TO host_requests_is_recipient_archived_not_null"
+    )
+    op.execute(
+        "ALTER TABLE host_requests RENAME CONSTRAINT host_requests_to_last_seen_message_id_not_null TO host_requests_recipient_last_seen_message_id_not_null"
+    )
+    op.execute(
+        "ALTER TABLE host_requests RENAME CONSTRAINT host_requests_to_sent_reference_reminders_not_null TO host_requests_recipient_sent_reference_reminders_not_null"
+    )
+    op.execute(
+        "ALTER TABLE host_requests RENAME CONSTRAINT host_requests_host_sent_request_reminders_not_null TO host_requests_recipient_sent_request_reminders_not_null"
+    )
+    op.execute(
+        "ALTER TABLE host_requests RENAME CONSTRAINT host_requests_to_user_id_not_null TO host_requests_recipient_user_id_not_null"
+    )
+    op.execute(
+        "ALTER TABLE postal_verification_attempts RENAME CONSTRAINT postal_verification_attempts_country_not_null TO postal_verification_attempts_country_code_not_null"
+    )
+    op.execute(
+        "ALTER TABLE users RENAME CONSTRAINT users_added_to_mailing_list_not_null TO users_in_sync_with_newsletter_not_null"
+    )
+    op.execute(
+        "ALTER TABLE users RENAME CONSTRAINT users_daily_order_key_not_null TO users_recommendation_score_not_null"
+    )
 
 
 def downgrade() -> None:
-    for table, old, new in RENAMES:
-        op.execute(f"ALTER TABLE {table} RENAME CONSTRAINT {new} TO {old}")
+    op.execute(
+        "ALTER TABLE users RENAME CONSTRAINT users_recommendation_score_not_null TO users_daily_order_key_not_null"
+    )
+    op.execute(
+        "ALTER TABLE users RENAME CONSTRAINT users_in_sync_with_newsletter_not_null TO users_added_to_mailing_list_not_null"
+    )
+    op.execute(
+        "ALTER TABLE postal_verification_attempts RENAME CONSTRAINT postal_verification_attempts_country_code_not_null TO postal_verification_attempts_country_not_null"
+    )
+    op.execute(
+        "ALTER TABLE host_requests RENAME CONSTRAINT host_requests_recipient_user_id_not_null TO host_requests_to_user_id_not_null"
+    )
+    op.execute(
+        "ALTER TABLE host_requests RENAME CONSTRAINT host_requests_recipient_sent_request_reminders_not_null TO host_requests_host_sent_request_reminders_not_null"
+    )
+    op.execute(
+        "ALTER TABLE host_requests RENAME CONSTRAINT host_requests_recipient_sent_reference_reminders_not_null TO host_requests_to_sent_reference_reminders_not_null"
+    )
+    op.execute(
+        "ALTER TABLE host_requests RENAME CONSTRAINT host_requests_recipient_last_seen_message_id_not_null TO host_requests_to_last_seen_message_id_not_null"
+    )
+    op.execute(
+        "ALTER TABLE host_requests RENAME CONSTRAINT host_requests_is_recipient_archived_not_null TO host_requests_is_host_archived_not_null"
+    )
+    op.execute(
+        "ALTER TABLE host_requests RENAME CONSTRAINT host_requests_is_initiator_archived_not_null TO host_requests_is_surfer_archived_not_null"
+    )
+    op.execute(
+        "ALTER TABLE host_requests RENAME CONSTRAINT host_requests_initiator_user_id_not_null TO host_requests_from_user_id_not_null"
+    )
+    op.execute(
+        "ALTER TABLE host_requests RENAME CONSTRAINT host_requests_initiator_sent_reference_reminders_not_null TO host_requests_from_sent_reference_reminders_not_null"
+    )
+    op.execute(
+        "ALTER TABLE host_requests RENAME CONSTRAINT host_requests_initiator_last_seen_message_id_not_null TO host_requests_from_last_seen_message_id_not_null"
+    )


### PR DESCRIPTION
Fixes `test:backend-migrations` failing on develop after the PG 18 upgrade.

PG 18's `pg_dump` emits the name of a NOT NULL constraint when it differs from the default `<table>_<column>_not_null` format. Several columns were renamed in earlier migrations without renaming the auto-generated NOT NULL constraints, so pg_dump now emits stale names on the migrations side but not on the `create_all()` side, producing a diff in the migration test.

Affected constraints (12 total) are from column renames in migrations 0025 (`from_`/`to_` → `surfer`/`host`), 0045 (`daily_order_key` → `recommendation_score`), 0056 (`added_to_mailing_list` → `in_sync_with_newsletter`), 0140 (`surfer`/`host` → `initiator`/`recipient`), and 0142 (`country` → `country_code`). Migration 0143 renames each stale NOT NULL constraint to match its current column name. Purely cosmetic — no data or runtime behavior changes.

## Testing
Verified in CI: `test:backend-migrations` should now pass.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._