### PR TITLE
Fix nginx outage mode by moving envoy upstream out of nginx.conf

### DIFF
--- a/app/nginx/nginx.conf
+++ b/app/nginx/nginx.conf
@@ -60,11 +60,6 @@ http {
         # Virtual Host Configs
         ##
 
-        upstream envoy_backend {
-                server envoy:8888;
-                keepalive 32;
-        }
-
         include /etc/nginx/sites-enabled/*;
 
         resolver 1.1.1.1;

--- a/app/nginx/sites-enabled/_upstreams.conf
+++ b/app/nginx/sites-enabled/_upstreams.conf
@@ -1,0 +1,4 @@
+upstream envoy_backend {
+    server envoy:8888;
+    keepalive 32;
+}


### PR DESCRIPTION
The `envoy_backend` upstream was defined directly in `nginx.conf`, which meant nginx tried to resolve `envoy:8888` at startup. When `OUTAGE_REDIRECT_URL` is set, `run.sh` clears `sites-enabled/*` and writes only `outage.conf` — but the upstream block in `nginx.conf` stayed, so nginx failed to start because envoy isn't running during an outage.

Moved the upstream into `sites-enabled/_upstreams.conf` so it's removed alongside `api.conf`/`web.conf` in outage mode. `upstream` must live in the `http {}` context, and `sites-enabled/*` is already included from there, so this is a valid place for it.

## Testing
- Manually inspected: in normal mode, `_upstreams.conf` is included and `envoy_backend` is available to `api.conf`/`web.conf`.
- In outage mode, `run.sh` removes everything under `sites-enabled/` (including `_upstreams.conf`) and writes `outage.conf`, which doesn't reference any upstream — so nginx no longer needs to resolve `envoy` at startup.

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._