### PR TITLE
[frontend] Show profile-incomplete dialog when adding a friend

### DIFF
--- a/app/web/components/ProfileIncompleteDialog/ProfileIncompleteDialog.tsx
+++ b/app/web/components/ProfileIncompleteDialog/ProfileIncompleteDialog.tsx
@@ -16,7 +16,11 @@ import { howToCompleteProfileUrl, routeToEditProfile } from "routes";
 interface ProfileIncompleteDialogProps {
   open: boolean;
   onClose: () => void;
-  attempted_action: "create_event" | "send_message" | "send_request";
+  attempted_action:
+    | "create_event"
+    | "send_message"
+    | "send_request"
+    | "send_friend_request";
 }
 
 export default function ProfileIncompleteDialog({

--- a/app/web/features/connections/friends/AddFriendButton.test.tsx
+++ b/app/web/features/connections/friends/AddFriendButton.test.tsx
@@ -1,10 +1,11 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import React, { useState } from "react";
 import { service } from "service";
 import wrapper from "test/hookWrapper";
 import i18n from "test/i18n";
+import { MockedService } from "test/utils";
 
 import AddFriendButton from "./AddFriendButton";
 
@@ -13,6 +14,32 @@ const { t } = i18n;
 const sendFriendRequestMock = service.api.sendFriendRequest as jest.Mock<
   ReturnType<typeof service.api.sendFriendRequest>
 >;
+
+const getAccountInfoMock = service.account.getAccountInfo as MockedService<
+  typeof service.account.getAccountInfo
+>;
+
+const accountInfo = {
+  username: "tester",
+  email: "email@couchers.org",
+  profileComplete: true,
+  phone: "+46701740605",
+  phoneVerified: true,
+  timezone: "Australia/Broken_Hill",
+  hasStrongVerification: false,
+  birthdateVerificationStatus: 1,
+  genderVerificationStatus: 3,
+  doNotEmail: false,
+  hasDonated: false,
+  isSuperuser: false,
+  uiLanguagePreference: "",
+  profilePublicVisibility: 1,
+  isVolunteer: false,
+  myHomeComplete: false,
+  shouldShowDonationBanner: false,
+};
+
+const incompleteAccountInfo = { ...accountInfo, profileComplete: false };
 
 function TestComponent() {
   const [mutationError, setMutationError] = useState("");
@@ -30,6 +57,10 @@ afterEach(() => {
 });
 
 describe("AddFriendButton", () => {
+  beforeEach(() => {
+    getAccountInfoMock.mockResolvedValue(accountInfo);
+  });
+
   it("renders the button correctly", () => {
     render(<TestComponent />, { wrapper });
     expect(
@@ -44,25 +75,27 @@ describe("AddFriendButton", () => {
     sendFriendRequestMock.mockImplementation(() => new Promise(() => void 0));
     render(<TestComponent />, { wrapper });
 
+    const button = screen.getByRole("button", {
+      name: t("connections:add_friend"),
+    });
+    await waitFor(() => expect(button).toBeEnabled());
+
     const user = userEvent.setup();
-    await user.click(
-      screen.getByRole("button", {
-        name: t("connections:add_friend"),
-      }),
-    );
+    await user.click(button);
     expect(await screen.findByRole("progressbar")).toBeVisible();
   });
 
   it("sets no error if the add friend action succeeded", async () => {
     sendFriendRequestMock.mockResolvedValue(new Empty());
     render(<TestComponent />, { wrapper });
-    const user = userEvent.setup();
 
-    await user.click(
-      screen.getByRole("button", {
-        name: t("connections:add_friend"),
-      }),
-    );
+    const button = screen.getByRole("button", {
+      name: t("connections:add_friend"),
+    });
+    await waitFor(() => expect(button).toBeEnabled());
+
+    const user = userEvent.setup();
+    await user.click(button);
 
     expect(await screen.findByText(/Success/)).toBeInTheDocument();
   });
@@ -74,15 +107,36 @@ describe("AddFriendButton", () => {
     );
     render(<TestComponent />, { wrapper });
 
-    const user = userEvent.setup();
+    const button = screen.getByRole("button", {
+      name: t("connections:add_friend"),
+    });
+    await waitFor(() => expect(button).toBeEnabled());
 
-    await user.click(
-      screen.getByRole("button", {
-        name: t("connections:add_friend"),
-      }),
-    );
+    const user = userEvent.setup();
+    await user.click(button);
+
     expect(
       await screen.findByText("Failed to add funny dog"),
     ).toBeInTheDocument();
+  });
+
+  it("pops up incomplete profile note if profile is incomplete", async () => {
+    getAccountInfoMock.mockResolvedValue(incompleteAccountInfo);
+    render(<TestComponent />, { wrapper });
+
+    const button = screen.getByRole("button", {
+      name: t("connections:add_friend"),
+    });
+    await waitFor(() => expect(button).toBeEnabled());
+
+    const user = userEvent.setup();
+    await user.click(button);
+
+    expect(
+      await screen.findByLabelText(
+        t("dashboard:complete_profile_dialog.title"),
+      ),
+    ).toBeVisible();
+    expect(sendFriendRequestMock).not.toHaveBeenCalled();
   });
 });

--- a/app/web/features/connections/friends/AddFriendButton.tsx
+++ b/app/web/features/connections/friends/AddFriendButton.tsx
@@ -1,13 +1,15 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import Button from "components/Button";
 import { PersonAddIcon } from "components/Icons";
+import ProfileIncompleteDialog from "components/ProfileIncompleteDialog/ProfileIncompleteDialog";
 import { doAntibot } from "features/antibot/antibot";
+import useAccountInfo from "features/auth/useAccountInfo";
 import { userKey } from "features/queryKeys";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { CONNECTIONS } from "i18n/namespaces";
 import { useTranslation } from "next-i18next";
 import { User } from "proto/api_pb";
-import React from "react";
+import React, { useState } from "react";
 import { service } from "service";
 
 import { SetMutationError } from ".";
@@ -23,6 +25,12 @@ export default function AddFriendButton({
 }: AddFriendButtonProps) {
   const queryClient = useQueryClient();
   const { t } = useTranslation([CONNECTIONS]);
+  const [showCantFriendDialog, setShowCantFriendDialog] =
+    useState<boolean>(false);
+
+  const { data: accountInfo, isLoading: isAccountInfoLoading } =
+    useAccountInfo();
+
   const { isPending, mutate: sendFriendRequest } = useMutation<
     Empty,
     Error,
@@ -64,15 +72,29 @@ export default function AddFriendButton({
     },
   });
 
+  const onClick = () => {
+    if (!accountInfo?.profileComplete) {
+      setShowCantFriendDialog(true);
+    } else {
+      sendFriendRequest({ setMutationError, userId });
+    }
+  };
+
   return (
-    <Button
-      startIcon={<PersonAddIcon />}
-      onClick={() => {
-        sendFriendRequest({ setMutationError, userId });
-      }}
-      loading={isPending}
-    >
-      {t("connections:add_friend")}
-    </Button>
+    <>
+      <ProfileIncompleteDialog
+        open={showCantFriendDialog}
+        onClose={() => setShowCantFriendDialog(false)}
+        attempted_action="send_friend_request"
+      />
+      <Button
+        startIcon={<PersonAddIcon />}
+        onClick={onClick}
+        loading={isPending}
+        disabled={isAccountInfoLoading}
+      >
+        {t("connections:add_friend")}
+      </Button>
+    </>
   );
 }

--- a/app/web/features/dashboard/locales/en.json
+++ b/app/web/features/dashboard/locales/en.json
@@ -12,6 +12,7 @@
     "actions": {
       "send_request": "send a request",
       "send_message": "send a message",
+      "send_friend_request": "send a friend request",
       "create_event": "create an event"
     },
     "edit_profile_button": "Edit your profile now",


### PR DESCRIPTION
Stacked on top of #8520. Apply the same client-side incomplete-profile gate to the friend-request action that already exists for messaging and host requests: clicking "Add friend" with an incomplete profile now opens \`ProfileIncompleteDialog\` instead of firing the request and showing the backend error.

Changes:
- Extend \`ProfileIncompleteDialog\`'s \`attempted_action\` union with \`send_friend_request\`.
- Add the matching \`send_friend_request\` label to \`features/dashboard/locales/en.json\`.
- Wire \`useAccountInfo\` into \`AddFriendButton\` and gate the mutation on \`profileComplete\`, mirroring \`MessageUserButton\`.

## Testing
- \`yarn test --testPathPattern AddFriendButton\` — 5/5 passing, including a new "pops up incomplete profile note if profile is incomplete" case.
- \`yarn lint:fix\` and \`yarn format\` clean.
- Existing \`MessageUserButton\` / \`ProfileIncompleteDialog\` tests still pass.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._