### PR TITLE
Backend/i18n: Support localized datetime formats

### DIFF
--- a/app/backend/src/couchers/i18n/context.py
+++ b/app/backend/src/couchers/i18n/context.py
@@ -46,8 +46,8 @@ class LocalizationContext:
         self.babel_locale = get_babel_locale(self.locale_list)
 
     def __setattr__(self, name: str, value: Any) -> None:
-        # Freeze after initialization. We can't use @dataclass(frozen=True) because some
-        # of our attributes are derived from others, so we can't use the default initializer.
+        # Freeze after initialization. We can't use @dataclass(frozen=True) because then
+        # we need the default initializer and some of our fields shouldn't be parameters.
         if hasattr(self, "babel_locale"):
             raise FrozenInstanceError(f"Cannot modify attribute {name}.")
         return object.__setattr__(self, name, value)

--- a/app/backend/src/couchers/i18n/context.py
+++ b/app/backend/src/couchers/i18n/context.py
@@ -1,4 +1,4 @@
-from dataclasses import FrozenInstanceError, dataclass
+from dataclasses import FrozenInstanceError
 from datetime import UTC, date, datetime, time, tzinfo
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -20,7 +20,6 @@ from couchers.models.users import User
 from couchers.utils import to_timezone
 
 
-@dataclass(init=False, slots=True)
 class LocalizationContext:
     """
     Specifies regional settings used for localization of strings and date/times.

--- a/app/backend/src/couchers/i18n/context.py
+++ b/app/backend/src/couchers/i18n/context.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass
+from dataclasses import FrozenInstanceError, dataclass
 from datetime import UTC, date, datetime, time, tzinfo
+from typing import Any
 from zoneinfo import ZoneInfo
 
 import babel
@@ -16,10 +17,10 @@ from couchers.i18n.localize import (
     localize_timezone,
 )
 from couchers.models.users import User
-from couchers.utils import to_aware_datetime
+from couchers.utils import to_timezone
 
 
-@dataclass(init=False)
+@dataclass(init=False, slots=True)
 class LocalizationContext:
     """
     Specifies regional settings used for localization of strings and date/times.
@@ -45,6 +46,13 @@ class LocalizationContext:
         self.timezone = timezone
         self.babel_locale = get_babel_locale(self.locale_list)
 
+    def __setattr__(self, name: str, value: Any) -> None:
+        # Freeze after initialization. We can't use @dataclass(frozen=True) because some
+        # of our attributes are derived from others, so we can't use the default initializer.
+        if hasattr(self, "babel_locale"):
+            raise FrozenInstanceError(f"Cannot modify attribute {name}.")
+        return setattr(self, name, value)
+
     @property
     def localized_timezone(self) -> str:
         return localize_timezone(self.timezone, self.babel_locale)
@@ -59,7 +67,7 @@ class LocalizationContext:
         self, value: date | datetime, *, abbrev: bool = False, with_year: bool = True, with_day_of_week: bool = False
     ) -> str:
         if isinstance(value, datetime):
-            value = value.astimezone(self.timezone).date()
+            value = to_timezone(value, self.timezone).date()
         return localize_date(
             value, self.babel_locale, abbrev=abbrev, with_year=with_year, with_day_of_week=with_day_of_week
         )
@@ -83,13 +91,8 @@ class LocalizationContext:
         with_day_of_week: bool = False,
         with_seconds: bool = False,
     ) -> str:
-        if isinstance(value, Timestamp):
-            value = to_aware_datetime(value)
-        else:
-            value = value.astimezone(self.timezone)
-
         return localize_datetime(
-            value,
+            to_timezone(value, self.timezone),
             self.babel_locale,
             abbrev=abbrev,
             with_year=with_year,
@@ -99,7 +102,7 @@ class LocalizationContext:
 
     def localize_time(self, value: datetime | time, *, with_seconds: bool = False) -> str:
         if isinstance(value, datetime):
-            value = value.astimezone(self.timezone).time()
+            value = to_timezone(value, self.timezone).time()
         return localize_time(value, self.babel_locale, with_seconds=with_seconds)
 
     @staticmethod

--- a/app/backend/src/couchers/i18n/context.py
+++ b/app/backend/src/couchers/i18n/context.py
@@ -50,7 +50,7 @@ class LocalizationContext:
         # of our attributes are derived from others, so we can't use the default initializer.
         if hasattr(self, "babel_locale"):
             raise FrozenInstanceError(f"Cannot modify attribute {name}.")
-        return setattr(self, name, value)
+        return object.__setattr__(self, name, value)
 
     @property
     def localized_timezone(self) -> str:

--- a/app/backend/src/couchers/i18n/context.py
+++ b/app/backend/src/couchers/i18n/context.py
@@ -8,6 +8,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from couchers.i18n.i18next import I18Next
 from couchers.i18n.locales import DEFAULT_LOCALE, get_locale_fallbacks
 from couchers.i18n.localize import (
+    get_babel_locale,
     get_main_i18next,
     localize_date,
     localize_datetime,
@@ -42,16 +43,7 @@ class LocalizationContext:
         self.locale = locale
         self.locale_list = [self.locale] + get_locale_fallbacks(self.locale)
         self.timezone = timezone
-        self.babel_locale = LocalizationContext._get_babel_locale(self.locale_list)
-
-    @staticmethod
-    def _get_babel_locale(locale_list: list[str]) -> babel.Locale:
-        for locale in locale_list:
-            try:
-                return babel.Locale.parse(locale)
-            except babel.UnknownLocaleError:
-                continue
-        return babel.Locale.parse(locale_list[0])  # Will raise babel.UnknownLocaleError
+        self.babel_locale = get_babel_locale(self.locale_list)
 
     @property
     def localized_timezone(self) -> str:

--- a/app/backend/src/couchers/i18n/context.py
+++ b/app/backend/src/couchers/i18n/context.py
@@ -2,22 +2,23 @@ from dataclasses import dataclass
 from datetime import UTC, date, datetime, time, tzinfo
 from zoneinfo import ZoneInfo
 
+import babel
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from couchers.i18n.i18next import I18Next
-from couchers.i18n.locales import DEFAULT_LOCALE
+from couchers.i18n.locales import DEFAULT_LOCALE, get_locale_fallbacks
 from couchers.i18n.localize import (
     get_main_i18next,
     localize_date,
-    localize_date_from_iso,
     localize_datetime,
     localize_time,
     localize_timezone,
 )
 from couchers.models.users import User
+from couchers.utils import to_aware_datetime
 
 
-@dataclass(frozen=True, slots=True, kw_only=True)
+@dataclass(init=False)
 class LocalizationContext:
     """
     Specifies regional settings used for localization of strings and date/times.
@@ -28,12 +29,33 @@ class LocalizationContext:
     # Note that a locale doesn't necessarily specify a region.
     locale: str
 
+    # The locale code and all of its fallbacks.
+    locale_list: list[str]
+
     # The timezone to use when formatting date-times and instants.
     timezone: tzinfo
 
+    # The Babel locale used for datetime formatting and other Unicode CLDR usage.
+    babel_locale: babel.Locale
+
+    def __init__(self, locale: str, timezone: tzinfo) -> None:
+        self.locale = locale
+        self.locale_list = [self.locale] + get_locale_fallbacks(self.locale)
+        self.timezone = timezone
+        self.babel_locale = LocalizationContext._get_babel_locale(self.locale_list)
+
+    @staticmethod
+    def _get_babel_locale(locale_list: list[str]) -> babel.Locale:
+        for locale in locale_list:
+            try:
+                return babel.Locale.parse(locale)
+            except babel.UnknownLocaleError:
+                continue
+        return babel.Locale.parse(locale_list[0])  # Will raise babel.UnknownLocaleError
+
     @property
     def localized_timezone(self) -> str:
-        return localize_timezone(self.timezone, self.locale)
+        return localize_timezone(self.timezone, self.babel_locale)
 
     def localize_string(
         self, key: str, *, i18next: I18Next | None = None, substitutions: dict[str, str | int] | None = None
@@ -41,21 +63,52 @@ class LocalizationContext:
         i18next = i18next or get_main_i18next()
         return i18next.localize(key, self.locale, substitutions=substitutions)
 
-    def localize_date(self, value: date | datetime) -> str:
+    def localize_date(
+        self, value: date | datetime, *, abbrev: bool = False, with_year: bool = True, with_day_of_week: bool = False
+    ) -> str:
         if isinstance(value, datetime):
             value = value.astimezone(self.timezone).date()
-        return localize_date(value, self.locale)
+        return localize_date(
+            value, self.babel_locale, abbrev=abbrev, with_year=with_year, with_day_of_week=with_day_of_week
+        )
 
-    def localize_date_from_iso(self, value: str) -> str:
-        return localize_date_from_iso(value, self.locale)
+    def localize_date_from_iso(
+        self, value: str, *, abbrev: bool = False, with_year: bool = True, with_day_of_week: bool = False
+    ) -> str:
+        return self.localize_date(
+            date.fromisoformat(value),
+            abbrev=abbrev,
+            with_year=with_year,
+            with_day_of_week=with_day_of_week,
+        )
 
-    def localize_datetime(self, value: datetime | Timestamp) -> str:
-        return localize_datetime(value, self.timezone, self.locale)
+    def localize_datetime(
+        self,
+        value: datetime | Timestamp,
+        *,
+        abbrev: bool = False,
+        with_year: bool = True,
+        with_day_of_week: bool = False,
+        with_seconds: bool = False,
+    ) -> str:
+        if isinstance(value, Timestamp):
+            value = to_aware_datetime(value)
+        else:
+            value = value.astimezone(self.timezone)
 
-    def localize_time(self, value: datetime | time) -> str:
+        return localize_datetime(
+            value,
+            self.babel_locale,
+            abbrev=abbrev,
+            with_year=with_year,
+            with_day_of_week=with_day_of_week,
+            with_seconds=with_seconds,
+        )
+
+    def localize_time(self, value: datetime | time, *, with_seconds: bool = False) -> str:
         if isinstance(value, datetime):
             value = value.astimezone(self.timezone).time()
-        return localize_time(value, self.locale)
+        return localize_time(value, self.babel_locale, with_seconds=with_seconds)
 
     @staticmethod
     def en_utc() -> LocalizationContext:

--- a/app/backend/src/couchers/i18n/localize.py
+++ b/app/backend/src/couchers/i18n/localize.py
@@ -24,6 +24,16 @@ def get_main_i18next() -> I18Next:
     return load_locales(Path(__file__).parent / "locales")
 
 
+def get_babel_locale(locale_list: list[str]) -> babel.Locale:
+    """Resolves a babel.Locale object from a list of locale candidates."""
+    for locale in locale_list:
+        try:
+            return babel.Locale.parse(locale)
+        except babel.UnknownLocaleError:
+            continue
+    raise LookupError(f"No babel locale found for locales {', '.join(locale_list)}")
+
+
 def localize_string(lang: str | None, key: str, *, substitutions: Mapping[str, str | int] | None = None) -> str:
     """
     Retrieves a translated string and performs substitutions.

--- a/app/backend/src/couchers/i18n/localize.py
+++ b/app/backend/src/couchers/i18n/localize.py
@@ -3,18 +3,19 @@ Defines low-level localization functions for strings, dates, etc.
 Most code should use the higher-level couchers.i18n.LocalizationContext object.
 """
 
-from collections.abc import Callable, Mapping
+import re
+from collections.abc import Mapping
 from datetime import date, datetime, time, tzinfo
 from functools import lru_cache
 from pathlib import Path
+from typing import cast
 
+import babel
 import phonenumbers
-from babel.dates import format_date, format_datetime, format_time, get_timezone_name
-from google.protobuf.timestamp_pb2 import Timestamp
+from babel.dates import get_datetime_format, get_timezone_name, match_skeleton, parse_pattern
 
 from couchers.i18n.i18next import I18Next
-from couchers.i18n.locales import DEFAULT_LOCALE, get_locale_fallbacks, load_locales
-from couchers.utils import to_aware_datetime
+from couchers.i18n.locales import DEFAULT_LOCALE, load_locales
 
 
 @lru_cache(maxsize=1)
@@ -38,83 +39,108 @@ def localize_string(lang: str | None, key: str, *, substitutions: Mapping[str, s
     return get_main_i18next().localize(key, lang or DEFAULT_LOCALE, substitutions)
 
 
-def localize_date(value: date, locale: str) -> str:
+def localize_date(
+    value: date, locale: babel.Locale, *, abbrev: bool = False, with_year: bool = True, with_day_of_week: bool = False
+) -> str:
     """Formats a time- and timezone-agnostic date for the given locale."""
-    return _localize_with_fallbacks(
-        locale,
-        lambda candidate_locale: format_date(value, locale=candidate_locale),
-        lambda: value.strftime("%A %-d %B %Y"),
-    )
+    pattern = _get_cldr_date_pattern(locale, abbrev=abbrev, with_year=with_year, with_day_of_week=with_day_of_week)
+    return parse_pattern(pattern).apply(value, locale)
 
 
-def localize_date_from_iso(value: str, locale: str) -> str:
-    """Formats a date in ISO YYYY-MM-DD format for the given locale."""
-    return localize_date(date.fromisoformat(value), locale)
-
-
-def localize_time(value: time, locale: str) -> str:
+def localize_time(value: time, locale: babel.Locale, *, with_seconds: bool = False) -> str:
     """Formats a date- and timezone-agnostic time for the given locale."""
-    return _localize_with_fallbacks(
-        locale,
-        lambda candidate_locale: format_time(value, locale=candidate_locale),
-        lambda: value.strftime("%-I:%M %p (%H:%M)"),
-    )
+    pattern = _get_cldr_time_pattern(locale, with_seconds=with_seconds)
+    return parse_pattern(pattern).apply(value, locale)
 
 
-def localize_datetime(value: datetime | Timestamp, timezone: tzinfo | None, locale: str) -> str:
-    """
-    Formats a date and time for the given locale.
-
-    Args:
-        datetime: The datetime or timestamp to be formatted.
-        timezone: An optional timezone in which to interpret the date. If None, uses datetime's timezone.
-        locale: The locale for which to format the date.
-
-    Returns:
-        The localized date and time string.
-    """
-    if isinstance(value, Timestamp):
-        value = to_aware_datetime(value)
-
+def localize_datetime(
+    value: datetime,
+    locale: babel.Locale,
+    *,
+    abbrev: bool = False,
+    with_year: bool = True,
+    with_day_of_week: bool = False,
+    with_seconds: bool = False,
+) -> str:
+    """Formats a date and time for the given locale."""
     # A timezone-unaware datetime is almost certainly a bug, so we don't support it.
     assert value.tzinfo is not None, "Cannot localize a timezone-unaware datetime."
 
-    if timezone is not None:
-        value = value.astimezone(timezone)
-
-    return _localize_with_fallbacks(
+    pattern = _combine_cldr_date_time_patterns(
         locale,
-        lambda candidate_locale: format_datetime(value, locale=candidate_locale),
-        lambda: localize_date(value.date(), locale) + " " + localize_time(value.time(), locale),
+        _get_cldr_date_pattern(locale, abbrev=abbrev, with_year=with_year, with_day_of_week=with_day_of_week),
+        _get_cldr_time_pattern(locale, with_seconds=with_seconds),
     )
+    return parse_pattern(pattern).apply(value, locale)
 
 
-def localize_timezone(timezone: tzinfo, locale: str) -> str:
-    return _localize_with_fallbacks(
-        locale,
-        lambda candidate_locale: get_timezone_name(timezone, locale=candidate_locale),
-        lambda: datetime.now(tz=timezone).strftime("%Z/UTC%z"),
-    )
-
-
-def _localize_with_fallbacks(
-    locale: str, localize: Callable[[str], str], fallback: Callable[[], str] | None = None
+def _get_cldr_date_pattern(
+    locale: babel.Locale, *, abbrev: bool = False, with_year: bool = True, with_day_of_week: bool = False
 ) -> str:
-    """
-    Attempts to localize a value using fallback locales if the locale is unavailable, or a final unlocalized fallback.
-    """
-    exception: Exception | None
-    for candidate_locale in [locale] + get_locale_fallbacks(locale):
-        try:
-            return localize(candidate_locale.replace("-", "_"))  # Babel expects "en_US", not "en-US".
-        except Exception as e:
-            exception = e
-            pass
+    # First build a Unicode CLDR datetime pattern skeleton, which is locale and order-agnostic,
+    # and only indicates the components we're interested in formatting.
+    # This is similar to Intl.DateTimeFormat in Javascript.
+    # See https://cldr.unicode.org/translation/date-time/date-time-symbols.
+    requested_skeleton = ""
 
-    if fallback:
-        return fallback()
+    if with_year:
+        requested_skeleton += "y"
+    requested_skeleton += "MMM" if abbrev else "MMMM"
+    requested_skeleton += "d"
+    if with_day_of_week:
+        requested_skeleton += "EEE" if abbrev else "EEEE"
 
-    raise exception or Exception(f"Failed to localize to {locale}.")
+    # Next, match that skeleton to a similar locale-supported skeleton,
+    # which allows us to lower it to a datetime pattern (locale and order-specific).
+    matched_skeleton = match_skeleton(requested_skeleton, options=locale.datetime_skeletons)
+    if not matched_skeleton:
+        raise ValueError(f"Locale {locale.english_name} has no matching datetime skeleton for '{requested_skeleton}'")
+
+    pattern: str = locale.datetime_skeletons[matched_skeleton].pattern
+
+    # By CLDR rules, skeleton matching might return a pattern with abbreviations where
+    # we asked for non-abbreviated forms, in which case we can update the returned pattern.
+    if not abbrev:
+        # Abbreviated to non-abbreviated month (MMM = abbreviated)
+        pattern = re.sub(r"(?<!M)MMM(?!M)", "MMMM", pattern)
+        if with_day_of_week:
+            # Abbreviated to non-abbreviated day of week (E = EEE = abbreviated)
+            pattern = re.sub(r"(?<!E)E{1,3}(?!E)", "EEEE", pattern)
+
+    return pattern
+
+
+def _get_cldr_time_pattern(locale: babel.Locale, *, with_seconds: bool = False) -> str:
+    # Use a reference format pattern to figure out if it's using 24h clock
+    reference_time_pattern: str = locale.time_formats["medium"].pattern
+
+    # Remove literals like 'of'
+    reference_time_pattern = re.sub("'[^']*'", "", reference_time_pattern)
+
+    # Extract only the hours, minutes and am/pm patterns.
+    requested_skeleton = re.sub("[^hHkKma]+", "", reference_time_pattern)
+    if with_seconds:
+        requested_skeleton += "ss"
+
+    # Next, match that skeleton to a similar locale-supported skeleton,
+    # which allows us to lower it to a datetime pattern (locale and order-specific).
+    matched_skeleton = match_skeleton(requested_skeleton, options=locale.datetime_skeletons)
+    if not matched_skeleton:
+        raise ValueError(f"Locale {locale.english_name} has no matching datetime skeleton for '{requested_skeleton}'")
+
+    return cast(str, locale.datetime_skeletons[matched_skeleton].pattern)  # "pattern" is Any-typed
+
+
+def _combine_cldr_date_time_patterns(locale: babel.Locale, date_pattern: str, time_pattern: str) -> str:
+    # get_datetime_format's return value is statically mistyped
+    combining_format = cast(str, get_datetime_format(locale=locale))
+
+    # CLDR defines {0} to be the time and {1} to be the date
+    return combining_format.replace("{1}", date_pattern).replace("{0}", time_pattern)
+
+
+def localize_timezone(timezone: tzinfo, locale: babel.Locale, *, short: bool = False) -> str:
+    return get_timezone_name(timezone, width="short" if short else "long", locale=locale)
 
 
 def format_phone_number(value: str) -> str:

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -1,4 +1,3 @@
-import dataclasses
 import logging
 
 from google.protobuf import empty_pb2
@@ -45,7 +44,7 @@ def _send_email_notification(session: Session, user: User, notification: Notific
 
     loc_context = LocalizationContext.from_user(user)
     if not context.get_boolean_value("notification_translations_enabled", default=False):
-        loc_context = dataclasses.replace(loc_context, locale="en")
+        loc_context = LocalizationContext(locale="en", timezone=loc_context.timezone)
 
     rendered = render_email_notification(
         user,

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -6,6 +6,8 @@ import logging
 from datetime import date
 from typing import Any, assert_never
 
+from google.protobuf.timestamp_pb2 import Timestamp
+
 from couchers import urls
 from couchers.i18n import LocalizationContext
 from couchers.i18n.i18next import LocalizationError
@@ -358,7 +360,7 @@ def _render_event__create_any(
         substitutions={
             "title": data.event.title,
             "user": data.inviting_user.name,
-            "date_and_time": loc_context.localize_datetime(data.event.start_time),
+            "date_and_time": _format_event_start_datetime(data.event.start_time, loc_context),
         },
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
@@ -373,7 +375,7 @@ def _render_event__create_approved(
         substitutions={
             "title": data.event.title,
             "user": data.inviting_user.name,
-            "date_and_time": loc_context.localize_datetime(data.event.start_time),
+            "date_and_time": _format_event_start_datetime(data.event.start_time, loc_context),
         },
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
@@ -433,7 +435,7 @@ def _render_event__reminder(
         loc_context,
         substitutions={
             "title": data.event.title,
-            "date_and_time": loc_context.localize_datetime(data.event.start_time),
+            "date_and_time": _format_event_start_datetime(data.event.start_time, loc_context),
         },
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
@@ -515,7 +517,7 @@ def _render_host_request__create(
         loc_context,
         substitutions={
             "user": data.surfer.name,
-            "start_date": loc_context.localize_date_from_iso(data.host_request.from_date),
+            "start_date": _format_host_request_start_date(data.host_request.from_date, loc_context),
             "count": night_count,
         },
         icon_user=data.surfer,
@@ -568,7 +570,7 @@ def _render_host_request__accept(
         loc_context,
         substitutions={
             "user": data.host.name,
-            "date": loc_context.localize_date_from_iso(data.host_request.from_date),
+            "date": _format_host_request_start_date(data.host_request.from_date, loc_context),
         },
         icon_user=data.host,
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
@@ -583,7 +585,7 @@ def _render_host_request__reject(
         loc_context,
         substitutions={
             "user": data.host.name,
-            "date": loc_context.localize_date_from_iso(data.host_request.from_date),
+            "date": _format_host_request_start_date(data.host_request.from_date, loc_context),
         },
         icon_user=data.host,
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
@@ -598,7 +600,7 @@ def _render_host_request__cancel(
         loc_context,
         substitutions={
             "user": data.surfer.name,
-            "date": loc_context.localize_date_from_iso(data.host_request.from_date),
+            "date": _format_host_request_start_date(data.host_request.from_date, loc_context),
         },
         icon_user=data.surfer,
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
@@ -613,7 +615,7 @@ def _render_host_request__confirm(
         loc_context,
         substitutions={
             "user": data.surfer.name,
-            "date": loc_context.localize_date_from_iso(data.host_request.from_date),
+            "date": _format_host_request_start_date(data.host_request.from_date, loc_context),
         },
         icon_user=data.surfer,
         action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
@@ -854,3 +856,15 @@ def _render_verification__sv_fail(
         body=_get_string(NotificationTopicAction.verification__sv_fail, body_key, loc_context),
         action_url=urls.account_settings_link(),
     )
+
+
+def _format_host_request_start_date(date: str, loc_context: LocalizationContext) -> str:
+    # Events are typically in the near future future,
+    # so the year is not useful but the day of week is.
+    return loc_context.localize_date_from_iso(date, with_year=False, with_day_of_week=True)
+
+
+def _format_event_start_datetime(timestamp: Timestamp, loc_context: LocalizationContext) -> str:
+    # Events are typically in the near future future,
+    # so the year is not useful but the day of week is.
+    return loc_context.localize_datetime(timestamp, with_year=False, with_day_of_week=True)

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -2,7 +2,7 @@ import http.cookies
 import re
 import typing
 from collections.abc import Mapping, Sequence
-from datetime import UTC, date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta, tzinfo
 from email.utils import formatdate
 from typing import TYPE_CHECKING, Any, overload
 from zoneinfo import ZoneInfo
@@ -100,6 +100,18 @@ def to_aware_datetime(ts: Timestamp) -> datetime:
     Turns a protobuf Timestamp object into a timezone-aware datetime
     """
     return ts.ToDatetime(tzinfo=UTC)
+
+
+def to_timezone(value: Timestamp | datetime, timezone: tzinfo) -> datetime:
+    """Returns an instant in time as a datetime in a given timezone."""
+    if isinstance(value, Timestamp):
+        return value.ToDatetime(timezone)
+
+    if value.tzinfo is None:
+        # A naive datetime does not represent a point in time.
+        raise ValueError("Cannot convert a naive datetime to a timezone.")
+
+    return value.astimezone(timezone)
 
 
 def now() -> datetime:

--- a/app/backend/src/tests/test_localize.py
+++ b/app/backend/src/tests/test_localize.py
@@ -1,25 +1,36 @@
 from datetime import UTC, date, datetime, time
 from zoneinfo import ZoneInfo
 
+import babel
+
 from couchers.i18n.localize import localize_date, localize_datetime, localize_time, localize_timezone
+
+babel_en = babel.Locale.parse("en")
+babel_es = babel.Locale.parse("es")
+babel_fr = babel.Locale.parse("fr")
+babel_zh = babel.Locale.parse("zh")
 
 
 def test_localize_date() -> None:
-    assert localize_date(date(2000, 1, 2), "en-US") == "Jan 2, 2000"
-    assert localize_date(date(2000, 1, 2), "fr-FR") == "2 janv. 2000"
+    assert localize_date(date(2000, 1, 2), babel_en) == "January 2, 2000"
+    assert localize_date(date(2000, 1, 2), babel_es, abbrev=True) == "2 ene 2000"
+    assert localize_date(date(2000, 1, 2), babel_fr, with_day_of_week=True) == "dimanche 2 janvier 2000"
+    assert localize_date(date(2000, 1, 2), babel_zh, with_year=False) == "1月2日"
+    assert localize_date(date(2000, 1, 2), babel_en, with_year=False, with_day_of_week=True) == "Sunday, January 2"
 
 
 def test_localize_time() -> None:
-    assert localize_time(time(14, 5), "en-US") == "2:05:00 PM"
-    assert localize_time(time(14, 5), "fr-FR") == "14:05:00"
+    assert localize_time(time(14, 5), babel_en) == "2:05 PM"
+    assert localize_time(time(14, 5), babel_fr) == "14:05"
+    assert localize_time(time(14, 5), babel_es, with_seconds=True) == "14:05:00"
 
 
 def test_localize_datetime() -> None:
     value = datetime(2000, 1, 2, 14, 5, tzinfo=UTC)
-    assert localize_datetime(value, UTC, "en-US") == "Jan 2, 2000, 2:05:00 PM"
-    assert localize_datetime(value, UTC, "fr-FR") == "2 janv. 2000, 14:05:00"
+    assert localize_datetime(value, babel_en) == "January 2, 2000, 2:05 PM"
+    assert localize_datetime(value, babel_fr) == "2 janvier 2000, 14:05"
 
 
 def test_localize_timezone() -> None:
-    assert localize_timezone(ZoneInfo("Europe/London"), "en") == "United Kingdom Time"
-    assert localize_timezone(ZoneInfo("Europe/London"), "es") == "hora de Reino Unido"
+    assert localize_timezone(ZoneInfo("Europe/London"), babel_en) == "United Kingdom Time"
+    assert localize_timezone(ZoneInfo("Europe/London"), babel_es) == "hora de Reino Unido"

--- a/app/backend/src/tests/test_templating.py
+++ b/app/backend/src/tests/test_templating.py
@@ -46,7 +46,7 @@ def test_date_formatting() -> None:
     the_date = date(1970, 1, 1)
     template = Jinja2Template(source="Date: {{ date }}", html=False)
     rendered = _render_en_utc(template, {"date": the_date})
-    assert rendered == "Date: Jan 1, 1970"
+    assert rendered == "Date: January 1, 1970"
 
 
 def _greeting_i18next(value: str) -> I18Next:

--- a/app/backend/src/tests/test_utils.py
+++ b/app/backend/src/tests/test_utils.py
@@ -1,13 +1,14 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
 from sqlalchemy import select, update
 from sqlalchemy.sql import func
 
 from couchers.db import session_scope
 from couchers.models import User
-from couchers.utils import dt_from_page_token, dt_to_page_token, http_date, now, wrap_coordinate
+from couchers.utils import dt_from_page_token, dt_to_page_token, http_date, now, to_timezone, wrap_coordinate
 from tests.fixtures.db import generate_user
 
 
@@ -148,3 +149,18 @@ def test_wrap_coordinate():
     for coords, coords_expected in test_coords:
         coords_wrapped = wrap_coordinate(*coords)
         assert coords_expected == coords_wrapped
+
+
+def test_to_timezone():
+    utc_plus_one = timezone(offset=timedelta(hours=1))
+
+    epoch_utc = to_timezone(Timestamp(seconds=0), UTC)
+    assert epoch_utc.isoformat() == "1970-01-01T00:00:00+00:00"
+
+    # With Timestamp
+    epoch_utc_plus_one = to_timezone(Timestamp(seconds=0), utc_plus_one)
+    assert epoch_utc_plus_one.isoformat() == "1970-01-01T01:00:00+01:00"
+
+    # With datetime
+    epoch_utc_plus_one = to_timezone(epoch_utc, utc_plus_one)
+    assert epoch_utc_plus_one.isoformat() == "1970-01-01T01:00:00+01:00"


### PR DESCRIPTION
We only supported one localized datetime format. This isn't quite enough in practice. For example, when we send a push notification about a host request, saying "May 16, 2026" is not ideal: the year is implicit, and it'd be useful to have the day of the week.

<img width="589" height="179" alt="image" src="https://github.com/user-attachments/assets/5abff32e-5359-4305-97b7-5e824e90e046" />

This implements multiple datetime formats with an API similar to the frontend's. Python doesn't have Javascript's  convenient `Intl.DateTimeFormat`, but the Babel library exposes everything from the Unicode CLDR that we need to implement the functionality, even if it gets a little a little gnarly. Hopefully I documented it well.

I also changed the defaults a little bit to use long-form month names and omit seconds (both unless requested). This aligns with the frontend and is hopefully less surprising.

I also gave `LocalizationContext` the job of resolving the `babel.Locale`, as to not have to do it on every formatting operation.

I also leveraged the new feature to tweak datetime formats in push notifications for events and host requests. I didn't change those in emails since I'm working on email changes in parallel.

Fixes #7885, #8490

## Testing
Updated and added tests.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me