### PR TITLE
Stop sending the host-request closed-state helper text as a real message

### DIFF
--- a/app/web/features/messages/requests/HostRequestSendField.test.tsx
+++ b/app/web/features/messages/requests/HostRequestSendField.test.tsx
@@ -9,6 +9,7 @@ import { service } from "service";
 import hostRequest from "test/fixtures/hostRequest.json";
 import wrapper from "test/hookWrapper";
 import i18n from "test/i18n";
+import { addDefaultUser } from "test/utils";
 
 import HostRequestSendField from "./HostRequestSendField";
 
@@ -303,7 +304,40 @@ describe("HostRequestSendField", () => {
     const input = document.getElementById(
       "host-request-message",
     ) as HTMLTextAreaElement;
-    expect(input.value).toBe(t("messages:request_closed_message"));
+    expect(input.value).toBe("");
+    expect(input.placeholder).toBe(t("messages:request_closed_message"));
+  });
+
+  it("does not send the closed-state placeholder text when re-accepting a rejected request", async () => {
+    const rejectedRequest = {
+      ...mockHostRequest,
+      status: HostRequestStatus.HOST_REQUEST_STATUS_REJECTED,
+      toDate: "2099-01-05",
+    };
+    addDefaultUser(rejectedRequest.hostUserId);
+
+    render(
+      <HostRequestSendField
+        hostRequest={rejectedRequest}
+        sendMutation={mockSendMutation}
+        respondMutation={mockRespondMutation}
+      />,
+      { wrapper },
+    );
+
+    const user = userEvent.setup();
+    await user.click(
+      await screen.findByRole("button", { name: t("global:accept") }),
+    );
+
+    await waitFor(() => {
+      expect(mockRespondMutation.mutate).toHaveBeenCalledTimes(1);
+    });
+    expect(mockRespondMutation.mutate).toHaveBeenCalledWith({
+      hostRequestId: rejectedRequest.hostRequestId,
+      status: HostRequestStatus.HOST_REQUEST_STATUS_ACCEPTED,
+      text: "",
+    });
   });
 
   it("disables the send button while a message is being sent", async () => {

--- a/app/web/features/messages/requests/HostRequestSendField.tsx
+++ b/app/web/features/messages/requests/HostRequestSendField.tsx
@@ -154,7 +154,7 @@ export default function HostRequestSendField({
       <StyledContainer>
         <TextField
           {...register("text")}
-          value={
+          placeholder={
             isRequestClosed ? t("messages:request_closed_message") : undefined
           }
           disabled={isRequestClosed}


### PR DESCRIPTION
The disabled-state helper "This host request is closed. To continue chatting, send the other person a normal message." was rendered into the message TextField's `value` prop. The same input is registered with react-hook-form, which on mount reads the DOM input's `.value` into `_formValues` (`getFieldValue` in `react-hook-form`). Any status-change button (e.g. a host clicking **Accept** to re-accept a rejected request, or a surfer clicking **Cancel** on a rejected request) goes through `handleSubmit`, which then passed that helper string as `text` to `RespondHostRequest`. The backend persists `request.text` as a real `Message` when non-empty, so the helper string showed up in the conversation history as if a user had typed it.

Fixed by switching `value` → `placeholder` on the disabled state, so the helper is purely cosmetic and is not picked up by the form.

## Testing
- Updated the existing "displays request closed message when request is cancelled" unit test to assert `placeholder` instead of `value`.
- Added a regression test that mounts a REJECTED host request as the host and clicks **Accept**: it asserts `respondMutation.mutate` is called with `text: ""`. Verified by reverting the source fix locally — the new test reproduces the bug (`text` is the helper string) and passes once the fix is reapplied.
- `yarn test features/messages/requests/HostRequestSendField.test.tsx` — 13/13 pass.
- `yarn lint` and `yarn format` clean for the changed files.

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._