### PR TITLE
Backend/requests: Fix malformed ics attachment

### DIFF
--- a/app/backend/src/couchers/email/calendar_events.py
+++ b/app/backend/src/couchers/email/calendar_events.py
@@ -32,7 +32,7 @@ def create_host_request_ics(
 
 
 def create_host_request_event(
-    host_request: HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext
+    host_request: HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext, sequence: int = 0
 ) -> Event:
     """Creates an ics event for a host request."""
 
@@ -40,7 +40,7 @@ def create_host_request_event(
     event.uid = get_host_request_event_uid(host_request.host_request_id)
 
     # Explicitly allow later sequencing of a cancellation with SEQUENCE:1
-    event.extra.append(ContentLine(name="SEQUENCE", value="0"))
+    event.extra.append(ContentLine(name="SEQUENCE", value=str(sequence)))
 
     if hosting:
         event.name = get_emails_i18next().localize(
@@ -76,14 +76,11 @@ def create_host_request_cancellation_attachment(
 def create_host_request_cancellation_ics(
     host_request: HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext
 ) -> str:
-    event = create_host_request_event(host_request, other_name, hosting, loc_context)
+    event = create_host_request_event(host_request, other_name, hosting, loc_context, sequence=1)
     event.name = get_emails_i18next().localize(
         "calendar_events.title_cancelled", loc_context.locale, {"title": event.name}
     )
     event.status = "CANCELLED"
-
-    # Sequence cancellation is after creation (which uses SEQUENCE:0)
-    event.extra.append(ContentLine(name="SEQUENCE", value="1"))
 
     # METHOD:PUBLISH means this is part of a stream of calendar event information.
     # Gmail™ will immediately remove the event from the user's calendar.

--- a/app/backend/src/tests/test_calendar_events.py
+++ b/app/backend/src/tests/test_calendar_events.py
@@ -100,6 +100,7 @@ def test_host_request_attachments(db, moderator):
     e = email_fields(mock)
     assert "accept" in e.subject and host.name in e.subject
     ics_event = _get_email_ics_attachment_calendar_event(e)
+    assert _get_ics_event_sequence(ics_event) == 0
     assert not ics_event.status
     assert ics_event.begin.date() == from_date
     assert ics_event.end.date() == (to_date + timedelta(days=1))
@@ -120,6 +121,7 @@ def test_host_request_attachments(db, moderator):
     e = email_fields(mock)
     assert "confirm" in e.subject and surfer.name in e.subject
     ics_event = _get_email_ics_attachment_calendar_event(e)
+    assert _get_ics_event_sequence(ics_event) == 0
     assert not ics_event.status
     assert ics_event.name == f"Hosting {surfer.name}"
 
@@ -137,6 +139,7 @@ def test_host_request_attachments(db, moderator):
     e = email_fields(mock)
     assert "cancel" in e.subject and surfer.name in e.subject
     ics_event = _get_email_ics_attachment_calendar_event(e)
+    assert _get_ics_event_sequence(ics_event) == 1
     assert ics_event.status == "CANCELLED"
 
 
@@ -147,3 +150,10 @@ def _get_email_ics_attachment_calendar_event(e) -> ics.Event:
     ics_calendar = ics.Calendar(ics_attachment.data.decode("utf-8"))
     assert len(ics_calendar.events) == 1
     return next(iter(ics_calendar.events))
+
+
+def _get_ics_event_sequence(event: ics.Event) -> int | None:
+    for x in event.extra:
+        if x.name == "SEQUENCE":
+            return int(x.value)
+    return None

--- a/app/backend/src/tests/test_calendar_events.py
+++ b/app/backend/src/tests/test_calendar_events.py
@@ -4,13 +4,13 @@ from datetime import timedelta
 import ics
 import pytest
 
-from couchers.email.calendar_events import create_host_request_ics
+from couchers.email.calendar_events import create_host_request_cancellation_ics, create_host_request_ics
 from couchers.i18n.context import LocalizationContext
 from couchers.proto import conversations_pb2, requests_pb2
 from couchers.proto.requests_pb2 import HostRequest
 from couchers.utils import today
 from tests.fixtures.db import generate_user
-from tests.fixtures.misc import email_fields, mock_notification_email
+from tests.fixtures.misc import Moderator, email_fields, mock_notification_email
 from tests.fixtures.sessions import requests_session
 from tests.test_requests import valid_request_text
 
@@ -20,7 +20,7 @@ def _(testconfig):
     pass
 
 
-def test_ics_content():
+def test_initial_ics_content():
     host_request = HostRequest(
         host_request_id=42, from_date="2000-01-01", to_date="2000-01-02", hosting_city="New York"
     )
@@ -28,19 +28,7 @@ def test_ics_content():
     ics = create_host_request_ics(
         host_request, other_name="Bob", hosting=True, loc_context=LocalizationContext.en_utc()
     )
-    ics = ics.replace("\r\n", "\n")
-
-    # Strip the domain in the UID, which depends on environment variables
-    ics = re.sub(
-        r"^UID:.*@(.*)$", lambda match: match[0].removesuffix(match[1]) + "<stripped>", ics, flags=re.MULTILINE
-    )
-
-    # Strip the domain in the URL and DESCRIPTION, which depends on environment variables
-    ics = re.sub(r"^(DESCRIPTION|URL):(.*)/(\d+)", r"\1:<stripped>/\3", ics, flags=re.MULTILINE)
-
-    assert (
-        ics
-        == """
+    assert _normalize_ics(ics) == _normalize_ics("""
 BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Couchers.org//Couchers//EN
@@ -56,11 +44,55 @@ URL:<stripped>/42
 END:VEVENT
 METHOD:PUBLISH
 END:VCALENDAR
-    """.strip()
+    """)
+
+
+def test_cancellation_ics_content():
+    host_request = HostRequest(
+        host_request_id=42, from_date="2000-01-01", to_date="2000-01-02", hosting_city="New York"
     )
 
+    ics = create_host_request_cancellation_ics(
+        host_request, other_name="Bob", hosting=True, loc_context=LocalizationContext.en_utc()
+    )
+    assert _normalize_ics(ics) == _normalize_ics("""
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Couchers.org//Couchers//EN
+BEGIN:VEVENT
+SEQUENCE:1
+DTSTART;VALUE=DATE:20000101
+DTEND;VALUE=DATE:20000103
+DESCRIPTION:<stripped>/42
+LOCATION:New York
+STATUS:CANCELLED
+SUMMARY:Cancelled: Hosting Bob
+UID:host_request.42@<stripped>
+URL:<stripped>/42
+END:VEVENT
+METHOD:PUBLISH
+END:VCALENDAR
+    """)
 
-def test_host_request_attachments(db, moderator):
+
+def _normalize_ics(ics: str) -> str:
+    # Normalize whitespace:
+    # - The ics library produces '\r\n', in-code literals are '\n'
+    # - In-code literals have start/end newlines and indentation.
+    ics = ics.replace("\r\n", "\n").strip()
+
+    # Strip the domain in the UID, which depends on environment variables
+    ics = re.sub(
+        r"^UID:.*@(.*)$", lambda match: match[0].removesuffix(match[1]) + "<stripped>", ics, flags=re.MULTILINE
+    )
+
+    # Strip the domain in the URL and DESCRIPTION, which depends on environment variables
+    ics = re.sub(r"^(DESCRIPTION|URL):(.*)/(\d+)", r"\1:<stripped>/\3", ics, flags=re.MULTILINE)
+
+    return ics
+
+
+def test_host_request_attachments(db, moderator: Moderator):
     host, host_token = generate_user(complete_profile=True)
     surfer, surfer_token = generate_user(complete_profile=True)
 


### PR DESCRIPTION
Fixes a bug introduced in #8635 whereas cancellation ics files would contain both `SEQUENCE:0` and `SEQUENCE:1`, thus interfering with correct cancellation (Gmail wouldn't have it).

## Testing
Added more testing, but full E2E testing with Gmail requires me merging and using NEXT.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
