### PR TITLE
Cookie banner should not obscure profile save button

### DIFF
--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -176,7 +176,7 @@ const StickySaveBar = styled(Box, {
 
   return {
     position: "fixed",
-    bottom: 0,
+    bottom: "var(--cookie-banner-height, 0px)",
     left: 0,
     right: 0,
     backgroundColor: "var(--mui-palette-background-paper)",
@@ -190,7 +190,7 @@ const StickySaveBar = styled(Box, {
     gap: theme.spacing(2),
 
     [theme.breakpoints.down("md")]: {
-      bottom: bottomNavHeight,
+      bottom: `calc(${bottomNavHeight}px + var(--cookie-banner-height, 0px))`,
       padding: theme.spacing(1),
       paddingBottom: safePadding,
     },


### PR DESCRIPTION
The cookie banner was obscuring the profile save button and we got a few bug reports about it.

This fixes it so the button appears above the cookie banner.


<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*
- Go in the Application screen of the dev console and clear the hasSeenCookieBanner from localStorage
- Log out, cookie banner should appear
- Log in and go to edit profile, keeping the cookiebanner up
- It should be visible

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

<img width="1165" height="750" alt="Screenshot 2026-05-14 at 10 40 17" src="https://github.com/user-attachments/assets/fbf351fe-7d5f-458d-b00d-374558918e5e" />

<img width="377" height="654" alt="Screenshot 2026-05-14 at 10 40 40" src="https://github.com/user-attachments/assets/19f78d71-bced-4a01-aea3-d27f2cb35bae" />


**Web frontend checklist**
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Remember to request review from couchers-org/web, couchers-org/backend or an individual.
Once your code is approved, you can merge it if you have write access.
--->
