### PR TITLE
Discover moderated content models dynamically

### DIFF
--- a/app/backend/src/couchers/models/conversations.py
+++ b/app/backend/src/couchers/models/conversations.py
@@ -10,6 +10,7 @@ from sqlalchemy.sql import expression
 from couchers.constants import DATETIME_INFINITY, DATETIME_MINUS_INFINITY
 from couchers.models.base import Base
 from couchers.models.host_requests import HostRequestStatus
+from couchers.models.moderation import ModerationObjectType
 from couchers.utils import now
 
 if TYPE_CHECKING:
@@ -38,6 +39,7 @@ class GroupChat(Base, kw_only=True):
 
     __tablename__ = "group_chats"
     __moderation_author_column__ = "creator_id"
+    __moderation_object_type__ = ModerationObjectType.group_chat
 
     conversation_id: Mapped[int] = mapped_column("id", ForeignKey("conversations.id"), primary_key=True)
 

--- a/app/backend/src/couchers/models/discussions.py
+++ b/app/backend/src/couchers/models/discussions.py
@@ -5,6 +5,7 @@ from sqlalchemy import BigInteger, DateTime, ForeignKey, String, UniqueConstrain
 from sqlalchemy.orm import Mapped, column_property, mapped_column, relationship
 
 from couchers.models.base import Base, communities_seq
+from couchers.models.moderation import ModerationObjectType
 
 if TYPE_CHECKING:
     from couchers.models import Cluster, User
@@ -17,6 +18,7 @@ class Discussion(Base, kw_only=True):
 
     __tablename__ = "discussions"
     __moderation_author_column__ = "creator_user_id"
