### PR TITLE
Add GetProfile RPC and migrate frontend to use it

### DIFF
--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -47,7 +47,7 @@ from couchers.notifications.notify import notify
 from couchers.proto import admin_pb2, admin_pb2_grpc, api_pb2, notification_data_pb2
 from couchers.proto.internal import jobs_pb2
 from couchers.resources import get_badge_dict
-from couchers.servicers.api import user_model_to_pb
+from couchers.servicers.api import profile_model_to_pb, user_model_to_pb
 from couchers.servicers.auth import create_session
 from couchers.servicers.events import generate_event_delete_notifications
 from couchers.servicers.moderation import bulk_set_user_content_visibility
@@ -199,6 +199,12 @@ class Admin(admin_pb2_grpc.AdminServicer):
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         return user_model_to_pb(user, session, context, is_admin_see_ghosts=True)
+
+    def GetProfile(self, request: admin_pb2.GetUserReq, context: CouchersContext, session: Session) -> api_pb2.Profile:
+        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
+        if not user:
+            context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
+        return profile_model_to_pb(user)
 
     def SearchUsers(
         self, request: admin_pb2.SearchUsersReq, context: CouchersContext, session: Session

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -177,15 +177,7 @@ fluency2api = {
 class API(api_pb2_grpc.APIServicer):
     def Ping(self, request: api_pb2.PingReq, context: CouchersContext, session: Session) -> api_pb2.PingRes:
         # auth ought to make sure the user exists
-        user = session.execute(
-            select(User)
-            .where(User.id == context.user_id)
-            .options(
-                selectinload(User.regions_visited),
-                selectinload(User.regions_lived),
-                selectinload(User.language_abilities),
-            )
-        ).scalar_one()
+        user = session.execute(select(User).where(User.id == context.user_id)).scalar_one()
 
         sent_reqs_query = select(HostRequest.conversation_id, HostRequest.initiator_last_seen_message_id).where(
             HostRequest.initiator_user_id == context.user_id
@@ -280,15 +272,7 @@ class API(api_pb2_grpc.APIServicer):
         )
 
     def GetUser(self, request: api_pb2.GetUserReq, context: CouchersContext, session: Session) -> api_pb2.User:
-        user = session.execute(
-            select(User)
-            .where(username_or_id(request.user))
-            .options(
-                selectinload(User.regions_visited),
-                selectinload(User.regions_lived),
-                selectinload(User.language_abilities),
-            )
-        ).scalar_one_or_none()
+        user = session.execute(select(User).where(username_or_id(request.user))).scalar_one_or_none()
 
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -310,7 +294,10 @@ class API(api_pb2_grpc.APIServicer):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
         if is_not_visible(session, context.user_id, user.id):
-            context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
+            return api_pb2.Profile(
+                user_id=user.id,
+                about_me=context.localization.localize_string("ghost_users.about_me"),
+            )
 
         return profile_model_to_pb(user)
 
@@ -1063,7 +1050,6 @@ def user_model_to_pb(
                 is_ghost=True,
                 username=GHOST_USERNAME,
                 name=context.localization.localize_string("ghost_users.display_name"),
-                about_me=context.localization.localize_string("ghost_users.about_me"),
             )
         raise GhostUserSerializationError(
             f"Tried to serialize ghost profile in user_model_to_pb without appropriate flags. "
@@ -1142,7 +1128,6 @@ def user_model_to_pb(
         username=db_user.username,
         name=db_user.name,
         city=db_user.city,
-        hometown=db_user.hometown,
         timezone=db_user.timezone,
         lat=lat,
         lng=lng,
@@ -1151,98 +1136,19 @@ def user_model_to_pb(
         community_standing=db_user.community_standing,
         num_references=num_references,
         gender=db_user.gender,
-        pronouns=db_user.pronouns,
         age=int(db_user.age),
         joined=Timestamp_from_datetime(db_user.display_joined),
         last_active=Timestamp_from_datetime(db_user.display_last_active),
-        hosting_status=hostingstatus2api[db_user.hosting_status],
-        meetup_status=meetupstatus2api[db_user.meetup_status],
-        occupation=db_user.occupation,
-        education=db_user.education,
-        about_me=db_user.about_me,
-        things_i_like=db_user.things_i_like,
-        about_place=db_user.about_place,
-        language_abilities=[
-            api_pb2.LanguageAbility(code=ability.language_code, fluency=fluency2api[ability.fluency])
-            for ability in db_user.language_abilities
-        ],
-        regions_visited=[region.code for region in db_user.regions_visited],
-        regions_lived=[region.code for region in db_user.regions_lived],
-        additional_information=db_user.additional_information,
         friends=friends_status,
         pending_friend_request=pending_friend_request,
-        smoking_allowed=smokinglocation2api[db_user.smoking_allowed],
-        sleeping_arrangement=sleepingarrangement2api[db_user.sleeping_arrangement],
-        parking_details=parkingdetails2api[db_user.parking_details],
         avatar_url=avatar_upload.full_url if avatar_upload else None,
         avatar_thumbnail_url=avatar_upload.thumbnail_url if avatar_upload else None,
-        profile_gallery_id=db_user.profile_gallery_id,
         badges=session.execute(select(UserBadge.badge_id).where(UserBadge.user_id == db_user.id).order_by(UserBadge.id))
         .scalars()
         .all(),
         **get_strong_verification_fields(session, db_user),
         **response_rate_to_pb(response_rate),  # type: ignore[arg-type]
     )
-
-    if db_user.max_guests is not None:
-        user.max_guests.value = db_user.max_guests
-
-    if db_user.last_minute is not None:
-        user.last_minute.value = db_user.last_minute
-
-    if db_user.has_pets is not None:
-        user.has_pets.value = db_user.has_pets
-
-    if db_user.accepts_pets is not None:
-        user.accepts_pets.value = db_user.accepts_pets
-
-    if db_user.pet_details is not None:
-        user.pet_details.value = db_user.pet_details
-
-    if db_user.has_kids is not None:
-        user.has_kids.value = db_user.has_kids
-
-    if db_user.accepts_kids is not None:
-        user.accepts_kids.value = db_user.accepts_kids
-
-    if db_user.kid_details is not None:
-        user.kid_details.value = db_user.kid_details
-
-    if db_user.has_housemates is not None:
-        user.has_housemates.value = db_user.has_housemates
-
-    if db_user.housemate_details is not None:
-        user.housemate_details.value = db_user.housemate_details
-
-    if db_user.wheelchair_accessible is not None:
-        user.wheelchair_accessible.value = db_user.wheelchair_accessible
-
-    if db_user.smokes_at_home is not None:
-        user.smokes_at_home.value = db_user.smokes_at_home
-
-    if db_user.drinking_allowed is not None:
-        user.drinking_allowed.value = db_user.drinking_allowed
-
-    if db_user.drinks_at_home is not None:
-        user.drinks_at_home.value = db_user.drinks_at_home
-
-    if db_user.other_host_info is not None:
-        user.other_host_info.value = db_user.other_host_info
-
-    if db_user.sleeping_details is not None:
-        user.sleeping_details.value = db_user.sleeping_details
-
-    if db_user.area is not None:
-        user.area.value = db_user.area
-
-    if db_user.house_rules is not None:
-        user.house_rules.value = db_user.house_rules
-
-    if db_user.parking is not None:
-        user.parking.value = db_user.parking
-
-    if db_user.camping_ok is not None:
-        user.camping_ok.value = db_user.camping_ok
 
     return user
 

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -295,6 +295,25 @@ class API(api_pb2_grpc.APIServicer):
 
         return user_model_to_pb(user, session, context, is_get_user_return_ghosts=True)
 
+    def GetProfile(self, request: api_pb2.GetProfileReq, context: CouchersContext, session: Session) -> api_pb2.Profile:
+        user = session.execute(
+            select(User)
+            .where(username_or_id(request.user))
+            .options(
+                selectinload(User.regions_visited),
+                selectinload(User.regions_lived),
+                selectinload(User.language_abilities),
+            )
+        ).scalar_one_or_none()
+
+        if not user:
+            context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
+
+        if is_not_visible(session, context.user_id, user.id):
+            context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
+
+        return profile_model_to_pb(user)
+
     def GetLiteUser(
         self, request: api_pb2.GetLiteUserReq, context: CouchersContext, session: Session
     ) -> api_pb2.LiteUser:
@@ -1226,6 +1245,75 @@ def user_model_to_pb(
         user.camping_ok.value = db_user.camping_ok
 
     return user
+
+
+def profile_model_to_pb(db_user: User) -> api_pb2.Profile:
+    profile = api_pb2.Profile(
+        user_id=db_user.id,
+        hometown=db_user.hometown,
+        pronouns=db_user.pronouns,
+        occupation=db_user.occupation,
+        education=db_user.education,
+        about_me=db_user.about_me,
+        things_i_like=db_user.things_i_like,
+        about_place=db_user.about_place,
+        additional_information=db_user.additional_information,
+        hosting_status=hostingstatus2api[db_user.hosting_status],
+        meetup_status=meetupstatus2api[db_user.meetup_status],
+        regions_visited=[region.code for region in db_user.regions_visited],
+        regions_lived=[region.code for region in db_user.regions_lived],
+        language_abilities=[
+            api_pb2.LanguageAbility(code=ability.language_code, fluency=fluency2api[ability.fluency])
+            for ability in db_user.language_abilities
+        ],
+        profile_gallery_id=db_user.profile_gallery_id,
+        smoking_allowed=smokinglocation2api[db_user.smoking_allowed],
+        sleeping_arrangement=sleepingarrangement2api[db_user.sleeping_arrangement],
+        parking_details=parkingdetails2api[db_user.parking_details],
+    )
+
+    if db_user.max_guests is not None:
+        profile.max_guests.value = db_user.max_guests
+    if db_user.last_minute is not None:
+        profile.last_minute.value = db_user.last_minute
+    if db_user.has_pets is not None:
+        profile.has_pets.value = db_user.has_pets
+    if db_user.accepts_pets is not None:
+        profile.accepts_pets.value = db_user.accepts_pets
+    if db_user.pet_details is not None:
+        profile.pet_details.value = db_user.pet_details
+    if db_user.has_kids is not None:
+        profile.has_kids.value = db_user.has_kids
+    if db_user.accepts_kids is not None:
+        profile.accepts_kids.value = db_user.accepts_kids
+    if db_user.kid_details is not None:
+        profile.kid_details.value = db_user.kid_details
+    if db_user.has_housemates is not None:
+        profile.has_housemates.value = db_user.has_housemates
+    if db_user.housemate_details is not None:
+        profile.housemate_details.value = db_user.housemate_details
+    if db_user.wheelchair_accessible is not None:
+        profile.wheelchair_accessible.value = db_user.wheelchair_accessible
+    if db_user.smokes_at_home is not None:
+        profile.smokes_at_home.value = db_user.smokes_at_home
+    if db_user.drinking_allowed is not None:
+        profile.drinking_allowed.value = db_user.drinking_allowed
+    if db_user.drinks_at_home is not None:
+        profile.drinks_at_home.value = db_user.drinks_at_home
+    if db_user.other_host_info is not None:
+        profile.other_host_info.value = db_user.other_host_info
+    if db_user.sleeping_details is not None:
+        profile.sleeping_details.value = db_user.sleeping_details
+    if db_user.area is not None:
+        profile.area.value = db_user.area
+    if db_user.house_rules is not None:
+        profile.house_rules.value = db_user.house_rules
+    if db_user.parking is not None:
+        profile.parking.value = db_user.parking
+    if db_user.camping_ok is not None:
+        profile.camping_ok.value = db_user.camping_ok
+
+    return profile
 
 
 def lite_user_to_pb(

--- a/app/backend/src/couchers/servicers/public.py
+++ b/app/backend/src/couchers/servicers/public.py
@@ -26,7 +26,13 @@ from couchers.models.uploads import get_avatar_upload
 from couchers.proto import api_pb2, public_pb2, public_pb2_grpc
 from couchers.proto.google.api import httpbody_pb2
 from couchers.resources import get_static_badge_dict
-from couchers.servicers.api import fluency2api, hostingstatus2api, meetupstatus2api, user_model_to_pb
+from couchers.servicers.api import (
+    fluency2api,
+    hostingstatus2api,
+    meetupstatus2api,
+    profile_model_to_pb,
+    user_model_to_pb,
+)
 from couchers.servicers.gis import _statement_to_geojson_response
 from couchers.utils import Timestamp_from_datetime, not_none, now
 
@@ -199,8 +205,12 @@ class Public(public_pb2_grpc.PublicServicer):
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
 
         if user.public_visibility == ProfilePublicVisibility.full:
+            logged_out_ctx = make_logged_out_context(localization=context.localization)
             return public_pb2.GetPublicUserRes(
-                full_user=user_model_to_pb(user, session, make_logged_out_context(localization=context.localization))
+                full_user=public_pb2.FullUser(
+                    user=user_model_to_pb(user, session, logged_out_ctx),
+                    profile=profile_model_to_pb(user),
+                )
             )
 
         num_references = session.execute(

--- a/app/backend/src/tests/test_activeness_probes.py
+++ b/app/backend/src/tests/test_activeness_probes.py
@@ -47,7 +47,7 @@ def test_activeness_probes_happy_path_inactive(db, push_collector: PushCollector
         assert not res.jailed
 
     with api_session(token) as api:
-        res = api.GetUser(api_pb2.GetUserReq(user=user.username))
+        res = api.GetProfile(api_pb2.GetProfileReq(user=user.username))
         assert res.hosting_status == api_pb2.HOSTING_STATUS_CANT_HOST
         assert res.meetup_status == api_pb2.MEETUP_STATUS_WANTS_TO_MEETUP
 
@@ -80,7 +80,7 @@ def test_activeness_probes_happy_path_active(db, push_collector: PushCollector):
         assert not res.jailed
 
     with api_session(token) as api:
-        res = api.GetUser(api_pb2.GetUserReq(user=user.username))
+        res = api.GetProfile(api_pb2.GetProfileReq(user=user.username))
         assert res.hosting_status == api_pb2.HOSTING_STATUS_CAN_HOST
         assert res.meetup_status == api_pb2.MEETUP_STATUS_WANTS_TO_MEETUP
 
@@ -159,6 +159,6 @@ def test_activeness_probes_expiry(db, push_collector: PushCollector):
         assert not res.jailed
 
     with api_session(token) as api:
-        res = api.GetUser(api_pb2.GetUserReq(user=user.username))
+        res = api.GetProfile(api_pb2.GetProfileReq(user=user.username))
         assert res.hosting_status == api_pb2.HOSTING_STATUS_MAYBE
         assert res.meetup_status == api_pb2.MEETUP_STATUS_OPEN_TO_MEETUP

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -17,6 +17,7 @@ from couchers.models import (
     ModerationState,
     ModerationVisibility,
     RateLimitAction,
+    SleepingArrangement,
     User,
     UserBadge,
 )
@@ -179,6 +180,66 @@ def test_get_user(db):
         assert res.user_id == user2.id
         assert res.username == user2.username
         assert res.name == user2.name
+
+
+def test_get_profile(db):
+    user1, token1 = generate_user()
+    user2, _ = generate_user(
+        complete_profile=False,
+        about_me="hello there",
+        things_i_like="long walks",
+        about_place="cozy couch",
+        hometown="Berlin",
+        occupation="Software engineer",
+        max_guests=3,
+        sleeping_arrangement=SleepingArrangement.private,
+    )
+
+    with api_session(token1) as api:
+        res = api.GetProfile(api_pb2.GetProfileReq(user=user2.username))
+        assert res.user_id == user2.id
+        assert res.about_me == "hello there"
+        assert res.things_i_like == "long walks"
+        assert res.about_place == "cozy couch"
+        assert res.hometown == "Berlin"
+        assert res.occupation == "Software engineer"
+        assert res.max_guests.value == 3
+        assert res.sleeping_arrangement == api_pb2.SLEEPING_ARRANGEMENT_PRIVATE
+        assert res.hosting_status in (
+            api_pb2.HOSTING_STATUS_UNKNOWN,
+            api_pb2.HOSTING_STATUS_CAN_HOST,
+            api_pb2.HOSTING_STATUS_MAYBE,
+            api_pb2.HOSTING_STATUS_CANT_HOST,
+        )
+
+    with api_session(token1) as api:
+        res = api.GetProfile(api_pb2.GetProfileReq(user=str(user2.id)))
+        assert res.user_id == user2.id
+
+
+def test_get_profile_not_found(db):
+    _, token1 = generate_user()
+
+    with api_session(token1) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.GetProfile(api_pb2.GetProfileReq(user="nonexistent_user_xyz"))
+        assert e.value.code() == grpc.StatusCode.NOT_FOUND
+
+
+@pytest.mark.parametrize("flag", ["deleted_at", "banned_at"])
+def test_get_profile_ghost_user(db, flag):
+    _, token1 = generate_user()
+    user2, _ = generate_user()
+
+    with session_scope() as session:
+        session.execute(update(User).where(User.id == user2.id).values(**{flag: func.now()}))
+
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+
+    with api_session(token1) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.GetProfile(api_pb2.GetProfileReq(user=user2.username))
+        assert e.value.code() == grpc.StatusCode.NOT_FOUND
 
 
 @pytest.mark.parametrize("flag", ["deleted_at", "banned_at"])

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -57,17 +57,16 @@ def test_ping(db):
 
     with real_api_session(token) as api:
         res = api.Ping(api_pb2.PingReq())
+        profile = api.GetProfile(api_pb2.GetProfileReq(user=str(user.id)))
 
     assert res.user.user_id == user.id
     assert res.user.username == user.username
     assert res.user.name == user.name
     assert res.user.city == user.city
-    assert res.user.hometown == user.hometown
     assert res.user.verification == 0.0
     assert res.user.community_standing == user.community_standing
     assert res.user.num_references == 0
     assert res.user.gender == user.gender
-    assert res.user.pronouns == user.pronouns
     assert res.user.age == user.age
 
     assert (res.user.lat, res.user.lng) == user.coordinates
@@ -78,21 +77,22 @@ def test_ping(db):
     # same for last_active
     assert user.last_active - timedelta(hours=1) <= to_aware_datetime(res.user.last_active) <= user.last_active
 
-    assert res.user.hosting_status == api_pb2.HOSTING_STATUS_CANT_HOST
-    assert res.user.meetup_status == api_pb2.MEETUP_STATUS_OPEN_TO_MEETUP
-
-    assert res.user.occupation == user.occupation
-    assert res.user.education == user.education
-    assert res.user.about_me == user.about_me
-    assert res.user.things_i_like == user.things_i_like
-    assert {language_ability.code for language_ability in res.user.language_abilities} == {"fin", "fra"}
-    assert res.user.about_place == user.about_place
-    assert res.user.regions_visited == ["FIN", "REU", "CHE"]  # Tests alphabetization by region name
-    assert res.user.regions_lived == ["EST", "FRA", "ESP"]  # Ditto
-    assert res.user.additional_information == user.additional_information
-
     assert res.user.friends == api_pb2.User.FriendshipStatus.NA
     assert not res.user.HasField("pending_friend_request")
+
+    assert profile.hometown == user.hometown
+    assert profile.pronouns == user.pronouns
+    assert profile.hosting_status == api_pb2.HOSTING_STATUS_CANT_HOST
+    assert profile.meetup_status == api_pb2.MEETUP_STATUS_OPEN_TO_MEETUP
+    assert profile.occupation == user.occupation
+    assert profile.education == user.education
+    assert profile.about_me == user.about_me
+    assert profile.things_i_like == user.things_i_like
+    assert {language_ability.code for language_ability in profile.language_abilities} == {"fin", "fra"}
+    assert profile.about_place == user.about_place
+    assert profile.regions_visited == ["FIN", "REU", "CHE"]  # Tests alphabetization by region name
+    assert profile.regions_lived == ["EST", "FRA", "ESP"]  # Ditto
+    assert profile.additional_information == user.additional_information
 
 
 def test_coords(db):
@@ -237,9 +237,13 @@ def test_get_profile_ghost_user(db, flag):
     refresh_materialized_views_rapid(empty_pb2.Empty())
 
     with api_session(token1) as api:
-        with pytest.raises(grpc.RpcError) as e:
-            api.GetProfile(api_pb2.GetProfileReq(user=user2.username))
-        assert e.value.code() == grpc.StatusCode.NOT_FOUND
+        res = api.GetProfile(api_pb2.GetProfileReq(user=user2.username))
+
+    assert res.user_id == user2.id
+    assert res.about_me.startswith("This user is no longer on the platform.")
+    assert res.hometown == ""
+    assert res.occupation == ""
+    assert res.hosting_status == 0
 
 
 @pytest.mark.parametrize("flag", ["deleted_at", "banned_at"])
@@ -254,15 +258,12 @@ def test_user_model_to_pb_ghost_user(db, flag):
 
     with api_session(token1) as api:
         user_pb = api.GetUser(api_pb2.GetUserReq(user=user2.username))
+        profile_pb = api.GetProfile(api_pb2.GetProfileReq(user=user2.username))
 
     assert user_pb.user_id == user2.id
     assert user_pb.is_ghost
     assert user_pb.username == "ghost"
     assert user_pb.name == "Deactivated Account"
-    assert (
-        user_pb.about_me
-        == "This user is no longer on the platform. They may have deleted their account, been blocked, or been banned. We recommend exercising caution with any further interaction with this user off the platform. You can always reach out to support if you need any help."
-    )
 
     assert user_pb.lat == 0
     assert user_pb.lng == 0
@@ -271,26 +272,20 @@ def test_user_model_to_pb_ghost_user(db, flag):
     assert user_pb.community_standing == 0.0
     assert user_pb.num_references == 0
     assert user_pb.age == 0
-    assert user_pb.hosting_status == 0
-    assert user_pb.meetup_status == 0
     assert user_pb.city == ""
-    assert user_pb.hometown == ""
     assert user_pb.timezone == ""
     assert user_pb.gender == ""
-    assert user_pb.pronouns == ""
-    assert user_pb.occupation == ""
-    assert user_pb.education == ""
-    assert user_pb.things_i_like == ""
-    assert user_pb.about_place == ""
-    assert user_pb.additional_information == ""
-    assert list(user_pb.language_abilities) == []
-    assert list(user_pb.regions_visited) == []
-    assert list(user_pb.regions_lived) == []
     assert list(user_pb.badges) == []
     assert user_pb.friends == api_pb2.User.FriendshipStatus.NOT_FRIENDS
     assert user_pb.avatar_url == ""
     assert user_pb.avatar_thumbnail_url == ""
     assert not user_pb.has_strong_verification
+
+    assert profile_pb.user_id == user2.id
+    assert (
+        profile_pb.about_me
+        == "This user is no longer on the platform. They may have deleted their account, been blocked, or been banned. We recommend exercising caution with any further interaction with this user off the platform. You can always reach out to support if you need any help."
+    )
 
     with api_session(token1) as api:
         lite_user_pb = api.GetLiteUser(api_pb2.GetLiteUserReq(user=user2.username))
@@ -320,15 +315,12 @@ def test_user_model_to_pb_ghost_user_blocked(db):
 
     with api_session(token1) as api:
         user_pb = api.GetUser(api_pb2.GetUserReq(user=user2.username))
+        profile_pb = api.GetProfile(api_pb2.GetProfileReq(user=user2.username))
 
     assert user_pb.user_id == user2.id
     assert user_pb.is_ghost
     assert user_pb.username == "ghost"
     assert user_pb.name == "Deactivated Account"
-    assert (
-        user_pb.about_me
-        == "This user is no longer on the platform. They may have deleted their account, been blocked, or been banned. We recommend exercising caution with any further interaction with this user off the platform. You can always reach out to support if you need any help."
-    )
 
     assert user_pb.lat == 0
     assert user_pb.lng == 0
@@ -337,26 +329,20 @@ def test_user_model_to_pb_ghost_user_blocked(db):
     assert user_pb.community_standing == 0.0
     assert user_pb.num_references == 0
     assert user_pb.age == 0
-    assert user_pb.hosting_status == 0
-    assert user_pb.meetup_status == 0
     assert user_pb.city == ""
-    assert user_pb.hometown == ""
     assert user_pb.timezone == ""
     assert user_pb.gender == ""
-    assert user_pb.pronouns == ""
-    assert user_pb.occupation == ""
-    assert user_pb.education == ""
-    assert user_pb.things_i_like == ""
-    assert user_pb.about_place == ""
-    assert user_pb.additional_information == ""
-    assert list(user_pb.language_abilities) == []
-    assert list(user_pb.regions_visited) == []
-    assert list(user_pb.regions_lived) == []
     assert list(user_pb.badges) == []
     assert user_pb.friends == api_pb2.User.FriendshipStatus.NOT_FRIENDS
     assert user_pb.avatar_url == ""
     assert user_pb.avatar_thumbnail_url == ""
     assert not user_pb.has_strong_verification
+
+    assert profile_pb.user_id == user2.id
+    assert (
+        profile_pb.about_me
+        == "This user is no longer on the platform. They may have deleted their account, been blocked, or been banned. We recommend exercising caution with any further interaction with this user off the platform. You can always reach out to support if you need any help."
+    )
 
     with api_session(token1) as api:
         lite_user_pb = api.GetLiteUser(api_pb2.GetLiteUserReq(user=user2.username))
@@ -385,6 +371,7 @@ def test_admin_viewing_ghost_users_sees_full_profile(db, flag):
 
     with admin_session(token_admin) as api:
         user_pb = api.GetUser(admin_pb2.GetUserReq(user=user.username))
+        profile_pb = api.GetProfile(admin_pb2.GetUserReq(user=user.username))
 
     assert user_pb.user_id == user.id
     assert user_pb.username == user.username
@@ -392,7 +379,7 @@ def test_admin_viewing_ghost_users_sees_full_profile(db, flag):
     assert user_pb.city == user.city
     assert user_pb.name != "Deactivated Account"
     assert user_pb.username != "ghost"
-    assert user_pb.hosting_status in (
+    assert profile_pb.hosting_status in (
         api_pb2.HOSTING_STATUS_UNKNOWN,
         api_pb2.HOSTING_STATUS_CAN_HOST,
         api_pb2.HOSTING_STATUS_MAYBE,
@@ -625,25 +612,26 @@ def test_update_profile(db):
         )
 
         user_details = api.GetUser(api_pb2.GetUserReq(user=user.username))
+        profile_details = api.GetProfile(api_pb2.GetProfileReq(user=user.username))
         assert user_details.name == "New name"
         assert user_details.city == "Timbuktu"
-        assert user_details.hometown == "Walla Walla"
-        assert user_details.pronouns == "Ro, Robo, Robots"
-        assert user_details.education == "Couchers U"
-        assert user_details.things_i_like == "Couchers"
         assert user_details.lat == 0.01
         assert user_details.lng == -2
         assert user_details.radius == 321
-        assert user_details.occupation == "Testing"
-        assert user_details.about_me == "I rule"
-        assert user_details.about_place == "My place"
-        assert user_details.hosting_status == api_pb2.HOSTING_STATUS_CAN_HOST
-        assert user_details.meetup_status == api_pb2.MEETUP_STATUS_WANTS_TO_MEETUP
-        assert user_details.language_abilities[0].code == "eng"
-        assert user_details.language_abilities[0].fluency == api_pb2.LanguageAbility.Fluency.FLUENCY_FLUENT
-        assert user_details.additional_information == "I <3 Couchers"
-        assert user_details.regions_visited == ["CXR", "FIN"]
-        assert user_details.regions_lived == ["EST", "USA"]
+        assert profile_details.hometown == "Walla Walla"
+        assert profile_details.pronouns == "Ro, Robo, Robots"
+        assert profile_details.education == "Couchers U"
+        assert profile_details.things_i_like == "Couchers"
+        assert profile_details.occupation == "Testing"
+        assert profile_details.about_me == "I rule"
+        assert profile_details.about_place == "My place"
+        assert profile_details.hosting_status == api_pb2.HOSTING_STATUS_CAN_HOST
+        assert profile_details.meetup_status == api_pb2.MEETUP_STATUS_WANTS_TO_MEETUP
+        assert profile_details.language_abilities[0].code == "eng"
+        assert profile_details.language_abilities[0].fluency == api_pb2.LanguageAbility.Fluency.FLUENCY_FLUENT
+        assert profile_details.additional_information == "I <3 Couchers"
+        assert profile_details.regions_visited == ["CXR", "FIN"]
+        assert profile_details.regions_lived == ["EST", "USA"]
 
         # Test unset values
         api.UpdateProfile(
@@ -666,20 +654,21 @@ def test_update_profile(db):
         )
 
         user_details = api.GetUser(api_pb2.GetUserReq(user=user.username))
-        assert not user_details.hometown
+        profile_details = api.GetProfile(api_pb2.GetProfileReq(user=user.username))
         assert not user_details.radius
-        assert not user_details.pronouns
-        assert not user_details.occupation
-        assert not user_details.education
-        assert not user_details.about_me
-        assert not user_details.things_i_like
-        assert not user_details.about_place
-        assert user_details.hosting_status == api_pb2.HOSTING_STATUS_CAN_HOST
-        assert user_details.meetup_status == api_pb2.MEETUP_STATUS_WANTS_TO_MEETUP
-        assert not user_details.language_abilities
-        assert not user_details.regions_visited
-        assert not user_details.regions_lived
-        assert not user_details.additional_information
+        assert not profile_details.hometown
+        assert not profile_details.pronouns
+        assert not profile_details.occupation
+        assert not profile_details.education
+        assert not profile_details.about_me
+        assert not profile_details.things_i_like
+        assert not profile_details.about_place
+        assert profile_details.hosting_status == api_pb2.HOSTING_STATUS_CAN_HOST
+        assert profile_details.meetup_status == api_pb2.MEETUP_STATUS_WANTS_TO_MEETUP
+        assert not profile_details.language_abilities
+        assert not profile_details.regions_visited
+        assert not profile_details.regions_lived
+        assert not profile_details.additional_information
 
 
 def test_update_profile_do_not_email(db):
@@ -709,7 +698,7 @@ def test_language_abilities(db):
     )
 
     with api_session(token) as api:
-        res = api.GetUser(api_pb2.GetUserReq(user=user.username))
+        res = api.GetProfile(api_pb2.GetProfileReq(user=user.username))
         assert len(res.language_abilities) == 2
 
         # can't add non-existent languages
@@ -750,7 +739,7 @@ def test_language_abilities(db):
         assert "violates unique constraint" in str(err2.value)
 
         # nothing changed
-        res = api.GetUser(api_pb2.GetUserReq(user=user.username))
+        res = api.GetProfile(api_pb2.GetProfileReq(user=user.username))
         assert len(res.language_abilities) == 2
 
         # now actually add a value
@@ -767,7 +756,7 @@ def test_language_abilities(db):
             )
         )
 
-        res = api.GetUser(api_pb2.GetUserReq(user=user.username))
+        res = api.GetProfile(api_pb2.GetProfileReq(user=user.username))
         assert len(res.language_abilities) == 1
         assert res.language_abilities[0].code == "eng"
         assert res.language_abilities[0].fluency == api_pb2.LanguageAbility.Fluency.FLUENCY_FLUENT
@@ -786,7 +775,7 @@ def test_language_abilities(db):
             )
         )
 
-        res = api.GetUser(api_pb2.GetUserReq(user=user.username))
+        res = api.GetProfile(api_pb2.GetProfileReq(user=user.username))
         assert len(res.language_abilities) == 1
         assert res.language_abilities[0].code == "fin"
         assert res.language_abilities[0].fluency == api_pb2.LanguageAbility.Fluency.FLUENCY_BEGINNER
@@ -805,7 +794,7 @@ def test_language_abilities(db):
             )
         )
 
-        res = api.GetUser(api_pb2.GetUserReq(user=user.username))
+        res = api.GetProfile(api_pb2.GetProfileReq(user=user.username))
         assert len(res.language_abilities) == 1
         assert res.language_abilities[0].code == "fin"
         assert res.language_abilities[0].fluency == api_pb2.LanguageAbility.Fluency.FLUENCY_BEGINNER
@@ -813,7 +802,7 @@ def test_language_abilities(db):
         # don't change it
         api.UpdateProfile(api_pb2.UpdateProfileReq())
 
-        res = api.GetUser(api_pb2.GetUserReq(user=user.username))
+        res = api.GetProfile(api_pb2.GetProfileReq(user=user.username))
         assert len(res.language_abilities) == 1
         assert res.language_abilities[0].code == "fin"
         assert res.language_abilities[0].fluency == api_pb2.LanguageAbility.Fluency.FLUENCY_BEGINNER
@@ -827,7 +816,7 @@ def test_language_abilities(db):
             )
         )
 
