### PR TITLE
Frontend/i18n: Make notification channels translatable

### DIFF
--- a/app/web/features/notifications/NotificationSettingsSubListItem.tsx
+++ b/app/web/features/notifications/NotificationSettingsSubListItem.tsx
@@ -126,7 +126,11 @@ export default function NotificationSettingsSubListItem({
           <ListItemIcon>
             <NotificationNewIcon />
           </ListItemIcon>
-          <ListItemText primary="Push" />
+          <ListItemText
+            primary={t(
+              "notifications:notification_settings.edit_preferences.channels.push_label",
+            )}
+          />
           <CustomColorSwitch
             customColor={theme.palette.primary.main}
             checked={push}
@@ -139,7 +143,11 @@ export default function NotificationSettingsSubListItem({
           <ListItemIcon>
             <MailOutline fontSize="medium" />
           </ListItemIcon>
-          <ListItemText primary="Email" />
+          <ListItemText
+            primary={t(
+              "notifications:notification_settings.edit_preferences.channels.email_label",
+            )}
+          />
           <CustomColorSwitch
             customColor={theme.palette.primary.main}
             checked={email}

--- a/app/web/features/notifications/locales/en.json
+++ b/app/web/features/notifications/locales/en.json
@@ -27,6 +27,10 @@
         "reference": "References",
         "discussion": "Discussions",
         "reply": "Replies"
+      },
+      "channels": {
+        "email_label": "Email",
+        "push_label": "Push"
       }
     },
     "push_notifications": {


### PR DESCRIPTION
These "Push" and "Email" strings were hardcoded:

<img width="1080" height="535" alt="image" src="https://github.com/user-attachments/assets/3512b310-2e77-47aa-8f55-b837ca02410f" />

## Testing
Ran locally

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, you can merge it if you have write access.
--->
