### PR TITLE
Add ellipsis menu to event page and add copy link

### DIFF
--- a/app/web/features/communities/events/CancelEventDialog.tsx
+++ b/app/web/features/communities/events/CancelEventDialog.tsx
@@ -50,18 +50,19 @@ export default function CancelEventDialog({
       </DialogContent>
       <DialogActions>
         <Button
-          onClick={handleCancelEvent}
-          loading={cancelEventMutation.isPending}
-        >
-          {t("global:yes")}
-        </Button>
-        <Button
+          variant="outlined"
           onClick={() =>
             props.onClose ? props.onClose({}, "escapeKeyDown") : null
           }
           loading={cancelEventMutation.isPending}
         >
           {t("global:no")}
+        </Button>
+        <Button
+          onClick={handleCancelEvent}
+          loading={cancelEventMutation.isPending}
+        >
+          {t("global:yes")}
         </Button>
       </DialogActions>
     </Dialog>

--- a/app/web/features/communities/events/EditEventPage.tsx
+++ b/app/web/features/communities/events/EditEventPage.tsx
@@ -1,8 +1,11 @@
+import { styled } from "@mui/material";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import Alert from "components/Alert";
 import Button from "components/Button";
 import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
+import HeaderButton from "components/HeaderButton";
 import HtmlMeta from "components/HtmlMeta";
+import { BackIcon } from "components/Icons";
 import NotFoundPage from "features/NotFoundPage";
 import { RpcError } from "grpc-web";
 import { useTranslation } from "i18n";
@@ -10,17 +13,38 @@ import { COMMUNITIES, GLOBAL, PROFILE } from "i18n/namespaces";
 import { useRouter } from "next/router";
 import { service } from "service";
 import type { UpdateEventInput } from "service/events";
+import { theme } from "theme";
 import dayjs from "utils/dayjs";
+import { sendNativeBack, useIsNativeEmbed } from "utils/nativeLink";
 
 import { Event } from "../../../proto/events_pb";
-import { routeToEvent } from "../../../routes";
+import { eventsRoute, routeToEvent } from "../../../routes";
 import { communityEventsBaseKey, eventKey } from "../../queryKeys";
 import EventForm, { CreateEventVariables } from "./EventForm";
 import { useEvent } from "./hooks";
 
+const StyledBackButton = styled(HeaderButton)(() => ({
+  width: "2.5rem",
+  height: "2.5rem",
+  marginTop: theme.spacing(2),
+}));
+
 export default function EditEventPage({ eventId }: { eventId: number }) {
   const { t } = useTranslation([GLOBAL, COMMUNITIES, PROFILE]);
   const router = useRouter();
+  const isNativeEmbed = useIsNativeEmbed();
+
+  const handleBackClick = () => {
+    if (isNativeEmbed) {
+      sendNativeBack();
+      return;
+    }
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.push(eventsRoute);
+    }
+  };
 
   const {
     data: event,
@@ -117,6 +141,12 @@ export default function EditEventPage({ eventId }: { eventId: number }) {
     ) : (
       <>
         <HtmlMeta title={t("communities:edit_event")} />
+        <StyledBackButton
+          onClick={handleBackClick}
+          aria-label={t("communities:previous_page")}
+        >
+          <BackIcon />
+        </StyledBackButton>
         <EventForm
           error={error}
           event={event}

--- a/app/web/features/communities/events/EventPage.test.tsx
+++ b/app/web/features/communities/events/EventPage.test.tsx
@@ -209,16 +209,24 @@ describe("Event page", () => {
     getEventMock.mockResolvedValue({ ...firstEvent, canEdit: true });
     renderEventPage();
 
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(await screen.findByTestId("event-page-more-options"));
+
     expect(
-      await screen.findByRole("button", { name: t("communities:edit_event") }),
+      await screen.findByRole("menuitem", {
+        name: t("communities:edit_event"),
+      }),
     ).toBeVisible();
   });
 
   it("does not show the 'edit event' button if the user does not have edit permission", async () => {
     renderEventPage();
 
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(await screen.findByTestId("event-page-more-options"));
+
     expect(
-      await screen.queryByRole("button", { name: t("communities:edit_event") }),
+      screen.queryByRole("menuitem", { name: t("communities:edit_event") }),
     ).not.toBeInTheDocument();
   });
 
@@ -227,8 +235,11 @@ describe("Event page", () => {
     getEventMock.mockResolvedValue({ ...firstEvent, creatorUserId: 1 });
     renderEventPage();
 
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(await screen.findByTestId("event-page-more-options"));
+
     expect(
-      await screen.findByRole("button", {
+      await screen.findByRole("menuitem", {
         name: t("communities:duplicate_event"),
       }),
     ).toBeVisible();
@@ -239,16 +250,17 @@ describe("Event page", () => {
     getEventMock.mockResolvedValue({ ...firstEvent, creatorUserId: 2 });
     renderEventPage();
 
-    await screen.findByRole("heading", { name: firstEvent.title });
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(await screen.findByTestId("event-page-more-options"));
 
     expect(
-      screen.queryByRole("button", {
+      screen.queryByRole("menuitem", {
         name: t("communities:duplicate_event"),
       }),
     ).not.toBeInTheDocument();
   });
 
-  it("disables the 'duplicate event' button for cancelled events", async () => {
+  it("hides the 'duplicate event' item for cancelled events", async () => {
     getEventMock.mockResolvedValue({
       ...firstEvent,
       creatorUserId: 1,
@@ -256,11 +268,14 @@ describe("Event page", () => {
     });
     renderEventPage();
 
-    const duplicateButton = await screen.findByRole("button", {
-      name: t("communities:duplicate_event"),
-    });
-    expect(duplicateButton).toBeDisabled();
-    expect(duplicateButton).toHaveAttribute("tabIndex", "-1");
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(await screen.findByTestId("event-page-more-options"));
+
+    expect(
+      screen.queryByRole("menuitem", {
+        name: t("communities:duplicate_event"),
+      }),
+    ).not.toBeInTheDocument();
   });
 
   it("allows duplicating past events", async () => {
@@ -272,11 +287,14 @@ describe("Event page", () => {
     getEventMock.mockResolvedValue(pastEvent);
     renderEventPage();
 
-    const duplicateButton = await screen.findByRole("button", {
-      name: t("communities:duplicate_event"),
-    });
-    expect(duplicateButton).toBeEnabled();
-    expect(duplicateButton).not.toHaveAttribute("tabIndex", "-1");
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(await screen.findByTestId("event-page-more-options"));
+
+    expect(
+      await screen.findByRole("menuitem", {
+        name: t("communities:duplicate_event"),
+      }),
+    ).toBeVisible();
   });
 
   it("navigates to create event page with duplicate query param when clicked", async () => {
@@ -285,11 +303,13 @@ describe("Event page", () => {
     renderEventPage();
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(await screen.findByTestId("event-page-more-options"));
 
-    const duplicateButton = await screen.findByRole("button", {
-      name: t("communities:duplicate_event"),
-    });
-    await user.click(duplicateButton);
+    await user.click(
+      await screen.findByRole("menuitem", {
+        name: t("communities:duplicate_event"),
+      }),
+    );
 
     await waitFor(() =>
       expect(mockRouter.push).toHaveBeenCalledWith(
@@ -302,15 +322,14 @@ describe("Event page", () => {
     getEventMock.mockResolvedValue({ ...firstEvent, creatorUserId: 1 });
     renderEventPage();
 
-    const duplicateButton = await screen.findByRole("button", {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(await screen.findByTestId("event-page-more-options"));
+
+    const duplicateItem = await screen.findByRole("menuitem", {
       name: t("communities:duplicate_event"),
     });
-    expect(duplicateButton).toHaveAttribute(
-      "aria-label",
-      t("communities:duplicate_event"),
-    );
-    expect(duplicateButton).toHaveAttribute("tabIndex", "0");
-    expect(duplicateButton).not.toBeDisabled();
+    expect(duplicateItem).toBeVisible();
+    expect(duplicateItem).not.toHaveAttribute("aria-disabled", "true");
   });
 
   it("shows the not found page if the user tries to find an event with an invalid ID in the URL", async () => {

--- a/app/web/features/communities/events/EventPage.tsx
+++ b/app/web/features/communities/events/EventPage.tsx
@@ -1,17 +1,16 @@
-import { ContentCopyOutlined, EditOutlined } from "@mui/icons-material";
 import {
-  Card,
-  Chip,
-  IconButton,
-  styled,
-  Tooltip,
-  Typography,
-} from "@mui/material";
+  CancelOutlined,
+  ContentCopyOutlined,
+  EditOutlined,
+  LinkOutlined,
+} from "@mui/icons-material";
+import { Card, Chip, styled, Typography } from "@mui/material";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { eventImagePlaceholderUrl } from "appConstants";
 import Alert from "components/Alert";
 import Button from "components/Button";
 import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
+import EllipsisMenu, { EllipsisMenuItem } from "components/EllipsisMenu";
 import HeaderButton from "components/HeaderButton";
 import HtmlMeta from "components/HtmlMeta";
 import { BackIcon, CalendarIcon } from "components/Icons";
@@ -110,13 +109,16 @@ const StyledCancelledChip = styled(Chip)(() => ({
   fontWeight: "bold",
 }));
 
-const StyledIconButton = styled(IconButton)(() => ({
-  flexShrink: 0,
-}));
-
 const StyledIconButtonGroup = styled("div")(() => ({
   display: "flex",
   gap: theme.spacing(0.5),
+}));
+
+const StyledInviteAndAttendanceRow = styled("div")(() => ({
+  display: "flex",
+  gap: theme.spacing(1),
+  alignItems: "center",
+  flexWrap: "wrap",
 }));
 
 const StyledActionButtonsContainer = styled("div")(() => ({
@@ -226,6 +228,20 @@ export default function EventPage({
     useState(false);
   const [inviteCommunityDialogIsOpen, setInviteCommunityDialogIsOpen] =
     useState(false);
+  const [ellipsisMenuAnchorEl, setEllipsisMenuAnchorEl] =
+    useState<Element | null>(null);
+  const [showCopyLinkSuccess, setShowCopyLinkSuccess] = useState(false);
+  const isEllipsisMenuOpen = Boolean(ellipsisMenuAnchorEl);
+
+  const handleEllipsisMenuOpen = (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) => {
+    setEllipsisMenuAnchorEl(event.currentTarget);
+  };
+
+  const handleEllipsisMenuClose = () => {
+    setEllipsisMenuAnchorEl(null);
+  };
 
   const isPastEvent = event?.endTime
     ? dayjs().isAfter(timestamp2Date(event.endTime))
@@ -251,6 +267,49 @@ export default function EventPage({
     }
   }, [event, eventSlug, router]);
 
+  const ellipsisMenuItems: EllipsisMenuItem[] = [
+    {
+      icon: LinkOutlined,
+      label: t("communities:copy_link"),
+      onClick: () => {
+        void navigator.clipboard.writeText(window.location.href);
+        setShowCopyLinkSuccess(true);
+      },
+      id: "copy-link",
+    },
+    ...(event?.canEdit && !event.isCancelled && !isPastEvent
+      ? ([
+          {
+            icon: EditOutlined,
+            label: t("communities:edit_event"),
+            onClick: () =>
+              router.push(routeToEditEvent(event!.eventId, event!.slug)),
+            id: "edit-event",
+          },
+        ] as EllipsisMenuItem[])
+      : []),
+    ...(isCreator && !event?.isCancelled
+      ? ([
+          {
+            icon: ContentCopyOutlined,
+            label: t("communities:duplicate_event"),
+            onClick: () => router.push(routeToDuplicateEvent(event!.eventId)),
+            id: "duplicate-event",
+          },
+        ] as EllipsisMenuItem[])
+      : []),
+    ...(event?.canEdit && !event.isCancelled && !isPastEvent
+      ? ([
+          {
+            icon: CancelOutlined,
+            label: t("communities:cancel_event"),
+            onClick: () => setCancelDialogIsOpen(true),
+            id: "cancel-event",
+          },
+        ] as EllipsisMenuItem[])
+      : []),
+  ];
+
   if (!isValidEventId) {
     return <NotFoundPage />;
   }
@@ -266,6 +325,11 @@ export default function EventPage({
       {showInviteCommunitySuccess && (
         <Snackbar severity="success">
           {t("communities:invite_community_dialog.toast_success")}
+        </Snackbar>
+      )}
+      {showCopyLinkSuccess && (
+        <Snackbar severity="success">
+          {t("communities:copy_link_success")}
         </Snackbar>
       )}
       {isLoading ? (
@@ -310,58 +374,18 @@ export default function EventPage({
                 )}
               </StyledTitle>
               <StyledActionButtonsContainer>
-                {(event.canEdit || isCreator) && (
-                  <StyledIconButtonGroup>
-                    {event.canEdit && (
-                      <Tooltip
-                        title={
-                          event.isCancelled || isPastEvent
-                            ? ""
-                            : t("communities:edit_event")
-                        }
-                      >
-                        <span>
-                          <StyledIconButton
-                            onClick={() =>
-                              router.push(
-                                routeToEditEvent(event.eventId, event.slug),
-                              )
-                            }
-                            disabled={event.isCancelled || isPastEvent}
-                            aria-label={t("communities:edit_event")}
-                            tabIndex={event.isCancelled || isPastEvent ? -1 : 0}
-                          >
-                            <EditOutlined />
-                          </StyledIconButton>
-                        </span>
-                      </Tooltip>
-                    )}
-                    {isCreator && (
-                      <Tooltip
-                        title={
-                          event.isCancelled
-                            ? ""
-                            : t("communities:duplicate_event")
-                        }
-                      >
-                        <span>
-                          <StyledIconButton
-                            onClick={() =>
-                              router.push(routeToDuplicateEvent(event.eventId))
-                            }
-                            disabled={event.isCancelled}
-                            aria-label={t("communities:duplicate_event")}
-                            tabIndex={event.isCancelled ? -1 : 0}
-                          >
-                            <ContentCopyOutlined />
-                          </StyledIconButton>
-                        </span>
-                      </Tooltip>
-                    )}
-                  </StyledIconButtonGroup>
-                )}
-                {event.canEdit && (
-                  <>
+                <StyledIconButtonGroup>
+                  <EllipsisMenu
+                    idName="event-page"
+                    isMenuOpen={isEllipsisMenuOpen}
+                    menuAnchorEl={ellipsisMenuAnchorEl}
+                    onMenuOpen={handleEllipsisMenuOpen}
+                    onMenuClose={handleEllipsisMenuClose}
+                    items={ellipsisMenuItems}
+                  />
+                </StyledIconButtonGroup>
+                <StyledInviteAndAttendanceRow>
+                  {event.canEdit && (
                     <Button
                       onClick={() => setInviteCommunityDialogIsOpen(true)}
                       variant="contained"
@@ -378,25 +402,25 @@ export default function EventPage({
                     >
                       {t("communities:invite_community_dialog_buttons.open")}
                     </Button>
+                  )}
+                  <AttendanceMenu
+                    loading={isSetEventAttendanceLoading}
+                    onChangeAttendanceState={(attendanceState) =>
+                      setEventAttendance(attendanceState)
+                    }
+                    attendanceState={event.attendanceState}
+                    id="event-page-attendance"
+                    disabled={event.isCancelled || isPastEvent}
+                  />
+                </StyledInviteAndAttendanceRow>
+                {event.canEdit && (
+                  <>
                     <InviteCommunityDialog
                       afterSuccess={() => setShowInviteCommunitySuccess(true)}
                       open={inviteCommunityDialogIsOpen}
                       onClose={() => setInviteCommunityDialogIsOpen(false)}
                       eventId={eventId}
                     />
-                    <Button
-                      onClick={() => setCancelDialogIsOpen(true)}
-                      variant="outlined"
-                      disabled={event.isCancelled || isPastEvent}
-                      aria-label={t("communities:cancel_event")}
-                      sx={{
-                        [theme.breakpoints.down("md")]: {
-                          ...ActionButtonSx,
-                        },
-                      }}
-                    >
-                      {t("communities:cancel_event")}
-                    </Button>
                     <CancelEventDialog
                       open={cancelDialogIsOpen}
                       onClose={() => setCancelDialogIsOpen(false)}
@@ -404,16 +428,6 @@ export default function EventPage({
                     />
                   </>
                 )}
-
-                <AttendanceMenu
-                  loading={isSetEventAttendanceLoading}
-                  onChangeAttendanceState={(attendanceState) =>
-                    setEventAttendance(attendanceState)
-                  }
-                  attendanceState={event.attendanceState}
-                  id="event-page-attendance"
-                  disabled={event.isCancelled || isPastEvent}
-                />
               </StyledActionButtonsContainer>
 
               <StyledEventTimeContainer>

--- a/app/web/features/communities/locales/en.json
+++ b/app/web/features/communities/locales/en.json
@@ -36,6 +36,8 @@
   "discussions_empty_state": "No discussions at the moment.",
   "discussions_label": "Discussions",
   "discussions_title": "Discussions",
+  "copy_link": "Copy link",
+  "copy_link_success": "Link copied to clipboard",
   "duplicate_event": "Duplicate event",
   "edit_event": "Edit event",
   "edit_info_page_title": "Edit local info",


### PR DESCRIPTION
- Adds our usual EllipsisMenu to the EventPage 
- Add "copy link" as an item
- Move "Duplicate event", "cancel event" and "edit event" in there too
- Add back button to EditEventPage
- Swapped order of buttons in "Cancel event dialog" and made the "no" outlined to match other places

<img width="1246" height="594" alt="Screenshot 2026-05-10 at 11 56 06" src="https://github.com/user-attachments/assets/ff655793-bc6e-419d-8128-92dd657b46ab" />


<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

Part of #8367 

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*
- Click the items and make sure they work

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->
**Web frontend checklist**
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, you can merge it if you have write access.
--->
