### PR TITLE
Disable strong verification reminder on dashboard

### DIFF
--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -30,7 +30,7 @@ from couchers.event_log import log_event
 from couchers.experimentation import check_gate
 from couchers.helpers.completed_profile import has_completed_profile
 from couchers.helpers.geoip import geoip_approximate_location
-from couchers.helpers.strong_verification import get_strong_verification_fields, has_strong_verification
+from couchers.helpers.strong_verification import get_strong_verification_fields
 from couchers.jobs.enqueue import queue_job
 from couchers.jobs.handlers import finalize_strong_verification
 from couchers.materialized_views import LiteUser
@@ -775,11 +775,6 @@ class Account(account_pb2_grpc.AccountServicer):
 
         if not has_completed_profile(session, user):
             reminders.append(account_pb2.Reminder(complete_profile_reminder=account_pb2.CompleteProfileReminder()))
-
-        if not has_strong_verification(session, user):
-            reminders.append(
-                account_pb2.Reminder(complete_verification_reminder=account_pb2.CompleteVerificationReminder())
-            )
 
         return account_pb2.GetRemindersRes(reminders=reminders)
 

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -997,7 +997,6 @@ def test_ListInviteCodes(db):
 
 
 def test_reminders(db, moderator):
-    # the strong verification reminder's absence is tested in test_strong_verification.py
     # reference writing reminders tested in test_AvailableWriteReferences_and_ListPendingReferencesToWrite
     # we use LiteUser, so remember to refresh materialized views
     user, token = generate_user(complete_profile=False)
@@ -1007,13 +1006,10 @@ def test_reminders(db, moderator):
 
     refresh_materialized_views_rapid(empty_pb2.Empty())
     with account_session(complete_token) as account:
-        assert [reminder.WhichOneof("reminder") for reminder in account.GetReminders(empty_pb2.Empty()).reminders] == [
-            "complete_verification_reminder"
-        ]
+        assert [reminder.WhichOneof("reminder") for reminder in account.GetReminders(empty_pb2.Empty()).reminders] == []
     with account_session(token) as account:
         assert [reminder.WhichOneof("reminder") for reminder in account.GetReminders(empty_pb2.Empty()).reminders] == [
             "complete_profile_reminder",
-            "complete_verification_reminder",
         ]
 
     today_plus_2 = (today() + timedelta(days=2)).isoformat()
@@ -1034,7 +1030,6 @@ def test_reminders(db, moderator):
         assert [reminder.WhichOneof("reminder") for reminder in reminders] == [
             "respond_to_host_request_reminder",
             "complete_profile_reminder",
-            "complete_verification_reminder",
         ]
         assert reminders[0].respond_to_host_request_reminder.host_request_id == host_request1_id
         assert reminders[0].respond_to_host_request_reminder.surfer_user.user_id == req_user1.id
@@ -1057,7 +1052,6 @@ def test_reminders(db, moderator):
             "respond_to_host_request_reminder",
             "respond_to_host_request_reminder",
             "complete_profile_reminder",
-            "complete_verification_reminder",
         ]
         assert reminders[0].respond_to_host_request_reminder.host_request_id == host_request1_id
         assert reminders[0].respond_to_host_request_reminder.surfer_user.user_id == req_user1.id
@@ -1083,7 +1077,6 @@ def test_reminders(db, moderator):
             "respond_to_host_request_reminder",
             "respond_to_host_request_reminder",
             "complete_profile_reminder",
-            "complete_verification_reminder",
         ]
         assert reminders[0].respond_to_host_request_reminder.host_request_id == host_request1_id
         assert reminders[0].respond_to_host_request_reminder.surfer_user.user_id == req_user1.id
@@ -1107,7 +1100,6 @@ def test_reminders(db, moderator):
             "respond_to_host_request_reminder",
             "respond_to_host_request_reminder",
             "complete_profile_reminder",
-            "complete_verification_reminder",
         ]
         assert reminders[0].respond_to_host_request_reminder.host_request_id == host_request2_id
         assert reminders[0].respond_to_host_request_reminder.surfer_user.user_id == req_user2.id

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -1140,7 +1140,6 @@ def test_AvailableWriteReferences_and_ListPendingReferencesToWrite(db, moderator
             "write_reference_reminder",
             "write_reference_reminder",
             "write_reference_reminder",
-            "complete_verification_reminder",
         ]
         assert reminders[0].write_reference_reminder.host_request_id == hr3
         assert reminders[0].write_reference_reminder.reference_type == references_pb2.REFERENCE_TYPE_HOSTED

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -368,11 +368,6 @@ def test_strong_verification_happy_path(db, monkeypatch):
             api.GetLiteUser(api_pb2.GetLiteUserReq(user=user.username)).has_strong_verification
             == res.has_strong_verification
         )
-    with account_session(token) as account:
-        assert not any(
-            reminder.HasField("complete_verification_reminder")
-            for reminder in account.GetReminders(empty_pb2.Empty()).reminders
-        )
 
     # check has_passport_sex_gender_exception
     with real_admin_session(superuser_token) as admin:
@@ -400,11 +395,6 @@ def test_strong_verification_happy_path(db, monkeypatch):
             api.GetLiteUser(api_pb2.GetLiteUserReq(user=user.username)).has_strong_verification
             == res.has_strong_verification
         )
-    with account_session(token) as account:
-        assert not any(
-            reminder.HasField("complete_verification_reminder")
-            for reminder in account.GetReminders(empty_pb2.Empty()).reminders
-        )
 
     with real_admin_session(superuser_token) as admin:
         res = admin.GetUserDetails(admin_pb2.GetUserDetailsReq(user=user.username))
@@ -430,11 +420,6 @@ def test_strong_verification_happy_path(db, monkeypatch):
         assert (
             api.GetLiteUser(api_pb2.GetLiteUserReq(user=user.username)).has_strong_verification
             == res.has_strong_verification
-        )
-    with account_session(token) as account:
-        assert any(
-            reminder.HasField("complete_verification_reminder")
-            for reminder in account.GetReminders(empty_pb2.Empty()).reminders
         )
 
     with real_admin_session(superuser_token) as admin:


### PR DESCRIPTION
Stops the backend from emitting the `complete_verification_reminder` from `GetReminders`, so the strong verification reminder no longer appears on the dashboard. The proto field and frontend handler are left in place as harmless dead code; can be removed in a follow-up if desired.

## Testing
Updated affected backend tests (`test_reminders`, `test_AvailableWriteReferences_and_ListPendingReferencesToWrite`, and the SV happy-path test) to drop assertions about the verification reminder.

```
uv run pytest src/tests/test_account.py::test_reminders src/tests/test_strong_verification.py src/tests/test_references.py::test_AvailableWriteReferences_and_ListPendingReferencesToWrite
```

All pass.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._