### PR TITLE
Add link to settings page section error to re-enable emails

### DIFF
--- a/app/web/features/auth/Settings.tsx
+++ b/app/web/features/auth/Settings.tsx
@@ -154,7 +154,7 @@ export default function Settings() {
           <MarginWrapper>
             <LanguagePickerSettings />
           </MarginWrapper>
-          <MarginWrapper>
+          <MarginWrapper id="do-not-email">
             <DoNotEmail />
           </MarginWrapper>
           <MarginWrapper>

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -28,14 +28,16 @@ import ProfileMarkdownInput from "features/profile/ProfileMarkdownInput";
 import ProfileTagInput from "features/profile/ProfileTagInput";
 import ProfileTextInput from "features/profile/ProfileTextInput";
 import useCurrentUser from "features/userQueries/useCurrentUser";
+import { StatusCode } from "grpc-web";
 import { Trans, useTranslation } from "i18n";
 import { AUTH, GLOBAL, PROFILE } from "i18n/namespaces";
 import { useRouter } from "next/router";
 import { HostingStatus, LanguageAbility, MeetupStatus } from "proto/api_pb";
 import React, { FormEvent, useEffect, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { howToMakeGreatProfileUrl } from "routes";
+import { howToMakeGreatProfileUrl, settingsRoute } from "routes";
 import { UpdateUserProfileData } from "service/index";
+import isGrpcError from "service/utils/isGrpcError";
 import { theme } from "theme";
 import {
   useIsMounted,
@@ -259,6 +261,7 @@ export default function EditProfileForm() {
     reset: resetUpdate,
     isPending: updateIsLoading,
     isError: updateError,
+    error: updateMutationError,
   } = useUpdateUserProfile();
   const { data: user } = useCurrentUser();
   const isMounted = useIsMounted();
@@ -460,6 +463,15 @@ export default function EditProfileForm() {
       {updateError && (
         <Alert severity="error">
           {errorMessage || t("global:error.unknown")}
+          {isGrpcError(updateMutationError) &&
+            updateMutationError.code === StatusCode.FAILED_PRECONDITION && (
+              <>
+                {" "}
+                <StyledLink href={`${settingsRoute}#do-not-email`}>
+                  {t("profile:do_not_email_error_link")}
+                </StyledLink>
+              </>
+            )}
         </Alert>
       )}
       {!user?.avatarUrl && (

--- a/app/web/features/profile/hooks/useUpdateUserProfile.ts
+++ b/app/web/features/profile/hooks/useUpdateUserProfile.ts
@@ -20,6 +20,7 @@ export default function useUpdateUserProfile() {
     isPending,
     isError,
     status,
+    error,
   } = useMutation<Empty, Error, UpdateUserProfileVariables>({
     mutationFn: ({ profileData }) => service.user.updateProfile(profileData),
     onError: (error, { setMutationError }) => {
@@ -35,5 +36,5 @@ export default function useUpdateUserProfile() {
     },
   });
 
-  return { reset, updateUserProfile, isPending, isError, status };
+  return { reset, updateUserProfile, isPending, isError, status, error };
 }

--- a/app/web/features/profile/locales/en.json
+++ b/app/web/features/profile/locales/en.json
@@ -1,5 +1,6 @@
 {
   "active": "Active",
+  "do_not_email_error_link": "Update your email settings to re-enable this.",
   "actions": {
     "back_to_dashboard": "Back to dashboard",
     "message_label": "Message",


### PR DESCRIPTION
I came across this error and didn't know how to fix it. Thought it was notification settings but those were all enabled so it was very confusing. Turns out there's another "re enable emails" section in account settings I didn't know about.

I'm improving the error message to link there so future people don't need to go on a big search to find it.

## Testing
- Go to account settings page and click "do not email me"
- Go to edit profile and change your hosting status to can or may host and save
- You should see the error and be able to click through to change the setting.

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, you can merge it if you have write access.
--->
