### PR TITLE
Hide content by non-visible users via moderation visibility checks

### DIFF
--- a/app/backend/src/couchers/models/conversations.py
+++ b/app/backend/src/couchers/models/conversations.py
@@ -10,6 +10,7 @@ from sqlalchemy.sql import expression
 from couchers.constants import DATETIME_INFINITY, DATETIME_MINUS_INFINITY
 from couchers.models.base import Base
 from couchers.models.host_requests import HostRequestStatus
+from couchers.models.moderation import ModerationObjectType
 from couchers.utils import now
 
 if TYPE_CHECKING:
@@ -38,6 +39,7 @@ class GroupChat(Base, kw_only=True):
 
     __tablename__ = "group_chats"
     __moderation_author_column__ = "creator_id"
+    __moderation_object_type__ = ModerationObjectType.group_chat
 
     conversation_id: Mapped[int] = mapped_column("id", ForeignKey("conversations.id"), primary_key=True)
 

--- a/app/backend/src/couchers/models/discussions.py
+++ b/app/backend/src/couchers/models/discussions.py
@@ -5,6 +5,7 @@ from sqlalchemy import BigInteger, DateTime, ForeignKey, String, UniqueConstrain
 from sqlalchemy.orm import Mapped, column_property, mapped_column, relationship
 
 from couchers.models.base import Base, communities_seq
+from couchers.models.moderation import ModerationObjectType
 
 if TYPE_CHECKING:
     from couchers.models import Cluster, User
@@ -17,6 +18,7 @@ class Discussion(Base, kw_only=True):
 
     __tablename__ = "discussions"
     __moderation_author_column__ = "creator_user_id"
