### PR TITLE
Hide content by non-visible users via moderation visibility checks

### DIFF
--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -67,7 +67,7 @@ from couchers.proto.internal import internal_pb2, jobs_pb2
 from couchers.servicers.api import lite_user_to_pb
 from couchers.servicers.public import format_volunteer_link
 from couchers.servicers.references import get_pending_references_to_write, reftype2api
-from couchers.sql import where_moderated_content_visible, where_users_column_visible
+from couchers.sql import where_moderated_content_visible
 from couchers.tasks import (
     maybe_send_contributor_form_email,
     send_account_deletion_report_email,
@@ -747,7 +747,6 @@ class Account(account_pb2_grpc.AccountServicer):
         query = select(HostRequest.conversation_id, LiteUser).join(
             LiteUser, LiteUser.id == HostRequest.initiator_user_id
         )
-        query = where_users_column_visible(query, context, HostRequest.initiator_user_id)
         query = where_moderated_content_visible(query, context, HostRequest, is_list_operation=True)
         pending_host_requests = session.execute(
             query.where(HostRequest.recipient_user_id == context.user_id)

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -209,7 +209,6 @@ class API(api_pb2_grpc.APIServicer):
         received_reqs_query = select(HostRequest.conversation_id, HostRequest.recipient_last_seen_message_id).where(
             HostRequest.recipient_user_id == context.user_id
         )
-        received_reqs_query = where_users_column_visible(received_reqs_query, context, HostRequest.initiator_user_id)
         received_reqs_query = where_moderated_content_visible(
             received_reqs_query, context, HostRequest, is_list_operation=True
         )
@@ -245,9 +244,6 @@ class API(api_pb2_grpc.APIServicer):
 
         pending_friend_request_query = select(func.count(FriendRelationship.id)).where(
             FriendRelationship.to_user_id == context.user_id
-        )
-        pending_friend_request_query = where_users_column_visible(
-            pending_friend_request_query, context, FriendRelationship.from_user_id
         )
         pending_friend_request_query = pending_friend_request_query.where(
             FriendRelationship.status == FriendStatus.pending
@@ -611,7 +607,6 @@ class API(api_pb2_grpc.APIServicer):
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session
     ) -> api_pb2.ListFriendsRes:
         rels_query = select(FriendRelationship)
-        rels_query = where_users_column_visible(rels_query, context, FriendRelationship.from_user_id)
         rels_query = where_users_column_visible(rels_query, context, FriendRelationship.to_user_id)
         rels_query = rels_query.where(
             or_(
@@ -629,7 +624,6 @@ class API(api_pb2_grpc.APIServicer):
         self, request: api_pb2.RemoveFriendReq, context: CouchersContext, session: Session
     ) -> empty_pb2.Empty:
         rel_query = select(FriendRelationship)
-        rel_query = where_users_column_visible(rel_query, context, FriendRelationship.from_user_id)
         rel_query = where_users_column_visible(rel_query, context, FriendRelationship.to_user_id)
         rel_query = rel_query.where(
             or_(

--- a/app/backend/src/couchers/servicers/references.py
+++ b/app/backend/src/couchers/servicers/references.py
@@ -64,7 +64,6 @@ def get_host_req_and_check_can_write_ref(
     Returns the host req and `surfed`, a boolean of if the user was the surfer or not
     """
     query = select(HostRequest)
-    query = where_users_column_visible(query, context, HostRequest.initiator_user_id)
     query = where_users_column_visible(query, context, HostRequest.recipient_user_id)
     query = where_moderated_content_visible(query, context, HostRequest, is_list_operation=False)
     query = query.where(HostRequest.conversation_id == host_request_id)
@@ -144,7 +143,6 @@ def get_pending_references_to_write(
         )
         .join(LiteUser, LiteUser.id == HostRequest.initiator_user_id)
     )
-    q2 = where_users_column_visible(q2, context, HostRequest.initiator_user_id)
     q2 = where_moderated_content_visible(q2, context, HostRequest, is_list_operation=True)
     q2 = q2.where(Reference.id == None)
     q2 = q2.where(HostRequest.can_write_reference)

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -373,11 +373,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         host_request = session.execute(
             where_moderated_content_visible(
                 where_users_column_visible(
-                    where_users_column_visible(
-                        select(HostRequest),
-                        context,
-                        HostRequest.initiator_user_id,
-                    ),
+                    select(HostRequest),
                     context,
                     HostRequest.recipient_user_id,
                 ),
@@ -411,16 +407,12 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         message_2 = aliased(Message)
         statement = where_moderated_content_visible(
             where_users_column_visible(
-                where_users_column_visible(
-                    select(Message, HostRequest, Conversation)
-                    .outerjoin(
-                        message_2, and_(Message.conversation_id == message_2.conversation_id, Message.id < message_2.id)
-                    )
-                    .join(HostRequest, HostRequest.conversation_id == Message.conversation_id)
-                    .join(Conversation, Conversation.id == HostRequest.conversation_id),
-                    context,
-                    HostRequest.initiator_user_id,
-                ),
+                select(Message, HostRequest, Conversation)
+                .outerjoin(
+                    message_2, and_(Message.conversation_id == message_2.conversation_id, Message.id < message_2.id)
+                )
+                .join(HostRequest, HostRequest.conversation_id == Message.conversation_id)
+                .join(Conversation, Conversation.id == HostRequest.conversation_id),
                 context,
                 HostRequest.recipient_user_id,
             ),
@@ -513,11 +505,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         host_request = session.execute(
             where_moderated_content_visible(
                 where_users_column_visible(
-                    where_users_column_visible(
-                        select(HostRequest),
-                        context,
-                        HostRequest.initiator_user_id,
-                    ),
+                    select(HostRequest),
                     context,
                     HostRequest.recipient_user_id,
                 ),

--- a/app/backend/src/couchers/sql.py
+++ b/app/backend/src/couchers/sql.py
@@ -150,6 +150,18 @@ def where_user_columns_visible_to_each_other[T: tuple[Any, ...]](
     )
 
 
+# moderated content models, with the column that ModerationState.object_id references
+_MODERATED_OBJECT_TYPES: list[tuple[ModerationObjectType, _ModeratedContent, InstrumentedAttribute[int]]] = [
+    (ModerationObjectType.host_request, HostRequest, HostRequest.conversation_id),
+    (ModerationObjectType.group_chat, GroupChat, GroupChat.conversation_id),
+    (ModerationObjectType.friend_request, FriendRelationship, FriendRelationship.id),
+    (ModerationObjectType.event_occurrence, EventOccurrence, EventOccurrence.id),
+    (ModerationObjectType.comment, Comment, Comment.id),
+    (ModerationObjectType.reply, Reply, Reply.id),
+    (ModerationObjectType.discussion, Discussion, Discussion.id),
+]
+
+
 def where_moderated_content_visible_to_user_column[T: tuple[Any, ...]](
     query: Select[T],
     table: _ModeratedContent,
@@ -163,15 +175,43 @@ def where_moderated_content_visible_to_user_column[T: tuple[Any, ...]](
     if not is_list_operation:
         conditions.append(aliased_mod_state.visibility == ModerationVisibility.unlisted)
 
+    author_column = getattr(table, table.__moderation_author_column__)
+
     # Authors can always see their own SHADOWED content
     conditions.append(
         and_(
             aliased_mod_state.visibility == ModerationVisibility.shadowed,
-            getattr(table, table.__moderation_author_column__) == user_id_column,
+            author_column == user_id_column,
         )
     )
 
-    return query.join(aliased_mod_state, aliased_mod_state.id == table.moderation_state_id).where(or_(*conditions))
+    # Content is hidden whenever its author is not visible to the user in user_id_column
+    author_user = aliased(User)
+    return (
+        query.join(aliased_mod_state, aliased_mod_state.id == table.moderation_state_id)
+        .join(author_user, author_user.id == author_column)
+        .where(or_(*conditions))
+        .where(author_user.is_visible)
+        .where(or_(author_user.shadowed_at.is_(None), author_user.id == user_id_column))
+        .where(
+            ~exists(
+                select(1)
+                .select_from(UserBlock)
+                .where(
+                    or_(
+                        and_(
+                            UserBlock.blocking_user_id == author_column,
+                            UserBlock.blocked_user_id == user_id_column,
+                        ),
+                        and_(
+                            UserBlock.blocking_user_id == user_id_column,
+                            UserBlock.blocked_user_id == author_column,
+                        ),
+                    )
+                )
+            )
+        )
+    )
 
 
 def where_moderated_content_visible[T: tuple[Any, ...]](
@@ -187,16 +227,20 @@ def where_moderated_content_visible[T: tuple[Any, ...]](
     if not is_list_operation:
         conditions.append(aliased_mod_state.visibility == ModerationVisibility.unlisted)
 
+    author_column = getattr(table, table.__moderation_author_column__)
+
     # Authors can always see their own SHADOWED content
     if context.is_logged_in():
         conditions.append(
             and_(
                 aliased_mod_state.visibility == ModerationVisibility.shadowed,
-                getattr(table, table.__moderation_author_column__) == context.user_id,
+                author_column == context.user_id,
             )
         )
 
-    return query.join(aliased_mod_state, aliased_mod_state.id == table.moderation_state_id).where(or_(*conditions))
+    # Content is hidden whenever its author is not visible to the viewer
+    query = query.join(aliased_mod_state, aliased_mod_state.id == table.moderation_state_id).where(or_(*conditions))
+    return where_users_column_visible(query, context, author_column)
 
 
 def moderation_state_column_visible(
@@ -211,96 +255,61 @@ def moderation_state_column_visible(
 
     The condition evaluates to True when:
     - The column is NULL (non-moderated content), OR
-    - The linked moderation state has visibility 'visible' or 'unlisted', OR
-    - The linked moderation state has visibility 'shadowed' and the current user is the author
+    - The linked content's author is visible to the viewer, AND either
+      - the linked moderation state has visibility 'visible' or 'unlisted', OR
+      - the linked moderation state has visibility 'shadowed' and the current user is the author
     """
     aliased_mod_state = aliased(ModerationState)
 
-    # For 'shadowed' content, check if the user is the author by looking up the content table
-    # using object_type and object_id on the moderation_state row
+    # Look up the moderated content via object_type/object_id to check the author per object type
     shadowed_conditions: list[ColumnElement[bool]] = []
-    if context.is_logged_in():
-        shadowed_conditions = [
+    author_visible_conditions: list[ColumnElement[bool]] = []
+    for object_type, model, object_id_column in _MODERATED_OBJECT_TYPES:
+        author_column = getattr(model, model.__moderation_author_column__)
+
+        author_user = aliased(User)
+        author_visible_conditions.append(
             and_(
-                aliased_mod_state.visibility == ModerationVisibility.shadowed,
-                or_(
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.host_request,
-                        exists(
-                            select(HostRequest.conversation_id).where(
-                                HostRequest.conversation_id == aliased_mod_state.object_id,
-                                HostRequest.initiator_user_id == context.user_id,
-                            )
-                        ),
-                    ),
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.group_chat,
-                        exists(
-                            select(GroupChat.conversation_id).where(
-                                GroupChat.conversation_id == aliased_mod_state.object_id,
-                                GroupChat.creator_id == context.user_id,
-                            )
-                        ),
-                    ),
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.friend_request,
-                        exists(
-                            select(FriendRelationship.id).where(
-                                FriendRelationship.id == aliased_mod_state.object_id,
-                                FriendRelationship.from_user_id == context.user_id,
-                            )
-                        ),
-                    ),
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.event_occurrence,
-                        exists(
-                            select(EventOccurrence.id).where(
-                                EventOccurrence.id == aliased_mod_state.object_id,
-                                EventOccurrence.creator_user_id == context.user_id,
-                            )
-                        ),
-                    ),
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.comment,
-                        exists(
-                            select(Comment.id).where(
-                                Comment.id == aliased_mod_state.object_id,
-                                Comment.author_user_id == context.user_id,
-                            )
-                        ),
-                    ),
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.reply,
-                        exists(
-                            select(Reply.id).where(
-                                Reply.id == aliased_mod_state.object_id,
-                                Reply.author_user_id == context.user_id,
-                            )
-                        ),
-                    ),
-                    and_(
-                        aliased_mod_state.object_type == ModerationObjectType.discussion,
-                        exists(
-                            select(Discussion.id).where(
-                                Discussion.id == aliased_mod_state.object_id,
-                                Discussion.creator_user_id == context.user_id,
-                            )
-                        ),
-                    ),
+                aliased_mod_state.object_type == object_type,
+                exists(
+                    select(1)
+                    .select_from(model)
+                    .join(author_user, author_user.id == author_column)
+                    .where(object_id_column == aliased_mod_state.object_id)
+                    .where(users_visible(context, author_user))
                 ),
             )
-        ]
+        )
+
+        if context.is_logged_in():
+            shadowed_conditions.append(
+                and_(
+                    aliased_mod_state.object_type == object_type,
+                    exists(
+                        select(1)
+                        .select_from(model)
+                        .where(object_id_column == aliased_mod_state.object_id)
+                        .where(author_column == context.user_id)
+                    ),
+                )
+            )
+
+    visibility_conditions = [
+        aliased_mod_state.visibility == ModerationVisibility.visible,
+        aliased_mod_state.visibility == ModerationVisibility.unlisted,
+    ]
+    if shadowed_conditions:
+        visibility_conditions.append(
+            and_(aliased_mod_state.visibility == ModerationVisibility.shadowed, or_(*shadowed_conditions))
+        )
 
     return or_(
         column.is_(None),
         exists(
             select(aliased_mod_state.id).where(
                 aliased_mod_state.id == column,
-                or_(
-                    aliased_mod_state.visibility == ModerationVisibility.visible,
-                    aliased_mod_state.visibility == ModerationVisibility.unlisted,
-                    *shadowed_conditions,
-                ),
+                or_(*author_visible_conditions),
+                or_(*visibility_conditions),
             )
         ),
     )


### PR DESCRIPTION
Content authored by deleted, banned, shadowed, or blocked users was hidden inconsistently — some query sites combined the user-visibility helpers with the moderated-content visibility checks, others used only one.

This folds the author's user-visibility into the moderated-content visibility helpers themselves, so content by a non-visible author is hidden everywhere the moderated check runs:

- `where_moderated_content_visible` / `where_moderated_content_visible_to_user_column` now also filter on the content author's visibility — deleted/banned authors are hidden from everyone; shadowed/blocked authors are hidden from everyone but the author themselves.
- `moderation_state_column_visible` (the notifications path) gained the same per-object-type author-visibility check.
- Removed the now-redundant `where_users_column_visible` calls on author columns at call sites that already apply the moderated check (`account.py`, `api.py`, `references.py`, `requests.py`).

Note: this is the behavior half of the work split out from #8647. The companion refactor (#8652) makes the moderated-model handling dynamic; this PR is written directly against `develop` and uses a small local `_MODERATED_OBJECT_TYPES` table that the refactor PR replaces — merging both will need that overlap resolved.

## Testing
- `make format` and `make mypy` pass (the two remaining mypy errors — `test_calendar_events.py` missing `ics` stubs and `fixtures/misc.py` return type — are pre-existing on `develop`).
- 337 tests pass across `test_moderation`, `test_threads`, `test_requests`, `test_references`, `test_conversations`, `test_notifications`, `test_events`, `test_blocking`, `test_visible_users`, `test_bg_jobs`, `test_api`.
- To replicate: `cd app/backend && make format && make mypy && uv run pytest`.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history (no DB changes)

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._