### PR TITLE
Add mod_score to User

### DIFF
--- a/app/backend/src/couchers/migrations/versions/0148_add_mod_score_to_user.py
+++ b/app/backend/src/couchers/migrations/versions/0148_add_mod_score_to_user.py
@@ -1,0 +1,24 @@
+"""Add mod_score to User
+
+Revision ID: 0148
+Revises: 0147
+Create Date: 2026-05-04 00:08:01.795622
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0148"
+down_revision = "0147"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("mod_score", sa.Float(), server_default="1", nullable=False))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "mod_score")

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -257,6 +257,8 @@ class User(Base, kw_only=True):
 
     recommendation_score: Mapped[float] = mapped_column(Float, server_default="0", init=False)
 
+    mod_score: Mapped[float] = mapped_column(Float, server_default="1", init=False)
+
     # Columns for verifying their phone number. State chart:
     #                                       ,-------------------,
     #                                       |    Start          |

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -146,6 +146,7 @@ def _user_to_details(session: Session, user: User) -> admin_pb2.UserDetails:
         acknowledged_mod_notes_count=user.mod_notes.where(~ModNote.is_pending).count(),
         admin_actions=action_pbs,
         admin_tags=list(admin_tags),
+        mod_score=user.mod_score,
     )
 
 

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -1075,3 +1075,13 @@ class Admin(admin_pb2_grpc.AdminServicer):
         session.flush()
         log_admin_action(session, context, user, "remove_tag", tag=request.tag)
         return _user_to_details(session, user)
+
+    def SetModScore(
+        self, request: admin_pb2.SetModScoreReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.UserDetails:
+        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
+        if not user:
+            context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
+        user.mod_score = request.mod_score
+        log_admin_action(session, context, user, "set_mod_score", note=f"mod_score={request.mod_score}")
+        return _user_to_details(session, user)

--- a/app/proto/admin.proto
+++ b/app/proto/admin.proto
@@ -97,6 +97,8 @@ service Admin {
   rpc AddAdminTagToUser(AddAdminTagToUserReq) returns (UserDetails) {}
 
   rpc RemoveAdminTagFromUser(RemoveAdminTagFromUserReq) returns (UserDetails) {}
+
+  rpc SetModScore(SetModScoreReq) returns (UserDetails) {}
 }
 
 message AdminActionLog {
@@ -525,4 +527,10 @@ message AddAdminTagToUserReq {
 message RemoveAdminTagFromUserReq {
   string user = 1;
   string tag = 2;
+}
+
+message SetModScoreReq {
+  // username, email, or user id
+  string user = 1;
+  double mod_score = 2;
 }

--- a/app/proto/admin.proto
+++ b/app/proto/admin.proto
@@ -140,6 +140,8 @@ message UserDetails {
 
   repeated AdminActionLog admin_actions = 18;
   repeated string admin_tags = 19;
+
+  double mod_score = 20;
 }
 
 message GetUserDetailsReq {


### PR DESCRIPTION
Adds a `mod_score` float column to the `User` model, defaulting to 1. Not used anywhere yet.

## Testing
N/A — column is unused.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._