### PR TITLE
Backend: Strongly type the config object

### DIFF
--- a/app/backend/src/app.py
+++ b/app/backend/src/app.py
@@ -17,7 +17,7 @@ import sentry_sdk
 from sentry_sdk.integrations import excepthook
 from sqlalchemy.sql import text
 
-from couchers.config import check_config, config
+from couchers.config import Config
 from couchers.db import apply_migrations, session_scope
 from couchers.experimentation import setup_experimentation
 from couchers.i18n.localize import get_main_i18next
@@ -27,7 +27,7 @@ from couchers.server import create_main_server, create_media_server
 from couchers.tracing import setup_tracing
 from dummy_data import add_dummy_data
 
-check_config(config)
+Config.current = Config.from_env()
 
 logging.basicConfig(
     format="[%(process)5d:%(thread)20d] %(asctime)s: %(name)s:%(lineno)d: %(message)s", level=logging.INFO
@@ -51,13 +51,13 @@ def log_unhandled_exception(
 def common_init() -> None:
     sys.excepthook = log_unhandled_exception
 
-    if config.sentry_enabled:
+    if Config.current.sentry_enabled:
         # Sends exception tracebacks to Sentry, a cloud service for collecting exceptions
         sentry_sdk.init(
-            config.sentry_url,
+            Config.current.sentry_url,
             traces_sample_rate=0.0,
-            environment=config.cookie_domain,
-            release=config.version,
+            environment=Config.current.cookie_domain,
+            release=Config.current.version,
             # The global excepthook picks up already handled gRPC errors (e.g. grpc.StatusCode.NOT_FOUND)
             disabled_integrations=[
                 excepthook.ExcepthookIntegration(),
@@ -81,16 +81,16 @@ def main() -> None:
 
     get_main_i18next()  # Force eager loading of translations
 
-    if config.add_dummy_data:
+    if Config.current.add_dummy_data:
         add_dummy_data()
 
     logger.info("Starting")
 
-    if config.role in ["scheduler", "all"]:
+    if Config.current.role in ["scheduler", "all"]:
         start_jobs_scheduler()
 
-    if config.role in ["worker", "all"]:
-        for _ in range(config.background_worker_count):
+    if Config.current.role in ["worker", "all"]:
+        for _ in range(Config.current.background_worker_count):
             start_jobs_worker()
 
     setup_tracing()
@@ -101,7 +101,7 @@ def main() -> None:
     # Worker processes initialize their own instance in _run_forever().
     setup_experimentation()
 
-    if config.role in ["api", "all"]:
+    if Config.current.role in ["api", "all"]:
         server = create_main_server(port=1751)
         server.start()
         media_server = create_media_server(port=1753)

--- a/app/backend/src/app.py
+++ b/app/backend/src/app.py
@@ -51,13 +51,13 @@ def log_unhandled_exception(
 def common_init() -> None:
     sys.excepthook = log_unhandled_exception
 
-    if config["SENTRY_ENABLED"]:
+    if config.sentry_enabled:
         # Sends exception tracebacks to Sentry, a cloud service for collecting exceptions
         sentry_sdk.init(
-            config["SENTRY_URL"],
+            config.sentry_url,
             traces_sample_rate=0.0,
-            environment=config["COOKIE_DOMAIN"],
-            release=config["VERSION"],
+            environment=config.cookie_domain,
+            release=config.version,
             # The global excepthook picks up already handled gRPC errors (e.g. grpc.StatusCode.NOT_FOUND)
             disabled_integrations=[
                 excepthook.ExcepthookIntegration(),
@@ -81,16 +81,16 @@ def main() -> None:
 
     get_main_i18next()  # Force eager loading of translations
 
-    if config["ADD_DUMMY_DATA"]:
+    if config.add_dummy_data:
         add_dummy_data()
 
     logger.info("Starting")
 
-    if config["ROLE"] in ["scheduler", "all"]:
+    if config.role in ["scheduler", "all"]:
         start_jobs_scheduler()
 
-    if config["ROLE"] in ["worker", "all"]:
-        for _ in range(config["BACKGROUND_WORKER_COUNT"]):
+    if config.role in ["worker", "all"]:
+        for _ in range(config.background_worker_count):
             start_jobs_worker()
 
     setup_tracing()
@@ -101,7 +101,7 @@ def main() -> None:
     # Worker processes initialize their own instance in _run_forever().
     setup_experimentation()
 
-    if config["ROLE"] in ["api", "all"]:
+    if config.role in ["api", "all"]:
         server = create_main_server(port=1751)
         server.start()
         media_server = create_media_server(port=1753)

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -6,7 +6,8 @@ import dataclasses
 import os
 import typing
 from collections.abc import Mapping
-from typing import Any, ClassVar, Literal, Self, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Self
+
 
 class ConfigMetaclass(type):
     _current: Config | None = None
@@ -21,6 +22,7 @@ class ConfigMetaclass(type):
     @current.setter
     def current(cls, value: Config | None) -> None:
         cls._current = value
+
 
 @dataclasses.dataclass(kw_only=True)
 class Config(metaclass=ConfigMetaclass):

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -2,222 +2,217 @@
 A simple config system
 """
 
+import dataclasses
 import os
-from typing import Any
+import typing
+from typing import Literal, Self
 
-CONFIG_T = list[tuple[str, type | list[str]] | tuple[str, type | list[str], str | int]]
 
-# Allowed config options, as tuples (name, type, default).
-# All fields are required
-CONFIG_OPTIONS: CONFIG_T = [
+@dataclasses.dataclass(kw_only=True)
+class Config:
     # Whether we're in dev mode
-    ("DEV", bool),
+    dev: bool
     # Whether we're `api` mode (answering API queries) or `scheduler` (scheduling background jobs), or `worker`
     # (servicing background jobs). Can also be set to `all` to do all three simultaneously
-    ("ROLE", ["api", "scheduler", "worker", "all"], "all"),
+    role: Literal["api", "scheduler", "worker", "all"] = "all"
     # number of bg worker processes, requires worker or all above
-    ("BACKGROUND_WORKER_COUNT", int, 2),
+    background_worker_count: int = 2
     # Version string
-    ("VERSION", str, "unknown"),
+    version: str = "unknown"
     # Base URL of frontend, e.g. https://couchers.org
-    ("BASE_URL", str),
+    base_url: str
     # URL of the backend, e.g. https://api.couchers.org
-    ("BACKEND_BASE_URL", str),
+    backend_base_url: str
     # URL of the console, e.g. https://console.couchers.org
-    ("CONSOLE_BASE_URL", str),
+    console_base_url: str
     # URL of the merch shop, e.g. https://shop.couchershq.org
-    ("MERCH_SHOP_URL", str),
+    merch_shop_url: str
     # Used to generate a variety of secrets
-    ("SECRET", bytes),
+    secret: bytes
     # Domain that cookies should set as their domain value
-    ("COOKIE_DOMAIN", str),
+    cookie_domain: str
     # SQLAlchemy database connection string
-    ("DATABASE_CONNECTION_STRING", str),
+    database_connection_string: str
     # OpenTelemetry endpoint to send traces to
-    ("OPENTELEMETRY_ENDPOINT", str, ""),
+    opentelemetry_endpoint: str = ""
     # Path to a GeoLite2-City.mmdb file for geocoding IPs in user session info
-    ("GEOLITE2_CITY_MMDB_FILE_LOCATION", str, ""),
-    ("GEOLITE2_ASN_MMDB_FILE_LOCATION", str, ""),
+    geolite2_city_mmdb_file_location: str = ""
+    geolite2_asn_mmdb_file_location: str = ""
     # Whether to try adding dummy data
-    ("ADD_DUMMY_DATA", bool),
+    add_dummy_data: bool
     # Donations
-    ("ENABLE_DONATIONS", bool),
-    ("STRIPE_API_KEY", str),
-    ("STRIPE_WEBHOOK_SECRET", str),
-    ("STRIPE_RECURRING_PRODUCT_ID", str),
+    enable_donations: bool
+    stripe_api_key: str
+    stripe_webhook_secret: str
+    stripe_recurring_product_id: str
     # Strong verification through Iris ID
-    ("ENABLE_STRONG_VERIFICATION", bool),
-    ("IRIS_ID_PUBKEY", str),
-    ("IRIS_ID_SECRET", str),
-    ("VERIFICATION_DATA_PUBLIC_KEY", bytes),
+    enable_strong_verification: bool
+    iris_id_pubkey: str
+    iris_id_secret: str
+    verification_data_public_key: bytes
     # Postal verification
-    ("ENABLE_POSTAL_VERIFICATION", bool),
+    enable_postal_verification: bool
     # MyPostcard API credentials
-    ("MYPOSTCARD_API_KEY", str),
-    ("MYPOSTCARD_USERNAME", str),
-    ("MYPOSTCARD_PASSWORD", str),
-    ("MYPOSTCARD_PRODUCT_CODE", str),
-    ("MYPOSTCARD_CAMPAIGN_ID", str),
+    mypostcard_api_key: str
+    mypostcard_username: str
+    mypostcard_password: str
+    mypostcard_product_code: str
+    mypostcard_campaign_id: str
     # SMS
-    ("ENABLE_SMS", bool),
-    ("SMS_SENDER_ID", str),
+    enable_sms: bool
+    sms_sender_id: str
     # Email
-    ("ENABLE_EMAIL", bool),
+    enable_email: bool
     # Sender name for outgoing notification emails e.g. "Couchers.org"
-    ("NOTIFICATION_EMAIL_SENDER", str),
+    notification_email_sender: str
     # Sender email, e.g. "notify@couchers.org"
-    ("NOTIFICATION_EMAIL_ADDRESS", str),
+    notification_email_address: str
     # An optional prefix for email subject, e.g. [STAGING]
-    ("NOTIFICATION_PREFIX", str, ""),
-    ("ENABLE_NOTIFICATION_TRANSLATIONS", bool),
-    ("ENABLE_EMAIL_ICS_ATTACHMENTS", bool),
+    notification_prefix: str = ""
+    enable_notification_translations: bool
+    enable_email_ics_attachments: bool
     # Address to send emails about reported users
-    ("REPORTS_EMAIL_RECIPIENT", str),
+    reports_email_recipient: str
     # Address to send contributor forms when users sign up/fill the form
-    ("CONTRIBUTOR_FORM_EMAIL_RECIPIENT", str),
+    contributor_form_email_recipient: str
     # Address to moderation notifications
-    ("MODS_EMAIL_RECIPIENT", str),
+    mods_email_recipient: str
     # SMTP settings
-    ("SMTP_HOST", str),
-    ("SMTP_PORT", int),
-    ("SMTP_USERNAME", str),
-    ("SMTP_PASSWORD", str),
+    smtp_host: str
+    smtp_port: int
+    smtp_username: str
+    smtp_password: str
     # Media server
-    ("ENABLE_MEDIA", bool),
-    ("MEDIA_SERVER_SECRET_KEY", bytes),
-    ("MEDIA_SERVER_BEARER_TOKEN", str),
-    ("MEDIA_SERVER_BASE_URL", str),
-    ("MEDIA_SERVER_UPLOAD_BASE_URL", str),
+    enable_media: bool
+    media_server_secret_key: bytes
+    media_server_bearer_token: str
+    media_server_base_url: str
+    media_server_upload_base_url: str
     # Bug reporting tool
-    ("BUG_TOOL_ENABLED", bool),
-    ("BUG_TOOL_GITHUB_REPO", str),
-    ("BUG_TOOL_GITHUB_USERNAME", str),
-    ("BUG_TOOL_GITHUB_TOKEN", str),
+    bug_tool_enabled: bool
+    bug_tool_github_repo: str
+    bug_tool_github_username: str
+    bug_tool_github_token: str
     # Sentry
-    ("SENTRY_ENABLED", bool),
-    ("SENTRY_URL", str),
+    sentry_enabled: bool
+    sentry_url: str
     # Push notifications
-    ("PUSH_NOTIFICATIONS_ENABLED", bool),
-    ("PUSH_NOTIFICATIONS_VAPID_PRIVATE_KEY", str),
-    ("PUSH_NOTIFICATIONS_VAPID_SUBJECT", str),
+    push_notifications_enabled: bool
+    push_notifications_vapid_private_key: str
+    push_notifications_vapid_subject: str
     # Whether to initiate new activeness probes
-    ("ACTIVENESS_PROBES_ENABLED", bool),
+    activeness_probes_enabled: bool
     # Listmonk (mailing list)
-    ("LISTMONK_ENABLED", bool),
-    ("LISTMONK_BASE_URL", str),
-    ("LISTMONK_API_USERNAME", str),
-    ("LISTMONK_API_KEY", str),
-    ("LISTMONK_LIST_ID", int),
+    listmonk_enabled: bool
+    listmonk_base_url: str
+    listmonk_api_username: str
+    listmonk_api_key: str
+    listmonk_list_id: int
     # Google recaptcha antibot
-    ("RECAPTHCA_ENABLED", bool),
-    ("RECAPTHCA_PROJECT_ID", str),
-    ("RECAPTHCA_API_KEY", str),
-    ("RECAPTHCA_SITE_KEY", str),
+    recapthca_enabled: bool
+    recapthca_project_id: str
+    recapthca_api_key: str
+    recapthca_site_key: str
     # Whether we're in test
-    ("IN_TEST", bool, "0"),
+    in_test: bool = False
     # Experimentation (feature flags via Statsig)
-    ("EXPERIMENTATION_ENABLED", bool, "0"),
+    experimentation_enabled: bool = False
     # When enabled, all feature gates return True (useful for development/testing)
-    ("EXPERIMENTATION_PASS_ALL_GATES", bool, "0"),
+    experimentation_pass_all_gates: bool = False
     # Statsig SDK configuration
-    ("STATSIG_SERVER_SECRET_KEY", str, ""),
-    ("STATSIG_ENVIRONMENT", str, "development"),
+    statsig_server_secret_key: str = ""
+    statsig_environment: str = "development"
     # Moderation auto-approval deadline in seconds (0 to disable auto-approval)
-    ("MODERATION_AUTO_APPROVE_DEADLINE_SECONDS", int),
+    moderation_auto_approve_deadline_seconds: int
     # User ID of the bot user for automated moderation actions
-    ("MODERATION_BOT_USER_ID", int),
+    moderation_bot_user_id: int
     # Enable development APIs (e.g., SendDevPushNotification)
-    ("ENABLE_DEV_APIS", bool),
+    enable_dev_apis: bool
     # Slack notifications
-    ("SLACK_ENABLED", bool),
-    ("SLACK_BOT_TOKEN", str),
-    ("SLACK_DONATIONS_CHANNEL", str),
-    ("SLACK_MERCH_CHANNEL", str),
-]
+    slack_enabled: bool
+    slack_bot_token: str
+    slack_donations_channel: str
+    slack_merch_channel: str
+
+    def copy(self) -> Self:
+        return dataclasses.replace(self)
+
+    def set_from(self, other: Config) -> None:
+        for field in dataclasses.fields(other):
+            setattr(self, field.name, getattr(other, field.name))
 
 
-def check_config(cfg: dict[str, Any]) -> None:
-    for name, *_ in CONFIG_OPTIONS:
-        if name not in cfg:
-            raise ValueError(f"Required config value {name} not set")
-
-    if not cfg["DEV"]:
+def check_config(cfg: Config) -> None:
+    if not cfg.dev:
         # checks for prod
-        if "https" not in cfg["BASE_URL"]:
+        if "https" not in cfg.base_url:
             raise Exception("Production site must be over HTTPS")
-        if not cfg["ENABLE_EMAIL"]:
+        if not cfg.enable_email:
             raise Exception("Production site must have email enabled")
-        if not cfg["ENABLE_SMS"]:
+        if not cfg.enable_sms:
             raise Exception("Production site must have SMS enabled")
-        if cfg["IN_TEST"]:
+        if cfg.in_test:
             raise Exception("IN_TEST while not DEV")
 
-    if cfg["ENABLE_DONATIONS"]:
-        if not cfg["STRIPE_API_KEY"] or not cfg["STRIPE_WEBHOOK_SECRET"] or not cfg["STRIPE_RECURRING_PRODUCT_ID"]:
+    if cfg.enable_donations:
+        if not cfg.stripe_api_key or not cfg.stripe_webhook_secret or not cfg.stripe_recurring_product_id:
             raise Exception("No Stripe API key/recurring donation ID but donations enabled")
 
-    if cfg["ENABLE_STRONG_VERIFICATION"]:
-        if not cfg["IRIS_ID_PUBKEY"] or not cfg["IRIS_ID_SECRET"] or not cfg["VERIFICATION_DATA_PUBLIC_KEY"]:
+    if cfg.enable_strong_verification:
+        if not cfg.iris_id_pubkey or not cfg.iris_id_secret or not cfg.verification_data_public_key:
             raise Exception("No Iris ID pubkey/secret or verification data pubkey but strong verification enabled")
 
-    if cfg["ENABLE_POSTAL_VERIFICATION"]:
+    if cfg.enable_postal_verification:
         if (
-            not cfg["MYPOSTCARD_API_KEY"]
-            or not cfg["MYPOSTCARD_USERNAME"]
-            or not cfg["MYPOSTCARD_PASSWORD"]
-            or not cfg["MYPOSTCARD_PRODUCT_CODE"]
-            or not cfg["MYPOSTCARD_CAMPAIGN_ID"]
+            not cfg.mypostcard_api_key
+            or not cfg.mypostcard_username
+            or not cfg.mypostcard_password
+            or not cfg.mypostcard_product_code
+            or not cfg.mypostcard_campaign_id
         ):
             raise Exception("MyPostcard API credentials not configured but postal verification enabled")
 
-    if cfg["EXPERIMENTATION_ENABLED"]:
-        if not cfg["STATSIG_SERVER_SECRET_KEY"]:
+    if cfg.experimentation_enabled:
+        if not cfg.statsig_server_secret_key:
             raise Exception("No Statsig server secret key but experimentation enabled")
 
 
-def make_config() -> dict[str, Any]:
-    cfg = {}
+def make_config() -> Config:
+    type_hints = typing.get_type_hints(Config)
+    kwargs: dict[str, object] = {}
 
-    for config_option in CONFIG_OPTIONS:
-        if len(config_option) == 2:
-            name, type_ = config_option
-            optional = False
-        elif len(config_option) == 3:
-            name, type_, default_value = config_option
-            optional = True
+    for field in dataclasses.fields(Config):
+        env_name = field.name.upper()
+        field_type = type_hints[field.name]
+        has_default = field.default is not dataclasses.MISSING
+
+        raw = os.getenv(env_name)
+        if not raw:
+            if not has_default:
+                raise ValueError(f"Required config value {env_name} not set")
+            kwargs[field.name] = field.default
+            continue
+
+        origin = typing.get_origin(field_type)
+        if origin is Literal:
+            allowed = typing.get_args(field_type)
+            if raw not in allowed:
+                raise ValueError(f"Invalid value for {env_name}, need one of {', '.join(allowed)}")
+            kwargs[field.name] = raw
+        elif field_type is bool:
+            if raw not in ("0", "1"):
+                raise ValueError(f'Invalid bool for {env_name}, need "0" or "1"')
+            kwargs[field.name] = raw == "1"
+        elif field_type is bytes:
+            kwargs[field.name] = bytes.fromhex(raw)
+        elif field_type is int:
+            kwargs[field.name] = int(raw)
+        elif field_type is str:
+            kwargs[field.name] = raw
         else:
-            raise ValueError("Invalid CONFIG_OPTIONS")
+            raise ValueError(f"Unknown type {field_type} for {env_name}")
 
-        value: str | int | bytes | None = os.getenv(name)
-
-        if not value:
-            if not optional:
-                # config value not set - will cause a KeyError when trying
-                # to access it.
-                continue
-            else:
-                value = default_value
-
-        if type_ is bool:
-            # 1 is true, 0 is false, everything else is illegal
-            if value not in ["0", "1"]:
-                raise ValueError(f'Invalid bool for {name}, need "0" or "1"')
-            value = value == "1"
-        elif type_ is bytes:
-            # decode from hex
-            if not isinstance(value, str):
-                raise RuntimeError(type(value))
-            value = bytes.fromhex(value)
-        elif isinstance(type_, list):
-            # list of allowed string values
-            if value not in type_:
-                raise ValueError(f"Invalid value for {name}, need one of {', '.join(type_)}")
-        else:
-            value = type_(value)
-
-        cfg[name] = value
-
-    return cfg
+    return Config(**kwargs)  # type: ignore[arg-type]
 
 
 config = make_config()

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -5,11 +5,25 @@ A simple config system
 import dataclasses
 import os
 import typing
-from typing import Literal, Self
+from collections.abc import Mapping
+from typing import Any, ClassVar, Literal, Self, TYPE_CHECKING
 
+class ConfigMetaclass(type):
+    _current: Config | None = None
+
+    @property
+    def current(cls) -> Config:
+        """Gets the current application-global Config object, raising an exception if not yet set."""
+        if cls._current is None:
+            raise Exception("No global configuration set.")
+        return cls._current
+
+    @current.setter
+    def current(cls, value: Config | None) -> None:
+        cls._current = value
 
 @dataclasses.dataclass(kw_only=True)
-class Config:
+class Config(metaclass=ConfigMetaclass):
     # Whether we're in dev mode
     dev: bool
     # Whether we're `api` mode (answering API queries) or `scheduler` (scheduling background jobs), or `worker`
@@ -134,85 +148,96 @@ class Config:
     slack_donations_channel: str
     slack_merch_channel: str
 
+    if TYPE_CHECKING:
+        # The metaclass implements the "current" class property,
+        # but mypy doesn't understand that, so give it a hint.
+        current: ClassVar[Config]
+
+    def __post_init__(self) -> None:
+        self.check()
+
     def copy(self) -> Self:
         return dataclasses.replace(self)
+
+    def with_changes(self, **changes: Any) -> Config:
+        return dataclasses.replace(self, **changes)
 
     def set_from(self, other: Config) -> None:
         for field in dataclasses.fields(other):
             setattr(self, field.name, getattr(other, field.name))
 
+    def check(self) -> None:
+        if not self.dev:
+            # checks for prod
+            if "https" not in self.base_url:
+                raise Exception("Production site must be over HTTPS")
+            if not self.enable_email:
+                raise Exception("Production site must have email enabled")
+            if not self.enable_sms:
+                raise Exception("Production site must have SMS enabled")
+            if self.in_test:
+                raise Exception("IN_TEST while not DEV")
 
-def check_config(cfg: Config) -> None:
-    if not cfg.dev:
-        # checks for prod
-        if "https" not in cfg.base_url:
-            raise Exception("Production site must be over HTTPS")
-        if not cfg.enable_email:
-            raise Exception("Production site must have email enabled")
-        if not cfg.enable_sms:
-            raise Exception("Production site must have SMS enabled")
-        if cfg.in_test:
-            raise Exception("IN_TEST while not DEV")
+        if self.enable_donations:
+            if not self.stripe_api_key or not self.stripe_webhook_secret or not self.stripe_recurring_product_id:
+                raise Exception("No Stripe API key/recurring donation ID but donations enabled")
 
-    if cfg.enable_donations:
-        if not cfg.stripe_api_key or not cfg.stripe_webhook_secret or not cfg.stripe_recurring_product_id:
-            raise Exception("No Stripe API key/recurring donation ID but donations enabled")
+        if self.enable_strong_verification:
+            if not self.iris_id_pubkey or not self.iris_id_secret or not self.verification_data_public_key:
+                raise Exception("No Iris ID pubkey/secret or verification data pubkey but strong verification enabled")
 
-    if cfg.enable_strong_verification:
-        if not cfg.iris_id_pubkey or not cfg.iris_id_secret or not cfg.verification_data_public_key:
-            raise Exception("No Iris ID pubkey/secret or verification data pubkey but strong verification enabled")
+        if self.enable_postal_verification:
+            if (
+                not self.mypostcard_api_key
+                or not self.mypostcard_username
+                or not self.mypostcard_password
+                or not self.mypostcard_product_code
+                or not self.mypostcard_campaign_id
+            ):
+                raise Exception("MyPostcard API credentials not configured but postal verification enabled")
 
-    if cfg.enable_postal_verification:
-        if (
-            not cfg.mypostcard_api_key
-            or not cfg.mypostcard_username
-            or not cfg.mypostcard_password
-            or not cfg.mypostcard_product_code
-            or not cfg.mypostcard_campaign_id
-        ):
-            raise Exception("MyPostcard API credentials not configured but postal verification enabled")
+        if self.experimentation_enabled:
+            if not self.statsig_server_secret_key:
+                raise Exception("No Statsig server secret key but experimentation enabled")
 
-    if cfg.experimentation_enabled:
-        if not cfg.statsig_server_secret_key:
-            raise Exception("No Statsig server secret key but experimentation enabled")
+    @staticmethod
+    def from_env() -> Config:
+        return Config.from_env_dict(os.environ)
 
+    @staticmethod
+    def from_env_dict(env: Mapping[str, Any]) -> Config:
+        type_hints = typing.get_type_hints(Config)
+        kwargs: dict[str, object] = {}
 
-def make_config() -> Config:
-    type_hints = typing.get_type_hints(Config)
-    kwargs: dict[str, object] = {}
+        for field in dataclasses.fields(Config):
+            env_name = field.name.upper()
+            field_type = type_hints[field.name]
+            has_default = field.default is not dataclasses.MISSING
 
-    for field in dataclasses.fields(Config):
-        env_name = field.name.upper()
-        field_type = type_hints[field.name]
-        has_default = field.default is not dataclasses.MISSING
+            raw = env.get(env_name)
+            if not raw:
+                if not has_default:
+                    raise ValueError(f"Required config value {env_name} not set")
+                kwargs[field.name] = field.default
+                continue
 
-        raw = os.getenv(env_name)
-        if not raw:
-            if not has_default:
-                raise ValueError(f"Required config value {env_name} not set")
-            kwargs[field.name] = field.default
-            continue
+            origin = typing.get_origin(field_type)
+            if origin is Literal:
+                allowed = typing.get_args(field_type)
+                if raw not in allowed:
+                    raise ValueError(f"Invalid value for {env_name}, need one of {', '.join(allowed)}")
+                kwargs[field.name] = raw
+            elif field_type is bool:
+                if raw not in ("0", "1"):
+                    raise ValueError(f'Invalid bool for {env_name}, need "0" or "1"')
+                kwargs[field.name] = raw == "1"
+            elif field_type is bytes:
+                kwargs[field.name] = bytes.fromhex(raw)
+            elif field_type is int:
+                kwargs[field.name] = int(raw)
+            elif field_type is str:
+                kwargs[field.name] = raw
+            else:
+                raise ValueError(f"Unknown type {field_type} for {env_name}")
 
-        origin = typing.get_origin(field_type)
-        if origin is Literal:
-            allowed = typing.get_args(field_type)
-            if raw not in allowed:
-                raise ValueError(f"Invalid value for {env_name}, need one of {', '.join(allowed)}")
-            kwargs[field.name] = raw
-        elif field_type is bool:
-            if raw not in ("0", "1"):
-                raise ValueError(f'Invalid bool for {env_name}, need "0" or "1"')
-            kwargs[field.name] = raw == "1"
-        elif field_type is bytes:
-            kwargs[field.name] = bytes.fromhex(raw)
-        elif field_type is int:
-            kwargs[field.name] = int(raw)
-        elif field_type is str:
-            kwargs[field.name] = raw
-        else:
-            raise ValueError(f"Unknown type {field_type} for {env_name}")
-
-    return Config(**kwargs)  # type: ignore[arg-type]
-
-
-config = make_config()
+        return Config(**kwargs)  # type: ignore[arg-type]

--- a/app/backend/src/couchers/crypto.py
+++ b/app/backend/src/couchers/crypto.py
@@ -127,7 +127,7 @@ def get_secret(name: str) -> bytes:
     """
     Derives a secret key from the root secret using a key derivation function
     """
-    return generate_hash_signature(name.encode("utf8"), config["SECRET"])
+    return generate_hash_signature(name.encode("utf8"), config.secret)
 
 
 UNSUBSCRIBE_KEY_NAME = "unsubscribe"

--- a/app/backend/src/couchers/crypto.py
+++ b/app/backend/src/couchers/crypto.py
@@ -13,7 +13,7 @@ from nacl.exceptions import InvalidkeyError
 from nacl.public import PrivateKey, PublicKey, SealedBox
 from nacl.utils import random as random_bytes
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.proto.internal import internal_pb2
 
 
@@ -127,7 +127,7 @@ def get_secret(name: str) -> bytes:
     """
     Derives a secret key from the root secret using a key derivation function
     """
-    return generate_hash_signature(name.encode("utf8"), config.secret)
+    return generate_hash_signature(name.encode("utf8"), Config.current.secret)
 
 
 UNSUBSCRIBE_KEY_NAME = "unsubscribe"

--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -58,7 +58,7 @@ def apply_migrations() -> None:
 @functools.cache
 def _get_base_engine() -> Engine:
     return create_engine(
-        config["DATABASE_CONNECTION_STRING"],
+        config.database_connection_string,
         # checks that the connections in the pool are alive before using them, which avoids the "server closed the
         # connection unexpectedly" errors
         pool_pre_ping=True,

--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -8,7 +8,7 @@ from os import getpid
 from threading import get_ident
 
 from alembic import command
-from alembic.config import Config
+from alembic.config import Config as AlembicConfig
 from geoalchemy2 import WKBElement
 from opentelemetry import trace
 from sqlalchemy import Engine, Row, Subquery, create_engine, select, text, true
@@ -17,7 +17,7 @@ from sqlalchemy.orm.session import Session
 from sqlalchemy.pool import QueuePool
 from sqlalchemy.sql import and_, func, literal, or_
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.constants import SERVER_THREADS, WORKER_THREADS
 from couchers.context import CouchersContext
 from couchers.models import (
@@ -47,7 +47,7 @@ def apply_migrations() -> None:
     cwd = os.getcwd()
     try:
         os.chdir(alembic_dir)
-        alembic_cfg = Config("alembic.ini")
+        alembic_cfg = AlembicConfig("alembic.ini")
         # alembic screws up logging config by default, this tells it not to screw it up if being run at startup like this
         alembic_cfg.set_main_option("dont_mess_up_logging", "False")
         command.upgrade(alembic_cfg, "head")
@@ -58,7 +58,7 @@ def apply_migrations() -> None:
 @functools.cache
 def _get_base_engine() -> Engine:
     return create_engine(
-        config.database_connection_string,
+        Config.current.database_connection_string,
         # checks that the connections in the pool are alive before using them, which avoids the "server closed the
         # connection unexpectedly" errors
         pool_pre_ping=True,

--- a/app/backend/src/couchers/email/calendar_events.py
+++ b/app/backend/src/couchers/email/calendar_events.py
@@ -106,5 +106,5 @@ def ics_to_attachment(ics: str, filename: str) -> EmailAttachment:
 
 
 def get_host_request_event_uid(host_request_id: int) -> str:
-    uid_domain = Address(addr_spec=config["NOTIFICATION_EMAIL_ADDRESS"]).domain
+    uid_domain = Address(addr_spec=config.notification_email_address).domain
     return f"host_request.{host_request_id}@{uid_domain}"

--- a/app/backend/src/couchers/email/calendar_events.py
+++ b/app/backend/src/couchers/email/calendar_events.py
@@ -5,7 +5,7 @@ from ics import Calendar, Event  # type: ignore[import-untyped]
 from ics.grammar.parse import ContentLine  # type: ignore[import-untyped]
 
 from couchers import urls
-from couchers.config import config
+from couchers.config import Config
 from couchers.email.rendering import get_emails_i18next
 from couchers.i18n import LocalizationContext
 from couchers.proto.internal.jobs_pb2 import EmailAttachment
@@ -106,5 +106,5 @@ def ics_to_attachment(ics: str, filename: str) -> EmailAttachment:
 
 
 def get_host_request_event_uid(host_request_id: int) -> str:
-    uid_domain = Address(addr_spec=config.notification_email_address).domain
+    uid_domain = Address(addr_spec=Config.current.notification_email_address).domain
     return f"host_request.{host_request_id}@{uid_domain}"

--- a/app/backend/src/couchers/email/queuing.py
+++ b/app/backend/src/couchers/email/queuing.py
@@ -70,13 +70,13 @@ def queue_userless_email(
     queue_email(
         session,
         jobs_pb2.SendEmailPayload(
-            sender_name=config["NOTIFICATION_EMAIL_SENDER"],
-            sender_email=config["NOTIFICATION_EMAIL_ADDRESS"],
+            sender_name=config.notification_email_sender,
+            sender_email=config.notification_email_address,
             recipient=recipient,
-            subject=config["NOTIFICATION_PREFIX"] + subject,
+            subject=config.notification_prefix + subject,
             plain=plain,
             html=html,
-            source_data=config["VERSION"] + f"/{template_name}",
+            source_data=config.version + f"/{template_name}",
         ),
     )
 
@@ -97,10 +97,10 @@ def queue_system_email(session: Session, recipient: str, template_name: str, tem
     queue_email(
         session,
         jobs_pb2.SendEmailPayload(
-            sender_name=config["NOTIFICATION_EMAIL_SENDER"],
-            sender_email=config["NOTIFICATION_EMAIL_ADDRESS"],
+            sender_name=config.notification_email_sender,
+            sender_email=config.notification_email_address,
             recipient=recipient,
-            subject=config["NOTIFICATION_PREFIX"] + frontmatter["subject"],
+            subject=config.notification_prefix + frontmatter["subject"],
             plain=plain,
             source_data=template_name,
         ),

--- a/app/backend/src/couchers/email/queuing.py
+++ b/app/backend/src/couchers/email/queuing.py
@@ -4,7 +4,7 @@ from typing import Any
 import yaml
 from sqlalchemy.orm.session import Session
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.i18n import LocalizationContext
 from couchers.jobs.enqueue import queue_job
 from couchers.metrics import emails_counter
@@ -70,13 +70,13 @@ def queue_userless_email(
     queue_email(
         session,
         jobs_pb2.SendEmailPayload(
-            sender_name=config.notification_email_sender,
-            sender_email=config.notification_email_address,
+            sender_name=Config.current.notification_email_sender,
+            sender_email=Config.current.notification_email_address,
             recipient=recipient,
-            subject=config.notification_prefix + subject,
+            subject=Config.current.notification_prefix + subject,
             plain=plain,
             html=html,
-            source_data=config.version + f"/{template_name}",
+            source_data=Config.current.version + f"/{template_name}",
         ),
     )
 
@@ -97,10 +97,10 @@ def queue_system_email(session: Session, recipient: str, template_name: str, tem
     queue_email(
         session,
         jobs_pb2.SendEmailPayload(
-            sender_name=config.notification_email_sender,
-            sender_email=config.notification_email_address,
+            sender_name=Config.current.notification_email_sender,
+            sender_email=Config.current.notification_email_address,
             recipient=recipient,
-            subject=config.notification_prefix + frontmatter["subject"],
+            subject=Config.current.notification_prefix + frontmatter["subject"],
             plain=plain,
             source_data=template_name,
         ),

--- a/app/backend/src/couchers/email/smtp.py
+++ b/app/backend/src/couchers/email/smtp.py
@@ -5,7 +5,7 @@ from email.utils import make_msgid
 from pathlib import Path
 from typing import cast
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.crypto import EMAIL_SOURCE_DATA_KEY_NAME, random_hex, simple_hash_signature
 from couchers.models import Email
 from couchers.proto.internal import jobs_pb2
@@ -21,7 +21,7 @@ def make_cid(sender_email: str) -> tuple[str, str]:
 
 def send_smtp_email(payload: jobs_pb2.SendEmailPayload) -> Email:
     """
-    Sends out the email through SMTP, settings from config.
+    Sends out the email through SMTP, settings from Config.current.
 
     Returns a models.Email object that can be straight away added to the database.
     """
@@ -68,13 +68,13 @@ def send_smtp_email(payload: jobs_pb2.SendEmailPayload) -> Email:
                 attachment.data, maintype=mime_maintype, subtype=mime_subtype, filename=attachment.filename
             )
 
-    with smtplib.SMTP(config.smtp_host, config.smtp_port) as server:
+    with smtplib.SMTP(Config.current.smtp_host, Config.current.smtp_port) as server:
         server.ehlo()
-        if not config.dev:
+        if not Config.current.dev:
             server.starttls()
             # stmplib docs recommend calling ehlo() before and after starttls()
             server.ehlo()
-            server.login(config.smtp_username, config.smtp_password)
+            server.login(Config.current.smtp_username, Config.current.smtp_password)
         server.sendmail(payload.sender_email, payload.recipient, msg.as_string())
 
     return Email(

--- a/app/backend/src/couchers/email/smtp.py
+++ b/app/backend/src/couchers/email/smtp.py
@@ -68,13 +68,13 @@ def send_smtp_email(payload: jobs_pb2.SendEmailPayload) -> Email:
                 attachment.data, maintype=mime_maintype, subtype=mime_subtype, filename=attachment.filename
             )
 
-    with smtplib.SMTP(config["SMTP_HOST"], config["SMTP_PORT"]) as server:
+    with smtplib.SMTP(config.smtp_host, config.smtp_port) as server:
         server.ehlo()
-        if not config["DEV"]:
+        if not config.dev:
             server.starttls()
             # stmplib docs recommend calling ehlo() before and after starttls()
             server.ehlo()
-            server.login(config["SMTP_USERNAME"], config["SMTP_PASSWORD"])
+            server.login(config.smtp_username, config.smtp_password)
         server.sendmail(payload.sender_email, payload.recipient, msg.as_string())
 
     return Email(

--- a/app/backend/src/couchers/event_log.py
+++ b/app/backend/src/couchers/event_log.py
@@ -43,7 +43,7 @@ def log_event(
             event_type=event_type,
             user_id=user_id,
             sofa=context._sofa,
-            version=config["VERSION"],
+            version=config.version,
             properties=properties,
             value=value,
             source=EventSource.backend,

--- a/app/backend/src/couchers/event_log.py
+++ b/app/backend/src/couchers/event_log.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from sqlalchemy.orm import Session
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.context import CouchersContext
 from couchers.models.logging import EventLog, EventSource
 
@@ -43,7 +43,7 @@ def log_event(
             event_type=event_type,
             user_id=user_id,
             sofa=context._sofa,
-            version=config.version,
+            version=Config.current.version,
             properties=properties,
             value=value,
             source=EventSource.backend,

--- a/app/backend/src/couchers/experimentation.py
+++ b/app/backend/src/couchers/experimentation.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING
 
 from statsig_python_core import Statsig, StatsigOptions, StatsigUser
 
-from couchers.config import config
+from couchers.config import Config
 
 if TYPE_CHECKING:
     from couchers.context import CouchersContext
@@ -60,7 +60,7 @@ def setup_experimentation() -> None:
         logger.debug("Experimentation already initialized in this process, skipping")
         return
 
-    if not config.experimentation_enabled:
+    if not Config.current.experimentation_enabled:
         logger.info("Experimentation is disabled, skipping initialization")
         _initialized = True
         return
@@ -68,10 +68,10 @@ def setup_experimentation() -> None:
     logger.info("Initializing experimentation framework")
 
     options = StatsigOptions()
-    options.environment = config.statsig_environment
+    options.environment = Config.current.statsig_environment
 
     # Create the shared instance for global access
-    statsig = Statsig.new_shared(config.statsig_server_secret_key, options)
+    statsig = Statsig.new_shared(Config.current.statsig_server_secret_key, options)
 
     # initialize() starts internal threads - this MUST happen after forking
     statsig.initialize().wait()
@@ -92,7 +92,7 @@ def _shutdown_experimentation() -> None:
     Shutdown the experimentation framework, flushing any pending events.
     Called automatically via atexit when the process exits.
     """
-    if not config.experimentation_enabled:
+    if not Config.current.experimentation_enabled:
         return
 
     if Statsig.has_shared_instance():
@@ -108,7 +108,7 @@ def _check_initialized() -> None:
     Raises:
         ExperimentationNotInitializedError: If experimentation is enabled but not initialized.
     """
-    if config.experimentation_enabled and not _initialized:
+    if Config.current.experimentation_enabled and not _initialized:
         raise ExperimentationNotInitializedError(
             "Experimentation is not initialized - call setup_experimentation() first"
         )
@@ -142,9 +142,9 @@ def check_gate(context: CouchersContext, gate_name: str) -> bool:
         ExperimentationNotInitializedError: If experimentation is enabled but not initialized.
     """
     _check_initialized()
-    if config.experimentation_pass_all_gates:
+    if Config.current.experimentation_pass_all_gates:
         return True
-    if not config.experimentation_enabled:
+    if not Config.current.experimentation_enabled:
         return False
     return Statsig.shared().check_gate(_get_statsig_user(context), gate_name)
 
@@ -165,7 +165,7 @@ def get_experiment(context: CouchersContext, experiment_name: str) -> dict[str, 
         ExperimentationNotInitializedError: If experimentation is enabled but not initialized.
     """
     _check_initialized()
-    if not config.experimentation_enabled:
+    if not Config.current.experimentation_enabled:
         return {}
     # TODO: remove type: ignore when upstream fixes types, see https://github.com/statsig-io/statsig-server-core/issues/36
     experiment = Statsig.shared().get_experiment(_get_statsig_user(context), experiment_name)  # type: ignore[attr-defined]
@@ -188,7 +188,7 @@ def get_dynamic_config(context: CouchersContext, config_name: str) -> dict[str, 
         ExperimentationNotInitializedError: If experimentation is enabled but not initialized.
     """
     _check_initialized()
-    if not config.experimentation_enabled:
+    if not Config.current.experimentation_enabled:
         return {}
     # TODO: remove type: ignore when upstream fixes types, see https://github.com/statsig-io/statsig-server-core/issues/36
     dynamic_config = Statsig.shared().get_dynamic_config(_get_statsig_user(context), config_name)  # type: ignore[attr-defined]
@@ -214,7 +214,7 @@ def log_event(
         ExperimentationNotInitializedError: If experimentation is enabled but not initialized.
     """
     _check_initialized()
-    if not config.experimentation_enabled:
+    if not Config.current.experimentation_enabled:
         return
     Statsig.shared().log_event(
         user=_get_statsig_user(context),

--- a/app/backend/src/couchers/experimentation.py
+++ b/app/backend/src/couchers/experimentation.py
@@ -60,7 +60,7 @@ def setup_experimentation() -> None:
         logger.debug("Experimentation already initialized in this process, skipping")
         return
 
-    if not config["EXPERIMENTATION_ENABLED"]:
+    if not config.experimentation_enabled:
         logger.info("Experimentation is disabled, skipping initialization")
         _initialized = True
         return
@@ -68,10 +68,10 @@ def setup_experimentation() -> None:
     logger.info("Initializing experimentation framework")
 
     options = StatsigOptions()
-    options.environment = config["STATSIG_ENVIRONMENT"]
+    options.environment = config.statsig_environment
 
     # Create the shared instance for global access
-    statsig = Statsig.new_shared(config["STATSIG_SERVER_SECRET_KEY"], options)
+    statsig = Statsig.new_shared(config.statsig_server_secret_key, options)
 
     # initialize() starts internal threads - this MUST happen after forking
     statsig.initialize().wait()
@@ -92,7 +92,7 @@ def _shutdown_experimentation() -> None:
     Shutdown the experimentation framework, flushing any pending events.
     Called automatically via atexit when the process exits.
     """
-    if not config["EXPERIMENTATION_ENABLED"]:
+    if not config.experimentation_enabled:
         return
 
     if Statsig.has_shared_instance():
@@ -108,7 +108,7 @@ def _check_initialized() -> None:
     Raises:
         ExperimentationNotInitializedError: If experimentation is enabled but not initialized.
     """
-    if config["EXPERIMENTATION_ENABLED"] and not _initialized:
+    if config.experimentation_enabled and not _initialized:
         raise ExperimentationNotInitializedError(
             "Experimentation is not initialized - call setup_experimentation() first"
         )
@@ -142,9 +142,9 @@ def check_gate(context: CouchersContext, gate_name: str) -> bool:
         ExperimentationNotInitializedError: If experimentation is enabled but not initialized.
     """
     _check_initialized()
-    if config["EXPERIMENTATION_PASS_ALL_GATES"]:
+    if config.experimentation_pass_all_gates:
         return True
-    if not config["EXPERIMENTATION_ENABLED"]:
+    if not config.experimentation_enabled:
         return False
     return Statsig.shared().check_gate(_get_statsig_user(context), gate_name)
 
@@ -165,7 +165,7 @@ def get_experiment(context: CouchersContext, experiment_name: str) -> dict[str, 
         ExperimentationNotInitializedError: If experimentation is enabled but not initialized.
     """
     _check_initialized()
-    if not config["EXPERIMENTATION_ENABLED"]:
+    if not config.experimentation_enabled:
         return {}
     # TODO: remove type: ignore when upstream fixes types, see https://github.com/statsig-io/statsig-server-core/issues/36
     experiment = Statsig.shared().get_experiment(_get_statsig_user(context), experiment_name)  # type: ignore[attr-defined]
@@ -188,7 +188,7 @@ def get_dynamic_config(context: CouchersContext, config_name: str) -> dict[str, 
         ExperimentationNotInitializedError: If experimentation is enabled but not initialized.
     """
     _check_initialized()
-    if not config["EXPERIMENTATION_ENABLED"]:
+    if not config.experimentation_enabled:
         return {}
     # TODO: remove type: ignore when upstream fixes types, see https://github.com/statsig-io/statsig-server-core/issues/36
     dynamic_config = Statsig.shared().get_dynamic_config(_get_statsig_user(context), config_name)  # type: ignore[attr-defined]
@@ -214,7 +214,7 @@ def log_event(
         ExperimentationNotInitializedError: If experimentation is enabled but not initialized.
     """
     _check_initialized()
-    if not config["EXPERIMENTATION_ENABLED"]:
+    if not config.experimentation_enabled:
         return
     Statsig.shared().log_event(
         user=_get_statsig_user(context),

--- a/app/backend/src/couchers/helpers/geoip.py
+++ b/app/backend/src/couchers/helpers/geoip.py
@@ -4,18 +4,18 @@ from ipaddress import IPv4Network, IPv6Network
 import geoip2.database
 from geoip2.errors import AddressNotFoundError
 
-from couchers.config import config
+from couchers.config import Config
 
 logger = logging.getLogger(__name__)
 
 
 def geoip_approximate_location(ip_address: str | None) -> str | None:
-    if config.geolite2_city_mmdb_file_location == "":
+    if Config.current.geolite2_city_mmdb_file_location == "":
         return None
     if ip_address is None:
         return None
     try:
-        with geoip2.database.Reader(config.geolite2_city_mmdb_file_location) as reader:
+        with geoip2.database.Reader(Config.current.geolite2_city_mmdb_file_location) as reader:
             response = reader.city(ip_address)
             city = response.city.name
             country = response.country.name
@@ -28,12 +28,12 @@ def geoip_approximate_location(ip_address: str | None) -> str | None:
 
 
 def geoip_asn(ip_address: str | None) -> tuple[int, str, IPv4Network | IPv6Network] | None:
-    if config.geolite2_asn_mmdb_file_location == "":
+    if Config.current.geolite2_asn_mmdb_file_location == "":
         return None
     if ip_address is None:
         return None
     try:
-        with geoip2.database.Reader(config.geolite2_asn_mmdb_file_location) as reader:
+        with geoip2.database.Reader(Config.current.geolite2_asn_mmdb_file_location) as reader:
             response = reader.asn(ip_address)
             asn_number = response.autonomous_system_number
             asn_org = response.autonomous_system_organization

--- a/app/backend/src/couchers/helpers/geoip.py
+++ b/app/backend/src/couchers/helpers/geoip.py
@@ -10,12 +10,12 @@ logger = logging.getLogger(__name__)
 
 
 def geoip_approximate_location(ip_address: str | None) -> str | None:
-    if config["GEOLITE2_CITY_MMDB_FILE_LOCATION"] == "":
+    if config.geolite2_city_mmdb_file_location == "":
         return None
     if ip_address is None:
         return None
     try:
-        with geoip2.database.Reader(config["GEOLITE2_CITY_MMDB_FILE_LOCATION"]) as reader:
+        with geoip2.database.Reader(config.geolite2_city_mmdb_file_location) as reader:
             response = reader.city(ip_address)
             city = response.city.name
             country = response.country.name
@@ -28,12 +28,12 @@ def geoip_approximate_location(ip_address: str | None) -> str | None:
 
 
 def geoip_asn(ip_address: str | None) -> tuple[int, str, IPv4Network | IPv6Network] | None:
-    if config["GEOLITE2_ASN_MMDB_FILE_LOCATION"] == "":
+    if config.geolite2_asn_mmdb_file_location == "":
         return None
     if ip_address is None:
         return None
     try:
-        with geoip2.database.Reader(config["GEOLITE2_ASN_MMDB_FILE_LOCATION"]) as reader:
+        with geoip2.database.Reader(config.geolite2_asn_mmdb_file_location) as reader:
             response = reader.asn(ip_address)
             asn_number = response.autonomous_system_number
             asn_org = response.autonomous_system_organization

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -137,7 +137,7 @@ logger = logging.getLogger(__name__)
 def send_email(payload: jobs_pb2.SendEmailPayload) -> None:
     logger.info(f"Sending email with subject '{payload.subject}' to '{payload.recipient}'")
     # selects a "sender", which either prints the email to the logger or sends it out with SMTP
-    sender = send_smtp_email if config["ENABLE_EMAIL"] else print_dev_email
+    sender = send_smtp_email if config.enable_email else print_dev_email
     # the sender must return a models.Email object that can be added to the database
     email = sender(payload)
     with session_scope() as session:
@@ -613,7 +613,7 @@ def send_host_request_reminders(payload: empty_pb2.Empty) -> None:
 
 
 def add_users_to_email_list(payload: empty_pb2.Empty) -> None:
-    if not config["LISTMONK_ENABLED"]:
+    if not config.listmonk_enabled:
         logger.info("Not adding users to mailing list")
         return
 
@@ -634,12 +634,12 @@ def add_users_to_email_list(payload: empty_pb2.Empty) -> None:
                 continue
 
             r = requests.post(
-                config["LISTMONK_BASE_URL"] + "/api/subscribers",
-                auth=(config["LISTMONK_API_USERNAME"], config["LISTMONK_API_KEY"]),
+                config.listmonk_base_url + "/api/subscribers",
+                auth=(config.listmonk_api_username, config.listmonk_api_key),
                 json={
                     "email": user.email,
                     "name": user.name,
-                    "lists": [config["LISTMONK_LIST_ID"]],
+                    "lists": [config.listmonk_list_id],
                     "preconfirm_subscriptions": True,
                     "attribs": {"couchers_user_id": user.id},
                     "status": "enabled",
@@ -891,7 +891,7 @@ def finalize_strong_verification(payload: jobs_pb2.FinalizeStrongVerificationPay
         ).scalar_one()
         response = requests.post(
             "https://passportreader.app/api/v1/session.get",
-            auth=(config["IRIS_ID_PUBKEY"], config["IRIS_ID_SECRET"]),
+            auth=(config.iris_id_pubkey, config.iris_id_secret),
             json={"id": verification_attempt.iris_session_id},
             timeout=10,
             verify="/etc/ssl/certs/ca-certificates.crt",
@@ -958,7 +958,7 @@ def finalize_strong_verification(payload: jobs_pb2.FinalizeStrongVerificationPay
 
         verification_attempt.has_full_data = True
         verification_attempt.passport_encrypted_data = asym_encrypt(
-            config["VERIFICATION_DATA_PUBLIC_KEY"], response.text.encode("utf8")
+            config.verification_data_public_key, response.text.encode("utf8")
         )
         verification_attempt.passport_date_of_birth = date.fromisoformat(json_data["date_of_birth"])
         verification_attempt.passport_sex = PassportSex[json_data["sex"].lower()]
@@ -999,7 +999,7 @@ def send_activeness_probes(payload: empty_pb2.Empty) -> None:
     with session_scope() as session:
         ## Step 1: create new activeness probes for those who need it and don't have one (if enabled)
 
-        if config["ACTIVENESS_PROBES_ENABLED"]:
+        if config.activeness_probes_enabled:
             # current activeness probes
             subquery = select(ActivenessProbe.user_id).where(ActivenessProbe.responded == None).subquery()
 
@@ -1305,7 +1305,7 @@ def check_mypostcard_jobs(payload: empty_pb2.Empty) -> None:
     """
     Checks that all MyPostcard jobs from the last week are tied to a postal verification attempt.
     """
-    if not config["ENABLE_POSTAL_VERIFICATION"]:
+    if not config.enable_postal_verification:
         return
 
     with session_scope() as session:
@@ -1492,7 +1492,7 @@ def check_database_consistency(payload: empty_pb2.Empty) -> None:
 
         # Ensure auto-approve deadline isn't being exceeded by a significant margin
         # The auto-approver runs every 15s, so allow 5 minutes grace before alerting
-        deadline_seconds = config["MODERATION_AUTO_APPROVE_DEADLINE_SECONDS"]
+        deadline_seconds = config.moderation_auto_approve_deadline_seconds
         if deadline_seconds > 0:
             grace_period = timedelta(minutes=5)
             stale_initial_review_items = session.execute(
@@ -1519,12 +1519,12 @@ def auto_approve_moderation_queue(payload: empty_pb2.Empty) -> None:
     Dead man's switch: auto-approves unresolved INITIAL_REVIEW items older than the deadline.
     Items explicitly actioned by moderators are left alone.
     """
-    deadline_seconds = config["MODERATION_AUTO_APPROVE_DEADLINE_SECONDS"]
+    deadline_seconds = config.moderation_auto_approve_deadline_seconds
     if deadline_seconds <= 0:
         return
 
     with session_scope() as session:
-        ctx = make_background_user_context(user_id=config["MODERATION_BOT_USER_ID"])
+        ctx = make_background_user_context(user_id=config.moderation_bot_user_id)
 
         items = (
             Moderation()

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -29,7 +29,7 @@ from sqlalchemy.sql import (
     update,
 )
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.constants import (
     ACTIVENESS_PROBE_EXPIRY_TIME,
     ACTIVENESS_PROBE_INACTIVITY_PERIOD,
@@ -137,7 +137,7 @@ logger = logging.getLogger(__name__)
 def send_email(payload: jobs_pb2.SendEmailPayload) -> None:
     logger.info(f"Sending email with subject '{payload.subject}' to '{payload.recipient}'")
     # selects a "sender", which either prints the email to the logger or sends it out with SMTP
-    sender = send_smtp_email if config.enable_email else print_dev_email
+    sender = send_smtp_email if Config.current.enable_email else print_dev_email
     # the sender must return a models.Email object that can be added to the database
     email = sender(payload)
     with session_scope() as session:
@@ -613,7 +613,7 @@ def send_host_request_reminders(payload: empty_pb2.Empty) -> None:
 
 
 def add_users_to_email_list(payload: empty_pb2.Empty) -> None:
-    if not config.listmonk_enabled:
+    if not Config.current.listmonk_enabled:
         logger.info("Not adding users to mailing list")
         return
 
@@ -634,12 +634,12 @@ def add_users_to_email_list(payload: empty_pb2.Empty) -> None:
                 continue
 
             r = requests.post(
-                config.listmonk_base_url + "/api/subscribers",
-                auth=(config.listmonk_api_username, config.listmonk_api_key),
+                Config.current.listmonk_base_url + "/api/subscribers",
+                auth=(Config.current.listmonk_api_username, Config.current.listmonk_api_key),
                 json={
                     "email": user.email,
                     "name": user.name,
-                    "lists": [config.listmonk_list_id],
+                    "lists": [Config.current.listmonk_list_id],
                     "preconfirm_subscriptions": True,
                     "attribs": {"couchers_user_id": user.id},
                     "status": "enabled",
@@ -891,7 +891,7 @@ def finalize_strong_verification(payload: jobs_pb2.FinalizeStrongVerificationPay
         ).scalar_one()
         response = requests.post(
             "https://passportreader.app/api/v1/session.get",
-            auth=(config.iris_id_pubkey, config.iris_id_secret),
+            auth=(Config.current.iris_id_pubkey, Config.current.iris_id_secret),
             json={"id": verification_attempt.iris_session_id},
             timeout=10,
             verify="/etc/ssl/certs/ca-certificates.crt",
@@ -958,7 +958,7 @@ def finalize_strong_verification(payload: jobs_pb2.FinalizeStrongVerificationPay
 
         verification_attempt.has_full_data = True
         verification_attempt.passport_encrypted_data = asym_encrypt(
-            config.verification_data_public_key, response.text.encode("utf8")
+            Config.current.verification_data_public_key, response.text.encode("utf8")
         )
         verification_attempt.passport_date_of_birth = date.fromisoformat(json_data["date_of_birth"])
         verification_attempt.passport_sex = PassportSex[json_data["sex"].lower()]
@@ -999,7 +999,7 @@ def send_activeness_probes(payload: empty_pb2.Empty) -> None:
     with session_scope() as session:
         ## Step 1: create new activeness probes for those who need it and don't have one (if enabled)
 
-        if config.activeness_probes_enabled:
+        if Config.current.activeness_probes_enabled:
             # current activeness probes
             subquery = select(ActivenessProbe.user_id).where(ActivenessProbe.responded == None).subquery()
 
@@ -1305,7 +1305,7 @@ def check_mypostcard_jobs(payload: empty_pb2.Empty) -> None:
     """
     Checks that all MyPostcard jobs from the last week are tied to a postal verification attempt.
     """
-    if not config.enable_postal_verification:
+    if not Config.current.enable_postal_verification:
         return
 
     with session_scope() as session:
@@ -1492,7 +1492,7 @@ def check_database_consistency(payload: empty_pb2.Empty) -> None:
 
         # Ensure auto-approve deadline isn't being exceeded by a significant margin
         # The auto-approver runs every 15s, so allow 5 minutes grace before alerting
-        deadline_seconds = config.moderation_auto_approve_deadline_seconds
+        deadline_seconds = Config.current.moderation_auto_approve_deadline_seconds
         if deadline_seconds > 0:
             grace_period = timedelta(minutes=5)
             stale_initial_review_items = session.execute(
@@ -1519,12 +1519,12 @@ def auto_approve_moderation_queue(payload: empty_pb2.Empty) -> None:
     Dead man's switch: auto-approves unresolved INITIAL_REVIEW items older than the deadline.
     Items explicitly actioned by moderators are left alone.
     """
-    deadline_seconds = config.moderation_auto_approve_deadline_seconds
+    deadline_seconds = Config.current.moderation_auto_approve_deadline_seconds
     if deadline_seconds <= 0:
         return
 
     with session_scope() as session:
-        ctx = make_background_user_context(user_id=config.moderation_bot_user_id)
+        ctx = make_background_user_context(user_id=Config.current.moderation_bot_user_id)
 
         items = (
             Moderation()

--- a/app/backend/src/couchers/jobs/worker.py
+++ b/app/backend/src/couchers/jobs/worker.py
@@ -17,7 +17,7 @@ from google.protobuf import empty_pb2
 from opentelemetry import trace
 from sqlalchemy import select
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.db import db_post_fork, session_scope, worker_repeatable_read_session_scope
 from couchers.experimentation import setup_experimentation
 from couchers.jobs.definitions import JOBS, Job
@@ -112,7 +112,7 @@ def process_job() -> bool:
             # add some info for debugging
             job.failure_info = traceback.format_exc()
 
-            if config.in_test:
+            if Config.current.in_test:
                 raise e
 
         # exiting ctx manager commits and releases the row lock

--- a/app/backend/src/couchers/jobs/worker.py
+++ b/app/backend/src/couchers/jobs/worker.py
@@ -112,7 +112,7 @@ def process_job() -> bool:
             # add some info for debugging
             job.failure_info = traceback.format_exc()
 
-            if config["IN_TEST"]:
+            if config.in_test:
                 raise e
 
         # exiting ctx manager commits and releases the row lock

--- a/app/backend/src/couchers/migrations/env.py
+++ b/app/backend/src/couchers/migrations/env.py
@@ -19,7 +19,7 @@ registry.register("postgresql", "sqlalchemy.dialects.postgresql.psycopg", "PGDia
 # access to the values within the .ini file in use.
 config: Config = context.config
 
-config.set_main_option("sqlalchemy.url", couchers_config["DATABASE_CONNECTION_STRING"])
+config.set_main_option("sqlalchemy.url", couchers_config.database_connection_string)
 
 
 # Interpret the config file for Python logging.

--- a/app/backend/src/couchers/migrations/env.py
+++ b/app/backend/src/couchers/migrations/env.py
@@ -4,23 +4,24 @@ from pathlib import Path
 from typing import Any
 
 from alembic import context
-from alembic.config import Config
+from alembic.config import Config as AlembicConfig
 from sqlalchemy import engine_from_config, pool
 from sqlalchemy.dialects import registry
 from sqlalchemy.schema import MetaData
 
 from couchers import models
-from couchers.config import config as couchers_config
+from couchers.config import Config
 
 # Register psycopg (psycopg3) as the default driver for postgresql:// URLs
 registry.register("postgresql", "sqlalchemy.dialects.postgresql.psycopg", "PGDialect_psycopg")
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
-config: Config = context.config
+config: AlembicConfig = context.config
 
-config.set_main_option("sqlalchemy.url", couchers_config.database_connection_string)
+config.set_main_option("sqlalchemy.url", Config.current.database_connection_string)
 
+Config.current = Config.from_env()
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.

--- a/app/backend/src/couchers/models/logging.py
+++ b/app/backend/src/couchers/models/logging.py
@@ -8,7 +8,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import expression
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.models.base import Base
 
 
@@ -32,7 +32,7 @@ class APICall(Base, kw_only=True):
 
     # backend version (normally e.g. develop-31469e3), allows us to figure out which proto definitions were used
     # note that `default` is a python side default, not hardcoded into DB schema
-    version: Mapped[str] = mapped_column(String, default=config.version)
+    version: Mapped[str] = mapped_column(String, default_factory=lambda: Config.current.version)
 
     # approximate time of the call
     time: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
@@ -89,7 +89,7 @@ class EventLog(Base, kw_only=True):
     occurred: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     # backend/frontend version
-    version: Mapped[str] = mapped_column(String, default=config.version)
+    version: Mapped[str] = mapped_column(String, default_factory=lambda: Config.current.version)
 
     # sofa, null for background/system events
     sofa: Mapped[str | None] = mapped_column(String, default=None)

--- a/app/backend/src/couchers/models/logging.py
+++ b/app/backend/src/couchers/models/logging.py
@@ -32,7 +32,7 @@ class APICall(Base, kw_only=True):
 
     # backend version (normally e.g. develop-31469e3), allows us to figure out which proto definitions were used
     # note that `default` is a python side default, not hardcoded into DB schema
-    version: Mapped[str] = mapped_column(String, default=config["VERSION"])
+    version: Mapped[str] = mapped_column(String, default=config.version)
 
     # approximate time of the call
     time: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
@@ -89,7 +89,7 @@ class EventLog(Base, kw_only=True):
     occurred: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     # backend/frontend version
-    version: Mapped[str] = mapped_column(String, default=config["VERSION"])
+    version: Mapped[str] = mapped_column(String, default=config.version)
 
     # sofa, null for background/system events
     sofa: Mapped[str | None] = mapped_column(String, default=None)

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -42,7 +42,7 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         return
 
     loc_context = LocalizationContext.from_user(user)
-    if not config["ENABLE_NOTIFICATION_TRANSLATIONS"]:
+    if not config.enable_notification_translations:
         loc_context = dataclasses.replace(loc_context, locale="en")
 
     rendered = render_email_notification(user, notification, loc_context)
@@ -50,10 +50,10 @@ def _send_email_notification(session: Session, user: User, notification: Notific
     queue_email(
         session,
         jobs_pb2.SendEmailPayload(
-            sender_name=config["NOTIFICATION_EMAIL_SENDER"],
-            sender_email=config["NOTIFICATION_EMAIL_ADDRESS"],
+            sender_name=config.notification_email_sender,
+            sender_email=config.notification_email_address,
             recipient=user.email,
-            subject=config["NOTIFICATION_PREFIX"] + rendered.subject,
+            subject=config.notification_prefix + rendered.subject,
             plain=rendered.body_plaintext,
             html=rendered.body_html,
             source_data=rendered.source_data,

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import exists, func
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.context import make_background_user_context
 from couchers.db import session_scope
 from couchers.email.queuing import queue_email
@@ -42,7 +42,7 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         return
 
     loc_context = LocalizationContext.from_user(user)
-    if not config.enable_notification_translations:
+    if not Config.current.enable_notification_translations:
         loc_context = dataclasses.replace(loc_context, locale="en")
 
     rendered = render_email_notification(user, notification, loc_context)
@@ -50,10 +50,10 @@ def _send_email_notification(session: Session, user: User, notification: Notific
     queue_email(
         session,
         jobs_pb2.SendEmailPayload(
-            sender_name=config.notification_email_sender,
-            sender_email=config.notification_email_address,
+            sender_name=Config.current.notification_email_sender,
+            sender_email=Config.current.notification_email_address,
             recipient=user.email,
-            subject=config.notification_prefix + rendered.subject,
+            subject=Config.current.notification_prefix + rendered.subject,
             plain=rendered.body_plaintext,
             html=rendered.body_html,
             source_data=rendered.source_data,

--- a/app/backend/src/couchers/notifications/push.py
+++ b/app/backend/src/couchers/notifications/push.py
@@ -116,7 +116,7 @@ def push_to_subscription(
     ttl: int = 0,
 ) -> None:
     # TODO(#7617): Support iOS-style title/subtitles
-    title = config["NOTIFICATION_PREFIX"] + content.title[: PushNotificationContent.MAX_TITLE_LENGTH]
+    title = config.notification_prefix + content.title[: PushNotificationContent.MAX_TITLE_LENGTH]
     body = content.body[: PushNotificationContent.MAX_BODY_LENGTH]
     icon_url = content.icon_url or urls.icon_url()
     action_url = content.action_url or ""

--- a/app/backend/src/couchers/notifications/push.py
+++ b/app/backend/src/couchers/notifications/push.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
 
 from couchers import urls
-from couchers.config import config
+from couchers.config import Config
 from couchers.jobs.enqueue import queue_job
 from couchers.models import PushNotificationSubscription
 from couchers.notifications.send_raw_push_notification import send_raw_push_notification_v2
@@ -116,7 +116,7 @@ def push_to_subscription(
     ttl: int = 0,
 ) -> None:
     # TODO(#7617): Support iOS-style title/subtitles
-    title = config.notification_prefix + content.title[: PushNotificationContent.MAX_TITLE_LENGTH]
+    title = Config.current.notification_prefix + content.title[: PushNotificationContent.MAX_TITLE_LENGTH]
     body = content.body[: PushNotificationContent.MAX_BODY_LENGTH]
     icon_url = content.icon_url or urls.icon_url()
     action_url = content.action_url or ""

--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import couchers.email.emails as emails
 from couchers import urls
-from couchers.config import config
+from couchers.config import Config
 from couchers.email.calendar_events import create_host_request_attachment, create_host_request_cancellation_attachment
 from couchers.email.rendering import (
     EmailFooter,
@@ -60,7 +60,7 @@ def render_email_notification(
         body_html = render_html_body(
             subject=subject, preview=preview, blocks=body_blocks, footer=footer, loc_context=loc_context
         )
-        source_data = f"notification; topic-action={notification.topic_action}; version={config.version}"
+        source_data = f"notification; topic-action={notification.topic_action}; version={Config.current.version}"
     else:
         # Email is still a custom-templated, nonlocalizable email.
         custom_templated = _get_custom_templated_email(notification, loc_context)
@@ -88,10 +88,10 @@ def render_email_notification(
         )
         body_html = html_tmplt.render(template_args, loc_context)
 
-        source_data = config.version + f"/{custom_templated.template_name}"
+        source_data = Config.current.version + f"/{custom_templated.template_name}"
 
     list_unsubscribe_header = get_list_unsubscribe_header(notification)
-    if config.enable_email_ics_attachments:
+    if Config.current.enable_email_ics_attachments:
         attachment = get_ics_attachment(notification, loc_context)
     else:
         attachment = None

--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -60,7 +60,7 @@ def render_email_notification(
         body_html = render_html_body(
             subject=subject, preview=preview, blocks=body_blocks, footer=footer, loc_context=loc_context
         )
-        source_data = f"notification; topic-action={notification.topic_action}; version={config['VERSION']}"
+        source_data = f"notification; topic-action={notification.topic_action}; version={config.version}"
     else:
         # Email is still a custom-templated, nonlocalizable email.
         custom_templated = _get_custom_templated_email(notification, loc_context)
@@ -88,10 +88,10 @@ def render_email_notification(
         )
         body_html = html_tmplt.render(template_args, loc_context)
 
-        source_data = config["VERSION"] + f"/{custom_templated.template_name}"
+        source_data = config.version + f"/{custom_templated.template_name}"
 
     list_unsubscribe_header = get_list_unsubscribe_header(notification)
-    if config.get("ENABLE_EMAIL_ICS_ATTACHMENTS"):
+    if config.enable_email_ics_attachments:
         attachment = get_ics_attachment(notification, loc_context)
     else:
         attachment = None

--- a/app/backend/src/couchers/notifications/send_raw_push_notification.py
+++ b/app/backend/src/couchers/notifications/send_raw_push_notification.py
@@ -100,8 +100,8 @@ def _send_web_push(
         not_none(sub.endpoint),
         not_none(sub.auth_key),
         not_none(sub.p256dh_key),
-        config["PUSH_NOTIFICATIONS_VAPID_SUBJECT"],
-        config["PUSH_NOTIFICATIONS_VAPID_PRIVATE_KEY"],
+        config.push_notifications_vapid_subject,
+        config.push_notifications_vapid_private_key,
         ttl=payload.ttl,
     )
 
@@ -194,7 +194,7 @@ def _send_expo(
 
 
 def send_raw_push_notification_v2(payload: jobs_pb2.SendRawPushNotificationPayloadV2) -> None:
-    if not config["PUSH_NOTIFICATIONS_ENABLED"]:
+    if not config.push_notifications_enabled:
         logger.info("Not sending push notification: push notifications disabled")
         return
 

--- a/app/backend/src/couchers/notifications/send_raw_push_notification.py
+++ b/app/backend/src/couchers/notifications/send_raw_push_notification.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from sqlalchemy import select
 from sqlalchemy.sql import func
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.db import session_scope
 from couchers.metrics import push_notification_counter
 from couchers.models import (
@@ -100,8 +100,8 @@ def _send_web_push(
         not_none(sub.endpoint),
         not_none(sub.auth_key),
         not_none(sub.p256dh_key),
-        config.push_notifications_vapid_subject,
-        config.push_notifications_vapid_private_key,
+        Config.current.push_notifications_vapid_subject,
+        Config.current.push_notifications_vapid_private_key,
         ttl=payload.ttl,
     )
 
@@ -194,7 +194,7 @@ def _send_expo(
 
 
 def send_raw_push_notification_v2(payload: jobs_pb2.SendRawPushNotificationPayloadV2) -> None:
-    if not config.push_notifications_enabled:
+    if not Config.current.push_notifications_enabled:
         logger.info("Not sending push notification: push notifications disabled")
         return
 

--- a/app/backend/src/couchers/phone/sms.py
+++ b/app/backend/src/couchers/phone/sms.py
@@ -32,12 +32,12 @@ def send_sms(number: str, message: str) -> str:
 
     assert len(message) <= 140, "Message too long"
 
-    if not config["ENABLE_SMS"]:
+    if not config.enable_sms:
         logger.info(f"SMS not enabled, need to send to {number}: {message}")
         return "SMS not enabled."
 
     sns = boto3.client("sns")
-    sender_id = config["SMS_SENDER_ID"]
+    sender_id = config.sms_sender_id
 
     response = sns.publish(
         PhoneNumber=number,

--- a/app/backend/src/couchers/phone/sms.py
+++ b/app/backend/src/couchers/phone/sms.py
@@ -5,7 +5,7 @@ import boto3
 import luhn
 
 from couchers import crypto
-from couchers.config import config
+from couchers.config import Config
 from couchers.db import session_scope
 from couchers.models import SMS
 
@@ -32,12 +32,12 @@ def send_sms(number: str, message: str) -> str:
 
     assert len(message) <= 140, "Message too long"
 
-    if not config.enable_sms:
+    if not Config.current.enable_sms:
         logger.info(f"SMS not enabled, need to send to {number}: {message}")
         return "SMS not enabled."
 
     sns = boto3.client("sns")
-    sender_id = config.sms_sender_id
+    sender_id = Config.current.sms_sender_id
 
     response = sns.publish(
         PhoneNumber=number,

--- a/app/backend/src/couchers/postal/my_postcard.py
+++ b/app/backend/src/couchers/postal/my_postcard.py
@@ -66,9 +66,9 @@ def _generate_back_left_side_png(verification_code: str) -> bytes:
 
 def _credentials() -> dict[str, str]:
     return {
-        "api_key": config["MYPOSTCARD_API_KEY"],
-        "username": config["MYPOSTCARD_USERNAME"],
-        "password": config["MYPOSTCARD_PASSWORD"],
+        "api_key": config.mypostcard_api_key,
+        "username": config.mypostcard_username,
+        "password": config.mypostcard_password,
     }
 
 
@@ -107,12 +107,12 @@ def _place_order(
     response = requests.post(
         f"{API_BASE}/place_order",
         data={
-            "api_key": config["MYPOSTCARD_API_KEY"],
+            "api_key": config.mypostcard_api_key,
             "auth_token": auth_token,
-            "product_code": config["MYPOSTCARD_PRODUCT_CODE"],
+            "product_code": config.mypostcard_product_code,
             "image_type": "png",
             "job_data": json.dumps(job_data),
-            "campaign_id": config["MYPOSTCARD_CAMPAIGN_ID"],
+            "campaign_id": config.mypostcard_campaign_id,
         },
         files={
             "photo": ("postcard.png", front_page, "image/png"),

--- a/app/backend/src/couchers/postal/my_postcard.py
+++ b/app/backend/src/couchers/postal/my_postcard.py
@@ -9,7 +9,7 @@ import requests
 from PIL import Image, ImageDraw, ImageFont
 
 from couchers import urls
-from couchers.config import config
+from couchers.config import Config
 from couchers.resources import (
     get_postcard_back_left_template,
     get_postcard_font,
@@ -66,9 +66,9 @@ def _generate_back_left_side_png(verification_code: str) -> bytes:
 
 def _credentials() -> dict[str, str]:
     return {
-        "api_key": config.mypostcard_api_key,
-        "username": config.mypostcard_username,
-        "password": config.mypostcard_password,
+        "api_key": Config.current.mypostcard_api_key,
+        "username": Config.current.mypostcard_username,
+        "password": Config.current.mypostcard_password,
     }
 
 
@@ -107,12 +107,12 @@ def _place_order(
     response = requests.post(
         f"{API_BASE}/place_order",
         data={
-            "api_key": config.mypostcard_api_key,
+            "api_key": Config.current.mypostcard_api_key,
             "auth_token": auth_token,
-            "product_code": config.mypostcard_product_code,
+            "product_code": Config.current.mypostcard_product_code,
             "image_type": "png",
             "job_data": json.dumps(job_data),
-            "campaign_id": config.mypostcard_campaign_id,
+            "campaign_id": Config.current.mypostcard_campaign_id,
         },
         files={
             "photo": ("postcard.png", front_page, "image/png"),

--- a/app/backend/src/couchers/resources.py
+++ b/app/backend/src/couchers/resources.py
@@ -160,7 +160,7 @@ def copy_resources_to_database(session: Session) -> None:
     timezone_areas_file = resources_folder / "timezone_areas.sql"
 
     if not timezone_areas_file.exists():
-        if not config["DEV"]:
+        if not config.dev:
             raise Exception("Missing timezone_areas.sql and not running in dev")
 
         timezone_areas_file = resources_folder / "timezone_areas.sql-fake"

--- a/app/backend/src/couchers/resources.py
+++ b/app/backend/src/couchers/resources.py
@@ -9,7 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import delete, text
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.db import session_scope
 from couchers.models import Language, Region, TimezoneArea
 
@@ -160,7 +160,7 @@ def copy_resources_to_database(session: Session) -> None:
     timezone_areas_file = resources_folder / "timezone_areas.sql"
 
     if not timezone_areas_file.exists():
-        if not config.dev:
+        if not Config.current.dev:
             raise Exception("Missing timezone_areas.sql and not running in dev")
 
         timezone_areas_file = resources_folder / "timezone_areas.sql-fake"

--- a/app/backend/src/couchers/server.py
+++ b/app/backend/src/couchers/server.py
@@ -121,7 +121,7 @@ def create_media_server(port: int, threads: int = 8) -> grpc.Server:
     media_server = grpc.server(
         futures.ThreadPoolExecutor(threads),
         interceptors=[
-            get_media_auth_interceptor(config["MEDIA_SERVER_BEARER_TOKEN"]),
+            get_media_auth_interceptor(config.media_server_bearer_token),
         ],
     )
     media_server.add_insecure_port(f"[::]:{port}")

--- a/app/backend/src/couchers/server.py
+++ b/app/backend/src/couchers/server.py
@@ -2,7 +2,7 @@ from concurrent import futures
 
 import grpc
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.constants import SERVER_THREADS
 from couchers.interceptors import (
     CouchersMiddlewareInterceptor,
@@ -121,7 +121,7 @@ def create_media_server(port: int, threads: int = 8) -> grpc.Server:
     media_server = grpc.server(
         futures.ThreadPoolExecutor(threads),
         interceptors=[
-            get_media_auth_interceptor(config.media_server_bearer_token),
+            get_media_auth_interceptor(Config.current.media_server_bearer_token),
         ],
     )
     media_server.add_insecure_port(f"[::]:{port}")

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -424,7 +424,7 @@ class Account(account_pb2_grpc.AccountServicer):
     def InitiateStrongVerification(
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session
     ) -> account_pb2.InitiateStrongVerificationRes:
-        if not config["ENABLE_STRONG_VERIFICATION"]:
+        if not config.enable_strong_verification:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "strong_verification_disabled")
 
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
@@ -452,9 +452,9 @@ class Account(account_pb2_grpc.AccountServicer):
         )
         response = requests.post(
             "https://passportreader.app/api/v1/session.create",
-            auth=(config["IRIS_ID_PUBKEY"], config["IRIS_ID_SECRET"]),
+            auth=(config.iris_id_pubkey, config.iris_id_secret),
             json={
-                "callback_url": f"{config['BACKEND_BASE_URL']}/iris/webhook",
+                "callback_url": f"{config.backend_base_url}/iris/webhook",
                 "face_verification": False,
                 "passport_only": True,
                 "reference": reference,

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -12,7 +12,7 @@ from sqlalchemy.sql import exists, func, update
 from user_agents import parse as user_agents_parse
 
 from couchers import urls
-from couchers.config import config
+from couchers.config import Config
 from couchers.constants import DONATION_DRIVE_START, PHONE_REVERIFICATION_INTERVAL, SMS_CODE_ATTEMPTS, SMS_CODE_LIFETIME
 from couchers.context import CouchersContext
 from couchers.crypto import (
@@ -424,7 +424,7 @@ class Account(account_pb2_grpc.AccountServicer):
     def InitiateStrongVerification(
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session
     ) -> account_pb2.InitiateStrongVerificationRes:
-        if not config.enable_strong_verification:
+        if not Config.current.enable_strong_verification:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "strong_verification_disabled")
 
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
@@ -452,9 +452,9 @@ class Account(account_pb2_grpc.AccountServicer):
         )
         response = requests.post(
             "https://passportreader.app/api/v1/session.create",
-            auth=(config.iris_id_pubkey, config.iris_id_secret),
+            auth=(Config.current.iris_id_pubkey, Config.current.iris_id_secret),
             json={
-                "callback_url": f"{config.backend_base_url}/iris/webhook",
+                "callback_url": f"{Config.current.backend_base_url}/iris/webhook",
                 "face_verification": False,
                 "passport_only": True,
                 "reference": reference,

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session, selectinload
 from sqlalchemy.sql import and_, delete, exists, func, intersect, or_, union
 
 from couchers import urls
-from couchers.config import config
+from couchers.config import Config
 from couchers.constants import GHOST_USERNAME
 from couchers.context import CouchersContext
 from couchers.crypto import b64encode, generate_hash_signature, random_hex
@@ -944,7 +944,7 @@ class API(api_pb2_grpc.APIServicer):
         ).SerializeToString()
 
         data = b64encode(req)
-        sig = b64encode(generate_hash_signature(req, config.media_server_secret_key))
+        sig = b64encode(generate_hash_signature(req, Config.current.media_server_secret_key))
 
         path = "upload?" + urlencode({"data": data, "sig": sig})
 

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -944,7 +944,7 @@ class API(api_pb2_grpc.APIServicer):
         ).SerializeToString()
 
         data = b64encode(req)
-        sig = b64encode(generate_hash_signature(req, config["MEDIA_SERVER_SECRET_KEY"]))
+        sig = b64encode(generate_hash_signature(req, config.media_server_secret_key))
 
         path = "upload?" + urlencode({"data": data, "sig": sig})
 

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import delete, func, or_
 
 from couchers import urls
-from couchers.config import config
+from couchers.config import Config
 from couchers.constants import ANTIBOT_FREQ, BANNED_USERNAME_PHRASES, GUIDELINES_VERSION, TOS_VERSION, UNDELETE_DAYS
 from couchers.context import CouchersContext
 from couchers.crypto import cookiesafe_secure_token, hash_password, urlsafe_secure_token, verify_password
@@ -708,7 +708,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
         return auth_pb2.UnsubscribeRes(response=respond_quick_link(request, context, session))
 
     def AntiBot(self, request: auth_pb2.AntiBotReq, context: CouchersContext, session: Session) -> auth_pb2.AntiBotRes:
-        if not config.recapthca_enabled:
+        if not Config.current.recapthca_enabled:
             return auth_pb2.AntiBotRes()
 
         ip_address = cast(str | None, context.headers.get("x-couchers-real-ip"))
@@ -716,11 +716,11 @@ class Auth(auth_pb2_grpc.AuthServicer):
         user_id = context.user_id if context.is_logged_in() else None
 
         resp = requests.post(
-            f"https://recaptchaenterprise.googleapis.com/v1/projects/{config.recapthca_project_id}/assessments?key={config.recapthca_api_key}",
+            f"https://recaptchaenterprise.googleapis.com/v1/projects/{Config.current.recapthca_project_id}/assessments?key={Config.current.recapthca_api_key}",
             json={
                 "event": {
                     "token": request.token,
-                    "siteKey": config.recapthca_site_key,
+                    "siteKey": Config.current.recapthca_site_key,
                     "userAgent": user_agent,
                     "userIpAddress": ip_address,
                     "expectedAction": request.action,
@@ -756,7 +756,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
     def AntiBotPolicy(
         self, request: auth_pb2.AntiBotPolicyReq, context: CouchersContext, session: Session
     ) -> auth_pb2.AntiBotPolicyRes:
-        if config.recapthca_enabled:
+        if Config.current.recapthca_enabled:
             if context.is_logged_in():
                 user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
                 if now() - user.last_antibot > ANTIBOT_FREQ:

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -708,7 +708,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
         return auth_pb2.UnsubscribeRes(response=respond_quick_link(request, context, session))
 
     def AntiBot(self, request: auth_pb2.AntiBotReq, context: CouchersContext, session: Session) -> auth_pb2.AntiBotRes:
-        if not config["RECAPTHCA_ENABLED"]:
+        if not config.recapthca_enabled:
             return auth_pb2.AntiBotRes()
 
         ip_address = cast(str | None, context.headers.get("x-couchers-real-ip"))
@@ -716,11 +716,11 @@ class Auth(auth_pb2_grpc.AuthServicer):
         user_id = context.user_id if context.is_logged_in() else None
 
         resp = requests.post(
-            f"https://recaptchaenterprise.googleapis.com/v1/projects/{config['RECAPTHCA_PROJECT_ID']}/assessments?key={config['RECAPTHCA_API_KEY']}",
+            f"https://recaptchaenterprise.googleapis.com/v1/projects/{config.recapthca_project_id}/assessments?key={config.recapthca_api_key}",
             json={
                 "event": {
                     "token": request.token,
-                    "siteKey": config["RECAPTHCA_SITE_KEY"],
+                    "siteKey": config.recapthca_site_key,
                     "userAgent": user_agent,
                     "userIpAddress": ip_address,
                     "expectedAction": request.action,
@@ -756,7 +756,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
     def AntiBotPolicy(
         self, request: auth_pb2.AntiBotPolicyReq, context: CouchersContext, session: Session
     ) -> auth_pb2.AntiBotPolicyRes:
-        if config["RECAPTHCA_ENABLED"]:
+        if config.recapthca_enabled:
             if context.is_logged_in():
                 user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
                 if now() - user.last_antibot > ANTIBOT_FREQ:

--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -1,7 +1,6 @@
 import json
 import time
 from datetime import UTC, datetime
-from typing import cast
 
 import grpc
 import requests
@@ -11,7 +10,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
 
 from couchers import urls
-from couchers.config import config
+from couchers.config import Config
 from couchers.constants import STABLE_THRESHOLD_SECONDS
 from couchers.context import CouchersContext
 from couchers.descriptor_pool import get_descriptors_pb
@@ -25,7 +24,7 @@ _start_time = time.monotonic()
 
 class Bugs(bugs_pb2_grpc.BugsServicer):
     def _version(self) -> str:
-        return config.version
+        return Config.current.version
 
     def Version(self, request: empty_pb2.Empty, context: CouchersContext, session: Session) -> bugs_pb2.VersionInfo:
         return bugs_pb2.VersionInfo(version=self._version())
@@ -33,11 +32,11 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
     def ReportBug(
         self, request: bugs_pb2.ReportBugReq, context: CouchersContext, session: Session
     ) -> bugs_pb2.ReportBugRes:
-        if not config.bug_tool_enabled:
+        if not Config.current.bug_tool_enabled:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "bug_tool_disabled")
 
-        repo = config.bug_tool_github_repo
-        auth = (config.bug_tool_github_username, config.bug_tool_github_token)
+        repo = Config.current.bug_tool_github_repo
+        auth = (Config.current.bug_tool_github_username, Config.current.bug_tool_github_token)
 
         if context.is_logged_in():
             username = session.execute(select(User.username).where(User.id == context.user_id)).scalar_one()

--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -25,7 +25,7 @@ _start_time = time.monotonic()
 
 class Bugs(bugs_pb2_grpc.BugsServicer):
     def _version(self) -> str:
-        return cast(str, config["VERSION"])
+        return config.version
 
     def Version(self, request: empty_pb2.Empty, context: CouchersContext, session: Session) -> bugs_pb2.VersionInfo:
         return bugs_pb2.VersionInfo(version=self._version())
@@ -33,11 +33,11 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
     def ReportBug(
         self, request: bugs_pb2.ReportBugReq, context: CouchersContext, session: Session
     ) -> bugs_pb2.ReportBugRes:
-        if not config["BUG_TOOL_ENABLED"]:
+        if not config.bug_tool_enabled:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "bug_tool_disabled")
 
-        repo = config["BUG_TOOL_GITHUB_REPO"]
-        auth = (config["BUG_TOOL_GITHUB_USERNAME"], config["BUG_TOOL_GITHUB_TOKEN"])
+        repo = config.bug_tool_github_repo
+        auth = (config.bug_tool_github_username, config.bug_tool_github_token)
 
         if context.is_logged_in():
             username = session.execute(select(User.username).where(User.id == context.user_id)).scalar_one()

--- a/app/backend/src/couchers/servicers/donations.py
+++ b/app/backend/src/couchers/servicers/donations.py
@@ -30,7 +30,7 @@ def _create_stripe_customer(session: Session, user: User) -> None:
         email=user.email,
         # metadata allows us to store arbitrary metadata for ourselves
         metadata={"user_id": user.id},  # type: ignore[dict-item]
-        api_key=config["STRIPE_API_KEY"],
+        api_key=config.stripe_api_key,
     )
     user.stripe_customer_id = customer.id
     # commit since we only ever want one stripe customer id per user, so if the rest of this api call fails, this will still be saved in the db
@@ -41,7 +41,7 @@ class Donations(donations_pb2_grpc.DonationsServicer):
     def InitiateDonation(
         self, request: donations_pb2.InitiateDonationReq, context: CouchersContext, session: Session
     ) -> donations_pb2.InitiateDonationRes:
-        if not config["ENABLE_DONATIONS"]:
+        if not config.enable_donations:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "donations_disabled")
 
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
@@ -55,7 +55,7 @@ class Donations(donations_pb2_grpc.DonationsServicer):
 
         if request.recurring:
             item = {
-                "price": config["STRIPE_RECURRING_PRODUCT_ID"],
+                "price": config.stripe_recurring_product_id,
                 "quantity": request.amount,
             }
         else:
@@ -81,7 +81,7 @@ class Donations(donations_pb2_grpc.DonationsServicer):
             payment_method_types=["card"],
             mode="subscription" if request.recurring else "payment",
             line_items=[item],  # type: ignore[list-item]
-            api_key=config["STRIPE_API_KEY"],
+            api_key=config.stripe_api_key,
         )
 
         session.add(
@@ -108,7 +108,7 @@ class Donations(donations_pb2_grpc.DonationsServicer):
     def GetDonationPortalLink(
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session
     ) -> donations_pb2.GetDonationPortalLinkRes:
-        if not config["ENABLE_DONATIONS"]:
+        if not config.enable_donations:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "donations_disabled")
 
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
@@ -119,7 +119,7 @@ class Donations(donations_pb2_grpc.DonationsServicer):
         stripe_session = stripe.billing_portal.Session.create(
             customer=not_none(user.stripe_customer_id),
             return_url=urls.donation_url(),
-            api_key=config["STRIPE_API_KEY"],
+            api_key=config.stripe_api_key,
         )
 
         return donations_pb2.GetDonationPortalLinkRes(stripe_portal_url=stripe_session.url)
@@ -135,8 +135,8 @@ class Stripe(stripe_pb2_grpc.StripeServicer):
         event = stripe.Webhook.construct_event(  # type: ignore[no-untyped-call]
             payload=request.data,
             sig_header=context.headers.get("stripe-signature"),
-            secret=config["STRIPE_WEBHOOK_SECRET"],
-            api_key=config["STRIPE_API_KEY"],
+            secret=config.stripe_webhook_secret,
+            api_key=config.stripe_api_key,
         )
         data = event["data"]
         event_type = event["type"]
@@ -148,7 +148,7 @@ class Stripe(stripe_pb2_grpc.StripeServicer):
         logger.info(f"Got signed Stripe webhook, {event_type=}, {event_id=}")
 
         if event_type == "charge.succeeded":
-            if metadata.get("site_url") == config["MERCH_SHOP_URL"]:
+            if metadata.get("site_url") == config.merch_shop_url:
                 # merch shop. look up this email and give them the swagster badge
                 customer_email = metadata["customer_email"]
                 amount = int(data_object["amount"]) // 100
@@ -161,7 +161,7 @@ class Stripe(stripe_pb2_grpc.StripeServicer):
                     customer_info = customer_email
                 try:
                     send_slack_message(
-                        config["SLACK_MERCH_CHANNEL"],
+                        config.slack_merch_channel,
                         f"Merch purchase: ${amount} from {customer_info}",
                     )
                 except Exception as e:
@@ -202,7 +202,7 @@ class Stripe(stripe_pb2_grpc.StripeServicer):
                 user_link = urls.user_link(username=user.username)
                 try:
                     send_slack_message(
-                        config["SLACK_DONATIONS_CHANNEL"],
+                        config.slack_donations_channel,
                         f"Donation received: ${amount} ({donation_type}) from <{user_link}|{user.name}>",
                     )
                 except Exception as e:

--- a/app/backend/src/couchers/servicers/donations.py
+++ b/app/backend/src/couchers/servicers/donations.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from couchers import urls
-from couchers.config import config
+from couchers.config import Config
 from couchers.context import CouchersContext
 from couchers.event_log import log_event
 from couchers.helpers.badges import user_add_badge
@@ -30,7 +30,7 @@ def _create_stripe_customer(session: Session, user: User) -> None:
         email=user.email,
         # metadata allows us to store arbitrary metadata for ourselves
         metadata={"user_id": user.id},  # type: ignore[dict-item]
-        api_key=config.stripe_api_key,
+        api_key=Config.current.stripe_api_key,
     )
     user.stripe_customer_id = customer.id
     # commit since we only ever want one stripe customer id per user, so if the rest of this api call fails, this will still be saved in the db
@@ -41,7 +41,7 @@ class Donations(donations_pb2_grpc.DonationsServicer):
     def InitiateDonation(
         self, request: donations_pb2.InitiateDonationReq, context: CouchersContext, session: Session
     ) -> donations_pb2.InitiateDonationRes:
-        if not config.enable_donations:
+        if not Config.current.enable_donations:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "donations_disabled")
 
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
@@ -55,7 +55,7 @@ class Donations(donations_pb2_grpc.DonationsServicer):
 
         if request.recurring:
             item = {
-                "price": config.stripe_recurring_product_id,
+                "price": Config.current.stripe_recurring_product_id,
                 "quantity": request.amount,
             }
         else:
@@ -81,7 +81,7 @@ class Donations(donations_pb2_grpc.DonationsServicer):
             payment_method_types=["card"],
             mode="subscription" if request.recurring else "payment",
             line_items=[item],  # type: ignore[list-item]
-            api_key=config.stripe_api_key,
+            api_key=Config.current.stripe_api_key,
         )
 
         session.add(
@@ -108,7 +108,7 @@ class Donations(donations_pb2_grpc.DonationsServicer):
     def GetDonationPortalLink(
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session
     ) -> donations_pb2.GetDonationPortalLinkRes:
-        if not config.enable_donations:
+        if not Config.current.enable_donations:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "donations_disabled")
 
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
@@ -119,7 +119,7 @@ class Donations(donations_pb2_grpc.DonationsServicer):
         stripe_session = stripe.billing_portal.Session.create(
             customer=not_none(user.stripe_customer_id),
             return_url=urls.donation_url(),
-            api_key=config.stripe_api_key,
+            api_key=Config.current.stripe_api_key,
         )
 
         return donations_pb2.GetDonationPortalLinkRes(stripe_portal_url=stripe_session.url)
@@ -135,8 +135,8 @@ class Stripe(stripe_pb2_grpc.StripeServicer):
         event = stripe.Webhook.construct_event(  # type: ignore[no-untyped-call]
             payload=request.data,
             sig_header=context.headers.get("stripe-signature"),
-            secret=config.stripe_webhook_secret,
-            api_key=config.stripe_api_key,
+            secret=Config.current.stripe_webhook_secret,
+            api_key=Config.current.stripe_api_key,
         )
         data = event["data"]
         event_type = event["type"]
@@ -148,7 +148,7 @@ class Stripe(stripe_pb2_grpc.StripeServicer):
         logger.info(f"Got signed Stripe webhook, {event_type=}, {event_id=}")
 
         if event_type == "charge.succeeded":
-            if metadata.get("site_url") == config.merch_shop_url:
+            if metadata.get("site_url") == Config.current.merch_shop_url:
                 # merch shop. look up this email and give them the swagster badge
                 customer_email = metadata["customer_email"]
                 amount = int(data_object["amount"]) // 100
@@ -161,7 +161,7 @@ class Stripe(stripe_pb2_grpc.StripeServicer):
                     customer_info = customer_email
                 try:
                     send_slack_message(
-                        config.slack_merch_channel,
+                        Config.current.slack_merch_channel,
                         f"Merch purchase: ${amount} from {customer_info}",
                     )
                 except Exception as e:
@@ -202,7 +202,7 @@ class Stripe(stripe_pb2_grpc.StripeServicer):
                 user_link = urls.user_link(username=user.username)
                 try:
                     send_slack_message(
-                        config.slack_donations_channel,
+                        Config.current.slack_donations_channel,
                         f"Donation received: ${amount} ({donation_type}) from <{user_link}|{user.name}>",
                     )
                 except Exception as e:

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -43,7 +43,7 @@ MAX_PAGINATION_LENGTH = 100
 
 @functools.cache
 def get_vapid_public_key() -> str:
-    return get_vapid_public_key_from_private_key(config["PUSH_NOTIFICATIONS_VAPID_PRIVATE_KEY"])
+    return get_vapid_public_key_from_private_key(config.push_notifications_vapid_private_key)
 
 
 def notification_to_pb(user: User, notification: Notification) -> notifications_pb2.Notification:
@@ -159,7 +159,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
     def GetVapidPublicKey(
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session
     ) -> notifications_pb2.GetVapidPublicKeyRes:
-        if not config["PUSH_NOTIFICATIONS_ENABLED"]:
+        if not config.push_notifications_enabled:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         return notifications_pb2.GetVapidPublicKeyRes(vapid_public_key=get_vapid_public_key())
@@ -170,7 +170,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         context: CouchersContext,
         session: Session,
     ) -> empty_pb2.Empty:
-        if not config["PUSH_NOTIFICATIONS_ENABLED"]:
+        if not config.push_notifications_enabled:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         data = json.loads(request.full_subscription_json)
@@ -205,7 +205,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
     def SendTestPushNotification(
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session
     ) -> empty_pb2.Empty:
-        if not config["PUSH_NOTIFICATIONS_ENABLED"]:
+        if not config.push_notifications_enabled:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         push_to_user(
@@ -227,7 +227,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         context: CouchersContext,
         session: Session,
     ) -> empty_pb2.Empty:
-        if not config["PUSH_NOTIFICATIONS_ENABLED"]:
+        if not config.push_notifications_enabled:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         # Check for existing subscription with this token
@@ -272,7 +272,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
     def SendTestMobilePushNotification(
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session
     ) -> empty_pb2.Empty:
-        if not config["PUSH_NOTIFICATIONS_ENABLED"]:
+        if not config.push_notifications_enabled:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         push_to_user(
@@ -291,10 +291,10 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
     def SendDevPushNotification(
         self, request: notifications_pb2.SendDevPushNotificationReq, context: CouchersContext, session: Session
     ) -> empty_pb2.Empty:
-        if not config["ENABLE_DEV_APIS"]:
+        if not config.enable_dev_apis:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "dev_apis_disabled")
 
-        if not config["PUSH_NOTIFICATIONS_ENABLED"]:
+        if not config.push_notifications_enabled:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         push_to_user(
@@ -320,10 +320,10 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         context: CouchersContext,
         session: Session,
     ) -> empty_pb2.Empty:
-        if not config["ENABLE_DEV_APIS"]:
+        if not config.enable_dev_apis:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "dev_apis_disabled")
 
-        if not config["PUSH_NOTIFICATIONS_ENABLED"]:
+        if not config.push_notifications_enabled:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -8,7 +8,7 @@ from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import or_
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.constants import DATETIME_INFINITY
 from couchers.context import CouchersContext
 from couchers.i18n import LocalizationContext
@@ -43,7 +43,7 @@ MAX_PAGINATION_LENGTH = 100
 
 @functools.cache
 def get_vapid_public_key() -> str:
-    return get_vapid_public_key_from_private_key(config.push_notifications_vapid_private_key)
+    return get_vapid_public_key_from_private_key(Config.current.push_notifications_vapid_private_key)
 
 
 def notification_to_pb(user: User, notification: Notification) -> notifications_pb2.Notification:
@@ -159,7 +159,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
     def GetVapidPublicKey(
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session
     ) -> notifications_pb2.GetVapidPublicKeyRes:
-        if not config.push_notifications_enabled:
+        if not Config.current.push_notifications_enabled:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         return notifications_pb2.GetVapidPublicKeyRes(vapid_public_key=get_vapid_public_key())
@@ -170,7 +170,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         context: CouchersContext,
         session: Session,
     ) -> empty_pb2.Empty:
-        if not config.push_notifications_enabled:
+        if not Config.current.push_notifications_enabled:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         data = json.loads(request.full_subscription_json)
@@ -205,7 +205,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
     def SendTestPushNotification(
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session
     ) -> empty_pb2.Empty:
-        if not config.push_notifications_enabled:
+        if not Config.current.push_notifications_enabled:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         push_to_user(
@@ -227,7 +227,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         context: CouchersContext,
         session: Session,
     ) -> empty_pb2.Empty:
-        if not config.push_notifications_enabled:
+        if not Config.current.push_notifications_enabled:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         # Check for existing subscription with this token
@@ -272,7 +272,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
     def SendTestMobilePushNotification(
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session
     ) -> empty_pb2.Empty:
-        if not config.push_notifications_enabled:
+        if not Config.current.push_notifications_enabled:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         push_to_user(
@@ -291,10 +291,10 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
     def SendDevPushNotification(
         self, request: notifications_pb2.SendDevPushNotificationReq, context: CouchersContext, session: Session
     ) -> empty_pb2.Empty:
-        if not config.enable_dev_apis:
+        if not Config.current.enable_dev_apis:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "dev_apis_disabled")
 
-        if not config.push_notifications_enabled:
+        if not Config.current.push_notifications_enabled:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         push_to_user(
@@ -320,10 +320,10 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         context: CouchersContext,
         session: Session,
     ) -> empty_pb2.Empty:
-        if not config.enable_dev_apis:
+        if not Config.current.enable_dev_apis:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "dev_apis_disabled")
 
-        if not config.push_notifications_enabled:
+        if not Config.current.push_notifications_enabled:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "push_notifications_disabled")
 
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()

--- a/app/backend/src/couchers/servicers/postal_verification.py
+++ b/app/backend/src/couchers/servicers/postal_verification.py
@@ -6,7 +6,7 @@ from google.protobuf import empty_pb2
 from sqlalchemy import exists, select
 from sqlalchemy.orm import Session
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.constants import (
     POSTAL_VERIFICATION_CODE_LIFETIME,
     POSTAL_VERIFICATION_MAX_ATTEMPTS,
@@ -58,7 +58,7 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
         """
         Step 1: User submits address for validation.
         """
-        if not config.enable_postal_verification:
+        if not Config.current.enable_postal_verification:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "postal_verification_disabled")
 
         # Check if there's an active attempt

--- a/app/backend/src/couchers/servicers/postal_verification.py
+++ b/app/backend/src/couchers/servicers/postal_verification.py
@@ -58,7 +58,7 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
         """
         Step 1: User submits address for validation.
         """
-        if not config["ENABLE_POSTAL_VERIFICATION"]:
+        if not config.enable_postal_verification:
             context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "postal_verification_disabled")
 
         # Check if there's an active attempt

--- a/app/backend/src/couchers/slack.py
+++ b/app/backend/src/couchers/slack.py
@@ -8,13 +8,13 @@ logger = logging.getLogger(__name__)
 
 
 def send_slack_message(channel: str, markdown: str) -> None:
-    if not config["SLACK_ENABLED"]:
+    if not config.slack_enabled:
         logger.info(f"Slack disabled, would have sent to {channel}: {markdown}")
         return
 
     response = requests.post(
         "https://slack.com/api/chat.postMessage",
-        headers={"Authorization": f"Bearer {config['SLACK_BOT_TOKEN']}"},
+        headers={"Authorization": f"Bearer {config.slack_bot_token}"},
         json={"channel": channel, "markdown_text": markdown},
         timeout=10,
     )

--- a/app/backend/src/couchers/slack.py
+++ b/app/backend/src/couchers/slack.py
@@ -2,19 +2,19 @@ import logging
 
 import requests
 
-from couchers.config import config
+from couchers.config import Config
 
 logger = logging.getLogger(__name__)
 
 
 def send_slack_message(channel: str, markdown: str) -> None:
-    if not config.slack_enabled:
+    if not Config.current.slack_enabled:
         logger.info(f"Slack disabled, would have sent to {channel}: {markdown}")
         return
 
     response = requests.post(
         "https://slack.com/api/chat.postMessage",
-        headers={"Authorization": f"Bearer {config.slack_bot_token}"},
+        headers={"Authorization": f"Bearer {Config.current.slack_bot_token}"},
         json={"channel": channel, "markdown_text": markdown},
         timeout=10,
     )

--- a/app/backend/src/couchers/tasks.py
+++ b/app/backend/src/couchers/tasks.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
 
 from couchers import urls
-from couchers.config import config
+from couchers.config import Config
 from couchers.constants import SIGNUP_EMAIL_TOKEN_VALIDITY
 from couchers.crypto import urlsafe_secure_token
 from couchers.db import session_scope
@@ -91,7 +91,7 @@ def send_content_report_email(session: Session, content_report: ContentReport) -
     logger.info("Sending content report email")
     queue_system_email(
         session,
-        config.reports_email_recipient,
+        Config.current.reports_email_recipient,
         "content_report",
         template_args={"report": content_report},
     )
@@ -102,7 +102,7 @@ def maybe_send_reference_report_email(session: Session, reference: Reference) ->
         logger.info("Sending reference report email")
         queue_system_email(
             session,
-            config.reports_email_recipient,
+            Config.current.reports_email_recipient,
             "reference_report",
             template_args={"reference": reference},
         )
@@ -121,7 +121,7 @@ def send_rate_limit_violation_report_email(
     user = session.get_one(User, rate_limit_violation.user_id)
     queue_system_email(
         session,
-        config.reports_email_recipient,
+        Config.current.reports_email_recipient,
         "rate_limit_violation_report",
         template_args={
             "user": user,
@@ -140,7 +140,7 @@ def send_duplicate_strong_verification_email(
     logger.info("Sending duplicate SV email")
     queue_system_email(
         session,
-        config.reports_email_recipient,
+        Config.current.reports_email_recipient,
         "duplicate_strong_verification_report",
         template_args={
             "new_user": new_attempt.user,
@@ -155,7 +155,7 @@ def maybe_send_contributor_form_email(session: Session, form: ContributorForm) -
     if form.should_notify:
         queue_system_email(
             session,
-            config.contributor_form_email_recipient,
+            Config.current.contributor_form_email_recipient,
             "contributor_form",
             template_args={"form": form},
         )
@@ -164,7 +164,7 @@ def maybe_send_contributor_form_email(session: Session, form: ContributorForm) -
 def send_event_community_invite_request_email(session: Session, request: EventCommunityInviteRequest) -> None:
     queue_system_email(
         session,
-        config.mods_email_recipient,
+        Config.current.mods_email_recipient,
         "event_community_invite_request",
         template_args={
             "event_link": urls.event_link(occurrence_id=request.occurrence.id, slug=request.occurrence.event.slug),
@@ -178,7 +178,7 @@ def send_account_deletion_report_email(session: Session, reason: AccountDeletion
     logger.info("Sending account deletion report email")
     queue_system_email(
         session,
-        config.reports_email_recipient,
+        Config.current.reports_email_recipient,
         "account_deletion_report",
         template_args={
             "reason": reason,

--- a/app/backend/src/couchers/tasks.py
+++ b/app/backend/src/couchers/tasks.py
@@ -91,7 +91,7 @@ def send_content_report_email(session: Session, content_report: ContentReport) -
     logger.info("Sending content report email")
     queue_system_email(
         session,
-        config["REPORTS_EMAIL_RECIPIENT"],
+        config.reports_email_recipient,
         "content_report",
         template_args={"report": content_report},
     )
@@ -102,7 +102,7 @@ def maybe_send_reference_report_email(session: Session, reference: Reference) ->
         logger.info("Sending reference report email")
         queue_system_email(
             session,
-            config["REPORTS_EMAIL_RECIPIENT"],
+            config.reports_email_recipient,
             "reference_report",
             template_args={"reference": reference},
         )
@@ -121,7 +121,7 @@ def send_rate_limit_violation_report_email(
     user = session.get_one(User, rate_limit_violation.user_id)
     queue_system_email(
         session,
-        config["REPORTS_EMAIL_RECIPIENT"],
+        config.reports_email_recipient,
         "rate_limit_violation_report",
         template_args={
             "user": user,
@@ -140,7 +140,7 @@ def send_duplicate_strong_verification_email(
     logger.info("Sending duplicate SV email")
     queue_system_email(
         session,
-        config["REPORTS_EMAIL_RECIPIENT"],
+        config.reports_email_recipient,
         "duplicate_strong_verification_report",
         template_args={
             "new_user": new_attempt.user,
@@ -155,7 +155,7 @@ def maybe_send_contributor_form_email(session: Session, form: ContributorForm) -
     if form.should_notify:
         queue_system_email(
             session,
-            config["CONTRIBUTOR_FORM_EMAIL_RECIPIENT"],
+            config.contributor_form_email_recipient,
             "contributor_form",
             template_args={"form": form},
         )
@@ -164,7 +164,7 @@ def maybe_send_contributor_form_email(session: Session, form: ContributorForm) -
 def send_event_community_invite_request_email(session: Session, request: EventCommunityInviteRequest) -> None:
     queue_system_email(
         session,
-        config["MODS_EMAIL_RECIPIENT"],
+        config.mods_email_recipient,
         "event_community_invite_request",
         template_args={
             "event_link": urls.event_link(occurrence_id=request.occurrence.id, slug=request.occurrence.event.slug),
@@ -178,7 +178,7 @@ def send_account_deletion_report_email(session: Session, reason: AccountDeletion
     logger.info("Sending account deletion report email")
     queue_system_email(
         session,
-        config["REPORTS_EMAIL_RECIPIENT"],
+        config.reports_email_recipient,
         "account_deletion_report",
         template_args={
             "reason": reason,

--- a/app/backend/src/couchers/tracing.py
+++ b/app/backend/src/couchers/tracing.py
@@ -7,12 +7,12 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.db import _get_base_engine
 
 
 def setup_tracing() -> None:
-    if config.opentelemetry_endpoint != "":
+    if Config.current.opentelemetry_endpoint != "":
         ThreadingInstrumentor().instrument()
 
         grpc_server_instrumentor = GrpcInstrumentorServer()  # type: ignore[no-untyped-call]
@@ -21,7 +21,7 @@ def setup_tracing() -> None:
 
         tracer = TracerProvider(resource=Resource(attributes={"service.name": "backend"}))
         tracer.add_span_processor(
-            BatchSpanProcessor(OTLPSpanExporter(endpoint=config.opentelemetry_endpoint, insecure=True))
+            BatchSpanProcessor(OTLPSpanExporter(endpoint=Config.current.opentelemetry_endpoint, insecure=True))
         )
 
         trace.set_tracer_provider(tracer)

--- a/app/backend/src/couchers/tracing.py
+++ b/app/backend/src/couchers/tracing.py
@@ -12,7 +12,7 @@ from couchers.db import _get_base_engine
 
 
 def setup_tracing() -> None:
-    if config["OPENTELEMETRY_ENDPOINT"] != "":
+    if config.opentelemetry_endpoint != "":
         ThreadingInstrumentor().instrument()
 
         grpc_server_instrumentor = GrpcInstrumentorServer()  # type: ignore[no-untyped-call]
@@ -21,7 +21,7 @@ def setup_tracing() -> None:
 
         tracer = TracerProvider(resource=Resource(attributes={"service.name": "backend"}))
         tracer.add_span_processor(
-            BatchSpanProcessor(OTLPSpanExporter(endpoint=config["OPENTELEMETRY_ENDPOINT"], insecure=True))
+            BatchSpanProcessor(OTLPSpanExporter(endpoint=config.opentelemetry_endpoint, insecure=True))
         )
 
         trace.set_tracer_provider(tracer)

--- a/app/backend/src/couchers/urls.py
+++ b/app/backend/src/couchers/urls.py
@@ -4,148 +4,148 @@
 # //app/web/src/routes.ts
 
 
-from couchers.config import config
+from couchers.config import Config
 
 
 def app_link() -> str:
-    return f"{config.base_url}/"
+    return f"{Config.current.base_url}/"
 
 
 def icon_url() -> str:
-    return f"{config.base_url}/logo512.png"
+    return f"{Config.current.base_url}/logo512.png"
 
 
 def profile_link() -> str:
-    return f"{config.base_url}/profile"
+    return f"{Config.current.base_url}/profile"
 
 
 def user_link(*, username: str) -> str:
-    return f"{config.base_url}/user/{username}"
+    return f"{Config.current.base_url}/user/{username}"
 
 
 def edit_profile_link() -> str:
-    return f"{config.base_url}/profile/edit"
+    return f"{Config.current.base_url}/profile/edit"
 
 
 def signup_link(*, token: str) -> str:
-    return f"{config.base_url}/signup?token={token}"
+    return f"{Config.current.base_url}/signup?token={token}"
 
 
 def account_settings_link() -> str:
-    return f"{config.base_url}/account-settings"
+    return f"{Config.current.base_url}/account-settings"
 
 
 def notification_settings_link() -> str:
-    return f"{config.base_url}/account-settings/notifications"
+    return f"{Config.current.base_url}/account-settings/notifications"
 
 
 def feature_preview_link() -> str:
-    return f"{config.base_url}/preview"
+    return f"{Config.current.base_url}/preview"
 
 
 def password_reset_link(*, password_reset_token: str) -> str:
-    return f"{config.base_url}/complete-password-reset?token={password_reset_token}"
+    return f"{Config.current.base_url}/complete-password-reset?token={password_reset_token}"
 
 
 def host_request_link_host() -> str:
-    return f"{config.base_url}/messages/hosting/"
+    return f"{Config.current.base_url}/messages/hosting/"
 
 
 def host_request_link_guest() -> str:
-    return f"{config.base_url}/messages/surfing/"
+    return f"{Config.current.base_url}/messages/surfing/"
 
 
 def host_request(*, host_request_id: str) -> str:
-    return f"{config.base_url}/messages/request/{host_request_id}"
+    return f"{Config.current.base_url}/messages/request/{host_request_id}"
 
 
 def messages_link() -> str:
-    return f"{config.base_url}/messages/"
+    return f"{Config.current.base_url}/messages/"
 
 
 def chat_link(*, chat_id: int) -> str:
-    return f"{config.base_url}/messages/chats/{chat_id}"
+    return f"{Config.current.base_url}/messages/chats/{chat_id}"
 
 
 def event_link(*, occurrence_id: int, slug: str = "e") -> str:
-    return f"{config.base_url}/event/{occurrence_id}/{slug}"
+    return f"{Config.current.base_url}/event/{occurrence_id}/{slug}"
 
 
 def community_link(*, node_id: int, slug: str = "e") -> str:
-    return f"{config.base_url}/community/{node_id}/{slug}"
+    return f"{Config.current.base_url}/community/{node_id}/{slug}"
 
 
 def discussion_link(*, discussion_id: str, slug: str = "e") -> str:
-    return f"{config.base_url}/discussion/{discussion_id}/{slug}"
+    return f"{Config.current.base_url}/discussion/{discussion_id}/{slug}"
 
 
 def leave_reference_link(*, reference_type: str, to_user_id: str, host_request_id: str | None = None) -> str:
     assert reference_type in ["friend", "surfed", "hosted"]
     if host_request_id:
-        return f"{config.base_url}/leave-reference/{reference_type}/{to_user_id}/{host_request_id}"
+        return f"{Config.current.base_url}/leave-reference/{reference_type}/{to_user_id}/{host_request_id}"
     else:
-        return f"{config.base_url}/leave-reference/{reference_type}/{to_user_id}"
+        return f"{Config.current.base_url}/leave-reference/{reference_type}/{to_user_id}"
 
 
 def profile_references_link() -> str:
-    return f"{config.base_url}/profile/references"
+    return f"{Config.current.base_url}/profile/references"
 
 
 def friend_requests_link() -> str:
-    return f"{config.base_url}/connections/friends/"
+    return f"{Config.current.base_url}/connections/friends/"
 
 
 def media_upload_url(*, path: str) -> str:
-    return f"{config.media_server_upload_base_url}/{path}"
+    return f"{Config.current.media_server_upload_base_url}/{path}"
 
 
 def change_email_link(*, confirmation_token: str) -> str:
-    return f"{config.base_url}/confirm-email?token={confirmation_token}"
+    return f"{Config.current.base_url}/confirm-email?token={confirmation_token}"
 
 
 def donation_url() -> str:
-    return f"{config.base_url}/donate"
+    return f"{Config.current.base_url}/donate"
 
 
 def donation_cancelled_url() -> str:
-    return f"{config.base_url}/donate?cancelled=true"
+    return f"{Config.current.base_url}/donate?cancelled=true"
 
 
 def donation_success_url() -> str:
-    return f"{config.base_url}/donate?success=true"
+    return f"{Config.current.base_url}/donate?success=true"
 
 
 def complete_strong_verification_url(*, verification_attempt_token: str) -> str:
-    return f"{config.base_url}/complete-strong-verification?verification_attempt_token={verification_attempt_token}"
+    return f"{Config.current.base_url}/complete-strong-verification?verification_attempt_token={verification_attempt_token}"
 
 
 def delete_account_link(*, account_deletion_token: str) -> str:
-    return f"{config.base_url}/delete-account?token={account_deletion_token}"
+    return f"{Config.current.base_url}/delete-account?token={account_deletion_token}"
 
 
 def recover_account_link(*, account_undelete_token: str) -> str:
-    return f"{config.base_url}/recover-account?token={account_undelete_token}"
+    return f"{Config.current.base_url}/recover-account?token={account_undelete_token}"
 
 
 def unsubscribe_link(*, payload: str, sig: str) -> str:
-    return f"{config.base_url}/quick-link?payload={payload}&sig={sig}"
+    return f"{Config.current.base_url}/quick-link?payload={payload}&sig={sig}"
 
 
 def quick_link(*, payload: str, sig: str) -> str:
-    return f"{config.base_url}/quick-link?payload={payload}&sig={sig}"
+    return f"{Config.current.base_url}/quick-link?payload={payload}&sig={sig}"
 
 
 def media_url(*, filename: str, size: str) -> str:
-    return f"{config.media_server_base_url}/img/{size}/{filename}"
+    return f"{Config.current.media_server_base_url}/img/{size}/{filename}"
 
 
 def console_link(*, page: str) -> str:
-    return f"{config.console_base_url}/{page}"
+    return f"{Config.current.console_base_url}/{page}"
 
 
 def invite_code_link(*, code: str) -> str:
-    return f"{config.base_url}/invite?code={code}"
+    return f"{Config.current.base_url}/invite?code={code}"
 
 
 def postal_verification_link(*, code: str) -> str:
-    return f"{config.base_url}/verify-postal?c={code}"
+    return f"{Config.current.base_url}/verify-postal?c={code}"

--- a/app/backend/src/couchers/urls.py
+++ b/app/backend/src/couchers/urls.py
@@ -8,144 +8,144 @@ from couchers.config import config
 
 
 def app_link() -> str:
-    return f"{config['BASE_URL']}/"
+    return f"{config.base_url}/"
 
 
 def icon_url() -> str:
-    return f"{config['BASE_URL']}/logo512.png"
+    return f"{config.base_url}/logo512.png"
 
 
 def profile_link() -> str:
-    return f"{config['BASE_URL']}/profile"
+    return f"{config.base_url}/profile"
 
 
 def user_link(*, username: str) -> str:
-    return f"{config['BASE_URL']}/user/{username}"
+    return f"{config.base_url}/user/{username}"
 
 
 def edit_profile_link() -> str:
-    return f"{config['BASE_URL']}/profile/edit"
+    return f"{config.base_url}/profile/edit"
 
 
 def signup_link(*, token: str) -> str:
-    return f"{config['BASE_URL']}/signup?token={token}"
+    return f"{config.base_url}/signup?token={token}"
 
 
 def account_settings_link() -> str:
-    return f"{config['BASE_URL']}/account-settings"
+    return f"{config.base_url}/account-settings"
 
 
 def notification_settings_link() -> str:
-    return f"{config['BASE_URL']}/account-settings/notifications"
+    return f"{config.base_url}/account-settings/notifications"
 
 
 def feature_preview_link() -> str:
-    return f"{config['BASE_URL']}/preview"
+    return f"{config.base_url}/preview"
 
 
 def password_reset_link(*, password_reset_token: str) -> str:
-    return f"{config['BASE_URL']}/complete-password-reset?token={password_reset_token}"
+    return f"{config.base_url}/complete-password-reset?token={password_reset_token}"
 
 
 def host_request_link_host() -> str:
-    return f"{config['BASE_URL']}/messages/hosting/"
+    return f"{config.base_url}/messages/hosting/"
 
 
 def host_request_link_guest() -> str:
-    return f"{config['BASE_URL']}/messages/surfing/"
+    return f"{config.base_url}/messages/surfing/"
 
 
 def host_request(*, host_request_id: str) -> str:
-    return f"{config['BASE_URL']}/messages/request/{host_request_id}"
+    return f"{config.base_url}/messages/request/{host_request_id}"
 
 
 def messages_link() -> str:
-    return f"{config['BASE_URL']}/messages/"
+    return f"{config.base_url}/messages/"
 
 
 def chat_link(*, chat_id: int) -> str:
-    return f"{config['BASE_URL']}/messages/chats/{chat_id}"
+    return f"{config.base_url}/messages/chats/{chat_id}"
 
 
 def event_link(*, occurrence_id: int, slug: str = "e") -> str:
-    return f"{config['BASE_URL']}/event/{occurrence_id}/{slug}"
+    return f"{config.base_url}/event/{occurrence_id}/{slug}"
 
 
 def community_link(*, node_id: int, slug: str = "e") -> str:
-    return f"{config['BASE_URL']}/community/{node_id}/{slug}"
+    return f"{config.base_url}/community/{node_id}/{slug}"
 
 
 def discussion_link(*, discussion_id: str, slug: str = "e") -> str:
-    return f"{config['BASE_URL']}/discussion/{discussion_id}/{slug}"
+    return f"{config.base_url}/discussion/{discussion_id}/{slug}"
 
 
 def leave_reference_link(*, reference_type: str, to_user_id: str, host_request_id: str | None = None) -> str:
     assert reference_type in ["friend", "surfed", "hosted"]
     if host_request_id:
-        return f"{config['BASE_URL']}/leave-reference/{reference_type}/{to_user_id}/{host_request_id}"
+        return f"{config.base_url}/leave-reference/{reference_type}/{to_user_id}/{host_request_id}"
     else:
-        return f"{config['BASE_URL']}/leave-reference/{reference_type}/{to_user_id}"
+        return f"{config.base_url}/leave-reference/{reference_type}/{to_user_id}"
 
 
 def profile_references_link() -> str:
-    return f"{config['BASE_URL']}/profile/references"
+    return f"{config.base_url}/profile/references"
 
 
 def friend_requests_link() -> str:
-    return f"{config['BASE_URL']}/connections/friends/"
+    return f"{config.base_url}/connections/friends/"
 
 
 def media_upload_url(*, path: str) -> str:
-    return f"{config['MEDIA_SERVER_UPLOAD_BASE_URL']}/{path}"
+    return f"{config.media_server_upload_base_url}/{path}"
 
 
 def change_email_link(*, confirmation_token: str) -> str:
-    return f"{config['BASE_URL']}/confirm-email?token={confirmation_token}"
+    return f"{config.base_url}/confirm-email?token={confirmation_token}"
 
 
 def donation_url() -> str:
-    return f"{config['BASE_URL']}/donate"
+    return f"{config.base_url}/donate"
 
 
 def donation_cancelled_url() -> str:
-    return f"{config['BASE_URL']}/donate?cancelled=true"
+    return f"{config.base_url}/donate?cancelled=true"
 
 
 def donation_success_url() -> str:
-    return f"{config['BASE_URL']}/donate?success=true"
+    return f"{config.base_url}/donate?success=true"
 
 
 def complete_strong_verification_url(*, verification_attempt_token: str) -> str:
-    return f"{config['BASE_URL']}/complete-strong-verification?verification_attempt_token={verification_attempt_token}"
+    return f"{config.base_url}/complete-strong-verification?verification_attempt_token={verification_attempt_token}"
 
 
 def delete_account_link(*, account_deletion_token: str) -> str:
-    return f"{config['BASE_URL']}/delete-account?token={account_deletion_token}"
+    return f"{config.base_url}/delete-account?token={account_deletion_token}"
 
 
 def recover_account_link(*, account_undelete_token: str) -> str:
-    return f"{config['BASE_URL']}/recover-account?token={account_undelete_token}"
+    return f"{config.base_url}/recover-account?token={account_undelete_token}"
 
 
 def unsubscribe_link(*, payload: str, sig: str) -> str:
-    return f"{config['BASE_URL']}/quick-link?payload={payload}&sig={sig}"
+    return f"{config.base_url}/quick-link?payload={payload}&sig={sig}"
 
 
 def quick_link(*, payload: str, sig: str) -> str:
-    return f"{config['BASE_URL']}/quick-link?payload={payload}&sig={sig}"
+    return f"{config.base_url}/quick-link?payload={payload}&sig={sig}"
 
 
 def media_url(*, filename: str, size: str) -> str:
-    return f"{config['MEDIA_SERVER_BASE_URL']}/img/{size}/{filename}"
+    return f"{config.media_server_base_url}/img/{size}/{filename}"
 
 
 def console_link(*, page: str) -> str:
-    return f"{config['CONSOLE_BASE_URL']}/{page}"
+    return f"{config.console_base_url}/{page}"
 
 
 def invite_code_link(*, code: str) -> str:
-    return f"{config['BASE_URL']}/invite?code={code}"
+    return f"{config.base_url}/invite?code={code}"
 
 
 def postal_verification_link(*, code: str) -> str:
-    return f"{config['BASE_URL']}/verify-postal?c={code}"
+    return f"{config.base_url}/verify-postal?c={code}"

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import Mapped
 from sqlalchemy.sql import func
 from sqlalchemy.types import DateTime
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.constants import EMAIL_REGEX, PREFERRED_LANGUAGE_COOKIE_EXPIRY
 from couchers.crypto import (
     create_sofa_id,
@@ -244,10 +244,10 @@ def _create_tasty_cookie(name: str, value: Any, expiry: datetime, httponly: bool
     # tell the browser when to stop sending the cookie
     cookie["expires"] = http_date(expiry)
     # restrict to our domain, note if there's no domain, it won't include subdomains
-    cookie["domain"] = config.cookie_domain
+    cookie["domain"] = Config.current.cookie_domain
     # path so that it's accessible for all API requests, otherwise defaults to something like /org.couchers.auth/
     cookie["path"] = "/"
-    if config.dev:
+    if Config.current.dev:
         # send only on requests from first-party domains
         cookie["samesite"] = "Strict"
     else:

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -244,10 +244,10 @@ def _create_tasty_cookie(name: str, value: Any, expiry: datetime, httponly: bool
     # tell the browser when to stop sending the cookie
     cookie["expires"] = http_date(expiry)
     # restrict to our domain, note if there's no domain, it won't include subdomains
-    cookie["domain"] = config["COOKIE_DOMAIN"]
+    cookie["domain"] = config.cookie_domain
     # path so that it's accessible for all API requests, otherwise defaults to something like /org.couchers.auth/
     cookie["path"] = "/"
-    if config["DEV"]:
+    if config.dev:
         # send only on requests from first-party domains
         cookie["samesite"] = "Strict"
     else:

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -22,11 +22,11 @@ from tests.fixtures.db import (  # noqa: E402
 )
 from tests.fixtures.misc import Moderator, PushCollector  # noqa: E402
 
-
 # Default for running with a database from docker-compose.test.yml.
 database_connection_string = os.environ.get(
     "DATABASE_CONNECTION_STRING",
-    "postgresql://postgres:06b3890acd2c235c41be0bbfe22f1b386a04bf02eedf8c977486355616be2aa1@localhost:6544/testdb")
+    "postgresql://postgres:06b3890acd2c235c41be0bbfe22f1b386a04bf02eedf8c977486355616be2aa1@localhost:6544/testdb",
+)
 
 
 @pytest.fixture(scope="session")

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -34,7 +34,7 @@ def postgres_engine() -> Generator[Engine]:
     """
     SQLAlchemy engine connected to "postgres" database.
     """
-    dsn = config["DATABASE_CONNECTION_STRING"]
+    dsn = config.database_connection_string
     if not dsn.endswith("/testdb"):
         raise RuntimeError(f"DATABASE_CONNECTION_STRING must point to /testdb, but was {dsn}")
 
@@ -58,7 +58,7 @@ def testdb_engine() -> Generator[Engine]:
     """
     SQLAlchemy engine connected to "testdb" database.
     """
-    dsn = config["DATABASE_CONNECTION_STRING"]
+    dsn = config.database_connection_string
     with autocommit_engine(dsn) as engine:
         yield engine
 
@@ -149,111 +149,108 @@ def db_class(setup_testdb: None, testdb_conn: Connection) -> None:
 @pytest.fixture(scope="class")
 def testconfig():
     prevconfig = config.copy()
-    config.clear()
-    config.update(prevconfig)
 
-    config["IN_TEST"] = True
+    config.in_test = True
 
-    config["DEV"] = True
-    config["SECRET"] = bytes.fromhex("448697d3886aec65830a1ea1497cdf804981e0c260d2f812cf2787c4ed1a262b")
-    config["VERSION"] = "testing_version"
-    config["BASE_URL"] = "http://localhost:3000"
-    config["BACKEND_BASE_URL"] = "http://localhost:8888"
-    config["CONSOLE_BASE_URL"] = "http://localhost:8888"
-    config["COOKIE_DOMAIN"] = "localhost"
+    config.dev = True
+    config.secret = bytes.fromhex("448697d3886aec65830a1ea1497cdf804981e0c260d2f812cf2787c4ed1a262b")
+    config.version = "testing_version"
+    config.base_url = "http://localhost:3000"
+    config.backend_base_url = "http://localhost:8888"
+    config.console_base_url = "http://localhost:8888"
+    config.cookie_domain = "localhost"
 
-    config["ENABLE_SMS"] = False
-    config["SMS_SENDER_ID"] = "invalid"
+    config.enable_sms = False
+    config.sms_sender_id = "invalid"
 
-    config["ENABLE_EMAIL"] = False
-    config["NOTIFICATION_EMAIL_SENDER"] = "Couchers.org"
-    config["NOTIFICATION_EMAIL_ADDRESS"] = "notify@couchers.org.invalid"
-    config["NOTIFICATION_PREFIX"] = "[TEST] "
-    config["REPORTS_EMAIL_RECIPIENT"] = "reports@couchers.org.invalid"
-    config["CONTRIBUTOR_FORM_EMAIL_RECIPIENT"] = "forms@couchers.org.invalid"
-    config["MODS_EMAIL_RECIPIENT"] = "mods@couchers.org.invalid"
-    config["ENABLE_EMAIL_ICS_ATTACHMENTS"] = True
+    config.enable_email = False
+    config.notification_email_sender = "Couchers.org"
+    config.notification_email_address = "notify@couchers.org.invalid"
+    config.notification_prefix = "[TEST] "
+    config.reports_email_recipient = "reports@couchers.org.invalid"
+    config.contributor_form_email_recipient = "forms@couchers.org.invalid"
+    config.mods_email_recipient = "mods@couchers.org.invalid"
+    config.enable_email_ics_attachments = True
 
-    config["ENABLE_DONATIONS"] = False
-    config["STRIPE_API_KEY"] = ""
-    config["STRIPE_WEBHOOK_SECRET"] = ""
-    config["STRIPE_RECURRING_PRODUCT_ID"] = ""
+    config.enable_donations = False
+    config.stripe_api_key = ""
+    config.stripe_webhook_secret = ""
+    config.stripe_recurring_product_id = ""
 
-    config["ENABLE_STRONG_VERIFICATION"] = False
-    config["IRIS_ID_PUBKEY"] = ""
-    config["IRIS_ID_SECRET"] = ""
+    config.enable_strong_verification = False
+    config.iris_id_pubkey = ""
+    config.iris_id_secret = ""
     # corresponds to private key e6c2fbf3756b387bc09a458a7b85935718ef3eb1c2777ef41d335c9f6c0ab272
-    config["VERIFICATION_DATA_PUBLIC_KEY"] = bytes.fromhex(
+    config.verification_data_public_key = bytes.fromhex(
         "dd740a2b2a35bf05041a28257ea439b30f76f056f3698000b71e6470cd82275f"
     )
 
-    config["ENABLE_POSTAL_VERIFICATION"] = False
-    config["MYPOSTCARD_API_KEY"] = "test-api-key"
-    config["MYPOSTCARD_USERNAME"] = "test-username"
-    config["MYPOSTCARD_PASSWORD"] = "test-password"
-    config["MYPOSTCARD_PRODUCT_CODE"] = "J9GCU"
-    config["MYPOSTCARD_CAMPAIGN_ID"] = "295"
+    config.enable_postal_verification = False
+    config.mypostcard_api_key = "test-api-key"
+    config.mypostcard_username = "test-username"
+    config.mypostcard_password = "test-password"
+    config.mypostcard_product_code = "J9GCU"
+    config.mypostcard_campaign_id = "295"
 
-    config["SMTP_HOST"] = "localhost"
-    config["SMTP_PORT"] = 587
-    config["SMTP_USERNAME"] = "username"
-    config["SMTP_PASSWORD"] = "password"
+    config.smtp_host = "localhost"
+    config.smtp_port = 587
+    config.smtp_username = "username"
+    config.smtp_password = "password"
 
-    config["ENABLE_MEDIA"] = True
-    config["MEDIA_SERVER_SECRET_KEY"] = bytes.fromhex(
+    config.enable_media = True
+    config.media_server_secret_key = bytes.fromhex(
         "91e29bbacc74fa7e23c5d5f34cca5015cb896e338a620003de94a502a461f4bc"
     )
-    config["MEDIA_SERVER_BEARER_TOKEN"] = "c02d383897d3b82774ced09c9e17802164c37e7e105d8927553697bf4550e91e"
-    config["MEDIA_SERVER_BASE_URL"] = "http://localhost:5001"
-    config["MEDIA_SERVER_UPLOAD_BASE_URL"] = "http://localhost:5001"
+    config.media_server_bearer_token = "c02d383897d3b82774ced09c9e17802164c37e7e105d8927553697bf4550e91e"
+    config.media_server_base_url = "http://localhost:5001"
+    config.media_server_upload_base_url = "http://localhost:5001"
 
-    config["BUG_TOOL_ENABLED"] = False
-    config["BUG_TOOL_GITHUB_REPO"] = "org/repo"
-    config["BUG_TOOL_GITHUB_USERNAME"] = "user"
-    config["BUG_TOOL_GITHUB_TOKEN"] = "token"
+    config.bug_tool_enabled = False
+    config.bug_tool_github_repo = "org/repo"
+    config.bug_tool_github_username = "user"
+    config.bug_tool_github_token = "token"
 
-    config["LISTMONK_ENABLED"] = False
-    config["LISTMONK_BASE_URL"] = "https://localhost"
-    config["LISTMONK_API_USERNAME"] = "..."
-    config["LISTMONK_API_KEY"] = "..."
-    config["LISTMONK_LIST_ID"] = 3
+    config.listmonk_enabled = False
+    config.listmonk_base_url = "https://localhost"
+    config.listmonk_api_username = "..."
+    config.listmonk_api_key = "..."
+    config.listmonk_list_id = 3
 
-    config["PUSH_NOTIFICATIONS_ENABLED"] = True
-    config["PUSH_NOTIFICATIONS_VAPID_PRIVATE_KEY"] = "uI1DCR4G1AdlmMlPfRLemMxrz9f3h4kvjfnI8K9WsVI"
-    config["PUSH_NOTIFICATIONS_VAPID_SUBJECT"] = "mailto:testing@couchers.org.invalid"
+    config.push_notifications_enabled = True
+    config.push_notifications_vapid_private_key = "uI1DCR4G1AdlmMlPfRLemMxrz9f3h4kvjfnI8K9WsVI"
+    config.push_notifications_vapid_subject = "mailto:testing@couchers.org.invalid"
 
-    config["ACTIVENESS_PROBES_ENABLED"] = True
+    config.activeness_probes_enabled = True
 
-    config["RECAPTHCA_ENABLED"] = False
-    config["RECAPTHCA_PROJECT_ID"] = "..."
-    config["RECAPTHCA_API_KEY"] = "..."
-    config["RECAPTHCA_SITE_KEY"] = "..."
+    config.recapthca_enabled = False
+    config.recapthca_project_id = "..."
+    config.recapthca_api_key = "..."
+    config.recapthca_site_key = "..."
 
-    config["EXPERIMENTATION_ENABLED"] = False
-    config["EXPERIMENTATION_PASS_ALL_GATES"] = True
-    config["STATSIG_SERVER_SECRET_KEY"] = ""
-    config["STATSIG_ENVIRONMENT"] = "testing"
+    config.experimentation_enabled = False
+    config.experimentation_pass_all_gates = True
+    config.statsig_server_secret_key = ""
+    config.statsig_environment = "testing"
 
     # Moderation auto-approval deadline - 0 disables, set in tests that need it
-    config["MODERATION_AUTO_APPROVE_DEADLINE_SECONDS"] = 0
+    config.moderation_auto_approve_deadline_seconds = 0
     # Bot user ID for automated moderation - will be set to a real user in tests that need it
-    config["MODERATION_BOT_USER_ID"] = 1
+    config.moderation_bot_user_id = 1
 
     # Dev APIs disabled by default in tests
-    config["ENABLE_DEV_APIS"] = False
+    config.enable_dev_apis = False
 
     # Slack notifications disabled by default in tests
-    config["SLACK_ENABLED"] = False
-    config["SLACK_BOT_TOKEN"] = ""
-    config["SLACK_DONATIONS_CHANNEL"] = ""
-    config["SLACK_MERCH_CHANNEL"] = ""
+    config.slack_enabled = False
+    config.slack_bot_token = ""
+    config.slack_donations_channel = ""
+    config.slack_merch_channel = ""
 
-    config["ENABLE_NOTIFICATION_TRANSLATIONS"] = False
+    config.enable_notification_translations = False
 
     yield None
 
-    config.clear()
-    config.update(prevconfig)
+    config.set_from(prevconfig)
 
 
 @pytest.fixture

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -12,13 +12,7 @@ from sqlalchemy.sql import text
 prometheus_multiproc_dir = TemporaryDirectory()
 os.environ["PROMETHEUS_MULTIPROC_DIR"] = prometheus_multiproc_dir.name
 
-# Default for running with a database from docker-compose.test.yml.
-if "DATABASE_CONNECTION_STRING" not in os.environ:  # pragma: no cover
-    os.environ["DATABASE_CONNECTION_STRING"] = (
-        "postgresql://postgres:06b3890acd2c235c41be0bbfe22f1b386a04bf02eedf8c977486355616be2aa1@localhost:6544/testdb"
-    )
-
-from couchers.config import config  # noqa: E402
+from couchers.config import Config  # noqa: E402
 from couchers.models import Base  # noqa: E402
 from tests.fixtures.db import (  # noqa: E402
     autocommit_engine,
@@ -29,12 +23,18 @@ from tests.fixtures.db import (  # noqa: E402
 from tests.fixtures.misc import Moderator, PushCollector  # noqa: E402
 
 
+# Default for running with a database from docker-compose.test.yml.
+database_connection_string = os.environ.get(
+    "DATABASE_CONNECTION_STRING",
+    "postgresql://postgres:06b3890acd2c235c41be0bbfe22f1b386a04bf02eedf8c977486355616be2aa1@localhost:6544/testdb")
+
+
 @pytest.fixture(scope="session")
 def postgres_engine() -> Generator[Engine]:
     """
     SQLAlchemy engine connected to "postgres" database.
     """
-    dsn = config.database_connection_string
+    dsn = database_connection_string
     if not dsn.endswith("/testdb"):
         raise RuntimeError(f"DATABASE_CONNECTION_STRING must point to /testdb, but was {dsn}")
 
@@ -58,7 +58,7 @@ def testdb_engine() -> Generator[Engine]:
     """
     SQLAlchemy engine connected to "testdb" database.
     """
-    dsn = config.database_connection_string
+    dsn = database_connection_string
     with autocommit_engine(dsn) as engine:
         yield engine
 
@@ -148,109 +148,92 @@ def db_class(setup_testdb: None, testdb_conn: Connection) -> None:
 
 @pytest.fixture(scope="class")
 def testconfig():
-    prevconfig = config.copy()
-
-    config.in_test = True
-
-    config.dev = True
-    config.secret = bytes.fromhex("448697d3886aec65830a1ea1497cdf804981e0c260d2f812cf2787c4ed1a262b")
-    config.version = "testing_version"
-    config.base_url = "http://localhost:3000"
-    config.backend_base_url = "http://localhost:8888"
-    config.console_base_url = "http://localhost:8888"
-    config.cookie_domain = "localhost"
-
-    config.enable_sms = False
-    config.sms_sender_id = "invalid"
-
-    config.enable_email = False
-    config.notification_email_sender = "Couchers.org"
-    config.notification_email_address = "notify@couchers.org.invalid"
-    config.notification_prefix = "[TEST] "
-    config.reports_email_recipient = "reports@couchers.org.invalid"
-    config.contributor_form_email_recipient = "forms@couchers.org.invalid"
-    config.mods_email_recipient = "mods@couchers.org.invalid"
-    config.enable_email_ics_attachments = True
-
-    config.enable_donations = False
-    config.stripe_api_key = ""
-    config.stripe_webhook_secret = ""
-    config.stripe_recurring_product_id = ""
-
-    config.enable_strong_verification = False
-    config.iris_id_pubkey = ""
-    config.iris_id_secret = ""
-    # corresponds to private key e6c2fbf3756b387bc09a458a7b85935718ef3eb1c2777ef41d335c9f6c0ab272
-    config.verification_data_public_key = bytes.fromhex(
-        "dd740a2b2a35bf05041a28257ea439b30f76f056f3698000b71e6470cd82275f"
+    Config.current = Config(
+        in_test=True,
+        dev=True,
+        secret=bytes.fromhex("448697d3886aec65830a1ea1497cdf804981e0c260d2f812cf2787c4ed1a262b"),
+        version="testing_version",
+        base_url="http://localhost:3000",
+        backend_base_url="http://localhost:8888",
+        console_base_url="http://localhost:8888",
+        merch_shop_url="",
+        database_connection_string=database_connection_string,
+        cookie_domain="localhost",
+        enable_sms=False,
+        sms_sender_id="invalid",
+        enable_email=False,
+        notification_email_sender="Couchers.org",
+        notification_email_address="notify@couchers.org.invalid",
+        notification_prefix="[TEST] ",
+        reports_email_recipient="reports@couchers.org.invalid",
+        contributor_form_email_recipient="forms@couchers.org.invalid",
+        mods_email_recipient="mods@couchers.org.invalid",
+        add_dummy_data=False,
+        enable_email_ics_attachments=True,
+        enable_donations=False,
+        stripe_api_key="",
+        stripe_webhook_secret="",
+        stripe_recurring_product_id="",
+        enable_strong_verification=False,
+        iris_id_pubkey="",
+        iris_id_secret="",
+        # corresponds to private key e6c2fbf3756b387bc09a458a7b85935718ef3eb1c2777ef41d335c9f6c0ab272
+        verification_data_public_key=bytes.fromhex("dd740a2b2a35bf05041a28257ea439b30f76f056f3698000b71e6470cd82275f"),
+        enable_postal_verification=False,
+        mypostcard_api_key="test-api-key",
+        mypostcard_username="test-username",
+        mypostcard_password="test-password",
+        mypostcard_product_code="J9GCU",
+        mypostcard_campaign_id="295",
+        smtp_host="localhost",
+        smtp_port=587,
+        smtp_username="username",
+        smtp_password="password",
+        enable_media=True,
+        media_server_secret_key=bytes.fromhex("91e29bbacc74fa7e23c5d5f34cca5015cb896e338a620003de94a502a461f4bc"),
+        media_server_bearer_token="c02d383897d3b82774ced09c9e17802164c37e7e105d8927553697bf4550e91e",
+        media_server_base_url="http://localhost:5001",
+        media_server_upload_base_url="http://localhost:5001",
+        bug_tool_enabled=False,
+        bug_tool_github_repo="org/repo",
+        bug_tool_github_username="user",
+        bug_tool_github_token="token",
+        sentry_enabled=False,
+        sentry_url="",
+        listmonk_enabled=False,
+        listmonk_base_url="https://localhost",
+        listmonk_api_username="...",
+        listmonk_api_key="...",
+        listmonk_list_id=3,
+        push_notifications_enabled=True,
+        push_notifications_vapid_private_key="uI1DCR4G1AdlmMlPfRLemMxrz9f3h4kvjfnI8K9WsVI",
+        push_notifications_vapid_subject="mailto:testing@couchers.org.invalid",
+        activeness_probes_enabled=True,
+        recapthca_enabled=False,
+        recapthca_project_id="...",
+        recapthca_api_key="...",
+        recapthca_site_key="...",
+        experimentation_enabled=False,
+        experimentation_pass_all_gates=True,
+        statsig_server_secret_key="",
+        statsig_environment="testing",
+        # Moderation auto-approval deadline - 0 disables, set in tests that need it
+        moderation_auto_approve_deadline_seconds=0,
+        # Bot user ID for automated moderation - will be set to a real user in tests that need it
+        moderation_bot_user_id=1,
+        # Dev APIs disabled by default in tests
+        enable_dev_apis=False,
+        # Slack notifications disabled by default in tests
+        slack_enabled=False,
+        slack_bot_token="",
+        slack_donations_channel="",
+        slack_merch_channel="",
+        enable_notification_translations=False,
     )
-
-    config.enable_postal_verification = False
-    config.mypostcard_api_key = "test-api-key"
-    config.mypostcard_username = "test-username"
-    config.mypostcard_password = "test-password"
-    config.mypostcard_product_code = "J9GCU"
-    config.mypostcard_campaign_id = "295"
-
-    config.smtp_host = "localhost"
-    config.smtp_port = 587
-    config.smtp_username = "username"
-    config.smtp_password = "password"
-
-    config.enable_media = True
-    config.media_server_secret_key = bytes.fromhex(
-        "91e29bbacc74fa7e23c5d5f34cca5015cb896e338a620003de94a502a461f4bc"
-    )
-    config.media_server_bearer_token = "c02d383897d3b82774ced09c9e17802164c37e7e105d8927553697bf4550e91e"
-    config.media_server_base_url = "http://localhost:5001"
-    config.media_server_upload_base_url = "http://localhost:5001"
-
-    config.bug_tool_enabled = False
-    config.bug_tool_github_repo = "org/repo"
-    config.bug_tool_github_username = "user"
-    config.bug_tool_github_token = "token"
-
-    config.listmonk_enabled = False
-    config.listmonk_base_url = "https://localhost"
-    config.listmonk_api_username = "..."
-    config.listmonk_api_key = "..."
-    config.listmonk_list_id = 3
-
-    config.push_notifications_enabled = True
-    config.push_notifications_vapid_private_key = "uI1DCR4G1AdlmMlPfRLemMxrz9f3h4kvjfnI8K9WsVI"
-    config.push_notifications_vapid_subject = "mailto:testing@couchers.org.invalid"
-
-    config.activeness_probes_enabled = True
-
-    config.recapthca_enabled = False
-    config.recapthca_project_id = "..."
-    config.recapthca_api_key = "..."
-    config.recapthca_site_key = "..."
-
-    config.experimentation_enabled = False
-    config.experimentation_pass_all_gates = True
-    config.statsig_server_secret_key = ""
-    config.statsig_environment = "testing"
-
-    # Moderation auto-approval deadline - 0 disables, set in tests that need it
-    config.moderation_auto_approve_deadline_seconds = 0
-    # Bot user ID for automated moderation - will be set to a real user in tests that need it
-    config.moderation_bot_user_id = 1
-
-    # Dev APIs disabled by default in tests
-    config.enable_dev_apis = False
-
-    # Slack notifications disabled by default in tests
-    config.slack_enabled = False
-    config.slack_bot_token = ""
-    config.slack_donations_channel = ""
-    config.slack_merch_channel = ""
-
-    config.enable_notification_translations = False
 
     yield None
 
-    config.set_from(prevconfig)
+    Config.current = None  # type: ignore[assignment]
 
 
 @pytest.fixture

--- a/app/backend/src/tests/test_activeness_probes.py
+++ b/app/backend/src/tests/test_activeness_probes.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from unittest.mock import patch
 
 import grpc
 import pytest

--- a/app/backend/src/tests/test_activeness_probes.py
+++ b/app/backend/src/tests/test_activeness_probes.py
@@ -6,7 +6,7 @@ import pytest
 from google.protobuf import empty_pb2
 from sqlalchemy import exists, select
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.db import session_scope
 from couchers.jobs.enqueue import queue_job
 from couchers.jobs.handlers import send_activeness_probes
@@ -90,28 +90,26 @@ def test_activeness_probes_happy_path_active(db, push_collector: PushCollector):
 
 
 def test_activeness_probes_disabled(db, push_collector: PushCollector):
-    new_config = config.copy()
-    new_config.activeness_probes_enabled = False
+    Config.current.activeness_probes_enabled = False
 
-    with patch("couchers.jobs.handlers.config", new_config):
-        user, token = generate_user(
-            hosting_status=HostingStatus.can_host,
-            meetup_status=MeetupStatus.wants_to_meetup,
-            last_active=now() - timedelta(days=335),
-        )
+    user, token = generate_user(
+        hosting_status=HostingStatus.can_host,
+        meetup_status=MeetupStatus.wants_to_meetup,
+        last_active=now() - timedelta(days=335),
+    )
 
-        with session_scope() as session:
-            queue_job(session, job=send_activeness_probes, payload=empty_pb2.Empty())
+    with session_scope() as session:
+        queue_job(session, job=send_activeness_probes, payload=empty_pb2.Empty())
 
-        process_jobs()
+    process_jobs()
 
-        with real_jail_session(token) as jail:
-            res = jail.JailInfo(empty_pb2.Empty())
-            assert not res.has_pending_activeness_probe
-            assert not res.jailed
+    with real_jail_session(token) as jail:
+        res = jail.JailInfo(empty_pb2.Empty())
+        assert not res.has_pending_activeness_probe
+        assert not res.jailed
 
-        with session_scope() as session:
-            assert not session.execute(select(exists(ActivenessProbe))).scalar_one()
+    with session_scope() as session:
+        assert not session.execute(select(exists(ActivenessProbe))).scalar_one()
 
 
 def test_activeness_probes_expiry(db, push_collector: PushCollector):

--- a/app/backend/src/tests/test_activeness_probes.py
+++ b/app/backend/src/tests/test_activeness_probes.py
@@ -91,7 +91,7 @@ def test_activeness_probes_happy_path_active(db, push_collector: PushCollector):
 
 def test_activeness_probes_disabled(db, push_collector: PushCollector):
     new_config = config.copy()
-    new_config["ACTIVENESS_PROBES_ENABLED"] = False
+    new_config.activeness_probes_enabled = False
 
     with patch("couchers.jobs.handlers.config", new_config):
         user, token = generate_user(

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -428,7 +428,7 @@ def test_job_retry(db):
 
     # if IN_TEST is true, then the bg worker will raise on exceptions
     new_config = config.copy()
-    new_config["IN_TEST"] = False
+    new_config.in_test = False
 
     with patch("couchers.jobs.worker.config", new_config), patch("couchers.jobs.worker.JOBS", MOCK_JOBS):
         process_job()
@@ -1218,11 +1218,11 @@ def test_send_host_request_reminders(db, moderator):
 
 def test_add_users_to_email_list(db):
     new_config = config.copy()
-    new_config["LISTMONK_ENABLED"] = True
-    new_config["LISTMONK_BASE_URL"] = "https://example.com"
-    new_config["LISTMONK_API_USERNAME"] = "test_user"
-    new_config["LISTMONK_API_KEY"] = "dummy_api_key"
-    new_config["LISTMONK_LIST_ID"] = 6
+    new_config.listmonk_enabled = True
+    new_config.listmonk_base_url = "https://example.com"
+    new_config.listmonk_api_username = "test_user"
+    new_config.listmonk_api_key = "dummy_api_key"
+    new_config.listmonk_list_id = 6
 
     with patch("couchers.jobs.handlers.config", new_config):
         with patch("couchers.jobs.handlers.requests.post") as mock:

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -10,7 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.sql import delete, func
 
 import couchers.jobs.worker
-from couchers.config import config
+from couchers.config import Config
 from couchers.constants import HOST_REQUEST_MAX_REMINDERS, HOST_REQUEST_REMINDER_INTERVAL
 from couchers.crypto import urlsafe_secure_token
 from couchers.db import session_scope
@@ -427,10 +427,9 @@ def test_job_retry(db):
     create_prometheus_server(port=8000)
 
     # if IN_TEST is true, then the bg worker will raise on exceptions
-    new_config = config.copy()
-    new_config.in_test = False
+    Config.current.in_test = False
 
-    with patch("couchers.jobs.worker.config", new_config), patch("couchers.jobs.worker.JOBS", MOCK_JOBS):
+    with patch("couchers.jobs.worker.JOBS", MOCK_JOBS):
         process_job()
         with session_scope() as session:
             assert (
@@ -1217,64 +1216,62 @@ def test_send_host_request_reminders(db, moderator):
 
 
 def test_add_users_to_email_list(db):
-    new_config = config.copy()
-    new_config.listmonk_enabled = True
-    new_config.listmonk_base_url = "https://example.com"
-    new_config.listmonk_api_username = "test_user"
-    new_config.listmonk_api_key = "dummy_api_key"
-    new_config.listmonk_list_id = 6
+    Config.current.listmonk_enabled = True
+    Config.current.listmonk_base_url = "https://example.com"
+    Config.current.listmonk_api_username = "test_user"
+    Config.current.listmonk_api_key = "dummy_api_key"
+    Config.current.listmonk_list_id = 6
 
-    with patch("couchers.jobs.handlers.config", new_config):
-        with patch("couchers.jobs.handlers.requests.post") as mock:
-            add_users_to_email_list(empty_pb2.Empty())
-        mock.assert_not_called()
+    with patch("couchers.jobs.handlers.requests.post") as mock:
+        add_users_to_email_list(empty_pb2.Empty())
+    mock.assert_not_called()
 
-        generate_user(in_sync_with_newsletter=False, email="testing1@couchers.invalid", name="Tester1", id=15)
-        generate_user(in_sync_with_newsletter=True, email="testing2@couchers.invalid", name="Tester2")
-        generate_user(in_sync_with_newsletter=False, email="testing3@couchers.invalid", name="Tester3 von test", id=17)
-        generate_user(
-            in_sync_with_newsletter=False, email="testing4@couchers.invalid", name="Tester4", opt_out_of_newsletter=True
-        )
+    generate_user(in_sync_with_newsletter=False, email="testing1@couchers.invalid", name="Tester1", id=15)
+    generate_user(in_sync_with_newsletter=True, email="testing2@couchers.invalid", name="Tester2")
+    generate_user(in_sync_with_newsletter=False, email="testing3@couchers.invalid", name="Tester3 von test", id=17)
+    generate_user(
+        in_sync_with_newsletter=False, email="testing4@couchers.invalid", name="Tester4", opt_out_of_newsletter=True
+    )
 
-        with patch("couchers.jobs.handlers.requests.post") as mock:
-            ret = mock.return_value
-            ret.status_code = 200
-            add_users_to_email_list(empty_pb2.Empty())
-        mock.assert_has_calls(
-            [
-                call(
-                    "https://example.com/api/subscribers",
-                    auth=("test_user", "dummy_api_key"),
-                    json={
-                        "email": "testing1@couchers.invalid",
-                        "name": "Tester1",
-                        "lists": [6],
-                        "preconfirm_subscriptions": True,
-                        "attribs": {"couchers_user_id": 15},
-                        "status": "enabled",
-                    },
-                    timeout=10,
-                ),
-                call(
-                    "https://example.com/api/subscribers",
-                    auth=("test_user", "dummy_api_key"),
-                    json={
-                        "email": "testing3@couchers.invalid",
-                        "name": "Tester3 von test",
-                        "lists": [6],
-                        "preconfirm_subscriptions": True,
-                        "attribs": {"couchers_user_id": 17},
-                        "status": "enabled",
-                    },
-                    timeout=10,
-                ),
-            ],
-            any_order=True,
-        )
+    with patch("couchers.jobs.handlers.requests.post") as mock:
+        ret = mock.return_value
+        ret.status_code = 200
+        add_users_to_email_list(empty_pb2.Empty())
+    mock.assert_has_calls(
+        [
+            call(
+                "https://example.com/api/subscribers",
+                auth=("test_user", "dummy_api_key"),
+                json={
+                    "email": "testing1@couchers.invalid",
+                    "name": "Tester1",
+                    "lists": [6],
+                    "preconfirm_subscriptions": True,
+                    "attribs": {"couchers_user_id": 15},
+                    "status": "enabled",
+                },
+                timeout=10,
+            ),
+            call(
+                "https://example.com/api/subscribers",
+                auth=("test_user", "dummy_api_key"),
+                json={
+                    "email": "testing3@couchers.invalid",
+                    "name": "Tester3 von test",
+                    "lists": [6],
+                    "preconfirm_subscriptions": True,
+                    "attribs": {"couchers_user_id": 17},
+                    "status": "enabled",
+                },
+                timeout=10,
+            ),
+        ],
+        any_order=True,
+    )
 
-        with patch("couchers.jobs.handlers.requests.post") as mock:
-            add_users_to_email_list(empty_pb2.Empty())
-        mock.assert_not_called()
+    with patch("couchers.jobs.handlers.requests.post") as mock:
+        add_users_to_email_list(empty_pb2.Empty())
+    mock.assert_not_called()
 
 
 def test_update_recommendation_scores(db):

--- a/app/backend/src/tests/test_bugs.py
+++ b/app/backend/src/tests/test_bugs.py
@@ -6,7 +6,7 @@ import pytest
 from google.protobuf import empty_pb2, timestamp_pb2
 from sqlalchemy import select
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.crypto import random_hex
 from couchers.db import session_scope
 from couchers.models.logging import EventLog, EventSource
@@ -45,7 +45,7 @@ def test_bugs(db):
                 "title": "subject",
                 "body": (
                     "Subject: subject\nDescription:\ndescription\n\nResults:\nresults\n\nBackend version: "
-                    + config.version
+                    + Config.current.version
                     + "\nFrontend version: frontend_version\nUser Agent: user_agent\nScreen resolution: 1920x1080\nPage: page\nUser: <not logged in>"
                 ),
                 "labels": ["bug tool", "bug: triage needed"],
@@ -59,22 +59,20 @@ def test_bugs(db):
 
             return _PostReturn()
 
-        new_config = config.copy()
-        new_config.bug_tool_enabled = True
+        Config.current.bug_tool_enabled = True
 
-        with patch("couchers.servicers.bugs.config", new_config):
-            with patch("couchers.servicers.bugs.requests.post", dud_post):
-                res = bugs.ReportBug(
-                    bugs_pb2.ReportBugReq(
-                        subject="subject",
-                        description="description",
-                        results="results",
-                        frontend_version="frontend_version",
-                        user_agent="user_agent",
-                        screen_resolution=bugs_pb2.ScreenResolution(width=1920, height=1080),
-                        page="page",
-                    )
+        with patch("couchers.servicers.bugs.requests.post", dud_post):
+            res = bugs.ReportBug(
+                bugs_pb2.ReportBugReq(
+                    subject="subject",
+                    description="description",
+                    results="results",
+                    frontend_version="frontend_version",
+                    user_agent="user_agent",
+                    screen_resolution=bugs_pb2.ScreenResolution(width=1920, height=1080),
+                    page="page",
                 )
+            )
 
     assert res.bug_id == "#11"
     assert res.bug_url == "https://github.com/org/repo/issues/11"
@@ -92,7 +90,7 @@ def test_bugs_with_user(db):
                 "title": "subject",
                 "body": (
                     "Subject: subject\nDescription:\ndescription\n\nResults:\nresults\n\nBackend version: "
-                    + config.version
+                    + Config.current.version
                     + "\nFrontend version: frontend_version\nUser Agent: user_agent\nScreen resolution: 390x844\nPage: page\nUser: [@testing_user](http://localhost:3000/user/testing_user) (1)"
                 ),
                 "labels": ["bug tool", "bug: triage needed"],
@@ -106,22 +104,20 @@ def test_bugs_with_user(db):
 
             return _PostReturn()
 
-        new_config = config.copy()
-        new_config.bug_tool_enabled = True
+        Config.current.bug_tool_enabled = True
 
-        with patch("couchers.servicers.bugs.config", new_config):
-            with patch("couchers.servicers.bugs.requests.post", dud_post):
-                res = bugs.ReportBug(
-                    bugs_pb2.ReportBugReq(
-                        subject="subject",
-                        description="description",
-                        results="results",
-                        frontend_version="frontend_version",
-                        user_agent="user_agent",
-                        screen_resolution=bugs_pb2.ScreenResolution(width=390, height=844),
-                        page="page",
-                    )
+        with patch("couchers.servicers.bugs.requests.post", dud_post):
+            res = bugs.ReportBug(
+                bugs_pb2.ReportBugReq(
+                    subject="subject",
+                    description="description",
+                    results="results",
+                    frontend_version="frontend_version",
+                    user_agent="user_agent",
+                    screen_resolution=bugs_pb2.ScreenResolution(width=390, height=844),
+                    page="page",
                 )
+            )
 
     assert res.bug_id == "#11"
     assert res.bug_url == "https://github.com/org/repo/issues/11"
@@ -136,23 +132,21 @@ def test_bugs_fails_on_network_error(db):
 
             return _PostReturn()
 
-        new_config = config.copy()
-        new_config.bug_tool_enabled = True
+        Config.current.bug_tool_enabled = True
 
-        with patch("couchers.servicers.bugs.config", new_config):
-            with patch("couchers.servicers.bugs.requests.post", dud_post):
-                with pytest.raises(grpc.RpcError) as e:
-                    res = bugs.ReportBug(
-                        bugs_pb2.ReportBugReq(
-                            subject="subject",
-                            description="description",
-                            results="results",
-                            frontend_version="frontend_version",
-                            user_agent="user_agent",
-                            page="page",
-                        )
+        with patch("couchers.servicers.bugs.requests.post", dud_post):
+            with pytest.raises(grpc.RpcError) as e:
+                res = bugs.ReportBug(
+                    bugs_pb2.ReportBugReq(
+                        subject="subject",
+                        description="description",
+                        results="results",
+                        frontend_version="frontend_version",
+                        user_agent="user_agent",
+                        page="page",
                     )
-                assert e.value.code() == grpc.StatusCode.INTERNAL
+                )
+            assert e.value.code() == grpc.StatusCode.INTERNAL
 
 
 def test_version():

--- a/app/backend/src/tests/test_bugs.py
+++ b/app/backend/src/tests/test_bugs.py
@@ -45,7 +45,7 @@ def test_bugs(db):
                 "title": "subject",
                 "body": (
                     "Subject: subject\nDescription:\ndescription\n\nResults:\nresults\n\nBackend version: "
-                    + config["VERSION"]
+                    + config.version
                     + "\nFrontend version: frontend_version\nUser Agent: user_agent\nScreen resolution: 1920x1080\nPage: page\nUser: <not logged in>"
                 ),
                 "labels": ["bug tool", "bug: triage needed"],
@@ -60,7 +60,7 @@ def test_bugs(db):
             return _PostReturn()
 
         new_config = config.copy()
-        new_config["BUG_TOOL_ENABLED"] = True
+        new_config.bug_tool_enabled = True
 
         with patch("couchers.servicers.bugs.config", new_config):
             with patch("couchers.servicers.bugs.requests.post", dud_post):
@@ -92,7 +92,7 @@ def test_bugs_with_user(db):
                 "title": "subject",
                 "body": (
                     "Subject: subject\nDescription:\ndescription\n\nResults:\nresults\n\nBackend version: "
-                    + config["VERSION"]
+                    + config.version
                     + "\nFrontend version: frontend_version\nUser Agent: user_agent\nScreen resolution: 390x844\nPage: page\nUser: [@testing_user](http://localhost:3000/user/testing_user) (1)"
                 ),
                 "labels": ["bug tool", "bug: triage needed"],
@@ -107,7 +107,7 @@ def test_bugs_with_user(db):
             return _PostReturn()
 
         new_config = config.copy()
-        new_config["BUG_TOOL_ENABLED"] = True
+        new_config.bug_tool_enabled = True
 
         with patch("couchers.servicers.bugs.config", new_config):
             with patch("couchers.servicers.bugs.requests.post", dud_post):
@@ -137,7 +137,7 @@ def test_bugs_fails_on_network_error(db):
             return _PostReturn()
 
         new_config = config.copy()
-        new_config["BUG_TOOL_ENABLED"] = True
+        new_config.bug_tool_enabled = True
 
         with patch("couchers.servicers.bugs.config", new_config):
             with patch("couchers.servicers.bugs.requests.post", dud_post):

--- a/app/backend/src/tests/test_db.py
+++ b/app/backend/src/tests/test_db.py
@@ -110,7 +110,7 @@ def test_get_parent_node_at_location(testing_communities):
 
 def pg_dump() -> str:
     return subprocess.run(
-        ["pg_dump", "-s", config["DATABASE_CONNECTION_STRING"]], stdout=subprocess.PIPE, encoding="ascii", check=True
+        ["pg_dump", "-s", config.database_connection_string], stdout=subprocess.PIPE, encoding="ascii", check=True
     ).stdout
 
 

--- a/app/backend/src/tests/test_db.py
+++ b/app/backend/src/tests/test_db.py
@@ -10,7 +10,7 @@ from google.protobuf import empty_pb2
 from sqlalchemy import select
 from sqlalchemy.sql import func
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.db import _get_base_engine, apply_migrations, get_parent_node_at_location, session_scope
 from couchers.jobs.handlers import DatabaseInconsistencyError, check_database_consistency
 from couchers.models import User
@@ -110,7 +110,10 @@ def test_get_parent_node_at_location(testing_communities):
 
 def pg_dump() -> str:
     return subprocess.run(
-        ["pg_dump", "-s", config.database_connection_string], stdout=subprocess.PIPE, encoding="ascii", check=True
+        ["pg_dump", "-s", Config.current.database_connection_string],
+        stdout=subprocess.PIPE,
+        encoding="ascii",
+        check=True,
     ).stdout
 
 

--- a/app/backend/src/tests/test_donations.py
+++ b/app/backend/src/tests/test_donations.py
@@ -5,8 +5,7 @@ import pytest
 from google.protobuf import empty_pb2
 from sqlalchemy import select
 
-import couchers.servicers.donations
-from couchers.config import config
+from couchers.config import Config
 from couchers.db import session_scope
 from couchers.jobs.handlers import update_badges
 from couchers.models import DonationInitiation, DonationType, Invoice, InvoiceType, User, UserBadge
@@ -21,19 +20,16 @@ def _(testconfig):
     pass
 
 
-def test_one_time_donation_flow(db, monkeypatch):
+def test_one_time_donation_flow(db):
     user, token = generate_user()
     user_email = user.email
     user_id = user.id
 
-    new_config = config.copy()
-    new_config.enable_donations = True
-    new_config.stripe_api_key = "dummy_api_key"
-    new_config.stripe_webhook_secret = "dummy_webhook_secret"
-    new_config.stripe_recurring_product_id = "price_1KIbmbIfR5z29g5kFWPEUnC6"
-    new_config.merch_shop_url = "https://shop.couchershq.org"
-
-    monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
+    Config.current.enable_donations = True
+    Config.current.stripe_api_key = "dummy_api_key"
+    Config.current.stripe_webhook_secret = "dummy_webhook_secret"
+    Config.current.stripe_recurring_product_id = "price_1KIbmbIfR5z29g5kFWPEUnC6"
+    Config.current.merch_shop_url = "https://shop.couchershq.org"
 
     ## User first makes a req to Donations.InitiateDonation
     with donations_session(token) as donations:
@@ -126,19 +122,16 @@ def test_one_time_donation_flow(db, monkeypatch):
         )
 
 
-def test_recurring_donation_flow(db, monkeypatch):
+def test_recurring_donation_flow(db):
     user, token = generate_user()
     user_email = user.email
     user_id = user.id
 
-    new_config = config.copy()
-    new_config.enable_donations = True
-    new_config.stripe_api_key = "dummy_api_key"
-    new_config.stripe_webhook_secret = "dummy_webhook_secret"
-    new_config.stripe_recurring_product_id = "price_1IRoHdE5kUmYuPWz9tX8UpRv"
-    new_config.merch_shop_url = "https://shop.couchershq.org"
-
-    monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
+    Config.current.enable_donations = True
+    Config.current.stripe_api_key = "dummy_api_key"
+    Config.current.stripe_webhook_secret = "dummy_webhook_secret"
+    Config.current.stripe_recurring_product_id = "price_1IRoHdE5kUmYuPWz9tX8UpRv"
+    Config.current.merch_shop_url = "https://shop.couchershq.org"
 
     ## User first makes a req to Donations.InitiateDonation
     with donations_session(token) as donations:
@@ -251,16 +244,13 @@ def test_recurring_donation_flow(db, monkeypatch):
         )
 
 
-def test_customer_portal_url(db, monkeypatch):
+def test_customer_portal_url(db):
     user, token = generate_user()
     user_email = user.email
     user_id = user.id
 
-    new_config = config.copy()
-    new_config.enable_donations = True
-    new_config.stripe_api_key = "dummy_api_key"
-
-    monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
+    Config.current.enable_donations = True
+    Config.current.stripe_api_key = "dummy_api_key"
 
     ## User first makes a req to Donations.InitiateDonation
     with donations_session(token) as donations:
@@ -281,16 +271,13 @@ def test_customer_portal_url(db, monkeypatch):
         )
 
 
-def test_merch_invoice_flow(db, monkeypatch):
+def test_merch_invoice_flow(db):
     """Test that external shop purchases (e.g., from merch shop) grant swagster badge but don't update last_donated"""
     user, token = generate_user(email="test@couchers.org.invalid", last_donated=None)
 
-    new_config = config.copy()
-    new_config.stripe_api_key = "dummy_api_key"
-    new_config.stripe_webhook_secret = "dummy_webhook_secret"
-    new_config.merch_shop_url = "https://shop.couchershq.org"
-
-    monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
+    Config.current.stripe_api_key = "dummy_api_key"
+    Config.current.stripe_webhook_secret = "dummy_webhook_secret"
+    Config.current.merch_shop_url = "https://shop.couchershq.org"
 
     ## Stripe sends a charge.succeeded webhook for a merch purchase
     fire_stripe_event("evt_merch_charge_succeeded")
@@ -306,16 +293,13 @@ def test_merch_invoice_flow(db, monkeypatch):
         assert badge is not None
 
 
-def test_merch_invoice_flow_nonexistent_user(db, monkeypatch):
+def test_merch_invoice_flow_nonexistent_user(db):
     """Test that external shop purchases for non-existent users don't error and don't grant badges"""
     user, _ = generate_user(last_donated=None)
 
-    new_config = config.copy()
-    new_config.stripe_api_key = "dummy_api_key"
-    new_config.stripe_webhook_secret = "dummy_webhook_secret"
-    new_config.merch_shop_url = "https://shop.couchershq.org"
-
-    monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
+    Config.current.stripe_api_key = "dummy_api_key"
+    Config.current.stripe_webhook_secret = "dummy_webhook_secret"
+    Config.current.merch_shop_url = "https://shop.couchershq.org"
 
     ## Stripe sends a charge.succeeded webhook for a merch purchase with a non-matching email
     fire_stripe_event("evt_merch_charge_succeeded")
@@ -329,60 +313,51 @@ def test_merch_invoice_flow_nonexistent_user(db, monkeypatch):
         assert len(badge_count) == 0
 
 
-def test_slack_notification_on_merch_purchase(db, monkeypatch):
+def test_slack_notification_on_merch_purchase(db):
     """Test that a Slack notification is sent when a merch purchase is made by a known user."""
     user, _ = generate_user(email="test@couchers.org.invalid", last_donated=None)
 
-    new_config = config.copy()
-    new_config.stripe_api_key = "dummy_api_key"
-    new_config.stripe_webhook_secret = "dummy_webhook_secret"
-    new_config.merch_shop_url = "https://shop.couchershq.org"
-
-    monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
+    Config.current.stripe_api_key = "dummy_api_key"
+    Config.current.stripe_webhook_secret = "dummy_webhook_secret"
+    Config.current.merch_shop_url = "https://shop.couchershq.org"
 
     with patch("couchers.servicers.donations.send_slack_message") as mock_slack:
         fire_stripe_event("evt_merch_charge_succeeded")
         mock_slack.assert_called_once()
         call_args = mock_slack.call_args[0]
-        assert call_args[0] == (config.slack_merch_channel or "merch")
+        assert call_args[0] == (Config.current.slack_merch_channel or "merch")
         assert "$50" in call_args[1]
         assert "Merch purchase" in call_args[1]
         assert user.name in call_args[1]
 
 
-def test_slack_notification_on_merch_purchase_unknown_user(db, monkeypatch):
+def test_slack_notification_on_merch_purchase_unknown_user(db):
     """Test that a Slack notification is sent with email when merch purchase is by an unknown user."""
     generate_user(last_donated=None)
 
-    new_config = config.copy()
-    new_config.stripe_api_key = "dummy_api_key"
-    new_config.stripe_webhook_secret = "dummy_webhook_secret"
-    new_config.merch_shop_url = "https://shop.couchershq.org"
-
-    monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
+    Config.current.stripe_api_key = "dummy_api_key"
+    Config.current.stripe_webhook_secret = "dummy_webhook_secret"
+    Config.current.merch_shop_url = "https://shop.couchershq.org"
 
     with patch("couchers.servicers.donations.send_slack_message") as mock_slack:
         fire_stripe_event("evt_merch_charge_succeeded")
         mock_slack.assert_called_once()
         call_args = mock_slack.call_args[0]
-        assert call_args[0] == (config.slack_merch_channel or "merch")
+        assert call_args[0] == (Config.current.slack_merch_channel or "merch")
         assert "$50" in call_args[1]
         assert "Merch purchase" in call_args[1]
         assert "test@couchers.org.invalid" in call_args[1]
 
 
-def test_slack_notification_on_one_time_donation(db, monkeypatch):
+def test_slack_notification_on_one_time_donation(db):
     """Test that a Slack notification is sent when a one-time donation is received."""
     user, token = generate_user()
 
-    new_config = config.copy()
-    new_config.enable_donations = True
-    new_config.stripe_api_key = "dummy_api_key"
-    new_config.stripe_webhook_secret = "dummy_webhook_secret"
-    new_config.stripe_recurring_product_id = "price_1KIbmbIfR5z29g5kFWPEUnC6"
-    new_config.merch_shop_url = "https://shop.couchershq.org"
-
-    monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
+    Config.current.enable_donations = True
+    Config.current.stripe_api_key = "dummy_api_key"
+    Config.current.stripe_webhook_secret = "dummy_webhook_secret"
+    Config.current.stripe_recurring_product_id = "price_1KIbmbIfR5z29g5kFWPEUnC6"
+    Config.current.merch_shop_url = "https://shop.couchershq.org"
 
     # Initiate a one-time donation
     with donations_session(token) as donations:
@@ -402,18 +377,15 @@ def test_slack_notification_on_one_time_donation(db, monkeypatch):
         assert user.name in call_args
 
 
-def test_slack_notification_on_recurring_donation(db, monkeypatch):
+def test_slack_notification_on_recurring_donation(db):
     """Test that a Slack notification is sent when a recurring donation is received."""
     user, token = generate_user()
 
-    new_config = config.copy()
-    new_config.enable_donations = True
-    new_config.stripe_api_key = "dummy_api_key"
-    new_config.stripe_webhook_secret = "dummy_webhook_secret"
-    new_config.stripe_recurring_product_id = "price_1IRoHdE5kUmYuPWz9tX8UpRv"
-    new_config.merch_shop_url = "https://shop.couchershq.org"
-
-    monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
+    Config.current.enable_donations = True
+    Config.current.stripe_api_key = "dummy_api_key"
+    Config.current.stripe_webhook_secret = "dummy_webhook_secret"
+    Config.current.stripe_recurring_product_id = "price_1IRoHdE5kUmYuPWz9tX8UpRv"
+    Config.current.merch_shop_url = "https://shop.couchershq.org"
 
     # Initiate a recurring donation
     with donations_session(token) as donations:

--- a/app/backend/src/tests/test_donations.py
+++ b/app/backend/src/tests/test_donations.py
@@ -27,11 +27,11 @@ def test_one_time_donation_flow(db, monkeypatch):
     user_id = user.id
 
     new_config = config.copy()
-    new_config["ENABLE_DONATIONS"] = True
-    new_config["STRIPE_API_KEY"] = "dummy_api_key"
-    new_config["STRIPE_WEBHOOK_SECRET"] = "dummy_webhook_secret"
-    new_config["STRIPE_RECURRING_PRODUCT_ID"] = "price_1KIbmbIfR5z29g5kFWPEUnC6"
-    new_config["MERCH_SHOP_URL"] = "https://shop.couchershq.org"
+    new_config.enable_donations = True
+    new_config.stripe_api_key = "dummy_api_key"
+    new_config.stripe_webhook_secret = "dummy_webhook_secret"
+    new_config.stripe_recurring_product_id = "price_1KIbmbIfR5z29g5kFWPEUnC6"
+    new_config.merch_shop_url = "https://shop.couchershq.org"
 
     monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
 
@@ -132,11 +132,11 @@ def test_recurring_donation_flow(db, monkeypatch):
     user_id = user.id
 
     new_config = config.copy()
-    new_config["ENABLE_DONATIONS"] = True
-    new_config["STRIPE_API_KEY"] = "dummy_api_key"
-    new_config["STRIPE_WEBHOOK_SECRET"] = "dummy_webhook_secret"
-    new_config["STRIPE_RECURRING_PRODUCT_ID"] = "price_1IRoHdE5kUmYuPWz9tX8UpRv"
-    new_config["MERCH_SHOP_URL"] = "https://shop.couchershq.org"
+    new_config.enable_donations = True
+    new_config.stripe_api_key = "dummy_api_key"
+    new_config.stripe_webhook_secret = "dummy_webhook_secret"
+    new_config.stripe_recurring_product_id = "price_1IRoHdE5kUmYuPWz9tX8UpRv"
+    new_config.merch_shop_url = "https://shop.couchershq.org"
 
     monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
 
@@ -257,8 +257,8 @@ def test_customer_portal_url(db, monkeypatch):
     user_id = user.id
 
     new_config = config.copy()
-    new_config["ENABLE_DONATIONS"] = True
-    new_config["STRIPE_API_KEY"] = "dummy_api_key"
+    new_config.enable_donations = True
+    new_config.stripe_api_key = "dummy_api_key"
 
     monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
 
@@ -286,9 +286,9 @@ def test_merch_invoice_flow(db, monkeypatch):
     user, token = generate_user(email="test@couchers.org.invalid", last_donated=None)
 
     new_config = config.copy()
-    new_config["STRIPE_API_KEY"] = "dummy_api_key"
-    new_config["STRIPE_WEBHOOK_SECRET"] = "dummy_webhook_secret"
-    new_config["MERCH_SHOP_URL"] = "https://shop.couchershq.org"
+    new_config.stripe_api_key = "dummy_api_key"
+    new_config.stripe_webhook_secret = "dummy_webhook_secret"
+    new_config.merch_shop_url = "https://shop.couchershq.org"
 
     monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
 
@@ -311,9 +311,9 @@ def test_merch_invoice_flow_nonexistent_user(db, monkeypatch):
     user, _ = generate_user(last_donated=None)
 
     new_config = config.copy()
-    new_config["STRIPE_API_KEY"] = "dummy_api_key"
-    new_config["STRIPE_WEBHOOK_SECRET"] = "dummy_webhook_secret"
-    new_config["MERCH_SHOP_URL"] = "https://shop.couchershq.org"
+    new_config.stripe_api_key = "dummy_api_key"
+    new_config.stripe_webhook_secret = "dummy_webhook_secret"
+    new_config.merch_shop_url = "https://shop.couchershq.org"
 
     monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
 
@@ -334,9 +334,9 @@ def test_slack_notification_on_merch_purchase(db, monkeypatch):
     user, _ = generate_user(email="test@couchers.org.invalid", last_donated=None)
 
     new_config = config.copy()
-    new_config["STRIPE_API_KEY"] = "dummy_api_key"
-    new_config["STRIPE_WEBHOOK_SECRET"] = "dummy_webhook_secret"
-    new_config["MERCH_SHOP_URL"] = "https://shop.couchershq.org"
+    new_config.stripe_api_key = "dummy_api_key"
+    new_config.stripe_webhook_secret = "dummy_webhook_secret"
+    new_config.merch_shop_url = "https://shop.couchershq.org"
 
     monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
 
@@ -344,7 +344,7 @@ def test_slack_notification_on_merch_purchase(db, monkeypatch):
         fire_stripe_event("evt_merch_charge_succeeded")
         mock_slack.assert_called_once()
         call_args = mock_slack.call_args[0]
-        assert call_args[0] == config.get("SLACK_MERCH_CHANNEL", "merch")
+        assert call_args[0] == (config.slack_merch_channel or "merch")
         assert "$50" in call_args[1]
         assert "Merch purchase" in call_args[1]
         assert user.name in call_args[1]
@@ -355,9 +355,9 @@ def test_slack_notification_on_merch_purchase_unknown_user(db, monkeypatch):
     generate_user(last_donated=None)
 
     new_config = config.copy()
-    new_config["STRIPE_API_KEY"] = "dummy_api_key"
-    new_config["STRIPE_WEBHOOK_SECRET"] = "dummy_webhook_secret"
-    new_config["MERCH_SHOP_URL"] = "https://shop.couchershq.org"
+    new_config.stripe_api_key = "dummy_api_key"
+    new_config.stripe_webhook_secret = "dummy_webhook_secret"
+    new_config.merch_shop_url = "https://shop.couchershq.org"
 
     monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
 
@@ -365,7 +365,7 @@ def test_slack_notification_on_merch_purchase_unknown_user(db, monkeypatch):
         fire_stripe_event("evt_merch_charge_succeeded")
         mock_slack.assert_called_once()
         call_args = mock_slack.call_args[0]
-        assert call_args[0] == config.get("SLACK_MERCH_CHANNEL", "merch")
+        assert call_args[0] == (config.slack_merch_channel or "merch")
         assert "$50" in call_args[1]
         assert "Merch purchase" in call_args[1]
         assert "test@couchers.org.invalid" in call_args[1]
@@ -376,11 +376,11 @@ def test_slack_notification_on_one_time_donation(db, monkeypatch):
     user, token = generate_user()
 
     new_config = config.copy()
-    new_config["ENABLE_DONATIONS"] = True
-    new_config["STRIPE_API_KEY"] = "dummy_api_key"
-    new_config["STRIPE_WEBHOOK_SECRET"] = "dummy_webhook_secret"
-    new_config["STRIPE_RECURRING_PRODUCT_ID"] = "price_1KIbmbIfR5z29g5kFWPEUnC6"
-    new_config["MERCH_SHOP_URL"] = "https://shop.couchershq.org"
+    new_config.enable_donations = True
+    new_config.stripe_api_key = "dummy_api_key"
+    new_config.stripe_webhook_secret = "dummy_webhook_secret"
+    new_config.stripe_recurring_product_id = "price_1KIbmbIfR5z29g5kFWPEUnC6"
+    new_config.merch_shop_url = "https://shop.couchershq.org"
 
     monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
 
@@ -407,11 +407,11 @@ def test_slack_notification_on_recurring_donation(db, monkeypatch):
     user, token = generate_user()
 
     new_config = config.copy()
-    new_config["ENABLE_DONATIONS"] = True
-    new_config["STRIPE_API_KEY"] = "dummy_api_key"
-    new_config["STRIPE_WEBHOOK_SECRET"] = "dummy_webhook_secret"
-    new_config["STRIPE_RECURRING_PRODUCT_ID"] = "price_1IRoHdE5kUmYuPWz9tX8UpRv"
-    new_config["MERCH_SHOP_URL"] = "https://shop.couchershq.org"
+    new_config.enable_donations = True
+    new_config.stripe_api_key = "dummy_api_key"
+    new_config.stripe_webhook_secret = "dummy_webhook_secret"
+    new_config.stripe_recurring_product_id = "price_1IRoHdE5kUmYuPWz9tX8UpRv"
+    new_config.merch_shop_url = "https://shop.couchershq.org"
 
     monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
 

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -5,9 +5,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from sqlalchemy import func, select, update
 
-import couchers.email
-import couchers.jobs.handlers
-from couchers.config import config
+from couchers.config import Config
 from couchers.crypto import b64decode, random_hex, urlsafe_secure_token
 from couchers.db import session_scope
 from couchers.models import (
@@ -314,7 +312,7 @@ def test_do_not_email_non_security_unsublink(db):
     assert "/quick-link?payload=" in e.html
 
 
-def test_email_prefix_config(db, monkeypatch):
+def test_email_prefix_config(db):
     user, _ = generate_user()
 
     with mock_notification_email() as mock:
@@ -336,12 +334,9 @@ def test_email_prefix_config(db, monkeypatch):
     assert e.sender_email == "notify@couchers.org.invalid"
     assert e.subject == "[TEST] Thank you for your donation to Couchers.org!"
 
-    new_config = config.copy()
-    new_config.notification_email_sender = "TestCo"
-    new_config.notification_email_address = "testco@testing.co.invalid"
-    new_config.notification_prefix = ""
-
-    monkeypatch.setattr(couchers.notifications.background, "config", new_config)
+    Config.current.notification_email_sender = "TestCo"
+    Config.current.notification_email_address = "testco@testing.co.invalid"
+    Config.current.notification_prefix = ""
 
     with mock_notification_email() as mock:
         with session_scope() as session:
@@ -363,13 +358,10 @@ def test_email_prefix_config(db, monkeypatch):
     assert e.subject == "Thank you for your donation to Couchers.org!"
 
 
-def test_send_donation_email(db, monkeypatch):
+def test_send_donation_email(db):
     user, _ = generate_user(name="Testy von Test", email="testing@couchers.org.invalid")
 
-    new_config = config.copy()
-    new_config.enable_email = True
-
-    monkeypatch.setattr(couchers.jobs.handlers, "config", new_config)
+    Config.current.enable_email = True
 
     with session_scope() as session:
         notify(

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -337,9 +337,9 @@ def test_email_prefix_config(db, monkeypatch):
     assert e.subject == "[TEST] Thank you for your donation to Couchers.org!"
 
     new_config = config.copy()
-    new_config["NOTIFICATION_EMAIL_SENDER"] = "TestCo"
-    new_config["NOTIFICATION_EMAIL_ADDRESS"] = "testco@testing.co.invalid"
-    new_config["NOTIFICATION_PREFIX"] = ""
+    new_config.notification_email_sender = "TestCo"
+    new_config.notification_email_address = "testco@testing.co.invalid"
+    new_config.notification_prefix = ""
 
     monkeypatch.setattr(couchers.notifications.background, "config", new_config)
 
@@ -367,7 +367,7 @@ def test_send_donation_email(db, monkeypatch):
     user, _ = generate_user(name="Testy von Test", email="testing@couchers.org.invalid")
 
     new_config = config.copy()
-    new_config["ENABLE_EMAIL"] = True
+    new_config.enable_email = True
 
     monkeypatch.setattr(couchers.jobs.handlers, "config", new_config)
 

--- a/app/backend/src/tests/test_moderation.py
+++ b/app/backend/src/tests/test_moderation.py
@@ -1810,7 +1810,7 @@ def test_auto_approve_moderation_queue_disabled_when_zero(db):
         mock.assert_not_called()
 
         # Ensure deadline is 0 (disabled)
-        config["MODERATION_AUTO_APPROVE_DEADLINE_SECONDS"] = 0
+        config.moderation_auto_approve_deadline_seconds = 0
 
         # Run the job
         auto_approve_moderation_queue(empty_pb2.Empty())
@@ -1894,8 +1894,8 @@ def test_auto_approve_moderation_queue_approves_old_items(db, push_collector: Pu
         queue_item.time_created = datetime.now(queue_item.time_created.tzinfo) - timedelta(minutes=2)
 
     # Set deadline to 60 seconds (items older than 60 seconds will be auto-approved)
-    config["MODERATION_AUTO_APPROVE_DEADLINE_SECONDS"] = 60
-    config["MODERATION_BOT_USER_ID"] = moderator.id
+    config.moderation_auto_approve_deadline_seconds = 60
+    config.moderation_bot_user_id = moderator.id
 
     # Run the job
     auto_approve_moderation_queue(empty_pb2.Empty())
@@ -1968,8 +1968,8 @@ def test_auto_approve_does_not_approve_recent_items(db):
         mock.assert_not_called()
 
     # Set deadline to 1 hour (items older than 1 hour will be auto-approved)
-    config["MODERATION_AUTO_APPROVE_DEADLINE_SECONDS"] = 3600
-    config["MODERATION_BOT_USER_ID"] = moderator.id
+    config.moderation_auto_approve_deadline_seconds = 3600
+    config.moderation_bot_user_id = moderator.id
 
     # Run the job - the item was just created, so it shouldn't be approved
     with mock_notification_email() as mock:
@@ -2053,8 +2053,8 @@ def test_auto_approve_does_not_approve_already_approved(db):
         log_count_before = len(log_res_before.log_entries)
 
     # Set deadline to 1 second
-    config["MODERATION_AUTO_APPROVE_DEADLINE_SECONDS"] = 1
-    config["MODERATION_BOT_USER_ID"] = moderator.id
+    config.moderation_auto_approve_deadline_seconds = 1
+    config.moderation_bot_user_id = moderator.id
 
     # Run the job
     auto_approve_moderation_queue(empty_pb2.Empty())
@@ -2117,8 +2117,8 @@ def test_auto_approve_does_not_approve_moderator_shadowed_items(db):
         queue_item.time_created = datetime.now(queue_item.time_created.tzinfo) - timedelta(minutes=10)
 
     # Set deadline to 1 second
-    config["MODERATION_AUTO_APPROVE_DEADLINE_SECONDS"] = 1
-    config["MODERATION_BOT_USER_ID"] = moderator.id
+    config.moderation_auto_approve_deadline_seconds = 1
+    config.moderation_bot_user_id = moderator.id
 
     # Get log count before
     with real_moderation_session(mod_token) as api:
@@ -2184,8 +2184,8 @@ def test_auto_approve_skips_shadowed_user_authored_items(db):
         ).scalar_one()
         queue_item.time_created = datetime.now(queue_item.time_created.tzinfo) - timedelta(minutes=10)
 
-    config["MODERATION_AUTO_APPROVE_DEADLINE_SECONDS"] = 60
-    config["MODERATION_BOT_USER_ID"] = moderator.id
+    config.moderation_auto_approve_deadline_seconds = 60
+    config.moderation_bot_user_id = moderator.id
 
     auto_approve_moderation_queue(empty_pb2.Empty())
 

--- a/app/backend/src/tests/test_moderation.py
+++ b/app/backend/src/tests/test_moderation.py
@@ -9,7 +9,7 @@ import pytest
 from google.protobuf import empty_pb2
 from sqlalchemy.sql import select
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.db import session_scope
 from couchers.jobs.handlers import auto_approve_moderation_queue
 from couchers.jobs.worker import process_job
@@ -1810,7 +1810,7 @@ def test_auto_approve_moderation_queue_disabled_when_zero(db):
         mock.assert_not_called()
 
         # Ensure deadline is 0 (disabled)
-        config.moderation_auto_approve_deadline_seconds = 0
+        Config.current.moderation_auto_approve_deadline_seconds = 0
 
         # Run the job
         auto_approve_moderation_queue(empty_pb2.Empty())
@@ -1894,8 +1894,8 @@ def test_auto_approve_moderation_queue_approves_old_items(db, push_collector: Pu
         queue_item.time_created = datetime.now(queue_item.time_created.tzinfo) - timedelta(minutes=2)
 
     # Set deadline to 60 seconds (items older than 60 seconds will be auto-approved)
-    config.moderation_auto_approve_deadline_seconds = 60
-    config.moderation_bot_user_id = moderator.id
+    Config.current.moderation_auto_approve_deadline_seconds = 60
+    Config.current.moderation_bot_user_id = moderator.id
 
     # Run the job
     auto_approve_moderation_queue(empty_pb2.Empty())
@@ -1968,8 +1968,8 @@ def test_auto_approve_does_not_approve_recent_items(db):
         mock.assert_not_called()
 
     # Set deadline to 1 hour (items older than 1 hour will be auto-approved)
-    config.moderation_auto_approve_deadline_seconds = 3600
-    config.moderation_bot_user_id = moderator.id
+    Config.current.moderation_auto_approve_deadline_seconds = 3600
+    Config.current.moderation_bot_user_id = moderator.id
 
     # Run the job - the item was just created, so it shouldn't be approved
     with mock_notification_email() as mock:
@@ -2053,8 +2053,8 @@ def test_auto_approve_does_not_approve_already_approved(db):
         log_count_before = len(log_res_before.log_entries)
 
     # Set deadline to 1 second
-    config.moderation_auto_approve_deadline_seconds = 1
-    config.moderation_bot_user_id = moderator.id
+    Config.current.moderation_auto_approve_deadline_seconds = 1
+    Config.current.moderation_bot_user_id = moderator.id
 
     # Run the job
     auto_approve_moderation_queue(empty_pb2.Empty())
@@ -2117,8 +2117,8 @@ def test_auto_approve_does_not_approve_moderator_shadowed_items(db):
         queue_item.time_created = datetime.now(queue_item.time_created.tzinfo) - timedelta(minutes=10)
 
     # Set deadline to 1 second
-    config.moderation_auto_approve_deadline_seconds = 1
-    config.moderation_bot_user_id = moderator.id
+    Config.current.moderation_auto_approve_deadline_seconds = 1
+    Config.current.moderation_bot_user_id = moderator.id
 
     # Get log count before
     with real_moderation_session(mod_token) as api:
@@ -2184,8 +2184,8 @@ def test_auto_approve_skips_shadowed_user_authored_items(db):
         ).scalar_one()
         queue_item.time_created = datetime.now(queue_item.time_created.tzinfo) - timedelta(minutes=10)
 
-    config.moderation_auto_approve_deadline_seconds = 60
-    config.moderation_bot_user_id = moderator.id
+    Config.current.moderation_auto_approve_deadline_seconds = 60
+    Config.current.moderation_bot_user_id = moderator.id
 
     auto_approve_moderation_queue(empty_pb2.Empty())
 

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -10,7 +10,7 @@ import pytest
 from google.protobuf import empty_pb2, timestamp_pb2
 from sqlalchemy import select, update
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.constants import DATETIME_INFINITY
 from couchers.context import make_background_user_context
 from couchers.crypto import b64decode
@@ -1069,7 +1069,7 @@ def test_SendDevPushNotification_success(db, push_collector: PushCollector):
     user, token = generate_user()
 
     # Enable dev APIs for this test
-    config.enable_dev_apis = True
+    Config.current.enable_dev_apis = True
 
     with notifications_session(token) as notifications:
         notifications.SendDevPushNotification(
@@ -1097,7 +1097,7 @@ def test_SendDevPushNotification_minimal(db, push_collector: PushCollector):
     """Test SendDevPushNotification with minimal parameters."""
     user, token = generate_user()
 
-    config.enable_dev_apis = True
+    Config.current.enable_dev_apis = True
 
     with notifications_session(token) as notifications:
         notifications.SendDevPushNotification(
@@ -1118,7 +1118,7 @@ def test_SendDevPushNotification_disabled(db, push_collector: PushCollector):
     user, token = generate_user()
 
     # Ensure dev APIs are disabled (default in tests)
-    config.enable_dev_apis = False
+    Config.current.enable_dev_apis = False
 
     with notifications_session(token) as notifications:
         with pytest.raises(grpc.RpcError) as e:
@@ -1138,8 +1138,8 @@ def test_SendDevPushNotification_push_notifications_disabled(db, push_collector:
     """Test SendDevPushNotification fails when push notifications are disabled."""
     user, token = generate_user()
 
-    config.enable_dev_apis = True
-    config.push_notifications_enabled = False
+    Config.current.enable_dev_apis = True
+    Config.current.push_notifications_enabled = False
 
     with notifications_session(token) as notifications:
         with pytest.raises(grpc.RpcError) as e:
@@ -1243,7 +1243,7 @@ def test_DebugRedeliverPushNotification_success(db, push_collector: PushCollecto
     """Test DebugRedeliverPushNotification redelivers an existing notification."""
     user, token = generate_user()
 
-    config.enable_dev_apis = True
+    Config.current.enable_dev_apis = True
 
     # Create a notification for the user
     with session_scope() as session:
@@ -1286,7 +1286,7 @@ def test_DebugRedeliverPushNotification_not_found(db, push_collector: PushCollec
     """Test DebugRedeliverPushNotification fails when notification doesn't exist."""
     user, token = generate_user()
 
-    config.enable_dev_apis = True
+    Config.current.enable_dev_apis = True
 
     with notifications_session(token) as notifications:
         with pytest.raises(grpc.RpcError) as e:
@@ -1304,7 +1304,7 @@ def test_DebugRedeliverPushNotification_wrong_user(db, push_collector: PushColle
     user1, token1 = generate_user()
     user2, token2 = generate_user()
 
-    config.enable_dev_apis = True
+    Config.current.enable_dev_apis = True
 
     # Create a notification for user1
     with session_scope() as session:
@@ -1343,7 +1343,7 @@ def test_DebugRedeliverPushNotification_disabled(db, push_collector: PushCollect
     """Test DebugRedeliverPushNotification fails when ENABLE_DEV_APIS is disabled."""
     user, token = generate_user()
 
-    config.enable_dev_apis = False
+    Config.current.enable_dev_apis = False
 
     with notifications_session(token) as notifications:
         with pytest.raises(grpc.RpcError) as e:
@@ -1360,8 +1360,8 @@ def test_DebugRedeliverPushNotification_push_notifications_disabled(db, push_col
     """Test DebugRedeliverPushNotification fails when push notifications are disabled."""
     user, token = generate_user()
 
-    config.enable_dev_apis = True
-    config.push_notifications_enabled = False
+    Config.current.enable_dev_apis = True
+    Config.current.push_notifications_enabled = False
 
     with notifications_session(token) as notifications:
         with pytest.raises(grpc.RpcError) as e:

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -1069,7 +1069,7 @@ def test_SendDevPushNotification_success(db, push_collector: PushCollector):
     user, token = generate_user()
 
     # Enable dev APIs for this test
-    config["ENABLE_DEV_APIS"] = True
+    config.enable_dev_apis = True
 
     with notifications_session(token) as notifications:
         notifications.SendDevPushNotification(
@@ -1097,7 +1097,7 @@ def test_SendDevPushNotification_minimal(db, push_collector: PushCollector):
     """Test SendDevPushNotification with minimal parameters."""
     user, token = generate_user()
 
-    config["ENABLE_DEV_APIS"] = True
+    config.enable_dev_apis = True
 
     with notifications_session(token) as notifications:
         notifications.SendDevPushNotification(
@@ -1118,7 +1118,7 @@ def test_SendDevPushNotification_disabled(db, push_collector: PushCollector):
     user, token = generate_user()
 
     # Ensure dev APIs are disabled (default in tests)
-    config["ENABLE_DEV_APIS"] = False
+    config.enable_dev_apis = False
 
     with notifications_session(token) as notifications:
         with pytest.raises(grpc.RpcError) as e:
@@ -1138,8 +1138,8 @@ def test_SendDevPushNotification_push_notifications_disabled(db, push_collector:
     """Test SendDevPushNotification fails when push notifications are disabled."""
     user, token = generate_user()
 
-    config["ENABLE_DEV_APIS"] = True
-    config["PUSH_NOTIFICATIONS_ENABLED"] = False
+    config.enable_dev_apis = True
+    config.push_notifications_enabled = False
 
     with notifications_session(token) as notifications:
         with pytest.raises(grpc.RpcError) as e:
@@ -1243,7 +1243,7 @@ def test_DebugRedeliverPushNotification_success(db, push_collector: PushCollecto
     """Test DebugRedeliverPushNotification redelivers an existing notification."""
     user, token = generate_user()
 
-    config["ENABLE_DEV_APIS"] = True
+    config.enable_dev_apis = True
 
     # Create a notification for the user
     with session_scope() as session:
@@ -1286,7 +1286,7 @@ def test_DebugRedeliverPushNotification_not_found(db, push_collector: PushCollec
     """Test DebugRedeliverPushNotification fails when notification doesn't exist."""
     user, token = generate_user()
 
-    config["ENABLE_DEV_APIS"] = True
+    config.enable_dev_apis = True
 
     with notifications_session(token) as notifications:
         with pytest.raises(grpc.RpcError) as e:
@@ -1304,7 +1304,7 @@ def test_DebugRedeliverPushNotification_wrong_user(db, push_collector: PushColle
     user1, token1 = generate_user()
     user2, token2 = generate_user()
 
-    config["ENABLE_DEV_APIS"] = True
+    config.enable_dev_apis = True
 
     # Create a notification for user1
     with session_scope() as session:
@@ -1343,7 +1343,7 @@ def test_DebugRedeliverPushNotification_disabled(db, push_collector: PushCollect
     """Test DebugRedeliverPushNotification fails when ENABLE_DEV_APIS is disabled."""
     user, token = generate_user()
 
-    config["ENABLE_DEV_APIS"] = False
+    config.enable_dev_apis = False
 
     with notifications_session(token) as notifications:
         with pytest.raises(grpc.RpcError) as e:
@@ -1360,8 +1360,8 @@ def test_DebugRedeliverPushNotification_push_notifications_disabled(db, push_col
     """Test DebugRedeliverPushNotification fails when push notifications are disabled."""
     user, token = generate_user()
 
-    config["ENABLE_DEV_APIS"] = True
-    config["PUSH_NOTIFICATIONS_ENABLED"] = False
+    config.enable_dev_apis = True
+    config.push_notifications_enabled = False
 
     with notifications_session(token) as notifications:
         with pytest.raises(grpc.RpcError) as e:

--- a/app/backend/src/tests/test_postal_verification.py
+++ b/app/backend/src/tests/test_postal_verification.py
@@ -33,7 +33,7 @@ def _(testconfig):
 
 def _monkeypatch_postal_verification_config(monkeypatch):
     new_config = config.copy()
-    new_config["ENABLE_POSTAL_VERIFICATION"] = True
+    new_config.enable_postal_verification = True
     monkeypatch.setattr(couchers.servicers.postal_verification, "config", new_config)
 
 

--- a/app/backend/src/tests/test_postal_verification.py
+++ b/app/backend/src/tests/test_postal_verification.py
@@ -6,8 +6,7 @@ import grpc
 import pytest
 from sqlalchemy import select
 
-import couchers.servicers.postal_verification
-from couchers.config import config
+from couchers.config import Config
 from couchers.constants import (
     POSTAL_VERIFICATION_CODE_LIFETIME,
     POSTAL_VERIFICATION_MAX_ATTEMPTS,
@@ -31,10 +30,8 @@ def _(testconfig):
     pass
 
 
-def _monkeypatch_postal_verification_config(monkeypatch):
-    new_config = config.copy()
-    new_config.enable_postal_verification = True
-    monkeypatch.setattr(couchers.servicers.postal_verification, "config", new_config)
+def _config_enable_postal_verification():
+    Config.current.enable_postal_verification = True
 
 
 def test_generate_postal_verification_code():
@@ -67,9 +64,9 @@ def test_postal_verification_disabled(db):
         assert e.value.code() == grpc.StatusCode.UNAVAILABLE
 
 
-def test_postal_verification_happy_path(db, monkeypatch):
+def test_postal_verification_happy_path(db):
     """Test the complete happy path for postal verification."""
-    _monkeypatch_postal_verification_config(monkeypatch)
+    _config_enable_postal_verification()
 
     user, token = generate_user()
 
@@ -152,9 +149,9 @@ def test_postal_verification_happy_path(db, monkeypatch):
         assert has_postal_verification(session, db_user)
 
 
-def test_postal_verification_wrong_code(db, monkeypatch):
+def test_postal_verification_wrong_code(db):
     """Test entering wrong verification codes."""
-    _monkeypatch_postal_verification_config(monkeypatch)
+    _config_enable_postal_verification()
 
     user, token = generate_user()
 
@@ -200,9 +197,9 @@ def test_postal_verification_wrong_code(db, monkeypatch):
         assert status.status == postal_verification_pb2.POSTAL_VERIFICATION_STATUS_FAILED
 
 
-def test_postal_verification_code_expiry(db, monkeypatch):
+def test_postal_verification_code_expiry(db):
     """Test that codes expire after the configured lifetime."""
-    _monkeypatch_postal_verification_config(monkeypatch)
+    _config_enable_postal_verification()
 
     user, token = generate_user()
 
@@ -246,9 +243,9 @@ def test_postal_verification_code_expiry(db, monkeypatch):
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
 
 
-def test_postal_verification_rate_limit(db, monkeypatch):
+def test_postal_verification_rate_limit(db):
     """Test rate limiting on postal verification attempts."""
-    _monkeypatch_postal_verification_config(monkeypatch)
+    _config_enable_postal_verification()
 
     user, token = generate_user()
 
@@ -292,9 +289,9 @@ def test_postal_verification_rate_limit(db, monkeypatch):
         assert status.next_attempt_allowed_at.seconds > 0
 
 
-def test_postal_verification_already_in_progress(db, monkeypatch):
+def test_postal_verification_already_in_progress(db):
     """Test that you can't start a new attempt while one is in progress."""
-    _monkeypatch_postal_verification_config(monkeypatch)
+    _config_enable_postal_verification()
 
     user, token = generate_user()
 
@@ -325,9 +322,9 @@ def test_postal_verification_already_in_progress(db, monkeypatch):
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
 
 
-def test_postal_verification_cancel(db, monkeypatch):
+def test_postal_verification_cancel(db):
     """Test cancelling a postal verification attempt."""
-    _monkeypatch_postal_verification_config(monkeypatch)
+    _config_enable_postal_verification()
 
     user, token = generate_user()
 
@@ -357,9 +354,9 @@ def test_postal_verification_cancel(db, monkeypatch):
         assert not status.has_active_attempt
 
 
-def test_postal_verification_can_cancel_after_postcard_sent(db, monkeypatch):
+def test_postal_verification_can_cancel_after_postcard_sent(db):
     """Test that you CAN cancel after the postcard is sent (e.g., if postcard is lost)."""
-    _monkeypatch_postal_verification_config(monkeypatch)
+    _config_enable_postal_verification()
 
     user, token = generate_user()
 
@@ -405,9 +402,9 @@ def test_postal_verification_can_cancel_after_postcard_sent(db, monkeypatch):
         assert not status.has_active_attempt
 
 
-def test_postal_verification_list_attempts(db, monkeypatch):
+def test_postal_verification_list_attempts(db):
     """Test listing postal verification attempts."""
-    _monkeypatch_postal_verification_config(monkeypatch)
+    _config_enable_postal_verification()
 
     user, token = generate_user()
 
@@ -458,9 +455,9 @@ def test_postal_verification_list_attempts(db, monkeypatch):
         assert res.attempts[1].postal_verification_attempt_id == attempt_id_1
 
 
-def test_postal_verification_address_validation(db, monkeypatch):
+def test_postal_verification_address_validation(db):
     """Test address validation errors."""
-    _monkeypatch_postal_verification_config(monkeypatch)
+    _config_enable_postal_verification()
 
     user, token = generate_user()
 
@@ -503,9 +500,9 @@ def test_postal_verification_address_validation(db, monkeypatch):
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
 
 
-def test_postal_verification_postcard_send_failure(db, monkeypatch):
+def test_postal_verification_postcard_send_failure(db):
     """Test handling of postcard send failure."""
-    _monkeypatch_postal_verification_config(monkeypatch)
+    _config_enable_postal_verification()
 
     user, token = generate_user()
 
@@ -539,9 +536,9 @@ def test_postal_verification_postcard_send_failure(db, monkeypatch):
         assert status.status == postal_verification_pb2.POSTAL_VERIFICATION_STATUS_IN_PROGRESS
 
 
-def test_postal_verification_code_case_insensitive(db, monkeypatch):
+def test_postal_verification_code_case_insensitive(db):
     """Test that verification codes are case insensitive."""
-    _monkeypatch_postal_verification_config(monkeypatch)
+    _config_enable_postal_verification()
 
     user, token = generate_user()
 
@@ -583,9 +580,9 @@ def test_postal_verification_code_case_insensitive(db, monkeypatch):
         assert res.success
 
 
-def test_postal_verification_attempt_not_found(db, monkeypatch):
+def test_postal_verification_attempt_not_found(db):
     """Test accessing non-existent attempts."""
-    _monkeypatch_postal_verification_config(monkeypatch)
+    _config_enable_postal_verification()
 
     user, token = generate_user()
 
@@ -605,9 +602,9 @@ def test_postal_verification_attempt_not_found(db, monkeypatch):
         assert e.value.code() == grpc.StatusCode.NOT_FOUND
 
 
-def test_postal_verification_other_user_attempt(db, monkeypatch):
+def test_postal_verification_other_user_attempt(db):
     """Test that users cannot access other users' attempts."""
-    _monkeypatch_postal_verification_config(monkeypatch)
+    _config_enable_postal_verification()
 
     user1, token1 = generate_user()
     user2, token2 = generate_user()
@@ -642,9 +639,9 @@ def test_postal_verification_other_user_attempt(db, monkeypatch):
         assert e.value.code() == grpc.StatusCode.NOT_FOUND
 
 
-def test_has_postal_verification_helper(db, monkeypatch):
+def test_has_postal_verification_helper(db):
     """Test the has_postal_verification helper function."""
-    _monkeypatch_postal_verification_config(monkeypatch)
+    _config_enable_postal_verification()
 
     user, token = generate_user()
 

--- a/app/backend/src/tests/test_slack.py
+++ b/app/backend/src/tests/test_slack.py
@@ -20,8 +20,8 @@ def test_send_slack_message_disabled():
 
 
 def test_send_slack_message_enabled():
-    config["SLACK_ENABLED"] = True
-    config["SLACK_BOT_TOKEN"] = "xoxb-test-token"
+    config.slack_enabled = True
+    config.slack_bot_token = "xoxb-test-token"
 
     with patch("couchers.slack.requests.post") as mock_post:
         mock_post.return_value.raise_for_status.return_value = None

--- a/app/backend/src/tests/test_slack.py
+++ b/app/backend/src/tests/test_slack.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from couchers.config import config
+from couchers.config import Config
 from couchers.slack import send_slack_message
 
 
@@ -20,8 +20,8 @@ def test_send_slack_message_disabled():
 
 
 def test_send_slack_message_enabled():
-    config.slack_enabled = True
-    config.slack_bot_token = "xoxb-test-token"
+    Config.current.slack_enabled = True
+    Config.current.slack_bot_token = "xoxb-test-token"
 
     with patch("couchers.slack.requests.post") as mock_post:
         mock_post.return_value.raise_for_status.return_value = None

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -238,7 +238,9 @@ def config_enable_strong_verification():
     Config.current.enable_strong_verification = True
     Config.current.iris_id_pubkey = "dummy_pubkey"
     Config.current.iris_id_secret = "dummy_secret"
-    Config.current.verification_data_public_key = bytes.fromhex("dd740a2b2a35bf05041a28257ea439b30f76f056f3698000b71e6470cd82275f")
+    Config.current.verification_data_public_key = bytes.fromhex(
+        "dd740a2b2a35bf05041a28257ea439b30f76f056f3698000b71e6470cd82275f"
+    )
 
     private_key = bytes.fromhex("e6c2fbf3756b387bc09a458a7b85935718ef3eb1c2777ef41d335c9f6c0ab272")
 

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -9,9 +9,7 @@ from google.protobuf import empty_pb2
 from sqlalchemy import select, update
 from sqlalchemy.sql import or_
 
-import couchers.jobs.handlers
-import couchers.servicers.account
-from couchers.config import config
+from couchers.config import Config
 from couchers.crypto import asym_decrypt, b64encode_unpadded
 from couchers.db import session_scope
 from couchers.jobs.handlers import update_badges
@@ -236,23 +234,17 @@ def do_and_check_sv(
         assert callbacks == ["INITIATED", "COMPLETED", "APPROVED"]
 
 
-def monkeypatch_sv_config(monkeypatch):
-    new_config = config.copy()
-    new_config.enable_strong_verification = True
-    new_config.iris_id_pubkey = "dummy_pubkey"
-    new_config.iris_id_secret = "dummy_secret"
-    new_config.verification_data_public_key = bytes.fromhex(
-        "dd740a2b2a35bf05041a28257ea439b30f76f056f3698000b71e6470cd82275f"
-    )
+def config_enable_strong_verification():
+    Config.current.enable_strong_verification = True
+    Config.current.iris_id_pubkey = "dummy_pubkey"
+    Config.current.iris_id_secret = "dummy_secret"
+    Config.current.verification_data_public_key = bytes.fromhex("dd740a2b2a35bf05041a28257ea439b30f76f056f3698000b71e6470cd82275f")
 
     private_key = bytes.fromhex("e6c2fbf3756b387bc09a458a7b85935718ef3eb1c2777ef41d335c9f6c0ab272")
 
-    monkeypatch.setattr(couchers.servicers.account, "config", new_config)
-    monkeypatch.setattr(couchers.jobs.handlers, "config", new_config)
 
-
-def test_strong_verification_happy_path(db, monkeypatch):
-    monkeypatch_sv_config(monkeypatch)
+def test_strong_verification_happy_path(db):
+    config_enable_strong_verification()
 
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
     _, superuser_token = generate_user(is_superuser=True)
@@ -430,8 +422,8 @@ def test_strong_verification_happy_path(db, monkeypatch):
         assert res.gender_verification_status == api_pb2.GENDER_VERIFICATION_STATUS_MISMATCH
 
 
-def test_strong_verification_delete_data(db, monkeypatch):
-    monkeypatch_sv_config(monkeypatch)
+def test_strong_verification_delete_data(db):
+    config_enable_strong_verification()
 
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
     _, superuser_token = generate_user(is_superuser=True)
@@ -503,8 +495,8 @@ def test_strong_verification_delete_data(db, monkeypatch):
         )
 
 
-def test_strong_verification_expiry(db, monkeypatch):
-    monkeypatch_sv_config(monkeypatch)
+def test_strong_verification_expiry(db):
+    config_enable_strong_verification()
 
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
     _, superuser_token = generate_user(is_superuser=True)
@@ -575,8 +567,8 @@ def test_strong_verification_expiry(db, monkeypatch):
     )
 
 
-def test_strong_verification_regression(db, monkeypatch):
-    monkeypatch_sv_config(monkeypatch)
+def test_strong_verification_regression(db):
+    config_enable_strong_verification()
 
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
 
@@ -597,8 +589,8 @@ def test_strong_verification_regression(db, monkeypatch):
         api.Ping(api_pb2.PingReq())
 
 
-def test_strong_verification_regression2(db, monkeypatch):
-    monkeypatch_sv_config(monkeypatch)
+def test_strong_verification_regression2(db):
+    config_enable_strong_verification()
 
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
 
@@ -647,8 +639,8 @@ def test_strong_verification_disabled(db):
         assert e.value.details() == "Strong verification is currently disabled."
 
 
-def test_strong_verification_delete_data_cant_reverify(db, monkeypatch, push_collector: PushCollector):
-    monkeypatch_sv_config(monkeypatch)
+def test_strong_verification_delete_data_cant_reverify(db, push_collector: PushCollector):
+    config_enable_strong_verification()
 
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
     _, superuser_token = generate_user(is_superuser=True)
@@ -796,8 +788,8 @@ def test_strong_verification_delete_data_cant_reverify(db, monkeypatch, push_col
         )
 
 
-def test_strong_verification_duplicate_other_user(db, monkeypatch, push_collector: PushCollector):
-    monkeypatch_sv_config(monkeypatch)
+def test_strong_verification_duplicate_other_user(db, push_collector: PushCollector):
+    config_enable_strong_verification()
 
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
     user2, token2 = generate_user(birthdate=date(1988, 1, 1), gender="Man")
@@ -938,8 +930,8 @@ def test_strong_verification_duplicate_other_user(db, monkeypatch, push_collecto
     )
 
 
-def test_strong_verification_non_passport(db, monkeypatch, push_collector: PushCollector):
-    monkeypatch_sv_config(monkeypatch)
+def test_strong_verification_non_passport(db, push_collector: PushCollector):
+    config_enable_strong_verification()
 
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
     _, superuser_token = generate_user(is_superuser=True)

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -238,10 +238,10 @@ def do_and_check_sv(
 
 def monkeypatch_sv_config(monkeypatch):
     new_config = config.copy()
-    new_config["ENABLE_STRONG_VERIFICATION"] = True
-    new_config["IRIS_ID_PUBKEY"] = "dummy_pubkey"
-    new_config["IRIS_ID_SECRET"] = "dummy_secret"
-    new_config["VERIFICATION_DATA_PUBLIC_KEY"] = bytes.fromhex(
+    new_config.enable_strong_verification = True
+    new_config.iris_id_pubkey = "dummy_pubkey"
+    new_config.iris_id_secret = "dummy_secret"
+    new_config.verification_data_public_key = bytes.fromhex(
         "dd740a2b2a35bf05041a28257ea439b30f76f056f3698000b71e6470cd82275f"
     )
 

--- a/app/backend/src/tests/test_verification.py
+++ b/app/backend/src/tests/test_verification.py
@@ -207,8 +207,8 @@ def test_phone_uniqueness(monkeypatch):
 
 def test_send_sms(db, monkeypatch):
     new_config = config.copy()
-    new_config["ENABLE_SMS"] = True
-    new_config["SMS_SENDER_ID"] = "CouchersOrg"
+    new_config.enable_sms = True
+    new_config.sms_sender_id = "CouchersOrg"
     monkeypatch.setattr(couchers.phone.sms, "config", new_config)
 
     msg_id = random_hex()
@@ -239,7 +239,7 @@ def test_send_sms(db, monkeypatch):
 
 
 def test_send_sms_disabled(db):
-    assert not config["ENABLE_SMS"]
+    assert not config.enable_sms
     assert couchers.phone.sms.send_sms("+46701740605", "Testing SMS message") == "SMS not enabled."
 
 

--- a/app/backend/src/tests/test_verification.py
+++ b/app/backend/src/tests/test_verification.py
@@ -6,7 +6,7 @@ from google.protobuf import empty_pb2
 from sqlalchemy import select, update
 
 import couchers.phone.sms
-from couchers.config import config
+from couchers.config import Config
 from couchers.crypto import random_hex
 from couchers.db import session_scope
 from couchers.models import SMS, User
@@ -206,10 +206,8 @@ def test_phone_uniqueness(monkeypatch):
 
 
 def test_send_sms(db, monkeypatch):
-    new_config = config.copy()
-    new_config.enable_sms = True
-    new_config.sms_sender_id = "CouchersOrg"
-    monkeypatch.setattr(couchers.phone.sms, "config", new_config)
+    Config.current.enable_sms = True
+    Config.current.sms_sender_id = "CouchersOrg"
 
     msg_id = random_hex()
 
@@ -239,7 +237,7 @@ def test_send_sms(db, monkeypatch):
 
 
 def test_send_sms_disabled(db):
-    assert not config.enable_sms
+    assert not Config.current.enable_sms
     assert couchers.phone.sms.send_sms("+46701740605", "Testing SMS message") == "SMS not enabled."
 
 


### PR DESCRIPTION
Redefines the `config` dict to a strongly-typed dataclass leveraging type annotations and default values, such that references throughout the codebase can be validated by mypy.

## Testing
Leaving to tests - I figure either everything will work or nothing will.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me