### PR TITLE
Add last_updated field to PhotoGallery

### DIFF
--- a/app/backend/src/couchers/migrations/versions/0150_add_last_updated_field_to_photogallery.py
+++ b/app/backend/src/couchers/migrations/versions/0150_add_last_updated_field_to_photogallery.py
@@ -1,0 +1,27 @@
+"""Add last_updated field to PhotoGallery
+
+Revision ID: 0150
+Revises: 0149
+Create Date: 2026-05-11 04:29:37.805098
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0150"
+down_revision = "0149"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "photo_galleries",
+        sa.Column("last_updated", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("photo_galleries", "last_updated")

--- a/app/backend/src/couchers/models/uploads.py
+++ b/app/backend/src/couchers/models/uploads.py
@@ -80,6 +80,7 @@ class PhotoGallery(Base, kw_only=True):
     owner_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
 
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
+    last_updated: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
 
     owner_user: Mapped[User] = relationship(init=False, foreign_keys=[owner_user_id], back_populates="galleries")
     photos: Mapped[list[PhotoGalleryItem]] = relationship(

--- a/app/backend/src/couchers/servicers/galleries.py
+++ b/app/backend/src/couchers/servicers/galleries.py
@@ -96,6 +96,7 @@ class Galleries(galleries_pb2_grpc.GalleriesServicer):
             caption=request.caption or None,
         )
         session.add(item)
+        gallery.last_updated = func.now()
         session.flush()
         session.refresh(gallery)
 
@@ -124,6 +125,7 @@ class Galleries(galleries_pb2_grpc.GalleriesServicer):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "gallery_item_not_found")
 
         session.delete(item)
+        gallery.last_updated = func.now()
         session.flush()
         session.refresh(gallery)
 
@@ -184,6 +186,7 @@ class Galleries(galleries_pb2_grpc.GalleriesServicer):
             session.execute(
                 update(PhotoGalleryItem).where(PhotoGalleryItem.id == request.item_id).values(position=new_position)
             )
+            gallery.last_updated = func.now()
 
         session.flush()
         session.refresh(gallery)
@@ -213,6 +216,7 @@ class Galleries(galleries_pb2_grpc.GalleriesServicer):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "gallery_item_not_found")
 
         item.caption = request.caption or None
+        gallery.last_updated = func.now()
         session.flush()
         session.refresh(gallery)
 


### PR DESCRIPTION
Adds a `last_updated` timestamp to `PhotoGallery` that is bumped whenever a gallery is mutated (photo added, removed, moved, or caption changed). Currently `User.profile_last_updated` is only updated via `UpdateProfile`, so changes to a user's profile photo gallery are not reflected anywhere; this gives gallery freshness its own timestamp on the gallery itself.

## Testing
- Existing gallery test suite (`src/tests/test_galleries.py`, 42 tests) still passes.
- No new tests added for `last_updated` behavior yet — could add coverage that each mutation advances the timestamp and the no-op move does not.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._