### PR TITLE
Backend/moderation: add from_visibility filter to SetUserContentVisibility

### DIFF
--- a/app/backend/src/couchers/servicers/moderation.py
+++ b/app/backend/src/couchers/servicers/moderation.py
@@ -542,7 +542,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
         if new_visibility is None:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "visibility_must_be_specified")
 
-        from_visibilities = {moderationvisibility2sql[v] for v in request.from_visibility}
+        from_visibilities = {moderationvisibility2sql.get(v) for v in request.from_visibility}
         if None in from_visibilities:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "visibility_must_be_specified")
 

--- a/app/backend/src/couchers/servicers/moderation.py
+++ b/app/backend/src/couchers/servicers/moderation.py
@@ -534,10 +534,20 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
     def SetUserContentVisibility(
         self, request: moderation_pb2.SetUserContentVisibilityReq, context: CouchersContext, session: Session
     ) -> moderation_pb2.SetUserContentVisibilityRes:
-        """Bulk-set visibility on every UMS-governed object authored by the given user."""
+        """Bulk-set visibility on every UMS-governed object authored by the given user.
+
+        If from_visibility is non-empty, only states currently at one of those visibilities are swept.
+        """
         new_visibility = moderationvisibility2sql[request.visibility]
         if new_visibility is None:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "visibility_must_be_specified")
+
+        from_visibilities: set[ModerationVisibility] = set()
+        for v in request.from_visibility:
+            mapped = moderationvisibility2sql[v]
+            if mapped is None:
+                context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "visibility_must_be_specified")
+            from_visibilities.add(mapped)
 
         user = session.execute(select(User).where(User.id == request.user_id)).scalar_one_or_none()
         if not user:
@@ -556,6 +566,8 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
 
         updated_count = 0
         for moderation_state in states:
+            if from_visibilities and moderation_state.visibility not in from_visibilities:
+                continue
             if moderation_state.visibility == new_visibility:
                 continue
 

--- a/app/backend/src/couchers/servicers/moderation.py
+++ b/app/backend/src/couchers/servicers/moderation.py
@@ -542,12 +542,9 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
         if new_visibility is None:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "visibility_must_be_specified")
 
-        from_visibilities: set[ModerationVisibility] = set()
-        for v in request.from_visibility:
-            mapped = moderationvisibility2sql[v]
-            if mapped is None:
-                context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "visibility_must_be_specified")
-            from_visibilities.add(mapped)
+        from_visibilities = {moderationvisibility2sql[v] for v in request.from_visibility}
+        if None in from_visibilities:
+            context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "visibility_must_be_specified")
 
         user = session.execute(select(User).where(User.id == request.user_id)).scalar_one_or_none()
         if not user:

--- a/app/backend/src/tests/test_moderation.py
+++ b/app/backend/src/tests/test_moderation.py
@@ -2846,6 +2846,166 @@ def test_SetUserContentVisibility_user_not_found(db):
     assert e.value.code() == grpc.StatusCode.NOT_FOUND
 
 
