### PR TITLE
Add metrics for users per community and user activity recency

### DIFF
--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -21,10 +21,10 @@ from sqlalchemy.sql.selectable import Select
 
 from couchers.db import session_scope
 from couchers.helpers.completed_profile import has_completed_profile_expression
+from couchers.materialized_views import ClusterSubscriptionCount
 from couchers.models import (
     BackgroundJob,
     Cluster,
-    ClusterSubscription,
     EventOccurrenceAttendee,
     HostingStatus,
     HostRequest,
@@ -163,19 +163,16 @@ users_gauge: Gauge = _make_gauge_from_query(
 
 # Number of users per community, labeled by community name. Only includes communities at the region level or
 # broader (world, macroregion, region).
-_users_per_community_node_types = [NodeType.world, NodeType.macroregion, NodeType.region]
 users_per_community_gauge: Gauge = _make_labeled_gauge_from_query(
     "couchers_users_per_community",
     "Number of users per community, for regions and broader",
     "community",
     (
-        select(Cluster.name, func.count(User.id))
+        select(Cluster.name, func.coalesce(ClusterSubscriptionCount.count, 0))
         .select_from(Node)
         .join(Cluster, and_(Cluster.parent_node_id == Node.id, Cluster.is_official_cluster))
-        .outerjoin(ClusterSubscription, ClusterSubscription.cluster_id == Cluster.id)
-        .outerjoin(User, and_(User.id == ClusterSubscription.user_id, User.is_visible))
-        .where(Node.node_type.in_(_users_per_community_node_types))
-        .group_by(Cluster.id, Cluster.name)
+        .outerjoin(ClusterSubscriptionCount, ClusterSubscriptionCount.cluster_id == Cluster.id)
+        .where(Node.node_type <= NodeType.region)
     ),
 )
 

--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -15,13 +15,25 @@ from prometheus_client import (
     multiprocess,
 )
 from prometheus_client.registry import CollectorRegistry
-from sqlalchemy import select
+from sqlalchemy import and_, case, select
 from sqlalchemy.sql import distinct, func
 from sqlalchemy.sql.selectable import Select
 
 from couchers.db import session_scope
 from couchers.helpers.completed_profile import has_completed_profile_expression
-from couchers.models import BackgroundJob, EventOccurrenceAttendee, HostingStatus, HostRequest, Message, Reference, User
+from couchers.models import (
+    BackgroundJob,
+    Cluster,
+    ClusterSubscription,
+    EventOccurrenceAttendee,
+    HostingStatus,
+    HostRequest,
+    Message,
+    Node,
+    NodeType,
+    Reference,
+    User,
+)
 from couchers.models.moderation import (
     ModerationAction,
     ModerationObjectType,
@@ -94,6 +106,41 @@ def _make_gauge_from_query(name: str, description: str, statement: Select[Any]) 
     return gauge
 
 
+# list of labeled gauges and the function to populate their label values just before collection
+_set_hacky_labeled_gauges_funcs: list[tuple[Gauge, Callable[[Gauge], None]]] = []
+
+
+def _make_labeled_gauge_from_query(
+    name: str,
+    description: str,
+    labelname: str,
+    statement: Select[Any],
+    default_label_values: list[str] | None = None,
+) -> Gauge:
+    """
+    Given a name, description, label name and statement, creates a gauge with one label set from the statement.
+
+    statement should be a sqlalchemy SELECT statement that returns rows of (label_value, count).
+
+    default_label_values, if given, are seeded to zero before the query results are applied, so that label
+    values with no matching rows are still emitted.
+    """
+
+    gauge = Gauge(name, description, labelnames=[labelname], multiprocess_mode="mostrecent")
+
+    def f(g: Gauge) -> None:
+        with tracer.start_as_current_span(f"metric.{name}"):
+            with session_scope() as session:
+                rows = session.execute(statement).all()
+        for label_value in default_label_values or []:
+            g.labels(label_value).set(0)
+        for label_value, count in rows:
+            g.labels(str(label_value)).set(count)
+
+    _set_hacky_labeled_gauges_funcs.append((gauge, f))
+    return gauge
+
+
 active_users_gauges: list[Gauge] = [
     _make_gauge_from_query(
         f"couchers_active_users_{name}",
@@ -112,6 +159,54 @@ active_users_gauges: list[Gauge] = [
 
 users_gauge: Gauge = _make_gauge_from_query(
     "couchers_users", "Total number of users", select(func.count()).select_from(User).where(User.is_visible)
+)
+
+# Number of users per community, labeled by community name. Only includes communities at the region level or
+# broader (world, macroregion, region).
+_users_per_community_node_types = [NodeType.world, NodeType.macroregion, NodeType.region]
+users_per_community_gauge: Gauge = _make_labeled_gauge_from_query(
+    "couchers_users_per_community",
+    "Number of users per community, for regions and broader",
+    "community",
+    (
+        select(Cluster.name, func.count(User.id))
+        .select_from(Node)
+        .join(Cluster, and_(Cluster.parent_node_id == Node.id, Cluster.is_official_cluster))
+        .outerjoin(ClusterSubscription, ClusterSubscription.cluster_id == Cluster.id)
+        .outerjoin(User, and_(User.id == ClusterSubscription.user_id, User.is_visible))
+        .where(Node.node_type.in_(_users_per_community_node_types))
+        .group_by(Cluster.id, Cluster.name)
+    ),
+)
+
+# Number of users bucketed by how recently they were last active.
+_active_users_buckets: list[tuple[str, timedelta | None]] = [
+    ("<1d", timedelta(days=1)),
+    ("1d-1w", timedelta(days=7)),
+    ("1w-1m", timedelta(days=31)),
+    ("1m-6m", timedelta(days=183)),
+    ("6m-12m", timedelta(days=365)),
+    ("12m-24m", timedelta(days=730)),
+    ("24m+", None),
+]
+_active_users_age = func.now() - User.last_active
+active_users_by_recency_gauge: Gauge = _make_labeled_gauge_from_query(
+    "couchers_active_users_by_recency",
+    "Number of users bucketed by how recently they were last active",
+    "period",
+    (
+        select(
+            case(
+                *[(_active_users_age < interval, label) for label, interval in _active_users_buckets if interval],
+                else_=_active_users_buckets[-1][0],
+            ).label("period"),
+            func.count(),
+        )
+        .select_from(User)
+        .where(User.is_visible)
+        .group_by("period")
+    ),
+    default_label_values=[label for label, _ in _active_users_buckets],
 )
 
 man_gauge: Gauge = _make_gauge_from_query(
@@ -548,6 +643,8 @@ def create_prometheus_server(port: int) -> Any:
         # set hacky gauges
         for gauge, f in _set_hacky_gauges_funcs:
             gauge.set(f())
+        for gauge, labeled_f in _set_hacky_labeled_gauges_funcs:
+            labeled_f(gauge)
 
         data = generate_latest(registry)
         start_response("200 OK", [("Content-type", CONTENT_TYPE_LATEST), ("Content-Length", str(len(data)))])

--- a/app/backend/src/tests/test_metrics.py
+++ b/app/backend/src/tests/test_metrics.py
@@ -1,9 +1,11 @@
 from datetime import timedelta
 
 import pytest
+from google.protobuf import empty_pb2
 from sqlalchemy import update
 
 from couchers.db import session_scope
+from couchers.materialized_views import refresh_materialized_views
 from couchers.metrics import (
     _set_hacky_labeled_gauges_funcs,
     active_users_by_recency_gauge,
@@ -45,6 +47,9 @@ def test_users_per_community_gauge(db):
         region = create_community(session, 0, 25, "Region", [user3], [user1], macroregion)
         # subregion is below the region level and must be excluded
         create_community(session, 0, 10, "Subregion", [user2], [user3], region)
+
+    # the gauge reads from the cluster_subscription_counts materialized view
+    refresh_materialized_views(empty_pb2.Empty())
 
     _populate(users_per_community_gauge)
     values = _sample_values(users_per_community_gauge)

--- a/app/backend/src/tests/test_metrics.py
+++ b/app/backend/src/tests/test_metrics.py
@@ -1,0 +1,81 @@
+from datetime import timedelta
+
+import pytest
+from sqlalchemy import update
+
+from couchers.db import session_scope
+from couchers.metrics import (
+    _set_hacky_labeled_gauges_funcs,
+    active_users_by_recency_gauge,
+    users_per_community_gauge,
+)
+from couchers.models import User
+from couchers.utils import now
+from tests.fixtures.db import generate_user
+from tests.test_communities import create_community
+
+
+@pytest.fixture(autouse=True)
+def _(testconfig):
+    pass
+
+
+def _populate(gauge):
+    for registered_gauge, f in _set_hacky_labeled_gauges_funcs:
+        if registered_gauge is gauge:
+            f(registered_gauge)
+            return
+    raise AssertionError("gauge is not a registered labeled gauge")
+
+
+def _sample_values(gauge):
+    return {
+        sample.labels[gauge._labelnames[0]]: sample.value for metric in gauge.collect() for sample in metric.samples
+    }
+
+
+def test_users_per_community_gauge():
+    user1, _ = generate_user()
+    user2, _ = generate_user()
+    user3, _ = generate_user()
+
+    with session_scope() as session:
+        world = create_community(session, 0, 100, "World", [user1], [], None)
+        macroregion = create_community(session, 0, 50, "Macroregion", [user2], [], world)
+        region = create_community(session, 0, 25, "Region", [user3], [user1], macroregion)
+        # subregion is below the region level and must be excluded
+        create_community(session, 0, 10, "Subregion", [user2], [user3], region)
+
+    _populate(users_per_community_gauge)
+    values = _sample_values(users_per_community_gauge)
+
+    assert values["World"] == 1
+    assert values["Macroregion"] == 1
+    assert values["Region"] == 2
+    assert "Subregion" not in values
+
+
+def test_active_users_by_recency_gauge():
+    ages = {
+        "<1d": timedelta(hours=2),
+        "1d-1w": timedelta(days=3),
+        "1w-1m": timedelta(days=14),
+        "1m-6m": timedelta(days=60),
+        "6m-12m": timedelta(days=250),
+        "12m-24m": timedelta(days=500),
+        "24m+": timedelta(days=800),
+    }
+    user_ids_by_bucket = {}
+    for bucket in ages:
+        user, _ = generate_user()
+        user_ids_by_bucket[bucket] = user.id
+
+    with session_scope() as session:
+        for bucket, age in ages.items():
+            session.execute(update(User).where(User.id == user_ids_by_bucket[bucket]).values(last_active=now() - age))
+
+    _populate(active_users_by_recency_gauge)
+    values = _sample_values(active_users_by_recency_gauge)
+
+    for bucket in ages:
+        assert values[bucket] == 1

--- a/app/backend/src/tests/test_metrics.py
+++ b/app/backend/src/tests/test_metrics.py
@@ -16,7 +16,7 @@ from tests.test_communities import create_community
 
 
 @pytest.fixture(autouse=True)
-def _(db, testconfig):
+def _(testconfig):
     pass
 
 
@@ -34,7 +34,7 @@ def _sample_values(gauge):
     }
 
 
-def test_users_per_community_gauge():
+def test_users_per_community_gauge(db):
     user1, _ = generate_user()
     user2, _ = generate_user()
     user3, _ = generate_user()
@@ -55,7 +55,7 @@ def test_users_per_community_gauge():
     assert "Subregion" not in values
 
 
-def test_active_users_by_recency_gauge():
+def test_active_users_by_recency_gauge(db):
     ages = {
         "<1d": timedelta(hours=2),
         "1d-1w": timedelta(days=3),

--- a/app/backend/src/tests/test_metrics.py
+++ b/app/backend/src/tests/test_metrics.py
@@ -16,7 +16,7 @@ from tests.test_communities import create_community
 
 
 @pytest.fixture(autouse=True)
-def _(testconfig):
+def _(db, testconfig):
     pass
 
 


### PR DESCRIPTION
Adds two new Prometheus metrics:
- couchers_users_per_community: number of users per community, labeled by community name, for communities at the region level and broader
- couchers_active_users_by_recency: number of users bucketed by how recently they were last active (<1d, 1d-1w, 1w-1m, 1m-6m, 6m-12m, 12m-24m, 24m+)

*Describe briefly what this PR is doing and why.*

<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