-        res = api.GetUser(api_pb2.GetUserReq(user=user.username))
+        res = api.GetProfile(api_pb2.GetProfileReq(user=user.username))
         assert len(res.language_abilities) == 0
 
 
@@ -1472,7 +1461,7 @@ def test_hosting_preferences(db):
     user2, token2 = generate_user()
 
     with api_session(token1) as api:
-        res = api.GetUser(api_pb2.GetUserReq(user=user1.username))
+        res = api.GetProfile(api_pb2.GetProfileReq(user=user1.username))
         assert not res.HasField("max_guests")
         assert not res.HasField("last_minute")
         assert not res.HasField("has_pets")
@@ -1528,7 +1517,7 @@ def test_hosting_preferences(db):
     # Use a second user to view the hosting preferences just to check
     # that it is public information.
     with api_session(token2) as api:
-        res = api.GetUser(api_pb2.GetUserReq(user=user1.username))
+        res = api.GetProfile(api_pb2.GetProfileReq(user=user1.username))
         assert res.max_guests.value == 3
         assert res.last_minute.value
         assert not res.has_pets.value
@@ -1583,7 +1572,7 @@ def test_hosting_preferences(db):
             )
         )
 
-        res = api.GetUser(api_pb2.GetUserReq(user=user1.username))
+        res = api.GetProfile(api_pb2.GetProfileReq(user=user1.username))
         assert not res.HasField("max_guests")
         assert not res.HasField("last_minute")
         assert not res.HasField("has_pets")