+    __moderation_object_type__ = ModerationObjectType.discussion
 
     id: Mapped[int] = mapped_column(
         BigInteger, communities_seq, primary_key=True, server_default=communities_seq.next_value(), init=False
@@ -84,6 +86,7 @@ class Comment(Base, kw_only=True):
 
     __tablename__ = "comments"
     __moderation_author_column__ = "author_user_id"
+    __moderation_object_type__ = ModerationObjectType.comment
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
@@ -104,6 +107,7 @@ class Reply(Base, kw_only=True):
 
     __tablename__ = "replies"
     __moderation_author_column__ = "author_user_id"
+    __moderation_object_type__ = ModerationObjectType.reply
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 

--- a/app/backend/src/couchers/models/events.py
+++ b/app/backend/src/couchers/models/events.py
@@ -24,6 +24,7 @@ from sqlalchemy.sql import expression
 from sqlalchemy.sql.elements import ColumnElement
 
 from couchers.models.base import Base, Geom, communities_seq
+from couchers.models.moderation import ModerationObjectType
 from couchers.utils import get_coordinates
 
 if TYPE_CHECKING:
@@ -112,6 +113,7 @@ class Event(Base, kw_only=True):
 class EventOccurrence(Base, kw_only=True):
     __tablename__ = "event_occurrences"
     __moderation_author_column__ = "creator_user_id"
+    __moderation_object_type__ = ModerationObjectType.event_occurrence
 
     id: Mapped[int] = mapped_column(
         BigInteger, communities_seq, primary_key=True, server_default=communities_seq.next_value(), init=False

--- a/app/backend/src/couchers/models/host_requests.py
+++ b/app/backend/src/couchers/models/host_requests.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Mapped, column_property, mapped_column, relationship
 from sqlalchemy.sql import expression
 
 from couchers.models.base import Base, Geom
+from couchers.models.moderation import ModerationObjectType
 from couchers.utils import date_in_timezone, now
 
 if TYPE_CHECKING:
@@ -41,6 +42,7 @@ class HostRequest(Base, kw_only=True):
 
     __tablename__ = "host_requests"
     __moderation_author_column__ = "initiator_user_id"
+    __moderation_object_type__ = ModerationObjectType.host_request
 
     conversation_id: Mapped[int] = mapped_column("id", ForeignKey("conversations.id"), primary_key=True)
     initiator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)

--- a/app/backend/src/couchers/models/moderation.py
+++ b/app/backend/src/couchers/models/moderation.py
@@ -7,7 +7,8 @@ to any moderatable content on the platform (host requests, discussions, events, 
 
 import enum
 from datetime import datetime
-from typing import TYPE_CHECKING
+from functools import cache
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from sqlalchemy import BigInteger, DateTime, Enum, ForeignKey, Index, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -15,7 +16,16 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from couchers.models.base import Base, moderation_seq
 
 if TYPE_CHECKING:
+    from couchers.models.conversations import GroupChat
+    from couchers.models.discussions import Comment, Discussion, Reply
+    from couchers.models.events import EventOccurrence
+    from couchers.models.host_requests import HostRequest
+    from couchers.models.rest import FriendRelationship
     from couchers.models.users import User
+
+    type ModeratedContentModel = type[
+        HostRequest | GroupChat | FriendRelationship | EventOccurrence | Comment | Reply | Discussion
+    ]
 
 
 class ModerationVisibility(enum.Enum):
@@ -186,3 +196,33 @@ class ModerationLog(Base, kw_only=True):
 
     def __repr__(self) -> str:
         return f"ModerationLog(id={self.id}, state_id={self.moderation_state_id}, action={self.action}, moderator={self.moderator_user_id}, time={self.time})"
+
+
+class ModeratedModel(NamedTuple):
+    """A model governed by the UMS, with its moderation metadata resolved."""
+
+    object_type: ModerationObjectType
+    model: ModeratedContentModel
+    # the InstrumentedAttribute of the model's author column; Any avoids descriptor-unwrapping on access
+    author_column: Any
+
+
+@cache
+def get_moderated_models() -> dict[ModerationObjectType, ModeratedModel]:
+    """
+    Maps each ModerationObjectType to its model and resolved moderation metadata.
+
+    Discovered from every mapped model that declares __moderation_object_type__, so the moderation
+    metadata stays on the models themselves rather than in a separate hand-maintained list.
+    """
+    models: dict[ModerationObjectType, ModeratedModel] = {}
+    for mapper in Base.registry.mappers:
+        cls = mapper.class_
+        if not hasattr(cls, "__moderation_object_type__"):
+            continue
+        models[cls.__moderation_object_type__] = ModeratedModel(
+            object_type=cls.__moderation_object_type__,
+            model=cls,
+            author_column=getattr(cls, cls.__moderation_author_column__),
+        )
+    return models

--- a/app/backend/src/couchers/models/rest.py
+++ b/app/backend/src/couchers/models/rest.py
@@ -29,6 +29,7 @@ from sqlalchemy.sql import expression
 
 from couchers.constants import GUIDELINES_VERSION
 from couchers.models.base import Base, Geom
+from couchers.models.moderation import ModerationObjectType
 from couchers.models.users import HostingStatus
 from couchers.utils import now
 
@@ -73,6 +74,7 @@ class FriendRelationship(Base, kw_only=True):
 
     __tablename__ = "friend_relationships"
     __moderation_author_column__ = "from_user_id"
+    __moderation_object_type__ = ModerationObjectType.friend_request
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -67,7 +67,7 @@ from couchers.proto.internal import internal_pb2, jobs_pb2
 from couchers.servicers.api import lite_user_to_pb
 from couchers.servicers.public import format_volunteer_link
 from couchers.servicers.references import get_pending_references_to_write, reftype2api
-from couchers.sql import where_moderated_content_visible, where_users_column_visible
+from couchers.sql import where_moderated_content_visible
 from couchers.tasks import (
     maybe_send_contributor_form_email,
     send_account_deletion_report_email,
@@ -747,7 +747,6 @@ class Account(account_pb2_grpc.AccountServicer):
         query = select(HostRequest.conversation_id, LiteUser).join(
             LiteUser, LiteUser.id == HostRequest.initiator_user_id
         )
-        query = where_users_column_visible(query, context, HostRequest.initiator_user_id)
         query = where_moderated_content_visible(query, context, HostRequest, is_list_operation=True)
         pending_host_requests = session.execute(
             query.where(HostRequest.recipient_user_id == context.user_id)

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -209,7 +209,6 @@ class API(api_pb2_grpc.APIServicer):
         received_reqs_query = select(HostRequest.conversation_id, HostRequest.recipient_last_seen_message_id).where(
             HostRequest.recipient_user_id == context.user_id
         )
-        received_reqs_query = where_users_column_visible(received_reqs_query, context, HostRequest.initiator_user_id)
         received_reqs_query = where_moderated_content_visible(
             received_reqs_query, context, HostRequest, is_list_operation=True
         )
@@ -245,9 +244,6 @@ class API(api_pb2_grpc.APIServicer):
 
         pending_friend_request_query = select(func.count(FriendRelationship.id)).where(
             FriendRelationship.to_user_id == context.user_id
-        )
-        pending_friend_request_query = where_users_column_visible(
-            pending_friend_request_query, context, FriendRelationship.from_user_id
         )
         pending_friend_request_query = pending_friend_request_query.where(
             FriendRelationship.status == FriendStatus.pending
@@ -611,7 +607,6 @@ class API(api_pb2_grpc.APIServicer):
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session
     ) -> api_pb2.ListFriendsRes:
         rels_query = select(FriendRelationship)
-        rels_query = where_users_column_visible(rels_query, context, FriendRelationship.from_user_id)
         rels_query = where_users_column_visible(rels_query, context, FriendRelationship.to_user_id)
         rels_query = rels_query.where(
             or_(
@@ -629,7 +624,6 @@ class API(api_pb2_grpc.APIServicer):
         self, request: api_pb2.RemoveFriendReq, context: CouchersContext, session: Session
     ) -> empty_pb2.Empty:
         rel_query = select(FriendRelationship)
-        rel_query = where_users_column_visible(rel_query, context, FriendRelationship.from_user_id)
         rel_query = where_users_column_visible(rel_query, context, FriendRelationship.to_user_id)
         rel_query = rel_query.where(
             or_(

--- a/app/backend/src/couchers/servicers/moderation.py
+++ b/app/backend/src/couchers/servicers/moderation.py
@@ -1,5 +1,4 @@
 import logging
-from typing import TYPE_CHECKING
 
 import grpc
 from sqlalchemy import and_, exists, not_, or_, select
@@ -36,13 +35,11 @@ from couchers.models import (
     NotificationDelivery,
     Reply,
     User,
+    get_moderated_models,
 )
 from couchers.proto import moderation_pb2, moderation_pb2_grpc
 from couchers.proto.internal import jobs_pb2
 from couchers.utils import Timestamp_from_datetime, now
-
-if TYPE_CHECKING:
-    from couchers.sql import _ModeratedContent
 
 logger = logging.getLogger(__name__)
 
@@ -123,16 +120,8 @@ moderationobjecttype2sql = {
     moderation_pb2.MODERATION_OBJECT_TYPE_DISCUSSION: ModerationObjectType.discussion,
 }
 
-# Mapping from ModerationObjectType to the SQLAlchemy model class
-moderationobjecttype2model: dict[ModerationObjectType, _ModeratedContent] = {
-    ModerationObjectType.host_request: HostRequest,
-    ModerationObjectType.group_chat: GroupChat,
-    ModerationObjectType.friend_request: FriendRelationship,
-    ModerationObjectType.event_occurrence: EventOccurrence,
-    ModerationObjectType.comment: Comment,
-    ModerationObjectType.reply: Reply,
-    ModerationObjectType.discussion: Discussion,
-}
+# Mapping from ModerationObjectType to the SQLAlchemy model class and its moderation metadata
+moderationobjecttype2model = get_moderated_models()
 
 
 def bulk_set_user_content_visibility(
@@ -147,10 +136,9 @@ def bulk_set_user_content_visibility(
     final_reason = reason or f"Bulk visibility update for user {user.id} to {new_visibility.name}"
 
     author_exists_clauses = []
-    for model in moderationobjecttype2model.values():
-        author_col = getattr(model, model.__moderation_author_column__)
+    for entry in moderationobjecttype2model.values():
         author_exists_clauses.append(
-            exists().where(and_(model.moderation_state_id == ModerationState.id, author_col == user.id))
+            exists().where(and_(entry.model.moderation_state_id == ModerationState.id, entry.author_column == user.id))
         )
 
     states = session.execute(select(ModerationState).where(or_(*author_exists_clauses))).scalars().all()
@@ -346,13 +334,12 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
 
             # Use EXISTS for efficient author filtering
             author_exists_clauses = []
-            for model in moderationobjecttype2model.values():
-                author_col = getattr(model, model.__moderation_author_column__)
+            for entry in moderationobjecttype2model.values():
                 author_exists_clauses.append(
                     exists().where(
                         and_(
-                            model.moderation_state_id == ModerationQueueItem.moderation_state_id,
-                            author_col == author_user_id,
+                            entry.model.moderation_state_id == ModerationQueueItem.moderation_state_id,
+                            entry.author_column == author_user_id,
                         )
                     )
                 )
@@ -687,13 +674,12 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
 
         if request.author_user_id:
             author_exists_clauses = []
-            for model in moderationobjecttype2model.values():
-                author_col = getattr(model, model.__moderation_author_column__)
+            for entry in moderationobjecttype2model.values():
                 author_exists_clauses.append(
                     exists().where(
                         and_(
-                            model.moderation_state_id == ModerationState.id,
-                            author_col == request.author_user_id,
+                            entry.model.moderation_state_id == ModerationState.id,
+                            entry.author_column == request.author_user_id,
                         )
                     )
                 )

--- a/app/backend/src/couchers/servicers/moderation.py
+++ b/app/backend/src/couchers/servicers/moderation.py
@@ -120,9 +120,6 @@ moderationobjecttype2sql = {
     moderation_pb2.MODERATION_OBJECT_TYPE_DISCUSSION: ModerationObjectType.discussion,
 }
 
-# Mapping from ModerationObjectType to the SQLAlchemy model class and its moderation metadata
-moderationobjecttype2model = get_moderated_models()
-
 
 def bulk_set_user_content_visibility(
     session: Session,
@@ -136,7 +133,7 @@ def bulk_set_user_content_visibility(
     final_reason = reason or f"Bulk visibility update for user {user.id} to {new_visibility.name}"
 
     author_exists_clauses = []
-    for entry in moderationobjecttype2model.values():
+    for entry in get_moderated_models().values():
         author_exists_clauses.append(
             exists().where(and_(entry.model.moderation_state_id == ModerationState.id, entry.author_column == user.id))
         )
@@ -334,7 +331,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
 
             # Use EXISTS for efficient author filtering
             author_exists_clauses = []
-            for entry in moderationobjecttype2model.values():
+            for entry in get_moderated_models().values():
                 author_exists_clauses.append(
                     exists().where(
                         and_(
@@ -674,7 +671,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
 
         if request.author_user_id:
             author_exists_clauses = []
-            for entry in moderationobjecttype2model.values():
+            for entry in get_moderated_models().values():
                 author_exists_clauses.append(
                     exists().where(
                         and_(

--- a/app/backend/src/couchers/servicers/references.py
+++ b/app/backend/src/couchers/servicers/references.py
@@ -64,7 +64,6 @@ def get_host_req_and_check_can_write_ref(
     Returns the host req and `surfed`, a boolean of if the user was the surfer or not
     """
     query = select(HostRequest)
-    query = where_users_column_visible(query, context, HostRequest.initiator_user_id)
     query = where_users_column_visible(query, context, HostRequest.recipient_user_id)
     query = where_moderated_content_visible(query, context, HostRequest, is_list_operation=False)
     query = query.where(HostRequest.conversation_id == host_request_id)
@@ -144,7 +143,6 @@ def get_pending_references_to_write(
         )
         .join(LiteUser, LiteUser.id == HostRequest.initiator_user_id)
     )
-    q2 = where_users_column_visible(q2, context, HostRequest.initiator_user_id)
     q2 = where_moderated_content_visible(q2, context, HostRequest, is_list_operation=True)
     q2 = q2.where(Reference.id == None)
     q2 = q2.where(HostRequest.can_write_reference)

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -373,11 +373,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         host_request = session.execute(
             where_moderated_content_visible(
                 where_users_column_visible(
-                    where_users_column_visible(
-                        select(HostRequest),
-                        context,
-                        HostRequest.initiator_user_id,
-                    ),
+                    select(HostRequest),
                     context,
                     HostRequest.recipient_user_id,
                 ),
@@ -411,16 +407,12 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         message_2 = aliased(Message)
         statement = where_moderated_content_visible(
             where_users_column_visible(
-                where_users_column_visible(
-                    select(Message, HostRequest, Conversation)
-                    .outerjoin(
-                        message_2, and_(Message.conversation_id == message_2.conversation_id, Message.id < message_2.id)
-                    )
-                    .join(HostRequest, HostRequest.conversation_id == Message.conversation_id)
-                    .join(Conversation, Conversation.id == HostRequest.conversation_id),
-                    context,
-                    HostRequest.initiator_user_id,
-                ),
+                select(Message, HostRequest, Conversation)
+                .outerjoin(
+                    message_2, and_(Message.conversation_id == message_2.conversation_id, Message.id < message_2.id)
+                )
+                .join(HostRequest, HostRequest.conversation_id == Message.conversation_id)
+                .join(Conversation, Conversation.id == HostRequest.conversation_id),
                 context,
                 HostRequest.recipient_user_id,
             ),
@@ -513,11 +505,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         host_request = session.execute(
             where_moderated_content_visible(
                 where_users_column_visible(
-                    where_users_column_visible(
-                        select(HostRequest),
-                        context,
-                        HostRequest.initiator_user_id,
-                    ),
+                    select(HostRequest),
                     context,
                     HostRequest.recipient_user_id,
                 ),

--- a/app/backend/src/couchers/sql.py
+++ b/app/backend/src/couchers/sql.py
@@ -6,30 +6,22 @@ from sqlalchemy.sql import Select, exists, union
 
 from couchers.context import CouchersContext
 from couchers.models import (
-    Comment,
-    Discussion,
-    EventOccurrence,
-    FriendRelationship,
-    GroupChat,
-    HostRequest,
-    ModerationObjectType,
     ModerationState,
     ModerationVisibility,
-    Reply,
     SignupFlow,
     User,
     UserBlock,
+    get_moderated_models,
 )
 from couchers.utils import is_valid_email, is_valid_user_id, is_valid_username
 
 if TYPE_CHECKING:
     from couchers.materialized_views import LiteUser
+    from couchers.models.moderation import ModeratedContentModel
 
     type _UserLike = type[User | LiteUser | SignupFlow]
     type _User = type[User | LiteUser]
-    type _ModeratedContent = type[
-        HostRequest | GroupChat | FriendRelationship | EventOccurrence | Comment | Reply | Discussion
-    ]
+    type _ModeratedContent = ModeratedContentModel
 
 
 def username_or_email(value: str, table: _UserLike = User) -> ColumnElement[bool]:
@@ -163,15 +155,43 @@ def where_moderated_content_visible_to_user_column[T: tuple[Any, ...]](
     if not is_list_operation:
         conditions.append(aliased_mod_state.visibility == ModerationVisibility.unlisted)
 
+    author_column = get_moderated_models()[table.__moderation_object_type__].author_column
+
     # Authors can always see their own SHADOWED content
     conditions.append(
         and_(
             aliased_mod_state.visibility == ModerationVisibility.shadowed,
-            getattr(table, table.__moderation_author_column__) == user_id_column,
+            author_column == user_id_column,
         )
     )
 
-    return query.join(aliased_mod_state, aliased_mod_state.id == table.moderation_state_id).where(or_(*conditions))
+    # Content is hidden whenever its author is not visible to the user in user_id_column
+    author_user = aliased(User)
+    return (
+        query.join(aliased_mod_state, aliased_mod_state.id == table.moderation_state_id)
+        .join(author_user, author_user.id == author_column)
+        .where(or_(*conditions))
+        .where(author_user.is_visible)
+        .where(or_(author_user.shadowed_at.is_(None), author_user.id == user_id_column))
+        .where(
+            ~exists(
+                select(1)
+                .select_from(UserBlock)
+                .where(
+                    or_(
+                        and_(
+                            UserBlock.blocking_user_id == author_column,
+                            UserBlock.blocked_user_id == user_id_column,
+                        ),
+                        and_(
+                            UserBlock.blocking_user_id == user_id_column,
+                            UserBlock.blocked_user_id == author_column,
+                        ),
+                    )
+                )
+            )
+        )
+    )
 
 
 def where_moderated_content_visible[T: tuple[Any, ...]](
@@ -187,16 +207,20 @@ def where_moderated_content_visible[T: tuple[Any, ...]](
     if not is_list_operation:
         conditions.append(aliased_mod_state.visibility == ModerationVisibility.unlisted)
 
+    author_column = get_moderated_models()[table.__moderation_object_type__].author_column
+
     # Authors can always see their own SHADOWED content
     if context.is_logged_in():
         conditions.append(
             and_(
                 aliased_mod_state.visibility == ModerationVisibility.shadowed,
-                getattr(table, table.__moderation_author_column__) == context.user_id,
+                author_column == context.user_id,
             )
         )
 
-    return query.join(aliased_mod_state, aliased_mod_state.id == table.moderation_state_id).where(or_(*conditions))
+    # Content is hidden whenever its author is not visible to the viewer
+    query = query.join(aliased_mod_state, aliased_mod_state.id == table.moderation_state_id).where(or_(*conditions))
+    return where_users_column_visible(query, context, author_column)
 
 
 def moderation_state_column_visible(
@@ -211,96 +235,61 @@ def moderation_state_column_visible(
 
     The condition evaluates to True when:
     - The column is NULL (non-moderated content), OR
-    - The linked moderation state has visibility 'visible' or 'unlisted', OR
-    - The linked moderation state has visibility 'shadowed' and the current user is the author
+    - The linked content's author is visible to the viewer, AND either
+      - the linked moderation state has visibility 'visible' or 'unlisted', OR
+      - the linked moderation state has visibility 'shadowed' and the current user is the author
     """
     aliased_mod_state = aliased(ModerationState)
 
-    # For 'shadowed' content, check if the user is the author by looking up the content table
-    # using object_type and object_id on the moderation_state row
+    # Look up the moderated content via object_type/object_id to check the author per object type
     shadowed_conditions: list[ColumnElement[bool]] = []
-    if context.is_logged_in():
-        shadowed_conditions = [
+    author_visible_conditions: list[ColumnElement[bool]] = []
+    for entry in get_moderated_models().values():
+        object_id_column = entry.model.__mapper__.primary_key[0]
+
+        author_user = aliased(User)
+        author_visible_conditions.append(
             and_(
-                aliased_mod_state.visibility == ModerationVisibility.shadowed,
-                or_(
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.host_request,
-                        exists(
-                            select(HostRequest.conversation_id).where(
-                                HostRequest.conversation_id == aliased_mod_state.object_id,
-                                HostRequest.initiator_user_id == context.user_id,
-                            )
-                        ),
-                    ),
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.group_chat,
-                        exists(
-                            select(GroupChat.conversation_id).where(
-                                GroupChat.conversation_id == aliased_mod_state.object_id,
-                                GroupChat.creator_id == context.user_id,
-                            )
-                        ),
-                    ),
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.friend_request,
-                        exists(
-                            select(FriendRelationship.id).where(
-                                FriendRelationship.id == aliased_mod_state.object_id,
-                                FriendRelationship.from_user_id == context.user_id,
-                            )
-                        ),
-                    ),
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.event_occurrence,
-                        exists(
-                            select(EventOccurrence.id).where(
-                                EventOccurrence.id == aliased_mod_state.object_id,
-                                EventOccurrence.creator_user_id == context.user_id,
-                            )
-                        ),
-                    ),
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.comment,
-                        exists(
-                            select(Comment.id).where(
-                                Comment.id == aliased_mod_state.object_id,
-                                Comment.author_user_id == context.user_id,
-                            )
-                        ),
-                    ),
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.reply,
-                        exists(
-                            select(Reply.id).where(
-                                Reply.id == aliased_mod_state.object_id,
-                                Reply.author_user_id == context.user_id,
-                            )
-                        ),
-                    ),
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.discussion,
-                        exists(
-                            select(Discussion.id).where(
-                                Discussion.id == aliased_mod_state.object_id,
-                                Discussion.creator_user_id == context.user_id,
-                            )
-                        ),
-                    ),
+                aliased_mod_state.object_type == entry.object_type,
+                exists(
+                    select(1)
+                    .select_from(entry.model)
+                    .join(author_user, author_user.id == entry.author_column)
+                    .where(object_id_column == aliased_mod_state.object_id)
+                    .where(users_visible(context, author_user))
                 ),
             )
-        ]
+        )
+
+        if context.is_logged_in():
+            shadowed_conditions.append(
+                and_(
+                    aliased_mod_state.object_type == entry.object_type,
+                    exists(
+                        select(1)
+                        .select_from(entry.model)
+                        .where(object_id_column == aliased_mod_state.object_id)
+                        .where(entry.author_column == context.user_id)
+                    ),
+                )
+            )
+
+    visibility_conditions = [
+        aliased_mod_state.visibility == ModerationVisibility.visible,
+        aliased_mod_state.visibility == ModerationVisibility.unlisted,
+    ]
+    if shadowed_conditions:
+        visibility_conditions.append(
+            and_(aliased_mod_state.visibility == ModerationVisibility.shadowed, or_(*shadowed_conditions))
+        )
 
     return or_(
         column.is_(None),
         exists(
             select(aliased_mod_state.id).where(
                 aliased_mod_state.id == column,
-                or_(
-                    aliased_mod_state.visibility == ModerationVisibility.visible,
-                    aliased_mod_state.visibility == ModerationVisibility.unlisted,
-                    *shadowed_conditions,
-                ),
+                or_(*author_visible_conditions),
+                or_(*visibility_conditions),
             )
         ),
     )

--- a/app/backend/src/couchers/sql.py
+++ b/app/backend/src/couchers/sql.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
 
     type _UserLike = type[User | LiteUser | SignupFlow]
     type _User = type[User | LiteUser]
-    type _ModeratedContent = ModeratedContentModel
 
 
 def username_or_email(value: str, table: _UserLike = User) -> ColumnElement[bool]:
@@ -144,7 +143,7 @@ def where_user_columns_visible_to_each_other[T: tuple[Any, ...]](
 
 def where_moderated_content_visible_to_user_column[T: tuple[Any, ...]](
     query: Select[T],
-    table: _ModeratedContent,
+    table: ModeratedContentModel,
     user_id_column: InstrumentedAttribute[int],
     is_list_operation: bool = False,
 ) -> Select[T]:
@@ -197,7 +196,7 @@ def where_moderated_content_visible_to_user_column[T: tuple[Any, ...]](
 def where_moderated_content_visible[T: tuple[Any, ...]](
     query: Select[T],
     context: CouchersContext,
-    table: _ModeratedContent,
+    table: ModeratedContentModel,
     is_list_operation: bool = False,
 ) -> Select[T]:
     aliased_mod_state = aliased(ModerationState)

--- a/app/backend/src/couchers/sql.py
+++ b/app/backend/src/couchers/sql.py
@@ -59,6 +59,22 @@ def _shadow_clause(context: CouchersContext, table: _User) -> ColumnElement[bool
     return table.shadowed_at.is_(None)
 
 
+def _users_block_each_other(
+    user_a: InstrumentedAttribute[int], user_b: InstrumentedAttribute[int]
+) -> ColumnElement[bool]:
+    """True when either of the two users (referenced by id columns) has blocked the other."""
+    return exists(
+        select(1)
+        .select_from(UserBlock)
+        .where(
+            or_(
+                and_(UserBlock.blocking_user_id == user_a, UserBlock.blocked_user_id == user_b),
+                and_(UserBlock.blocking_user_id == user_b, UserBlock.blocked_user_id == user_a),
+            )
+        )
+    )
+
+
 def users_visible(context: CouchersContext, table: _User = User) -> ColumnElement[bool]:
     """
     Filters out users that should not be visible: blocked, deleted, banned, or shadowed (to others).
@@ -95,16 +111,7 @@ def users_visible_to_each_other(*, self_user: _User, other_user: _User) -> Colum
         self_user.is_visible,
         other_user.is_visible,
         other_user.shadowed_at.is_(None),
-        ~exists(
-            select(1)
-            .select_from(UserBlock)
-            .where(
-                or_(
-                    and_(UserBlock.blocking_user_id == self_user.id, UserBlock.blocked_user_id == other_user.id),
-                    and_(UserBlock.blocking_user_id == other_user.id, UserBlock.blocked_user_id == self_user.id),
-                )
-            )
-        ),
+        ~_users_block_each_other(self_user.id, other_user.id),
     )
 
 
@@ -126,18 +133,26 @@ def where_user_columns_visible_to_each_other[T: tuple[Any, ...]](
         .where(self_user.is_visible)
         .where(other_user.is_visible)
         .where(other_user.shadowed_at.is_(None))
-        .where(
-            ~exists(
-                select(1)
-                .select_from(UserBlock)
-                .where(
-                    or_(
-                        and_(UserBlock.blocking_user_id == self_user.id, UserBlock.blocked_user_id == other_user.id),
-                        and_(UserBlock.blocking_user_id == other_user.id, UserBlock.blocked_user_id == self_user.id),
-                    )
-                )
-            )
-        )
+        .where(~_users_block_each_other(self_user.id, other_user.id))
+    )
+
+
+def _where_user_column_visible_to_user_column[T: tuple[Any, ...]](
+    query: Select[T], *, user_column: InstrumentedAttribute[int], viewer_column: InstrumentedAttribute[int]
+) -> Select[T]:
+    """
+    Filters so the user in user_column is visible to the viewer in viewer_column: not deleted or
+    banned, not shadowed (unless the viewer is that user), and not blocked either way.
+
+    The column-based counterpart of where_users_column_visible, for when the viewer is a column
+    rather than the request context.
+    """
+    user = aliased(User)
+    return (
+        query.join(user, user.id == user_column)
+        .where(user.is_visible)
+        .where(or_(user.shadowed_at.is_(None), user.id == viewer_column))
+        .where(~_users_block_each_other(user_column, viewer_column))
     )
 
 
@@ -165,32 +180,8 @@ def where_moderated_content_visible_to_user_column[T: tuple[Any, ...]](
     )
 
     # Content is hidden whenever its author is not visible to the user in user_id_column
-    author_user = aliased(User)
-    return (
-        query.join(aliased_mod_state, aliased_mod_state.id == table.moderation_state_id)
-        .join(author_user, author_user.id == author_column)
-        .where(or_(*conditions))
-        .where(author_user.is_visible)
-        .where(or_(author_user.shadowed_at.is_(None), author_user.id == user_id_column))
-        .where(
-            ~exists(
-                select(1)
-                .select_from(UserBlock)
-                .where(
-                    or_(
-                        and_(
-                            UserBlock.blocking_user_id == author_column,
-                            UserBlock.blocked_user_id == user_id_column,
-                        ),
-                        and_(
-                            UserBlock.blocking_user_id == user_id_column,
-                            UserBlock.blocked_user_id == author_column,
-                        ),
-                    )
-                )
-            )
-        )
-    )
+    query = query.join(aliased_mod_state, aliased_mod_state.id == table.moderation_state_id).where(or_(*conditions))
+    return _where_user_column_visible_to_user_column(query, user_column=author_column, viewer_column=user_id_column)
 
 
 def where_moderated_content_visible[T: tuple[Any, ...]](


### PR DESCRIPTION
Previously, content authored by deleted, banned, shadowed, or blocked users was hidden inconsistently — some query sites combined the user-visibility helpers with the moderated-content visibility checks, others used only one. This folds author user-visibility into the moderated-content visibility helpers themselves, so content by a non-visible author is hidden everywhere the moderated check runs:

- `where_moderated_content_visible` / `where_moderated_content_visible_to_user_column` now also filter on the content author's visibility (deleted/banned hidden from everyone; shadowed/blocked hidden from everyone but the author).
- `moderation_state_column_visible` (notifications path) gained the same per-object-type author check.
- Removed now-redundant `where_users_column_visible` calls on author columns at call sites that already apply the moderated check.
- Replaced the hand-maintained moderated-model tables with dynamic discovery: each moderated model declares `__moderation_object_type__` (alongside the existing `__moderation_author_column__`), and `get_moderated_models()` resolves the model, object type, and author column from that metadata. This also removes the duplicate `moderationobjecttype2model` dict.

## Testing
- `make format` and `make mypy` pass (the two remaining mypy errors — `test_calendar_events.py` missing `ics` stubs and `fixtures/misc.py` return type — are pre-existing on `develop`).
- 379 tests pass across `test_moderation`, `test_threads`, `test_discussions`, `test_communities`, `test_requests`, `test_references`, `test_conversations`, `test_notifications`, `test_events`, `test_blocking`, `test_visible_users`, `test_groups`, `test_bg_jobs`, `test_api`.
- To replicate: `cd app/backend && make format && make mypy && uv run pytest`.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history (no DB changes; rebased onto `develop`)

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._