### PR TITLE
Clear host request dashboard reminder when host sends a message

### DIFF
--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -8,7 +8,7 @@ import requests
 from google.protobuf import empty_pb2
 from sqlalchemy import select
 from sqlalchemy.orm import Session
-from sqlalchemy.sql import func, update
+from sqlalchemy.sql import exists, func, update
 from user_agents import parse as user_agents_parse
 
 from couchers import urls
@@ -47,6 +47,7 @@ from couchers.models import (
     HostRequest,
     HostRequestStatus,
     InviteCode,
+    Message,
     ModNote,
     ProfilePublicVisibility,
     StrongVerificationAttempt,
@@ -740,6 +741,9 @@ class Account(account_pb2_grpc.AccountServicer):
         user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
 
         # responding to reqs comes first in desc order of when they were received
+        host_has_sent_message = select(1).where(
+            Message.conversation_id == HostRequest.conversation_id, Message.author_id == HostRequest.recipient_user_id
+        )
         query = select(HostRequest.conversation_id, LiteUser).join(
             LiteUser, LiteUser.id == HostRequest.initiator_user_id
         )
@@ -749,6 +753,7 @@ class Account(account_pb2_grpc.AccountServicer):
             query.where(HostRequest.recipient_user_id == context.user_id)
             .where(HostRequest.status == HostRequestStatus.pending)
             .where(HostRequest.start_time > func.now())
+            .where(~exists(host_has_sent_message))
             .order_by(HostRequest.conversation_id.asc())
         ).all()
         reminders = [

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -1106,6 +1106,38 @@ def test_reminders(db, moderator):
         assert reminders[1].respond_to_host_request_reminder.host_request_id == host_request3_id
         assert reminders[1].respond_to_host_request_reminder.surfer_user.user_id == req_user1.id
 
+    # host replies to req2 with a message: reminder should clear even though it's still pending
+    with requests_session(token) as api:
+        api.SendHostRequestMessage(
+            requests_pb2.SendHostRequestMessageReq(host_request_id=host_request2_id, text="Let me think about it")
+        )
+
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+    with account_session(token) as account:
+        reminders = account.GetReminders(empty_pb2.Empty()).reminders
+        assert [reminder.WhichOneof("reminder") for reminder in reminders] == [
+            "respond_to_host_request_reminder",
+            "complete_profile_reminder",
+        ]
+        assert reminders[0].respond_to_host_request_reminder.host_request_id == host_request3_id
+        assert reminders[0].respond_to_host_request_reminder.surfer_user.user_id == req_user1.id
+
+    # surfer sending a message should not clear the reminder
+    with requests_session(req_user_token1) as api:
+        api.SendHostRequestMessage(
+            requests_pb2.SendHostRequestMessageReq(host_request_id=host_request3_id, text="Any update?")
+        )
+
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+    with account_session(token) as account:
+        reminders = account.GetReminders(empty_pb2.Empty()).reminders
+        assert [reminder.WhichOneof("reminder") for reminder in reminders] == [
+            "respond_to_host_request_reminder",
+            "complete_profile_reminder",
+        ]
+        assert reminders[0].respond_to_host_request_reminder.host_request_id == host_request3_id
+        assert reminders[0].respond_to_host_request_reminder.surfer_user.user_id == req_user1.id
+
 
 def test_volunteer_stuff(db):
     # taken from couchers/app/backend/resources/badges.json


### PR DESCRIPTION
The dashboard "respond to host request" reminder previously only disappeared once the host accepted or rejected the request. If the host instead replied to the surfer with a message (without yet accepting/rejecting), the reminder kept nagging them on the dashboard.

This brings `GetReminders()` in line with the email reminder background job (`send_host_request_reminders`), which already excluded host requests where the recipient had sent any message in the conversation.

## Testing
Extended `test_reminders` in `test_account.py`:
- After the host sends a message on a still-pending request, that request no longer appears in the reminders list.
- A message from the surfer (initiator) does not clear the reminder.

Run with: `uv run pytest src/tests/test_account.py::test_reminders` from `app/backend`.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._