### PR TITLE
Backend: Add ListAdminActions and ListModerationStates RPCs

### DIFF
--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import grpc
 from google.protobuf import empty_pb2
 from sqlalchemy import select
-from sqlalchemy.orm import Session, selectinload
+from sqlalchemy.orm import Session, aliased, selectinload
 from sqlalchemy.sql import and_, func, or_
 from user_agents import parse as user_agents_parse
 
@@ -114,6 +114,8 @@ def _user_to_details(session: Session, user: User) -> admin_pb2.UserDetails:
                 level=adminactionlevel2api[action.level],
                 note=action.note or "",
                 tag=action.tag or "",
+                target_user_id=action.target_user_id,
+                target_username=user.username,
             )
         )
 
@@ -1085,3 +1087,49 @@ class Admin(admin_pb2_grpc.AdminServicer):
         user.mod_score = request.mod_score
         log_admin_action(session, context, user, "set_mod_score", note=f"mod_score={request.mod_score}")
         return _user_to_details(session, user)
+
+    def ListAdminActions(
+        self, request: admin_pb2.ListAdminActionsReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.ListAdminActionsRes:
+        page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
+
+        admin_user = aliased(User)
+        target_user = aliased(User)
+
+        statement = (
+            select(AdminAction, admin_user.username, target_user.username)
+            .join(admin_user, AdminAction.admin_user_id == admin_user.id)
+            .join(target_user, AdminAction.target_user_id == target_user.id)
+        )
+
+        if request.admin_user_id:
+            statement = statement.where(AdminAction.admin_user_id == request.admin_user_id)
+        if request.target_user_id:
+            statement = statement.where(AdminAction.target_user_id == request.target_user_id)
+        if request.page_token:
+            statement = statement.where(AdminAction.id < int(request.page_token))
+
+        statement = statement.order_by(AdminAction.id.desc()).limit(page_size + 1)
+
+        rows = session.execute(statement).all()
+
+        action_pbs = [
+            admin_pb2.AdminActionLog(
+                admin_action_id=action.id,
+                created=Timestamp_from_datetime(action.created),
+                admin_user_id=action.admin_user_id,
+                admin_username=admin_username,
+                action_type=action.action_type,
+                level=adminactionlevel2api[action.level],
+                note=action.note or "",
+                tag=action.tag or "",
+                target_user_id=action.target_user_id,
+                target_username=target_username,
+            )
+            for action, admin_username, target_username in rows[:page_size]
+        ]
+
+        return admin_pb2.ListAdminActionsRes(
+            admin_actions=action_pbs,
+            next_page_token=str(rows[page_size - 1][0].id) if len(rows) > page_size else None,
+        )

--- a/app/backend/src/couchers/servicers/moderation.py
+++ b/app/backend/src/couchers/servicers/moderation.py
@@ -605,3 +605,46 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
         )
 
         return moderation_pb2.SetUserContentVisibilityRes(updated_count=updated_count)
+
+    def ListModerationStates(
+        self, request: moderation_pb2.ListModerationStatesReq, context: CouchersContext, session: Session
+    ) -> moderation_pb2.ListModerationStatesRes:
+        """Chronological, paginated list of ModerationState rows. Optional author_user_id filter."""
+        page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
+
+        statement = select(ModerationState)
+
+        if request.page_token:
+            page_token_id = int(request.page_token)
+            if request.newest_first:
+                statement = statement.where(ModerationState.id < page_token_id)
+            else:
+                statement = statement.where(ModerationState.id > page_token_id)
+
+        if request.author_user_id:
+            author_exists_clauses = []
+            for model in moderationobjecttype2model.values():
+                author_col = getattr(model, model.__moderation_author_column__)
+                author_exists_clauses.append(
+                    exists().where(
+                        and_(
+                            model.moderation_state_id == ModerationState.id,
+                            author_col == request.author_user_id,
+                        )
+                    )
+                )
+            statement = statement.where(or_(*author_exists_clauses))
+
+        if request.newest_first:
+            statement = statement.order_by(ModerationState.created.desc(), ModerationState.id.desc())
+        else:
+            statement = statement.order_by(ModerationState.created.asc(), ModerationState.id.asc())
+
+        states = session.execute(statement.limit(page_size + 1)).scalars().all()
+
+        state_pbs = [moderation_state_to_pb(state, session) for state in states[:page_size]]
+
+        return moderation_pb2.ListModerationStatesRes(
+            moderation_states=state_pbs,
+            next_page_token=str(states[page_size - 1].id) if len(states) > page_size else None,
+        )

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -1303,6 +1303,84 @@ def test_search_users_by_admin_note(db):
         assert user2.id not in user_ids
 
 
