### PR TITLE
Backend/emails: Prepare for migration to localizable emails

### DIFF
--- a/app/backend/src/couchers/email/dump_emails.py
+++ b/app/backend/src/couchers/email/dump_emails.py
@@ -46,11 +46,12 @@ def main() -> None:
     loc_context = LocalizationContext(locale=args.locale, timezone=UTC)
 
     footer = EmailFooter(
+        timezone_name="UTC",
         unsubscribe_info=UnsubscribeInfo(
             manage_notifications_url="https://example.com/manage-notifications",
             do_not_email_url="https://example.com/do-not-email",
             topic_action_link=UnsubscribeLink(text="topic-action", url="https://example.com/unsubscribe"),
-        )
+        ),
     )
 
     filter_regex = re.compile(re.escape(args.filter).replace(r"\*", ".*?"))

--- a/app/backend/src/couchers/email/rendering.py
+++ b/app/backend/src/couchers/email/rendering.py
@@ -75,6 +75,7 @@ class EmailFooter:
         args["footer_timezone_name"] = self.timezone_name
         args["footer_copyright_year"] = self.copyright_year
 
+        args["footer_email_is_critical"] = self.unsubscribe_info is None
         if unsubscribe_info := self.unsubscribe_info:
             args.update(unsubscribe_info.to_template_args())
 

--- a/app/backend/src/couchers/email/rendering.py
+++ b/app/backend/src/couchers/email/rendering.py
@@ -66,8 +66,19 @@ class ActionBlock(EmailBlock):
 
 @dataclass(kw_only=True)
 class EmailFooter:
+    timezone_name: str
     copyright_year: int = now().year
     unsubscribe_info: UnsubscribeInfo | None
+
+    def to_template_args(self) -> dict[str, Any]:
+        args: dict[str, Any] = {}
+        args["footer_timezone_name"] = self.timezone_name
+        args["footer_copyright_year"] = self.copyright_year
+
+        if unsubscribe_info := self.unsubscribe_info:
+            args.update(unsubscribe_info.to_template_args())
+
+        return args
 
 
 @dataclass(kw_only=True)
@@ -76,6 +87,19 @@ class UnsubscribeInfo:
     do_not_email_url: str
     topic_action_link: UnsubscribeLink
     topic_key_link: UnsubscribeLink | None = None
+
+    def to_template_args(self) -> dict[str, Any]:
+        args: dict[str, Any] = {}
+        args["footer_manage_notifications_link"] = self.manage_notifications_url
+        args["footer_do_not_email_link"] = self.do_not_email_url
+        args["footer_notification_topic_action"] = self.topic_action_link.text
+        args["footer_notification_topic_action_link"] = self.topic_action_link.url
+
+        if topic_key_link := self.topic_key_link:
+            args["footer_notification_topic_key"] = topic_key_link.text
+            args["footer_notification_topic_key_link"] = topic_key_link.url
+
+        return args
 
 
 @dataclass(kw_only=True)
