### PR TITLE
Add machine-readable data payload to admin notes

### DIFF
--- a/app/backend/src/couchers/i18n/locales/en.json
+++ b/app/backend/src/couchers/i18n/locales/en.json
@@ -7,6 +7,8 @@
     "admin_blog_title_too_long": "The blog post title is too long.",
     "admin_cannot_edit_badge": "Admins cannot edit that badge.",
     "admin_note_cant_be_empty": "The admin note cannot be empty.",
+    "admin_note_data_must_be_valid_json": "The admin note data must be valid JSON.",
+    "admin_note_requires_exactly_one_of_note_or_data": "Provide exactly one of admin_note or data.",
     "already_admin": "That user is already an admin.",
     "already_have_dm": "You already have a direct message chat with this user.",
     "already_in_chat": "That user is already in the chat.",

--- a/app/backend/src/couchers/migrations/versions/0151_add_machine_readable_data_payload_to_.py
+++ b/app/backend/src/couchers/migrations/versions/0151_add_machine_readable_data_payload_to_.py
@@ -21,7 +21,13 @@ def upgrade() -> None:
     op.add_column(
         "admin_actions", sa.Column("data", postgresql.JSONB(none_as_null=True, astext_type=sa.Text()), nullable=True)
     )
+    op.create_check_constraint(
+        constraint_name="note_xor_data",
+        table_name="admin_actions",
+        condition="note IS NULL OR data IS NULL",
+    )
 
 
 def downgrade() -> None:
+    op.drop_constraint("ck_admin_actions_note_xor_data", "admin_actions", type_="check")
     op.drop_column("admin_actions", "data")