+def test_ListAdminActions_empty(db):
+    super_user, super_token = generate_user(is_superuser=True)
+
+    with real_admin_session(super_token) as api:
+        res = api.ListAdminActions(admin_pb2.ListAdminActionsReq())
+    assert len(res.admin_actions) == 0
+    assert res.next_page_token == ""
+
+
+def test_ListAdminActions_returns_newest_first_with_target_info(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    user1, _ = generate_user()
+    user2, _ = generate_user()
+
+    with real_admin_session(super_token) as api:
+        api.AddAdminNote(admin_pb2.AddAdminNoteReq(user=user1.username, admin_note="first note"))
+        api.AddAdminNote(admin_pb2.AddAdminNoteReq(user=user2.username, admin_note="second note"))
+        api.BanUser(admin_pb2.BanUserReq(user=user1.username, admin_note="ban reason"))
+
+        res = api.ListAdminActions(admin_pb2.ListAdminActionsReq())
+
+    assert len(res.admin_actions) == 3
+    # Newest first
+    assert res.admin_actions[0].action_type == "ban"
+    assert res.admin_actions[0].target_user_id == user1.id
+    assert res.admin_actions[0].target_username == user1.username
+    assert res.admin_actions[0].admin_user_id == super_user.id
+    assert res.admin_actions[0].admin_username == super_user.username
+    assert res.admin_actions[1].action_type == "note"
+    assert res.admin_actions[1].target_user_id == user2.id
+    assert res.admin_actions[2].action_type == "note"
+    assert res.admin_actions[2].target_user_id == user1.id
+
+
+def test_ListAdminActions_filter_by_admin_and_target(db):
+    super1, super1_token = generate_user(is_superuser=True)
+    super2, super2_token = generate_user(is_superuser=True)
+    user1, _ = generate_user()
+    user2, _ = generate_user()
+
+    with real_admin_session(super1_token) as api:
+        api.AddAdminNote(admin_pb2.AddAdminNoteReq(user=user1.username, admin_note="from super1 to user1"))
+        api.AddAdminNote(admin_pb2.AddAdminNoteReq(user=user2.username, admin_note="from super1 to user2"))
+    with real_admin_session(super2_token) as api:
+        api.AddAdminNote(admin_pb2.AddAdminNoteReq(user=user1.username, admin_note="from super2 to user1"))
+
+    with real_admin_session(super1_token) as api:
+        res = api.ListAdminActions(admin_pb2.ListAdminActionsReq(admin_user_id=super1.id))
+        assert {a.note for a in res.admin_actions} == {"from super1 to user1", "from super1 to user2"}
+
+        res = api.ListAdminActions(admin_pb2.ListAdminActionsReq(target_user_id=user1.id))
+        assert {a.note for a in res.admin_actions} == {"from super1 to user1", "from super2 to user1"}
+
+        res = api.ListAdminActions(admin_pb2.ListAdminActionsReq(admin_user_id=super1.id, target_user_id=user1.id))
+        assert [a.note for a in res.admin_actions] == ["from super1 to user1"]
+
+
+def test_ListAdminActions_pagination(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    user, _ = generate_user()
+
+    with real_admin_session(super_token) as api:
+        for i in range(3):
+            api.AddAdminNote(admin_pb2.AddAdminNoteReq(user=user.username, admin_note=f"note {i}"))
+
+        res = api.ListAdminActions(admin_pb2.ListAdminActionsReq(page_size=2))
+        assert len(res.admin_actions) == 2
+        assert res.next_page_token != ""
+        first_page_notes = [a.note for a in res.admin_actions]
+
+        res2 = api.ListAdminActions(admin_pb2.ListAdminActionsReq(page_size=2, page_token=res.next_page_token))
+        assert len(res2.admin_actions) == 1
+        assert res2.next_page_token == ""
+
+    all_notes = first_page_notes + [a.note for a in res2.admin_actions]
+    assert set(all_notes) == {"note 0", "note 1", "note 2"}
+
+
 # community invite feature tested in test_events.py
 # SendBlogPostNotification tested in test_notifications.py
 # MarkUserNeedsLocationUpdate tested in test_jail.py

--- a/app/backend/src/tests/test_moderation.py
+++ b/app/backend/src/tests/test_moderation.py
@@ -2844,3 +2844,66 @@ def test_SetUserContentVisibility_user_not_found(db):
                 )
             )
     assert e.value.code() == grpc.StatusCode.NOT_FOUND
