### PR TITLE
Instrument search → request funnel

### DIFF
--- a/app/web/features/analytics/foregroundTracker.ts
+++ b/app/web/features/analytics/foregroundTracker.ts
@@ -1,0 +1,42 @@
+/**
+ * Accumulates wall-clock and foreground (document visible) time since creation.
+ *
+ * Wire `onVisibilityChange` to the document's `visibilitychange` event, then
+ * call `finalize()` once (e.g. on unmount) to read the totals.
+ */
+export interface ForegroundTracker {
+  onVisibilityChange: () => void;
+  finalize: () => { foregroundMs: number; totalMs: number };
+}
+
+export function createForegroundTracker(): ForegroundTracker {
+  const startedAt = performance.now();
+  let foregroundAccumMs = 0;
+  let visibleSince: number | null =
+    typeof document !== "undefined" && document.visibilityState === "visible"
+      ? startedAt
+      : null;
+
+  return {
+    onVisibilityChange() {
+      const now = performance.now();
+      if (document.visibilityState === "visible") {
+        if (visibleSince === null) visibleSince = now;
+      } else if (visibleSince !== null) {
+        foregroundAccumMs += now - visibleSince;
+        visibleSince = null;
+      }
+    },
+    finalize() {
+      const now = performance.now();
+      if (visibleSince !== null) {
+        foregroundAccumMs += now - visibleSince;
+        visibleSince = null;
+      }
+      return {
+        foregroundMs: Math.round(foregroundAccumMs),
+        totalMs: Math.round(now - startedAt),
+      };
+    },
+  };
+}

--- a/app/web/features/analytics/hooks.test.ts
+++ b/app/web/features/analytics/hooks.test.ts
@@ -355,4 +355,152 @@ describe("useImpressionRef", () => {
 
     expect(mockLogEvent).not.toHaveBeenCalled();
   });