@@ -1968,8 +1957,6 @@ def test_GetUser_ghost_user_by_id(db, flag):
         assert user_pb.username == "ghost"
         assert user_pb.name == "Deactivated Account"
         assert user_pb.city == ""
-        assert user_pb.hosting_status == 0
-        assert user_pb.meetup_status == 0
 
 
 def test_GetUser_blocked_user(db):

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -206,10 +206,11 @@ def test_signup_incremental(db):
 
     with api_session(sess_token) as api:
         res = api.GetUser(api_pb2.GetUserReq(user=str(user_id)))
+        profile_res = api.GetProfile(api_pb2.GetProfileReq(user=str(user_id)))
 
     assert res.username == "frodo"
     assert res.gender == "Bot"
-    assert res.hosting_status == api_pb2.HOSTING_STATUS_MAYBE
+    assert profile_res.hosting_status == api_pb2.HOSTING_STATUS_MAYBE
     assert res.city == "New York City"
     assert res.lat == 40.7331
     assert res.lng == -73.9778

--- a/app/backend/src/tests/test_public.py
+++ b/app/backend/src/tests/test_public.py
@@ -562,8 +562,8 @@ def test_GetPublicUser_full_visibility(db):
     with public_session() as public:
         res = public.GetPublicUser(public_pb2.GetPublicUserReq(user="full_user"))
         assert res.HasField("full_user")
-        assert res.full_user.username == "full_user"
-        assert res.full_user.name == "Full User"
-        assert res.full_user.city == "Testing city"
+        assert res.full_user.user.username == "full_user"
+        assert res.full_user.user.name == "Full User"
+        assert res.full_user.user.city == "Testing city"
         # Full user should have all the fields from the complete user profile
-        assert res.full_user.hosting_status == api_pb2.HOSTING_STATUS_CANT_HOST
+        assert res.full_user.profile.hosting_status == api_pb2.HOSTING_STATUS_CANT_HOST

--- a/app/proto/admin.proto
+++ b/app/proto/admin.proto
@@ -25,6 +25,10 @@ service Admin {
     // Get info about a particular user, ignores the fact that they may be banned/deleted
   }
 
+  rpc GetProfile(GetUserReq) returns (org.couchers.api.core.Profile) {
+    // Get the editable profile of a user, ignores the fact that they may be banned/deleted
+  }
+
   rpc SearchUsers(SearchUsersReq) returns (SearchUsersRes) {}
 
   rpc ChangeUserGender(ChangeUserGenderReq) returns (UserDetails) {}

--- a/app/proto/api.proto
+++ b/app/proto/api.proto
@@ -20,6 +20,10 @@ service API {
     // Get info about a particular user
   }
 
+  rpc GetProfile(GetProfileReq) returns (Profile) {
+    // Get the editable profile (markdown bio, hosting prefs, my-home) for a user
+  }
+
   rpc GetLiteUser(GetLiteUserReq) returns (LiteUser) {
     // Get minimal info about a particular user
   }