+
+
+def test_ListModerationStates_empty(db):
+    super_user, super_token = generate_user(is_superuser=True)
+
+    with real_moderation_session(super_token) as api:
+        res = api.ListModerationStates(moderation_pb2.ListModerationStatesReq())
+    assert len(res.moderation_states) == 0
+    assert res.next_page_token == ""
+
+
+def test_ListModerationStates_returns_states_chronologically(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    surfer, surfer_token = generate_user()
+    host, _ = generate_user()
+
+    state1_id = create_test_host_request_with_moderation(surfer_token, host.id)
+    state2_id = create_test_host_request_with_moderation(surfer_token, host.id)
+    state3_id = create_test_host_request_with_moderation(surfer_token, host.id)
+
+    with real_moderation_session(super_token) as api:
+        res = api.ListModerationStates(moderation_pb2.ListModerationStatesReq())
+        assert [s.moderation_state_id for s in res.moderation_states] == [state1_id, state2_id, state3_id]
+
+        res_newest = api.ListModerationStates(moderation_pb2.ListModerationStatesReq(newest_first=True))
+        assert [s.moderation_state_id for s in res_newest.moderation_states] == [state3_id, state2_id, state1_id]
+
+
+def test_ListModerationStates_filter_by_author(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    surfer1, surfer1_token = generate_user()
+    surfer2, surfer2_token = generate_user()
+    host, _ = generate_user()
+
+    state1_id = create_test_host_request_with_moderation(surfer1_token, host.id)
+    state2_id = create_test_host_request_with_moderation(surfer2_token, host.id)
+    state3_id = create_test_host_request_with_moderation(surfer1_token, host.id)
+
+    with real_moderation_session(super_token) as api:
+        res = api.ListModerationStates(moderation_pb2.ListModerationStatesReq(author_user_id=surfer1.id))
+        assert {s.moderation_state_id for s in res.moderation_states} == {state1_id, state3_id}
+
+        res = api.ListModerationStates(moderation_pb2.ListModerationStatesReq(author_user_id=surfer2.id))
+        assert [s.moderation_state_id for s in res.moderation_states] == [state2_id]
+
+
+def test_ListModerationStates_pagination(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    surfer, surfer_token = generate_user()
+    host, _ = generate_user()
+
+    state_ids = [create_test_host_request_with_moderation(surfer_token, host.id) for _ in range(3)]
+
+    with real_moderation_session(super_token) as api:
+        res = api.ListModerationStates(moderation_pb2.ListModerationStatesReq(page_size=2))
+        assert [s.moderation_state_id for s in res.moderation_states] == state_ids[:2]
+        assert res.next_page_token != ""
+
+        res2 = api.ListModerationStates(
+            moderation_pb2.ListModerationStatesReq(page_size=2, page_token=res.next_page_token)
+        )
+        assert [s.moderation_state_id for s in res2.moderation_states] == [state_ids[2]]
+        assert res2.next_page_token == ""

--- a/app/proto/admin.proto
+++ b/app/proto/admin.proto
@@ -112,7 +112,6 @@ message AdminActionLog {
   string note = 6;   // optional note/details
   string tag = 7;    // for tag-related actions
   AdminActionLevel level = 8;
-  // populated by ListAdminActions; empty when this message is embedded in UserDetails (target is implicit)
   int64 target_user_id = 9;
   string target_username = 10;
 }

--- a/app/proto/admin.proto
+++ b/app/proto/admin.proto
@@ -99,6 +99,8 @@ service Admin {
   rpc RemoveAdminTagFromUser(RemoveAdminTagFromUserReq) returns (UserDetails) {}
 
   rpc SetModScore(SetModScoreReq) returns (UserDetails) {}
+
+  rpc ListAdminActions(ListAdminActionsReq) returns (ListAdminActionsRes) {}
 }
 
 message AdminActionLog {
@@ -110,6 +112,9 @@ message AdminActionLog {
   string note = 6;   // optional note/details
   string tag = 7;    // for tag-related actions
   AdminActionLevel level = 8;
+  // populated by ListAdminActions; empty when this message is embedded in UserDetails (target is implicit)
+  int64 target_user_id = 9;
+  string target_username = 10;
 }
 
 message AdminTagInfo {
@@ -533,4 +538,19 @@ message SetModScoreReq {
   // username, email, or user id
   string user = 1;
   double mod_score = 2;
+}
+
+message ListAdminActionsReq {
+  // Filter to actions performed by this admin (optional)
+  int64 admin_user_id = 1;
+  // Filter to actions targeting this user (optional)
+  int64 target_user_id = 2;
+
+  uint32 page_size = 3;
+  string page_token = 4;
+}
+
+message ListAdminActionsRes {
+  repeated AdminActionLog admin_actions = 1;
+  string next_page_token = 2;
 }

--- a/app/proto/moderation.proto
+++ b/app/proto/moderation.proto
@@ -22,6 +22,8 @@ service Moderation {
   rpc UnflagContent(UnflagContentReq) returns (UnflagContentRes) {}
 
   rpc SetUserContentVisibility(SetUserContentVisibilityReq) returns (SetUserContentVisibilityRes) {}
+
+  rpc ListModerationStates(ListModerationStatesReq) returns (ListModerationStatesRes) {}
 }
 
 
@@ -179,4 +181,19 @@ message SetUserContentVisibilityReq {
 
 message SetUserContentVisibilityRes {
   int64 updated_count = 1;  // number of ModerationState rows whose visibility changed
+}
+
+message ListModerationStatesReq {
+  // Filter to states authored by this user (optional)
+  int64 author_user_id = 1;
+
+  uint32 page_size = 2;
+  string page_token = 3;
+  // Order by newest first (default: false = oldest first)
+  bool newest_first = 4;
+}
+
+message ListModerationStatesRes {
+  repeated ModerationStateInfo moderation_states = 1;
+  string next_page_token = 2;
 }


### PR DESCRIPTION
Adds two new admin/moderation review RPCs to support browsing historical activity from the admin UI:

- `Admin.ListAdminActions` — paginated list of admin action log entries, optionally filtered by `admin_user_id` and/or `target_user_id`. Returns newest first. The `AdminActionLog` message gains `target_user_id` and `target_username` fields so callers can render rows without an extra lookup.
- `Moderation.ListModerationStates` — paginated list of `ModerationState` rows, ordered chronologically (with optional `newest_first`). Supports filtering to states whose underlying content was authored by a specific user, by `EXISTS`-checking each registered moderation object type's author column.

## Testing
- Added unit tests covering empty results, ordering, filtering by admin/target/author, and pagination for both RPCs.
- `make format` and `make mypy` pass.
- `uv run pytest src/tests/test_admin.py src/tests/test_moderation.py` (run locally before pushing).

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto \`develop\` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._