### PR TITLE
Fix PR skill branch naming guidance

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -29,11 +29,11 @@ If there are no meaningful changes to commit, tell the user and stop.
 Branch names in this repo follow the pattern: `<area>/<type>/<short-description>`
 
 Where:
-- `<area>` is one of: `backend`, `web`, `frontend`, `mobile`, or a username/handle for cross-cutting changes
+- `<area>` is one of: `backend`, `web`, `frontend`, `mobile`, `devops`, `docs`, or another area that matches the changed files. For cross-cutting changes spanning multiple areas, pick the one that best describes the change.
 - `<type>` is one of: `feature`, `bugfix`, `fix`, `refactor`, or similar
 - `<short-description>` is a short kebab-case description
 
-Infer area and type from the changed files and the nature of the changes. If you can't determine the area, use the user's GitHub username from `git config user.name` (lowercased).
+Infer area and type from the changed files and the nature of the changes. Never use a username as the area.
 
 ### 3. Run linters and formatters
 


### PR DESCRIPTION
Drops the username fallback from the PR skill's branch-naming rule and expands the allowed area list (adds `devops` and `docs`, and explicitly permits other areas that match the changed files). The previous wording caused the skill to pick `aapeli/...` for a backend-only change instead of `backend/...`.

## Testing
Re-ran the PR skill on this very change — it picked `docs/fix/...` as expected.

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._