### PR TITLE
Devex: Automerge Weblate PRs with the merge strategy

### DIFF
--- a/.github/workflows/weblate-automerge.yml
+++ b/.github/workflows/weblate-automerge.yml
@@ -1,5 +1,5 @@
-# Weblate PRs must be merged using the merge strategy, otherwise we run into conflicts.
-# Enabling automerge at PR creation time helps ensure we merge correctly.
+# Sets Weblate PRs to automerge using the merge strategy,
+# which avoids later running into Weblate merge conflicts.
 name: Automerge Weblate PRs
 
 on:

--- a/.github/workflows/weblate-automerge.yml
+++ b/.github/workflows/weblate-automerge.yml
@@ -5,6 +5,7 @@ name: Automerge Weblate PRs
 on:
   pull_request:
     types: [opened]
+    branches: [develop]
 
 jobs:
   automerge:
@@ -12,8 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event.pull_request.user.login == 'CouchersBot' &&
-      github.head_ref == 'web/translations' &&
-      github.base_ref == 'develop'
+      github.head_ref == 'web/translations'
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token

--- a/.github/workflows/weblate-automerge.yml
+++ b/.github/workflows/weblate-automerge.yml
@@ -1,0 +1,28 @@
+# Weblate PRs must be merged using the merge strategy, otherwise we run into conflicts.
+# Enabling automerge at PR creation time helps ensure we merge correctly.
+name: Automerge Weblate PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  automerge:
+    name: Mark Weblate PRs as automerge
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.user.login == 'CouchersBot' &&
+      github.head_ref == 'web/translations' &&
+      github.base_ref == 'develop'
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Enable automerge
+        run: gh pr merge --auto --merge "${{ github.event.pull_request.number }}"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
Weblate PRs must be merged using the merge strategy, otherwise we later run into Weblate merge conflicts. We can configure the merge strategy by setting automerge. This will still require a human approval due to branch protection rules.

## Testing
None: New github workflows are generally not testable, especially if they target PRs to `develop`. I'll have to wait until the next time Weblate opens a PR.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
