### PR TITLE
Backend/emails: Use protobuf SendEmailPayload as param object

### DIFF
--- a/app/backend/src/couchers/email/dev.py
+++ b/app/backend/src/couchers/email/dev.py
@@ -2,20 +2,12 @@ import logging
 
 from couchers.crypto import random_hex
 from couchers.models import Email
+from couchers.proto.internal import jobs_pb2
 
 logger = logging.getLogger(__name__)
 
 
-def print_dev_email(
-    sender_name: str,
-    sender_email: str,
-    recipient: str,
-    subject: str,
-    plain: str,
-    html: str,
-    list_unsubscribe_header: str | None,
-    source_data: str | None,
-) -> Email:
+def print_dev_email(payload: jobs_pb2.SendEmailPayload) -> Email:
     """
     Generates a dummy Email object and prints the plain email contents to the logger
 
@@ -26,16 +18,16 @@ def print_dev_email(
     message_id = random_hex()
 
     logger.info("Dev email:")
-    logger.info(plain)
+    logger.info(payload.plain)
 
     return Email(
         id=message_id,
-        sender_name=sender_name,
-        sender_email=sender_email,
-        recipient=recipient,
-        subject=subject,
-        plain=plain,
-        html=html,
-        list_unsubscribe_header=list_unsubscribe_header,
-        source_data=source_data,
+        sender_name=payload.sender_name,
+        sender_email=payload.sender_email,
+        recipient=payload.recipient,
+        subject=payload.subject,
+        plain=payload.plain,
+        html=payload.html,
+        list_unsubscribe_header=payload.list_unsubscribe_header,
+        source_data=payload.source_data,
     )

--- a/app/backend/src/couchers/email/queuing.py
+++ b/app/backend/src/couchers/email/queuing.py
@@ -30,8 +30,10 @@ def _queue_email(session: Session, payload: jobs_pb2.SendEmailPayload) -> None:
 
     emails_counter.inc()
 
+
 def queue_email(session: Session, payload: jobs_pb2.SendEmailPayload) -> None:
     _queue_email(session, payload)
+
 
 def queue_userless_email(
     session: Session, recipient: str, subject: str, template_name: str, template_args: dict[str, Any]

--- a/app/backend/src/couchers/email/queuing.py
+++ b/app/backend/src/couchers/email/queuing.py
@@ -13,17 +13,7 @@ from couchers.templating import Jinja2Template, template_folder
 from couchers.utils import now
 
 
-def _queue_email(
-    session: Session,
-    sender_name: str,
-    sender_email: str,
-    recipient: str,
-    subject: str,
-    plain: str,
-    html: str | None,
-    list_unsubscribe_header: str | None,
-    source_data: str | None,
-) -> None:
+def _queue_email(session: Session, payload: jobs_pb2.SendEmailPayload) -> None:
     """
     This indirection is so that this can be easily mocked. Not sure how to do it better :(
     """
@@ -31,16 +21,6 @@ def _queue_email(
     # Import here to avoid circular dependency
     from couchers.jobs.handlers import send_email  # noqa: PLC0415
 
-    payload = jobs_pb2.SendEmailPayload(
-        sender_name=sender_name,
-        sender_email=sender_email,
-        recipient=recipient,
-        subject=subject,
-        plain=plain,
-        html=html,
-        list_unsubscribe_header=list_unsubscribe_header,
-        source_data=source_data,
-    )
     queue_job(
         session,
         job=send_email,
@@ -50,30 +30,8 @@ def _queue_email(
 
     emails_counter.inc()
 
-
-def queue_email(
-    session: Session,
-    sender_name: str,
-    sender_email: str,
-    recipient: str,
-    subject: str,
-    plain: str,
-    html: str | None,
-    list_unsubscribe_header: str | None = None,
-    source_data: str | None = None,
-) -> None:
-    _queue_email(
-        session=session,
-        sender_name=sender_name,
-        sender_email=sender_email,
-        recipient=recipient,
-        subject=subject,
-        plain=plain,
-        html=html,
-        list_unsubscribe_header=list_unsubscribe_header,
-        source_data=source_data,
-    )
-
+def queue_email(session: Session, payload: jobs_pb2.SendEmailPayload) -> None:
+    _queue_email(session, payload)
 
 def queue_userless_email(
     session: Session, recipient: str, subject: str, template_name: str, template_args: dict[str, Any]
@@ -109,13 +67,15 @@ def queue_userless_email(
 
     queue_email(
         session,
-        sender_name=config["NOTIFICATION_EMAIL_SENDER"],
-        sender_email=config["NOTIFICATION_EMAIL_ADDRESS"],
-        recipient=recipient,
-        subject=config["NOTIFICATION_PREFIX"] + subject,
-        plain=plain,
-        html=html,
-        source_data=config["VERSION"] + f"/{template_name}",
+        jobs_pb2.SendEmailPayload(
+            sender_name=config["NOTIFICATION_EMAIL_SENDER"],
+            sender_email=config["NOTIFICATION_EMAIL_ADDRESS"],
+            recipient=recipient,
+            subject=config["NOTIFICATION_PREFIX"] + subject,
+            plain=plain,
+            html=html,
+            source_data=config["VERSION"] + f"/{template_name}",
+        ),
     )
 
 
@@ -134,11 +94,12 @@ def queue_system_email(session: Session, recipient: str, template_name: str, tem
 
     queue_email(
         session,
-        sender_name=config["NOTIFICATION_EMAIL_SENDER"],
-        sender_email=config["NOTIFICATION_EMAIL_ADDRESS"],
-        recipient=recipient,
-        subject=config["NOTIFICATION_PREFIX"] + frontmatter["subject"],
-        plain=plain,
-        html=None,
-        source_data=template_name,
+        jobs_pb2.SendEmailPayload(
+            sender_name=config["NOTIFICATION_EMAIL_SENDER"],
+            sender_email=config["NOTIFICATION_EMAIL_ADDRESS"],
+            recipient=recipient,
+            subject=config["NOTIFICATION_PREFIX"] + frontmatter["subject"],
+            plain=plain,
+            source_data=template_name,
+        ),
     )

--- a/app/backend/src/couchers/email/smtp.py
+++ b/app/backend/src/couchers/email/smtp.py
@@ -8,6 +8,7 @@ from typing import cast
 from couchers.config import config
 from couchers.crypto import EMAIL_SOURCE_DATA_KEY_NAME, random_hex, simple_hash_signature
 from couchers.models import Email
+from couchers.proto.internal import jobs_pb2
 
 template_base = Path(Path(__file__).parent / ".." / ".." / ".." / "templates" / "v2")
 
@@ -18,16 +19,7 @@ def make_cid(sender_email: str) -> tuple[str, str]:
     return cid, without_tag
 
 
-def send_smtp_email(
-    sender_name: str,
-    sender_email: str,
-    recipient: str,
-    subject: str,
-    plain: str,
-    html: str,
-    list_unsubscribe_header: str | None,
-    source_data: str | None,
-) -> Email:
+def send_smtp_email(payload: jobs_pb2.SendEmailPayload) -> Email:
     """
     Sends out the email through SMTP, settings from config.
 
@@ -35,34 +27,35 @@ def send_smtp_email(
     """
     message_id = random_hex()
     msg = EmailMessage()
-    msg["Subject"] = subject
-    msg["From"] = Address(sender_name, addr_spec=sender_email)
-    msg["To"] = Address(addr_spec=recipient)
+    msg["Subject"] = payload.subject
+    msg["From"] = Address(payload.sender_name, addr_spec=payload.sender_email)
+    msg["To"] = Address(addr_spec=payload.recipient)
     msg["X-Couchers-ID"] = message_id
 
-    if list_unsubscribe_header:
-        msg["List-Unsubscribe"] = list_unsubscribe_header
+    if payload.list_unsubscribe_header:
+        msg["List-Unsubscribe"] = payload.list_unsubscribe_header
 
-    if source_data:
-        msg["X-Couchers-Source-Data"] = source_data
-        msg["X-Couchers-Source-Sig"] = simple_hash_signature(source_data, EMAIL_SOURCE_DATA_KEY_NAME)
+    if payload.source_data:
+        msg["X-Couchers-Source-Data"] = payload.source_data
+        msg["X-Couchers-Source-Sig"] = simple_hash_signature(payload.source_data, EMAIL_SOURCE_DATA_KEY_NAME)
 
-    msg.set_content(plain)
+    msg.set_content(payload.plain)
 
-    if html:
+    updated_html = payload.html
+    if updated_html:
         # for any png files in attachment_imgs/, goes through and replaces instances of the filename with attachment
         used_attachments = []
         for attachment in (template_base / "attachment_imgs").glob("*.png"):
             attachment_html_path = str(attachment.relative_to(template_base))
-            if attachment_html_path not in html:
+            if attachment_html_path not in updated_html:
                 continue
             # it's used in this template, so attach and replace it
             data = attachment.read_bytes()
-            cid, wcid = make_cid(sender_email)
-            html = html.replace(attachment_html_path, f"cid:{wcid}")
+            cid, wcid = make_cid(payload.sender_email)
+            updated_html = updated_html.replace(attachment_html_path, f"cid:{wcid}")
             used_attachments.append((cid, "image", "png", data))
 
-        msg.add_alternative(html, subtype="html")
+        msg.add_alternative(updated_html, subtype="html")
 
         for cid, mime_type, mime_subtype, data in used_attachments:
             payloads = cast(list[MIMEPart], msg.get_payload())
@@ -75,16 +68,16 @@ def send_smtp_email(
             # stmplib docs recommend calling ehlo() before and after starttls()
             server.ehlo()
             server.login(config["SMTP_USERNAME"], config["SMTP_PASSWORD"])
-        server.sendmail(sender_email, recipient, msg.as_string())
+        server.sendmail(payload.sender_email, payload.recipient, msg.as_string())
 
     return Email(
         id=message_id,
-        sender_name=sender_name,
-        sender_email=sender_email,
-        recipient=recipient,
-        subject=subject,
-        plain=plain,
-        html=html,
-        list_unsubscribe_header=list_unsubscribe_header,
-        source_data=source_data,
+        sender_name=payload.sender_name,
+        sender_email=payload.sender_email,
+        recipient=payload.recipient,
+        subject=payload.subject,
+        plain=payload.plain,
+        html=updated_html,
+        list_unsubscribe_header=payload.list_unsubscribe_header,
+        source_data=payload.source_data,
     )

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -139,16 +139,7 @@ def send_email(payload: jobs_pb2.SendEmailPayload) -> None:
     # selects a "sender", which either prints the email to the logger or sends it out with SMTP
     sender = send_smtp_email if config["ENABLE_EMAIL"] else print_dev_email
     # the sender must return a models.Email object that can be added to the database
-    email = sender(
-        sender_name=payload.sender_name,
-        sender_email=payload.sender_email,
-        recipient=payload.recipient,
-        subject=payload.subject,
-        plain=payload.plain,
-        html=payload.html,
-        list_unsubscribe_header=payload.list_unsubscribe_header,
-        source_data=payload.source_data,
-    )
+    email = sender(payload)
     with session_scope() as session:
         session.add(email)
 

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -10,7 +10,6 @@ from couchers.config import config
 from couchers.context import make_background_user_context
 from couchers.db import session_scope
 from couchers.email.queuing import queue_email
-from couchers.proto.internal import jobs_pb2
 from couchers.i18n import LocalizationContext
 from couchers.models import (
     Notification,

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -10,6 +10,7 @@ from couchers.config import config
 from couchers.context import make_background_user_context
 from couchers.db import session_scope
 from couchers.email.queuing import queue_email
+from couchers.proto.internal import jobs_pb2
 from couchers.i18n import LocalizationContext
 from couchers.models import (
     Notification,
@@ -49,14 +50,16 @@ def _send_email_notification(session: Session, user: User, notification: Notific
 
     queue_email(
         session,
-        sender_name=config["NOTIFICATION_EMAIL_SENDER"],
-        sender_email=config["NOTIFICATION_EMAIL_ADDRESS"],
-        recipient=user.email,
-        subject=config["NOTIFICATION_PREFIX"] + rendered.subject,
-        plain=rendered.body_plaintext,
-        html=rendered.body_html,
-        source_data=rendered.source_data,
-        list_unsubscribe_header=rendered.list_unsubscribe_header,
+        jobs_pb2.SendEmailPayload(
+            sender_name=config["NOTIFICATION_EMAIL_SENDER"],
+            sender_email=config["NOTIFICATION_EMAIL_ADDRESS"],
+            recipient=user.email,
+            subject=config["NOTIFICATION_PREFIX"] + rendered.subject,
+            plain=rendered.body_plaintext,
+            html=rendered.body_html,
+            source_data=rendered.source_data,
+            list_unsubscribe_header=rendered.list_unsubscribe_header,
+        ),
     )
 
 

--- a/app/backend/src/tests/fixtures/misc.py
+++ b/app/backend/src/tests/fixtures/misc.py
@@ -10,6 +10,7 @@ from couchers.jobs.worker import process_job
 from couchers.models import User
 from couchers.notifications.push import PushNotificationContent
 from couchers.proto import moderation_pb2
+from couchers.proto.internal import jobs_pb2
 from tests.fixtures.sessions import real_moderation_session
 
 
@@ -25,30 +26,9 @@ def mock_notification_email() -> Generator[Mock]:
         process_jobs()
 
 
-@dataclass
-class EmailData:
-    sender_name: str
-    sender_email: str
-    recipient: str
-    subject: str
-    plain: str
-    html: str
-    source_data: str
-    list_unsubscribe_header: str
-
-
-def email_fields(mock: Mock, call_ix: int = 0) -> EmailData:
-    _, kw = mock.call_args_list[call_ix]
-    return EmailData(
-        sender_name=kw.get("sender_name"),
-        sender_email=kw.get("sender_email"),
-        recipient=kw.get("recipient"),
-        subject=kw.get("subject"),
-        plain=kw.get("plain"),
-        html=kw.get("html"),
-        source_data=kw.get("source_data"),
-        list_unsubscribe_header=kw.get("list_unsubscribe_header"),
-    )
+def email_fields(mock: Mock, call_ix: int = 0) -> jobs_pb2.SendEmailPayload:
+    args, _ = mock.call_args_list[call_ix]
+    return args[1]
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -16,6 +16,7 @@ from couchers.crypto import urlsafe_secure_token
 from couchers.db import session_scope
 from couchers.email.dev import print_dev_email
 from couchers.email.queuing import queue_email
+from couchers.proto.internal import jobs_pb2
 from couchers.jobs import handlers
 from couchers.jobs.definitions import Job
 from couchers.jobs.enqueue import queue_job
@@ -78,20 +79,26 @@ def _check_job_counter(job, status, attempt, exception):
 
 def test_email_job(db):
     with session_scope() as session:
-        queue_email(session, "sender_name", "sender_email", "recipient", "subject", "plain", "html")
-
-    def mock_print_dev_email(
-        sender_name, sender_email, recipient, subject, plain, html, list_unsubscribe_header, source_data
-    ):
-        assert sender_name == "sender_name"
-        assert sender_email == "sender_email"
-        assert recipient == "recipient"
-        assert subject == "subject"
-        assert plain == "plain"
-        assert html == "html"
-        return print_dev_email(
-            sender_name, sender_email, recipient, subject, plain, html, list_unsubscribe_header, source_data
+        queue_email(
+            session,
+            jobs_pb2.SendEmailPayload(
+                sender_name="sender_name",
+                sender_email="sender_email",
+                recipient="recipient",
+                subject="subject",
+                plain="plain",
+                html="html",
+            ),
         )
+
+    def mock_print_dev_email(payload):
+        assert payload.sender_name == "sender_name"
+        assert payload.sender_email == "sender_email"
+        assert payload.recipient == "recipient"
+        assert payload.subject == "subject"
+        assert payload.plain == "plain"
+        assert payload.html == "html"
+        return print_dev_email(payload)
 
     with patch("couchers.jobs.handlers.print_dev_email", mock_print_dev_email):
         process_job()
@@ -278,7 +285,17 @@ def test_refresh_materialized_views(db):
 
 def test_service_jobs(db):
     with session_scope() as session:
-        queue_email(session, "sender_name", "sender_email", "recipient", "subject", "plain", "html")
+        queue_email(
+            session,
+            jobs_pb2.SendEmailPayload(
+                sender_name="sender_name",
+                sender_email="sender_email",
+                recipient="recipient",
+                subject="subject",
+                plain="plain",
+                html="html",
+            ),
+        )
 
     # we create this HitSleep exception here, and mock out the normal sleep(1) in the infinite loop to instead raise
     # this. that allows us to conveniently get out of the infinite loop and know we had no more jobs left

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -16,7 +16,6 @@ from couchers.crypto import urlsafe_secure_token
 from couchers.db import session_scope
 from couchers.email.dev import print_dev_email
 from couchers.email.queuing import queue_email
-from couchers.proto.internal import jobs_pb2
 from couchers.jobs import handlers
 from couchers.jobs.definitions import Job
 from couchers.jobs.enqueue import queue_job
@@ -54,6 +53,7 @@ from couchers.models import (
     Volunteer,
 )
 from couchers.proto import conversations_pb2, requests_pb2
+from couchers.proto.internal import jobs_pb2
 from couchers.utils import now, today
 from tests.fixtures.db import generate_user, make_friends, make_user_block, make_volunteer
 from tests.fixtures.misc import PushCollector, process_jobs

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -195,7 +195,7 @@ def test_email_patching_fails(db):
     assert friend_relationship is not None
     moderator.approve_friend_request(friend_relationship.id)
 
-    with patch("couchers.email.queuing.queue_email", mock_queue_email):
+    with patch("couchers.email.queuing._queue_email", mock_queue_email):
         with pytest.raises(Exception) as e:
             process_jobs()
 

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -185,7 +185,7 @@ def test_email_patching_fails(db):
 
     patched_msg = random_hex(64)
 
-    def mock_queue_email(session, **kwargs):
+    def mock_queue_email(session, payload):
         raise Exception(patched_msg)
 
     with api_session(from_token) as api:
@@ -195,7 +195,7 @@ def test_email_patching_fails(db):
     assert friend_relationship is not None
     moderator.approve_friend_request(friend_relationship.id)
 
-    with patch("couchers.email.queuing._queue_email", mock_queue_email):
+    with patch("couchers.email.queuing.queue_email", mock_queue_email):
         with pytest.raises(Exception) as e:
             process_jobs()
 


### PR DESCRIPTION
We pass the 8 properties of `SendEmailPayload` as separate params in various places. This will become more unwieldly when adding support for attachments (for event icals), or moving the email attachment fixup to the email templating code, both of which will require additional params and sub-objects. Update the code to pass `SendEmailPayload` since it has the shape we need.

## Testing
Tests in CI

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me