### PR TITLE
Events/i18n: Remove start/end display times from protos

### DIFF
--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -194,8 +194,6 @@ def event_to_pb(session: Session, occurrence: EventOccurrence, context: Couchers
         start_time=Timestamp_from_datetime(occurrence.start_time),
         end_time=Timestamp_from_datetime(occurrence.end_time),
         timezone=occurrence.timezone,
-        start_time_display=str(occurrence.start_time),
-        end_time_display=str(occurrence.end_time),
         attendance_state=attendancestate2api[attendance_state],
         organizer=event.organizers.where(EventOrganizer.user_id == context.user_id).one_or_none() is not None,
         subscriber=event.subscribers.where(EventSubscription.user_id == context.user_id).one_or_none() is not None,

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -90,8 +90,6 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
         assert to_aware_datetime(res.start_time) == start_time
         assert to_aware_datetime(res.end_time) == end_time
         # assert res.timezone == "UTC"
-        assert res.start_time_display
-        assert res.end_time_display
         assert res.attendance_state == events_pb2.ATTENDANCE_STATE_GOING
         assert res.organizer
         assert res.subscriber
@@ -129,8 +127,6 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
         assert to_aware_datetime(res.start_time) == start_time
         assert to_aware_datetime(res.end_time) == end_time
         # assert res.timezone == "UTC"
-        assert res.start_time_display
-        assert res.end_time_display
         assert res.attendance_state == events_pb2.ATTENDANCE_STATE_NOT_GOING
         assert not res.organizer
         assert not res.subscriber
@@ -163,8 +159,6 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
         assert to_aware_datetime(res.start_time) == start_time
         assert to_aware_datetime(res.end_time) == end_time
         # assert res.timezone == "UTC"
-        assert res.start_time_display
-        assert res.end_time_display
         assert res.attendance_state == events_pb2.ATTENDANCE_STATE_NOT_GOING
         assert not res.organizer
         assert not res.subscriber
@@ -209,8 +203,6 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
         assert to_aware_datetime(res.start_time) == start_time
         assert to_aware_datetime(res.end_time) == end_time
         # assert res.timezone == "UTC"
-        assert res.start_time_display
-        assert res.end_time_display
         assert res.attendance_state == events_pb2.ATTENDANCE_STATE_GOING
         assert res.organizer
         assert res.subscriber
@@ -246,8 +238,6 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
         assert to_aware_datetime(res.start_time) == start_time
         assert to_aware_datetime(res.end_time) == end_time
         # assert res.timezone == "UTC"
-        assert res.start_time_display
-        assert res.end_time_display
         assert res.attendance_state == events_pb2.ATTENDANCE_STATE_NOT_GOING
         assert not res.organizer
         assert not res.subscriber
@@ -278,8 +268,6 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
         assert to_aware_datetime(res.start_time) == start_time
         assert to_aware_datetime(res.end_time) == end_time
         # assert res.timezone == "UTC"
-        assert res.start_time_display
-        assert res.end_time_display
         assert res.attendance_state == events_pb2.ATTENDANCE_STATE_NOT_GOING
         assert not res.organizer
         assert not res.subscriber
@@ -582,8 +570,6 @@ def test_ScheduleEvent(db):
         assert to_aware_datetime(res.start_time) == new_start_time
         assert to_aware_datetime(res.end_time) == new_end_time
         # assert res.timezone == "UTC"
-        assert res.start_time_display
-        assert res.end_time_display
         assert res.attendance_state == events_pb2.ATTENDANCE_STATE_GOING
         assert res.organizer
         assert res.subscriber
@@ -785,8 +771,6 @@ def test_UpdateEvent_single(db, moderator: Moderator):
         assert to_aware_datetime(res.start_time) == start_time
         assert to_aware_datetime(res.end_time) == end_time
         # assert res.timezone == "UTC"
-        assert res.start_time_display
-        assert res.end_time_display
         assert res.attendance_state == events_pb2.ATTENDANCE_STATE_GOING
         assert res.organizer
         assert res.subscriber
@@ -819,8 +803,6 @@ def test_UpdateEvent_single(db, moderator: Moderator):
         assert to_aware_datetime(res.start_time) == start_time
         assert to_aware_datetime(res.end_time) == end_time
         # assert res.timezone == "UTC"
-        assert res.start_time_display
-        assert res.end_time_display
         assert res.attendance_state == events_pb2.ATTENDANCE_STATE_NOT_GOING
         assert not res.organizer
         assert not res.subscriber
@@ -853,8 +835,6 @@ def test_UpdateEvent_single(db, moderator: Moderator):
         assert to_aware_datetime(res.start_time) == start_time
         assert to_aware_datetime(res.end_time) == end_time
         # assert res.timezone == "UTC"
-        assert res.start_time_display
-        assert res.end_time_display
         assert res.attendance_state == events_pb2.ATTENDANCE_STATE_NOT_GOING
         assert not res.organizer
         assert not res.subscriber
@@ -895,8 +875,6 @@ def test_UpdateEvent_single(db, moderator: Moderator):
         assert to_aware_datetime(res.start_time) == start_time
         assert to_aware_datetime(res.end_time) == end_time
         # assert res.timezone == "UTC"
-        assert res.start_time_display
-        assert res.end_time_display
         assert res.attendance_state == events_pb2.ATTENDANCE_STATE_GOING
         assert res.organizer
         assert res.subscriber
@@ -929,8 +907,6 @@ def test_UpdateEvent_single(db, moderator: Moderator):
         assert to_aware_datetime(res.start_time) == start_time
         assert to_aware_datetime(res.end_time) == end_time
         # assert res.timezone == "UTC"
-        assert res.start_time_display
-        assert res.end_time_display
         assert res.attendance_state == events_pb2.ATTENDANCE_STATE_NOT_GOING
         assert not res.organizer
         assert not res.subscriber
@@ -961,8 +937,6 @@ def test_UpdateEvent_single(db, moderator: Moderator):
         assert to_aware_datetime(res.start_time) == start_time
         assert to_aware_datetime(res.end_time) == end_time
         # assert res.timezone == "UTC"
-        assert res.start_time_display
-        assert res.end_time_display
         assert res.attendance_state == events_pb2.ATTENDANCE_STATE_NOT_GOING
         assert not res.organizer
         assert not res.subscriber
@@ -1174,8 +1148,6 @@ def test_GetEvent(db, moderator: Moderator):
         assert to_aware_datetime(res.start_time) == start_time
         assert to_aware_datetime(res.end_time) == end_time
         # assert res.timezone == "UTC"
-        assert res.start_time_display
-        assert res.end_time_display
         assert res.attendance_state == events_pb2.ATTENDANCE_STATE_GOING
         assert res.organizer
         assert res.subscriber
@@ -1208,8 +1180,6 @@ def test_GetEvent(db, moderator: Moderator):
         assert to_aware_datetime(res.start_time) == start_time
         assert to_aware_datetime(res.end_time) == end_time
         # assert res.timezone == "UTC"
-        assert res.start_time_display
-        assert res.end_time_display
         assert res.attendance_state == events_pb2.ATTENDANCE_STATE_NOT_GOING
         assert not res.organizer
         assert not res.subscriber
@@ -1242,8 +1212,6 @@ def test_GetEvent(db, moderator: Moderator):
         assert to_aware_datetime(res.start_time) == start_time
         assert to_aware_datetime(res.end_time) == end_time
         # assert res.timezone == "UTC"
-        assert res.start_time_display
-        assert res.end_time_display
         assert res.attendance_state == events_pb2.ATTENDANCE_STATE_NOT_GOING
         assert not res.organizer
         assert not res.subscriber

--- a/app/proto/events.proto
+++ b/app/proto/events.proto
@@ -134,8 +134,9 @@ message Event {
   // the tzdata timezone identifier
   string timezone = 18;
 
-  reserved 19, "start_time_display"; // Was unused and not localized
-  reserved 20, "end_time_display"; // Was unused and not localized
+  // start/end_time_display were unused and not localized
+  reserved 19, 20;
+  reserved "start_time_display", "end_time_display";
 
   // the user's attendance state
   AttendanceState attendance_state = 21;

--- a/app/proto/events.proto
+++ b/app/proto/events.proto
@@ -134,6 +134,9 @@ message Event {
   // the tzdata timezone identifier
   string timezone = 18;
 
+  reserved 19, "start_time_display"; // Was unused and not localized
+  reserved 20, "end_time_display"; // Was unused and not localized
+
   // the user's attendance state
   AttendanceState attendance_state = 21;
   // whether the current user is a subscriber/organizer to the event

--- a/app/proto/events.proto
+++ b/app/proto/events.proto
@@ -134,10 +134,6 @@ message Event {
   // the tzdata timezone identifier
   string timezone = 18;
 
-  // the start/end times as localized strings (according to the above timezone)
-  string start_time_display = 19;
-  string end_time_display = 20;
-
   // the user's attendance state
   AttendanceState attendance_state = 21;
   // whether the current user is a subscriber/organizer to the event

--- a/app/web/test/fixtures/events.json
+++ b/app/web/test/fixtures/events.json
@@ -32,8 +32,6 @@
     "slug": "weekly-meetup",
     "startTime": { "nanos": 0, "seconds": 1624934247.732 },
     "endTime": { "nanos": 0, "seconds": 1624937847 },
-    "startTimeDisplay": "",
-    "endTimeDisplay": "",
     "title": "Weekly Meetup",
     "timezone": "Europe/Amsterdam"
   },
@@ -68,8 +66,6 @@
     "slug": "planting-season-meetup",
     "startTime": { "nanos": 0, "seconds": 1625000420 },
     "endTime": { "nanos": 0, "seconds": 1625004020 },
-    "startTimeDisplay": "",
-    "endTimeDisplay": "",
     "title": "Planting Season Meetup",
     "timezone": "Europe/Amsterdam"
   },
@@ -106,8 +102,6 @@
     "slug": "cherry-blossom-bike-ride",
     "startTime": { "nanos": 0, "seconds": 1625000420 },
     "endTime": { "nanos": 0, "seconds": 1625018400 },
-    "startTimeDisplay": "",
-    "endTimeDisplay": "",
     "title": "Cherry Blossom Bike Ride around the entire Amsterdam because I like to write long event titles",
     "timezone": "Europe/Amsterdam"
   },
@@ -144,8 +138,6 @@
     "slug": "cherry-blossom-bike-ride",
     "startTime": { "nanos": 0, "seconds": 1625000420 },
     "endTime": { "nanos": 0, "seconds": 1625018400 },
-    "startTimeDisplay": "",
-    "endTimeDisplay": "",
     "title": "A cancelled event",
     "timezone": "Europe/Amsterdam"
   }


### PR DESCRIPTION
Localization of datetimes should happen on the frontend, which can decide what format to use based on the context (e.g. abbreviated months, weekdays or not). The backend-provided time display value was not localized properly and unused. Better just remove it.

## Testing
This was dead code. Tests should cover regressions.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
