### PR TITLE
Backend/moderation: Restore author-visibility filtering for thread comments and replies

### DIFF
--- a/app/backend/src/couchers/servicers/threads.py
+++ b/app/backend/src/couchers/servicers/threads.py
@@ -48,16 +48,24 @@ def unpack_thread_id(thread_id: int) -> tuple[int, int]:
 
 def total_num_responses(session: Session, context: CouchersContext, database_id: int) -> int:
     comments = where_moderated_content_visible(
-        select(func.count()).select_from(Comment).where(Comment.thread_id == database_id),
+        where_users_column_visible(
+            select(func.count()).select_from(Comment).where(Comment.thread_id == database_id),
+            context,
+            Comment.author_user_id,
+        ),
         context,
         Comment,
         is_list_operation=True,
     )
     replies = where_moderated_content_visible(
-        select(func.count())
-        .select_from(Reply)
-        .join(Comment, Comment.id == Reply.comment_id)
-        .where(Comment.thread_id == database_id),
+        where_users_column_visible(
+            select(func.count())
+            .select_from(Reply)
+            .join(Comment, Comment.id == Reply.comment_id)
+            .where(Comment.thread_id == database_id),
+            context,
+            Reply.author_user_id,
+        ),
         context,
         Reply,
         is_list_operation=True,
@@ -239,15 +247,32 @@ class Threads(threads_pb2_grpc.ThreadsServicer):
             if not session.execute(select(Thread).where(Thread.id == database_id)).scalar_one_or_none():
                 context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "thread_not_found")
 