--- a/app/backend/src/couchers/migrations/versions/0151_add_machine_readable_data_payload_to_.py
+++ b/app/backend/src/couchers/migrations/versions/0151_add_machine_readable_data_payload_to_.py
@@ -1,0 +1,27 @@
+"""Add machine-readable data payload to admin notes
+
+Revision ID: 0151
+Revises: 0150
+Create Date: 2026-05-15 05:41:24.160635
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "0151"
+down_revision = "0150"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "admin_actions", sa.Column("data", postgresql.JSONB(none_as_null=True, astext_type=sa.Text()), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("admin_actions", "data")

--- a/app/backend/src/couchers/models/admin.py
+++ b/app/backend/src/couchers/models/admin.py
@@ -1,8 +1,19 @@
 import enum
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import BigInteger, DateTime, Enum, ForeignKey, Index, String, UniqueConstraint, func
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Index,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from couchers.models.base import Base
@@ -30,12 +41,16 @@ class AdminAction(Base, kw_only=True):
     level: Mapped[AdminActionLevel] = mapped_column(Enum(AdminActionLevel), server_default="normal")
 
     note: Mapped[str | None] = mapped_column(String, default=None)
+    data: Mapped[Any | None] = mapped_column(JSONB(none_as_null=True), default=None)
     tag: Mapped[str | None] = mapped_column(String, default=None)
 
     admin_user: Mapped[User] = relationship(init=False, foreign_keys="AdminAction.admin_user_id")
     target_user: Mapped[User] = relationship(init=False, foreign_keys="AdminAction.target_user_id")
 
-    __table_args__ = (Index("ix_admin_actions_target_created", target_user_id, created),)
+    __table_args__ = (
+        Index("ix_admin_actions_target_created", target_user_id, created),
+        CheckConstraint("note IS NULL OR data IS NULL", name="note_xor_data"),
+    )
 
 
 class AdminTag(Base, kw_only=True):

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from datetime import timedelta
 
@@ -79,6 +80,7 @@ def log_admin_action(
     target_user: User,
     action_type: str,
     note: str | None = None,
+    data: object | None = None,
     tag: str | None = None,
     level: AdminActionLevel = AdminActionLevel.normal,
 ) -> AdminAction:
@@ -88,6 +90,7 @@ def log_admin_action(
         action_type=action_type,
         level=level,
         note=note,
+        data=data,
         tag=tag,
     )
     session.add(action)
@@ -115,6 +118,7 @@ def _user_to_details(session: Session, user: User) -> admin_pb2.UserDetails:
                 action_type=action.action_type,
                 level=adminactionlevel2api[action.level],
                 note=action.note or "",
+                data=json.dumps(action.data) if action.data is not None else "",
                 tag=action.tag or "",
                 target_user_id=action.target_user_id,
                 target_username=user.username,
@@ -456,10 +460,28 @@ class Admin(admin_pb2_grpc.AdminServicer):
         user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
-        if not request.admin_note.strip():
-            context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "admin_note_cant_be_empty")
+        has_note = bool(request.admin_note.strip())
+        has_data = bool(request.data.strip())
+        if has_note == has_data:
+            context.abort_with_error_code(
+                grpc.StatusCode.INVALID_ARGUMENT, "admin_note_requires_exactly_one_of_note_or_data"
+            )
+        data = None
+        if has_data:
+            try:
+                data = json.loads(request.data)
+            except json.JSONDecodeError:
+                context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "admin_note_data_must_be_valid_json")
         level = api2adminactionlevel.get(request.level, AdminActionLevel.normal)
-        log_admin_action(session, context, user, "note", note=request.admin_note, level=level)
+        log_admin_action(
+            session,
+            context,
+            user,
+            "note",
+            note=request.admin_note if has_note else None,
+            data=data,
+            level=level,
+        )
         return _user_to_details(session, user)
 
     def GetContentReport(
@@ -1160,6 +1182,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
                 action_type=action.action_type,
                 level=adminactionlevel2api[action.level],
                 note=action.note or "",
+                data=json.dumps(action.data) if action.data is not None else "",
                 tag=action.tag or "",
                 target_user_id=action.target_user_id,
                 target_username=target_username,

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date, datetime, timedelta
 
 import grpc
@@ -326,7 +327,55 @@ def test_AddAdminNote_blank(db):
         with pytest.raises(grpc.RpcError) as e:
             api.AddAdminNote(admin_pb2.AddAdminNoteReq(user=normal_user.username, admin_note=empty_admin_note))
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
-        assert e.value.details() == "The admin note cannot be empty."
+        assert e.value.details() == "Provide exactly one of admin_note or data."
+
+
+def test_AddAdminNote_data(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    normal_user, _ = generate_user()
+    payload = '{"kind": "flag", "score": 0.87, "reasons": ["spam", "burst"]}'
+
+    with real_admin_session(super_token) as api:
+        res = api.AddAdminNote(admin_pb2.AddAdminNoteReq(user=normal_user.username, data=payload))
+    assert len(res.admin_actions) == 1
+    assert res.admin_actions[0].action_type == "note"
+    assert res.admin_actions[0].note == ""
+    assert json.loads(res.admin_actions[0].data) == {"kind": "flag", "score": 0.87, "reasons": ["spam", "burst"]}
+
+
+def test_AddAdminNote_both_note_and_data(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    normal_user, _ = generate_user()
+
+    with real_admin_session(super_token) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.AddAdminNote(
+                admin_pb2.AddAdminNoteReq(user=normal_user.username, admin_note="note text", data='{"x": 1}')
+            )
+        assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+        assert e.value.details() == "Provide exactly one of admin_note or data."
+
+
+def test_AddAdminNote_neither(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    normal_user, _ = generate_user()
+
+    with real_admin_session(super_token) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.AddAdminNote(admin_pb2.AddAdminNoteReq(user=normal_user.username))
+        assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+        assert e.value.details() == "Provide exactly one of admin_note or data."
+
+
+def test_AddAdminNote_invalid_json(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    normal_user, _ = generate_user()
+
+    with real_admin_session(super_token) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.AddAdminNote(admin_pb2.AddAdminNoteReq(user=normal_user.username, data="{not valid json"))
+        assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+        assert e.value.details() == "The admin note data must be valid JSON."
 
 
 def test_admin_content_reports(db):

--- a/app/proto/admin.proto
+++ b/app/proto/admin.proto
@@ -113,11 +113,12 @@ message AdminActionLog {
   int64 admin_user_id = 3;
   string admin_username = 4;
   string action_type = 5;
-  string note = 6;   // optional note/details
+  string note = 6;   // optional human-readable note/details
   string tag = 7;    // for tag-related actions
   AdminActionLevel level = 8;
   int64 target_user_id = 9;
   string target_username = 10;
+  string data = 11;  // optional machine-readable JSON payload
 }
 
 message AdminTagInfo {
@@ -250,8 +251,10 @@ message UnshadowUserReq {
 message AddAdminNoteReq {
   // username, email, or user id
   string user = 1;
+  // exactly one of admin_note or data must be provided; data is a JSON-encoded object
   string admin_note = 2;
   AdminActionLevel level = 3;  // defaults to NORMAL if unset
+  string data = 4;
 }
 
 message ContentReport {


### PR DESCRIPTION
Adds a nullable JSONB `data` column to `admin_actions` alongside the existing text `note`. `AddAdminNote` now accepts either a human-readable `admin_note` string or a JSON-encoded `data` string, and requires exactly one of them. The proto `AdminActionLog` exposes the stored payload back as a JSON string.

A DB-level `CHECK (note IS NULL OR data IS NULL)` constraint guarantees the two fields are never both populated; the stricter "exactly one" rule is enforced by the `AddAdminNote` servicer (other action types that legitimately set neither are unaffected).

## Testing
- New unit tests in `test_admin.py` cover the data path, both-populated, neither-populated, and invalid-JSON cases
- Existing `AddAdminNote` tests still pass (full `test_admin.py` suite: 52 passed)
- `make format` clean; mypy clean for the changed files

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._