@@ -146,7 +170,7 @@ def render_plaintext_body(*, blocks: list[EmailBlock], footer: EmailFooter, loc_
     footer_template = Jinja2Template(
         source=(template_folder / "_footer.txt").read_text(encoding="utf8").strip(), html=False
     )
-    footer_template_args = _get_footer_template_args(footer)
+    footer_template_args = footer.to_template_args()
     return "".join(concat) + footer_template.render(footer_template_args, loc_context)
 
 
@@ -173,23 +197,6 @@ def _to_plaintext(text: str | Markup) -> str:
 
     # We've handled tags but still have escapes like "&gt;", convert those to plaintext.
     return unescape(text)
-
-
-def _get_footer_template_args(footer: EmailFooter) -> dict[str, Any]:
-    args: dict[str, Any] = {}
-    args["footer_copyright_year"] = footer.copyright_year
-
-    if unsubscribe_info := footer.unsubscribe_info:
-        args["footer_manage_notifications_link"] = unsubscribe_info.manage_notifications_url
-        args["footer_do_not_email_link"] = unsubscribe_info.do_not_email_url
-        args["footer_notification_topic_action"] = unsubscribe_info.topic_action_link.text
-        args["footer_notification_topic_action_link"] = unsubscribe_info.topic_action_link.url
-
-        if topic_key_link := unsubscribe_info.topic_key_link:
-            args["footer_notification_topic_key"] = topic_key_link.text
-            args["footer_notification_topic_key_link"] = topic_key_link.url
-
-    return args
 
 
 @dataclass
@@ -251,7 +258,7 @@ class HTMLRenderer:
                     raise AssertionError(f"Unexpected email block type: {block.__class__}")
 
         # Render the footer
-        footer_template_args = _get_footer_template_args(footer)
+        footer_template_args = footer.to_template_args()
         concats.append(self.footer_template.render(footer_template_args, loc_context))
 
         return "\n".join(concats)

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -6,7 +6,6 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import exists, func
 
-from couchers import urls
 from couchers.config import config
 from couchers.context import make_background_user_context
 from couchers.db import session_scope
@@ -19,19 +18,12 @@ from couchers.models import (
     User,
 )
 from couchers.notifications.push import push_to_user
-from couchers.notifications.quick_links import (
-    generate_do_not_email,
-    generate_unsub_topic_action,
-    generate_unsub_topic_key,
-)
-from couchers.notifications.render_email import get_list_unsubscribe_header, render_email_notification
+from couchers.notifications.render_email import render_email_notification
 from couchers.notifications.render_push import render_push_notification
 from couchers.notifications.settings import get_preference
 from couchers.notifications.utils import can_notify_deleted_user
 from couchers.proto.internal import jobs_pb2
 from couchers.sql import moderation_state_column_visible
-from couchers.templating import Jinja2Template, template_folder
-from couchers.utils import now
 
 logger = logging.getLogger(__name__)
 
@@ -53,56 +45,18 @@ def _send_email_notification(session: Session, user: User, notification: Notific
     if not config["ENABLE_NOTIFICATION_TRANSLATIONS"]:
         loc_context = dataclasses.replace(loc_context, locale="en")
 
-    rendered = render_email_notification(notification, loc_context)
+    rendered = render_email_notification(user, notification, loc_context)
 
-    template_args = {
-        **rendered.template_args,
-        "header_subject": rendered.subject,
-        "header_preview": rendered.preview,
-        "user": user,
-        "time": notification.created,
-        "footer_timezone_name": loc_context.localized_timezone,
-        "footer_copyright_year": now().year,
-    }
-
-    if notification.topic_action.is_critical:
-        template_args["footer_email_is_critical"] = True
-    else:
-        template_args["footer_email_is_critical"] = False
-        template_args["footer_manage_notifications_link"] = urls.notification_settings_link()
-        template_args["footer_do_not_email_link"] = generate_do_not_email(user)
-
-        if rendered.topic_action_unsubscribe_text:
-            template_args["footer_notification_topic_action"] = rendered.topic_action_unsubscribe_text
-            template_args["footer_notification_topic_action_link"] = generate_unsub_topic_action(notification)
-
-        if rendered.topic_key_unsubscribe_text:
-            template_args["footer_notification_topic_key"] = rendered.topic_key_unsubscribe_text
-            template_args["footer_notification_topic_key_link"] = generate_unsub_topic_key(notification)
-
-    # Format plaintext template
-    plain_tmplt_body = (template_folder / f"{rendered.template_name}.txt").read_text()
-    plain_tmplt_footer = (template_folder / "_footer.txt").read_text()
-    plain_tmplt = Jinja2Template(source=plain_tmplt_body + plain_tmplt_footer, html=False)
-    plain = plain_tmplt.render(template_args, loc_context)
-
-    # Format html template
-    html_tmplt = Jinja2Template(
-        source=(template_folder / "generated_html" / f"{rendered.template_name}.html").read_text(), html=True
-    )
-    html = html_tmplt.render(template_args, loc_context)
-
-    list_unsubscribe_header = get_list_unsubscribe_header(notification)
     queue_email(
         session,
         sender_name=config["NOTIFICATION_EMAIL_SENDER"],
         sender_email=config["NOTIFICATION_EMAIL_ADDRESS"],
         recipient=user.email,
         subject=config["NOTIFICATION_PREFIX"] + rendered.subject,
-        plain=plain,
-        html=html,
-        source_data=config["VERSION"] + f"/{rendered.template_name}",
-        list_unsubscribe_header=list_unsubscribe_header,
+        plain=rendered.body_plaintext,
+        html=rendered.body_html,
+        source_data=rendered.source_data,
+        list_unsubscribe_header=rendered.list_unsubscribe_header,
     )
 
 

--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -3,23 +3,78 @@ from dataclasses import dataclass
 from typing import Any
 
 from couchers import urls
+from couchers.config import config
+from couchers.email.rendering import EmailFooter, UnsubscribeInfo, UnsubscribeLink
 from couchers.i18n import LocalizationContext
 from couchers.i18n.localize import format_phone_number
-from couchers.models import Notification, NotificationTopicAction
+from couchers.models import Notification, NotificationTopicAction, User
 from couchers.notifications.quick_links import (
     can_unsubscribe_topic_key,
+    generate_do_not_email,
     generate_quick_decline_link,
     generate_unsub_topic_action,
     generate_unsub_topic_key,
 )
 from couchers.proto import api_pb2, notification_data_pb2
+from couchers.templating import Jinja2Template, template_folder
 from couchers.utils import now, to_aware_datetime
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, slots=True)
 class RenderedEmailNotification:
+    subject: str
+    body_plaintext: str
+    body_html: str | None
+    source_data: str | None
+    list_unsubscribe_header: str | None
+
+
+def render_email_notification(
+    user: User, notification: Notification, loc_context: LocalizationContext
+) -> RenderedEmailNotification:
+    footer = get_email_footer(user, notification, loc_context)
+
+    # Currently only support custom templated emails,
+    # in the future will also support couchers.email.emails (single generic template).
+    custom_templated = _get_custom_templated_email(notification, loc_context)
+
+    template_args = {
+        **custom_templated.template_args,
+        "header_subject": custom_templated.subject,
+        "header_preview": custom_templated.preview,
+        "user": user,
+        "time": notification.created,
+        **footer.to_template_args(),
+    }
+
+    # Format plaintext template
+    plain_tmplt_body = (template_folder / f"{custom_templated.template_name}.txt").read_text()
+    plain_tmplt_footer = (template_folder / "_footer.txt").read_text()
+    plain_tmplt = Jinja2Template(source=plain_tmplt_body + plain_tmplt_footer, html=False)
+    plain = plain_tmplt.render(template_args, loc_context)
+
+    # Format html template
+    html_tmplt = Jinja2Template(
+        source=(template_folder / "generated_html" / f"{custom_templated.template_name}.html").read_text(), html=True
+    )
+    html = html_tmplt.render(template_args, loc_context)
+
+    list_unsubscribe_header = get_list_unsubscribe_header(notification)
+    source_data = config["VERSION"] + f"/{custom_templated.template_name}"
+
+    return RenderedEmailNotification(
+        subject=custom_templated.subject,
+        body_plaintext=plain,
+        body_html=html,
+        source_data=source_data,
+        list_unsubscribe_header=list_unsubscribe_header,
+    )
+
+
+@dataclass(kw_only=True)
+class CustomTemplatedEmail:
     # email subject
     subject: str
     # shows up when listing emails in many clients
@@ -28,15 +83,11 @@ class RenderedEmailNotification:
     template_name: str
     # other template args
     template_args: dict[str, Any]
-    # the link label on the topic_action unsubscribe link
-    topic_action_unsubscribe_text: str | None = None
-    # the link label on the topic_key unsubscribe link
-    topic_key_unsubscribe_text: str | None = None
 
 
-def render_email_notification(
-    notification: Notification, loc_context: LocalizationContext
-) -> RenderedEmailNotification:
+# Gets the data necessary to template an email for which we have a custom template,
+# e.g. not yet using couchers.email.emails.
+def _get_custom_templated_email(notification: Notification, loc_context: LocalizationContext) -> CustomTemplatedEmail:
     data = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
     if notification.topic == "host_request":
         view_link = urls.host_request(host_request_id=data.host_request.host_request_id)
@@ -45,7 +96,7 @@ def render_email_notification(
             other = data.user
             # "declined your host request", or similar
             message = f"{other.name} sent you message(s) in {their_your} host request"
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=message,
                 preview=message,
                 template_name="host_request__plain",
@@ -55,12 +106,11 @@ def render_email_notification(
                     "message": message,
                     "other": UserTemplateArgs.from_protobuf_user(other),
                 },
-                topic_action_unsubscribe_text="missed messages in host requests",
             )
         elif notification.action == "create":
             other = data.surfer
             message = f"{other.name} sent you a host request"
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=message,
                 preview=message,
                 template_name="host_request__new",
@@ -72,7 +122,6 @@ def render_email_notification(
                     "other": UserTemplateArgs.from_protobuf_user(other),
                     "text": data.text,
                 },
-                topic_action_unsubscribe_text="new host requests",
             )
         elif notification.action == "message":
             other = data.user
