### PR TITLE
Backend: update community-invites console path to /tools

### DIFF
--- a/app/backend/src/couchers/tasks.py
+++ b/app/backend/src/couchers/tasks.py
@@ -169,7 +169,7 @@ def send_event_community_invite_request_email(session: Session, request: EventCo
         template_args={
             "event_link": urls.event_link(occurrence_id=request.occurrence.id, slug=request.occurrence.event.slug),
             "user_link": urls.user_link(username=request.user.username),
-            "view_link": urls.console_link(page="admin/community-invites"),
+            "view_link": urls.console_link(page="tools/community-invites"),
         },
     )
 


### PR DESCRIPTION
Updates the `view_link` in the event community invite request email to point at `tools/community-invites` instead of `admin/community-invites`, matching the new console route.

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

- Verified the only path under `console.couchers.org` referenced from the backend is the one updated here (single call site in `tasks.py`).
- Ran `make format` — no changes.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._