+
+  describe("with minDurationMs", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("fires after the element is continuously visible for the duration", () => {
+      const { result } = renderHook(() =>
+        useImpressionRef(
+          "card.viewed",
+          { card_id: "1" },
+          { minDurationMs: 250 },
+        ),
+      );
+
+      const node = document.createElement("div");
+      act(() => {
+        result.current(node);
+      });
+
+      act(() => {
+        lastCallback(
+          [{ isIntersecting: true } as IntersectionObserverEntry],
+          {} as IntersectionObserver,
+        );
+      });
+
+      expect(mockLogEvent).not.toHaveBeenCalled();
+
+      act(() => {
+        jest.advanceTimersByTime(250);
+      });
+
+      expect(mockLogEvent).toHaveBeenCalledTimes(1);
+      expect(mockLogEvent).toHaveBeenCalledWith("card.viewed", {
+        card_id: "1",
+      });
+      expect(mockDisconnect).toHaveBeenCalled();
+    });
+
+    it("does not fire if the element leaves before the duration elapses", () => {
+      const { result } = renderHook(() =>
+        useImpressionRef("card.viewed", {}, { minDurationMs: 250 }),
+      );
+
+      const node = document.createElement("div");
+      act(() => {
+        result.current(node);
+      });
+
+      act(() => {
+        lastCallback(
+          [{ isIntersecting: true } as IntersectionObserverEntry],
+          {} as IntersectionObserver,
+        );
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+
+      act(() => {
+        lastCallback(
+          [{ isIntersecting: false } as IntersectionObserverEntry],
+          {} as IntersectionObserver,
+        );
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+
+      expect(mockLogEvent).not.toHaveBeenCalled();
+    });
+
+    it("restarts the timer when the element re-enters after leaving", () => {
+      const { result } = renderHook(() =>
+        useImpressionRef("card.viewed", {}, { minDurationMs: 250 }),
+      );
+
+      const node = document.createElement("div");
+      act(() => {
+        result.current(node);
+      });
+
+      act(() => {
+        lastCallback(
+          [{ isIntersecting: true } as IntersectionObserverEntry],
+          {} as IntersectionObserver,
+        );
+      });
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+      act(() => {
+        lastCallback(
+          [{ isIntersecting: false } as IntersectionObserverEntry],
+          {} as IntersectionObserver,
+        );
+      });
+
+      // Re-enter — timer should restart from zero
+      act(() => {
+        lastCallback(
+          [{ isIntersecting: true } as IntersectionObserverEntry],
+          {} as IntersectionObserver,
+        );
+      });
+      act(() => {
+        jest.advanceTimersByTime(249);
+      });
+      expect(mockLogEvent).not.toHaveBeenCalled();
+
+      act(() => {
+        jest.advanceTimersByTime(1);
+      });
+      expect(mockLogEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it("clears the pending timer on unmount", () => {
+      const { result, unmount } = renderHook(() =>
+        useImpressionRef("card.viewed", {}, { minDurationMs: 250 }),
+      );
+
+      const node = document.createElement("div");
+      act(() => {
+        result.current(node);
+      });
+      act(() => {
+        lastCallback(
+          [{ isIntersecting: true } as IntersectionObserverEntry],
+          {} as IntersectionObserver,
+        );
+      });
+
+      unmount();
+
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+
+      expect(mockLogEvent).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/app/web/features/analytics/hooks.ts
+++ b/app/web/features/analytics/hooks.ts
@@ -55,28 +55,37 @@ export function useDurationEvent(
 }
 
 /**
- * Returns a callback ref. When the element enters the viewport,
- * fires the event once via IntersectionObserver.
+ * Returns a callback ref. Fires the event once via IntersectionObserver after
+ * the element has been continuously >= `threshold` visible for `minDurationMs`
+ * (default 0 = fires on first intersection).
  *
- * `properties` and `threshold` are stored in refs so callers don't
- * need to memoize them — the observer is only recreated when `eventType` changes.
+ * `properties`, `threshold`, and `minDurationMs` are stored in refs so callers
+ * don't need to memoize them — the observer is only recreated when
+ * `eventType` changes.
  */
 export function useImpressionRef(
   eventType: string,
   properties: Record<string, unknown> = {},
-  options?: { threshold?: number },
+  options?: { threshold?: number; minDurationMs?: number },
 ) {
   const observerRef = useRef<IntersectionObserver | null>(null);
+  const visibleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasFiredRef = useRef(false);
   const propsRef = useRef(properties);
   propsRef.current = properties;
   const thresholdRef = useRef(options?.threshold ?? 0.5);
   thresholdRef.current = options?.threshold ?? 0.5;
+  const minDurationRef = useRef(options?.minDurationMs ?? 0);
+  minDurationRef.current = options?.minDurationMs ?? 0;
 
   // Cleanup on unmount
   useEffect(() => {
     return () => {
       observerRef.current?.disconnect();
+      if (visibleTimerRef.current) {
+        clearTimeout(visibleTimerRef.current);
+        visibleTimerRef.current = null;
+      }
     };
   }, []);
 
@@ -84,17 +93,38 @@ export function useImpressionRef(
     (node: HTMLElement | null) => {
       // Disconnect previous observer
       observerRef.current?.disconnect();
+      if (visibleTimerRef.current) {
+        clearTimeout(visibleTimerRef.current);
+        visibleTimerRef.current = null;
+      }
 
       if (!node || hasFiredRef.current) return;
+
+      const fire = () => {
+        if (hasFiredRef.current) return;
+        hasFiredRef.current = true;
+        logEvent(eventType, propsRef.current);
+        observerRef.current?.disconnect();
+      };
 
       observerRef.current = new IntersectionObserver(
         (entries) => {
           for (const entry of entries) {
-            if (entry.isIntersecting && !hasFiredRef.current) {
-              hasFiredRef.current = true;
-              logEvent(eventType, propsRef.current);
-              observerRef.current?.disconnect();
-              break;
+            if (hasFiredRef.current) return;
+            if (entry.isIntersecting) {
+              if (minDurationRef.current === 0) {
+                fire();
+                return;
+              }
+              if (!visibleTimerRef.current) {
+                visibleTimerRef.current = setTimeout(() => {
+                  visibleTimerRef.current = null;
+                  fire();
+                }, minDurationRef.current);
+              }
+            } else if (visibleTimerRef.current) {
+              clearTimeout(visibleTimerRef.current);
+              visibleTimerRef.current = null;
             }
           }
         },

--- a/app/web/features/analytics/searchAnalyticsContext.tsx
+++ b/app/web/features/analytics/searchAnalyticsContext.tsx
@@ -1,0 +1,36 @@
+import { createContext, ReactNode, useContext, useMemo } from "react";
+
+import { getOrCreateSearchSessionId } from "./searchAttribution";
+
+interface SearchAnalyticsValue {
+  searchSessionId: string;
+  searchQueryId: string;
+  pageNumber: number;
+}
+
+const SearchAnalyticsContext = createContext<SearchAnalyticsValue | null>(null);
+
+export function SearchAnalyticsProvider({
+  children,
+  searchQueryId,
+  pageNumber,
+}: {
+  children: ReactNode;
+  searchQueryId: string;
+  pageNumber: number;
+}) {
+  const searchSessionId = useMemo(() => getOrCreateSearchSessionId(), []);
+  const value = useMemo(
+    () => ({ searchSessionId, searchQueryId, pageNumber }),
+    [searchSessionId, searchQueryId, pageNumber],
+  );
+  return (
+    <SearchAnalyticsContext.Provider value={value}>
+      {children}
+    </SearchAnalyticsContext.Provider>
+  );
+}
+
+export function useSearchAnalytics(): SearchAnalyticsValue | null {
+  return useContext(SearchAnalyticsContext);
+}

--- a/app/web/features/analytics/searchAttribution.test.ts
+++ b/app/web/features/analytics/searchAttribution.test.ts
@@ -1,0 +1,86 @@
+import {
+  getOrCreateSearchSessionId,
+  makeResultId,
+  makeSearchQueryId,
+  readSearchReferrer,
+  setSearchReferrer,
+} from "./searchAttribution";
+
+const SESSION_TTL_MS = 30 * 60 * 1000;
+
+describe("makeSearchQueryId", () => {
+  it("returns a fresh unique id on each call", () => {
+    const a = makeSearchQueryId();
+    const b = makeSearchQueryId();
+    expect(a).toBeTruthy();
+    expect(b).toBeTruthy();
+    expect(a).not.toEqual(b);
+  });
+});
+
+describe("getOrCreateSearchSessionId", () => {
+  it("reuses the same id within the idle window", () => {
+    const first = getOrCreateSearchSessionId();
+    const second = getOrCreateSearchSessionId();
+    expect(second).toEqual(first);
+  });
+
+  it("rolls over after the idle window elapses", () => {
+    const nowSpy = jest.spyOn(Date, "now");
+    nowSpy.mockReturnValue(0);
+    const first = getOrCreateSearchSessionId();
+
+    nowSpy.mockReturnValue(SESSION_TTL_MS + 1);
+    const second = getOrCreateSearchSessionId();
+
+    expect(second).not.toEqual(first);
+  });
+});
+
+describe("makeResultId", () => {
+  it("encodes the query, user and position", () => {
+    expect(makeResultId("query-1", 42, 3)).toEqual("query-1:42:3");
+  });
+});
+
+describe("search referrer", () => {
+  it("round-trips for the matching user", () => {
+    setSearchReferrer({
+      searchSessionId: "sess",
+      searchQueryId: "query",
+      resultId: "query:7:0",
+      userId: 7,
+    });
+    const referrer = readSearchReferrer(7);
+    expect(referrer).toMatchObject({
+      searchSessionId: "sess",
+      searchQueryId: "query",
+      resultId: "query:7:0",
+      userId: 7,
+    });
+  });
+
+  it("returns null for a different user", () => {
+    setSearchReferrer({
+      searchSessionId: "sess",
+      searchQueryId: "query",
+      resultId: "query:7:0",
+      userId: 7,
+    });
+    expect(readSearchReferrer(8)).toBeNull();
+  });
+
+  it("returns null once the referrer has expired", () => {
+    const nowSpy = jest.spyOn(Date, "now");
+    nowSpy.mockReturnValue(0);
+    setSearchReferrer({
+      searchSessionId: "sess",
+      searchQueryId: "query",
+      resultId: "query:7:0",
+      userId: 7,
+    });
+
+    nowSpy.mockReturnValue(SESSION_TTL_MS + 1);
+    expect(readSearchReferrer(7)).toBeNull();
+  });
+});

--- a/app/web/features/analytics/searchAttribution.ts
+++ b/app/web/features/analytics/searchAttribution.ts
@@ -1,0 +1,117 @@
+/**
+ * Search session ID and click-referrer storage backed by sessionStorage.
+ *
+ * The search session ID rolls over after 30 minutes of inactivity. The click
+ * referrer captures the (session, query, result) triple at the moment the user
+ * clicks a search result so downstream pages (profile, host request form) can
+ * attribute their events back to the originating search.
+ */
+
+const SESSION_KEY = "search.session";
+const REFERRER_KEY = "search.referrer";
+const SESSION_TTL_MS = 30 * 60 * 1000;
+
+interface StoredSession {
+  id: string;
+  lastActiveAt: number;
+}
+
+export interface SearchReferrer {
+  searchSessionId: string;
+  searchQueryId: string;
+  resultId: string;
+  userId: number;
+  setAt: number;
+}
+
+function generateId(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function readSession(): StoredSession | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(SESSION_KEY);
+    return raw ? (JSON.parse(raw) as StoredSession) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeSession(s: StoredSession): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(SESSION_KEY, JSON.stringify(s));
+  } catch {
+    // sessionStorage unavailable (private mode, quota) — drop silently
+  }
+}
+
+export function getOrCreateSearchSessionId(): string {
+  const now = Date.now();
+  const existing = readSession();
+  if (existing && now - existing.lastActiveAt < SESSION_TTL_MS) {
+    writeSession({ id: existing.id, lastActiveAt: now });
+    return existing.id;
+  }
+  const id = generateId();
+  writeSession({ id, lastActiveAt: now });
+  return id;
+}
+
+export function makeSearchQueryId(): string {
+  return generateId();
+}
+
+export function makeResultId(
+  searchQueryId: string,
+  userId: number,
+  position: number,
+): string {
+  return `${searchQueryId}:${userId}:${position}`;
+}
+
+export function setSearchReferrer(
+  referrer: Omit<SearchReferrer, "setAt">,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(
+      REFERRER_KEY,
+      JSON.stringify({ ...referrer, setAt: Date.now() }),
+    );
+  } catch {
+    // sessionStorage unavailable — drop silently
+  }
+}
+
+export function readSearchReferrer(userId: number): SearchReferrer | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(REFERRER_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as SearchReferrer;
+    if (parsed.userId !== userId) return null;
+    if (Date.now() - parsed.setAt > SESSION_TTL_MS) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function referrerToProperties(
+  referrer: SearchReferrer | null,
+): Record<string, unknown> {
+  if (!referrer) return {};
+  return {
+    referrer_search_session_id: referrer.searchSessionId,
+    referrer_search_query_id: referrer.searchQueryId,
+    referrer_result_id: referrer.resultId,
+  };
+}

--- a/app/web/features/analytics/searchAttribution.ts
+++ b/app/web/features/analytics/searchAttribution.ts
@@ -24,16 +24,6 @@ export interface SearchReferrer {
   setAt: number;
 }
 
-function generateId(): string {
-  if (
-    typeof crypto !== "undefined" &&
-    typeof crypto.randomUUID === "function"
-  ) {
-    return crypto.randomUUID();
-  }
-  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
-}
-
 function readSession(): StoredSession | null {
   if (typeof window === "undefined") return null;
   try {
@@ -60,13 +50,13 @@ export function getOrCreateSearchSessionId(): string {
     writeSession({ id: existing.id, lastActiveAt: now });
     return existing.id;
   }
-  const id = generateId();
+  const id = crypto.randomUUID();
   writeSession({ id, lastActiveAt: now });
   return id;
 }
 
 export function makeSearchQueryId(): string {
-  return generateId();
+  return crypto.randomUUID();
 }
 
 export function makeResultId(

--- a/app/web/features/profile/view/NewHostRequest.tsx
+++ b/app/web/features/profile/view/NewHostRequest.tsx
@@ -6,17 +6,30 @@ import Datepicker from "components/Datepicker";
 import StyledLink from "components/StyledLink";
 import TextField from "components/TextField";
 import dayjs from "dayjs";
+import { useLogEvent } from "features/analytics/hooks";
+import {
+  readSearchReferrer,
+  referrerToProperties,
+} from "features/analytics/searchAttribution";
 import { useProfileUser } from "features/profile/hooks/useProfileUser";
 import { useLiteUser } from "features/userQueries/useLiteUsers";
 import { Trans, useTranslation } from "i18n";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { howToWriteRequestGuideUrl } from "routes";
 import { service } from "service";
 import { CreateHostRequestWrapper } from "service/requests";
 import { theme } from "theme";
 import { isSameOrFutureDate } from "utils/date";
+
+const TYPING_GAP_CAP_MS = 3000;
+
+function isFormField(target: EventTarget | null): boolean {
+  if (!target || !(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA";
+}
 
 const StyledTitle = styled(Typography)(() => ({
   marginTop: theme.spacing(1),
@@ -84,12 +97,115 @@ export default function NewHostRequest({
 
   const textField = watch("text") ?? "";
 
+  const logEvent = useLogEvent();
+  const formRef = useRef<HTMLFormElement | null>(null);
+  const submittedRef = useRef(false);
+  const latestValuesRef = useRef<{
+    text: string;
+    fromDate: dayjs.Dayjs | null;
+    toDate: dayjs.Dayjs | null;
+  }>({ text: "", fromDate: null, toDate: null });
+  const watchedText = watch("text");
+  const watchedFromDateForRef = watch("fromDate");
+  const watchedToDateForRef = watch("toDate");
+  latestValuesRef.current = {
+    text: watchedText ?? "",
+    fromDate: watchedFromDateForRef ?? null,
+    toDate: watchedToDateForRef ?? null,
+  };
+
+  useEffect(() => {
+    const startedAt = performance.now();
+    let foregroundAccumMs = 0;
+    let visibleSince: number | null =
+      typeof document !== "undefined" && document.visibilityState === "visible"
+        ? startedAt
+        : null;
+    let focusAccumMs = 0;
+    let focusSince: number | null = null;
+    let activeTypingMs = 0;
+    let lastKeystroke: number | null = null;
+    let keystrokeCount = 0;
+
+    const onVis = () => {
+      const now = performance.now();
+      if (document.visibilityState === "visible") {
+        if (visibleSince === null) visibleSince = now;
+      } else if (visibleSince !== null) {
+        foregroundAccumMs += now - visibleSince;
+        visibleSince = null;
+      }
+    };
+    const onFocusIn = (e: FocusEvent) => {
+      if (!isFormField(e.target)) return;
+      if (focusSince === null) focusSince = performance.now();
+    };
+    const onFocusOut = (e: FocusEvent) => {
+      if (!isFormField(e.target)) return;
+      if (focusSince !== null) {
+        focusAccumMs += performance.now() - focusSince;
+        focusSince = null;
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!isFormField(e.target)) return;
+      const now = performance.now();
+      if (lastKeystroke !== null) {
+        const gap = now - lastKeystroke;
+        if (gap <= TYPING_GAP_CAP_MS) activeTypingMs += gap;
+      }
+      lastKeystroke = now;
+      keystrokeCount += 1;
+    };
+
+    document.addEventListener("visibilitychange", onVis);
+    const formEl = formRef.current;
+    formEl?.addEventListener("focusin", onFocusIn);
+    formEl?.addEventListener("focusout", onFocusOut);
+    formEl?.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      document.removeEventListener("visibilitychange", onVis);
+      formEl?.removeEventListener("focusin", onFocusIn);
+      formEl?.removeEventListener("focusout", onFocusOut);
+      formEl?.removeEventListener("keydown", onKeyDown);
+
+      const now = performance.now();
+      if (visibleSince !== null) foregroundAccumMs += now - visibleSince;
+      if (focusSince !== null) focusAccumMs += now - focusSince;
+      const totalMs = now - startedAt;
+
+      const { text, fromDate, toDate } = latestValuesRef.current;
+      const referrerProps = referrerToProperties(
+        readSearchReferrer(user.userId),
+      );
+
+      logEvent("host_request.form_closed", {
+        host_user_id: user.userId,
+        submitted: submittedRef.current,
+        form_open_ms: Math.round(foregroundAccumMs),
+        form_open_total_ms: Math.round(totalMs),
+        focus_ms: Math.round(focusAccumMs),
+        active_typing_ms: Math.round(activeTypingMs),
+        keystroke_count: keystrokeCount,
+        text_length: text.length,
+        from_date: fromDate ? fromDate.format("YYYY-MM-DD") : null,
+        to_date: toDate ? toDate.format("YYYY-MM-DD") : null,
+        ...referrerProps,
+      });
+    };
+    // Effect intentionally has no deps: it should only run on mount/unmount,
+    // matching the form's open/close lifecycle (Collapse mountOnEnter/unmountOnExit).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const { error, mutate } = useMutation({
     mutationFn: (data: CreateHostRequestWrapper) => {
       return service.requests.createHostRequest(data);
     },
 
     onSuccess: () => {
+      submittedRef.current = true;
       setIsRequesting(false);
       setIsRequestSuccess(true);
     },
@@ -126,7 +242,7 @@ export default function NewHostRequest({
       {hostError ? (
         <Alert severity={"error"}>{hostError?.message}</Alert>
       ) : (
-        <form onSubmit={onSubmit}>
+        <form onSubmit={onSubmit} ref={formRef}>
           <StyledRequestRow>
             <StyledDateRow>
               <StyledDatepicker

--- a/app/web/features/profile/view/NewHostRequest.tsx
+++ b/app/web/features/profile/view/NewHostRequest.tsx
@@ -6,6 +6,7 @@ import Datepicker from "components/Datepicker";
 import StyledLink from "components/StyledLink";
 import TextField from "components/TextField";
 import dayjs from "dayjs";
+import { createForegroundTracker } from "features/analytics/foregroundTracker";
 import { useLogEvent } from "features/analytics/hooks";
 import {
   readSearchReferrer,
@@ -15,7 +16,7 @@ import { useProfileUser } from "features/profile/hooks/useProfileUser";
 import { useLiteUser } from "features/userQueries/useLiteUsers";
 import { Trans, useTranslation } from "i18n";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
-import React, { useEffect, useRef } from "react";
+import React, { MutableRefObject, useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { howToWriteRequestGuideUrl } from "routes";
 import { service } from "service";
@@ -25,10 +26,107 @@ import { isSameOrFutureDate } from "utils/date";
 
 const TYPING_GAP_CAP_MS = 3000;
 
+interface FormValuesSnapshot {
+  text: string;
+  fromDate: dayjs.Dayjs | null;
+  toDate: dayjs.Dayjs | null;
+}
+
 function isFormField(target: EventTarget | null): boolean {
   if (!target || !(target instanceof HTMLElement)) return false;
   const tag = target.tagName;
   return tag === "INPUT" || tag === "TEXTAREA";
+}
+
+/**
+ * Logs `host_request.form_closed` when the form unmounts (closed or submitted),
+ * reporting engagement: time open and visible, time a field was focused, active
+ * typing time and keystroke count, the final draft length and dates, whether it
+ * was submitted, and any search referrer that led the user here.
+ *
+ * Runs once for the form's open/close lifecycle, so it reads the latest form
+ * values and submitted flag from refs rather than re-subscribing on each change.
+ */
+function useHostRequestFormTracking({
+  hostUserId,
+  formRef,
+  getSubmitted,
+  getLatestValues,
+}: {
+  hostUserId: number;
+  formRef: MutableRefObject<HTMLFormElement | null>;
+  getSubmitted: () => boolean;
+  getLatestValues: () => FormValuesSnapshot;
+}) {
+  const logEvent = useLogEvent();
+
+  useEffect(() => {
+    const tracker = createForegroundTracker();
+    let focusAccumMs = 0;
+    let focusSince: number | null = null;
+    let activeTypingMs = 0;
+    let lastKeystroke: number | null = null;
+    let keystrokeCount = 0;
+
+    const onFocusIn = (e: FocusEvent) => {
+      if (!isFormField(e.target)) return;
+      if (focusSince === null) focusSince = performance.now();
+    };
+    const onFocusOut = (e: FocusEvent) => {
+      if (!isFormField(e.target)) return;
+      if (focusSince !== null) {
+        focusAccumMs += performance.now() - focusSince;
+        focusSince = null;
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!isFormField(e.target)) return;
+      const now = performance.now();
+      if (lastKeystroke !== null) {
+        const gap = now - lastKeystroke;
+        if (gap <= TYPING_GAP_CAP_MS) activeTypingMs += gap;
+      }
+      lastKeystroke = now;
+      keystrokeCount += 1;
+    };
+
+    document.addEventListener("visibilitychange", tracker.onVisibilityChange);
+    const formEl = formRef.current;
+    formEl?.addEventListener("focusin", onFocusIn);
+    formEl?.addEventListener("focusout", onFocusOut);
+    formEl?.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      document.removeEventListener(
+        "visibilitychange",
+        tracker.onVisibilityChange,
+      );
+      formEl?.removeEventListener("focusin", onFocusIn);
+      formEl?.removeEventListener("focusout", onFocusOut);
+      formEl?.removeEventListener("keydown", onKeyDown);
+
+      if (focusSince !== null) focusAccumMs += performance.now() - focusSince;
+      const { foregroundMs, totalMs } = tracker.finalize();
+
+      const { text, fromDate, toDate } = getLatestValues();
+      const referrerProps = referrerToProperties(readSearchReferrer(hostUserId));
+
+      logEvent("host_request.form_closed", {
+        host_user_id: hostUserId,
+        submitted: getSubmitted(),
+        form_open_ms: foregroundMs,
+        form_open_total_ms: totalMs,
+        focus_ms: Math.round(focusAccumMs),
+        active_typing_ms: Math.round(activeTypingMs),
+        keystroke_count: keystrokeCount,
+        text_length: text.length,
+        from_date: fromDate ? fromDate.format("YYYY-MM-DD") : null,
+        to_date: toDate ? toDate.format("YYYY-MM-DD") : null,
+        ...referrerProps,
+      });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 }
 
 const StyledTitle = styled(Typography)(() => ({
@@ -97,107 +195,25 @@ export default function NewHostRequest({
 
   const textField = watch("text") ?? "";
 
-  const logEvent = useLogEvent();
   const formRef = useRef<HTMLFormElement | null>(null);
   const submittedRef = useRef(false);
-  const latestValuesRef = useRef<{
-    text: string;
-    fromDate: dayjs.Dayjs | null;
-    toDate: dayjs.Dayjs | null;
-  }>({ text: "", fromDate: null, toDate: null });
-  const watchedText = watch("text");
-  const watchedFromDateForRef = watch("fromDate");
-  const watchedToDateForRef = watch("toDate");
+  const latestValuesRef = useRef<FormValuesSnapshot>({
+    text: "",
+    fromDate: null,
+    toDate: null,
+  });
   latestValuesRef.current = {
-    text: watchedText ?? "",
-    fromDate: watchedFromDateForRef ?? null,
-    toDate: watchedToDateForRef ?? null,
+    text: watch("text") ?? "",
+    fromDate: watch("fromDate") ?? null,
+    toDate: watch("toDate") ?? null,
   };
 
-  useEffect(() => {
-    const startedAt = performance.now();
-    let foregroundAccumMs = 0;
-    let visibleSince: number | null =
-      typeof document !== "undefined" && document.visibilityState === "visible"
-        ? startedAt
-        : null;
-    let focusAccumMs = 0;
-    let focusSince: number | null = null;
-    let activeTypingMs = 0;
-    let lastKeystroke: number | null = null;
-    let keystrokeCount = 0;
-
-    const onVis = () => {
-      const now = performance.now();
-      if (document.visibilityState === "visible") {
-        if (visibleSince === null) visibleSince = now;
-      } else if (visibleSince !== null) {
-        foregroundAccumMs += now - visibleSince;
-        visibleSince = null;
-      }
-    };
-    const onFocusIn = (e: FocusEvent) => {
-      if (!isFormField(e.target)) return;
-      if (focusSince === null) focusSince = performance.now();
-    };
-    const onFocusOut = (e: FocusEvent) => {
-      if (!isFormField(e.target)) return;
-      if (focusSince !== null) {
-        focusAccumMs += performance.now() - focusSince;
-        focusSince = null;
-      }
-    };
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (!isFormField(e.target)) return;
-      const now = performance.now();
-      if (lastKeystroke !== null) {
-        const gap = now - lastKeystroke;
-        if (gap <= TYPING_GAP_CAP_MS) activeTypingMs += gap;
-      }
-      lastKeystroke = now;
-      keystrokeCount += 1;
-    };
-
-    document.addEventListener("visibilitychange", onVis);
-    const formEl = formRef.current;
-    formEl?.addEventListener("focusin", onFocusIn);
-    formEl?.addEventListener("focusout", onFocusOut);
-    formEl?.addEventListener("keydown", onKeyDown);
-
-    return () => {
-      document.removeEventListener("visibilitychange", onVis);
-      formEl?.removeEventListener("focusin", onFocusIn);
-      formEl?.removeEventListener("focusout", onFocusOut);
-      formEl?.removeEventListener("keydown", onKeyDown);
-
-      const now = performance.now();
-      if (visibleSince !== null) foregroundAccumMs += now - visibleSince;
-      if (focusSince !== null) focusAccumMs += now - focusSince;
-      const totalMs = now - startedAt;
-
-      const { text, fromDate, toDate } = latestValuesRef.current;
-      const referrerProps = referrerToProperties(
-        readSearchReferrer(user.userId),
-      );
-
-      logEvent("host_request.form_closed", {
-        host_user_id: user.userId,
-        submitted: submittedRef.current,
-        form_open_ms: Math.round(foregroundAccumMs),
-        form_open_total_ms: Math.round(totalMs),
-        focus_ms: Math.round(focusAccumMs),
-        active_typing_ms: Math.round(activeTypingMs),
-        keystroke_count: keystrokeCount,
-        text_length: text.length,
-        from_date: fromDate ? fromDate.format("YYYY-MM-DD") : null,
-        to_date: toDate ? toDate.format("YYYY-MM-DD") : null,
-        ...referrerProps,
-      });
-    };
-    // Effect intentionally has no deps: it should only run on mount/unmount,
-    // matching the form's open/close lifecycle (Collapse mountOnEnter/unmountOnExit).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  useHostRequestFormTracking({
+    hostUserId: user.userId,
+    formRef,
+    getSubmitted: () => submittedRef.current,
+    getLatestValues: () => latestValuesRef.current,
+  });
 
   const { error, mutate } = useMutation({
     mutationFn: (data: CreateHostRequestWrapper) => {

--- a/app/web/features/profile/view/NewHostRequest.tsx
+++ b/app/web/features/profile/view/NewHostRequest.tsx
@@ -109,7 +109,9 @@ function useHostRequestFormTracking({
       const { foregroundMs, totalMs } = tracker.finalize();
 
       const { text, fromDate, toDate } = getLatestValues();
-      const referrerProps = referrerToProperties(readSearchReferrer(hostUserId));
+      const referrerProps = referrerToProperties(
+        readSearchReferrer(hostUserId),
+      );
 
       logEvent("host_request.form_closed", {
         host_user_id: hostUserId,

--- a/app/web/features/profile/view/UserPage.tsx
+++ b/app/web/features/profile/view/UserPage.tsx
@@ -3,6 +3,7 @@ import Alert from "components/Alert";
 import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
 import HtmlMeta from "components/HtmlMeta";
 import Snackbar from "components/Snackbar";
+import { createForegroundTracker } from "features/analytics/foregroundTracker";
 import { useLogEvent } from "features/analytics/hooks";
 import {
   readSearchReferrer,
@@ -22,6 +23,40 @@ import { routeToUser, UserTab } from "routes";
 import UserCard from "./UserCard";
 
 const REQUEST_ID = "request";
+
+/**
+ * Logs `profile.tab_viewed` when the viewed tab changes or the page unmounts,
+ * reporting how long the tab was open (`total_ms`) and visible (`foreground_ms`),
+ * plus any search referrer that led the user here.
+ */
+function useProfileTabViewTracking(userId: number | undefined, tab: UserTab) {
+  const logEvent = useLogEvent();
+  const referrerProps = useMemo(
+    () => referrerToProperties(userId ? readSearchReferrer(userId) : null),
+    [userId],
+  );
+
+  useEffect(() => {
+    if (!userId) return;
+    const tracker = createForegroundTracker();
+    document.addEventListener("visibilitychange", tracker.onVisibilityChange);
+
+    return () => {
+      document.removeEventListener(
+        "visibilitychange",
+        tracker.onVisibilityChange,
+      );
+      const { foregroundMs, totalMs } = tracker.finalize();
+      logEvent("profile.tab_viewed", {
+        user_id: userId,
+        tab,
+        foreground_ms: foregroundMs,
+        total_ms: totalMs,
+        ...referrerProps,
+      });
+    };
+  }, [tab, userId, logEvent, referrerProps]);
+}
 
 export const StyledProfileRoot = styled("div")(({ theme }) => ({
   padding: theme.spacing(1),
@@ -64,47 +99,7 @@ export default function UserPage({
     }
   }, [isRequesting, isMessaging]);
 
-  const logEvent = useLogEvent();
-  const userId = user?.userId;
-  const referrerProps = useMemo(
-    () => referrerToProperties(userId ? readSearchReferrer(userId) : null),
-    [userId],
-  );
-
-  useEffect(() => {
-    if (!userId) return;
-    const startedAt = performance.now();
-    let foregroundAccumMs = 0;
-    let visibleSince: number | null =
-      typeof document !== "undefined" && document.visibilityState === "visible"
-        ? startedAt
-        : null;
-
-    const onVis = () => {
-      const now = performance.now();
-      if (document.visibilityState === "visible") {
-        if (visibleSince === null) visibleSince = now;
-      } else if (visibleSince !== null) {
-        foregroundAccumMs += now - visibleSince;
-        visibleSince = null;
-      }
-    };
-    document.addEventListener("visibilitychange", onVis);
-
-    return () => {
-      document.removeEventListener("visibilitychange", onVis);
-      const now = performance.now();
-      if (visibleSince !== null) foregroundAccumMs += now - visibleSince;
-      const totalMs = now - startedAt;
-      logEvent("profile.tab_viewed", {
-        user_id: userId,
-        tab,
-        foreground_ms: Math.round(foregroundAccumMs),
-        total_ms: Math.round(totalMs),
-        ...referrerProps,
-      });
-    };
-  }, [tab, userId, logEvent, referrerProps]);
+  useProfileTabViewTracking(user?.userId, tab);
 
   return (
     <>

--- a/app/web/features/profile/view/UserPage.tsx
+++ b/app/web/features/profile/view/UserPage.tsx
@@ -3,6 +3,11 @@ import Alert from "components/Alert";
 import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
 import HtmlMeta from "components/HtmlMeta";
 import Snackbar from "components/Snackbar";
+import { useLogEvent } from "features/analytics/hooks";
+import {
+  readSearchReferrer,
+  referrerToProperties,
+} from "features/analytics/searchAttribution";
 import { ProfileUserProvider } from "features/profile/hooks/useProfileUser";
 import NewHostRequest from "features/profile/view/NewHostRequest";
 import NewMessage from "features/profile/view/NewMessage";
@@ -11,7 +16,7 @@ import useUserByUsername from "features/userQueries/useUserByUsername";
 import { useTranslation } from "i18n";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
 import { useRouter } from "next/router";
-import { useLayoutEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { routeToUser, UserTab } from "routes";
 
 import UserCard from "./UserCard";
@@ -59,6 +64,48 @@ export default function UserPage({
     }
   }, [isRequesting, isMessaging]);
 
+  const logEvent = useLogEvent();
+  const userId = user?.userId;
+  const referrerProps = useMemo(
+    () => referrerToProperties(userId ? readSearchReferrer(userId) : null),
+    [userId],
+  );
+
+  useEffect(() => {
+    if (!userId) return;
+    const startedAt = performance.now();
+    let foregroundAccumMs = 0;
+    let visibleSince: number | null =
+      typeof document !== "undefined" && document.visibilityState === "visible"
+        ? startedAt
+        : null;
+
+    const onVis = () => {
+      const now = performance.now();
+      if (document.visibilityState === "visible") {
+        if (visibleSince === null) visibleSince = now;
+      } else if (visibleSince !== null) {
+        foregroundAccumMs += now - visibleSince;
+        visibleSince = null;
+      }
+    };
+    document.addEventListener("visibilitychange", onVis);
+
+    return () => {
+      document.removeEventListener("visibilitychange", onVis);
+      const now = performance.now();
+      if (visibleSince !== null) foregroundAccumMs += now - visibleSince;
+      const totalMs = now - startedAt;
+      logEvent("profile.tab_viewed", {
+        user_id: userId,
+        tab,
+        foreground_ms: Math.round(foregroundAccumMs),
+        total_ms: Math.round(totalMs),
+        ...referrerProps,
+      });
+    };
+  }, [tab, userId, logEvent, referrerProps]);
+
   return (
     <>
       <HtmlMeta title={user?.name} />
@@ -85,7 +132,7 @@ export default function UserPage({
               }}
               top={
                 <>
-                  <Collapse in={isRequesting}>
+                  <Collapse in={isRequesting} mountOnEnter unmountOnExit>
                     <NewHostRequest
                       setIsRequesting={setIsRequesting}
                       setIsRequestSuccess={setIsSuccessRequest}

--- a/app/web/features/search/SeachResultUserCard.tsx
+++ b/app/web/features/search/SeachResultUserCard.tsx
@@ -264,7 +264,7 @@ const SearchResultUserCard = ({
     <StyledCard
       isHighlighted={isHighlighted}
       onClick={handleUserCardClick}
-      onClickCapture={analytics ? handleClickCapture : undefined}
+      onClickCapture={handleClickCapture}
       ref={analytics ? impressionRef : undefined}
     >
       <StyledTopContent>

--- a/app/web/features/search/SeachResultUserCard.tsx
+++ b/app/web/features/search/SeachResultUserCard.tsx
@@ -4,11 +4,18 @@ import Avatar from "components/Avatar";
 import { OpenInNewIcon } from "components/Icons";
 import ProfileLink from "components/ProfileLink/ProfileLink";
 import StyledLink from "components/StyledLink";
+import { useImpressionRef, useLogEvent } from "features/analytics/hooks";
+import { useSearchAnalytics } from "features/analytics/searchAnalyticsContext";
+import {
+  makeResultId,
+  setSearchReferrer,
+} from "features/analytics/searchAttribution";
 import { ResponseRateText } from "features/profile/view/userLabels";
 import { useTranslation } from "i18n";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
 import { TFunction } from "i18next";
 import { SearchUser } from "proto/search_pb";
+import { MouseEvent } from "react";
 import LinesEllipsis from "react-lines-ellipsis";
 import { routeToUser } from "routes";
 import { theme } from "theme";
@@ -23,7 +30,38 @@ import { aboutText, truncateWithEllipsis } from "./utils/constants";
 interface SearchResultUserCardProps {
   isHighlighted?: boolean;
   onUserCardClick: (userId: number) => void;
+  position: number;
   user: SearchUser.AsObject;
+}
+
+function responseRateBucket(user: SearchUser.AsObject): string | null {
+  if (user.most) return "most";
+  if (user.some) return "some";
+  if (user.low) return "low";
+  if (user.insufficientData) return "insufficient";
+  return null;
+}
+
+function displayedAttributes(
+  user: SearchUser.AsObject,
+): Record<string, unknown> {
+  const lastActive = user.lastActive
+    ? timestamp2Date(user.lastActive).getTime()
+    : null;
+  return {
+    has_avatar: user.avatarUrl.length > 0,
+    has_about: user.profileSnippet.length > 0,
+    profile_snippet_length: user.profileSnippet.length,
+    age: user.age,
+    gender: user.gender,
+    hosting_status: user.hostingStatus,
+    meetup_status: user.meetupStatus,
+    num_references: user.numReferences,
+    has_completed_profile: user.hasCompletedProfile,
+    has_completed_my_home: user.hasCompletedMyHome,
+    last_active_ms: lastActive,
+    response_rate_bucket: responseRateBucket(user),
+  };
 }
 
 const StyledCard = styled("div", {
@@ -154,6 +192,7 @@ const generateAboutText = (
 const SearchResultUserCard = ({
   isHighlighted = false,
   onUserCardClick,
+  position,
   user,
 }: SearchResultUserCardProps) => {
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
@@ -163,12 +202,71 @@ const SearchResultUserCard = ({
     i18n: { language: locale },
   } = useTranslation([GLOBAL, PROFILE]);
 
+  const analytics = useSearchAnalytics();
+  const logEvent = useLogEvent();
+  const attrs = displayedAttributes(user);
+  const resultId = analytics
+    ? makeResultId(analytics.searchQueryId, user.userId, position)
+    : null;
+
+  const impressionProps = analytics
+    ? {
+        search_session_id: analytics.searchSessionId,
+        search_query_id: analytics.searchQueryId,
+        page_number: analytics.pageNumber,
+        result_id: resultId,
+        user_id: user.userId,
+        position,
+        surface: "list",
+        ...attrs,
+      }
+    : {};
+  const impressionRef = useImpressionRef(
+    "search.result_impressed",
+    impressionProps,
+    { threshold: 0.5, minDurationMs: 250 },
+  );
+
   const handleUserCardClick = () => {
     onUserCardClick(user.userId);
   };
 
+  const handleClickCapture = (e: MouseEvent<HTMLDivElement>) => {
+    if (!analytics || !resultId) return;
+    const target = e.target as HTMLElement | null;
+    const anchor = target?.closest("a");
+    if (!anchor) return;
+    setSearchReferrer({
+      searchSessionId: analytics.searchSessionId,
+      searchQueryId: analytics.searchQueryId,
+      resultId,
+      userId: user.userId,
+    });
+    logEvent("search.result_clicked", {
+      search_session_id: analytics.searchSessionId,
+      search_query_id: analytics.searchQueryId,
+      page_number: analytics.pageNumber,
+      result_id: resultId,
+      user_id: user.userId,
+      position,
+      surface: "list",
+      opened_in_new_tab:
+        anchor.getAttribute("target") === "_blank" ||
+        e.metaKey ||
+        e.ctrlKey ||
+        e.button === 1,
+      was_selected_on_map: isHighlighted,
+      ...attrs,
+    });
+  };
+
   return (
-    <StyledCard isHighlighted={isHighlighted} onClick={handleUserCardClick}>
+    <StyledCard
+      isHighlighted={isHighlighted}
+      onClick={handleUserCardClick}
+      onClickCapture={analytics ? handleClickCapture : undefined}
+      ref={analytics ? impressionRef : undefined}
+    >
       <StyledTopContent>
         <Avatar openInNewTab user={user} />
         <FlexColumn>

--- a/app/web/features/search/SearchPage.tsx
+++ b/app/web/features/search/SearchPage.tsx
@@ -1,6 +1,9 @@
 import { styled } from "@mui/material";
 import HtmlMeta from "components/HtmlMeta";
 import { DEFAULT_DRAWER_WIDTH } from "components/ResizeableDrawer";
+import { useLogEvent } from "features/analytics/hooks";
+import { SearchAnalyticsProvider } from "features/analytics/searchAnalyticsContext";
+import { getOrCreateSearchSessionId } from "features/analytics/searchAttribution";
 import {
   MapViewOptions,
   MapViews,
@@ -10,7 +13,7 @@ import {
 import { useTranslation } from "i18n";
 import { GLOBAL, SEARCH } from "i18n/namespaces";
 import { HostingStatus, MeetupStatus } from "proto/api_pb";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { LngLatLike, MapProvider, MapRef } from "react-map-gl/maplibre";
 
 import { useUserSearch } from "./hooks/useUserSearch";
@@ -116,7 +119,45 @@ export default function SearchPage() {
     currentRange,
     totalItems,
     users,
+    searchQueryId,
   } = useUserSearch(searchParams, mapSearchState);
+
+  const logEvent = useLogEvent();
+  const lastRenderedKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!users || isLoading) return;
+    const key = `${searchQueryId}:${mapSearchState.pageNumber}`;
+    if (lastRenderedKeyRef.current === key) return;
+    lastRenderedKeyRef.current = key;
+    logEvent("search.results_rendered", {
+      search_session_id: getOrCreateSearchSessionId(),
+      search_query_id: searchQueryId,
+      page_number: mapSearchState.pageNumber,
+      num_results: users.length,
+      total_items: totalItems,
+      has_next_page: hasNextPage,
+      has_previous_page: hasPreviousPage,
+      map_view: mapView,
+      query: mapSearchState.search.query ?? null,
+      bbox: mapSearchState.search.bbox ?? null,
+      zoom: mapSearchState.uiOnly.zoom,
+      filters: mapSearchState.filters,
+    });
+  }, [
+    users,
+    isLoading,
+    searchQueryId,
+    mapSearchState.pageNumber,
+    mapSearchState.search.query,
+    mapSearchState.search.bbox,
+    mapSearchState.uiOnly.zoom,
+    mapSearchState.filters,
+    hasNextPage,
+    hasPreviousPage,
+    totalItems,
+    mapView,
+    logEvent,
+  ]);
 
   const handleLoadPreviousPage = () => {
     fetchPreviousPage();
@@ -195,24 +236,29 @@ export default function SearchPage() {
             onZoomIn={handleZoomIn}
           />
         </SearchControlsWrapper>
-        <MapSearchContent
-          error={error}
-          drawerWidth={drawerWidth}
-          hasPreviousPage={hasPreviousPage}
-          hasNextPage={hasNextPage}
-          isLoading={isLoading}
-          mapRef={mapRef}
-          mapView={mapView}
-          currentRange={currentRange}
-          onDrawerWidthChange={handleDrawerWidthChange}
-          onLoadPreviousPage={handleLoadPreviousPage}
-          onLoadNextPage={handleLoadNextPage}
-          onSetMapView={handleSetMapView}
-          onZoomIn={handleZoomIn}
-          onZoomOut={handleZoomOut}
-          totalItems={totalItems}
-          users={users}
-        />
+        <SearchAnalyticsProvider
+          searchQueryId={searchQueryId}
+          pageNumber={mapSearchState.pageNumber}
+        >
+          <MapSearchContent
+            error={error}
+            drawerWidth={drawerWidth}
+            hasPreviousPage={hasPreviousPage}
+            hasNextPage={hasNextPage}
+            isLoading={isLoading}
+            mapRef={mapRef}
+            mapView={mapView}
+            currentRange={currentRange}
+            onDrawerWidthChange={handleDrawerWidthChange}
+            onLoadPreviousPage={handleLoadPreviousPage}
+            onLoadNextPage={handleLoadNextPage}
+            onSetMapView={handleSetMapView}
+            onZoomIn={handleZoomIn}
+            onZoomOut={handleZoomOut}
+            totalItems={totalItems}
+            users={users}
+          />
+        </SearchAnalyticsProvider>
       </MapProvider>
     </SearchPageContainer>
   );

--- a/app/web/features/search/SearchResultListContent.tsx
+++ b/app/web/features/search/SearchResultListContent.tsx
@@ -210,7 +210,7 @@ const SearchResultListContent = ({
         </Box>
       )}
       <UserCardsWrapper>
-        {users?.map((user) => (
+        {users?.map((user, index) => (
           <StyledCardWrapper
             key={user?.userId}
             id={`search-result-${user?.userId}`}
@@ -218,6 +218,7 @@ const SearchResultListContent = ({
             <SearchResultUserCard
               isHighlighted={selectedUserId === user.userId}
               onUserCardClick={onUserCardClick}
+              position={index}
               user={user}
             />
           </StyledCardWrapper>

--- a/app/web/features/search/hooks/useUserSearch.ts
+++ b/app/web/features/search/hooks/useUserSearch.ts
@@ -1,6 +1,8 @@
 import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
+import { makeSearchQueryId } from "features/analytics/searchAttribution";
 import { RpcError } from "grpc-web";
 import { UserSearchV2Res } from "proto/search_pb";
+import { useMemo } from "react";
 import { service } from "service";
 
 import { FilterOptions } from "../SearchPage";
@@ -86,6 +88,14 @@ export function useUserSearch(
     totalItems,
   });
 
+  // Stable per searchParams reference: rolls when filters/bbox/query change,
+  // stays put across pagination within the same intent.
+  const searchQueryId = useMemo(
+    () => makeSearchQueryId(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [searchParams],
+  );
+
   return {
     error,
     users,
@@ -96,5 +106,6 @@ export function useUserSearch(
     fetchPreviousPage,
     currentRange,
     totalItems,
+    searchQueryId,
   };
 }

--- a/app/web/features/search/hooks/useUserSearch.ts
+++ b/app/web/features/search/hooks/useUserSearch.ts
@@ -2,7 +2,7 @@ import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
 import { makeSearchQueryId } from "features/analytics/searchAttribution";
 import { RpcError } from "grpc-web";
 import { UserSearchV2Res } from "proto/search_pb";
-import { useMemo } from "react";
+import { useRef } from "react";
 import { service } from "service";
 
 import { FilterOptions } from "../SearchPage";
@@ -88,13 +88,18 @@ export function useUserSearch(
     totalItems,
   });
 
-  // Stable per searchParams reference: rolls when filters/bbox/query change,
-  // stays put across pagination within the same intent.
-  const searchQueryId = useMemo(
-    () => makeSearchQueryId(),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [searchParams],
-  );
+  // Rolls when filters/bbox/query change, stays put across pagination within
+  // the same intent. searchParams keeps a stable reference across pagination.
+  const searchQueryIdRef = useRef<string | null>(null);
+  const prevSearchParamsRef = useRef<FilterOptions | null>(null);
+  if (
+    searchQueryIdRef.current === null ||
+    prevSearchParamsRef.current !== searchParams
+  ) {
+    prevSearchParamsRef.current = searchParams;
+    searchQueryIdRef.current = makeSearchQueryId();
+  }
+  const searchQueryId = searchQueryIdRef.current;
 
   return {
     error,

--- a/app/web/test/setupTests.ts
+++ b/app/web/test/setupTests.ts
@@ -72,6 +72,15 @@ global.crypto = {
   },
 };
 
+// jsdom's Crypto has no randomUUID; back it with Node's implementation.
+if (typeof global.crypto.randomUUID !== "function") {
+  Object.defineProperty(global.crypto, "randomUUID", {
+    configurable: true,
+    writable: true,
+    value: () => crypto.randomUUID(),
+  });
+}
+
 // Polyfill TextDecoder and TextEncoder for maplibre-gl
 // @ts-expect-error Polyfilling for test environment
 global.TextDecoder = TextDecoder;


### PR DESCRIPTION
Adds frontend analytics events across the host search → host request flow.

**Search**
- `search.results_rendered` — once per backend response (filters, bbox, query, zoom, mapView, num_results, has_next_page)
- `search.result_impressed` — IntersectionObserver, ≥50% visible for ≥250ms continuous (per result-card)
- `search.result_clicked` — fires on profile-bound clicks within a result card; writes a click referrer to `sessionStorage`

**Profile**
- `profile.tab_viewed` — emitted on tab change/unmount with `foreground_ms` (paused while document hidden) and `total_ms`

**Host request form**
- `host_request.form_closed` — emitted on close/unmount with `form_open_ms` (foreground), `form_open_total_ms`, `focus_ms`, `active_typing_ms` (sum of inter-keystroke gaps capped at 3s), `keystroke_count`, `submitted`, `text_length`, `from_date`, `to_date`

**Correlation**
- `search_session_id` (30-min idle rollover) + `search_query_id` + `result_id` stored in `sessionStorage`; profile and form events carry `referrer_*` fields when present.

**Other**
- `useImpressionRef` extended with a `minDurationMs` option (4 new tests).
- `Collapse` around `NewHostRequest` switched to `mountOnEnter unmountOnExit` so mount/unmount matches form open/close.

## Testing
- `yarn typecheck`, `yarn lint`, `yarn test` (115 suites / 802 tests) all pass.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._