@@ -80,8 +129,7 @@ def render_email_notification(
                 message = f"{other.name} sent you a message in their host request"
             else:
                 message = f"{other.name} sent you a message in your host request"
-            topic_action_unsub_text = "messages in host request"
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=message,
                 preview=message,
                 template_name="host_request__message",
@@ -92,7 +140,6 @@ def render_email_notification(
                     "other": UserTemplateArgs.from_protobuf_user(other),
                     "text": data.text,
                 },
-                topic_action_unsubscribe_text=topic_action_unsub_text,
             )
         elif notification.action in ["accept", "reject", "confirm", "cancel"]:
             if notification.action in ["accept", "reject"]:
@@ -109,7 +156,7 @@ def render_email_notification(
             }[notification.action]
             # "declined your host request", or similar
             message = f"{other.name} {actioned} {their_your} host request"
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=message,
                 preview=message,
                 template_name="host_request__plain",
@@ -119,12 +166,11 @@ def render_email_notification(
                     "message": message,
                     "other": UserTemplateArgs.from_protobuf_user(other),
                 },
-                topic_action_unsubscribe_text=f"{actioned} host requests",
             )
         elif notification.action == "reminder":
             message = f"You have a pending host request from {data.surfer.name}!"
             description = "Please respond to the request!"
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=message,
                 preview=description,
                 template_name="host_request__plain",