+            visible_reply_count = (
+                where_moderated_content_visible(
+                    where_users_column_visible(
+                        select(func.count(Reply.id)).where(Reply.comment_id == Comment.id),
+                        context,
+                        Reply.author_user_id,
+                    ),
+                    context,
+                    Reply,
+                    is_list_operation=True,
+                )
+                .correlate(Comment)
+                .scalar_subquery()
+            )
+
             res = session.execute(
                 where_moderated_content_visible(
-                    select(Comment, func.count(Reply.id))
-                    .outerjoin(Reply, Reply.comment_id == Comment.id)
-                    .where(Comment.thread_id == database_id)
-                    .where(Comment.id < page_start)
-                    .group_by(Comment.id)
-                    .order_by(Comment.created.desc())
-                    .limit(page_size + 1),
+                    where_users_column_visible(
+                        select(Comment, visible_reply_count)
+                        .where(Comment.thread_id == database_id)
+                        .where(Comment.id < page_start)
+                        .order_by(Comment.created.desc())
+                        .limit(page_size + 1),
+                        context,
+                        Comment.author_user_id,
+                    ),
                     context,
                     Comment,
                     is_list_operation=True,
@@ -267,7 +292,11 @@ class Threads(threads_pb2_grpc.ThreadsServicer):
         elif depth == 1:
             if not session.execute(
                 where_moderated_content_visible(
-                    select(Comment).where(Comment.id == database_id),
+                    where_users_column_visible(
+                        select(Comment).where(Comment.id == database_id),
+                        context,
+                        Comment.author_user_id,
+                    ),
                     context,
                     Comment,
                 )
@@ -277,11 +306,15 @@ class Threads(threads_pb2_grpc.ThreadsServicer):
             res = (
                 session.execute(  # type: ignore[assignment]
                     where_moderated_content_visible(
-                        select(Reply)
-                        .where(Reply.comment_id == database_id)
-                        .where(Reply.id < page_start)
-                        .order_by(Reply.created.desc())
-                        .limit(page_size + 1),
+                        where_users_column_visible(
+                            select(Reply)
+                            .where(Reply.comment_id == database_id)
+                            .where(Reply.id < page_start)
+                            .order_by(Reply.created.desc())
+                            .limit(page_size + 1),
+                            context,
+                            Reply.author_user_id,
+                        ),
                         context,
                         Reply,
                         is_list_operation=True,

--- a/app/backend/src/tests/test_threads.py
+++ b/app/backend/src/tests/test_threads.py
@@ -14,9 +14,11 @@ from couchers.models import (
     ModerationVisibility,
     Reply,
     Thread,
+    User,
 )
 from couchers.proto import moderation_pb2, threads_pb2
 from couchers.servicers.threads import pack_thread_id
+from couchers.utils import now
 from tests.fixtures.db import generate_user
 from tests.fixtures.sessions import real_moderation_session, threads_session
 
@@ -261,6 +263,76 @@ def test_shadowed_reply_visible_to_author_only(db):
     with threads_session(other_token) as api:
         ret = api.GetThread(threads_pb2.GetThreadReq(thread_id=comment_thread_id))
         assert len(ret.replies) == 0
+
+
+def _approve(session, moderation_state_id):
+    session.execute(
+        select(ModerationState).where(ModerationState.id == moderation_state_id)
+    ).scalar_one().visibility = ModerationVisibility.visible
+
+
+def test_comment_by_invisible_user_hidden(db):
+    """A comment by a deleted/banned user is hidden from others even when its moderation state is visible."""
+    author, author_token = generate_user()
+    other, other_token = generate_user()
+
+    parent_thread_id, comment_thread_id = _make_thread_and_comment(author_token, content="from invisible user")
+    comment_db_id = comment_thread_id // 10
+
+    with session_scope() as session:
+        comment = session.execute(select(Comment).where(Comment.id == comment_db_id)).scalar_one()
+        _approve(session, comment.moderation_state_id)
+
+    # while the author is visible, the comment shows
+    with threads_session(other_token) as api:
+        assert len(api.GetThread(threads_pb2.GetThreadReq(thread_id=parent_thread_id)).replies) == 1
+
+    # delete the author
+    with session_scope() as session:
+        session.execute(select(User).where(User.id == author.id)).scalar_one().deleted_at = now()
+
+    # the comment is now hidden from other users
+    with threads_session(other_token) as api:
+        assert len(api.GetThread(threads_pb2.GetThreadReq(thread_id=parent_thread_id)).replies) == 0
+
+
+def test_reply_by_invisible_user_hidden(db):
+    """A reply by a deleted/banned user is hidden from others even when its moderation state is visible."""
+    commenter, commenter_token = generate_user()
+    replier, replier_token = generate_user()
+    viewer, viewer_token = generate_user()
+
+    # comment by a user who stays visible, so the parent comment can still be navigated to
+    parent_thread_id, comment_thread_id = _make_thread_and_comment(commenter_token, content="hi")
+    comment_db_id = comment_thread_id // 10
+    with session_scope() as session:
+        comment = session.execute(select(Comment).where(Comment.id == comment_db_id)).scalar_one()
+        _approve(session, comment.moderation_state_id)
+
+    with threads_session(replier_token) as api:
+        reply_thread_id = api.PostReply(
+            threads_pb2.PostReplyReq(thread_id=comment_thread_id, content="my reply")
+        ).thread_id
+    reply_db_id = reply_thread_id // 10
+    with session_scope() as session:
+        reply = session.execute(select(Reply).where(Reply.id == reply_db_id)).scalar_one()
+        _approve(session, reply.moderation_state_id)
+
+    # while the replier is visible, the reply shows and is counted on the parent comment
+    with threads_session(viewer_token) as api:
+        assert len(api.GetThread(threads_pb2.GetThreadReq(thread_id=comment_thread_id)).replies) == 1
+        parent = api.GetThread(threads_pb2.GetThreadReq(thread_id=parent_thread_id))
+        assert parent.replies[0].num_replies == 1
+
+    # delete the replier
+    with session_scope() as session:
+        session.execute(select(User).where(User.id == replier.id)).scalar_one().deleted_at = now()
+
+    # the reply is now hidden from other users and no longer counted on the parent comment
+    with threads_session(viewer_token) as api:
+        assert len(api.GetThread(threads_pb2.GetThreadReq(thread_id=comment_thread_id)).replies) == 0
+        parent = api.GetThread(threads_pb2.GetThreadReq(thread_id=parent_thread_id))
+        assert parent.replies[0].num_replies == 0
 
 
 def test_admin_can_approve_comment(db):


### PR DESCRIPTION
The recent UMS moderation PRs for thread comments/replies (#8510) and discussions (#8511) introduced `where_moderated_content_visible()`, which only checks an item's moderation *state* — not whether its author is a deleted, banned, blocked, or shadowed user.

In `threads.py` the moderation PR **replaced** `where_users_column_visible()` with `where_moderated_content_visible()` instead of applying both. The two are orthogonal checks and are used together everywhere else in the codebase (`references.py`, `api.py`, `requests.py`, etc.). The regression: comments and replies authored by invisible users were no longer hidden from other users.

This PR:
- Restores `where_users_column_visible()` alongside `where_moderated_content_visible()` in all `GetThread` queries (comment list, reply list, parent-comment existence check) and in `total_num_responses()`.
- Fixes a pre-existing inconsistency where the per-comment `num_replies` count included replies regardless of moderation state or author visibility — it now uses a correlated subquery with both filters, matching the depth-1 reply list.

Discussions are cluster-owned community content and were never filtered by creator visibility (before or after the moderation PR), so they are intentionally left unchanged.

## Testing
- Added `test_comment_by_invisible_user_hidden` and `test_reply_by_invisible_user_hidden` to `test_threads.py`. Both approve the moderation state so they isolate the author-visibility check; the reply test also asserts the parent comment's `num_replies` count drops when the replier is deleted.
- `uv run pytest src/tests/test_threads.py src/tests/test_discussions.py src/tests/test_events.py` — all pass.
- `make format` and `make mypy` clean for the changed files.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._