### PR TITLE
ci: allow expo-doctor failures so they don't block deploy

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -584,6 +584,7 @@ test:mobile-expo-doctor:
   image: node:22
   inherit:
     default: false
+  allow_failure: true
   script:
     - cd app/mobile
     - npm ci


### PR DESCRIPTION
Adds `allow_failure: true` to the `test:mobile-expo-doctor` job so that an expo-doctor failure surfaces as a warning rather than failing the pipeline. This prevents it from blocking the release/deploy stages.

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

- Inspected `app/.gitlab-ci.yml` to confirm the `allow_failure: true` flag is set on `test:mobile-expo-doctor` only
- Pipeline behavior to verify in CI: when expo-doctor fails, the job is marked as allowed-failure and downstream `wait:before-release` / `release:*` / `deploy:*` jobs continue to run

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._