+def test_SetUserContentVisibility_from_visibility_filter(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    surfer, surfer_token = generate_user()
+    host, _ = generate_user()
+
+    today_plus_2 = (today() + timedelta(days=2)).isoformat()
+    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    with requests_session(surfer_token) as api:
+        hr_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=host.id,
+                from_date=today_plus_2,
+                to_date=today_plus_3,
+                text=valid_request_text(),
+            )
+        ).host_request_id
+
+    with real_moderation_session(super_token) as api:
+        api.SetUserContentVisibility(
+            moderation_pb2.SetUserContentVisibilityReq(
+                user_id=surfer.id,
+                visibility=moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
+            )
+        )
+
+    with real_moderation_session(super_token) as api:
+        res = api.SetUserContentVisibility(
+            moderation_pb2.SetUserContentVisibilityReq(
+                user_id=surfer.id,
+                visibility=moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
+                from_visibility=[moderation_pb2.MODERATION_VISIBILITY_SHADOWED],
+            )
+        )
+    assert res.updated_count == 0
+
+    with session_scope() as session:
+        state = _get_moderation_state(session, ModerationObjectType.host_request, hr_id)
+        assert state.visibility == ModerationVisibility.visible
+
+    with real_moderation_session(super_token) as api:
+        res = api.SetUserContentVisibility(
+            moderation_pb2.SetUserContentVisibilityReq(
+                user_id=surfer.id,
+                visibility=moderation_pb2.MODERATION_VISIBILITY_SHADOWED,
+                from_visibility=[moderation_pb2.MODERATION_VISIBILITY_VISIBLE],
+            )
+        )
+    assert res.updated_count == 1
+
+    with session_scope() as session:
+        state = _get_moderation_state(session, ModerationObjectType.host_request, hr_id)
+        assert state.visibility == ModerationVisibility.shadowed
+
+
+def test_SetUserContentVisibility_from_visibility_multi(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    surfer, surfer_token = generate_user()
+    host1, _ = generate_user()
+    host2, _ = generate_user()
+
+    today_plus_2 = (today() + timedelta(days=2)).isoformat()
+    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    with requests_session(surfer_token) as api:
+        hr1_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=host1.id,
+                from_date=today_plus_2,
+                to_date=today_plus_3,
+                text=valid_request_text(),
+            )
+        ).host_request_id
+        hr2_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=host2.id,
+                from_date=today_plus_2,
+                to_date=today_plus_3,
+                text=valid_request_text(),
+            )
+        ).host_request_id
+
+    with session_scope() as session:
+        state1_id = _get_moderation_state(session, ModerationObjectType.host_request, hr1_id).id
+
+    with real_moderation_session(super_token) as api:
+        api.ModerateContent(
+            moderation_pb2.ModerateContentReq(
+                moderation_state_id=state1_id,
+                action=moderation_pb2.MODERATION_ACTION_APPROVE,
+                visibility=moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
+            )
+        )
+
+    with real_moderation_session(super_token) as api:
+        res = api.SetUserContentVisibility(
+            moderation_pb2.SetUserContentVisibilityReq(
+                user_id=surfer.id,
+                visibility=moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
+                from_visibility=[
+                    moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
+                    moderation_pb2.MODERATION_VISIBILITY_SHADOWED,
+                ],
+            )
+        )
+    assert res.updated_count == 2
+
+    with session_scope() as session:
+        state1 = _get_moderation_state(session, ModerationObjectType.host_request, hr1_id)
+        state2 = _get_moderation_state(session, ModerationObjectType.host_request, hr2_id)
+        assert state1.visibility == ModerationVisibility.hidden
+        assert state2.visibility == ModerationVisibility.hidden
+
+
+def test_SetUserContentVisibility_from_visibility_empty_is_any(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    surfer, surfer_token = generate_user()
+    host, _ = generate_user()
+
+    today_plus_2 = (today() + timedelta(days=2)).isoformat()
+    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+    with requests_session(surfer_token) as api:
+        hr_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=host.id,
+                from_date=today_plus_2,
+                to_date=today_plus_3,
+                text=valid_request_text(),
+            )
+        ).host_request_id
+
+    with real_moderation_session(super_token) as api:
+        res = api.SetUserContentVisibility(
+            moderation_pb2.SetUserContentVisibilityReq(
+                user_id=surfer.id,
+                visibility=moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
+                from_visibility=[],
+            )
+        )
+    assert res.updated_count == 1
+
+    with session_scope() as session:
+        state = _get_moderation_state(session, ModerationObjectType.host_request, hr_id)
+        assert state.visibility == ModerationVisibility.hidden
+
+
+def test_SetUserContentVisibility_from_visibility_unspecified_rejected(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    target, _ = generate_user()
+
+    with real_moderation_session(super_token) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.SetUserContentVisibility(
+                moderation_pb2.SetUserContentVisibilityReq(
+                    user_id=target.id,
+                    visibility=moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
+                    from_visibility=[moderation_pb2.MODERATION_VISIBILITY_UNSPECIFIED],
+                )
+            )
+    assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+
 def test_ListModerationStates_empty(db):
     super_user, super_token = generate_user(is_superuser=True)
 

--- a/app/proto/moderation.proto
+++ b/app/proto/moderation.proto
@@ -177,6 +177,8 @@ message SetUserContentVisibilityReq {
   int64 user_id = 1;
   ModerationVisibility visibility = 2;  // must be set
   string reason = 3;  // optional; free-form admin note recorded in ModerationLog
+  // If non-empty, only sweep states currently at one of these visibilities. Empty = any visibility (default).
+  repeated ModerationVisibility from_visibility = 4;
 }
 
 message SetUserContentVisibilityRes {


### PR DESCRIPTION
Adds an optional `from_visibility` repeated field to `SetUserContentVisibilityReq` that narrows the bulk sweep to moderation states currently at one of the given visibilities. An empty list preserves the existing behavior of sweeping any visibility.

This lets admins do targeted transitions (e.g. flip only currently-`visible` content to `shadowed`) without touching content that's already been moderated to a different state.

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

- Added unit tests covering: filter that matches nothing, filter that matches one, multi-visibility filter, empty filter (any), and rejection of `MODERATION_VISIBILITY_UNSPECIFIED` in the filter list.
- `make format`, `make mypy`, and `uv run pytest src/tests/test_moderation.py` all pass locally.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._