+    __moderation_object_type__ = ModerationObjectType.discussion
 
     id: Mapped[int] = mapped_column(
         BigInteger, communities_seq, primary_key=True, server_default=communities_seq.next_value(), init=False
@@ -84,6 +86,7 @@ class Comment(Base, kw_only=True):
 
     __tablename__ = "comments"
     __moderation_author_column__ = "author_user_id"
+    __moderation_object_type__ = ModerationObjectType.comment
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
@@ -104,6 +107,7 @@ class Reply(Base, kw_only=True):
 
     __tablename__ = "replies"
     __moderation_author_column__ = "author_user_id"
+    __moderation_object_type__ = ModerationObjectType.reply
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 

--- a/app/backend/src/couchers/models/events.py
+++ b/app/backend/src/couchers/models/events.py
@@ -24,6 +24,7 @@ from sqlalchemy.sql import expression
 from sqlalchemy.sql.elements import ColumnElement
 
 from couchers.models.base import Base, Geom, communities_seq
+from couchers.models.moderation import ModerationObjectType
 from couchers.utils import get_coordinates
 
 if TYPE_CHECKING:
@@ -112,6 +113,7 @@ class Event(Base, kw_only=True):
 class EventOccurrence(Base, kw_only=True):
     __tablename__ = "event_occurrences"
     __moderation_author_column__ = "creator_user_id"
+    __moderation_object_type__ = ModerationObjectType.event_occurrence
 
     id: Mapped[int] = mapped_column(
         BigInteger, communities_seq, primary_key=True, server_default=communities_seq.next_value(), init=False

--- a/app/backend/src/couchers/models/host_requests.py
+++ b/app/backend/src/couchers/models/host_requests.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Mapped, column_property, mapped_column, relationship
 from sqlalchemy.sql import expression
 
 from couchers.models.base import Base, Geom
+from couchers.models.moderation import ModerationObjectType
 from couchers.utils import date_in_timezone, now
 
 if TYPE_CHECKING:
@@ -41,6 +42,7 @@ class HostRequest(Base, kw_only=True):
 
     __tablename__ = "host_requests"
     __moderation_author_column__ = "initiator_user_id"
+    __moderation_object_type__ = ModerationObjectType.host_request
 
     conversation_id: Mapped[int] = mapped_column("id", ForeignKey("conversations.id"), primary_key=True)
     initiator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)

--- a/app/backend/src/couchers/models/moderation.py
+++ b/app/backend/src/couchers/models/moderation.py
@@ -9,9 +9,9 @@ import enum
 from dataclasses import dataclass
 from datetime import datetime
 from functools import cache
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Protocol
 
-from sqlalchemy import BigInteger, DateTime, Enum, ForeignKey, Index, String, func
+from sqlalchemy import BigInteger, ColumnElement, DateTime, Enum, ForeignKey, Index, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from couchers.models.base import Base, moderation_seq
@@ -203,10 +203,9 @@ class ModeratedModel:
 
     object_type: ModerationObjectType
     model: type[ModeratedContent]
-    # InstrumentedAttributes/Columns resolved from the model; Any avoids descriptor-unwrapping on access
-    author_column: Any
-    object_id_column: Any
-    moderation_state_id_column: Any
+    author_column: ColumnElement[int]
+    object_id_column: ColumnElement[int]
+    moderation_state_id_column: ColumnElement[int]
 
 
 @cache
@@ -226,7 +225,7 @@ def get_moderated_models() -> dict[ModerationObjectType, ModeratedModel]:
         models[model.__moderation_object_type__] = ModeratedModel(
             object_type=model.__moderation_object_type__,
             model=model,
-            author_column=getattr(model, model.__moderation_author_column__),
+            author_column=mapper.columns[model.__moderation_author_column__],
             object_id_column=mapper.primary_key[0],
             moderation_state_id_column=mapper.columns["moderation_state_id"],
         )

--- a/app/backend/src/couchers/models/moderation.py
+++ b/app/backend/src/couchers/models/moderation.py
@@ -9,7 +9,7 @@ import enum
 from dataclasses import dataclass
 from datetime import datetime
 from functools import cache
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from sqlalchemy import BigInteger, DateTime, Enum, ForeignKey, Index, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -17,16 +17,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from couchers.models.base import Base, moderation_seq
 
 if TYPE_CHECKING:
-    from couchers.models.conversations import GroupChat
-    from couchers.models.discussions import Comment, Discussion, Reply
-    from couchers.models.events import EventOccurrence
-    from couchers.models.host_requests import HostRequest
-    from couchers.models.rest import FriendRelationship
     from couchers.models.users import User
-
-    type ModeratedContentModel = type[
-        HostRequest | GroupChat | FriendRelationship | EventOccurrence | Comment | Reply | Discussion
-    ]
 
 
 class ModerationVisibility(enum.Enum):
@@ -199,14 +190,23 @@ class ModerationLog(Base, kw_only=True):
         return f"ModerationLog(id={self.id}, state_id={self.moderation_state_id}, action={self.action}, moderator={self.moderator_user_id}, time={self.time})"
 
 
+class ModeratedContent(Protocol):
+    """A model governed by the UMS, identified by the moderation metadata it declares as class attributes."""
+
+    __moderation_object_type__: ModerationObjectType
+    __moderation_author_column__: str
+
+
 @dataclass(frozen=True)
 class ModeratedModel:
     """A model governed by the UMS, with its moderation metadata resolved."""
 
     object_type: ModerationObjectType
-    model: ModeratedContentModel
-    # the InstrumentedAttribute of the model's author column; Any avoids descriptor-unwrapping on access
+    model: type[ModeratedContent]
+    # InstrumentedAttributes/Columns resolved from the model; Any avoids descriptor-unwrapping on access
     author_column: Any
+    object_id_column: Any
+    moderation_state_id_column: Any
 
 
 @cache
@@ -222,9 +222,12 @@ def get_moderated_models() -> dict[ModerationObjectType, ModeratedModel]:
         cls = mapper.class_
         if not hasattr(cls, "__moderation_object_type__"):
             continue
-        models[cls.__moderation_object_type__] = ModeratedModel(
-            object_type=cls.__moderation_object_type__,
-            model=cls,
-            author_column=getattr(cls, cls.__moderation_author_column__),
+        model: type[ModeratedContent] = cls
+        models[model.__moderation_object_type__] = ModeratedModel(
+            object_type=model.__moderation_object_type__,
+            model=model,
+            author_column=getattr(model, model.__moderation_author_column__),
+            object_id_column=mapper.primary_key[0],
+            moderation_state_id_column=mapper.columns["moderation_state_id"],
         )
     return models

--- a/app/backend/src/couchers/models/moderation.py
+++ b/app/backend/src/couchers/models/moderation.py
@@ -6,9 +6,10 @@ to any moderatable content on the platform (host requests, discussions, events, 
 """
 
 import enum
+from dataclasses import dataclass
 from datetime import datetime
 from functools import cache
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import BigInteger, DateTime, Enum, ForeignKey, Index, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -198,7 +199,8 @@ class ModerationLog(Base, kw_only=True):
         return f"ModerationLog(id={self.id}, state_id={self.moderation_state_id}, action={self.action}, moderator={self.moderator_user_id}, time={self.time})"
 
 
-class ModeratedModel(NamedTuple):
+@dataclass(frozen=True)
+class ModeratedModel:
     """A model governed by the UMS, with its moderation metadata resolved."""
 
     object_type: ModerationObjectType

--- a/app/backend/src/couchers/models/moderation.py
+++ b/app/backend/src/couchers/models/moderation.py
@@ -7,7 +7,8 @@ to any moderatable content on the platform (host requests, discussions, events, 
 
 import enum
 from datetime import datetime
-from typing import TYPE_CHECKING
+from functools import cache
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from sqlalchemy import BigInteger, DateTime, Enum, ForeignKey, Index, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -15,7 +16,16 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from couchers.models.base import Base, moderation_seq
 
 if TYPE_CHECKING:
+    from couchers.models.conversations import GroupChat
+    from couchers.models.discussions import Comment, Discussion, Reply
+    from couchers.models.events import EventOccurrence
+    from couchers.models.host_requests import HostRequest
+    from couchers.models.rest import FriendRelationship
     from couchers.models.users import User
+
+    type ModeratedContentModel = type[
+        HostRequest | GroupChat | FriendRelationship | EventOccurrence | Comment | Reply | Discussion
+    ]
 
 
 class ModerationVisibility(enum.Enum):
@@ -186,3 +196,33 @@ class ModerationLog(Base, kw_only=True):
 
     def __repr__(self) -> str:
         return f"ModerationLog(id={self.id}, state_id={self.moderation_state_id}, action={self.action}, moderator={self.moderator_user_id}, time={self.time})"
+
+
+class ModeratedModel(NamedTuple):
+    """A model governed by the UMS, with its moderation metadata resolved."""
+
+    object_type: ModerationObjectType
+    model: ModeratedContentModel
+    # the InstrumentedAttribute of the model's author column; Any avoids descriptor-unwrapping on access
+    author_column: Any
+
+
+@cache
+def get_moderated_models() -> dict[ModerationObjectType, ModeratedModel]:
+    """
+    Maps each ModerationObjectType to its model and resolved moderation metadata.
+
+    Discovered from every mapped model that declares __moderation_object_type__, so the moderation
+    metadata stays on the models themselves rather than in a separate hand-maintained list.
+    """
+    models: dict[ModerationObjectType, ModeratedModel] = {}
+    for mapper in Base.registry.mappers:
+        cls = mapper.class_
+        if not hasattr(cls, "__moderation_object_type__"):
+            continue
+        models[cls.__moderation_object_type__] = ModeratedModel(
+            object_type=cls.__moderation_object_type__,
+            model=cls,
+            author_column=getattr(cls, cls.__moderation_author_column__),
+        )
+    return models

--- a/app/backend/src/couchers/models/rest.py
+++ b/app/backend/src/couchers/models/rest.py
@@ -29,6 +29,7 @@ from sqlalchemy.sql import expression
 
 from couchers.constants import GUIDELINES_VERSION
 from couchers.models.base import Base, Geom
+from couchers.models.moderation import ModerationObjectType
 from couchers.models.users import HostingStatus
 from couchers.utils import now
 
@@ -73,6 +74,7 @@ class FriendRelationship(Base, kw_only=True):
 
     __tablename__ = "friend_relationships"
     __moderation_author_column__ = "from_user_id"
+    __moderation_object_type__ = ModerationObjectType.friend_request
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 

--- a/app/backend/src/couchers/servicers/moderation.py
+++ b/app/backend/src/couchers/servicers/moderation.py
@@ -135,7 +135,7 @@ def bulk_set_user_content_visibility(
     author_exists_clauses = []
     for entry in get_moderated_models().values():
         author_exists_clauses.append(
-            exists().where(and_(entry.model.moderation_state_id == ModerationState.id, entry.author_column == user.id))
+            exists().where(and_(entry.moderation_state_id_column == ModerationState.id, entry.author_column == user.id))
         )
 
     states = session.execute(select(ModerationState).where(or_(*author_exists_clauses))).scalars().all()
@@ -335,7 +335,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
                 author_exists_clauses.append(
                     exists().where(
                         and_(
-                            entry.model.moderation_state_id == ModerationQueueItem.moderation_state_id,
+                            entry.moderation_state_id_column == ModerationQueueItem.moderation_state_id,
                             entry.author_column == author_user_id,
                         )
                     )
@@ -675,7 +675,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
                 author_exists_clauses.append(
                     exists().where(
                         and_(
-                            entry.model.moderation_state_id == ModerationState.id,
+                            entry.moderation_state_id_column == ModerationState.id,
                             entry.author_column == request.author_user_id,
                         )
                     )

--- a/app/backend/src/couchers/servicers/moderation.py
+++ b/app/backend/src/couchers/servicers/moderation.py
@@ -1,5 +1,4 @@
 import logging
-from typing import TYPE_CHECKING
 
 import grpc
 from sqlalchemy import and_, exists, not_, or_, select
@@ -36,13 +35,11 @@ from couchers.models import (
     NotificationDelivery,
     Reply,
     User,
+    get_moderated_models,
 )
 from couchers.proto import moderation_pb2, moderation_pb2_grpc
 from couchers.proto.internal import jobs_pb2
 from couchers.utils import Timestamp_from_datetime, now
-
-if TYPE_CHECKING:
-    from couchers.sql import _ModeratedContent
 
 logger = logging.getLogger(__name__)
 
@@ -123,17 +120,6 @@ moderationobjecttype2sql = {
     moderation_pb2.MODERATION_OBJECT_TYPE_DISCUSSION: ModerationObjectType.discussion,
 }
 
-# Mapping from ModerationObjectType to the SQLAlchemy model class
-moderationobjecttype2model: dict[ModerationObjectType, _ModeratedContent] = {
-    ModerationObjectType.host_request: HostRequest,
-    ModerationObjectType.group_chat: GroupChat,
-    ModerationObjectType.friend_request: FriendRelationship,
-    ModerationObjectType.event_occurrence: EventOccurrence,
-    ModerationObjectType.comment: Comment,
-    ModerationObjectType.reply: Reply,
-    ModerationObjectType.discussion: Discussion,
-}
-
 
 def bulk_set_user_content_visibility(
     session: Session,
@@ -147,10 +133,9 @@ def bulk_set_user_content_visibility(
     final_reason = reason or f"Bulk visibility update for user {user.id} to {new_visibility.name}"
 
     author_exists_clauses = []
-    for model in moderationobjecttype2model.values():
-        author_col = getattr(model, model.__moderation_author_column__)
+    for entry in get_moderated_models().values():
         author_exists_clauses.append(
-            exists().where(and_(model.moderation_state_id == ModerationState.id, author_col == user.id))
+            exists().where(and_(entry.model.moderation_state_id == ModerationState.id, entry.author_column == user.id))
         )
 
     states = session.execute(select(ModerationState).where(or_(*author_exists_clauses))).scalars().all()
@@ -346,13 +331,12 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
 
             # Use EXISTS for efficient author filtering
             author_exists_clauses = []
-            for model in moderationobjecttype2model.values():
-                author_col = getattr(model, model.__moderation_author_column__)
+            for entry in get_moderated_models().values():
                 author_exists_clauses.append(
                     exists().where(
                         and_(
-                            model.moderation_state_id == ModerationQueueItem.moderation_state_id,
-                            author_col == author_user_id,
+                            entry.model.moderation_state_id == ModerationQueueItem.moderation_state_id,
+                            entry.author_column == author_user_id,
                         )
                     )
                 )
@@ -687,13 +671,12 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
 
         if request.author_user_id:
             author_exists_clauses = []
-            for model in moderationobjecttype2model.values():
-                author_col = getattr(model, model.__moderation_author_column__)
+            for entry in get_moderated_models().values():
                 author_exists_clauses.append(
                     exists().where(
                         and_(
-                            model.moderation_state_id == ModerationState.id,
-                            author_col == request.author_user_id,
+                            entry.model.moderation_state_id == ModerationState.id,
+                            entry.author_column == request.author_user_id,
                         )
                     )
                 )

--- a/app/backend/src/couchers/sql.py
+++ b/app/backend/src/couchers/sql.py
@@ -6,30 +6,21 @@ from sqlalchemy.sql import Select, exists, union
 
 from couchers.context import CouchersContext
 from couchers.models import (
-    Comment,
-    Discussion,
-    EventOccurrence,
-    FriendRelationship,
-    GroupChat,
-    HostRequest,
-    ModerationObjectType,
     ModerationState,
     ModerationVisibility,
-    Reply,
     SignupFlow,
     User,
     UserBlock,
+    get_moderated_models,
 )
 from couchers.utils import is_valid_email, is_valid_user_id, is_valid_username
 
 if TYPE_CHECKING:
     from couchers.materialized_views import LiteUser
+    from couchers.models.moderation import ModeratedContentModel
 
     type _UserLike = type[User | LiteUser | SignupFlow]
     type _User = type[User | LiteUser]
-    type _ModeratedContent = type[
-        HostRequest | GroupChat | FriendRelationship | EventOccurrence | Comment | Reply | Discussion
-    ]
 
 
 def username_or_email(value: str, table: _UserLike = User) -> ColumnElement[bool]:
@@ -68,6 +59,22 @@ def _shadow_clause(context: CouchersContext, table: _User) -> ColumnElement[bool
     return table.shadowed_at.is_(None)
 
 
+def _users_block_each_other(
+    user_a: InstrumentedAttribute[int], user_b: InstrumentedAttribute[int]
+) -> ColumnElement[bool]:
+    """True when either of the two users (referenced by id columns) has blocked the other."""
+    return exists(
+        select(1)
+        .select_from(UserBlock)
+        .where(
+            or_(
+                and_(UserBlock.blocking_user_id == user_a, UserBlock.blocked_user_id == user_b),
+                and_(UserBlock.blocking_user_id == user_b, UserBlock.blocked_user_id == user_a),
+            )
+        )
+    )
+
+
 def users_visible(context: CouchersContext, table: _User = User) -> ColumnElement[bool]:
     """
     Filters out users that should not be visible: blocked, deleted, banned, or shadowed (to others).
@@ -104,16 +111,7 @@ def users_visible_to_each_other(*, self_user: _User, other_user: _User) -> Colum
         self_user.is_visible,
         other_user.is_visible,
         other_user.shadowed_at.is_(None),
-        ~exists(
-            select(1)
-            .select_from(UserBlock)
-            .where(
-                or_(
-                    and_(UserBlock.blocking_user_id == self_user.id, UserBlock.blocked_user_id == other_user.id),
-                    and_(UserBlock.blocking_user_id == other_user.id, UserBlock.blocked_user_id == self_user.id),
-                )
-            )
-        ),
+        ~_users_block_each_other(self_user.id, other_user.id),
     )
 
 
@@ -135,24 +133,13 @@ def where_user_columns_visible_to_each_other[T: tuple[Any, ...]](
         .where(self_user.is_visible)
         .where(other_user.is_visible)
         .where(other_user.shadowed_at.is_(None))
-        .where(
-            ~exists(
-                select(1)
-                .select_from(UserBlock)
-                .where(
-                    or_(
-                        and_(UserBlock.blocking_user_id == self_user.id, UserBlock.blocked_user_id == other_user.id),
-                        and_(UserBlock.blocking_user_id == other_user.id, UserBlock.blocked_user_id == self_user.id),
-                    )
-                )
-            )
-        )
+        .where(~_users_block_each_other(self_user.id, other_user.id))
     )
 
 
 def where_moderated_content_visible_to_user_column[T: tuple[Any, ...]](
     query: Select[T],
-    table: _ModeratedContent,
+    table: ModeratedContentModel,
     user_id_column: InstrumentedAttribute[int],
     is_list_operation: bool = False,
 ) -> Select[T]:
@@ -177,7 +164,7 @@ def where_moderated_content_visible_to_user_column[T: tuple[Any, ...]](
 def where_moderated_content_visible[T: tuple[Any, ...]](
     query: Select[T],
     context: CouchersContext,
-    table: _ModeratedContent,
+    table: ModeratedContentModel,
     is_list_operation: bool = False,
 ) -> Select[T]:
     aliased_mod_state = aliased(ModerationState)
@@ -216,80 +203,22 @@ def moderation_state_column_visible(
     """
     aliased_mod_state = aliased(ModerationState)
 
-    # For 'shadowed' content, check if the user is the author by looking up the content table
-    # using object_type and object_id on the moderation_state row
+    # For 'shadowed' content, look up the moderated content via object_type/object_id to check the author
     shadowed_conditions: list[ColumnElement[bool]] = []
     if context.is_logged_in():
-        shadowed_conditions = [
-            and_(
-                aliased_mod_state.visibility == ModerationVisibility.shadowed,
-                or_(
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.host_request,
-                        exists(
-                            select(HostRequest.conversation_id).where(
-                                HostRequest.conversation_id == aliased_mod_state.object_id,
-                                HostRequest.initiator_user_id == context.user_id,
-                            )
-                        ),
+        for entry in get_moderated_models().values():
+            object_id_column = entry.model.__mapper__.primary_key[0]
+            shadowed_conditions.append(
+                and_(
+                    aliased_mod_state.object_type == entry.object_type,
+                    exists(
+                        select(1)
+                        .select_from(entry.model)
+                        .where(object_id_column == aliased_mod_state.object_id)
+                        .where(entry.author_column == context.user_id)
                     ),
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.group_chat,
-                        exists(
-                            select(GroupChat.conversation_id).where(
-                                GroupChat.conversation_id == aliased_mod_state.object_id,
-                                GroupChat.creator_id == context.user_id,
-                            )
-                        ),
-                    ),
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.friend_request,
-                        exists(
-                            select(FriendRelationship.id).where(
-                                FriendRelationship.id == aliased_mod_state.object_id,
-                                FriendRelationship.from_user_id == context.user_id,
-                            )
-                        ),
-                    ),
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.event_occurrence,
-                        exists(
-                            select(EventOccurrence.id).where(
-                                EventOccurrence.id == aliased_mod_state.object_id,
-                                EventOccurrence.creator_user_id == context.user_id,
-                            )
-                        ),
-                    ),
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.comment,
-                        exists(
-                            select(Comment.id).where(
-                                Comment.id == aliased_mod_state.object_id,
-                                Comment.author_user_id == context.user_id,
-                            )
-                        ),
-                    ),
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.reply,
-                        exists(
-                            select(Reply.id).where(
-                                Reply.id == aliased_mod_state.object_id,
-                                Reply.author_user_id == context.user_id,
-                            )
-                        ),
-                    ),
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.discussion,
-                        exists(
-                            select(Discussion.id).where(
-                                Discussion.id == aliased_mod_state.object_id,
-                                Discussion.creator_user_id == context.user_id,
-                            )
-                        ),
-                    ),
-                ),
+                )
             )
-        ]
 
     return or_(
         column.is_(None),

--- a/app/backend/src/couchers/sql.py
+++ b/app/backend/src/couchers/sql.py
@@ -17,7 +17,7 @@ from couchers.utils import is_valid_email, is_valid_user_id, is_valid_username
 
 if TYPE_CHECKING:
     from couchers.materialized_views import LiteUser
-    from couchers.models.moderation import ModeratedContentModel
+    from couchers.models.moderation import ModeratedContent
 
     type _UserLike = type[User | LiteUser | SignupFlow]
     type _User = type[User | LiteUser]
@@ -139,10 +139,11 @@ def where_user_columns_visible_to_each_other[T: tuple[Any, ...]](
 
 def where_moderated_content_visible_to_user_column[T: tuple[Any, ...]](
     query: Select[T],
-    table: ModeratedContentModel,
+    table: type[ModeratedContent],
     user_id_column: InstrumentedAttribute[int],
     is_list_operation: bool = False,
 ) -> Select[T]:
+    entry = get_moderated_models()[table.__moderation_object_type__]
     aliased_mod_state = aliased(ModerationState)
     conditions = [aliased_mod_state.visibility == ModerationVisibility.visible]
 
@@ -154,19 +155,22 @@ def where_moderated_content_visible_to_user_column[T: tuple[Any, ...]](
     conditions.append(
         and_(
             aliased_mod_state.visibility == ModerationVisibility.shadowed,
-            getattr(table, table.__moderation_author_column__) == user_id_column,
+            entry.author_column == user_id_column,
         )
     )
 
-    return query.join(aliased_mod_state, aliased_mod_state.id == table.moderation_state_id).where(or_(*conditions))
+    return query.join(aliased_mod_state, aliased_mod_state.id == entry.moderation_state_id_column).where(
+        or_(*conditions)
+    )
 
 
 def where_moderated_content_visible[T: tuple[Any, ...]](
     query: Select[T],
     context: CouchersContext,
-    table: ModeratedContentModel,
+    table: type[ModeratedContent],
     is_list_operation: bool = False,
 ) -> Select[T]:
+    entry = get_moderated_models()[table.__moderation_object_type__]
     aliased_mod_state = aliased(ModerationState)
     conditions = [aliased_mod_state.visibility == ModerationVisibility.visible]
 
@@ -179,11 +183,13 @@ def where_moderated_content_visible[T: tuple[Any, ...]](
         conditions.append(
             and_(
                 aliased_mod_state.visibility == ModerationVisibility.shadowed,
-                getattr(table, table.__moderation_author_column__) == context.user_id,
+                entry.author_column == context.user_id,
             )
         )
 
-    return query.join(aliased_mod_state, aliased_mod_state.id == table.moderation_state_id).where(or_(*conditions))
+    return query.join(aliased_mod_state, aliased_mod_state.id == entry.moderation_state_id_column).where(
+        or_(*conditions)
+    )
 
 
 def moderation_state_column_visible(
@@ -207,14 +213,13 @@ def moderation_state_column_visible(
     shadowed_conditions: list[ColumnElement[bool]] = []
     if context.is_logged_in():
         for entry in get_moderated_models().values():
-            object_id_column = entry.model.__mapper__.primary_key[0]
             shadowed_conditions.append(
                 and_(
                     aliased_mod_state.object_type == entry.object_type,
                     exists(
                         select(1)
                         .select_from(entry.model)
-                        .where(object_id_column == aliased_mod_state.object_id)
+                        .where(entry.object_id_column == aliased_mod_state.object_id)
                         .where(entry.author_column == context.user_id)
                     ),
                 )


### PR DESCRIPTION
Pure refactor of the Unified Moderation System plumbing, no behavior change.

Previously the set of UMS-governed models was encoded in several hand-maintained places: the seven per-object-type branches inside `moderation_state_column_visible`, the `moderationobjecttype2model` dict in `servicers/moderation.py`, and the `_ModeratedContent` union in `sql.py`. Adding a moderated type meant updating each.

This replaces them with a single source of truth on the models themselves:

- Each moderated model declares `__moderation_object_type__` alongside the existing `__moderation_author_column__`.
- `get_moderated_models()` discovers them by scanning the SQLAlchemy mapper registry and returns `{ModerationObjectType: ModeratedModel}`, where `ModeratedModel` resolves the model, object type, and author column.
- `moderation_state_column_visible` and `servicers/moderation.py` now iterate that registry instead of hardcoded lists.
- The duplicated mutual-block `exists(...)` clause is factored into a `_users_block_each_other` helper.

## Testing
- `make format` and `make mypy` pass (the two remaining mypy errors — `test_calendar_events.py` missing `ics` stubs and `fixtures/misc.py` return type — are pre-existing on `develop`).
- 142 tests pass across `test_moderation`, `test_threads`, `test_notifications`, `test_discussions`.
- To replicate: `cd app/backend && make format && make mypy && uv run pytest`.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history (no DB changes)

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._