### PR TITLE
nginx: skip cert fetch on startup when existing cert is still valid

### DIFF
--- a/app/nginx/scripts/get-certs.sh
+++ b/app/nginx/scripts/get-certs.sh
@@ -29,6 +29,13 @@ for LINE in $(cat /scripts/domains); do
         flags="$flags --challenge-alias $ALIAS_DOMAIN"
     fi
 
+    # skip if we already have a cert that's valid for more than 3 days; cron will handle renewals
+    CERT_FILE=/certs/live/$folder/fullchain.pem
+    if [[ -f $CERT_FILE ]] && openssl x509 -checkend $((3*86400)) -noout -in "$CERT_FILE" >/dev/null 2>&1; then
+        echo "Skipping $DOMAIN: existing cert valid for >3 days"
+        continue
+    fi
+
     mkdir -p /certs/live/$folder
 
     /scripts/acme.sh/acme.sh --home /certs --issue --dns dns_aws $flags \


### PR DESCRIPTION
On deploy, the nginx container's `run.sh` calls `get-certs.sh`, which iterates over every domain and runs `acme.sh --issue`. If a cert happens to be inside acme.sh's renewal window at the moment of a deploy, this triggers a renewal against Let's Encrypt before the site comes up. This causes ~1 min downtime.

This PR adds a per-domain guard in `get-certs.sh`: if `fullchain.pem` already exists and is valid for more than 3 days, skip the `acme.sh --issue` call. The cron-based renewal (every 2 hours) continues to handle actual renewals, so deploys no longer touch Let's Encrypt as long as cron is healthy. The 3-day buffer is a safety net so that a long cron outage still gets rescued by a deploy before expiry.

## Testing
Reviewed on production by inspecting the script logic. Manual test plan:
- Deploy with healthy certs in `/certs/live/<domain>/fullchain.pem`: log should show `Skipping <domain>: existing cert valid for >3 days` for each domain and no acme.sh calls.
- Deploy with a missing cert file: acme.sh runs and issues a new cert as before.
- Deploy with a cert expiring within 3 days: acme.sh runs and renews.

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._