### PR TITLE
Devex: Switch from CODEOWNERS to autoreviewers.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,1 @@
-# Only the last matching line's owners are added to the PR
-* @aapeliv
-/app/**/locales/*.json @tristanlabelle # Watch Weblate integrations
-/app/web/ @nabramow
-/docs/ @aapeliv @nabramow
+# Deprecated in favor of autoreviewers.yml since CODEOWNERS can only match one rule.

--- a/.github/autoreviewers.yml
+++ b/.github/autoreviewers.yml
@@ -1,9 +1,11 @@
 # Defines PR reviewers based on modified file paths.
-# The syntax is as the dorny/paths-filter action accepts,
-# but our filter names are a label plus a comma-delimited people/teams to assign.
+# This is an input to the dorny/paths-filter GitHub action,
+# configured to match rules if EVERY glob applies (to support exclusions).
+# Filter names are a label plus a comma-delimited people/teams to assign.
 backend Couchers-org/backend:
   - 'app/backend/**'
   - '!app/backend/**/locales/*.json'
+media Couchers-org/backend:
   - 'app/media/**'
 web Couchers-org/web:
   - 'app/web/**'
@@ -11,8 +13,9 @@ web Couchers-org/web:
 mobile Couchers-org/mobile:
   - 'app/mobile/**'
   - '!app/mobile/**/locales/*.json'
-i18n tristanlabelle:
+locales tristanlabelle:
   - 'app/**/locales/*.json'
+i18n tristanlabelle:
   - 'app/**/i18n/**'
 docs aapeliv,nabramow:
   - 'docs/**'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,6 +29,7 @@ Fill applicable checklists below, or remove those that don't apply.
 - [x] Maintainers can merge this PR for me
 
 <!--
-Remember to request review from couchers-org/web, couchers-org/backend or an individual.
+Create the code review as a draft if still iterating or validating via CI.
+Once published, reviewers will be added based on changes, but feel free to add more.
 Once your code is approved, you can merge it if you have write access.
 --->

--- a/.github/workflows/add-reviewers.yml
+++ b/.github/workflows/add-reviewers.yml
@@ -30,6 +30,9 @@ jobs:
         id: filter
         with:
           filters: .github/autoreviewers.yml
+          # Require every glob to match for a rule to match,
+          # otherwise we cannot express exclusions.
+          # e.g. 'app/web/**' + '!**/en.json' needs to be AND, not OR
           predicate-quantifier: every
 
       - name: Collect reviewers from matched rules

--- a/.github/workflows/add-reviewers.yml
+++ b/.github/workflows/add-reviewers.yml
@@ -19,7 +19,7 @@ jobs:
   add-reviewers:
     name: Add reviewers
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]' && !github.event.pull_request.draft
+    if: "!github.event.pull_request.draft"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/add-reviewers.yml
+++ b/.github/workflows/add-reviewers.yml
@@ -19,37 +19,66 @@ jobs:
   add-reviewers:
     name: Add reviewers
     runs-on: ubuntu-latest
-    # Let tristanlabelle validate this workflow before switching from CODEOWNERS
-    if: github.event.pull_request.user.login == 'tristanlabelle' && github.actor != 'dependabot[bot]' && !github.event.pull_request.draft
+    if: github.actor != 'dependabot[bot]' && !github.event.pull_request.draft
     steps:
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/autoreviewers.yml
+
+      - name: Match rules from autoreviewers.yml
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: .github/autoreviewers.yml
+          predicate-quantifier: every
 
-      - name: Add reviewers
+      - name: Collect reviewers from matched rules
+        id: collect-reviewers
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           # The "changes" output is a JSON array of filter names.
           FILTER_CHANGES: ${{ steps.filter.outputs.changes }}
         run: |
-          # Filter keys are "<name> <reviewer1,reviewer2,...>"; extract reviewers from matched filters.
-          MATCHED_REVIEWERS=$(echo "$FILTER_CHANGES" | jq -r '.[] | split(" ")[1] | split(",") | .[]')
+          # Filter keys are "<name> <reviewer1,reviewer2,...>"; process matched filters.
+          REVIEWERS=()
+          while IFS= read -r entry; do
+            [[ -n "$entry" ]] || continue
+            RULE_NAME="${entry%% *}"
+            REVIEWERS_STR="${entry#* }"
 
-          ARGS=()
-          while IFS= read -r reviewer; do
-            # Ignore empty entries
-            [[ -n "$reviewer" ]] || continue
-            # The PR author cannot be a reviewer on their own PR
-            [[ "$reviewer" == "$PR_AUTHOR" ]] && continue
+            echo "Matched rule \"$RULE_NAME\" with reviewers: $REVIEWERS_STR"
+            IFS=',' read -ra reviewers <<< "$REVIEWERS_STR"
+            for reviewer in "${reviewers[@]}"; do
+              [[ -n "$reviewer" ]] || continue
+              # The PR author cannot be a reviewer on their own PR
+              [[ "$reviewer" == "$PR_AUTHOR" ]] && continue
+              # Avoid adding the same reviewer twice
+              [[ " ${REVIEWERS[*]} " == *" $reviewer "* ]] && continue
+              REVIEWERS+=("$reviewer")
+            done
+          done < <(echo "$FILTER_CHANGES" | jq -r '.[]')
 
-            echo "Adding reviewer: $reviewer"
-            ARGS+=(--add-reviewer "$reviewer")
-          done <<< "$MATCHED_REVIEWERS"
-
-          if [[ ${#ARGS[@]} -gt 0 ]]; then
-            gh pr edit "$PR_NUMBER" "${ARGS[@]}"
+          if [[ ${#REVIEWERS[@]} -gt 0 ]]; then
+            echo "Collected reviewers: $(IFS=','; echo "${REVIEWERS[*]}")"
+          else
+            echo "No reviewers collected"
           fi
+
+          echo "reviewers=$(IFS=','; echo "${REVIEWERS[*]}")" >> "$GITHUB_OUTPUT"
+
+      - name: Add reviewers
+        if: steps.collect-reviewers.outputs.reviewers != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEWERS: ${{ steps.collect-reviewers.outputs.reviewers }}
+        run: |
+          GH_PR_EDIT_ARGS=()
+          IFS=',' read -ra reviewers <<< "$REVIEWERS"
+          for reviewer in "${reviewers[@]}"; do
+            GH_PR_EDIT_ARGS+=(--add-reviewer "$reviewer")
+          done
+
+          echo "Adding reviewers: $REVIEWERS"
+          gh pr edit "$PR_NUMBER" "${GH_PR_EDIT_ARGS[@]}"


### PR DESCRIPTION
Follow-up to #8601 that removes `CODEOWNERS` in favor of `autoreviewers.yml` after testing.

To support exclusions (e.g. frontend excluding locales-only changes), I had to switch dorny/path-filters to "every" mode, which requires all globs to pass. Thus we have to split off rules that should match on either of multiple paths.

I also split the workflow in more easily debuggable steps.

## Testing
Plenty of iteration in #8627

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