@@ -134,12 +180,11 @@ def render_email_notification(
                     "message": description,
                     "other": UserTemplateArgs.from_protobuf_user(data.surfer),
                 },
-                topic_action_unsubscribe_text="Pending host request reminders",
             )
     elif notification.topic_action == NotificationTopicAction.password__change:
         title = "Your password was changed"
         message = "Your login password for Couchers.org was changed."
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=title,
             preview=message,
             template_name="security",
@@ -150,7 +195,7 @@ def render_email_notification(
         )
     elif notification.topic_action == NotificationTopicAction.password_reset__start:
         message = "Someone initiated a password change on your account."
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject="Reset your Couchers.org password",
             preview=message,
             template_name="password_reset",
@@ -161,7 +206,7 @@ def render_email_notification(
     elif notification.topic_action == NotificationTopicAction.password_reset__complete:
         title = "Your password was successfully reset"
         message = "Your password on Couchers.org was changed. If that was you, then no further action is needed."
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=title,
             preview=title,
             template_name="security",
@@ -173,7 +218,7 @@ def render_email_notification(
     elif notification.topic_action == NotificationTopicAction.email_address__change:
         title = "An email change was initiated on your account"
         message = f"An email change to the email <b>{data.new_email}</b> was initiated on your account."
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=title,
             preview=title,
             template_name="security",
@@ -185,7 +230,7 @@ def render_email_notification(
     elif notification.topic_action == NotificationTopicAction.email_address__verify:
         title = "Email change completed"
         message = "Your new email address has been verified."
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=title,
             preview=message,
             template_name="security",
@@ -197,7 +242,7 @@ def render_email_notification(
     elif notification.topic_action == NotificationTopicAction.phone_number__change:
         title = "Phone verification started"
         message = f"You started phone number verification with the number <b>{format_phone_number(data.phone)}</b>."
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=title,
             preview=message,
             template_name="security",
@@ -210,7 +255,7 @@ def render_email_notification(
         title = "Phone successfully verified"
         message = f"Your phone was successfully verified as <b>{format_phone_number(data.phone)}</b> on Couchers.org."
         message_plain = f"Your phone was successfully verified as {format_phone_number(data.phone)} on Couchers.org."
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=title,
             preview=message_plain,
             template_name="security",
@@ -223,7 +268,7 @@ def render_email_notification(
         title = "Your gender was changed"
         message = f"Your gender on Couchers.org was changed to <b>{data.gender}</b> by an admin."
         message_plain = f"Your gender on Couchers.org was changed to {data.gender} by an admin."
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=title,
             preview=message_plain,
             template_name="security",
@@ -237,7 +282,7 @@ def render_email_notification(
         birthdate = loc_context.localize_date_from_iso(data.birthdate)
         message = f"Your date of birth on Couchers.org was changed to <b>{birthdate}</b> by an admin."
         message_plain = f"Your date of birth on Couchers.org was changed to {birthdate} by an admin."
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=title,
             preview=message_plain,
             template_name="security",
@@ -247,7 +292,7 @@ def render_email_notification(
             },
         )
     elif notification.topic_action == NotificationTopicAction.api_key__create:
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject="Your API key for Couchers.org",
             preview="We have issued you an API key as per your request.",
             template_name="api_key",
@@ -259,7 +304,7 @@ def render_email_notification(
     elif notification.topic_action.display in ["badge:add", "badge:remove"]:
         actioned = "added to" if notification.action == "add" else "removed from"
         title = f"The {data.badge_name} badge was {actioned} your profile"
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=title,
             preview=title,
             template_name="badge",
@@ -268,7 +313,6 @@ def render_email_notification(
                 "actioned": actioned,
                 "unsub_type": "badge additions" if notification.action == "add" else "badge removals",
             },
-            topic_action_unsubscribe_text="badge additions" if notification.action == "add" else "badge removals",
         )
     elif notification.topic_action == NotificationTopicAction.donation__received:
         title = loc_context.localize_string("notifications.donation_received.title")
@@ -278,7 +322,7 @@ def render_email_notification(
                 "amount": data.amount,
             },
         )
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=title,
             preview=message,
             template_name="donation_received",
@@ -286,12 +330,11 @@ def render_email_notification(
                 "amount": data.amount,
                 "receipt_url": data.receipt_url,
             },
-            topic_action_unsubscribe_text="donations received",
         )
     elif notification.topic_action == NotificationTopicAction.friend_request__create:
         other = data.other_user
         preview = f"You've received a friend request from {other.name}"
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=f"{other.name} wants to be your friend on Couchers.org!",
             preview=preview,
             template_name="friend_request",
@@ -299,23 +342,21 @@ def render_email_notification(
                 "friend_requests_link": urls.friend_requests_link(),
                 "other": UserTemplateArgs.from_protobuf_user(other),
             },
-            topic_action_unsubscribe_text="new friend requests",
         )
     elif notification.topic_action == NotificationTopicAction.friend_request__accept:
         other = data.other_user
         title = f"{other.name} accepted your friend request!"
         preview = f"{other.name} has accepted your friend request"
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=title,
             preview=preview,
             template_name="friend_request_accepted",
             template_args={
                 "other": UserTemplateArgs.from_protobuf_user(other),
             },
-            topic_action_unsubscribe_text="accepted friend requests",
         )
     elif notification.topic_action == NotificationTopicAction.account_deletion__start:
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject="Confirm your Couchers.org account deletion",
             preview="Please confirm that you want to delete your Couchers.org account.",
             template_name="account_deletion_start",
@@ -325,7 +366,7 @@ def render_email_notification(
         )
     elif notification.topic_action == NotificationTopicAction.account_deletion__complete:
         title = "Your Couchers.org account has been deleted"
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=title,
             preview="We have deleted your Couchers.org account, to undo, follow the link in this email.",
             template_name="account_deletion_complete",
@@ -337,7 +378,7 @@ def render_email_notification(
     elif notification.topic_action == NotificationTopicAction.account_deletion__recovered:
         title = "Your Couchers.org account has been recovered!"
         subtitle = "We have recovered your Couchers.org account as per your request! Welcome back!"
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=title,
             preview=subtitle,
             template_name="account_deletion_recovered",
@@ -346,7 +387,7 @@ def render_email_notification(
             },
         )
     elif notification.topic_action == NotificationTopicAction.chat__message:
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=data.message,
             preview="You received a message on Couchers.org!",
             template_name="chat_message",
@@ -356,11 +397,9 @@ def render_email_notification(
                 "text": data.text,
                 "view_link": urls.chat_link(chat_id=data.group_chat_id),
             },
-            topic_action_unsubscribe_text="new chat messages",
-            topic_key_unsubscribe_text="this chat (mute)",
         )
     elif notification.topic_action == NotificationTopicAction.chat__missed_messages:
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject="You have unseen messages on Couchers.org!",
             preview="You missed some messages on the platform.",
             template_name="chat_unseen_messages",
@@ -375,7 +414,6 @@ def render_email_notification(
                     for item in data.messages
                 ]
             },
