### PR TITLE
Fix profile photo gallery hover jump

### DIFF
--- a/app/web/features/profile/view/ProfilePhotoGallery.tsx
+++ b/app/web/features/profile/view/ProfilePhotoGallery.tsx
@@ -35,11 +35,10 @@ const StyledImageListItem = styled(ImageListItem)(({ theme }) => ({
   cursor: "pointer",
   overflow: "hidden",
   borderRadius: theme.shape.borderRadius,
-  transition: "box-shadow 0.2s ease, transform 0.2s ease",
+  transition: "box-shadow 0.2s ease",
   border: `1px solid var(--mui-palette-grey-300)`,
   "&:hover": {
     boxShadow: theme.shadows[4],
-    transform: "scale(1.02)",
   },
   "& img": {
     width: "100%",


### PR DESCRIPTION
The profile photo gallery items had a `transform: scale(1.02)` on hover, which made the hovered image visibly jump and clip into the grid gaps. Removed the scale transform — the box-shadow on hover is enough of a hover affordance.

## Testing
- Open a user profile that has a photo gallery and hover over thumbnails: the image no longer jumps/scales, just gains a soft shadow.
- Verified at desktop, tablet, and mobile breakpoints.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._