### PR TITLE
chore: remove watch mode on test command

### DIFF
--- a/app/web/package.json
+++ b/app/web/package.json
@@ -19,7 +19,7 @@
     "lint:fix": "eslint . --ext .ts,.tsx,.js,.jsx,.json --fix",
     "serve": "next start",
     "test-ci": "tsc && cross-env NEXT_PUBLIC_API_BASE_URL=http://localhost:8888 CI=true TZ=UTC jest --runInBand --coverageReporters=\"cobertura\" --coverageReporters=\"lcov\" --reporters=\"default\" --reporters=\"jest-junit\" --coverage",
-    "test": "cross-env NEXT_PUBLIC_API_BASE_URL=http://localhost:8888 TZ=UTC jest --watch",
+    "test": "cross-env NEXT_PUBLIC_API_BASE_URL=http://localhost:8888 TZ=UTC jest",
     "typecheck": "tsc --noEmit",
     "knip": "knip"
   },


### PR DESCRIPTION
*Describe briefly what this PR is doing and why.*

<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

With the existing instruction and `test` command, I noticed that when Claude tries to use it to verify its work hasn't broken existing/new tests it has written, it hangs since `yarn test` runs jest in watch mode.

I figured it's better to remove it and if anyone ever wants to run in watch mode again, appending `--watch` at the end of `yarn test` feels less of a nuisance than getting Claude stuck

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
N/A - no actual code changes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, you can merge it if you have write access.
--->
