### PR TITLE
Add blog post: response to Couchsurfing.com update

### DIFF
--- a/app/web/markdown/blog/2026/05/09/couch-surfing-community-looking-at-us.md
+++ b/app/web/markdown/blog/2026/05/09/couch-surfing-community-looking-at-us.md
@@ -1,0 +1,63 @@
+---
+is_blog_post: true
+title: The Couch Surfing Community Is Looking at Us. Let's Show Them Who We Are.
+slug: couch-surfing-community-looking-at-us
+description: "Couchsurfing.com just pushed an update that's leaving thousands looking elsewhere. Here's how you can help make Couchers.org feel alive for the new wave of people landing this week."
+date: 2026/05/09
+author: Emily
+author_username: emily
+---
+
+For years, when we told people about Couchers.org, a common response was a polite "oh cool, I'll check it out sometime." This week that all changed when Couchsurfing.com™ pushed an update that many are saying ruins the experience for its users in ways that will be hard to walk back, and suddenly tens of thousands of surfers and hosts are asking: *what else is out there? Is this the end of our community?*
+
+We already [wrote a note on Reddit](https://www.reddit.com/r/couchsurfing/comments/1t67ja4/a_note_from_couchersorg_regarding_the_cs_update/) about the sudden changes on Couchsurfing.com™. Some of the reported changes Couchsurfing.com™ released this week:
+
+* Full home addresses now auto-shared with guests a day before arrival
+* A surprise verification paywall stacked on top of subscriptions people already paid for
+* References from banned members suddenly visible again on profiles
+* Search so broken that active hosts are buried under dead and inactive profiles
+* People straight up can't log in, with immediately expired email tokens, random logouts, and failed sign-ins locking members out of their own accounts
+* Dating app-adjacent, low-context, vibe-coded UI
+* … and that's just to name a few 😬
+
+Meanwhile, we have spent the past 5+ years laying the groundwork to build Couchers.org as a 501(c)(3) non-profit that prevents any way to commercialize the magic of our community. And everything we release is tested extensively by volunteers and users. Exhibit A: our Android and iOS apps are in public beta, after going through months of internal testing by our team to crush bugs and nail down the details.
+
+So this post is for the people who already have a Couchers.org profile, who already get it, who already showed up to support our community-led, volunteer-run project and bring the good vibes back.
+
+The new wave of people looking around right now will land wherever it feels alive. And whether Couchers.org feels alive depends largely on you.
+
+## What this moment is about
+
+Couchsurfing.com™ was not always big. It got big because over the course of two decades a generation of travelers and hosts made profiles, answered requests, hosted strangers, and ran meetups in their cities. That generation built something real, and a lot of us were part of it.
+
+Moments like this week, where a huge group of people simultaneously starts looking for a new platform, are rare. The last time it happened was during the 2020 paywall, when all of this started — thanks to the passion of a handful of people determined to give the community a place to gather and rebuild. Now we have over 73,800 users (nearly 1,000 more have joined since the Couchsurfing.com™ update), a working platform, an Android and iOS app in final beta, a community search feature, event tools, improved dashboard, redesign messages view, public trips in development, and hundreds of other fixes shipped ([see details of our last release here](https://couchers.org/blog/2026/02/05/couchers-v1.2-release)). The volunteers are ready for more, but we need your help to make sure that new joiners not only land with us, but stick around.
+
+## What we need your help with
+
+**Flip your hosting status to whatever is honest right now.** Can host, may host, can't host. Keep it up to date! A search result with twenty profiles that say "maybe" beats a search result with two profiles that say "can host" (but actually can't) and eighteen that say "can't."
+
+**Update your profile.** Add a recent photo. Make sure your "My Home" section is filled out if you'd like to host! Rewrite your bio so it sounds like you in 2026… not you in 2020. If you have done Strong Verification, take advantage of photo galleries and enjoy a shiny badge.
+
+**Answer your messages!** Even a kind "no" is an active gesture. Silence is what made Couchsurfing.com™ search feel like a graveyard. We can be different by simply replying.
+
+**Try organizing a meetup.** Coffee, a walk, a park/beach hangout, a drink at a bar. Post it as an event. Use the "Invite the community" button to send invitations to all members in your community and get more visibility. Message some Couchers.org members personally to invite them or find a co-host. People searching your city for signs of life will see it and think, "oh, this is a real place!" If you need ideas, drop your local community builder a line.
+
+**Phone a friend.** You don't need to spam everyone, but just a single person who might actually love Couchers.org. A former Couchsurfer who you haven't talked to in years? A friend who just started traveling? The friend who was a skeptic back then, but maybe more curious now? We even have an "Invite a friend" feature in the main menu you can use to see how many sign up with your link!
+
+**Talk about us.** Maybe in a group chat or in a social media comment (and don't worry, we seem to have Reddit covered). Or even better: in person in a hostel common room or at a traveler meetup! Remember, we don't have a marketing budget … so word of mouth really counts!
+
+**Follow us on social media and share our posts.** [Instagram](https://www.instagram.com/couchersorg) | [Facebook](https://www.facebook.com/Couchers.org) | [Tiktok](https://www.tiktok.com/@couchersorg) | [Bluesky](https://bsky.app/profile/couchers.bsky.social) | [Reddit](https://www.reddit.com/r/couchers/)
+
+To cut to the chase, we are a fully volunteer organization, [funded by community donations](https://couchers.org/blog/2026/02/16/couchers-inc-financials-2025), with every line of code written by people who do this in their spare time. We cannot outspend anyone. We never could and we never would want to.
+
+What we have instead is a community that chose to be here on purpose, for the right reasons, with no paywall holding anyone hostage. When a new person lands on the platform this week and sees your fully completed profile in their city, with a recent photo and a bio that sounds like a human: that does more for Couchers.org than any post we could write. Now's the best time to show people that you're still just as enthusiastic as you were when you originally signed up.
+
+## Small actions, massive impact
+
+If you read this far, pick one thing from the list above and do it today. This is the moment where people are going to be looking at us closer than ever.
+
+And if you want to do more than that, we are *always* looking for volunteers. Event organizers in your city, front-end developers who know React and Typescript, mobile developers familiar with Expo and React Native, backend developers who can work in Python, and blog writers or social media people who would like to share their surfing or hosting experience with Couchers. A single post from an active user is a massive help.
+
+Let's put an end to the myth that our platform is "too small," or "too inactive," to be a new home for people leaving Couchsurfing.com™. Because we know as well as anyone how lovely of a home it is, and our doors are wide open!
+
+See you on Couchers.org!


### PR DESCRIPTION
Adds a new blog post by Emily for 2026-05-09 responding to the Couchsurfing.com™ update earlier this week. The post asks existing Couchers.org members to update their hosting status, refresh profiles, reply to messages, organize meetups, and otherwise help the platform feel alive for the new wave of arrivals.

## Testing
Markdown-only change. No code paths affected. Frontmatter follows the same shape as recent posts (e.g. `2026/02/16/couchers-inc-financials-2025.md`), and links are either external or absolute internal `/blog/...` paths.

- [ ] Render the blog index and the post page locally to confirm formatting (headers, bullet list, links) looks right

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._