### PR TITLE
Frontend: Remove tag input header text

### DIFF
--- a/app/web/features/profile/ProfileTagInput.tsx
+++ b/app/web/features/profile/ProfileTagInput.tsx
@@ -91,17 +91,6 @@ const StyledPopper = styled(Popper)(() => ({
   zIndex: 101,
 }));
 
-const StyledHeader = styled("div")(() => ({
-  borderBottomColor: "var(--mui-palette-divider)",
-  borderBottomStyle: "solid",
-  borderBottomWidth: 1,
-  fontSize: theme.typography.body1.fontSize,
-  padding: theme.spacing(1, 2),
-  "& > p": {
-    whiteSpace: "pre-line",
-  },
-}));
-
 const StyledInputBase = styled(InputBase)(({ theme }) => ({
   "& input": {
     "&:focus": {

--- a/app/web/features/profile/ProfileTagInput.tsx
+++ b/app/web/features/profile/ProfileTagInput.tsx
@@ -4,7 +4,6 @@ import {
   Checkbox,
   IconButton,
   InputBase,
-  Link,
   Paper,
   Popper,
   styled,
@@ -14,7 +13,7 @@ import Autocomplete, {
   AutocompleteCloseReason,
 } from "@mui/material/Autocomplete";
 import { CloseIcon, ExpandMoreIcon } from "components/Icons";
-import { Trans, useTranslation } from "i18n";
+import { useTranslation } from "i18n";
 import { PROFILE } from "i18n/namespaces";
 import React, { useRef, useState } from "react";
 import { ControllerRenderProps } from "react-hook-form";

--- a/app/web/features/profile/ProfileTagInput.tsx
+++ b/app/web/features/profile/ProfileTagInput.tsx
@@ -234,25 +234,6 @@ export default function ProfileTagInput({
           anchorEl={anchorEl.current}
           placement="bottom-start"
         >
-          <StyledHeader>
-            <Typography>
-              <Trans
-                t={t}
-                i18nKey="profile_tag_input.header_text"
-                components={{
-                  support_link: (
-                    <Link
-                      href="mailto:support@couchers.org"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      underline="hover"
-                      onMouseDown={(e) => e.preventDefault()}
-                    />
-                  ),
-                }}
-              />
-            </Typography>
-          </StyledHeader>
           <Autocomplete
             {...inputFieldProps}
             open

--- a/app/web/features/profile/locales/en.json
+++ b/app/web/features/profile/locales/en.json
@@ -266,7 +266,6 @@
   "response_time_text_almost_all": "Usually in {{p33}} to {{p66}}",
   "unsaved_changes_warning": "You haven't saved your changes. Are you sure you want to leave the page?",
   "profile_tag_input": {
-    "header_text": "Press 'Enter' to add\n<support_link>Email us</support_link> to add an entry",
     "remove_button_a11y_text": "Remove {{tag}}"
   },
   "view_in_admin_console": "View user in admin console",


### PR DESCRIPTION
This header text has several issues, I believe more than make it worth keeping:

1. 'Enter' does not actually enter the text written as a filter. Try it: https://next.couchershq.org/profile/edit/about
2. The two sentences in one string are confusing to localize without context (why I looked into this). I think this specific control doesn't need to remind users that they can contact us.
3. The header only appears when the pop-up pops downwards:

<img width="526" height="1064" alt="image" src="https://github.com/user-attachments/assets/146fa1e6-36b2-49d3-ad3e-9673491efd57" />

<img width="538" height="837" alt="image" src="https://github.com/user-attachments/assets/27069048-67eb-466c-84ef-fc7f6779585b" />

## Testing
Ran locally.

<img width="565" height="969" alt="image" src="https://github.com/user-attachments/assets/3f2de2fb-85e9-4f15-90c4-c9318226e2ac" />

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, you can merge it if you have write access.
--->
