### PR TITLE
Devops/PR skill: add Claude usage and iteration scoring

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -86,11 +86,11 @@ Read the PR template from `.github/pull_request_template.md` in this repo. Fill 
 
   Be honest. If the user dictated the approach in detail, Design is None or Some. If the user wrote or substantially rewrote the code themselves, Implementation is None or Some. If the user manually tested or you never ran/tested the changes, Review is None or Some. Judge from the actual conversation, not optimistically.
 
-  Score **Amount of iteration** separately on the same scale — this measures total back-and-forth/rework regardless of who drove it:
-  - **None** — one-shot; first attempt accepted as-is.
-  - **Some** — minor refinements or follow-up tweaks.
-  - **Most** — substantial rework or course correction along the way.
-  - **All** — many rounds; repeated redirection or rewriting.
+  Score **Amount of iteration** as **One-shot**, **Light**, **Moderate**, or **Heavy** — this measures total back-and-forth/rework regardless of who drove it:
+  - **One-shot** — first attempt accepted as-is.
+  - **Light** — minor refinements or follow-up tweaks.
+  - **Moderate** — substantial rework or course correction along the way.
+  - **Heavy** — many rounds; repeated redirection or rewriting.
 
 ```bash
 gh pr create --base develop --title "<short title>" --body "$(cat <<'EOF'

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -71,17 +71,34 @@ Read the PR template from `.github/pull_request_template.md` in this repo. Fill 
 - Fill in the Testing section with what was done or what should be done
 - Include the appropriate checklist(s) — backend, web, or both — based on which areas were changed. Remove checklists that don't apply.
 - Keep the "For maintainers" section as-is
-- Append the following note as the very last line of the PR body, after the "For maintainers" section (separated by a blank line):
+- Append the following two lines as the very last lines of the PR body, after the "For maintainers" section (separated by a blank line):
 
   ```
   _This PR was created with the Couchers PR skill._
+  _Claude usage — Design: <score> · Implementation: <score> · Review: <score>_
+  _Amount of iteration: <score>_
   ```
+
+  Score each Claude usage category as **None**, **Some**, **Most**, or **All** based on Claude's share of the work:
+  - **Design** — deciding *what* to build and the approach (the idea, architecture, API shape, edge cases to handle).
+  - **Implementation** — writing the actual code that landed in the diff.
+  - **Review** — testing, running the code, verifying behavior, debugging, catching issues.
+
+  Be honest. If the user dictated the approach in detail, Design is None or Some. If the user wrote or substantially rewrote the code themselves, Implementation is None or Some. If the user manually tested or you never ran/tested the changes, Review is None or Some. Judge from the actual conversation, not optimistically.
+
+  Score **Amount of iteration** separately on the same scale — this measures total back-and-forth/rework regardless of who drove it:
+  - **None** — one-shot; first attempt accepted as-is.
+  - **Some** — minor refinements or follow-up tweaks.
+  - **Most** — substantial rework or course correction along the way.
+  - **All** — many rounds; repeated redirection or rewriting.
 
 ```bash
 gh pr create --base develop --title "<short title>" --body "$(cat <<'EOF'
 <filled-in PR template>
 
 _This PR was created with the Couchers PR skill._
+_Claude usage — Design: <score> · Implementation: <score> · Review: <score>_
+_Amount of iteration: <score>_
 EOF
 )"
 ```


### PR DESCRIPTION
Updates the `/pr` skill so the trailer appended to PRs created via the skill now includes a self-assessment of how heavily Claude was used and how much back-and-forth the work required.

The trailer now has two extra lines:

- `_Claude usage — Design: <score> · Implementation: <score> · Review: <score>_` — Claude's share of each phase, scored None / Some / Most / All.
- `_Amount of iteration: <score>_` — total rework regardless of who drove it, on the same scale (separated onto its own line because the semantics differ from the share-of-work scores).

Guidance is included to score honestly based on the actual conversation (e.g. if the user dictated the design, Design is None or Some).

## Testing
*No runtime behavior changes — this only edits a skill prompt file. The next PR created via `/pr` will exercise the new trailer.*

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._
_Claude usage — Design: Some · Implementation: All · Review: None_
_Amount of iteration: Light_