### PR TITLE
Fix docker-compose for dev

### DIFF
--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     command: ["postgres", "-c", "shared_preload_libraries=pg_stat_statements"]
     # to also log all queries, add: , "-c", "log_statement=all"
     volumes:
-      - "./data/postgres/pgdata:/var/lib/postgresql/data"
+      - "./data/postgres/:/var/lib/postgresql/"
     restart: unless-stopped
     ports:
       - 6545:6545


### PR DESCRIPTION
Fixes the dev docker-compose so the full postgres directory is mounted instead of just the `pgdata` subdirectory. This keeps config files that postgres writes alongside `pgdata` together with the data, which avoids issues when starting up the dev database.

## Testing
- Start the dev environment with `docker-compose up` from `app/` and confirm postgres comes up cleanly.

**Backend checklist**
- [x] Run the backend locally and it works

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._