-            topic_action_unsubscribe_text="unseen chat messages",
         )
     elif notification.topic == "event":
         event = data.event
@@ -397,7 +435,7 @@ def render_email_notification(
                 if data.in_community
                 else None
             )
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=subject,
                 preview=f"{start_text} on Couchers.org!",
                 template_name="event_create",
@@ -411,15 +449,10 @@ def render_email_notification(
                     "event": event,
                     "view_link": event_link,
                 },
-                topic_action_unsubscribe_text=(
-                    "new events by community members"
-                    if notification.action == "create_any"
-                    else "invitations to events (approved by moderators)"
-                ),
             )
         elif notification.action == "update":
             updated_text = ", ".join(data.updated_items)
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=f'{data.updating_user.name} updated "{event.title}"',
                 preview="An event you are subscribed to was updated.",
                 template_name="event_update",
@@ -430,10 +463,9 @@ def render_email_notification(
                     "updated_text": updated_text,
                     "view_link": event_link,
                 },
-                topic_action_unsubscribe_text="event updates",
             )
         elif notification.action == "cancel":
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=f'{data.cancelling_user.name} cancelled "{event.title}"',
                 preview="An event you are subscribed to has been cancelled.",
                 template_name="event_cancel",
@@ -443,10 +475,9 @@ def render_email_notification(
                     "event": event,
                     "view_link": event_link,
                 },
-                topic_action_unsubscribe_text="event cancellations",
             )
         elif notification.action == "delete":
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=f'A moderator deleted "{event.title}"',
                 preview="An event you are subscribed to has been deleted.",
                 template_name="event_delete",
@@ -454,10 +485,9 @@ def render_email_notification(
                     "time_display": time_display,
                     "event": event,
                 },
-                topic_action_unsubscribe_text="event deletions",
             )
         elif notification.action == "invite_organizer":
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=f'{data.inviting_user.name} invited you to co-organize "{event.title}"',
                 preview="You were invited to co-organize an event on Couchers.org.",
                 template_name="event_invite_organizer",
@@ -467,10 +497,9 @@ def render_email_notification(
                     "event": event,
                     "view_link": event_link,
                 },
-                topic_action_unsubscribe_text="invitations to co-organize events",
             )
         elif notification.action == "comment":
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=f'{data.author.name} commented on "{event.title}"',
                 preview="Someone commented on an event you are attending.",
                 template_name="event_comment",
