### PR TITLE
Fix AccessStats crash on INET ip_address and end_time bound

### DIFF
--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -910,7 +910,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
             )
             .where(UserActivity.user_id == user.id)
             .where(UserActivity.period >= start_time)
-            .where(UserActivity.period >= end_time)
+            .where(UserActivity.period <= end_time)
             .order_by(func.max(UserActivity.period).desc())
             .group_by(UserActivity.ip_address, UserActivity.user_agent)
         ).all()
@@ -918,11 +918,12 @@ class Admin(admin_pb2_grpc.AdminServicer):
         out = admin_pb2.AccessStatsRes()
 
         for ip_address, user_agent, api_call_count, periods_count, first_seen, last_seen in user_activity:
+            ip_address_str = str(ip_address) if ip_address is not None else None
             user_agent_data = user_agents_parse(user_agent or "")
-            asn = geoip_asn(ip_address)
+            asn = geoip_asn(ip_address_str)
             out.stats.append(
                 admin_pb2.AccessStat(
-                    ip_address=ip_address,
+                    ip_address=ip_address_str,
                     asn=str(asn[0]) if asn else None,
                     asorg=str(asn[1]) if asn else None,
                     asnetwork=str(asn[2]) if asn else None,
@@ -930,7 +931,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
                     operating_system=user_agent_data.os.family,
                     browser=user_agent_data.browser.family,
                     device=user_agent_data.device.family,
-                    approximate_location=geoip_approximate_location(ip_address) or "Unknown",
+                    approximate_location=geoip_approximate_location(ip_address_str) or "Unknown",
                     api_call_count=api_call_count,
                     periods_count=periods_count,
                     first_seen=Timestamp_from_datetime(first_seen),

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -896,8 +896,10 @@ class Admin(admin_pb2_grpc.AdminServicer):
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
-        start_time = to_aware_datetime(request.start_time) if request.start_time else now() - timedelta(days=90)
-        end_time = to_aware_datetime(request.end_time) if request.end_time else now()
+        start_time = (
+            to_aware_datetime(request.start_time) if request.HasField("start_time") else now() - timedelta(days=90)
+        )
+        end_time = to_aware_datetime(request.end_time) if request.HasField("end_time") else now()
 
         user_activity = session.execute(
             select(

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -13,6 +13,7 @@ from couchers.models import (
     ModerationUserList,
     Reference,
     User,
+    UserActivity,
     UserSession,
 )
 from couchers.proto import account_pb2, admin_pb2, auth_pb2, events_pb2, references_pb2, reporting_pb2
@@ -848,6 +849,63 @@ def test_admin_delete_account_url(db, push_collector: PushCollector):
     assert push.content.body == "You can restore it within 7 days using the link we emailed you."
     mock.assert_called_once()
     e = email_fields(mock)
+
+
+def test_AccessStats(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    normal_user, normal_token = generate_user()
+
+    # Insert UserActivity rows: a couple inside the default 90-day window, one well
+    # outside it, and one with NULL ip_address / user_agent. The INET column is
+    # returned by psycopg3 as an IPv4Address/IPv6Address object, which used to
+    # crash the proto string assignment.
+    in_window_1 = now() - timedelta(days=1)
+    in_window_2 = now() - timedelta(days=10)
+    out_of_window = now() - timedelta(days=200)
+    with session_scope() as session:
+        session.add(
+            UserActivity(
+                user_id=normal_user.id, period=in_window_1, ip_address="1.2.3.4", user_agent="ua-a", api_calls=5
+            )
+        )
+        session.add(
+            UserActivity(
+                user_id=normal_user.id, period=in_window_2, ip_address="2001:db8::1", user_agent="ua-b", api_calls=3
+            )
+        )
+        session.add(
+            UserActivity(
+                user_id=normal_user.id, period=out_of_window, ip_address="9.9.9.9", user_agent="ua-old", api_calls=99
+            )
+        )
+        session.add(UserActivity(user_id=normal_user.id, period=in_window_1, api_calls=1))
+
+    with real_admin_session(super_token) as api:
+        res = api.AccessStats(admin_pb2.AccessStatsReq(user=normal_user.username))
+
+    by_ip = {s.ip_address: s for s in res.stats}
+    assert "1.2.3.4" in by_ip
+    assert by_ip["1.2.3.4"].api_call_count == 5
+    assert by_ip["1.2.3.4"].user_agent == "ua-a"
+    assert "2001:db8::1" in by_ip
+    assert by_ip["2001:db8::1"].api_call_count == 3
+    # NULL ip_address row produces an empty-string ip_address in the proto
+    assert "" in by_ip
+    assert by_ip[""].api_call_count == 1
+    # out-of-window row is excluded by the 90-day default
+    assert "9.9.9.9" not in by_ip
+
+    # explicit end_time should bound the upper end of the window (regression: was >=)
+    with real_admin_session(super_token) as api:
+        res = api.AccessStats(
+            admin_pb2.AccessStatsReq(
+                user=normal_user.username,
+                start_time=Timestamp_from_datetime(now() - timedelta(days=5)),
+                end_time=Timestamp_from_datetime(now()),
+            )
+        )
+    ips = {s.ip_address for s in res.stats}
+    assert ips == {"1.2.3.4", ""}
 
 
 def test_SetLastDonated(db):


### PR DESCRIPTION
Fixes a crash and two related filter bugs in the admin `AccessStats` RPC.

- `UserActivity.ip_address` is an `INET` column. psycopg3 returns INET values as `IPv4Address`/`IPv6Address` objects; passing those directly to a proto3 string field raises `TypeError: bad argument type for built-in operation`. Wrap in `str()` (and pass to the geoip helpers, which expect strings).
- The end-of-window filter was `UserActivity.period >= end_time`; corrected to `<=` so it actually bounds the upper end.
- `if request.start_time` is always truthy for an unset proto3 message field, so the `now() - timedelta(days=90)` / `now()` defaults were dead code and both bounds defaulted to the epoch when callers omitted the timestamps. Switched to `request.HasField(...)`. (This was masked in production by the `>=` bug above — with both timestamps sent by the client, the `>=` typo just collapsed the filter to `period >= end_time`, returning a sliver of recent rows that then crashed on the IPv4Address proto bug.)

Added `test_AccessStats` covering the INET→str conversion, NULL `ip_address` handling, the default 90-day window, and the explicit `end_time` upper bound.

## Testing
`uv run pytest src/tests/test_admin.py::test_AccessStats` passes. The new test fails without the servicer fixes (proto crash, then empty results once `<=` is applied without HasField).

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._