### PR TITLE
Devex: Add workflow to assign PR reviewers

### DIFF
--- a/.github/autoreviewers.yml
+++ b/.github/autoreviewers.yml
@@ -1,0 +1,18 @@
+# Defines PR reviewers based on modified file paths.
+# The syntax is as the dorny/paths-filter action accepts,
+# but our filter names are a label plus a comma-delimited people/teams to assign.
+backend Couchers-org/backend:
+  - 'app/backend/**'
+  - '!app/backend/**/locales/*.json'
+  - 'app/media/**'
+web Couchers-org/web:
+  - 'app/web/**'
+  - '!app/web/**/locales/*.json'
+mobile Couchers-org/mobile:
+  - 'app/mobile/**'
+  - '!app/mobile/**/locales/*.json'
+i18n tristanlabelle:
+  - 'app/**/locales/*.json'
+  - 'app/**/i18n/**'
+docs aapeliv,nabramow:
+  - 'docs/**'

--- a/.github/workflows/add-reviewers.yml
+++ b/.github/workflows/add-reviewers.yml
@@ -1,0 +1,55 @@
+# Adds reviewers upon publishing a PR based on changed files.
+# Works around limitations of GitHub's CODEOWNERS, which can only match one rule,
+# whereas our changes can straddle frontend and backend, for example.
+name: Add reviewers
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  add-reviewers:
+    name: Add reviewers
+    runs-on: ubuntu-latest
+    # Let tristanlabelle validate this workflow before switching from CODEOWNERS
+    if: github.event.pull_request.user.login == 'tristanlabelle' && github.actor != 'dependabot[bot]' && !github.event.pull_request.draft
+    steps:
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: .github/autoreviewers.yml
+
+      - name: Add reviewers
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          # The "changes" output is a JSON array of filter names.
+          FILTER_CHANGES: ${{ steps.filter.outputs.changes }}
+        run: |
+          # Filter keys are "<name> <reviewer1,reviewer2,...>"; extract reviewers from matched filters.
+          MATCHED_REVIEWERS=$(echo "$FILTER_CHANGES" | jq -r '.[] | split(" ")[1] | split(",") | .[]')
+
+          ARGS=()
+          while IFS= read -r reviewer; do
+            # Ignore empty entries
+            [[ -n "$reviewer" ]] || continue
+            # The PR author cannot be a reviewer on their own PR
+            [[ "$reviewer" == "$PR_AUTHOR" ]] && continue
+
+            echo "Adding reviewer: $reviewer"
+            ARGS+=(--add-reviewer "$reviewer")
+          done <<< "$MATCHED_REVIEWERS"
+
+          if [[ ${#ARGS[@]} -gt 0 ]]; then
+            gh pr edit "$PR_NUMBER" "${ARGS[@]}"
+          fi


### PR DESCRIPTION
This workflow will replace CODEOWNERS and address two issues:

1. CODEOWNERS can only match one rule, so it can't add two sets of reviewers for changes straddling frontend and backend.
2. It's easy to forget to add reviewing teams, which hinders cross-participation in code reviews.

New GitHub workflows are untestable, so this is scoped to `github.event.pull_request.user.login == 'tristanlabelle'`. I will test it after merging, then follow up with a PR that switches us from CODEOWNERS.

## Testing
Will test after merging (currently only targeting PRs of yours truly).

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