@@ -481,10 +510,9 @@ def render_email_notification(
                     "content": data.reply.content,
                     "view_link": event_link,
                 },
-                topic_action_unsubscribe_text="event comments",
             )
         elif notification.action == "reminder":
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=f'Reminder: "{data.event.title}" starts soon',
                 preview="Don't forget your upcoming event on Couchers.org",
                 template_name="event_reminder",
@@ -493,13 +521,12 @@ def render_email_notification(
                     "event": event,
                     "view_link": event_link,
                 },
-                topic_action_unsubscribe_text="event reminders",
             )
     elif notification.topic == "discussion":
         discussion = data.discussion
         discussion_link = urls.discussion_link(discussion_id=discussion.discussion_id, slug=discussion.slug)
         if notification.action == "create":
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=f'{data.author.name} created a discussion: "{discussion.title}"',
                 preview="Someone created a discussion in a community or group you are subscribed to.",
                 template_name="discussion_create",
@@ -508,10 +535,9 @@ def render_email_notification(
                     "discussion": discussion,
                     "view_link": discussion_link,
                 },
-                topic_action_unsubscribe_text="new discussions",
             )
         elif notification.action == "comment":
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=f'{data.author.name} commented on "{discussion.title}"',
                 preview="Someone commented on your discussion.",
                 template_name="discussion_comment",
@@ -521,7 +547,6 @@ def render_email_notification(
                     "reply": data.reply,
                     "view_link": discussion_link,
                 },
-                topic_action_unsubscribe_text="discussion comments",
             )
     elif notification.topic_action == NotificationTopicAction.thread__reply:
         parent = data.WhichOneof("reply_parent")
@@ -534,7 +559,7 @@ def render_email_notification(
         else:
             raise Exception("Can only do replies to events and discussions")
 
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=f'{data.author.name} replied in "{title}"',
             preview="Someone replied in a comment thread you have participated in.",
             template_name="comment_reply",
@@ -544,12 +569,11 @@ def render_email_notification(
                 "reply": data.reply,
                 "view_link": view_link,
             },
-            topic_action_unsubscribe_text="comment replies",
         )
     elif notification.topic == "reference":
         if notification.action == "receive_friend":
             title = f"You've received a friend reference from {data.from_user.name}!"
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=title,
                 preview=data.text,
                 template_name="friend_reference",
@@ -558,7 +582,6 @@ def render_email_notification(
                     "profile_references_link": urls.profile_references_link(),
                     "text": data.text,
                 },
-                topic_action_unsubscribe_text="new references from friends",
             )
         elif notification.action in ["receive_hosted", "receive_surfed"]:
             title = f"You've received a reference from {data.from_user.name}!"
@@ -574,7 +597,7 @@ def render_email_notification(
                 preview = data.text
             else:
                 preview = "Please go and write a reference for them too. It's a nice gesture and helps us build a community together!"
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=title,
                 preview=preview,
                 template_name="host_reference",
@@ -586,7 +609,6 @@ def render_email_notification(
                     "both_written": True if data.text else False,
                     "surfed": surfed,
                 },
-                topic_action_unsubscribe_text="new references from " + ("hosts" if surfed else "surfers"),
             )
         elif notification.action in ["reminder_hosted", "reminder_surfed"]:
             # what was my type? i surfed with them if i get a surfed reminder
@@ -598,7 +620,7 @@ def render_email_notification(
             )
             title = f"You have {data.days_left} days to write a reference for {data.other_user.name}!"
             preview = "It's a nice gesture to write references and helps us build a community together! References will become visible 2 weeks after the stay, or when you've both written a reference for each other, whichever happens first."
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=title,
                 preview=preview,
                 template_name="reference_reminder",
@@ -608,11 +630,10 @@ def render_email_notification(
                     "days_left": str(data.days_left),
                     "surfed": surfed,
                 },
-                topic_action_unsubscribe_text=("surfed" if surfed else "hosted") + " reference reminders",
             )
     elif notification.topic_action == NotificationTopicAction.onboarding__reminder:
         if notification.key == "1":
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject="Welcome to Couchers.org and the future of couch surfing",
                 preview="We are so excited to have you join our community!",
                 template_name="onboarding1",
@@ -620,22 +641,20 @@ def render_email_notification(
                     "app_link": urls.app_link(),
                     "edit_profile_link": urls.edit_profile_link(),
                 },
-                topic_action_unsubscribe_text="onboarding emails",
             )
         elif notification.key == "2":
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject="Complete your profile on Couchers.org",
                 preview="We would ask one big favour of you: please fill out your profile by adding a photo and some text.",
                 template_name="onboarding2",
                 template_args={
                     "edit_profile_link": urls.edit_profile_link(),
                 },
