### PR TITLE
Fix push and cookie banner covering stuff

### DIFF
--- a/app/web/components/AppRoute.test.tsx
+++ b/app/web/components/AppRoute.test.tsx
@@ -3,14 +3,26 @@ import useAuthStore from "features/auth/useAuthStore";
 import React from "react";
 import wrapper from "test/hookWrapper";
 
-import Navigation from "./Navigation";
+import { appGetLayout } from "./AppRoute";
 
 jest.mock("features/auth/useAuthStore");
+jest.mock("components/Navigation", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("components/Footer", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("components/CookieBanner", () => ({
+  __esModule: true,
+  default: () => null,
+}));
 
-jest.mock("features/donations/DonationBanner", () => ({
-  DonationBanner: () => (
-    <div role="status" aria-label="Donation banner">
-      Donation banner
+jest.mock("features/notifications/PushNotificationBanner", () => ({
+  PushNotificationBanner: () => (
+    <div role="status" aria-label="Push notification banner">
+      Push notification banner
     </div>
   ),
 }));
@@ -19,12 +31,12 @@ const mockUseAuthStore = useAuthStore as jest.MockedFunction<
   typeof useAuthStore
 >;
 
-describe("Navigation", () => {
+describe("AppRoute", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("renders the donation banner when the user is authenticated", async () => {
+  it("renders the push notification banner when the user is authenticated", async () => {
     mockUseAuthStore.mockReturnValue({
       authState: {
         authenticated: true,
@@ -45,15 +57,16 @@ describe("Navigation", () => {
       },
     });
 
-    render(<Navigation />, { wrapper });
+    render(appGetLayout({ isPrivate: false })(<div>content</div>), { wrapper });
 
-    // Wait for component to mount and banners to appear
     await waitFor(() => {
-      expect(screen.getByLabelText("Donation banner")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Push notification banner"),
+      ).toBeInTheDocument();
     });
   });
 
-  it("does not render the donation banner when the user is not authenticated", () => {
+  it("does not render the push notification banner when the user is not authenticated", () => {
     mockUseAuthStore.mockReturnValue({
       authState: {
         authenticated: false,
@@ -74,8 +87,10 @@ describe("Navigation", () => {
       },
     });
 
-    render(<Navigation />, { wrapper });
+    render(appGetLayout({ isPrivate: false })(<div>content</div>), { wrapper });
 
-    expect(screen.queryByLabelText("Donation banner")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Push notification banner"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/app/web/components/AppRoute.tsx
+++ b/app/web/components/AppRoute.tsx
@@ -5,8 +5,9 @@ import CookieBanner from "components/CookieBanner";
 import ErrorBoundary from "components/ErrorBoundary";
 import Footer from "components/Footer";
 import { useAuthContext } from "features/auth/AuthProvider";
+import { PushNotificationBanner } from "features/notifications/PushNotificationBanner";
 import { useRouter } from "next/router";
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { jailRoute, loginRoute } from "routes";
 import { theme } from "theme";
 import { useIsNativeEmbed } from "utils/nativeLink";
@@ -61,12 +62,14 @@ const PageWrapper = styled(Box, {
     display: "flex",
     flexDirection: "column",
     flex: 1,
+    paddingBottom: "var(--cookie-banner-height, 0px)",
     ...(isNoOverflow && {
       overflow: "hidden",
       minHeight: 0,
     }),
     ...(hasBottomNav && {
-      paddingBottom: "calc(56px + env(safe-area-inset-bottom, 0px))",
+      paddingBottom:
+        "calc(56px + env(safe-area-inset-bottom, 0px) + var(--cookie-banner-height, 0px))",
     }),
   }),
 );
@@ -106,6 +109,24 @@ function AppRoute({
   const isJailed = authState.jailed;
   const isNativeEmbed = useIsNativeEmbed();
 
+  const headerRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    const updateNavHeight = () => {
+      if (headerRef.current) {
+        document.documentElement.style.setProperty(
+          "--nav-height",
+          `${headerRef.current.offsetHeight}px`,
+        );
+      }
+    };
+    updateNavHeight();
+    const resizeObserver = new ResizeObserver(updateNavHeight);
+    if (headerRef.current) {
+      resizeObserver.observe(headerRef.current);
+    }
+    return () => resizeObserver.disconnect();
+  }, [isAuthenticated, isNativeEmbed]);
+
   //there must be the same loading state on auth'd pages on server and client
   //for hydration matching, so we will display a loader until mounted.
   const [isMounted, setIsMounted] = useState(false);
@@ -128,7 +149,11 @@ function AppRoute({
       ) : (
         <>
           {variant === "no-overflow" ? globalStylesNoOverflow : globalStyles}
-          <Navigation />
+          <div ref={headerRef}>
+            <Navigation />
+            {!isNativeEmbed && isAuthenticated && <PushNotificationBanner />}
+          </div>
+          <CookieBanner />
           {/* Temporary container injected for marketing to test dynamic "announcements".
            * Find a better spot to componentise this code once plan is more finalised with this */}
           <div id="announcements"></div>
@@ -159,7 +184,6 @@ function AppRoute({
           </PageWrapper>
         </>
       )}
-      {!isPrivate && <CookieBanner />}
     </ErrorBoundary>
   );
 }

--- a/app/web/components/CookieBanner.tsx
+++ b/app/web/components/CookieBanner.tsx
@@ -2,20 +2,20 @@ import { styled, Typography } from "@mui/material";
 import IconButton from "components/IconButton";
 import { CloseIcon } from "components/Icons";
 import StyledLink from "components/StyledLink";
-import { useAuthContext } from "features/auth/AuthProvider";
 import { Trans, useTranslation } from "i18n";
 import { usePersistedState } from "platform/usePersistedState";
+import { useEffect, useRef } from "react";
 import { tosRoute } from "routes";
 import { useIsMounted } from "utils/hooks";
 import { useIsNativeEmbed } from "utils/nativeLink";
 
 const StyledWrapper = styled("div")(({ theme }) => ({
   position: "fixed",
-  zIndex: theme.zIndex.snackbar,
-  left: theme.spacing(0),
-  right: theme.spacing(0),
-  backgroundColor: "var(--mui-palette-background-paper)",
   bottom: 0,
+  left: 0,
+  right: 0,
+  zIndex: theme.zIndex.snackbar,
+  backgroundColor: "var(--mui-palette-background-paper)",
   padding: theme.spacing(2, 4),
   boxShadow: theme.shadows[4],
 
@@ -28,8 +28,7 @@ const StyledWrapper = styled("div")(({ theme }) => ({
 
 const StyledCloseButton = styled(IconButton)(({ theme }) => ({
   position: "absolute",
-  top: theme.spacing(4),
-  transform: "translateY(-50%)",
+  top: theme.spacing(1),
   right: theme.spacing(1),
 }));
 
@@ -38,18 +37,33 @@ export default function CookieBanner() {
   // since we are using localStorage, make sure don't render unless mounted
   // or there will be hydration mismatches
   const isMounted = useIsMounted().current;
-  const auth = useAuthContext();
   const [hasSeen, setHasSeen] = usePersistedState("hasSeenCookieBanner", false);
   const isNativeEmbed = useIsNativeEmbed();
+  const bannerRef = useRef<HTMLDivElement>(null);
 
-  // Don't show cookie banner in native mobile app
-  // Mobile apps use app store privacy mechanisms, not cookie banners
-  // Only essential cookies are used (session/auth), which don't require consent
-  if (auth.authState.authenticated || isNativeEmbed) return null;
+  useEffect(() => {
+    const el = bannerRef.current;
+    if (!el) return;
+    const updateHeight = () => {
+      document.documentElement.style.setProperty(
+        "--cookie-banner-height",
+        `${el.offsetHeight}px`,
+      );
+    };
+    updateHeight();
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      document.documentElement.style.removeProperty("--cookie-banner-height");
+    };
+  }, [hasSeen, isMounted]);
+
+  if (isNativeEmbed) return null;
 
   //specifically not using our snackbar, which is designed for alerts
   return isMounted && !hasSeen ? (
-    <StyledWrapper aria-live="polite">
+    <StyledWrapper ref={bannerRef} aria-live="polite">
       <StyledCloseButton
         aria-label={t("close")}
         onClick={() => setHasSeen(true)}

--- a/app/web/components/Navigation/BottomNavigation.tsx
+++ b/app/web/components/Navigation/BottomNavigation.tsx
@@ -23,9 +23,9 @@ import {
   searchRoute,
 } from "routes";
 
-const StyledPaper = styled(Paper)(({ theme }) => ({
+const StyledPaper = styled(Paper)(() => ({
   position: "fixed",
-  bottom: 0,
+  bottom: "var(--cookie-banner-height, 0px)",
   left: 0,
   right: 0,
   zIndex: 1100,

--- a/app/web/components/Navigation/Navigation.tsx
+++ b/app/web/components/Navigation/Navigation.tsx
@@ -16,14 +16,13 @@ import { CloseIcon, MenuIcon } from "components/Icons";
 import ExternalNavButton from "components/Navigation/ExternalNavButton";
 import { useAuthContext } from "features/auth/AuthProvider";
 import { DonationBanner } from "features/donations/DonationBanner";
-import { PushNotificationBanner } from "features/notifications/PushNotificationBanner";
 import LanguagePickerSelect from "features/translate/LanguagePickerSelect";
 import useNotifications from "features/useNotifications";
 import { GLOBAL } from "i18n/namespaces";
 import { TFunction } from "i18next";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
-import React, { useLayoutEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import CouchersLogo from "resources/CouchersLogo";
 import {
   blogRoute,
@@ -279,41 +278,16 @@ export default function Navigation() {
 
   const [open, setOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
 
   const { data: pingData } = useNotifications();
   const { authState } = useAuthContext();
-
+  const isAuthenticated = isMounted && authState.authenticated;
   const isNativeEmbed = useIsNativeEmbed();
 
   const { t } = useTranslation(GLOBAL);
 
-  const navRef = useRef<HTMLDivElement>(null);
-
-  // Update CSS custom property with actual Navigation height
-  // useLayoutEffect runs synchronously before browser paint to prevent flickering
-  useLayoutEffect(() => {
-    const updateNavHeight = () => {
-      if (navRef.current) {
-        const height = navRef.current.offsetHeight;
-        document.documentElement.style.setProperty(
-          "--nav-height",
-          `${height}px`,
-        );
-      }
-    };
-
-    updateNavHeight();
-
-    // Use ResizeObserver to update when banners appear/disappear
-    const resizeObserver = new ResizeObserver(updateNavHeight);
-    if (navRef.current) {
-      resizeObserver.observe(navRef.current);
-    }
-
-    return () => {
-      resizeObserver.disconnect();
-    };
-  }, [authState.authenticated, isNativeEmbed]);
+  useEffect(() => setIsMounted(true), []);
 
   const handleDrawerOpen = () => {
     setOpen(true);
@@ -326,7 +300,7 @@ export default function Navigation() {
   const drawerItems = (
     <div>
       <List>
-        {(authState.authenticated ? loggedInDrawerMenu : loggedOutDrawerMenu)(
+        {(isAuthenticated ? loggedInDrawerMenu : loggedOutDrawerMenu)(
           t,
           pingData,
         ).map(({ name, route, notificationCount, externalLink }) => (
@@ -364,10 +338,10 @@ export default function Navigation() {
   );
 
   return (
-    <StyledAppBar position="sticky" color="inherit" ref={navRef}>
+    <StyledAppBar position="sticky" color="inherit">
       <StyledToolbar>
         <StyledNav sx={{ marginLeft: 2 }}>
-          {isMobile && !authState.authenticated && (
+          {isMobile && !isAuthenticated && (
             <>
               <IconButton
                 aria-label="open drawer"
@@ -406,12 +380,12 @@ export default function Navigation() {
             </>
           )}
           <Box sx={{ display: "inline-flex", alignItems: "center" }}>
-            <CouchersLogo isLoggedIn={authState.authenticated} />
+            <CouchersLogo isLoggedIn={isAuthenticated} />
           </Box>
 
           {!isMobile && (
             <StyledFlexbox>
-              {(authState.authenticated ? loggedInNavMenu : loggedOutNavMenu)(
+              {(isAuthenticated ? loggedInNavMenu : loggedOutNavMenu)(
                 t,
                 pingData,
               ).map(({ name, route, notificationCount, externalLink }) =>
@@ -439,7 +413,7 @@ export default function Navigation() {
             {isNativeEmbed && <ReportButton />}
             <DarkModeToggle />
           </Box>
-          {authState.authenticated ? (
+          {isAuthenticated ? (
             <>
               <LoggedInMenu
                 menuOpen={menuOpen}
@@ -488,12 +462,9 @@ export default function Navigation() {
         </StyledMenuContainer>
       </StyledToolbar>
       <GlobalMessage />
-      {!isNativeEmbed && authState.authenticated && <DonationBanner />}
-      {!isNativeEmbed && authState.authenticated && <PushNotificationBanner />}
+      {!isNativeEmbed && isAuthenticated && <DonationBanner />}
       {/* Bottom navigation for mobile browsers only (not native app) when logged in */}
-      {isMobile && !isNativeEmbed && authState.authenticated && (
-        <BottomNavigation />
-      )}
+      {isMobile && !isNativeEmbed && isAuthenticated && <BottomNavigation />}
     </StyledAppBar>
   );
 }

--- a/app/web/features/landing/LandingPage.tsx
+++ b/app/web/features/landing/LandingPage.tsx
@@ -70,7 +70,7 @@ export default function LandingPage() {
         <Box
           sx={{
             position: "fixed",
-            bottom: 0,
+            bottom: "var(--cookie-banner-height, 0px)",
             left: 0,
             right: 0,
             backgroundColor: "var(--mui-palette-background-paper)",

--- a/app/web/features/search/SearchControls.tsx
+++ b/app/web/features/search/SearchControls.tsx
@@ -36,9 +36,9 @@ const MapControlsWrapper = styled("div", {
 
     ...(!isMobile && {
       position: "absolute",
-      top: theme.spacing(8),
+      top: theme.spacing(1),
       zIndex: 2,
-      right: 0, // Ensure it stays within bounds
+      right: 0,
     }),
 
     ...(!isMobile &&

--- a/app/web/features/search/SearchPage.tsx
+++ b/app/web/features/search/SearchPage.tsx
@@ -51,6 +51,7 @@ const SearchPageContainer = styled("div")(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
   height: "100%",
+  position: "relative",
 
   [theme.breakpoints.down("md")]: {
     display: "grid",


### PR DESCRIPTION
Fixes CookieBanner and PushNotificationBanner so they don't block key stuff in the app.

<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->
Closes #8477, Closes #8489 

## Testing
- Go in the browser console Application screen, go in localStorage and clear it and also clear cookies
- Refresh the page, go to landing page and cookie banner should be there
- Go into mobile view, cookie banner should not block the "Join us" bar at bottom
- Log in, leave both banners up
- Go to search, the push notification banner should not block the search bar
- Close the banners, it should work and go back to normal screen
- 
<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, you can merge it if you have write access.
--->
