### PR TITLE
Backend: enforce unique active friend relationship per user pair

### DIFF
--- a/app/backend/src/couchers/migrations/versions/0146_unique_active_friend_relationship.py
+++ b/app/backend/src/couchers/migrations/versions/0146_unique_active_friend_relationship.py
@@ -1,0 +1,46 @@
+"""Unique active friend relationship per user pair
+
+Revision ID: 0146
+Revises: 0145
+Create Date: 2026-04-24 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0146"
+down_revision = "0145"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # For each unordered user pair with more than one active (pending/accepted)
+    # friend_relationship, cancel all but the latest (highest id) row.
+    op.execute("""
+        UPDATE friend_relationships
+        SET status = 'cancelled', time_responded = now()
+        WHERE id IN (
+            SELECT id FROM (
+                SELECT id,
+                       row_number() OVER (
+                           PARTITION BY least(from_user_id, to_user_id),
+                                        greatest(from_user_id, to_user_id)
+                           ORDER BY id DESC
+                       ) AS rn
+                FROM friend_relationships
+                WHERE status IN ('pending', 'accepted')
+            ) ranked
+            WHERE rn > 1
+        )
+    """)
+    op.execute("""
+        CREATE UNIQUE INDEX uq_friend_relationships_active_pair
+        ON friend_relationships (least(from_user_id, to_user_id), greatest(from_user_id, to_user_id))
+        WHERE status IN ('pending', 'accepted')
+    """)
+
+
+def downgrade() -> None:
+    op.drop_index("uq_friend_relationships_active_pair", table_name="friend_relationships")

--- a/app/backend/src/couchers/models/rest.py
+++ b/app/backend/src/couchers/models/rest.py
@@ -69,7 +69,6 @@ class FriendRelationship(Base, kw_only=True):
     Friendship relations between users
 
     TODO: make this better with sqlalchemy self-referential stuff
-    TODO: constraint on only one row per user pair where accepted or pending
     """
 
     __tablename__ = "friend_relationships"
@@ -102,6 +101,14 @@ class FriendRelationship(Base, kw_only=True):
             status,
             to_user_id,
             from_user_id,
+        ),
+        # At most one active (pending or accepted) relationship per unordered user pair
+        Index(
+            "uq_friend_relationships_active_pair",
+            func.least(from_user_id, to_user_id),
+            func.greatest(from_user_id, to_user_id),
+            unique=True,
+            postgresql_where=status.in_([FriendStatus.pending, FriendStatus.accepted]),
         ),
     )
 

--- a/app/backend/src/tests/test_model_constraints.py
+++ b/app/backend/src/tests/test_model_constraints.py
@@ -7,6 +7,11 @@ from couchers.models import (
     ActivenessProbe,
     ActivenessProbeStatus,
     Cluster,
+    FriendRelationship,
+    FriendStatus,
+    ModerationObjectType,
+    ModerationState,
+    ModerationVisibility,
     Node,
     NodeType,
     Page,
@@ -222,3 +227,59 @@ def test_activeness_probes_cant_have_multiple(db):
         with session_scope() as session:
             session.add(ActivenessProbe(user_id=user.id))
     assert "violates unique constraint" in str(e.value)
+
+
+def _add_friend_relationship(session, from_user_id, to_user_id, status):
+    moderation_state = ModerationState(
+        object_type=ModerationObjectType.friend_request,
+        object_id=0,
+        visibility=ModerationVisibility.visible,
+    )
+    session.add(moderation_state)
+    session.flush()
+    fr = FriendRelationship(
+        from_user_id=from_user_id,
+        to_user_id=to_user_id,
+        status=status,
+        moderation_state_id=moderation_state.id,
+    )
+    session.add(fr)
+    session.flush()
+    moderation_state.object_id = fr.id
+    return fr
+
+
+def test_friend_relationship_unique_active_pair(db):
+    # can't have two active (pending/accepted) FriendRelationship rows for the same user pair,
+    # regardless of direction
+    user1, _ = generate_user()
+    user2, _ = generate_user()
+    user3, _ = generate_user()
+
+    # baseline: one pending relationship is fine
+    with session_scope() as session:
+        _add_friend_relationship(session, user1.id, user2.id, FriendStatus.pending)
+
+    # can't add a second active row in the same direction
+    with pytest.raises(IntegrityError) as e:
+        with session_scope() as session:
+            _add_friend_relationship(session, user1.id, user2.id, FriendStatus.pending)
+    assert "violates unique constraint" in str(e.value)
+    assert "uq_friend_relationships_active_pair" in str(e.value)
+
+    # can't add a second active row in the reverse direction either
+    with pytest.raises(IntegrityError) as e:
+        with session_scope() as session:
+            _add_friend_relationship(session, user2.id, user1.id, FriendStatus.accepted)
+    assert "violates unique constraint" in str(e.value)
+    assert "uq_friend_relationships_active_pair" in str(e.value)
+
+    # a cancelled or rejected row for the same pair is allowed alongside the active one
+    with session_scope() as session:
+        _add_friend_relationship(session, user1.id, user2.id, FriendStatus.cancelled)
+        _add_friend_relationship(session, user2.id, user1.id, FriendStatus.rejected)
+
+    # and active rows for different pairs are unaffected
+    with session_scope() as session:
+        _add_friend_relationship(session, user1.id, user3.id, FriendStatus.pending)
+        _add_friend_relationship(session, user3.id, user2.id, FriendStatus.accepted)


### PR DESCRIPTION
Fixes a bug where two `friend_relationship` rows could coexist in `pending` or `accepted` status between the same pair of users (a race in `SendFriendRequest`, flagged by a pre-existing `TODO` in the model).

Adds a partial unique index on `friend_relationships` over `(LEAST(from_user_id, to_user_id), GREATEST(from_user_id, to_user_id))` limited to `status IN ('pending', 'accepted')`, so the constraint is symmetric across direction and doesn't block historical `rejected`/`cancelled` rows from accumulating.

The migration first cancels older duplicates per pair (keeping the latest by `id`) so the index can be created on existing data without error.

## Testing
* New test `test_friend_relationship_unique_active_pair` in `src/tests/test_model_constraints.py` verifies:
  * second active row in the same direction raises `IntegrityError`
  * second active row in the reverse direction raises `IntegrityError`
  * `cancelled` / `rejected` rows for the same pair remain allowed
  * active rows for different pairs are unaffected
* Ran `make format` and `uv run pytest src/tests/test_model_constraints.py src/tests/test_api.py src/tests/test_references.py src/tests/test_visible_users.py` — all passing.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._