-                topic_action_unsubscribe_text="onboarding emails",
             )
     elif notification.topic_action == NotificationTopicAction.modnote__create:
         title = "You have received a mod note"
         message = "You have received an important note from the moderators. You must read and acknowledge it before continuing to use the platform."
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=title,
             preview=message,
             template_name="mod_note",
@@ -644,7 +663,7 @@ def render_email_notification(
     elif notification.topic_action == NotificationTopicAction.verification__sv_success:
         title = "Strong Verification succeeded"
         message = "You have been verified with Strong Verification! You will now see a tick next to your name on the platform."
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=title,
             preview=message,
             template_name="strong_verification_success",
@@ -662,7 +681,7 @@ def render_email_notification(
             reason_message = "You tried to verify with a passport that has already been used for verification. Please use another passport."
         else:
             raise Exception("Shouldn't get here")
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=title,
             preview=title,
             template_name="security",
@@ -675,7 +694,7 @@ def render_email_notification(
         if notification.action == "postcard_sent":
             title = "Your verification postcard is on its way"
             message = f"We've sent a postcard with your verification code to {data.city}, {data.country}. It should arrive within 1-3 weeks depending on your location. Once it arrives, enter the code on the platform to complete verification."
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=title,
                 preview=message,
                 template_name="security",
@@ -687,7 +706,7 @@ def render_email_notification(
         elif notification.action == "success":
             title = "Postal Verification succeeded"
             message = "You have been verified with Postal Verification! Your address has been confirmed."
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=title,
                 preview=message,
                 template_name="security",
@@ -706,7 +725,7 @@ def render_email_notification(
                 reason_message = (
                     "Your postal verification attempt has failed. You can start a new verification attempt."
                 )
-            return RenderedEmailNotification(
+            return CustomTemplatedEmail(
                 subject=title,
                 preview=title,
                 template_name="security",
@@ -717,7 +736,7 @@ def render_email_notification(
             )
     elif notification.topic_action == NotificationTopicAction.activeness__probe:
         title = "Are you still open to hosting on Couchers.org?"
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=title,
             preview=title,
             template_name="activeness_probe",
@@ -728,7 +747,7 @@ def render_email_notification(
         )
     elif notification.topic_action == NotificationTopicAction.general__new_blog_post:
         title = f"New blog post: {data.title}"
-        return RenderedEmailNotification(
+        return CustomTemplatedEmail(
             subject=title,
             preview=data.blurb,
             template_name="new_blog_post",
@@ -737,7 +756,6 @@ def render_email_notification(
                 "blurb": data.blurb,
                 "url": data.url,
             },
-            topic_action_unsubscribe_text="new blog post alerts",
         )
 
     raise NotImplementedError(f"Unknown topic-action: {notification.topic}:{notification.action}")
@@ -756,6 +774,113 @@ def get_list_unsubscribe_header(notification: Notification) -> str | None:
         list_unsubscribe_url = generate_unsub_topic_action(notification)
 
     return f"<{list_unsubscribe_url}>"
+
+
+def get_topic_action_unsubscribe_text(topic_action: NotificationTopicAction) -> str:
+    assert not topic_action.is_critical
+    # Not localized because the design will change so avoid useless work by translators.
+    match topic_action:
+        case NotificationTopicAction.host_request__missed_messages:
+            return "missed messages in host requests"
+        case NotificationTopicAction.host_request__create:
+            return "new host requests"
+        case NotificationTopicAction.host_request__message:
+            return "messages in host request"
+        case NotificationTopicAction.host_request__accept:
+            return "accepted host requests"
+        case NotificationTopicAction.host_request__reject:
+            return "declined host requests"
+        case NotificationTopicAction.host_request__confirm:
+            return "confirmed host requests"
+        case NotificationTopicAction.host_request__cancel:
+            return "cancelled host requests"
+        case NotificationTopicAction.host_request__reminder:
+            return "Pending host request reminders"
+        case NotificationTopicAction.reference__receive_friend:
+            return "new references from friends"
+        case NotificationTopicAction.reference__receive_hosted:
+            return "new references from hosts"
+        case NotificationTopicAction.reference__receive_surfed:
+            return "new references from surfers"
+        case NotificationTopicAction.reference__reminder_hosted:
+            return "hosted reference reminders"
+        case NotificationTopicAction.reference__reminder_surfed:
+            return "surfed reference reminders"
+        case NotificationTopicAction.badge__add:
+            return "badge additions"
+        case NotificationTopicAction.badge__remove:
+            return "badge removals"
+        case NotificationTopicAction.chat__message:
+            return "new chat messages"
+        case NotificationTopicAction.chat__missed_messages:
+            return "unseen chat messages"
+        case NotificationTopicAction.event__create_approved:
+            return "invitations to events (approved by moderators)"
+        case NotificationTopicAction.event__create_any:
+            return "new events by community members"
+        case NotificationTopicAction.event__update:
+            return "event updates"
+        case NotificationTopicAction.event__cancel:
+            return "event cancellations"
+        case NotificationTopicAction.event__delete:
+            return "event deletions"
+        case NotificationTopicAction.event__invite_organizer:
+            return "invitations to co-organize events"
+        case NotificationTopicAction.event__reminder:
+            return "event reminders"
+        case NotificationTopicAction.event__comment:
+            return "event comments"
+        case NotificationTopicAction.discussion__create:
+            return "new discussions"
+        case NotificationTopicAction.discussion__comment:
+            return "discussion comments"
+        case NotificationTopicAction.thread__reply:
+            return "comment replies"
+        case NotificationTopicAction.friend_request__create:
+            return "new friend requests"
+        case NotificationTopicAction.friend_request__accept:
+            return "accepted friend requests"
+        case NotificationTopicAction.onboarding__reminder:
+            return "onboarding emails"
+        case NotificationTopicAction.postal_verification__postcard_sent:
+            return "postal verification postcards"
+        case NotificationTopicAction.general__new_blog_post:
+            return "new blog post alerts"
+        case _:
+            raise ValueError(f"No topic-action unsubscribe text for {topic_action}")
+
+
+def get_topic_key_unsubscribe_text(topic_action: NotificationTopicAction) -> str:
+    assert can_unsubscribe_topic_key(topic_action)
+    # Not localized because the design will change so avoid useless work by translators.
+    match topic_action:
+        case NotificationTopicAction.chat__message:
+            return "this chat (mute)"
+        case _:
+            raise AssertionError(f"No topic-key description for {topic_action}")
+
+
+def get_email_footer(user: User, notification: Notification, loc_context: LocalizationContext) -> EmailFooter:
+    return EmailFooter(
+        timezone_name=loc_context.localized_timezone,
+        copyright_year=now().year,
+        unsubscribe_info=UnsubscribeInfo(
+            manage_notifications_url=urls.notification_settings_link(),
+            do_not_email_url=generate_do_not_email(user),
+            topic_action_link=UnsubscribeLink(
+                text=get_topic_action_unsubscribe_text(notification.topic_action),
+                url=generate_unsub_topic_action(notification),
+            ),
+            topic_key_link=UnsubscribeLink(
+                text=get_topic_key_unsubscribe_text(notification.topic_action),
+                url=generate_unsub_topic_key(notification),
+            )
+            if can_unsubscribe_topic_key(notification.topic_action)
+            else None,
+        )
+        if not notification.topic_action.is_critical
+        else None,
+    )
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/app/backend/src/tests/test_notification_settings.py
+++ b/app/backend/src/tests/test_notification_settings.py
@@ -1,5 +1,9 @@
+import pytest
+
 from couchers.i18n.locales import DEFAULT_LOCALE
 from couchers.models.notifications import NotificationTopicAction
+from couchers.notifications.quick_links import can_unsubscribe_topic_key
+from couchers.notifications.render_email import get_topic_action_unsubscribe_text, get_topic_key_unsubscribe_text
 from couchers.notifications.settings import settings_layout
 from couchers.notifications.utils import get_topic_action_description
 
@@ -30,3 +34,21 @@ def test_all_notifications_have_descriptions() -> None:
     for topic_action in NotificationTopicAction:
         # Will throw if there's no string
         assert get_topic_action_description(topic_action, locale=DEFAULT_LOCALE) != ""
+
+
+def test_topic_action_unsubscribe_text_iff_unsubscribable() -> None:
+    for topic_action in NotificationTopicAction:
+        if topic_action.is_critical:
+            with pytest.raises(AssertionError):
+                get_topic_action_unsubscribe_text(topic_action)
+        else:
+            assert get_topic_action_unsubscribe_text(topic_action)
+
+
+def test_topic_key_unsubscribe_text_iff_unsubscribable() -> None:
+    for topic_action in NotificationTopicAction:
+        if can_unsubscribe_topic_key(topic_action):
+            assert get_topic_key_unsubscribe_text(topic_action)
+        else:
+            with pytest.raises(AssertionError):
+                get_topic_key_unsubscribe_text(topic_action)


### PR DESCRIPTION
#7964 added a framework for making localizable emails, but it isn't used yet. This is the next step: refactoring the existing email-building code so that two branches can co-exist: one for old system, one for the new system, so I can migrate on a per-email basis.

I made `RenderedEmailNotification` more generic so it can be produced by both the old and the new system. The old system's logic is preserved but now produces a `CustomTemplatedEmail`. Unsubscribe text for topic actions was extracted as it'll be used by both branches. The new system isn't hooked up yet, that'll be the next PR.

## Testing
Ran backend + frontend locally and managed to receive a fine-looking email.

<img width="1072" height="1326" alt="image" src="https://github.com/user-attachments/assets/466c9e02-1ab7-45b2-8bef-e6fcd6b60b57" />


**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
