### PR TITLE
Backend/push: Fix ios_title not being used.

### DIFF
--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -179,7 +179,7 @@ def _get_content(
     icon_url = _avatar_url_or_default(icon_user) if icon_user else None
 
     return PushNotificationContent(
-        title=title, ios_title=title, ios_subtitle=ios_subtitle, body=body, icon_url=icon_url, action_url=action_url
+        title=title, ios_title=ios_title, ios_subtitle=ios_subtitle, body=body, icon_url=icon_url, action_url=action_url
     )
 
 

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -20,7 +20,7 @@ from couchers.proto import api_pb2, conversations_pb2, notification_data_pb2, no
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_HOURS
 from couchers.utils import Duration_from_timedelta, now, to_aware_datetime
 from tests.fixtures.db import generate_user, make_friends, make_user_block, make_user_invisible
-from tests.fixtures.misc import PushCollector, email_fields, mock_notification_email
+from tests.fixtures.misc import PushCollector, email_fields, mock_notification_email, process_jobs
 from tests.fixtures.sessions import api_session, conversations_session, notifications_session
 
 
@@ -723,16 +723,17 @@ def test_send_direct_message(db, moderator, push_collector: PushCollector):
 
         c1.SendDirectMessage(conversations_pb2.SendDirectMessageReq(recipient_user_id=user2.id, text=message2))
 
+    process_jobs()
+
     push = push_collector.pop_for_user(user2.id, last=False)
-    assert push.topic_action == NotificationTopicAction.chat__message
+    assert push.topic_action == NotificationTopicAction.chat__message.display
     assert push.content.title == user1.name
     assert push.content.body == message1
 
     push = push_collector.pop_for_user(user2.id, last=True)
-    assert push.topic_action == NotificationTopicAction.chat__message
+    assert push.topic_action == NotificationTopicAction.chat__message.display
     assert push.content.title == user1.name
     assert push.content.body == message2
-
 
     with conversations_session(token2) as c2:
         # Fetch the chat by ID returned from SendDirectMessage

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -20,7 +20,7 @@ from couchers.proto import api_pb2, conversations_pb2, notification_data_pb2, no
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_HOURS
 from couchers.utils import Duration_from_timedelta, now, to_aware_datetime
 from tests.fixtures.db import generate_user, make_friends, make_user_block, make_user_invisible
-from tests.fixtures.misc import email_fields, mock_notification_email
+from tests.fixtures.misc import PushCollector, email_fields, mock_notification_email
 from tests.fixtures.sessions import api_session, conversations_session, notifications_session
 
 
@@ -707,7 +707,7 @@ def test_send_message(db):
         assert e.value.details() == "You can't send a message in this chat."
 
 
-def test_send_direct_message(db, moderator):
+def test_send_direct_message(db, moderator, push_collector: PushCollector):
     user1, token1 = generate_user(complete_profile=True)
     user2, token2 = generate_user(complete_profile=True)
 
@@ -722,6 +722,17 @@ def test_send_direct_message(db, moderator):
         moderator.approve_group_chat(res.group_chat_id)
 
         c1.SendDirectMessage(conversations_pb2.SendDirectMessageReq(recipient_user_id=user2.id, text=message2))
+
+    push = push_collector.pop_for_user(user2.id, last=False)
+    assert push.topic_action == NotificationTopicAction.chat__message
+    assert push.content.title == user1.name
+    assert push.content.body == message1
+
+    push = push_collector.pop_for_user(user2.id, last=True)
+    assert push.topic_action == NotificationTopicAction.chat__message
+    assert push.content.title == user1.name
+    assert push.content.body == message2
+
 
     with conversations_session(token2) as c2:
         # Fetch the chat by ID returned from SendDirectMessage

--- a/app/backend/src/tests/test_discussions.py
+++ b/app/backend/src/tests/test_discussions.py
@@ -91,6 +91,8 @@ def test_create_and_get_discussion(db, push_collector: PushCollector):
 
     push = push_collector.pop_for_user(user2_id, last=True)
     assert push.content.title == "New discussion: dummy title"
+    assert push.content.ios_title == "New Discussion"
+    assert push.content.ios_subtitle == "dummy title"
     assert push.content.body == f"{user.name} started the discussion in Testing Community."
 
     with discussions_session(token) as api:

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -2223,8 +2223,16 @@ def test_event_threads(db, push_collector: PushCollector, moderator: Moderator):
 
     process_jobs()
 
-    assert push_collector.pop_for_user(user1.id, last=True).content.title == f"{user2.name} • Dummy Title"
-    assert push_collector.pop_for_user(user2.id, last=True).content.title == f"{user3.name} • Dummy Title"
+    push = push_collector.pop_for_user(user1.id, last=True)
+    assert push.topic_action == NotificationTopicAction.event__comment
+    assert push.content.title == f"{user2.name} • Dummy Title"
+    assert push.content.ios_title == user2.name
+    assert push.content.ios_subtitle == "Dummy Title"
+    assert push.content.body == "hi"
+
+    push = push_collector.pop_for_user(user2.id, last=True)
+    assert push.content.title == f"{user3.name} • Dummy Title"
+
     assert push_collector.count_for_user(user4_id) == 0
 
 

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -2224,7 +2224,7 @@ def test_event_threads(db, push_collector: PushCollector, moderator: Moderator):
     process_jobs()
 
     push = push_collector.pop_for_user(user1.id, last=True)
-    assert push.topic_action == NotificationTopicAction.event__comment
+    assert push.topic_action == NotificationTopicAction.event__comment.display
     assert push.content.title == f"{user2.name} • Dummy Title"
     assert push.content.ios_title == user2.name
     assert push.content.ios_subtitle == "Dummy Title"

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -2227,7 +2227,7 @@ def test_event_threads(db, push_collector: PushCollector, moderator: Moderator):
     assert push.topic_action == NotificationTopicAction.event__comment.display
     assert push.content.title == f"{user2.name} • Dummy Title"
     assert push.content.ios_title == user2.name
-    assert push.content.ios_subtitle == "Dummy Title"
+    assert push.content.ios_subtitle == "Commented on Dummy Title"
     assert push.content.body == "hi"
 
     push = push_collector.pop_for_user(user2.id, last=True)


### PR DESCRIPTION
The point of `ios_title` is to be shorter than `title` since it is accompanied with `ios_subtitle`.

## Testing
Added some tests.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me