@@ -317,6 +321,56 @@ message User {
 
 message GetUserReq {
   string user = 1;
+}
+
+message GetProfileReq {
+  string user = 1;
+}
+
+message Profile {
+  int64 user_id = 1;
+
+  string hometown = 2;
+  string pronouns = 3;
+  string occupation = 4;
+  string education = 5; // CommonMark without images
+  string about_me = 6; // CommonMark without images
+  string things_i_like = 7; // CommonMark without images
+  string about_place = 8; // CommonMark without images
+  string additional_information = 9; // CommonMark without images
+
+  HostingStatus hosting_status = 10;
+  MeetupStatus meetup_status = 11;
+
+  repeated string regions_visited = 12;
+  repeated string regions_lived = 13;
+  repeated LanguageAbility language_abilities = 14;
+
+  uint64 profile_gallery_id = 15;
+
+  google.protobuf.UInt32Value max_guests = 20;
+  google.protobuf.BoolValue last_minute = 21;
+  google.protobuf.BoolValue has_pets = 22;
+  google.protobuf.BoolValue accepts_pets = 23;
+  google.protobuf.StringValue pet_details = 24;
+  google.protobuf.BoolValue has_kids = 25;
+  google.protobuf.BoolValue accepts_kids = 26;
+  google.protobuf.StringValue kid_details = 27;
+  google.protobuf.BoolValue has_housemates = 28;
+  google.protobuf.StringValue housemate_details = 29;
+  google.protobuf.BoolValue wheelchair_accessible = 30;
+  SmokingLocation smoking_allowed = 31;
+  google.protobuf.BoolValue smokes_at_home = 32;
+  google.protobuf.BoolValue drinking_allowed = 33;
+  google.protobuf.BoolValue drinks_at_home = 34;
+  google.protobuf.StringValue other_host_info = 35; // CommonMark without images
+  SleepingArrangement sleeping_arrangement = 36;
+  google.protobuf.StringValue sleeping_details = 37; // CommonMark without images
+  google.protobuf.StringValue area = 38; // CommonMark without images
+  google.protobuf.StringValue house_rules = 39; // CommonMark without images
+  google.protobuf.BoolValue parking = 40;
+  ParkingDetails parking_details = 41;
+  google.protobuf.BoolValue camping_ok = 42;
 }
 
 message LiteUser {

--- a/app/proto/api.proto
+++ b/app/proto/api.proto
@@ -219,6 +219,18 @@ enum GenderVerificationStatus {
 }
 
 message User {
+  // Profile fields moved to the Profile message; fetch via GetProfile.
+  reserved 13, 14, 15, 16, 22, 24, 25, 26, 27, 28, 30, 31, 37, 40, 41, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 123;
+  reserved
+    "hometown", "pronouns", "hosting_status", "meetup_status", "occupation", "education",
+    "about_me", "things_i_like", "about_place", "additional_information",
+    "regions_visited", "regions_lived", "language_abilities", "profile_gallery_id",
+    "max_guests", "last_minute", "has_pets", "accepts_pets", "pet_details",
+    "has_kids", "accepts_kids", "kid_details", "has_housemates", "housemate_details",
+    "wheelchair_accessible", "smoking_allowed", "smokes_at_home", "drinking_allowed",
+    "drinks_at_home", "other_host_info", "sleeping_arrangement", "sleeping_details",
+    "area", "house_rules", "parking", "parking_details", "camping_ok";
+
   enum FriendshipStatus {
     NOT_FRIENDS = 0;
     FRIENDS = 1;
@@ -232,7 +244,6 @@ message User {
   string username = 2;
   string name = 3;
   string city = 4;
-  string hometown = 100;
 
   // the user's time zonename derived from their coordinates, for example "Australia/Melbourne"
   string timezone = 122;
@@ -248,54 +259,16 @@ message User {
   double community_standing = 6;
   uint32 num_references = 7;
   string gender = 8;
-  string pronouns = 101;
   uint32 age = 9;
   google.protobuf.Timestamp joined = 11; // not exact
   google.protobuf.Timestamp last_active = 12; // not exact
-  HostingStatus hosting_status = 13;
-  MeetupStatus meetup_status = 102;
-  string occupation = 14;
-  string education = 103; // CommonMark without images
-  string about_me = 15; // CommonMark without images
-  // string my_travels = 104; // CommonMark without images
-  string things_i_like = 105; // CommonMark without images
-  string about_place = 16; // CommonMark without images
-  repeated string regions_visited = 40;
-  repeated string regions_lived = 41;
-  string additional_information = 106; // CommonMark without images
 
   FriendshipStatus friends = 20;
   // only present if friends == FriendshipStatus.PENDING
   FriendRequest pending_friend_request = 36;
 
-  google.protobuf.UInt32Value max_guests = 22;
-  google.protobuf.BoolValue last_minute = 24;
-  google.protobuf.BoolValue has_pets = 107;
-  google.protobuf.BoolValue accepts_pets = 25;
-  google.protobuf.StringValue pet_details = 108;
-  google.protobuf.BoolValue has_kids = 109;
-  google.protobuf.BoolValue accepts_kids = 26;
-  google.protobuf.StringValue kid_details = 110;
-  google.protobuf.BoolValue has_housemates = 111;
-  google.protobuf.StringValue housemate_details = 112;
-  google.protobuf.BoolValue wheelchair_accessible = 27;
-  SmokingLocation smoking_allowed = 28;
-  google.protobuf.BoolValue smokes_at_home = 113;
-  google.protobuf.BoolValue drinking_allowed = 114;
-  google.protobuf.BoolValue drinks_at_home = 115;
-  google.protobuf.StringValue other_host_info = 116; // CommonMark without images
-  SleepingArrangement sleeping_arrangement = 117;
-  google.protobuf.StringValue sleeping_details = 118; // CommonMark without images
-  google.protobuf.StringValue area = 30; // CommonMark without images
-  google.protobuf.StringValue house_rules = 31; // CommonMark without images
-  google.protobuf.BoolValue parking = 119;
-  ParkingDetails parking_details = 120; // CommonMark without images
-  google.protobuf.BoolValue camping_ok = 121;
-
   string avatar_url = 32;
   string avatar_thumbnail_url = 44;
-  uint64 profile_gallery_id = 123;
-  repeated LanguageAbility language_abilities = 37;
 
   repeated string badges = 38;
 

--- a/app/proto/public.proto
+++ b/app/proto/public.proto
@@ -94,8 +94,13 @@ message GetPublicUserRes {
   oneof profile {
     LimitedUser limited_user = 1;
     MostUser most_user = 2;
-    org.couchers.api.core.User full_user = 3;
+    FullUser full_user = 3;
   }
+}
+
+message FullUser {
+  org.couchers.api.core.User user = 1;
+  org.couchers.api.core.Profile profile = 2;
 }
 
 message GetSignupPageInfoRes {

--- a/app/web/features/dashboard/DashboardUserProfileSummary.tsx
+++ b/app/web/features/dashboard/DashboardUserProfileSummary.tsx
@@ -5,6 +5,7 @@ import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
 import { ProfileUserProvider } from "features/profile/hooks/useProfileUser";
 import UserOverview from "features/profile/view/UserOverview";
 import useCurrentUser from "features/userQueries/useCurrentUser";
+import { useCurrentProfile } from "features/userQueries/useProfile";
 import { DASHBOARD } from "i18n/namespaces";
 import Link from "next/link";
 import { useTranslation } from "next-i18next";
@@ -33,17 +34,23 @@ function DashboardUserProfileSummaryActions() {
 
 export default function DashboardUserProfileSummary() {
   const { data: user, error, isLoading } = useCurrentUser();
+  const {
+    data: profile,
+    error: profileError,
+    isLoading: isProfileLoading,
+  } = useCurrentProfile();
   const desktopMode = useMediaQuery((theme: Theme) =>
     theme.breakpoints.up("sm"),
   );
   return (
     <>
       {error && <Alert severity="error">{error}</Alert>}
-      {isLoading ? (
+      {profileError && <Alert severity="error">{profileError.message}</Alert>}
+      {isLoading || isProfileLoading ? (
         <CenteredSpinner />
-      ) : user ? (
+      ) : user && profile ? (
         desktopMode ? (
-          <ProfileUserProvider user={user}>
+          <ProfileUserProvider user={user} profile={profile}>
             <UserOverview
               actions={<DashboardUserProfileSummaryActions />}
               showHostAndMeetAvailability

--- a/app/web/features/mod/ModUserPage.tsx
+++ b/app/web/features/mod/ModUserPage.tsx
@@ -74,7 +74,8 @@ export default function ModUserPage({
 }) {
   const router = useRouter();
 
-  const { user, userDetails, isLoading, error } = useUserWithDetails(username);
+  const { user, profile, userDetails, isLoading, error } =
+    useUserWithDetails(username);
 
   return (
     <>
@@ -82,9 +83,9 @@ export default function ModUserPage({
       {error && <Alert severity="error">{error}</Alert>}
       {isLoading ? (
         <CenteredSpinner />
-      ) : user && userDetails ? (
+      ) : user && profile && userDetails ? (
         <ModUserDetails userDetails={userDetails}>
-          <ProfileUserProvider user={user}>
+          <ProfileUserProvider user={user} profile={profile}>
             <BanDeleteBanner userDetails={userDetails} />
             <StyledProfileRoot>
               <UserOverview

--- a/app/web/features/mod/hooks.ts
+++ b/app/web/features/mod/hooks.ts
@@ -73,8 +73,7 @@ export default function useUserWithDetails(user: string) {
     query.isLoading || profileQuery.isLoading || detailsQuery.isLoading;
   const isFetching =
     query.isFetching || profileQuery.isFetching || detailsQuery.isFetching;
-  const isError =
-    query.isError || profileQuery.isError || detailsQuery.isError;
+  const isError = query.isError || profileQuery.isError || detailsQuery.isError;
 
   return {
     user: query.data,

--- a/app/web/features/mod/hooks.ts
+++ b/app/web/features/mod/hooks.ts
@@ -11,7 +11,7 @@ import {
 import { userStaleTime } from "features/userQueries/constants";
 import { RpcError } from "grpc-web";
 import { ListUserIdsRes, UserDetails } from "proto/admin_pb";
-import { User } from "proto/api_pb";
+import { Profile, User } from "proto/api_pb";
 import { service } from "service";
 
 export const useNewUsers = () => {
@@ -45,6 +45,12 @@ export default function useUserWithDetails(user: string) {
     staleTime: userStaleTime,
   });
 
+  const profileQuery = useQuery<Profile.AsObject, RpcError>({
+    queryFn: () => service.admin.getProfile(user),
+    queryKey: ["modProfile", user],
+    staleTime: userStaleTime,
+  });
+
   const detailsQuery = useQuery<UserDetails.AsObject, RpcError>({
     queryFn: () => service.admin.getUserDetails(user),
     queryKey: [modUserDetailsKey(user)],
@@ -55,17 +61,24 @@ export default function useUserWithDetails(user: string) {
   if (query.error?.message) {
     errors.push(query.error?.message || "");
   }
+  if (profileQuery.error?.message) {
+    errors.push(profileQuery.error?.message || "");
+  }
   if (detailsQuery.error?.message) {
     errors.push(detailsQuery.error?.message || "");
   }
 
   const error = errors.join("\n");
-  const isLoading = query.isLoading || detailsQuery.isLoading;
-  const isFetching = query.isFetching || detailsQuery.isFetching;
-  const isError = query.isError || detailsQuery.isError;
+  const isLoading =
+    query.isLoading || profileQuery.isLoading || detailsQuery.isLoading;
+  const isFetching =
+    query.isFetching || profileQuery.isFetching || detailsQuery.isFetching;
+  const isError =
+    query.isError || profileQuery.isError || detailsQuery.isError;
 
   return {
     user: query.data,
+    profile: profileQuery.data,
     userDetails: detailsQuery.data,
     error,
     isError,

--- a/app/web/features/profile/ProfileSheet.tsx
+++ b/app/web/features/profile/ProfileSheet.tsx
@@ -7,6 +7,7 @@ import NewHostRequest from "features/profile/view/NewHostRequest";
 import NewMessage from "features/profile/view/NewMessage";
 import Overview from "features/profile/view/Overview";
 import UserCard from "features/profile/view/UserCard";
+import { useProfile } from "features/userQueries/useProfile";
 import { useUser } from "features/userQueries/useUsers";
 import { useTranslation } from "i18n";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
@@ -57,6 +58,9 @@ export default function ProfileSheet() {
   const { t } = useTranslation([GLOBAL, PROFILE]);
   const router = useRouter();
   const { data: user, isLoading } = useUser(openProfileUserId ?? undefined);
+  const { data: profile, isLoading: isProfileLoading } = useProfile(
+    openProfileUserId ?? undefined,
+  );
   const scrollRef = useRef<HTMLDivElement>(null);
   const [tab, setTab] = useState<UserTab>("about");
   const [isRequesting, setIsRequesting] = useState(false);
@@ -115,9 +119,9 @@ export default function ProfileSheet() {
               {t("profile:message_form.success")}
             </Snackbar>
           )}
-          {isLoading && <CenteredSpinner />}
-          {user && (
-            <ProfileUserProvider user={user}>
+          {(isLoading || isProfileLoading) && <CenteredSpinner />}
+          {user && profile && (
+            <ProfileUserProvider user={user} profile={profile}>
               <Overview
                 setIsRequesting={setIsRequesting}
                 setIsMessaging={setIsMessaging}

--- a/app/web/features/profile/edit/EditHostingPreference.test.tsx
+++ b/app/web/features/profile/edit/EditHostingPreference.test.tsx
@@ -4,7 +4,7 @@ import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { service } from "service";
 import wrapper from "test/hookWrapper";
 import i18n from "test/i18n";
-import { getUser } from "test/serviceMockDefaults";
+import { getProfile, getUser } from "test/serviceMockDefaults";
 
 import { ParkingDetails } from "../../../proto/api_pb";
 import { addDefaultUser, MockedService } from "../../../test/utils";
@@ -16,6 +16,9 @@ jest.mock("components/MarkdownInput");
 
 const getUserMock = service.user.getUser as MockedService<
   typeof service.user.getUser
+>;
+const getProfileMock = service.user.getProfile as MockedService<
+  typeof service.user.getProfile
 >;
 const updateHostingPreferenceMock = service.user
   .updateHostingPreference as MockedService<
@@ -30,6 +33,7 @@ describe("EditHostingPreference", () => {
   beforeEach(() => {
     addDefaultUser(1);
     getUserMock.mockImplementation(getUser);
+    getProfileMock.mockImplementation(getProfile);
     updateHostingPreferenceMock.mockResolvedValue(new Empty());
   });
 
@@ -72,6 +76,10 @@ describe("EditHostingPreference", () => {
 
     getUserMock.mockImplementation(async (user) => ({
       ...(await getUser(user)),
+      aboutPlace: "",
+    }));
+    getProfileMock.mockImplementation(async (user) => ({
+      ...(await getProfile(user)),
       aboutPlace: "",
     }));
     renderPage();

--- a/app/web/features/profile/edit/EditHostingPreference.tsx
+++ b/app/web/features/profile/edit/EditHostingPreference.tsx
@@ -1,52 +1,54 @@
 import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
-import useCurrentUser from "features/userQueries/useCurrentUser";
+import { useCurrentProfile } from "features/userQueries/useProfile";
 import React from "react";
 
 import {
   ParkingDetails,
+  Profile,
   SleepingArrangement,
   SmokingLocation,
-  User,
 } from "../../../proto/api_pb";
 import { HostingPreferenceData } from "../../../service/user";
 import { DEFAULT_ABOUT_HOME_HEADINGS } from "./constants";
 import EditHostingPreferenceForm from "./EditHostingPreferenceForm";
 
 export default function EditHostingPreference() {
-  const { data: user } = useCurrentUser();
+  const { data: profile } = useCurrentProfile();
 
-  if (user) {
-    const userToFormValues = (user: User.AsObject): HostingPreferenceData => ({
-      lastMinute: !!user.lastMinute?.value,
-      wheelchairAccessible: !!user.wheelchairAccessible?.value,
-      campingOk: !!user.campingOk?.value,
-      acceptsKids: !!user.acceptsKids?.value,
-      acceptsPets: !!user.acceptsPets?.value,
-      drinkingAllowed: !!user.drinkingAllowed?.value,
-      maxGuests: user.maxGuests?.value ?? 1,
+  if (profile) {
+    const profileToFormValues = (
+      profile: Profile.AsObject,
+    ): HostingPreferenceData => ({
+      lastMinute: !!profile.lastMinute?.value,
+      wheelchairAccessible: !!profile.wheelchairAccessible?.value,
+      campingOk: !!profile.campingOk?.value,
+      acceptsKids: !!profile.acceptsKids?.value,
+      acceptsPets: !!profile.acceptsPets?.value,
+      drinkingAllowed: !!profile.drinkingAllowed?.value,
+      maxGuests: profile.maxGuests?.value ?? 1,
       smokingAllowed:
-        user.smokingAllowed || SmokingLocation.SMOKING_LOCATION_UNKNOWN,
-      aboutPlace: user.aboutPlace || DEFAULT_ABOUT_HOME_HEADINGS,
+        profile.smokingAllowed || SmokingLocation.SMOKING_LOCATION_UNKNOWN,
+      aboutPlace: profile.aboutPlace || DEFAULT_ABOUT_HOME_HEADINGS,
       sleepingArrangement:
-        user.sleepingArrangement ||
+        profile.sleepingArrangement ||
         SleepingArrangement.SLEEPING_ARRANGEMENT_UNKNOWN,
-      hasHousemates: !!user.hasHousemates?.value,
-      housemateDetails: user.housemateDetails?.value ?? "",
-      hasKids: !!user.hasKids?.value,
-      kidDetails: user.kidDetails?.value ?? "",
-      hasPets: !!user.hasPets?.value,
-      petDetails: user.petDetails?.value ?? "",
-      parking: !!user.parking?.value,
+      hasHousemates: !!profile.hasHousemates?.value,
+      housemateDetails: profile.housemateDetails?.value ?? "",
+      hasKids: !!profile.hasKids?.value,
+      kidDetails: profile.kidDetails?.value ?? "",
+      hasPets: !!profile.hasPets?.value,
+      petDetails: profile.petDetails?.value ?? "",
+      parking: !!profile.parking?.value,
       parkingDetails:
-        user.parkingDetails || ParkingDetails.PARKING_DETAILS_UNKNOWN,
-      drinksAtHome: !!user.drinksAtHome?.value,
-      smokesAtHome: !!user.smokesAtHome?.value,
-      area: user.area?.value ?? "",
-      sleepingDetails: user.sleepingDetails?.value ?? "",
-      houseRules: user.houseRules?.value ?? "",
-      otherHostInfo: user.otherHostInfo?.value ?? "",
+        profile.parkingDetails || ParkingDetails.PARKING_DETAILS_UNKNOWN,
+      drinksAtHome: !!profile.drinksAtHome?.value,
+      smokesAtHome: !!profile.smokesAtHome?.value,
+      area: profile.area?.value ?? "",
+      sleepingDetails: profile.sleepingDetails?.value ?? "",
+      houseRules: profile.houseRules?.value ?? "",
+      otherHostInfo: profile.otherHostInfo?.value ?? "",
     });
-    return <EditHostingPreferenceForm user={userToFormValues(user)} />;
+    return <EditHostingPreferenceForm user={profileToFormValues(profile)} />;
   }
 
   return <CenteredSpinner />;

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -28,6 +28,7 @@ import ProfileMarkdownInput from "features/profile/ProfileMarkdownInput";
 import ProfileTagInput from "features/profile/ProfileTagInput";
 import ProfileTextInput from "features/profile/ProfileTextInput";
 import useCurrentUser from "features/userQueries/useCurrentUser";
+import { useCurrentProfile } from "features/userQueries/useProfile";
 import { StatusCode } from "grpc-web";
 import { Trans, useTranslation } from "i18n";
 import { AUTH, GLOBAL, PROFILE } from "i18n/namespaces";
@@ -264,6 +265,7 @@ export default function EditProfileForm() {
     error: updateMutationError,
   } = useUpdateUserProfile();
   const { data: user } = useCurrentUser();
+  const { data: profile } = useCurrentProfile();
   const isMounted = useIsMounted();
   const [errorMessage, setErrorMessage] = useSafeState<string | null>(
     isMounted,
@@ -293,28 +295,28 @@ export default function EditProfileForm() {
   // Reset form with user data when user and data are loaded
   // This allows only showing save bar once something changes
   useEffect(() => {
-    if (user && languages && regions) {
+    if (user && profile && languages && regions) {
       reset(
         {
           name: user.name,
-          pronouns: user.pronouns,
-          hometown: user.hometown,
-          occupation: user.occupation,
-          education: user.education,
-          hostingStatus: user.hostingStatus,
-          meetupStatus: user.meetupStatus,
-          fluentLanguages: user.languageAbilitiesList
+          pronouns: profile.pronouns,
+          hometown: profile.hometown,
+          occupation: profile.occupation,
+          education: profile.education,
+          hostingStatus: profile.hostingStatus,
+          meetupStatus: profile.meetupStatus,
+          fluentLanguages: profile.languageAbilitiesList
             .map((ability) => languages[ability.code] || "")
             .filter(Boolean),
-          regionsVisited: user.regionsVisitedList
+          regionsVisited: profile.regionsVisitedList
             .map((region) => regions[region] || "")
             .filter(Boolean),
-          regionsLived: user.regionsLivedList
+          regionsLived: profile.regionsLivedList
             .map((region) => regions[region] || "")
             .filter(Boolean),
-          aboutMe: user.aboutMe,
-          thingsILike: user.thingsILike || DEFAULT_HOBBIES_HEADINGS,
-          additionalInformation: user.additionalInformation,
+          aboutMe: profile.aboutMe,
+          thingsILike: profile.thingsILike || DEFAULT_HOBBIES_HEADINGS,
+          additionalInformation: profile.additionalInformation,
           location: {
             city: user.city,
             lat: user.lat,
@@ -333,8 +335,8 @@ export default function EditProfileForm() {
           hometown: "",
           occupation: "",
           education: "",
-          hostingStatus: user?.hostingStatus,
-          meetupStatus: user?.meetupStatus,
+          hostingStatus: profile?.hostingStatus,
+          meetupStatus: profile?.meetupStatus,
           fluentLanguages: [],
           regionsVisited: [],
           regionsLived: [],
@@ -351,7 +353,7 @@ export default function EditProfileForm() {
         { keepDirty: false, keepErrors: false },
       );
     }
-  }, [user, reset, languages, regions]);
+  }, [user, profile, reset, languages, regions]);
 
   // Scroll to gallery editor if hash is #gallery (from ProfilePage avatar click)
   useEffect(() => {
@@ -479,7 +481,7 @@ export default function EditProfileForm() {
           {t("profile:helper_text.missing_profile_photo")}
         </StyledAlert>
       )}
-      {user && languages && regions ? (
+      {user && profile && languages && regions ? (
         <>
           <HelpTextContainer>
             <Typography>
@@ -557,7 +559,7 @@ export default function EditProfileForm() {
 
               <FieldGroup ref={galleryEditorRef}>
                 <GalleryEditor
-                  galleryId={user.profileGalleryId}
+                  galleryId={profile.profileGalleryId}
                   userId={user.userId}
                   title={t("profile:gallery.profile_photos_title")}
                   description={t("profile:gallery.profile_photos_description")}
@@ -637,7 +639,7 @@ export default function EditProfileForm() {
               <FieldGroup>
                 <Controller
                   control={control}
-                  defaultValue={user.hostingStatus}
+                  defaultValue={profile.hostingStatus}
                   name="hostingStatus"
                   render={({ field }) => (
                     <StatusCardGroup
@@ -711,7 +713,7 @@ export default function EditProfileForm() {
               <FieldGroup>
                 <Controller
                   control={control}
-                  defaultValue={user.meetupStatus}
+                  defaultValue={profile.meetupStatus}
                   name="meetupStatus"
                   render={({ field }) => (
                     <StatusCardGroup
@@ -803,7 +805,7 @@ export default function EditProfileForm() {
                 </Typography>
                 <Controller
                   control={control}
-                  defaultValue={user.pronouns}
+                  defaultValue={profile.pronouns}
                   name="pronouns"
                   render={({ field }) => {
                     const other =
@@ -858,7 +860,7 @@ export default function EditProfileForm() {
                 <FieldGroup>
                   <Controller
                     control={control}
-                    defaultValue={user.languageAbilitiesList.map(
+                    defaultValue={profile.languageAbilitiesList.map(
                       (ability) => languages[ability.code],
                     )}
                     name="fluentLanguages"
@@ -883,7 +885,7 @@ export default function EditProfileForm() {
                   id="hometown"
                   {...register("hometown")}
                   label={t("profile:edit_profile_headings.hometown")}
-                  defaultValue={user.hometown}
+                  defaultValue={profile.hometown}
                 />
               </FieldGroup>
 
@@ -892,7 +894,7 @@ export default function EditProfileForm() {
                   id="occupation"
                   {...register("occupation")}
                   label={t("profile:edit_profile_headings.occupation")}
-                  defaultValue={user.occupation}
+                  defaultValue={profile.occupation}
                 />
               </FieldGroup>
 
@@ -901,7 +903,7 @@ export default function EditProfileForm() {
                   id="education"
                   {...register("education")}
                   label={t("profile:edit_profile_headings.education")}
-                  defaultValue={user.education}
+                  defaultValue={profile.education}
                 />
               </FieldGroup>
             </ProfileSection>
@@ -931,7 +933,7 @@ export default function EditProfileForm() {
                   label={t("profile:heading.about_me")}
                   name="aboutMe"
                   placeholder={DEFAULT_ABOUT_ME_HEADINGS}
-                  defaultValue={user.aboutMe}
+                  defaultValue={profile.aboutMe}
                   control={control}
                   warning={aboutMeField.length < ABOUT_ME_MIN_LENGTH}
                   helperText={
@@ -971,7 +973,7 @@ export default function EditProfileForm() {
                   id="thingsILike"
                   label={t("profile:heading.hobbies_section")}
                   name="thingsILike"
-                  defaultValue={user.thingsILike || DEFAULT_HOBBIES_HEADINGS}
+                  defaultValue={profile.thingsILike || DEFAULT_HOBBIES_HEADINGS}
                   control={control}
                 />
               </FieldGroup>
@@ -981,7 +983,7 @@ export default function EditProfileForm() {
                   id="additionalInformation"
                   label={t("profile:heading.additional_information_section")}
                   name="additionalInformation"
-                  defaultValue={user.additionalInformation}
+                  defaultValue={profile.additionalInformation}
                   control={control}
                 />
               </FieldGroup>
@@ -1002,7 +1004,7 @@ export default function EditProfileForm() {
                 <FieldGroup>
                   <Controller
                     control={control}
-                    defaultValue={user.regionsVisitedList.map(
+                    defaultValue={profile.regionsVisitedList.map(
                       (region) => regions[region],
                     )}
                     name="regionsVisited"
@@ -1024,7 +1026,7 @@ export default function EditProfileForm() {
                 <FieldGroup>
                   <Controller
                     control={control}
-                    defaultValue={user.regionsLivedList.map(
+                    defaultValue={profile.regionsLivedList.map(
                       (region) => regions[region],
                     )}
                     name="regionsLived"

--- a/app/web/features/profile/edit/EditProfilePage.test.tsx
+++ b/app/web/features/profile/edit/EditProfilePage.test.tsx
@@ -3,7 +3,12 @@ import userEvent from "@testing-library/user-event";
 import { service } from "service";
 import wrapper from "test/hookWrapper";
 import i18n from "test/i18n";
-import { getLanguages, getRegions, getUser } from "test/serviceMockDefaults";
+import {
+  getLanguages,
+  getProfile,
+  getRegions,
+  getUser,
+} from "test/serviceMockDefaults";
 import { addDefaultUser } from "test/utils";
 
 import EditProfilePage from "./EditProfilePage";
@@ -15,6 +20,10 @@ jest.mock("components/MarkdownInput");
 
 const getUserMock = service.user.getUser as jest.MockedFunction<
   typeof service.user.getUser
+>;
+
+const getProfileMock = service.user.getProfile as jest.MockedFunction<
+  typeof service.user.getProfile
 >;
 
 const getLanguagesMock = service.resources.getLanguages as jest.MockedFunction<
@@ -45,11 +54,13 @@ describe("Edit profile", () => {
     addDefaultUser();
     getRegionsMock.mockImplementation(getRegions);
     getLanguagesMock.mockImplementation(getLanguages);
+    getProfileMock.mockImplementation(getProfile);
   });
 
   afterEach(() => {
     updateProfileMock.mockClear();
     getUserMock.mockClear();
+    getProfileMock.mockClear();
     uploadFileMock.mockClear();
   });
 
@@ -110,6 +121,11 @@ describe("Edit profile", () => {
       aboutMe: "",
       thingsILike: "",
     }));
+    getProfileMock.mockImplementation(async (user) => ({
+      ...(await getProfile(user)),
+      aboutMe: "",
+      thingsILike: "",
+    }));
     await renderPage();
 
     const user = userEvent.setup();
@@ -152,6 +168,11 @@ describe("Edit profile", () => {
       aboutMe: "",
       thingsILike: "",
     }));
+    getProfileMock.mockImplementation(async (user) => ({
+      ...(await getProfile(user)),
+      aboutMe: "",
+      thingsILike: "",
+    }));
 
     await renderPage();
 
@@ -178,6 +199,11 @@ describe("Edit profile", () => {
 
     getUserMock.mockImplementation(async (user) => ({
       ...(await getUser(user)),
+      aboutMe: "",
+      thingsILike: "",
+    }));
+    getProfileMock.mockImplementation(async (user) => ({
+      ...(await getProfile(user)),
       aboutMe: "",
       thingsILike: "",
     }));

--- a/app/web/features/profile/hooks/useProfileUser.tsx
+++ b/app/web/features/profile/hooks/useProfileUser.tsx
@@ -1,4 +1,4 @@
-import { User } from "proto/api_pb";
+import { Profile, User } from "proto/api_pb";
 import * as React from "react";
 
 const ProfileUserContext = React.createContext<User.AsObject>(
@@ -6,18 +6,27 @@ const ProfileUserContext = React.createContext<User.AsObject>(
 );
 ProfileUserContext.displayName = "ProfileUserContext";
 
+const ProfileDataContext = React.createContext<Profile.AsObject>(
+  {} as Profile.AsObject,
+);
+ProfileDataContext.displayName = "ProfileDataContext";
+
 interface ProfileUserProviderProps {
   children?: React.ReactNode;
   user: User.AsObject;
+  profile: Profile.AsObject;
 }
 
 export function ProfileUserProvider({
   children,
   user,
+  profile,
 }: ProfileUserProviderProps) {
   return (
     <ProfileUserContext.Provider value={user}>
-      {children}
+      <ProfileDataContext.Provider value={profile}>
+        {children}
+      </ProfileDataContext.Provider>
     </ProfileUserContext.Provider>
   );
 }
@@ -28,4 +37,12 @@ export function useProfileUser() {
     throw new Error("No ProfileUserContext provided!");
   }
   return profileUser;
+}
+
+export function useProfileData() {
+  const profileData = React.useContext(ProfileDataContext);
+  if (profileData === null) {
+    throw new Error("No ProfileDataContext provided!");
+  }
+  return profileData;
 }

--- a/app/web/features/profile/view/About.test.tsx
+++ b/app/web/features/profile/view/About.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { User } from "proto/api_pb";
+import { ProfileUserProvider } from "features/profile/hooks/useProfileUser";
+import { Profile, User } from "proto/api_pb";
 import { service } from "service";
 import wrapper from "test/hookWrapper";
 import { getLanguages, getRegions } from "test/serviceMockDefaults";
@@ -19,8 +20,21 @@ beforeEach(() => {
   getRegionsMock.mockImplementation(getRegions);
 });
 
-function renderAbout(user?: User.AsObject) {
-  return render(<About user={user || defaultUser} />, { wrapper });
+function renderAbout(overrides?: {
+  user?: Partial<User.AsObject>;
+  profile?: Partial<Profile.AsObject>;
+}) {
+  const user = { ...defaultUser, ...overrides?.user } as User.AsObject;
+  const profile = {
+    ...defaultProfile,
+    ...overrides?.profile,
+  } as Profile.AsObject;
+  return render(
+    <ProfileUserProvider user={user} profile={profile}>
+      <About />
+    </ProfileUserProvider>,
+    { wrapper },
+  );
 }
 describe("About (user)", () => {
   it("displays both visited and lived regions", async () => {
@@ -38,9 +52,10 @@ describe("About (user)", () => {
 
   it("should display age and gender without verification icons when unspecified ", async () => {
     renderAbout({
-      ...defaultUser,
-      genderVerificationStatus: 0,
-      birthdateVerificationStatus: 0,
+      user: {
+        genderVerificationStatus: 0,
+        birthdateVerificationStatus: 0,
+      },
     });
 
     const checkIcon = screen.queryByTestId("check-circle-icon");
@@ -50,9 +65,10 @@ describe("About (user)", () => {
   });
   it("should display age and gender without verification icons when unverified", async () => {
     renderAbout({
-      ...defaultUser,
-      genderVerificationStatus: 1,
-      birthdateVerificationStatus: 1,
+      user: {
+        genderVerificationStatus: 1,
+        birthdateVerificationStatus: 1,
+      },
     });
 
     const checkIcon = screen.queryByTestId("check-circle-icon");
@@ -63,9 +79,10 @@ describe("About (user)", () => {
 
   it("should display verification ticks when verified", async () => {
     renderAbout({
-      ...defaultUser,
-      genderVerificationStatus: 2,
-      birthdateVerificationStatus: 2,
+      user: {
+        genderVerificationStatus: 2,
+        birthdateVerificationStatus: 2,
+      },
     });
 
     const checkIcons = screen.queryAllByTestId("check-circle-icon");
@@ -76,9 +93,10 @@ describe("About (user)", () => {
 
   it("should display error icons when mismatched", async () => {
     renderAbout({
-      ...defaultUser,
-      genderVerificationStatus: 3,
-      birthdateVerificationStatus: 3,
+      user: {
+        genderVerificationStatus: 3,
+        birthdateVerificationStatus: 3,
+      },
     });
 
     const checkIcons = screen.queryByTestId("check-circle-icon");
@@ -89,9 +107,10 @@ describe("About (user)", () => {
 
   it("displays None when there are no regions", async () => {
     renderAbout({
-      ...defaultUser,
-      regionsVisitedList: [],
-      regionsLivedList: [],
+      profile: {
+        regionsVisitedList: [],
+        regionsLivedList: [],
+      },
     });
     expect((await screen.findAllByText("None")).length).toBe(2);
   });

--- a/app/web/features/profile/view/About.tsx
+++ b/app/web/features/profile/view/About.tsx
@@ -1,18 +1,17 @@
 import { styled, Typography, useTheme } from "@mui/material";
 import Divider from "components/Divider";
 import Markdown from "components/Markdown";
+import {
+  useProfileData,
+  useProfileUser,
+} from "features/profile/hooks/useProfileUser";
 import { useTranslation } from "i18n";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
-import { User } from "proto/api_pb";
 import { ComposableMap, Geographies, Geography } from "react-simple-maps";
 
 import { useRegions } from "../hooks/useRegions";
 import ProfilePhotoGallery from "./ProfilePhotoGallery";
 import { AgeGenderLanguagesLabels, RemainingAboutLabels } from "./userLabels";
-
-interface AboutProps {
-  user: User.AsObject;
-}
 
 const StyledWrapper = styled("div")(({ theme }) => ({
   marginTop: theme.spacing(1),
@@ -22,51 +21,53 @@ const StyledDivider = styled(Divider)(({ theme }) => ({
   marginTop: theme.spacing(3),
 }));
 
-export default function About({ user }: AboutProps) {
+export default function About() {
   const { t } = useTranslation([GLOBAL, PROFILE]);
   const theme = useTheme();
   const { regions } = useRegions();
+  const user = useProfileUser();
+  const profile = useProfileData();
   return (
     <StyledWrapper>
       <Typography variant="h1">
         {t("profile:heading.overview_section")}
       </Typography>
-      <AgeGenderLanguagesLabels user={user} />
-      <RemainingAboutLabels user={user} />
+      <AgeGenderLanguagesLabels user={user} profile={profile} />
+      <RemainingAboutLabels user={user} profile={profile} />
 
-      {user.profileGalleryId && user.profileGalleryId > 0 && (
+      {profile.profileGalleryId && profile.profileGalleryId > 0 && (
         <>
-          <ProfilePhotoGallery galleryId={user.profileGalleryId} />
+          <ProfilePhotoGallery galleryId={profile.profileGalleryId} />
           <StyledDivider />
         </>
       )}
 
-      {!user.profileGalleryId && <StyledDivider />}
+      {!profile.profileGalleryId && <StyledDivider />}
 
-      {user.aboutMe && (
+      {profile.aboutMe && (
         <>
           <Typography variant="h1">
             {t("profile:heading.who_section")}
           </Typography>
-          <Markdown source={user.aboutMe} />
+          <Markdown source={profile.aboutMe} />
           <StyledDivider />
         </>
       )}
-      {user.thingsILike && (
+      {profile.thingsILike && (
         <>
           <Typography variant="h1">
             {t("profile:heading.hobbies_section")}
           </Typography>
-          <Markdown source={user.thingsILike} />
+          <Markdown source={profile.thingsILike} />
           <StyledDivider />
         </>
       )}
-      {user.additionalInformation && (
+      {profile.additionalInformation && (
         <>
           <Typography variant="h1">
             {t("profile:heading.additional_information_section")}
           </Typography>
-          <Markdown source={user.additionalInformation} />
+          <Markdown source={profile.additionalInformation} />
           <StyledDivider />
         </>
       )}
@@ -74,8 +75,8 @@ export default function About({ user }: AboutProps) {
         {t("profile:heading.travel_section")}
       </Typography>
       <Typography variant="body1">
-        {regions && user.regionsVisitedList.length > 0
-          ? user.regionsVisitedList
+        {regions && profile.regionsVisitedList.length > 0
+          ? profile.regionsVisitedList
               .map((country) => regions[country])
               .join(`, `)
           : t("profile:regions_empty_state")}
@@ -83,8 +84,10 @@ export default function About({ user }: AboutProps) {
       <StyledDivider />
       <Typography variant="h1">{t("profile:heading.lived_section")}</Typography>
       <Typography variant="body1">
-        {regions && user.regionsLivedList.length > 0
-          ? user.regionsLivedList.map((country) => regions[country]).join(`, `)
+        {regions && profile.regionsLivedList.length > 0
+          ? profile.regionsLivedList
+              .map((country) => regions[country])
+              .join(`, `)
           : t("profile:regions_empty_state")}
       </Typography>
       <StyledDivider />
@@ -95,9 +98,9 @@ export default function About({ user }: AboutProps) {
             geographies.map((geo) => {
               let color = theme.palette.grey[200];
               if (regions) {
-                if (user.regionsLivedList.includes(geo.id)) {
+                if (profile.regionsLivedList.includes(geo.id)) {
                   color = theme.palette.primary.main;
-                } else if (user.regionsVisitedList.includes(geo.id)) {
+                } else if (profile.regionsVisitedList.includes(geo.id)) {
                   color = theme.palette.secondary.main;
                 }
               }

--- a/app/web/features/profile/view/Home.tsx
+++ b/app/web/features/profile/view/Home.tsx
@@ -8,9 +8,9 @@ import {
   sleepingArrangementLabelsShort,
   smokingLocationLabels,
 } from "features/profile/constants";
+import { useProfileData } from "features/profile/hooks/useProfileUser";
 import { useTranslation } from "i18n";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
-import { User } from "proto/api_pb";
 
 const StyledRoot = styled("div")({
   display: "flex",
@@ -28,12 +28,9 @@ const StyledSpacedDivider = styled(Divider)(({ theme }) => ({
   marginTop: theme.spacing(3),
 }));
 
-interface HomeProps {
-  user: User.AsObject;
-}
-
-export default function Home({ user }: HomeProps) {
+export default function Home() {
   const { t } = useTranslation([GLOBAL, PROFILE]);
+  const profile = useProfileData();
 
   return (
     <>
@@ -44,35 +41,35 @@ export default function Home({ user }: HomeProps) {
           </Typography>
           <LabelAndText
             label={t("profile:home_info_headings.last_minute")}
-            text={booleanConversion(t, user.lastMinute?.value)}
+            text={booleanConversion(t, profile.lastMinute?.value)}
           />
           <LabelAndText
             label={t("profile:home_info_headings.wheelchair")}
-            text={booleanConversion(t, user.wheelchairAccessible?.value)}
+            text={booleanConversion(t, profile.wheelchairAccessible?.value)}
           />
           <LabelAndText
             label={t("profile:edit_home_questions.accept_camping")}
-            text={booleanConversion(t, user.campingOk?.value)}
+            text={booleanConversion(t, profile.campingOk?.value)}
           />
           <LabelAndText
             label={t("profile:home_info_headings.max_guests")}
-            text={`${user.maxGuests?.value || t("profile:unspecified_info")}`}
+            text={`${profile.maxGuests?.value || t("profile:unspecified_info")}`}
           />
           <LabelAndText
             label={t("profile:edit_home_questions.accept_kids")}
-            text={booleanConversion(t, user.acceptsKids?.value)}
+            text={booleanConversion(t, profile.acceptsKids?.value)}
           />
           <LabelAndText
             label={t("profile:edit_home_questions.accept_pets")}
-            text={booleanConversion(t, user.acceptsPets?.value)}
+            text={booleanConversion(t, profile.acceptsPets?.value)}
           />
           <LabelAndText
             label={t("profile:edit_home_questions.accept_drinking")}
-            text={booleanConversion(t, user.drinkingAllowed?.value)}
+            text={booleanConversion(t, profile.drinkingAllowed?.value)}
           />
           <LabelAndText
             label={t("profile:edit_home_questions.accept_smoking")}
-            text={`${smokingLocationLabels(t)[user.smokingAllowed]}`}
+            text={`${smokingLocationLabels(t)[profile.smokingAllowed]}`}
           />
         </StyledInfoColumn>
         <StyledInfoColumn>
@@ -82,91 +79,91 @@ export default function Home({ user }: HomeProps) {
           <LabelAndText
             label={t("profile:home_info_headings.space")}
             text={
-              sleepingArrangementLabelsShort(t)[user.sleepingArrangement] ||
+              sleepingArrangementLabelsShort(t)[profile.sleepingArrangement] ||
               t("profile:unspecified_info")
             }
           />
           <LabelAndText
             label={t("profile:home_info_headings.parking")}
-            text={booleanConversion(t, user.parking?.value)}
+            text={booleanConversion(t, profile.parking?.value)}
           />
           <LabelAndText
             label={t("profile:home_info_headings.parking_details")}
-            text={parkingDetailsLabels(t)[user.parkingDetails]}
+            text={parkingDetailsLabels(t)[profile.parkingDetails]}
           />
           <LabelAndText
             label={t("profile:home_info_headings.has_housemates")}
-            text={`${booleanConversion(t, user.hasHousemates?.value)}${
-              user.housemateDetails?.value
-                ? `, ${user.housemateDetails?.value}`
+            text={`${booleanConversion(t, profile.hasHousemates?.value)}${
+              profile.housemateDetails?.value
+                ? `, ${profile.housemateDetails?.value}`
                 : ""
             }`}
           />
           <LabelAndText
             label={t("profile:home_info_headings.has_kids")}
-            text={`${booleanConversion(t, user.hasKids?.value)}${
-              user.kidDetails?.value ? `, ${user.kidDetails?.value}` : ""
+            text={`${booleanConversion(t, profile.hasKids?.value)}${
+              profile.kidDetails?.value ? `, ${profile.kidDetails?.value}` : ""
             }`}
           />
           <LabelAndText
             label={t("profile:home_info_headings.has_pets")}
-            text={`${booleanConversion(t, user.hasPets?.value)}${
-              user.petDetails?.value ? `, ${user.petDetails?.value}` : ""
+            text={`${booleanConversion(t, profile.hasPets?.value)}${
+              profile.petDetails?.value ? `, ${profile.petDetails?.value}` : ""
             }`}
           />
           <LabelAndText
             label={t("profile:home_info_headings.host_drinking")}
-            text={booleanConversion(t, user.drinksAtHome?.value)}
+            text={booleanConversion(t, profile.drinksAtHome?.value)}
           />
           <LabelAndText
             label={t("profile:home_info_headings.host_smoking")}
-            text={booleanConversion(t, user.smokesAtHome?.value)}
+            text={booleanConversion(t, profile.smokesAtHome?.value)}
           />
         </StyledInfoColumn>
       </StyledRoot>
       <StyledSpacedDivider />
-      {user.aboutPlace && (
+      {profile.aboutPlace && (
         <>
           <Typography variant="h1">
             {t("profile:home_info_headings.about_home")}
           </Typography>
-          <Markdown source={user.aboutPlace} />
+          <Markdown source={profile.aboutPlace} />
           <StyledSpacedDivider />
         </>
       )}
-      {user.area && (
+      {profile.area && (
         <>
           <Typography variant="h1">
             {t("profile:home_info_headings.local_area")}
           </Typography>
-          <Markdown source={user.area?.value} />
+          <Markdown source={profile.area?.value} />
           <StyledSpacedDivider />
         </>
       )}
-      {user.sleepingDetails && (
+      {profile.sleepingDetails && (
         <>
           <Typography variant="h1">
             {t("profile:home_info_headings.sleeping_arrangement")}
           </Typography>
-          <Markdown source={user.sleepingDetails?.value} />
+          <Markdown source={profile.sleepingDetails?.value} />
           <StyledSpacedDivider />
         </>
       )}
-      {user.houseRules && (
+      {profile.houseRules && (
         <>
           <Typography variant="h1">
             {t("profile:home_info_headings.house_rules")}
           </Typography>
-          <Markdown source={user.houseRules?.value} />
+          <Markdown source={profile.houseRules?.value} />
           <StyledSpacedDivider />
         </>
       )}
-      {user.otherHostInfo && (
+      {profile.otherHostInfo && (
         <>
           <Typography variant="h1">
             {t("profile:heading.additional_information_section")}
           </Typography>
-          <Markdown source={user.otherHostInfo?.value} />
+          <Markdown source={profile.otherHostInfo?.value} />
         </>
       )}
     </>

--- a/app/web/features/profile/view/Overview.tsx
+++ b/app/web/features/profile/view/Overview.tsx
@@ -21,7 +21,7 @@ import {
   UserTab,
 } from "routes";
 
-import { useProfileUser } from "../hooks/useProfileUser";
+import { useProfileData, useProfileUser } from "../hooks/useProfileUser";
 import AdminPanelUserButton from "./AdminPanelUserButton";
 import ProfileReportFlagButton from "./ProfileReportFlagButton";
 
@@ -70,8 +70,9 @@ function DefaultActions({
 }) {
   const { t } = useTranslation([GLOBAL, PROFILE]);
   const user = useProfileUser();
+  const profile = useProfileData();
   const disableHosting =
-    user.hostingStatus === HostingStatus.HOSTING_STATUS_CANT_HOST;
+    profile.hostingStatus === HostingStatus.HOSTING_STATUS_CANT_HOST;
 
   const [mutationError, setMutationError] = useState("");
   const [showCantRequestDialog, setShowCantRequestDialog] =

--- a/app/web/features/profile/view/ProfilePage.test.tsx
+++ b/app/web/features/profile/view/ProfilePage.test.tsx
@@ -1,9 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import useCurrentUser from "features/userQueries/useCurrentUser";
+import { useCurrentProfile } from "features/userQueries/useProfile";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import mockRouter from "next-router-mock";
 import { service } from "service";
+import defaultProfile from "test/fixtures/defaultProfile.json";
 import defaultUser from "test/fixtures/defaultUser.json";
 import galleryFixtures from "test/fixtures/gallery.json";
 import wrapper from "test/hookWrapper";
@@ -11,6 +13,7 @@ import i18n from "test/i18n";
 import {
   getAccountInfo,
   getLanguages,
+  getProfile,
   getRegions,
   getUser,
 } from "test/serviceMockDefaults";
@@ -21,11 +24,15 @@ import ProfilePage from "./ProfilePage";
 const { t } = i18n;
 
 jest.mock("features/userQueries/useCurrentUser");
+jest.mock("features/userQueries/useProfile");
 
 jest.mock("react-simple-maps");
 
 const getUserMock = service.user.getUser as MockedService<
   typeof service.user.getUser
+>;
+const getProfileMock = service.user.getProfile as MockedService<
+  typeof service.user.getProfile
 >;
 const reportContentMock = service.reporting.reportContent as MockedService<
   typeof service.reporting.reportContent
@@ -41,6 +48,9 @@ const getRegionsMock = service.resources.getRegions as jest.MockedFunction<
 
 const useCurrentUserMock = useCurrentUser as jest.MockedFunction<
   typeof useCurrentUser
+>;
+const useCurrentProfileMock = useCurrentProfile as jest.MockedFunction<
+  typeof useCurrentProfile
 >;
 
 const getGalleryMock = service.gallery.getGallery as jest.MockedFunction<
@@ -62,6 +72,7 @@ describe("Profile page", () => {
 
   beforeEach(() => {
     getUserMock.mockImplementation(getUser);
+    getProfileMock.mockImplementation(getProfile);
     getLanguagesMock.mockImplementation(getLanguages);
     getRegionsMock.mockImplementation(getRegions);
     getAccountInfoMock.mockImplementation(getAccountInfo);
@@ -79,6 +90,13 @@ describe("Profile page", () => {
         isFetching: false,
         error: "",
       });
+      useCurrentProfileMock.mockReturnValue({
+        data: defaultProfile,
+        isLoading: false,
+        isError: false,
+        isFetching: false,
+        error: null,
+      } as unknown as ReturnType<typeof useCurrentProfile>);
     });
 
     describe("and a tab is opened", () => {

--- a/app/web/features/profile/view/ProfilePage.tsx
+++ b/app/web/features/profile/view/ProfilePage.tsx
@@ -5,6 +5,7 @@ import HtmlMeta from "components/HtmlMeta";
 import { ProfileUserProvider } from "features/profile/hooks/useProfileUser";
 import Overview from "features/profile/view/Overview";
 import useCurrentUser from "features/userQueries/useCurrentUser";
+import { useCurrentProfile } from "features/userQueries/useProfile";
 import { useTranslation } from "i18n";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
 import { useRouter } from "next/router";
@@ -35,15 +36,23 @@ export default function ProfilePage({ tab = "about" }: { tab?: UserTab }) {
   const router = useRouter();
 
   const { data: user, error, isLoading } = useCurrentUser();
+  const {
+    data: profile,
+    error: profileError,
+    isLoading: isProfileLoading,
+  } = useCurrentProfile();
 
   return (
     <>
       <HtmlMeta title={t("global:nav.profile")} />
       {error && <Alert severity="error">{error}</Alert>}
-      {isLoading ? (
+      {profileError && (
+        <Alert severity="error">{profileError.message}</Alert>
+      )}
+      {isLoading || isProfileLoading ? (
         <CenteredSpinner />
-      ) : user ? (
-        <ProfileUserProvider user={user}>
+      ) : user && profile ? (
+        <ProfileUserProvider user={user} profile={profile}>
           <StyledWrapper>
             <Overview tab={tab} />
             <UserCard

--- a/app/web/features/profile/view/ProfilePage.tsx
+++ b/app/web/features/profile/view/ProfilePage.tsx
@@ -46,9 +46,7 @@ export default function ProfilePage({ tab = "about" }: { tab?: UserTab }) {
     <>
       <HtmlMeta title={t("global:nav.profile")} />
       {error && <Alert severity="error">{error}</Alert>}
-      {profileError && (
-        <Alert severity="error">{profileError.message}</Alert>
-      )}
+      {profileError && <Alert severity="error">{profileError.message}</Alert>}
       {isLoading || isProfileLoading ? (
         <CenteredSpinner />
       ) : user && profile ? (

--- a/app/web/features/profile/view/References.test.tsx
+++ b/app/web/features/profile/view/References.test.tsx
@@ -38,7 +38,7 @@ function assertDateBadgeIsVisible(reference: ReturnType<typeof within>) {
 
 function renderReferences() {
   render(
-    <ProfileUserProvider user={users[0]}>
+    <ProfileUserProvider user={users[0]} profile={defaultProfile}>
       <References />
     </ProfileUserProvider>,
     { wrapper },

--- a/app/web/features/profile/view/UserCard.tsx
+++ b/app/web/features/profile/view/UserCard.tsx
@@ -94,11 +94,11 @@ export default function UserCard({
         />
         {top || null}
         <TabPanel value="about" sx={{ padding: 0 }}>
-          <About user={user} />
+          <About />
         </TabPanel>
         {modPanel}
         <TabPanel value="home">
-          <Home user={user}></Home>
+          <Home />
         </TabPanel>
         <TabPanel value="references">
           <References />

--- a/app/web/features/profile/view/UserOverview.test.tsx
+++ b/app/web/features/profile/view/UserOverview.test.tsx
@@ -18,7 +18,7 @@ describe("UserOverview", () => {
   describe("when user is loaded and provided via context", () => {
     it("should display the user name", () => {
       render(
-        <ProfileUserProvider user={defaultUser}>
+        <ProfileUserProvider user={defaultUser} profile={defaultProfile}>
           <UserOverview showHostAndMeetAvailability={false} />
         </ProfileUserProvider>,
         { wrapper },
@@ -28,7 +28,7 @@ describe("UserOverview", () => {
 
     it("should display the user username with a leading @", () => {
       render(
-        <ProfileUserProvider user={defaultUser}>
+        <ProfileUserProvider user={defaultUser} profile={defaultProfile}>
           <UserOverview showHostAndMeetAvailability={false} />
         </ProfileUserProvider>,
         { wrapper },
@@ -38,7 +38,7 @@ describe("UserOverview", () => {
 
     it("should display the user location", () => {
       render(
-        <ProfileUserProvider user={defaultUser}>
+        <ProfileUserProvider user={defaultUser} profile={defaultProfile}>
           <UserOverview showHostAndMeetAvailability={false} />
         </ProfileUserProvider>,
         { wrapper },
@@ -54,7 +54,7 @@ describe("UserOverview", () => {
 
       it("should display the hosting and meeting status when showHostAndMeetAvailability is true", () => {
         render(
-          <ProfileUserProvider user={defaultUser}>
+          <ProfileUserProvider user={defaultUser} profile={defaultProfile}>
             <UserOverview showHostAndMeetAvailability />
           </ProfileUserProvider>,
           { wrapper },
@@ -65,7 +65,7 @@ describe("UserOverview", () => {
 
       it("should not display the hosting and meeting status when showHostAndMeetAvailability is false", () => {
         render(
-          <ProfileUserProvider user={defaultUser}>
+          <ProfileUserProvider user={defaultUser} profile={defaultProfile}>
             <UserOverview showHostAndMeetAvailability={false} />
           </ProfileUserProvider>,
           { wrapper },
@@ -91,7 +91,7 @@ describe("UserOverview", () => {
       const expectedLabelVerification = t("global:verification_score");
 
       render(
-        <ProfileUserProvider user={defaultUser}>
+        <ProfileUserProvider user={defaultUser} profile={defaultProfile}>
           <UserOverview showHostAndMeetAvailability={false} />
         </ProfileUserProvider>,
         { wrapper },
@@ -107,7 +107,7 @@ describe("UserOverview", () => {
 
     it("should render the action buttons", () => {
       render(
-        <ProfileUserProvider user={defaultUser}>
+        <ProfileUserProvider user={defaultUser} profile={defaultProfile}>
           <UserOverview
             showHostAndMeetAvailability={false}
             actions={
@@ -126,6 +126,7 @@ describe("UserOverview", () => {
       render(
         <ProfileUserProvider
           user={{ ...defaultUser, hasStrongVerification: false }}
+          profile={defaultProfile}
         >
           <UserOverview showHostAndMeetAvailability={false} />
         </ProfileUserProvider>,
@@ -140,6 +141,7 @@ describe("UserOverview", () => {
       render(
         <ProfileUserProvider
           user={{ ...defaultUser, hasStrongVerification: true }}
+          profile={defaultProfile}
         >
           <UserOverview showHostAndMeetAvailability={false} />
         </ProfileUserProvider>,

--- a/app/web/features/profile/view/UserOverview.tsx
+++ b/app/web/features/profile/view/UserOverview.tsx
@@ -17,7 +17,7 @@ import { HostingStatus, MeetupStatus } from "proto/api_pb";
 import React from "react";
 import { routeToEditProfile, routeToUser } from "routes";
 
-import { useProfileUser } from "../hooks/useProfileUser";
+import { useProfileData, useProfileUser } from "../hooks/useProfileUser";
 import { Badges } from "./Badges";
 import { ReferencesLastActiveLabels, ResponseRateLabel } from "./userLabels";
 
@@ -103,6 +103,7 @@ export default function UserOverview({
 }: UserOverviewProps) {
   const { t } = useTranslation([GLOBAL, PROFILE]);
   const user = useProfileUser();
+  const profile = useProfileData();
 
   const shouldMakeAvatarClickable = isOwnProfile && !user.avatarUrl;
 
@@ -156,7 +157,7 @@ export default function UserOverview({
             icon={CouchIcon}
             text={
               hostingStatusLabels(t)[
-                user.hostingStatus || HostingStatus.HOSTING_STATUS_UNKNOWN
+                profile.hostingStatus || HostingStatus.HOSTING_STATUS_UNKNOWN
               ]
             }
           />
@@ -164,7 +165,7 @@ export default function UserOverview({
             icon={LocationIcon}
             text={
               meetupStatusLabels(t)[
-                user.meetupStatus || MeetupStatus.MEETUP_STATUS_UNKNOWN
+                profile.meetupStatus || MeetupStatus.MEETUP_STATUS_UNKNOWN
               ]
             }
           />

--- a/app/web/features/profile/view/UserPage.test.tsx
+++ b/app/web/features/profile/view/UserPage.test.tsx
@@ -15,7 +15,12 @@ import { service } from "service";
 import mockUsers from "test/fixtures/users.json";
 import wrapper from "test/hookWrapper";
 import i18n from "test/i18n";
-import { getLanguages, getRegions, getUser } from "test/serviceMockDefaults";
+import {
+  getLanguages,
+  getProfile,
+  getRegions,
+  getUser,
+} from "test/serviceMockDefaults";
 import { addDefaultUser, MockedService } from "test/utils";
 
 import { sectionLabels } from "./UserCard";
@@ -28,6 +33,9 @@ jest.mock("react-simple-maps");
 
 const getUserMock = service.user.getUser as MockedService<
   typeof service.user.getUser
+>;
+const getProfileMock = service.user.getProfile as MockedService<
+  typeof service.user.getProfile
 >;
 const reportContentMock = service.reporting.reportContent as MockedService<
   typeof service.reporting.reportContent
@@ -61,6 +69,7 @@ describe("User page", () => {
 
   beforeEach(() => {
     getUserMock.mockImplementation(getUser);
+    getProfileMock.mockImplementation(getProfile);
     reportContentMock.mockResolvedValue(new Empty());
     getLanguagesMock.mockImplementation(getLanguages);
     getRegionsMock.mockImplementation(getRegions);

--- a/app/web/features/profile/view/UserPage.tsx
+++ b/app/web/features/profile/view/UserPage.tsx
@@ -7,6 +7,7 @@ import { ProfileUserProvider } from "features/profile/hooks/useProfileUser";
 import NewHostRequest from "features/profile/view/NewHostRequest";
 import NewMessage from "features/profile/view/NewMessage";
 import Overview from "features/profile/view/Overview";
+import useProfileByUsername from "features/userQueries/useProfileByUsername";
 import useUserByUsername from "features/userQueries/useUserByUsername";
 import { useTranslation } from "i18n";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
@@ -47,6 +48,11 @@ export default function UserPage({
   const router = useRouter();
 
   const { data: user, isLoading, error } = useUserByUsername(username, true);
+  const {
+    data: profile,
+    isLoading: isProfileLoading,
+    error: profileError,
+  } = useProfileByUsername(username, true);
 
   const [isRequesting, setIsRequesting] = useState(false);
   const [isSuccessRequest, setIsSuccessRequest] = useState(false);
@@ -66,10 +72,11 @@ export default function UserPage({
         <Snackbar severity="success">{t("request_form.success")}</Snackbar>
       )}
       {error && <Alert severity="error">{error}</Alert>}
-      {isLoading ? (
+      {profileError && <Alert severity="error">{profileError}</Alert>}
+      {isLoading || isProfileLoading ? (
         <CenteredSpinner />
-      ) : user ? (
-        <ProfileUserProvider user={user}>
+      ) : user && profile ? (
+        <ProfileUserProvider user={user} profile={profile}>
           <StyledProfileRoot>
             <Overview
               setIsRequesting={setIsRequesting}

--- a/app/web/features/profile/view/leaveReference/LeaveReferencePage.test.tsx
+++ b/app/web/features/profile/view/leaveReference/LeaveReferencePage.test.tsx
@@ -10,7 +10,11 @@ import { leaveReferenceBaseRoute, ReferenceStep } from "routes";
 import { service } from "service";
 import wrapper from "test/hookWrapper";
 import i18n from "test/i18n";
-import { getAvailableReferences, getUser } from "test/serviceMockDefaults";
+import {
+  getAvailableReferences,
+  getProfile,
+  getUser,
+} from "test/serviceMockDefaults";
 import { MockedService } from "test/utils";
 
 import LeaveReferencePage from "./LeaveReferencePage";
@@ -23,6 +27,9 @@ const getAvailableReferencesMock = service.references
 >;
 const getUserMock = service.user.getUser as MockedService<
   typeof service.user.getUser
+>;
+const getProfileMock = service.user.getProfile as MockedService<
+  typeof service.user.getProfile
 >;
 const getHostRequestReferenceStatusMock = service.references
   .getHostRequestReferenceStatus as unknown as jest.MockedFunction<
@@ -86,6 +93,7 @@ function renderLeaveRequestReferencePage(
 describe("LeaveReferencePage", () => {
   beforeEach(() => {
     getUserMock.mockImplementation(getUser);
+    getProfileMock.mockImplementation(getProfile);
     getAvailableReferencesMock.mockImplementation(getAvailableReferences);
     getHostRequestReferenceStatusMock.mockResolvedValue({
       hasGiven: false,

--- a/app/web/features/profile/view/leaveReference/LeaveReferencePage.tsx
+++ b/app/web/features/profile/view/leaveReference/LeaveReferencePage.tsx
@@ -7,6 +7,7 @@ import { ProfileUserProvider } from "features/profile/hooks/useProfileUser";
 import ReferenceForm from "features/profile/view/leaveReference/ReferenceForm";
 import UserOverview from "features/profile/view/UserOverview";
 import { hasGivenHostRequestReferenceKey } from "features/queryKeys";
+import { useProfile } from "features/userQueries/useProfile";
 import { useUser } from "features/userQueries/useUsers";
 import { useTranslation } from "i18n";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
@@ -73,6 +74,11 @@ export default function LeaveReferencePage({
     error: userError,
   } = useUser(userId);
   const {
+    data: profile,
+    isLoading: isProfileLoading,
+    error: profileError,
+  } = useProfile(userId);
+  const {
     data: availableReferences,
     isLoading: isAvailableReferencesLoading,
     error: availableReferencesError,
@@ -88,14 +94,17 @@ export default function LeaveReferencePage({
     );
   }
 
-  if (userError || availableReferencesError) {
+  if (userError || profileError || availableReferencesError) {
     return (
       <Alert severity="error">
-        {userError || availableReferencesError?.message || ""}
+        {userError ||
+          profileError?.message ||
+          availableReferencesError?.message ||
+          ""}
       </Alert>
     );
   }
-  if (isUserLoading || isAvailableReferencesLoading) {
+  if (isUserLoading || isProfileLoading || isAvailableReferencesLoading) {
     return <CenteredSpinner />;
   }
 
@@ -171,7 +180,7 @@ export default function LeaveReferencePage({
 
   return (
     <StyledRoot>
-      <ProfileUserProvider user={user!}>
+      <ProfileUserProvider user={user!} profile={profile!}>
         {!isMobile && <UserOverview showHostAndMeetAvailability={false} />}
         <StyledFormWrapper>
           <ReferenceForm

--- a/app/web/features/profile/view/userLabels.tsx
+++ b/app/web/features/profile/view/userLabels.tsx
@@ -7,6 +7,7 @@ import { COMMUNITIES, GLOBAL, PROFILE } from "i18n/namespaces";
 import {
   BirthdateVerificationStatus,
   GenderVerificationStatus,
+  Profile,
   User,
 } from "proto/api_pb";
 import { theme } from "theme";
@@ -145,14 +146,16 @@ const styledIcon = <C extends React.ComponentType<React.ComponentProps<C>>>(
 const StyledCheckCircleIcon = styledIcon(CheckCircleIcon);
 const StyledErrorIcon = styledIcon(ErrorIcon);
 
-const AgeAndGenderRenderer = ({ user }: Props) => {
-  const {
-    birthdateVerificationStatus,
-    genderVerificationStatus,
-    age,
-    gender,
-    pronouns,
-  } = user;
+const AgeAndGenderRenderer = ({
+  user,
+  profile,
+}: {
+  user: User.AsObject;
+  profile: Profile.AsObject;
+}) => {
+  const { birthdateVerificationStatus, genderVerificationStatus, age, gender } =
+    user;
+  const { pronouns } = profile;
   const { t } = useTranslation("profile");
 
   const getBirthdateVerificationIcon = (
@@ -222,7 +225,13 @@ const AgeAndGenderRenderer = ({ user }: Props) => {
   );
 };
 
-export const AgeGenderLanguagesLabels = ({ user }: Props) => {
+export const AgeGenderLanguagesLabels = ({
+  user,
+  profile,
+}: {
+  user: User.AsObject;
+  profile: Profile.AsObject;
+}) => {
   const { t } = useTranslation("profile");
   const { languages } = useLanguages();
 
@@ -230,13 +239,13 @@ export const AgeGenderLanguagesLabels = ({ user }: Props) => {
     <>
       <LabelAndText
         label={t("heading.age_gender")}
-        text={<AgeAndGenderRenderer user={user} />}
+        text={<AgeAndGenderRenderer user={user} profile={profile} />}
       />
       {languages && (
         <LabelAndText
           label={t("heading.languages_fluent")}
           text={
-            user.languageAbilitiesList
+            profile.languageAbilitiesList
               .map((ability) => languages[ability.code])
               .join(", ") || t("languages_fluent_false")
           }
@@ -246,7 +255,13 @@ export const AgeGenderLanguagesLabels = ({ user }: Props) => {
   );
 };
 
-export const RemainingAboutLabels = ({ user }: Props) => {
+export const RemainingAboutLabels = ({
+  user,
+  profile,
+}: {
+  user: User.AsObject;
+  profile: Profile.AsObject;
+}) => {
   const {
     t,
     i18n: { language: locale },
@@ -255,15 +270,15 @@ export const RemainingAboutLabels = ({ user }: Props) => {
     <>
       <LabelAndText
         label={t("profile:heading.hometown")}
-        text={user.hometown}
+        text={profile.hometown}
       />
       <LabelAndText
         label={t("profile:heading.occupation")}
-        text={user.occupation}
+        text={profile.occupation}
       />
       <LabelAndText
         label={t("profile:heading.education")}
-        text={user.education}
+        text={profile.education}
       />
       <LabelAndText
         label={t("profile:heading.joined")}

--- a/app/web/features/queryKeys.ts
+++ b/app/web/features/queryKeys.ts
@@ -31,6 +31,10 @@ export function liteUserKey(userId?: number) {
   return userId === undefined ? ["liteUser"] : ["liteUser", userId];
 }
 
+export function profileKey(userId?: number) {
+  return userId === undefined ? ["profile"] : ["profile", userId];
+}
+
 export const liteUsersKey = (ids: number[] | string[]) => ["liteUsers", ...ids];
 
 export const referencesGivenKey = "referencesGiven";

--- a/app/web/features/search/HostMeetupReferenceStatus.tsx
+++ b/app/web/features/search/HostMeetupReferenceStatus.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from "i18n";
 import { PROFILE } from "i18n/namespaces";
 import { TFunction } from "i18next";
 import { HostingStatus, MeetupStatus, User } from "proto/api_pb";
+import { SearchUser } from "proto/search_pb";
 import { theme } from "theme";
 
 const Wrapper = styled("div")(({ theme }) => ({
@@ -61,8 +62,8 @@ const HostMeetupReferenceStatus = ({
   meetupStatus,
   numberReferences,
 }: {
-  hostingStatus: User.AsObject["hostingStatus"];
-  meetupStatus: User.AsObject["meetupStatus"];
+  hostingStatus: SearchUser.AsObject["hostingStatus"];
+  meetupStatus: SearchUser.AsObject["meetupStatus"];
   numberReferences: User.AsObject["numReferences"];
 }) => {
   const { t } = useTranslation([PROFILE]);

--- a/app/web/features/userQueries/useProfile.ts
+++ b/app/web/features/userQueries/useProfile.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuthContext } from "features/auth/AuthProvider";
+import { profileKey } from "features/queryKeys";
+import { userStaleTime } from "features/userQueries/constants";
+import { RpcError } from "grpc-web";
+import { useRouter } from "next/router";
+import { Profile } from "proto/api_pb";
+import { loginRoute } from "routes";
+import { service } from "service";
+
+export function useProfile(userId: number | undefined) {
+  return useQuery<Profile.AsObject, RpcError>({
+    queryFn: () => service.user.getProfile(userId!.toString()),
+    queryKey: profileKey(userId),
+    staleTime: userStaleTime,
+    enabled: !!userId,
+  });
+}
+
+export function useCurrentProfile() {
+  const authState = useAuthContext().authState;
+  const router = useRouter();
+  if (!authState.userId && typeof window !== "undefined") {
+    router.push(loginRoute);
+  }
+  return useProfile(authState.userId ?? undefined);
+}

--- a/app/web/features/userQueries/useProfileByUsername.ts
+++ b/app/web/features/userQueries/useProfileByUsername.ts
@@ -1,0 +1,76 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { reactQueryRetries } from "appConstants";
+import { profileKey, username2Id } from "features/queryKeys";
+import {
+  username2IdStaleTime,
+  userStaleTime,
+} from "features/userQueries/constants";
+import { RpcError, StatusCode } from "grpc-web";
+import { Profile } from "proto/api_pb";
+import { useEffect } from "react";
+import { service } from "service";
+
+export default function useProfileByUsername(
+  username: string,
+  invalidate = false,
+) {
+  const usernameQuery = useQuery<
+    { username: string; userId: number },
+    RpcError
+  >({
+    gcTime: username2IdStaleTime,
+    queryFn: async () => {
+      const user = await service.user.getUser(username);
+      return {
+        userId: user.userId,
+        username: user.username,
+      };
+    },
+    queryKey: [username2Id, username],
+    retry: (failureCount, error) => {
+      return (
+        error.code !== StatusCode.NOT_FOUND && failureCount <= reactQueryRetries
+      );
+    },
+    staleTime: username2IdStaleTime,
+    enabled: !!username,
+  });
+
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    if (invalidate && usernameQuery.data?.userId) {
+      queryClient.invalidateQueries({
+        queryKey: profileKey(usernameQuery.data.userId),
+      });
+    }
+  }, [invalidate, queryClient, usernameQuery.data?.userId]);
+
+  const query = useQuery<Profile.AsObject, RpcError>({
+    enabled: !!usernameQuery.data,
+    queryFn: () =>
+      service.user.getProfile(usernameQuery.data?.userId.toString() || ""),
+    queryKey: profileKey(usernameQuery.data?.userId ?? 0),
+    staleTime: userStaleTime,
+  });
+
+  const errors = [];
+  if (usernameQuery.error?.message) {
+    errors.push(usernameQuery.error?.message || "");
+  }
+  if (query.error?.message) {
+    errors.push(query.error?.message || "");
+  }
+
+  const error = errors.join("\n");
+  const isLoading = usernameQuery.isLoading || query.isLoading;
+  const isFetching = usernameQuery.isFetching || query.isFetching;
+  const isError = usernameQuery.isError || query.isError;
+
+  return {
+    data: query.data,
+    error,
+    isError,
+    isFetching,
+    isLoading,
+  };
+}

--- a/app/web/service/admin.ts
+++ b/app/web/service/admin.ts
@@ -5,7 +5,7 @@ import {
   ListUserIdsReq,
   UserDetails,
 } from "proto/admin_pb";
-import { User } from "proto/api_pb";
+import { Profile, User } from "proto/api_pb";
 
 import client from "./client";
 
@@ -15,6 +15,14 @@ export async function getUser(user: string): Promise<User.AsObject> {
     req.setUser(user);
   }
   return (await client.admin.getUser(req)).toObject();
+}
+
+export async function getProfile(user: string): Promise<Profile.AsObject> {
+  const req = new GetUserReq();
+  if (user) {
+    req.setUser(user);
+  }
+  return (await client.admin.getProfile(req)).toObject();
 }
 
 export async function getUserDetails(

--- a/app/web/service/user.ts
+++ b/app/web/service/user.ts
@@ -3,12 +3,14 @@ import wrappers from "google-protobuf/google/protobuf/wrappers_pb";
 import {
   GetLiteUserReq,
   GetLiteUsersReq,
+  GetProfileReq,
   GetUserReq,
   LanguageAbility,
   NullableBoolValue,
   NullableStringValue,
   NullableUInt32Value,
   PingReq,
+  Profile,
   RepeatedLanguageAbilityValue,
   RepeatedStringValue,
   UpdateProfileReq,
@@ -99,6 +101,21 @@ export async function getUser(user: string): Promise<User.AsObject> {
   }
 
   const response = await client.api.getUser(userReq);
+
+  return response.toObject();
+}
+
+/**
+ * Returns Profile record by Username or id
+ *
+ * @param {string} user
+ * @returns {Promise<Profile.AsObject>}
+ */
+export async function getProfile(user: string): Promise<Profile.AsObject> {
+  const req = new GetProfileReq();
+  req.setUser(user);
+
+  const response = await client.api.getProfile(req);
 
   return response.toObject();
 }

--- a/app/web/test/fixtures/defaultProfile.json
+++ b/app/web/test/fixtures/defaultProfile.json
@@ -1,0 +1,30 @@
+{
+  "userId": 1,
+  "hometown": "Brisbane",
+  "pronouns": "He/him",
+  "occupation": "Mathematician",
+  "education": "Uni",
+  "aboutMe": "Some generic stuff.",
+  "thingsILike": "hospex",
+  "aboutPlace": "About Aapeli's place",
+  "additionalInformation": "",
+  "hostingStatus": 2,
+  "meetupStatus": 1,
+  "regionsVisitedList": ["AUS"],
+  "regionsLivedList": ["AUS", "FIN", "SWE", "USA"],
+  "languageAbilitiesList": [
+    {
+      "code": "eng",
+      "fluency": 4
+    },
+    {
+      "code": "fin",
+      "fluency": 3
+    }
+  ],
+  "profileGalleryId": 1,
+  "sleeping_arrangement": 2,
+  "sleepingArrangement": 2,
+  "parkingDetails": 3,
+  "smokingAllowed": 1
+}

--- a/app/web/test/serviceMockDefaults.ts
+++ b/app/web/test/serviceMockDefaults.ts
@@ -3,6 +3,7 @@ import {
   GenderVerificationStatus,
   GetLiteUsersRes,
   LiteUser,
+  Profile,
   User,
 } from "proto/api_pb";
 import { GetBlockedUsersRes } from "proto/blocking_pb";
@@ -52,6 +53,11 @@ const liteUserMap: Record<string, LiteUser.AsObject> = {
 
 export async function getUser(userId: string): Promise<User.AsObject> {
   return userMap[userId];
+}
+
+export async function getProfile(userId: string): Promise<Profile.AsObject> {
+  // users.json fixtures still carry profile-shaped fields, so we can reuse them.
+  return userMap[userId] as unknown as Profile.AsObject;
 }
 
 export async function getLiteUser(userId: string): Promise<LiteUser.AsObject> {

--- a/app/web/test/setupTests.ts
+++ b/app/web/test/setupTests.ts
@@ -12,6 +12,7 @@ import sentryTestkit from "sentry-testkit";
 import i18n from "test/i18n";
 import { TextDecoder, TextEncoder } from "util";
 
+import profile from "./fixtures/defaultProfile.json";
 import user from "./fixtures/defaultUser.json";
 
 jest.mock("service");
@@ -62,6 +63,7 @@ jest.mock("features/weblate/useWeblateStats", () => ({
 jest.setTimeout(10000);
 
 global.defaultUser = user;
+global.defaultProfile = profile;
 global.localStorage = createWebStorageMock();
 global.sessionStorage = createWebStorageMock();
 
@@ -108,6 +110,7 @@ global.ResizeObserver = class ResizeObserver {
 declare global {
   /* eslint-disable no-var */ // Disable the rule for this block
   var defaultUser: typeof user;
+  var defaultProfile: typeof profile;
   var testKit: ReturnType<typeof sentryTestkit>["testkit"];
   /* eslint-enable no-var */ // Re-enable the rule
 }


### PR DESCRIPTION
Splits the user-editable profile bundle (about_me, hosting prefs, my-home, regions, languages, profile gallery, hosting/meetup status) out of `GetUser` into a dedicated `GetProfile` RPC, with a parallel `Admin.GetProfile` that bypasses visibility for moderators. The User proto is shrunk: all 37 profile fields are now `reserved` and only the social-card fields (id/name/city/age/timezone/lat/lng/radius/gender/joined/last_active/badges/verification/friends/response_rate/avatar) ship over the wire on `GetUser`.

Frontend now fetches `Profile` separately via new `useProfile` / `useCurrentProfile` / `useProfileByUsername` hooks; `ProfileUserProvider` carries both `user` and `profile`, and all profile-rendering subcomponents (`About`, `Home`, `Overview`, `UserOverview`, `userLabels`) plus the edit forms (`EditProfile`, `EditHostingPreference`) read profile fields via the new `useProfileData` context / `useCurrentProfile` hook.

For the public profile API, `GetPublicUser`'s `full_user` variant now returns a `FullUser { User user; Profile profile; }` wrapper so logged-out viewers of full-visibility profiles still get profile data.

This is the second of three steps:
1. ~~Establish the `GetProfile` boundary and migrate all consumers.~~ (done in earlier commit)
2. **This shrinks the `User` proto** so the schema split can follow without proto churn.

## Testing
- Backend: `make -C app/backend format` clean; `pytest src/tests/` — **945 passed** in 175s (includes new tests `test_get_profile`, `test_get_profile_not_found`, `test_get_profile_ghost_user`; existing ghost / update_profile / language_abilities / hosting_preferences / activeness / signup / public tests updated to read profile fields via `GetProfile`).
- Web: `yarn lint` and `yarn tsc --noEmit` clean; `yarn test` — **798 passed**, 1 skipped (existing skip).
- Not exercised in a running browser yet — worth a manual clickthrough of profile page, profile sheet, edit forms, mod view, dashboard summary, leave-reference page, and the logged-out public profile (`/u/<username>` with profile_public_visibility=full) before merging.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._