### PR TITLE
Backend/tests: Add EmailCollector, like PushCollector

### DIFF
--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -28,7 +28,7 @@ from tests.fixtures.db import (  # noqa: E402
     generate_user,
     populate_testing_resources,
 )
-from tests.fixtures.misc import Moderator, PushCollector  # noqa: E402
+from tests.fixtures.misc import EmailCollector, Moderator, PushCollector  # noqa: E402
 
 
 @pytest.fixture(scope="session")
@@ -297,6 +297,15 @@ def fast_passwords():
     with patch("couchers.crypto.nacl.pwhash.verify", fast_verify):
         with patch("couchers.crypto.nacl.pwhash.str", fast_hash):
             yield
+
+
+@pytest.fixture
+def email_collector():
+    """Captures emails and allows inspecting them."""
+    collector = EmailCollector()
+
+    with patch("couchers.email.queuing._queue_email", collector.mock_queue_email):
+        yield collector
 
 
 @pytest.fixture

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -302,9 +302,8 @@ def fast_passwords():
 @pytest.fixture
 def email_collector():
     """Captures emails and allows inspecting them."""
-    collector = EmailCollector()
 
-    with patch("couchers.email.queuing._queue_email", collector.mock_queue_email):
+    with EmailCollector() as collector:
         yield collector
 
 
@@ -313,9 +312,7 @@ def push_collector():
     """
     See test_SendTestPushNotification for an example on how to use this fixture
     """
-    collector = PushCollector()
-
-    with patch("couchers.notifications.push._push_to_user", collector.push_to_user):
+    with PushCollector() as collector:
         yield collector
 
 

--- a/app/backend/src/tests/fixtures/misc.py
+++ b/app/backend/src/tests/fixtures/misc.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from unittest.mock import patch
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -19,14 +20,27 @@ def process_jobs() -> None:
 
 
 class EmailCollector:
+    """Intercepts emails so they can be verified by tests."""
+
     def __init__(self) -> None:
         # Collected emails by recipient address, chronologically.
         self.by_recipient: dict[str, list[jobs_pb2.SendEmailPayload]] = {}
+        self._patch = patch("couchers.email.queuing._queue_email", self._mock_queue_email)
 
-    def mock_queue_email(self, session: Session, payload: jobs_pb2.SendEmailPayload) -> None:
+    def _mock_queue_email(self, session: Session, payload: jobs_pb2.SendEmailPayload) -> None:
         if payload.recipient not in self.by_recipient:
             self.by_recipient[payload.recipient] = []
         self.by_recipient[payload.recipient].append(payload)
+
+    def __enter__(self):
+        process_jobs() # Flush any emails prior to this point
+        self.by_recipient.clear()
+        self._patch.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._patch.stop()
+        return False  # Let any exception propagate
 
     def count(self) -> int:
         process_jobs()
@@ -39,20 +53,26 @@ class EmailCollector:
     def count_for_mods(self) -> int:
         return self.count_for_recipient(config["MODS_EMAIL_RECIPIENT"])
 
+    def count_for_reports(self) -> int:
+        return self.count_for_recipient(config["REPORTS_EMAIL_RECIPIENT"])
+
     def pop_for_recipient(self, recipient: str, *, last: bool = False) -> jobs_pb2.SendEmailPayload:
         """
         Removes and returns the oldest email queued to a given recipient,
         optionally asserting that it is the last one.
         """
         process_jobs()
-        pushes = self.by_recipient.get(recipient)
-        assert pushes, f"No emails to pop for recipient {recipient}."
+        emails = self.by_recipient.get(recipient)
+        assert emails, f"No emails to pop for recipient {recipient}."
         if last:
-            assert len(pushes) == 1, f"Expected a single email for recipient {recipient}."
-        return pushes.pop(0)
+            assert len(emails) == 1, f"Expected a single email for recipient {recipient}."
+        return emails.pop(0)
 
     def pop_for_mods(self, *, last: bool = False) -> jobs_pb2.SendEmailPayload:
         return self.pop_for_recipient(config["MODS_EMAIL_RECIPIENT"], last=last)
+
+    def pop_for_reports(self, *, last: bool = False) -> jobs_pb2.SendEmailPayload:
+        return self.pop_for_recipient(config["REPORTS_EMAIL_RECIPIENT"], last=last)
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -64,14 +84,27 @@ class Push:
 
 
 class PushCollector:
-    def __init__(self) -> None:
-        self.by_user: dict[int, list[Push]] = {}
-        """Collected notifications by user id, chronologically."""
+    """Captures push notifications and allows inspecting them."""
 
-    def push_to_user(self, session: Session, user_id: int, **kwargs: Any) -> None:
+    def __init__(self) -> None:
+        # Collected notifications by user id, chronologically.
+        self.by_user: dict[int, list[Push]] = {}
+        self._patch = patch("couchers.notifications.push._push_to_user", self._mock_push_to_user)
+
+    def _mock_push_to_user(self, session: Session, user_id: int, **kwargs: Any) -> None:
         if user_id not in self.by_user:
             self.by_user[user_id] = []
         self.by_user[user_id].append(Push(**kwargs))
+
+    def __enter__(self):
+        process_jobs() # Flush any push notifications prior to this point
+        self.by_user.clear()
+        self._patch.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._patch.stop()
+        return False  # Let any exception propagate
 
     def count_for_user(self, user_id: int) -> int:
         process_jobs()

--- a/app/backend/src/tests/fixtures/misc.py
+++ b/app/backend/src/tests/fixtures/misc.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
-from unittest.mock import patch
 from typing import Any
+from unittest.mock import patch
 
 from sqlalchemy.orm import Session
 
@@ -33,7 +33,7 @@ class EmailCollector:
         self.by_recipient[payload.recipient].append(payload)
 
     def __enter__(self):
-        process_jobs() # Flush any emails prior to this point
+        process_jobs()  # Flush any emails prior to this point
         self.by_recipient.clear()
         self._patch.start()
         return self
@@ -97,7 +97,7 @@ class PushCollector:
         self.by_user[user_id].append(Push(**kwargs))
 
     def __enter__(self):
-        process_jobs() # Flush any push notifications prior to this point
+        process_jobs()  # Flush any push notifications prior to this point
         self.by_user.clear()
         self._patch.start()
         return self

--- a/app/backend/src/tests/fixtures/misc.py
+++ b/app/backend/src/tests/fixtures/misc.py
@@ -39,7 +39,7 @@ class EmailCollector:
     def count_for_mods(self) -> int:
         return self.count_for_recipient(config["MODS_EMAIL_RECIPIENT"])
 
-    def pop_for_recipient(self, recipient: str, last: bool = False) -> jobs_pb2.SendEmailPayload:
+    def pop_for_recipient(self, recipient: str, *, last: bool = False) -> jobs_pb2.SendEmailPayload:
         """
         Removes and returns the oldest email queued to a given recipient,
         optionally asserting that it is the last one.
@@ -51,8 +51,8 @@ class EmailCollector:
             assert len(pushes) == 1, f"Expected a single email for recipient {recipient}."
         return pushes.pop(0)
 
-    def pop_for_mods(self, last: bool = False) -> jobs_pb2.SendEmailPayload:
-        return self.pop_for_recipient(config["MODS_EMAIL_RECIPIENT"])
+    def pop_for_mods(self, *, last: bool = False) -> jobs_pb2.SendEmailPayload:
+        return self.pop_for_recipient(config["MODS_EMAIL_RECIPIENT"], last=last)
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -74,13 +74,15 @@ class PushCollector:
         self.by_user[user_id].append(Push(**kwargs))
 
     def count_for_user(self, user_id: int) -> int:
+        process_jobs()
         return len(self.by_user.get(user_id, []))
 
-    def pop_for_user(self, user_id: int, last: bool = False) -> Push:
+    def pop_for_user(self, user_id: int, *, last: bool = False) -> Push:
         """
         Removes and returns the oldest push notification received by the given user,
         optionally asserting that it is the last one.
         """
+        process_jobs()
         pushes = self.by_user.get(user_id)
         assert pushes, f"No notifications to pop for user {user_id}."
         if last:

--- a/app/backend/src/tests/fixtures/misc.py
+++ b/app/backend/src/tests/fixtures/misc.py
@@ -1,11 +1,9 @@
-from collections.abc import Generator
-from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
-from unittest.mock import Mock, patch
 
 from sqlalchemy.orm import Session
 
+from couchers.config import config
 from couchers.jobs.worker import process_job
 from couchers.models import User
 from couchers.notifications.push import PushNotificationContent
@@ -20,16 +18,41 @@ def process_jobs() -> None:
         pass
 
 
-@contextmanager
-def mock_notification_email() -> Generator[Mock]:
-    with patch("couchers.email.queuing._queue_email") as mock:
-        yield mock
+class EmailCollector:
+    def __init__(self) -> None:
+        # Collected emails by recipient address, chronologically.
+        self.by_recipient: dict[str, list[jobs_pb2.SendEmailPayload]] = {}
+
+    def mock_queue_email(self, session: Session, payload: jobs_pb2.SendEmailPayload) -> None:
+        if payload.recipient not in self.by_recipient:
+            self.by_recipient[payload.recipient] = []
+        self.by_recipient[payload.recipient].append(payload)
+
+    def count(self) -> int:
         process_jobs()
+        return sum(len(v) for v in self.by_recipient.values())
 
+    def count_for_recipient(self, recipient: str) -> int:
+        process_jobs()
+        return len(self.by_recipient.get(recipient, []))
 
-def email_fields(mock: Mock, call_ix: int = 0) -> jobs_pb2.SendEmailPayload:
-    args, _ = mock.call_args_list[call_ix]
-    return args[1]
+    def count_for_mods(self) -> int:
+        return self.count_for_recipient(config["MODS_EMAIL_RECIPIENT"])
+
+    def pop_for_recipient(self, recipient: str, last: bool = False) -> jobs_pb2.SendEmailPayload:
+        """
+        Removes and returns the oldest email queued to a given recipient,
+        optionally asserting that it is the last one.
+        """
+        process_jobs()
+        pushes = self.by_recipient.get(recipient)
+        assert pushes, f"No emails to pop for recipient {recipient}."
+        if last:
+            assert len(pushes) == 1, f"Expected a single email for recipient {recipient}."
+        return pushes.pop(0)
+
+    def pop_for_mods(self, last: bool = False) -> jobs_pb2.SendEmailPayload:
+        return self.pop_for_recipient(config["MODS_EMAIL_RECIPIENT"])
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -41,7 +64,7 @@ class Push:
 
 
 class PushCollector:
-    def __init__(self):
+    def __init__(self) -> None:
         self.by_user: dict[int, list[Push]] = {}
         """Collected notifications by user id, chronologically."""
 

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -693,8 +693,6 @@ def test_full_delete_account_with_recovery(db, email_collector: EmailCollector, 
     assert email.subject == "[TEST] Confirm your Couchers.org account deletion"
     assert email.recipient == user.email
     assert "account deletion" in email.subject.lower()
-    assert token in email.plain
-    assert token in email.html
     unique_string = "You requested that we delete your account from Couchers.org."
     assert unique_string in email.plain
     assert unique_string in email.html
@@ -715,6 +713,8 @@ def test_full_delete_account_with_recovery(db, email_collector: EmailCollector, 
         assert not user_.undelete_token
         assert not user_.undelete_until
 
+    assert delete_token in email.plain
+    assert delete_token in email.html
     delete_url = f"http://localhost:3000/delete-account?token={delete_token}"
     assert delete_url in email.plain
     assert delete_url in email.html

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -722,7 +722,7 @@ def test_full_delete_account_with_recovery(db, email_collector: EmailCollector, 
     with auth_api_session() as (auth_api, metadata_interceptor):
         auth_api.ConfirmDeleteAccount(
             auth_pb2.ConfirmDeleteAccountReq(
-                token=token,
+                token=delete_token,
             )
         )
 

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -25,7 +25,7 @@ from couchers.models import (
 from couchers.proto import account_pb2, api_pb2, auth_pb2, conversations_pb2, requests_pb2
 from couchers.utils import now, today
 from tests.fixtures.db import generate_user, make_volunteer
-from tests.fixtures.misc import PushCollector, email_fields, mock_notification_email, process_jobs
+from tests.fixtures.misc import EmailCollector, PushCollector, process_jobs
 from tests.fixtures.sessions import (
     account_session,
     auth_api_session,
@@ -157,23 +157,22 @@ def test_GetAccountInfo_regression(db):
         res = account.GetAccountInfo(empty_pb2.Empty())
 
 
-def test_ChangePasswordV2_normal(db, fast_passwords, push_collector: PushCollector):
+def test_ChangePasswordV2_normal(db, fast_passwords, email_collector: EmailCollector, push_collector: PushCollector):
     # user has old password and is changing to new password
     old_password = random_hex()
     new_password = random_hex()
     user, token = generate_user(hashed_password=hash_password(old_password))
 
     with account_session(token) as account:
-        with mock_notification_email() as mock:
-            account.ChangePasswordV2(
-                account_pb2.ChangePasswordV2Req(
-                    old_password=old_password,
-                    new_password=new_password,
-                )
+        account.ChangePasswordV2(
+            account_pb2.ChangePasswordV2Req(
+                old_password=old_password,
+                new_password=new_password,
             )
+        )
 
-    mock.assert_called_once()
-    assert email_fields(mock).subject == "[TEST] Your password was changed"
+    email = email_collector.pop_for_recipient(user.email, last=True)
+    assert email.subject == "[TEST] Your password was changed"
 
     push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Password changed"
@@ -646,14 +645,13 @@ def test_contributor_form(db):
         assert res.filled_contributor_form
 
 
-def test_DeleteAccount_start(db):
+def test_DeleteAccount_start(db, email_collector: EmailCollector):
     user, token = generate_user()
 
     with account_session(token) as account:
-        with mock_notification_email() as mock:
-            account.DeleteAccount(account_pb2.DeleteAccountReq(confirm=True, reason=None))
-        mock.assert_called_once()
-        assert email_fields(mock).subject == "[TEST] Confirm your Couchers.org account deletion"
+        account.DeleteAccount(account_pb2.DeleteAccountReq(confirm=True, reason=None))
+        email = email_collector.pop_for_recipient(user.email, last=True)
+        assert email.subject == "[TEST] Confirm your Couchers.org account deletion"
 
     with session_scope() as session:
         deletion_token: AccountDeletionToken = session.execute(
@@ -679,7 +677,7 @@ def test_DeleteAccount_message_storage(db):
         assert session.execute(select(func.count()).select_from(AccountDeletionReason)).scalar_one() == 3
 
 
-def test_full_delete_account_with_recovery(db, push_collector: PushCollector):
+def test_full_delete_account_with_recovery(db, email_collector: EmailCollector, push_collector: PushCollector):
     user, token = generate_user()
     user_id = user.id
 
@@ -689,20 +687,27 @@ def test_full_delete_account_with_recovery(db, push_collector: PushCollector):
         assert err.value.code() == grpc.StatusCode.FAILED_PRECONDITION
         assert err.value.details() == "Please confirm your account deletion."
 
-        # Check the right email is sent
-        with mock_notification_email() as mock:
-            account.DeleteAccount(account_pb2.DeleteAccountReq(confirm=True))
+        account.DeleteAccount(account_pb2.DeleteAccountReq(confirm=True))
+
+    email = email_collector.pop_for_recipient(user.email, last=True)
+    assert email.subject == "[TEST] Confirm your Couchers.org account deletion"
+    assert email.recipient == user.email
+    assert "account deletion" in email.subject.lower()
+    assert token in email.plain
+    assert token in email.html
+    unique_string = "You requested that we delete your account from Couchers.org."
+    assert unique_string in email.plain
+    assert unique_string in email.html
+    assert "support@couchers.org" in email.plain
+    assert "support@couchers.org" in email.html
 
     push = push_collector.pop_for_user(user_id, last=True)
     assert push.content.title == "Account deletion requested"
     assert push.content.body == "Use the link we emailed you to confirm."
 
-    mock.assert_called_once()
-    e = email_fields(mock)
-
     with session_scope() as session:
         token_o = session.execute(select(AccountDeletionToken)).scalar_one()
-        token = token_o.token
+        delete_token = token_o.token
 
         user_ = session.execute(select(User).where(User.id == user_id)).scalar_one()
         assert token_o.user == user_
@@ -710,34 +715,31 @@ def test_full_delete_account_with_recovery(db, push_collector: PushCollector):
         assert not user_.undelete_token
         assert not user_.undelete_until
 
-    assert email_fields(mock).subject == "[TEST] Confirm your Couchers.org account deletion"
-    assert e.recipient == user.email
-    assert "account deletion" in e.subject.lower()
-    assert token in e.plain
-    assert token in e.html
-    unique_string = "You requested that we delete your account from Couchers.org."
-    assert unique_string in e.plain
-    assert unique_string in e.html
-    url = f"http://localhost:3000/delete-account?token={token}"
-    assert url in e.plain
-    assert url in e.html
-    assert "support@couchers.org" in e.plain
-    assert "support@couchers.org" in e.html
+    delete_url = f"http://localhost:3000/delete-account?token={delete_token}"
+    assert delete_url in email.plain
+    assert delete_url in email.html
 
-    with mock_notification_email() as mock:
-        with auth_api_session() as (auth_api, metadata_interceptor):
-            auth_api.ConfirmDeleteAccount(
-                auth_pb2.ConfirmDeleteAccountReq(
-                    token=token,
-                )
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        auth_api.ConfirmDeleteAccount(
+            auth_pb2.ConfirmDeleteAccountReq(
+                token=token,
             )
+        )
+
+    email = email_collector.pop_for_recipient(user.email, last=True)
+    assert email.recipient == user.email
+    assert "account has been deleted" in email.subject.lower()
+    unique_string = "You have successfully deleted your account from Couchers.org."
+    assert unique_string in email.plain
+    assert unique_string in email.html
+    assert "7 days" in email.plain
+    assert "7 days" in email.html
+    assert "support@couchers.org" in email.plain
+    assert "support@couchers.org" in email.html
 
     push = push_collector.pop_for_user(user_id, last=True)
     assert push.content.title == "Account deleted"
     assert push.content.body == "You can restore it within 7 days using the link we emailed you."
-
-    mock.assert_called_once()
-    e = email_fields(mock)
 
     with session_scope() as session:
         assert not session.execute(select(AccountDeletionToken)).scalar_one_or_none()
@@ -750,41 +752,29 @@ def test_full_delete_account_with_recovery(db, push_collector: PushCollector):
 
         undelete_token = user_.undelete_token
 
-    assert e.recipient == user.email
-    assert "account has been deleted" in e.subject.lower()
-    unique_string = "You have successfully deleted your account from Couchers.org."
-    assert unique_string in e.plain
-    assert unique_string in e.html
-    assert "7 days" in e.plain
-    assert "7 days" in e.html
-    url = f"http://localhost:3000/recover-account?token={undelete_token}"
-    assert url in e.plain
-    assert url in e.html
-    assert "support@couchers.org" in e.plain
-    assert "support@couchers.org" in e.html
+    undelete_url = f"http://localhost:3000/recover-account?token={undelete_token}"
+    assert undelete_url in email.plain
+    assert undelete_url in email.html
 
-    with mock_notification_email() as mock:
-        with auth_api_session() as (auth_api, metadata_interceptor):
-            auth_api.RecoverAccount(
-                auth_pb2.RecoverAccountReq(
-                    token=undelete_token,
-                )
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        auth_api.RecoverAccount(
+            auth_pb2.RecoverAccountReq(
+                token=undelete_token,
             )
+        )
+
+    email = email_collector.pop_for_recipient(user.email, last=True)
+    assert email.recipient == user.email
+    assert "account has been recovered" in email.subject.lower()
+    unique_string = "Your account on Couchers.org has been successfully recovered!"
+    assert unique_string in email.plain
+    assert unique_string in email.html
+    assert "support@couchers.org" in email.plain
+    assert "support@couchers.org" in email.html
 
     push = push_collector.pop_for_user(user_id, last=True)
     assert push.content.title == "Account restored"
     assert push.content.body == "Welcome back!"
-
-    mock.assert_called_once()
-    e = email_fields(mock)
-
-    assert e.recipient == user.email
-    assert "account has been recovered" in e.subject.lower()
-    unique_string = "Your account on Couchers.org has been successfully recovered!"
-    assert unique_string in e.plain
-    assert unique_string in e.html
-    assert "support@couchers.org" in e.plain
-    assert "support@couchers.org" in e.html
 
     with session_scope() as session:
         assert not session.execute(select(AccountDeletionToken)).scalar_one_or_none()

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -34,7 +34,7 @@ from couchers.proto import (
 )
 from couchers.utils import Timestamp_from_datetime, now, parse_date
 from tests.fixtures.db import add_users_to_new_moderation_list, generate_user, make_friends
-from tests.fixtures.misc import EmailCollector, PushCollector, process_jobs
+from tests.fixtures.misc import EmailCollector, PushCollector
 from tests.fixtures.sessions import (
     account_session,
     auth_api_session,

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -34,7 +34,7 @@ from couchers.proto import (
 )
 from couchers.utils import Timestamp_from_datetime, now, parse_date
 from tests.fixtures.db import add_users_to_new_moderation_list, generate_user, make_friends
-from tests.fixtures.misc import PushCollector, email_fields, mock_notification_email
+from tests.fixtures.misc import EmailCollector, PushCollector, process_jobs
 from tests.fixtures.sessions import (
     account_session,
     auth_api_session,
@@ -120,13 +120,12 @@ def test_GetUserDetails(db):
     assert not res.deleted
 
 
-def test_ChangeUserGender(db, push_collector: PushCollector):
+def test_ChangeUserGender(db, email_collector: EmailCollector, push_collector: PushCollector):
     super_user, super_token = generate_user(is_superuser=True)
     normal_user, normal_token = generate_user()
 
     with real_admin_session(super_token) as api:
-        with mock_notification_email() as mock:
-            res = api.ChangeUserGender(admin_pb2.ChangeUserGenderReq(user=normal_user.username, gender="Machine"))
+        res = api.ChangeUserGender(admin_pb2.ChangeUserGenderReq(user=normal_user.username, gender="Machine"))
     assert res.user_id == normal_user.id
     assert res.username == normal_user.username
     assert res.email == normal_user.email
@@ -135,19 +134,18 @@ def test_ChangeUserGender(db, push_collector: PushCollector):
     assert not res.banned
     assert not res.deleted
 
-    mock.assert_called_once()
-    e = email_fields(mock)
-    assert e.subject == "[TEST] Your gender was changed"
-    assert e.recipient == normal_user.email
-    assert "Machine" in e.plain
-    assert "Machine" in e.html
+    email = email_collector.pop_for_recipient(normal_user.email, last=True)
+    assert email.subject == "[TEST] Your gender was changed"
+    assert email.recipient == normal_user.email
+    assert "Machine" in email.plain
+    assert "Machine" in email.html
 
     push = push_collector.pop_for_user(normal_user.id, last=True)
     assert push.content.title == "Gender changed"
     assert push.content.body == "An admin changed your gender to Machine."
 
 
-def test_ChangeUserBirthdate(db, push_collector: PushCollector):
+def test_ChangeUserBirthdate(db, email_collector: EmailCollector, push_collector: PushCollector):
     super_user, super_token = generate_user(is_superuser=True)
     normal_user, normal_token = generate_user(birthdate=date(year=2000, month=1, day=1))
 
@@ -155,10 +153,9 @@ def test_ChangeUserBirthdate(db, push_collector: PushCollector):
         res = api.GetUserDetails(admin_pb2.GetUserDetailsReq(user=normal_user.username))
         assert parse_date(res.birthdate) == date(year=2000, month=1, day=1)
 
-        with mock_notification_email() as mock:
-            res = api.ChangeUserBirthdate(
-                admin_pb2.ChangeUserBirthdateReq(user=normal_user.username, birthdate="1990-05-25")
-            )
+        res = api.ChangeUserBirthdate(
+            admin_pb2.ChangeUserBirthdateReq(user=normal_user.username, birthdate="1990-05-25")
+        )
 
     assert res.user_id == normal_user.id
     assert res.username == normal_user.username
@@ -168,12 +165,11 @@ def test_ChangeUserBirthdate(db, push_collector: PushCollector):
     assert not res.banned
     assert not res.deleted
 
-    mock.assert_called_once()
-    e = email_fields(mock)
-    assert e.subject == "[TEST] Your date of birth was changed"
-    assert e.recipient == normal_user.email
-    assert "1990" in e.plain
-    assert "1990" in e.html
+    email = email_collector.pop_for_recipient(normal_user.email, last=True)
+    assert email.subject == "[TEST] Your date of birth was changed"
+    assert email.recipient == normal_user.email
+    assert "1990" in email.plain
+    assert "1990" in email.html
 
     push = push_collector.pop_for_user(normal_user.id, last=True)
     assert push.content.title == "Birthdate changed"
@@ -512,7 +508,7 @@ def test_RecoverDeletedUser_after_user_initiated_deletion(db, push_collector: Pu
         assert user.undelete_until is None
 
 
-def test_CreateApiKey(db, push_collector: PushCollector):
+def test_CreateApiKey(db, email_collector: EmailCollector, push_collector: PushCollector):
     with session_scope() as session:
         super_user, super_token = generate_user(is_superuser=True)
         normal_user, normal_token = generate_user()
@@ -527,13 +523,11 @@ def test_CreateApiKey(db, push_collector: PushCollector):
             == 0
         )
 
-    with mock_notification_email() as mock:
-        with real_admin_session(super_token) as api:
-            res = api.CreateApiKey(admin_pb2.CreateApiKeyReq(user=normal_user.username))
+    with real_admin_session(super_token) as api:
+        res = api.CreateApiKey(admin_pb2.CreateApiKeyReq(user=normal_user.username))
 
-    mock.assert_called_once()
-    e = email_fields(mock)
-    assert e.subject == "[TEST] Your API key for Couchers.org"
+    email = email_collector.pop_for_recipient(normal_user.email, last=True)
+    assert email.subject == "[TEST] Your API key for Couchers.org"
 
     with session_scope() as session:
         token = session.execute(
@@ -543,16 +537,16 @@ def test_CreateApiKey(db, push_collector: PushCollector):
             .where(UserSession.user_id == normal_user.id)
         ).scalar_one()
 
-        assert token in e.plain
-        assert token in e.html
+        assert token in email.plain
+        assert token in email.html
 
-    assert e.recipient == normal_user.email
-    assert "api key" in e.subject.lower()
+    assert email.recipient == normal_user.email
+    assert "api key" in email.subject.lower()
     unique_string = "We've issued you with the following API key:"
-    assert unique_string in e.plain
-    assert unique_string in e.html
-    assert "support@couchers.org" in e.plain
-    assert "support@couchers.org" in e.html
+    assert unique_string in email.plain
+    assert unique_string in email.html
+    assert "support@couchers.org" in email.plain
+    assert "support@couchers.org" in email.html
 
     push = push_collector.pop_for_user(normal_user.id, last=True)
     assert push.content.title == "API key created"
@@ -573,19 +567,18 @@ def test_GetChats(db):
     assert len(res.group_chats) == 0
 
 
-def test_badges(db, push_collector: PushCollector):
+def test_badges(db, email_collector: EmailCollector, push_collector: PushCollector):
     super_user, super_token = generate_user(is_superuser=True)
     normal_user, normal_token = generate_user()
 
     with real_admin_session(super_token) as api:
         # can add a badge
         assert "swagster" not in api.GetUserDetails(admin_pb2.GetUserDetailsReq(user=normal_user.username)).badges
-        with mock_notification_email() as mock:
-            res = api.AddBadge(admin_pb2.AddBadgeReq(user=normal_user.username, badge_id="swagster"))
+        res = api.AddBadge(admin_pb2.AddBadgeReq(user=normal_user.username, badge_id="swagster"))
         assert "swagster" in res.badges
 
         # badge emails are disabled by default
-        mock.assert_not_called()
+        assert email_collector.count_for_recipient(normal_user.email) == 0
 
         push = push_collector.pop_for_user(normal_user.id, last=True)
         assert push.content.title == "New profile badge: Swagster"
@@ -605,12 +598,11 @@ def test_badges(db, push_collector: PushCollector):
 
         # can remove badge
         assert "swagster" in api.GetUserDetails(admin_pb2.GetUserDetailsReq(user=normal_user.username)).badges
-        with mock_notification_email() as mock:
-            res = api.RemoveBadge(admin_pb2.RemoveBadgeReq(user=normal_user.username, badge_id="swagster"))
+        res = api.RemoveBadge(admin_pb2.RemoveBadgeReq(user=normal_user.username, badge_id="swagster"))
         assert "swagster" not in res.badges
 
         # badge emails are disabled by default
-        mock.assert_not_called()
+        assert email_collector.count_for_recipient(normal_user.email) == 0
 
         push = push_collector.pop_for_user(normal_user.id, last=True)
         assert push.content.title == "Profile badge removed"
@@ -1007,7 +999,7 @@ def test_RemoveUserFromModerationUserList(db):
             assert session.get(ModerationUserList, moderation_list_id) is None
 
 
-def test_admin_delete_account_url(db, push_collector: PushCollector):
+def test_admin_delete_account_url(db, email_collector: EmailCollector, push_collector: PushCollector):
     super_user, super_token = generate_user(is_superuser=True)
 
     user, token = generate_user()
@@ -1026,19 +1018,17 @@ def test_admin_delete_account_url(db, push_collector: PushCollector):
         assert token_o.user.id == user_id
         assert url == f"http://localhost:3000/delete-account?token={token}"
 
-    with mock_notification_email() as mock:
-        with auth_api_session() as (auth_api, metadata_interceptor):
-            auth_api.ConfirmDeleteAccount(
-                auth_pb2.ConfirmDeleteAccountReq(
-                    token=token,
-                )
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        auth_api.ConfirmDeleteAccount(
+            auth_pb2.ConfirmDeleteAccountReq(
+                token=token,
             )
+        )
 
     push = push_collector.pop_for_user(user_id, last=True)
     assert push.content.title == "Account deleted"
     assert push.content.body == "You can restore it within 7 days using the link we emailed you."
-    mock.assert_called_once()
-    e = email_fields(mock)
+    email_collector.pop_for_recipient(user.email, last=True)
 
 
 def test_AccessStats(db):

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -26,7 +26,7 @@ from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_
 from couchers.resources import get_badge_dict
 from couchers.utils import create_coordinate, now, to_aware_datetime
 from tests.fixtures.db import generate_user, make_friends, make_user_block
-from tests.fixtures.misc import PushCollector, email_fields, mock_notification_email
+from tests.fixtures.misc import EmailCollector, PushCollector, process_jobs
 from tests.fixtures.sessions import (
     api_session,
     blocking_session,
@@ -824,7 +824,7 @@ def test_pending_friend_request_count(db, moderator):
         assert res.pending_friend_request_count == 0
 
 
-def test_friend_request_flow(db, push_collector: PushCollector, moderator):
+def test_friend_request_flow(db, email_collector: EmailCollector, push_collector: PushCollector, moderator):
     user1, token1 = generate_user(complete_profile=True)
     user2, token2 = generate_user(complete_profile=True)
     user3, token3 = generate_user()
@@ -862,25 +862,23 @@ def test_friend_request_flow(db, push_collector: PushCollector, moderator):
         assert len(res.received) == 0
 
     # Moderator approves the friend request - this triggers the notification
-    with mock_notification_email() as mock:
-        moderator.approve_friend_request(friend_request_id)
+    moderator.approve_friend_request(friend_request_id)
 
     push = push_collector.pop_for_user(user2.id, last=True)
     assert push.content.title == f"Friend request from {user1.name}"
     assert push.content.body == f"{user1.name} wants to be your friend."
 
-    mock.assert_called_once()
-    e = email_fields(mock)
-    assert e.recipient == user2.email
-    assert e.subject == f"[TEST] {user1.name} wants to be your friend on Couchers.org!"
-    assert user2.name in e.plain
-    assert user2.name in e.html
-    assert user1.name in e.plain
-    assert user1.name in e.html
-    assert "http://localhost:5001/img/thumbnail/" not in e.plain
-    assert "http://localhost:5001/img/thumbnail/" in e.html
-    assert "http://localhost:3000/connections/friends/" in e.plain
-    assert "http://localhost:3000/connections/friends/" in e.html
+    email = email_collector.pop_for_recipient(user2.email, last=True)
+    assert email.recipient == user2.email
+    assert email.subject == f"[TEST] {user1.name} wants to be your friend on Couchers.org!"
+    assert user2.name in email.plain
+    assert user2.name in email.html
+    assert user1.name in email.plain
+    assert user1.name in email.html
+    assert "http://localhost:5001/img/thumbnail/" not in email.plain
+    assert "http://localhost:5001/img/thumbnail/" in email.html
+    assert "http://localhost:3000/connections/friends/" in email.plain
+    assert "http://localhost:3000/connections/friends/" in email.html
 
     # Now recipient can see the approved friend request
     with api_session(token2) as api:
@@ -895,8 +893,7 @@ def test_friend_request_flow(db, push_collector: PushCollector, moderator):
         fr_id = res.received[0].friend_request_id
 
         # accept it
-        with mock_notification_email() as mock:
-            api.RespondFriendRequest(api_pb2.RespondFriendRequestReq(friend_request_id=fr_id, accept=True))
+        api.RespondFriendRequest(api_pb2.RespondFriendRequestReq(friend_request_id=fr_id, accept=True))
 
         # check it's gone
         res = api.ListFriendRequests(empty_pb2.Empty())
@@ -914,18 +911,17 @@ def test_friend_request_flow(db, push_collector: PushCollector, moderator):
     assert push.content.title == f"{user2.name} accepted your friend request"
     assert push.content.body == f"You are now friends with {user2.name}."
 
-    mock.assert_called_once()
-    e = email_fields(mock)
-    assert e.recipient == user1.email
-    assert e.subject == f"[TEST] {user2.name} accepted your friend request!"
-    assert user1.name in e.plain
-    assert user1.name in e.html
-    assert user2.name in e.plain
-    assert user2.name in e.html
-    assert "http://localhost:5001/img/thumbnail/" not in e.plain
-    assert "http://localhost:5001/img/thumbnail/" in e.html
-    assert f"http://localhost:3000/user/{user2.username}" in e.plain
-    assert f"http://localhost:3000/user/{user2.username}" in e.html
+    email = email_collector.pop_for_recipient(user1.email, last=True)
+    assert email.recipient == user1.email
+    assert email.subject == f"[TEST] {user2.name} accepted your friend request!"
+    assert user1.name in email.plain
+    assert user1.name in email.html
+    assert user2.name in email.plain
+    assert user2.name in email.html
+    assert "http://localhost:5001/img/thumbnail/" not in email.plain
+    assert "http://localhost:5001/img/thumbnail/" in email.html
+    assert f"http://localhost:3000/user/{user2.username}" in email.plain
+    assert f"http://localhost:3000/user/{user2.username}" in email.html
 
     with api_session(token1) as api:
         # check it's gone
@@ -1069,49 +1065,45 @@ def test_cant_friend_request_incomplete_profile(db):
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user1.id))
 
 
-def test_excessive_friend_requests_are_reported(db):
+def test_excessive_friend_requests_are_reported(db, email_collector: EmailCollector):
     """Test that excessive friend requests are first reported in a warning email and finally lead blocking of further requests."""
     user, token = generate_user()
     rate_limit_definition = RATE_LIMIT_DEFINITIONS[RateLimitAction.friend_request]
     with api_session(token) as api:
         # Test warning email
-        with mock_notification_email() as mock_email:
-            for _ in range(rate_limit_definition.warning_limit):
-                friend_user, _ = generate_user()
-                _ = api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=friend_user.id))
-
-            assert mock_email.call_count == 0
+        for _ in range(rate_limit_definition.warning_limit):
             friend_user, _ = generate_user()
             _ = api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=friend_user.id))
 
-            assert mock_email.call_count == 1
-            email = email_fields(mock_email).plain
-            assert email.startswith(
-                f"User {user.username} has sent {rate_limit_definition.warning_limit} friend requests in the past {RATE_LIMIT_HOURS} hours."
-            )
+        assert email_collector.count_for_mods() == 0
+        friend_user, _ = generate_user()
+        _ = api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=friend_user.id))
+
+        email = email_collector.pop_for_mods(last=True)
+        assert email.plain.startswith(
+            f"User {user.username} has sent {rate_limit_definition.warning_limit} friend requests in the past {RATE_LIMIT_HOURS} hours."
+        )
 
         # Test ban after exceeding FRIEND_REQUEST_HARD_LIMIT
-        with mock_notification_email() as mock_email:
-            for _ in range(rate_limit_definition.hard_limit - rate_limit_definition.warning_limit - 1):
-                friend_user, _ = generate_user()
-                _ = api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=friend_user.id))
-
-            assert mock_email.call_count == 0
+        for _ in range(rate_limit_definition.hard_limit - rate_limit_definition.warning_limit - 1):
             friend_user, _ = generate_user()
-            with pytest.raises(grpc.RpcError) as exc_info:
-                _ = api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=friend_user.id))
-            assert exc_info.value.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
-            assert (
-                exc_info.value.details()
-                == "You have sent a lot of friend requests in the past 24 hours. To avoid spam, you can't send any more for now."
-            )
+            _ = api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=friend_user.id))
 
-            assert mock_email.call_count == 1
-            email = email_fields(mock_email).plain
-            assert email.startswith(
-                f"User {user.username} has sent {rate_limit_definition.hard_limit} friend requests in the past {RATE_LIMIT_HOURS} hours."
-            )
-            assert "The user has been blocked from sending further friend requests for now." in email
+        assert email_collector.count_for_mods() == 0
+        friend_user, _ = generate_user()
+        with pytest.raises(grpc.RpcError) as exc_info:
+            _ = api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=friend_user.id))
+        assert exc_info.value.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
+        assert (
+            exc_info.value.details()
+            == "You have sent a lot of friend requests in the past 24 hours. To avoid spam, you can't send any more for now."
+        )
+
+        email = email_collector.pop_for_mods(last=True)
+        assert email.plain.startswith(
+            f"User {user.username} has sent {rate_limit_definition.hard_limit} friend requests in the past {RATE_LIMIT_HOURS} hours."
+        )
+        assert "The user has been blocked from sending further friend requests for now." in email.plain
 
 
 def test_ListFriends(db, moderator):

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -26,7 +26,7 @@ from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_
 from couchers.resources import get_badge_dict
 from couchers.utils import create_coordinate, now, to_aware_datetime
 from tests.fixtures.db import generate_user, make_friends, make_user_block
-from tests.fixtures.misc import EmailCollector, PushCollector, process_jobs
+from tests.fixtures.misc import EmailCollector, PushCollector
 from tests.fixtures.sessions import (
     api_session,
     blocking_session,

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -1075,11 +1075,11 @@ def test_excessive_friend_requests_are_reported(db, email_collector: EmailCollec
             friend_user, _ = generate_user()
             _ = api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=friend_user.id))
 
-        assert email_collector.count_for_mods() == 0
+        assert email_collector.count_for_reports() == 0
         friend_user, _ = generate_user()
         _ = api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=friend_user.id))
 
-        email = email_collector.pop_for_mods(last=True)
+        email = email_collector.pop_for_reports(last=True)
         assert email.plain.startswith(
             f"User {user.username} has sent {rate_limit_definition.warning_limit} friend requests in the past {RATE_LIMIT_HOURS} hours."
         )
@@ -1089,7 +1089,7 @@ def test_excessive_friend_requests_are_reported(db, email_collector: EmailCollec
             friend_user, _ = generate_user()
             _ = api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=friend_user.id))
 
-        assert email_collector.count_for_mods() == 0
+        assert email_collector.count_for_reports() == 0
         friend_user, _ = generate_user()
         with pytest.raises(grpc.RpcError) as exc_info:
             _ = api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=friend_user.id))
@@ -1099,7 +1099,7 @@ def test_excessive_friend_requests_are_reported(db, email_collector: EmailCollec
             == "You have sent a lot of friend requests in the past 24 hours. To avoid spam, you can't send any more for now."
         )
 
-        email = email_collector.pop_for_mods(last=True)
+        email = email_collector.pop_for_reports(last=True)
         assert email.plain.startswith(
             f"User {user.username} has sent {rate_limit_definition.hard_limit} friend requests in the past {RATE_LIMIT_HOURS} hours."
         )

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -318,7 +318,7 @@ def test_basic_login(db):
         auth_api.Deauthenticate(empty_pb2.Empty(), metadata=(("cookie", f"couchers-sesh={reply_token}"),))
 
 
-def test_login_part_signed_up_verified_email(db, email_collector: EmailCollector):
+def test_login_part_signed_up_verified_email(db):
     """
     If you try to log in but didn't finish singing up, we send you a new email and ask you to finish signing up.
     """
@@ -338,18 +338,19 @@ def test_login_part_signed_up_verified_email(db, email_collector: EmailCollector
     with auth_api_session() as (auth_api, metadata_interceptor):
         auth_api.SignupFlow(auth_pb2.SignupFlowReq(email_token=email_token))
 
-    with auth_api_session() as (auth_api, metadata_interceptor):
-        with pytest.raises(grpc.RpcError) as err:
-            auth_api.Authenticate(auth_pb2.AuthReq(user="email@couchers.org.invalid", password="wrong pwd"))
-        assert err.value.details() == "Please check your email for a link to continue signing up."
+    with EmailCollector() as email_collector:
+        with auth_api_session() as (auth_api, metadata_interceptor):
+            with pytest.raises(grpc.RpcError) as err:
+                auth_api.Authenticate(auth_pb2.AuthReq(user="email@couchers.org.invalid", password="wrong pwd"))
+            assert err.value.details() == "Please check your email for a link to continue signing up."
 
-    email = email_collector.pop_for_recipient("email@couchers.org.invalid", last=True)
-    assert email.recipient == "email@couchers.org.invalid"
-    assert flow_token in email.plain
-    assert flow_token in email.html
+        email = email_collector.pop_for_recipient("email@couchers.org.invalid", last=True)
+        assert email.recipient == "email@couchers.org.invalid"
+        assert flow_token in email.plain
+        assert flow_token in email.html
 
 
-def test_login_part_signed_up_not_verified_email(db, email_collector: EmailCollector):
+def test_login_part_signed_up_not_verified_email(db):
     with auth_api_session() as (auth_api, metadata_interceptor):
         res = auth_api.SignupFlow(
             auth_pb2.SignupFlowReq(
@@ -372,20 +373,21 @@ def test_login_part_signed_up_not_verified_email(db, email_collector: EmailColle
     flow_token = res.flow_token
     assert res.need_verify_email
 
-    with auth_api_session() as (auth_api, metadata_interceptor):
-        with pytest.raises(grpc.RpcError) as err:
-            auth_api.Authenticate(auth_pb2.AuthReq(user="frodo", password="wrong pwd"))
-        assert err.value.details() == "Please check your email for a link to continue signing up."
+    with EmailCollector() as email_collector:
+        with auth_api_session() as (auth_api, metadata_interceptor):
+            with pytest.raises(grpc.RpcError) as err:
+                auth_api.Authenticate(auth_pb2.AuthReq(user="frodo", password="wrong pwd"))
+            assert err.value.details() == "Please check your email for a link to continue signing up."
 
-    with session_scope() as session:
-        flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
-        email_token = flow.email_token
+        with session_scope() as session:
+            flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
+            email_token = flow.email_token
 
-    email = email_collector.pop_for_recipient("email@couchers.org.invalid", last=True)
-    assert email.recipient == "email@couchers.org.invalid"
-    assert email_token
-    assert email_token in email.plain
-    assert email_token in email.html
+        email = email_collector.pop_for_recipient("email@couchers.org.invalid", last=True)
+        assert email.recipient == "email@couchers.org.invalid"
+        assert email_token
+        assert email_token in email.plain
+        assert email_token in email.html
 
 
 def test_banned_user(db):

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -22,7 +22,7 @@ from couchers.models import (
 from couchers.proto import account_pb2, api_pb2, auth_pb2
 from couchers.utils import now
 from tests.fixtures.db import generate_user
-from tests.fixtures.misc import PushCollector, email_fields, mock_notification_email
+from tests.fixtures.misc import EmailCollector, PushCollector
 from tests.fixtures.sessions import (
     MetadataKeeperInterceptor,
     account_session,
@@ -318,7 +318,7 @@ def test_basic_login(db):
         auth_api.Deauthenticate(empty_pb2.Empty(), metadata=(("cookie", f"couchers-sesh={reply_token}"),))
 
 
-def test_login_part_signed_up_verified_email(db):
+def test_login_part_signed_up_verified_email(db, email_collector: EmailCollector):
     """
     If you try to log in but didn't finish singing up, we send you a new email and ask you to finish signing up.
     """
@@ -338,20 +338,18 @@ def test_login_part_signed_up_verified_email(db):
     with auth_api_session() as (auth_api, metadata_interceptor):
         auth_api.SignupFlow(auth_pb2.SignupFlowReq(email_token=email_token))
 
-    with mock_notification_email() as mock:
-        with auth_api_session() as (auth_api, metadata_interceptor):
-            with pytest.raises(grpc.RpcError) as err:
-                auth_api.Authenticate(auth_pb2.AuthReq(user="email@couchers.org.invalid", password="wrong pwd"))
-            assert err.value.details() == "Please check your email for a link to continue signing up."
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        with pytest.raises(grpc.RpcError) as err:
+            auth_api.Authenticate(auth_pb2.AuthReq(user="email@couchers.org.invalid", password="wrong pwd"))
+        assert err.value.details() == "Please check your email for a link to continue signing up."
 
-    assert mock.call_count == 1
-    e = email_fields(mock)
-    assert e.recipient == "email@couchers.org.invalid"
-    assert flow_token in e.plain
-    assert flow_token in e.html
+    email = email_collector.pop_for_recipient("email@couchers.org.invalid", last=True)
+    assert email.recipient == "email@couchers.org.invalid"
+    assert flow_token in email.plain
+    assert flow_token in email.html
 
 
-def test_login_part_signed_up_not_verified_email(db):
+def test_login_part_signed_up_not_verified_email(db, email_collector: EmailCollector):
     with auth_api_session() as (auth_api, metadata_interceptor):
         res = auth_api.SignupFlow(
             auth_pb2.SignupFlowReq(
@@ -374,22 +372,20 @@ def test_login_part_signed_up_not_verified_email(db):
     flow_token = res.flow_token
     assert res.need_verify_email
 
-    with mock_notification_email() as mock:
-        with auth_api_session() as (auth_api, metadata_interceptor):
-            with pytest.raises(grpc.RpcError) as err:
-                auth_api.Authenticate(auth_pb2.AuthReq(user="frodo", password="wrong pwd"))
-            assert err.value.details() == "Please check your email for a link to continue signing up."
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        with pytest.raises(grpc.RpcError) as err:
+            auth_api.Authenticate(auth_pb2.AuthReq(user="frodo", password="wrong pwd"))
+        assert err.value.details() == "Please check your email for a link to continue signing up."
 
     with session_scope() as session:
         flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
         email_token = flow.email_token
 
-    assert mock.call_count == 1
-    e = email_fields(mock)
-    assert e.recipient == "email@couchers.org.invalid"
+    email = email_collector.pop_for_recipient("email@couchers.org.invalid", last=True)
+    assert email.recipient == "email@couchers.org.invalid"
     assert email_token
-    assert email_token in e.plain
-    assert email_token in e.html
+    assert email_token in email.plain
+    assert email_token in email.html
 
 
 def test_banned_user(db):
@@ -431,29 +427,27 @@ def test_invalid_token(db):
     assert e.value.details() == "Unauthorized"
 
 
-def test_password_reset_v2(db, push_collector: PushCollector):
+def test_password_reset_v2(db, email_collector: EmailCollector, push_collector: PushCollector):
     user, token = generate_user(hashed_password=hash_password("mypassword"))
 
     with auth_api_session() as (auth_api, metadata_interceptor):
-        with mock_notification_email() as mock:
-            res = auth_api.ResetPassword(auth_pb2.ResetPasswordReq(user=user.username))
+        res = auth_api.ResetPassword(auth_pb2.ResetPasswordReq(user=user.username))
 
     with session_scope() as session:
         password_reset_token = session.execute(select(PasswordResetToken.token)).scalar_one()
 
-    assert mock.call_count == 1
-    e = email_fields(mock)
-    assert e.recipient == user.email
-    assert "reset" in e.subject.lower()
-    assert password_reset_token in e.plain
-    assert password_reset_token in e.html
+    email = email_collector.pop_for_recipient(user.email, last=True)
+    assert email.recipient == user.email
+    assert "reset" in email.subject.lower()
+    assert password_reset_token in email.plain
+    assert password_reset_token in email.html
     unique_string = "You asked for your password to be reset on Couchers.org."
-    assert unique_string in e.plain
-    assert unique_string in e.html
-    assert f"http://localhost:3000/complete-password-reset?token={password_reset_token}" in e.plain
-    assert f"http://localhost:3000/complete-password-reset?token={password_reset_token}" in e.html
-    assert "support@couchers.org" in e.plain
-    assert "support@couchers.org" in e.html
+    assert unique_string in email.plain
+    assert unique_string in email.html
+    assert f"http://localhost:3000/complete-password-reset?token={password_reset_token}" in email.plain
+    assert f"http://localhost:3000/complete-password-reset?token={password_reset_token}" in email.html
+    assert "support@couchers.org" in email.plain
+    assert "support@couchers.org" in email.html
 
     push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Password reset requested"
@@ -471,10 +465,9 @@ def test_password_reset_v2(db, push_collector: PushCollector):
     # make sure we can set a good password
     with auth_api_session() as (auth_api, metadata_interceptor):
         pwd = random_hex()
-        with mock_notification_email() as mock:
-            auth_api.CompletePasswordResetV2(
-                auth_pb2.CompletePasswordResetV2Req(password_reset_token=password_reset_token, new_password=pwd)
-            )
+        auth_api.CompletePasswordResetV2(
+            auth_pb2.CompletePasswordResetV2Req(password_reset_token=password_reset_token, new_password=pwd)
+        )
 
     push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Password reset"
@@ -741,32 +734,30 @@ def test_signup_continue_with_email(db):
         assert e.value.details() == "Please check your email for a link to continue signing up."
 
 
-def test_signup_resend_email(db):
+def test_signup_resend_email(db, email_collector: EmailCollector):
     with auth_api_session() as (auth_api, metadata_interceptor):
-        with mock_notification_email() as mock:
-            res = auth_api.SignupFlow(
-                auth_pb2.SignupFlowReq(
-                    basic=auth_pb2.SignupBasic(name="testing", email="email@couchers.org.invalid"),
-                    account=auth_pb2.SignupAccount(
-                        username="frodo",
-                        password="a very insecure password",
-                        birthdate="1970-01-01",
-                        gender="Bot",
-                        hosting_status=api_pb2.HOSTING_STATUS_CAN_HOST,
-                        city="New York City",
-                        lat=40.7331,
-                        lng=-73.9778,
-                        radius=500,
-                        accept_tos=True,
-                    ),
-                    feedback=auth_pb2.ContributorForm(),
-                    accept_community_guidelines=wrappers_pb2.BoolValue(value=True),
-                    motivations=auth_pb2.SignupMotivations(motivations=["surfing"]),
-                )
+        res = auth_api.SignupFlow(
+            auth_pb2.SignupFlowReq(
+                basic=auth_pb2.SignupBasic(name="testing", email="email@couchers.org.invalid"),
+                account=auth_pb2.SignupAccount(
+                    username="frodo",
+                    password="a very insecure password",
+                    birthdate="1970-01-01",
+                    gender="Bot",
+                    hosting_status=api_pb2.HOSTING_STATUS_CAN_HOST,
+                    city="New York City",
+                    lat=40.7331,
+                    lng=-73.9778,
+                    radius=500,
+                    accept_tos=True,
+                ),
+                feedback=auth_pb2.ContributorForm(),
+                accept_community_guidelines=wrappers_pb2.BoolValue(value=True),
+                motivations=auth_pb2.SignupMotivations(motivations=["surfing"]),
             )
-        assert mock.call_count == 1
-        e = email_fields(mock)
-        assert e.recipient == "email@couchers.org.invalid"
+        )
+
+    email_collector.pop_for_recipient("email@couchers.org.invalid", last=True)
 
     flow_token = res.flow_token
     assert flow_token
@@ -780,19 +771,17 @@ def test_signup_resend_email(db):
 
     # ask for a new signup email
     with auth_api_session() as (auth_api, metadata_interceptor):
-        with mock_notification_email() as mock:
-            res = auth_api.SignupFlow(
-                auth_pb2.SignupFlowReq(
-                    flow_token=flow_token,
-                    resend_verification_email=True,
-                )
+        res = auth_api.SignupFlow(
+            auth_pb2.SignupFlowReq(
+                flow_token=flow_token,
+                resend_verification_email=True,
             )
-        assert mock.call_count == 1
-        e = email_fields(mock)
-        assert e.recipient == "email@couchers.org.invalid"
-        assert email_token
-        assert email_token in e.plain
-        assert email_token in e.html
+        )
+
+    email = email_collector.pop_for_recipient("email@couchers.org.invalid", last=True)
+    assert email_token
+    assert email_token in email.plain
+    assert email_token in email.html
 
     with session_scope() as session:
         flow = session.execute(select(SignupFlow)).scalar_one()

--- a/app/backend/src/tests/test_calendar_events.py
+++ b/app/backend/src/tests/test_calendar_events.py
@@ -170,7 +170,7 @@ def test_host_request_attachments(db, email_collector: EmailCollector, moderator
     assert ics_event.status == "CANCELLED"
 
 
-def test_host_request_attachments_disabled(db, feature_flags, moderator: Moderator):
+def test_host_request_attachments_disabled(db, email_collector: EmailCollector, feature_flags, moderator: Moderator):
     feature_flags.set("email_ics_attachments_enabled", False)
 
     host, host_token = generate_user(complete_profile=True)
@@ -189,23 +189,23 @@ def test_host_request_attachments_disabled(db, feature_flags, moderator: Moderat
             )
         ).host_request_id
 
-    with mock_notification_email():
-        moderator.approve_host_request(hr_id)
+    moderator.approve_host_request(hr_id)
+
+    email_collector.pop_for_recipient(host.email, last=True)
 
     # Host accepts: normally the surfer would get a calendar attachment, but the flag is off
     with requests_session(host_token) as api:
-        with mock_notification_email() as mock:
-            api.RespondHostRequest(
-                requests_pb2.RespondHostRequestReq(
-                    host_request_id=hr_id,
-                    status=conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED,
-                    text="Accepting host request",
-                )
+        api.RespondHostRequest(
+            requests_pb2.RespondHostRequestReq(
+                host_request_id=hr_id,
+                status=conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED,
+                text="Accepting host request",
             )
+        )
 
-    e = email_fields(mock)
-    assert "accept" in e.subject and host.name in e.subject
-    assert not e.attachments
+    email = email_collector.pop_for_recipient(surfer.email, last=True)
+    assert "accept" in email.subject and host.name in email.subject
+    assert not email.attachments
 
 
 def _get_email_ics_attachment_calendar_event(e) -> ics.Event:

--- a/app/backend/src/tests/test_calendar_events.py
+++ b/app/backend/src/tests/test_calendar_events.py
@@ -10,7 +10,7 @@ from couchers.proto import conversations_pb2, requests_pb2
 from couchers.proto.requests_pb2 import HostRequest
 from couchers.utils import today
 from tests.fixtures.db import generate_user
-from tests.fixtures.misc import Moderator, EmailCollector
+from tests.fixtures.misc import EmailCollector, Moderator
 from tests.fixtures.sessions import requests_session
 from tests.test_requests import valid_request_text
 

--- a/app/backend/src/tests/test_calendar_events.py
+++ b/app/backend/src/tests/test_calendar_events.py
@@ -10,7 +10,7 @@ from couchers.proto import conversations_pb2, requests_pb2
 from couchers.proto.requests_pb2 import HostRequest
 from couchers.utils import today
 from tests.fixtures.db import generate_user
-from tests.fixtures.misc import Moderator, email_fields, mock_notification_email
+from tests.fixtures.misc import Moderator, EmailCollector
 from tests.fixtures.sessions import requests_session
 from tests.test_requests import valid_request_text
 
@@ -92,7 +92,7 @@ def _normalize_ics(ics: str) -> str:
     return ics
 
 
-def test_host_request_attachments(db, moderator: Moderator):
+def test_host_request_attachments(db, email_collector: EmailCollector, moderator: Moderator):
     host, host_token = generate_user(complete_profile=True)
     surfer, surfer_token = generate_user(complete_profile=True)
 
@@ -110,28 +110,25 @@ def test_host_request_attachments(db, moderator: Moderator):
             )
         ).host_request_id
 
-    with mock_notification_email() as mock:
-        moderator.approve_host_request(hr_id)
+    moderator.approve_host_request(hr_id)
 
-    mock.assert_called_once()
-    e = email_fields(mock)
-    assert "request" in e.subject and surfer.name in e.subject
-    assert not e.attachments
+    email = email_collector.pop_for_recipient(host.email, last=True)
+    assert "request" in email.subject and surfer.name in email.subject
+    assert not email.attachments
 
     # Host accepts, surfer gets a calendar attachment
     with requests_session(host_token) as api:
-        with mock_notification_email() as mock:
-            api.RespondHostRequest(
-                requests_pb2.RespondHostRequestReq(
-                    host_request_id=hr_id,
-                    status=conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED,
-                    text="Accepting host request",
-                )
+        api.RespondHostRequest(
+            requests_pb2.RespondHostRequestReq(
+                host_request_id=hr_id,
+                status=conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED,
+                text="Accepting host request",
             )
+        )
 
-    e = email_fields(mock)
-    assert "accept" in e.subject and host.name in e.subject
-    ics_event = _get_email_ics_attachment_calendar_event(e)
+    email = email_collector.pop_for_recipient(surfer.email, last=True)
+    assert "accept" in email.subject and host.name in email.subject
+    ics_event = _get_email_ics_attachment_calendar_event(email)
     assert _get_ics_event_sequence(ics_event) == 0
     assert not ics_event.status
     assert ics_event.begin.date() == from_date
@@ -139,38 +136,36 @@ def test_host_request_attachments(db, moderator: Moderator):
     assert ics_event.name == f"Surfing with {host.name}"
     assert ics_event.location == host.city
 
-    # Surfer confirms, hosts gets a calendar attachment
+    # Surfer confirms, host gets a calendar attachment
     with requests_session(surfer_token) as api:
-        with mock_notification_email() as mock:
-            api.RespondHostRequest(
-                requests_pb2.RespondHostRequestReq(
-                    host_request_id=hr_id,
-                    status=conversations_pb2.HOST_REQUEST_STATUS_CONFIRMED,
-                    text="Confirming host request",
-                )
+        api.RespondHostRequest(
+            requests_pb2.RespondHostRequestReq(
+                host_request_id=hr_id,
+                status=conversations_pb2.HOST_REQUEST_STATUS_CONFIRMED,
+                text="Confirming host request",
             )
+        )
 
-    e = email_fields(mock)
-    assert "confirm" in e.subject and surfer.name in e.subject
-    ics_event = _get_email_ics_attachment_calendar_event(e)
+    email = email_collector.pop_for_recipient(host.email, last=True)
+    assert "confirm" in email.subject and surfer.name in email.subject
+    ics_event = _get_email_ics_attachment_calendar_event(email)
     assert _get_ics_event_sequence(ics_event) == 0
     assert not ics_event.status
     assert ics_event.name == f"Hosting {surfer.name}"
 
-    # Host cancels, surfer gets a calendar attachment
+    # Surfer cancels, host gets a calendar attachment
     with requests_session(surfer_token) as api:
-        with mock_notification_email() as mock:
-            api.RespondHostRequest(
-                requests_pb2.RespondHostRequestReq(
-                    host_request_id=hr_id,
-                    status=conversations_pb2.HOST_REQUEST_STATUS_CANCELLED,
-                    text="Cancelling host request",
-                )
+        api.RespondHostRequest(
+            requests_pb2.RespondHostRequestReq(
+                host_request_id=hr_id,
+                status=conversations_pb2.HOST_REQUEST_STATUS_CANCELLED,
+                text="Cancelling host request",
             )
+        )
 
-    e = email_fields(mock)
-    assert "cancel" in e.subject and surfer.name in e.subject
-    ics_event = _get_email_ics_attachment_calendar_event(e)
+    email = email_collector.pop_for_recipient(host.email, last=True)
+    assert "cancel" in email.subject and surfer.name in email.subject
+    ics_event = _get_email_ics_attachment_calendar_event(email)
     assert _get_ics_event_sequence(ics_event) == 1
     assert ics_event.status == "CANCELLED"
 

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -20,7 +20,7 @@ from couchers.proto import api_pb2, conversations_pb2, notification_data_pb2, no
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_HOURS
 from couchers.utils import Duration_from_timedelta, now, to_aware_datetime
 from tests.fixtures.db import generate_user, make_friends, make_user_block, make_user_invisible
-from tests.fixtures.misc import PushCollector, email_fields, mock_notification_email, process_jobs
+from tests.fixtures.misc import EmailCollector, PushCollector, process_jobs
 from tests.fixtures.sessions import api_session, conversations_session, notifications_session
 
 
@@ -753,49 +753,47 @@ def test_send_direct_message(db, moderator, push_collector: PushCollector):
         assert messages[0].author_user_id == user1.id
 
 
-def test_excessive_chat_initiations_are_reported(db):
+def test_excessive_chat_initiations_are_reported(db, email_collector: EmailCollector):
     """Test that excessive chat initiations are first reported in a warning email and finally lead blocking of further contacting other users."""
     user, token = generate_user()
     rate_limit_definition = RATE_LIMIT_DEFINITIONS[RateLimitAction.chat_initiation]
     with conversations_session(token) as c:
         # Test warning email
-        with mock_notification_email() as mock_email:
-            for _ in range(rate_limit_definition.warning_limit):
-                recipient_user, _ = generate_user()
-                _ = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[recipient_user.id]))
-
-            assert mock_email.call_count == 0
+        for _ in range(rate_limit_definition.warning_limit):
             recipient_user, _ = generate_user()
             _ = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[recipient_user.id]))
 
-            assert mock_email.call_count == 1
-            email = email_fields(mock_email).plain
-            assert email.startswith(
-                f"User {user.username} has sent {rate_limit_definition.warning_limit} chat initiations in the past {RATE_LIMIT_HOURS} hours."
-            )
+        assert email_collector.count_for_mods() == 0
+
+        recipient_user, _ = generate_user()
+        _ = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[recipient_user.id]))
+
+        email = email_collector.pop_for_mods(last=True)
+        assert email.plain.startswith(
+            f"User {user.username} has sent {rate_limit_definition.warning_limit} chat initiations in the past {RATE_LIMIT_HOURS} hours."
+        )
 
         # Test new chat initiations fail after exceeding CHAT_INITIATION_HARD_LIMIT
-        with mock_notification_email() as mock_email:
-            for _ in range(rate_limit_definition.hard_limit - rate_limit_definition.warning_limit - 1):
-                recipient_user, _ = generate_user()
-                _ = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[recipient_user.id]))
-
-            assert mock_email.call_count == 0
+        for _ in range(rate_limit_definition.hard_limit - rate_limit_definition.warning_limit - 1):
             recipient_user, _ = generate_user()
-            with pytest.raises(grpc.RpcError) as exc_info:
-                _ = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[recipient_user.id]))
-            assert exc_info.value.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
-            assert (
-                exc_info.value.details()
-                == "You have messaged a lot of users in the past 24 hours. To avoid spam, you can't contact any more users for now."
-            )
+            _ = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[recipient_user.id]))
 
-            assert mock_email.call_count == 1
-            email = email_fields(mock_email).plain
-            assert email.startswith(
-                f"User {user.username} has sent {rate_limit_definition.hard_limit} chat initiations in the past {RATE_LIMIT_HOURS} hours."
-            )
-            assert "The user has been blocked from sending further chat initiations for now." in email
+        assert email_collector.count_for_mods() == 0
+
+        recipient_user, _ = generate_user()
+        with pytest.raises(grpc.RpcError) as exc_info:
+            _ = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[recipient_user.id]))
+        assert exc_info.value.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
+        assert (
+            exc_info.value.details()
+            == "You have messaged a lot of users in the past 24 hours. To avoid spam, you can't contact any more users for now."
+        )
+
+        email = email_collector.pop_for_mods(last=True)
+        assert email.plain.startswith(
+            f"User {user.username} has sent {rate_limit_definition.hard_limit} chat initiations in the past {RATE_LIMIT_HOURS} hours."
+        )
+        assert "The user has been blocked from sending further chat initiations for now." in email.plain
 
 
 def test_leave_invite_to_group_chat(db, moderator):

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -763,12 +763,12 @@ def test_excessive_chat_initiations_are_reported(db, email_collector: EmailColle
             recipient_user, _ = generate_user()
             _ = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[recipient_user.id]))
 
-        assert email_collector.count_for_mods() == 0
+        assert email_collector.count_for_reports() == 0
 
         recipient_user, _ = generate_user()
         _ = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[recipient_user.id]))
 
-        email = email_collector.pop_for_mods(last=True)
+        email = email_collector.pop_for_reports(last=True)
         assert email.plain.startswith(
             f"User {user.username} has sent {rate_limit_definition.warning_limit} chat initiations in the past {RATE_LIMIT_HOURS} hours."
         )
@@ -778,7 +778,7 @@ def test_excessive_chat_initiations_are_reported(db, email_collector: EmailColle
             recipient_user, _ = generate_user()
             _ = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[recipient_user.id]))
 
-        assert email_collector.count_for_mods() == 0
+        assert email_collector.count_for_reports() == 0
 
         recipient_user, _ = generate_user()
         with pytest.raises(grpc.RpcError) as exc_info:
@@ -789,7 +789,7 @@ def test_excessive_chat_initiations_are_reported(db, email_collector: EmailColle
             == "You have messaged a lot of users in the past 24 hours. To avoid spam, you can't contact any more users for now."
         )
 
-        email = email_collector.pop_for_mods(last=True)
+        email = email_collector.pop_for_reports(last=True)
         assert email.plain.startswith(
             f"User {user.username} has sent {rate_limit_definition.hard_limit} chat initiations in the past {RATE_LIMIT_HOURS} hours."
         )

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -33,7 +33,7 @@ from couchers.tasks import (
 )
 from couchers.utils import Timestamp_from_datetime, now
 from tests.fixtures.db import generate_user, get_friend_relationship, make_friends
-from tests.fixtures.misc import Moderator, email_fields, mock_notification_email, process_jobs
+from tests.fixtures.misc import EmailCollector, Moderator, process_jobs
 from tests.fixtures.sessions import (
     api_session,
     auth_api_session,
@@ -49,24 +49,22 @@ def _(testconfig):
     pass
 
 
-def test_signup_verification_email(db):
+def test_signup_verification_email(db, email_collector: EmailCollector):
     request_email = f"{random_hex(12)}@couchers.org.invalid"
 
     flow = SignupFlow(name="Frodo", email=request_email, flow_token="")
 
     with session_scope() as session:
-        with mock_notification_email() as mock:
-            send_signup_email(session, flow)
+        send_signup_email(session, flow)
 
-    assert mock.call_count == 1
-    e = email_fields(mock)
-    assert e.recipient == request_email
+    email = email_collector.pop_for_recipient(request_email, last=True)
+    assert email.recipient == request_email
     assert flow.email_token
-    assert flow.email_token in e.html
-    assert flow.email_token in e.html
+    assert flow.email_token in email.html
+    assert flow.email_token in email.html
 
 
-def test_report_email(db):
+def test_report_email(db, email_collector: EmailCollector):
     user_reporter, api_token_author = generate_user()
     user_author, api_token_reported = generate_user()
 
@@ -83,8 +81,7 @@ def test_report_email(db):
         session.add(report)
         session.flush()
 
-        with mock_notification_email() as mock:
-            send_content_report_email(session, report)
+        send_content_report_email(session, report)
 
         # Load all data before session closes
         author_username = report.author_user.username
@@ -96,22 +93,20 @@ def test_report_email(db):
         reason = report.reason
         description = report.description
 
-    assert mock.call_count == 1
-
-    e = email_fields(mock)
-    assert e.recipient == "reports@couchers.org.invalid"
-    assert author_username in e.plain
-    assert str(author_id) in e.plain
-    assert author_email in e.plain
-    assert reporting_username in e.plain
-    assert str(reporting_id) in e.plain
-    assert reporting_email in e.plain
-    assert reason in e.plain
-    assert description in e.plain
-    assert "report" in e.subject.lower()
+    email = email_collector.pop_for_recipient("reports@couchers.org.invalid", last=True)
+    assert email.recipient == "reports@couchers.org.invalid"
+    assert author_username in email.plain
+    assert str(author_id) in email.plain
+    assert author_email in email.plain
+    assert reporting_username in email.plain
+    assert str(reporting_id) in email.plain
+    assert reporting_email in email.plain
+    assert reason in email.plain
+    assert description in email.plain
+    assert "report" in email.subject.lower()
 
 
-def test_reference_report_email_not_sent(db):
+def test_reference_report_email_not_sent(db, email_collector: EmailCollector):
     from_user, api_token_author = generate_user()
     to_user, api_token_reported = generate_user()
 
@@ -139,14 +134,12 @@ def test_reference_report_email_not_sent(db):
         moderation_state.object_id = reference.id
 
         # no email sent for a positive ref
+        maybe_send_reference_report_email(session, reference)
 
-        with mock_notification_email() as mock:
-            maybe_send_reference_report_email(session, reference)
-
-        assert mock.call_count == 0
+    assert email_collector.count_for_recipient("reports@couchers.org.invalid") == 0
 
 
-def test_reference_report_email(db):
+def test_reference_report_email(db, email_collector: EmailCollector):
     from_user, api_token_author = generate_user()
     to_user, api_token_reported = generate_user()
 
@@ -174,24 +167,25 @@ def test_reference_report_email(db):
         session.flush()
         moderation_state.object_id = reference.id
 
-        with mock_notification_email() as mock:
-            maybe_send_reference_report_email(session, reference)
+        maybe_send_reference_report_email(session, reference)
 
-        assert mock.call_count == 1
-        e = email_fields(mock)
-        assert e.recipient == "reports@couchers.org.invalid"
-        assert "report" in e.subject.lower()
-        assert "reference" in e.subject.lower()
-        assert from_user.username in e.plain
-        assert str(from_user.id) in e.plain
-        assert from_user.email in e.plain
-        assert to_user.username in e.plain
-        assert str(to_user.id) in e.plain
-        assert to_user.email in e.plain
-        assert reference.text in e.plain
-        assert "friend" in e.plain.lower()
-        assert reference.private_text
-        assert reference.private_text in e.plain
+        reference_text = reference.text
+        reference_private_text = reference.private_text
+
+    email = email_collector.pop_for_recipient("reports@couchers.org.invalid", last=True)
+    assert email.recipient == "reports@couchers.org.invalid"
+    assert "report" in email.subject.lower()
+    assert "reference" in email.subject.lower()
+    assert from_user.username in email.plain
+    assert str(from_user.id) in email.plain
+    assert from_user.email in email.plain
+    assert to_user.username in email.plain
+    assert str(to_user.id) in email.plain
+    assert to_user.email in email.plain
+    assert reference_text in email.plain
+    assert "friend" in email.plain.lower()
+    assert reference_private_text
+    assert reference_private_text in email.plain
 
 
 def test_email_patching_fails(db):
@@ -225,32 +219,30 @@ def test_email_patching_fails(db):
     assert str(e.value) == patched_msg
 
 
-def test_email_changed_confirmation_sent_to_new_email(db):
+def test_email_changed_confirmation_sent_to_new_email(db, email_collector: EmailCollector):
     confirmation_token = urlsafe_secure_token()
     user, user_token = generate_user()
     user.new_email = f"{random_hex(12)}@couchers.org.invalid"
     user.new_email_token = confirmation_token
     with session_scope() as session:
-        with mock_notification_email() as mock:
-            send_email_changed_confirmation_to_new_email(session, user)
+        send_email_changed_confirmation_to_new_email(session, user)
 
-    assert mock.call_count == 1
-    e = email_fields(mock)
-    assert "new email" in e.subject
-    assert e.recipient == user.new_email
-    assert user.name in e.plain
-    assert user.name in e.html
-    assert user.email in e.plain
-    assert user.email in e.html
-    assert "Your old email address is" in e.plain
-    assert "Your old email address is" in e.html
-    assert f"http://localhost:3000/confirm-email?token={confirmation_token}" in e.plain
-    assert f"http://localhost:3000/confirm-email?token={confirmation_token}" in e.html
-    assert "support@couchers.org" in e.plain
-    assert "support@couchers.org" in e.html
+    email = email_collector.pop_for_recipient(user.new_email, last=True)
+    assert "new email" in email.subject
+    assert email.recipient == user.new_email
+    assert user.name in email.plain
+    assert user.name in email.html
+    assert user.email in email.plain
+    assert user.email in email.html
+    assert "Your old email address is" in email.plain
+    assert "Your old email address is" in email.html
+    assert f"http://localhost:3000/confirm-email?token={confirmation_token}" in email.plain
+    assert f"http://localhost:3000/confirm-email?token={confirmation_token}" in email.html
+    assert "support@couchers.org" in email.plain
+    assert "support@couchers.org" in email.html
 
 
-def test_do_not_email_security(db):
+def test_do_not_email_security(db, email_collector: EmailCollector):
     user, token = generate_user()
 
     password_reset_token = urlsafe_secure_token()
@@ -260,37 +252,35 @@ def test_do_not_email_security(db):
 
     # make sure we still get security emails
 
-    with mock_notification_email() as mock:
-        with session_scope() as session:
-            notify(
-                session,
-                user_id=user.id,
-                topic_action=NotificationTopicAction.password_reset__start,
-                key="",
-                data=notification_data_pb2.PasswordResetStart(
-                    password_reset_token=password_reset_token,
-                ),
-            )
+    with session_scope() as session:
+        notify(
+            session,
+            user_id=user.id,
+            topic_action=NotificationTopicAction.password_reset__start,
+            key="",
+            data=notification_data_pb2.PasswordResetStart(
+                password_reset_token=password_reset_token,
+            ),
+        )
 
-    assert mock.call_count == 1
-    e = email_fields(mock)
-    assert e.recipient == user.email
-    assert "reset" in e.subject.lower()
-    assert password_reset_token in e.plain
-    assert password_reset_token in e.html
+    email = email_collector.pop_for_recipient(user.email, last=True)
+    assert email.recipient == user.email
+    assert "reset" in email.subject.lower()
+    assert password_reset_token in email.plain
+    assert password_reset_token in email.html
     unique_string = "You asked for your password to be reset on Couchers.org."
-    assert unique_string in e.plain
-    assert unique_string in e.html
-    assert f"http://localhost:3000/complete-password-reset?token={password_reset_token}" in e.plain
-    assert f"http://localhost:3000/complete-password-reset?token={password_reset_token}" in e.html
-    assert "support@couchers.org" in e.plain
-    assert "support@couchers.org" in e.html
+    assert unique_string in email.plain
+    assert unique_string in email.html
+    assert f"http://localhost:3000/complete-password-reset?token={password_reset_token}" in email.plain
+    assert f"http://localhost:3000/complete-password-reset?token={password_reset_token}" in email.html
+    assert "support@couchers.org" in email.plain
+    assert "support@couchers.org" in email.html
 
-    assert "/quick-link?payload=" not in e.plain
-    assert "/quick-link?payload=" not in e.html
+    assert "/quick-link?payload=" not in email.plain
+    assert "/quick-link?payload=" not in email.html
 
 
-def test_do_not_email_non_security(db):
+def test_do_not_email_non_security(db, email_collector: EmailCollector):
     user, token1 = generate_user(complete_profile=True)
     from_user, token2 = generate_user(complete_profile=True)
     # Need a moderator to approve the friend request since UMS defers notification
@@ -307,13 +297,10 @@ def test_do_not_email_non_security(db):
     assert friend_relationship is not None
     moderator.approve_friend_request(friend_relationship.id)
 
-    with mock_notification_email() as mock:
-        process_jobs()
-
-    assert mock.call_count == 0
+    assert email_collector.count_for_recipient(user.email) == 0
 
 
-def test_do_not_email_non_security_unsublink(db):
+def test_do_not_email_non_security_unsublink(db, email_collector: EmailCollector):
     user, _ = generate_user(complete_profile=True)
     from_user, token2 = generate_user(complete_profile=True)
     # Need a moderator to approve the friend request since UMS defers notification
@@ -327,37 +314,31 @@ def test_do_not_email_non_security_unsublink(db):
     assert friend_relationship is not None
     moderator.approve_friend_request(friend_relationship.id)
 
-    with mock_notification_email() as mock:
-        process_jobs()
+    email = email_collector.pop_for_recipient(user.email, last=True)
 
-    assert mock.call_count == 1
-    e = email_fields(mock)
-
-    assert "/quick-link?payload=" in e.plain
-    assert "/quick-link?payload=" in e.html
+    assert "/quick-link?payload=" in email.plain
+    assert "/quick-link?payload=" in email.html
 
 
-def test_email_prefix_config(db, monkeypatch):
+def test_email_prefix_config(db, email_collector: EmailCollector, monkeypatch):
     user, _ = generate_user()
 
-    with mock_notification_email() as mock:
-        with session_scope() as session:
-            notify(
-                session,
-                user_id=user.id,
-                topic_action=NotificationTopicAction.donation__received,
-                key="",
-                data=notification_data_pb2.DonationReceived(
-                    amount=20,
-                    receipt_url="https://example.com/receipt/12345",
-                ),
-            )
+    with session_scope() as session:
+        notify(
+            session,
+            user_id=user.id,
+            topic_action=NotificationTopicAction.donation__received,
+            key="",
+            data=notification_data_pb2.DonationReceived(
+                amount=20,
+                receipt_url="https://example.com/receipt/12345",
+            ),
+        )
 
-    assert mock.call_count == 1
-    e = email_fields(mock)
-    assert e.sender_name == "Couchers.org"
-    assert e.sender_email == "notify@couchers.org.invalid"
-    assert e.subject == "[TEST] Thank you for your donation to Couchers.org!"
+    email1 = email_collector.pop_for_recipient(user.email, last=True)
+    assert email1.sender_name == "Couchers.org"
+    assert email1.sender_email == "notify@couchers.org.invalid"
+    assert email1.subject == "[TEST] Thank you for your donation to Couchers.org!"
 
     new_config = config.copy()
     new_config["NOTIFICATION_EMAIL_SENDER"] = "TestCo"
@@ -366,24 +347,22 @@ def test_email_prefix_config(db, monkeypatch):
 
     monkeypatch.setattr(couchers.notifications.background, "config", new_config)
 
-    with mock_notification_email() as mock:
-        with session_scope() as session:
-            notify(
-                session,
-                user_id=user.id,
-                topic_action=NotificationTopicAction.donation__received,
-                key="",
-                data=notification_data_pb2.DonationReceived(
-                    amount=20,
-                    receipt_url="https://example.com/receipt/12345",
-                ),
-            )
+    with session_scope() as session:
+        notify(
+            session,
+            user_id=user.id,
+            topic_action=NotificationTopicAction.donation__received,
+            key="",
+            data=notification_data_pb2.DonationReceived(
+                amount=20,
+                receipt_url="https://example.com/receipt/12345",
+            ),
+        )
 
-    assert mock.call_count == 1
-    e = email_fields(mock)
-    assert e.sender_name == "TestCo"
-    assert e.sender_email == "testco@testing.co.invalid"
-    assert e.subject == "Thank you for your donation to Couchers.org!"
+    email2 = email_collector.pop_for_recipient(user.email, last=True)
+    assert email2.sender_name == "TestCo"
+    assert email2.sender_email == "testco@testing.co.invalid"
+    assert email2.subject == "Thank you for your donation to Couchers.org!"
 
 
 def test_send_donation_email(db, monkeypatch):
@@ -453,39 +432,37 @@ This is a security email, you cannot unsubscribe from it.
         assert email.source_data == "testing_version/donation_received"
 
 
-def test_chat_missed_messages_list_unsubscribe_header(db):
+def test_chat_missed_messages_list_unsubscribe_header(db, email_collector: EmailCollector):
     """
     Regression test: chat__missed_messages has key="" (it's a summary, not tied to a single chat).
     The List-Unsubscribe header must use a topic_action unsubscribe link, not a topic_key link.
     """
     user, _ = generate_user()
 
-    with mock_notification_email() as mock:
-        with session_scope() as session:
-            notify(
-                session,
-                user_id=user.id,
-                topic_action=NotificationTopicAction.chat__missed_messages,
-                key="",
-                data=notification_data_pb2.ChatMissedMessages(
-                    messages=[
-                        notification_data_pb2.ChatMessage(
-                            author=api_pb2.User(name="Test User", user_id=2, username="testuser"),
-                            message="You missed 1 message(s) from Test User",
-                            text="Hello!",
-                            group_chat_id=99,
-                        ),
-                    ],
-                ),
-            )
+    with session_scope() as session:
+        notify(
+            session,
+            user_id=user.id,
+            topic_action=NotificationTopicAction.chat__missed_messages,
+            key="",
+            data=notification_data_pb2.ChatMissedMessages(
+                messages=[
+                    notification_data_pb2.ChatMessage(
+                        author=api_pb2.User(name="Test User", user_id=2, username="testuser"),
+                        message="You missed 1 message(s) from Test User",
+                        text="Hello!",
+                        group_chat_id=99,
+                    ),
+                ],
+            ),
+        )
 
-    assert mock.call_count == 1
-    e = email_fields(mock)
+    email = email_collector.pop_for_recipient(user.email, last=True)
 
-    assert e.list_unsubscribe_header
+    assert email.list_unsubscribe_header
 
     # Extract the List-Unsubscribe URL and call the Unsubscribe endpoint
-    url = e.list_unsubscribe_header.strip("<>")
+    url = email.list_unsubscribe_header.strip("<>")
     url_parts = urlparse(url)
     params = parse_qs(url_parts.query)
 
@@ -499,7 +476,7 @@ def test_chat_missed_messages_list_unsubscribe_header(db):
         assert res.response
 
 
-def test_email_deleted_users_regression(db, moderator: Moderator):
+def test_email_deleted_users_regression(db, email_collector: EmailCollector, moderator: Moderator):
     """
     We introduced a bug in notify v2 where we would email deleted/banned users.
     """
@@ -551,9 +528,9 @@ def test_email_deleted_users_regression(db, moderator: Moderator):
     moderator.approve_event_occurrence(event_id)
 
     with events_session(creating_token) as api:
-        with mock_notification_email() as mock:
-            api.RequestCommunityInvite(events_pb2.RequestCommunityInviteReq(event_id=event_id))
-        assert mock.call_count == 1
+        api.RequestCommunityInvite(events_pb2.RequestCommunityInviteReq(event_id=event_id))
+
+    email_collector.pop_for_mods(last=True)
 
     with real_editor_session(super_token) as editor:
         res = editor.ListEventCommunityInviteRequests(editor_pb2.ListEventCommunityInviteRequestsReq())
@@ -571,12 +548,11 @@ def test_email_deleted_users_regression(db, moderator: Moderator):
         # should only notify creating_user, super_user and normal_user
         assert res.requests[0].approx_users_to_notify == 3
 
-        with mock_notification_email() as mock:
-            editor.DecideEventCommunityInviteRequest(
-                editor_pb2.DecideEventCommunityInviteRequestReq(
-                    event_community_invite_request_id=res.requests[0].event_community_invite_request_id,
-                    approve=True,
-                )
+        editor.DecideEventCommunityInviteRequest(
+            editor_pb2.DecideEventCommunityInviteRequestReq(
+                event_community_invite_request_id=res.requests[0].event_community_invite_request_id,
+                approve=True,
             )
+        )
 
-        assert mock.call_count == 3
+    assert email_collector.count() == 3

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -26,7 +26,7 @@ from couchers.proto import editor_pb2, events_pb2, threads_pb2
 from couchers.tasks import enforce_community_memberships
 from couchers.utils import Timestamp_from_datetime, now, to_aware_datetime
 from tests.fixtures.db import generate_user
-from tests.fixtures.misc import Moderator, PushCollector, email_fields, mock_notification_email, process_jobs
+from tests.fixtures.misc import EmailCollector, Moderator, PushCollector, process_jobs
 from tests.fixtures.sessions import events_session, real_editor_session, threads_session
 from tests.test_communities import create_community, create_group
 
@@ -2341,7 +2341,7 @@ def test_list_past_events_regression(db):
         assert len(res.events) == 1
 
 
-def test_community_invite_requests(db, moderator: Moderator):
+def test_community_invite_requests(db, email_collector: EmailCollector, moderator: Moderator):
     user1, token1 = generate_user(complete_profile=True)
     user2, token2 = generate_user()
     user3, token3 = generate_user()
@@ -2378,14 +2378,12 @@ def test_community_invite_requests(db, moderator: Moderator):
     moderator.approve_event_occurrence(event_id)
 
     with events_session(token1) as api:
-        with mock_notification_email() as mock:
-            api.RequestCommunityInvite(events_pb2.RequestCommunityInviteReq(event_id=event_id))
-        assert mock.call_count == 1
-        e = email_fields(mock)
-        assert e.recipient == "mods@couchers.org.invalid"
+        api.RequestCommunityInvite(events_pb2.RequestCommunityInviteReq(event_id=event_id))
 
-        assert user_url in e.plain
-        assert event_url in e.plain
+        email = email_collector.pop_for_mods(last=True)
+
+        assert user_url in email.plain
+        assert event_url in email.plain
 
         # can't send another req
         with pytest.raises(grpc.RpcError) as err:

--- a/app/backend/src/tests/test_jail.py
+++ b/app/backend/src/tests/test_jail.py
@@ -8,7 +8,7 @@ from couchers.proto import admin_pb2, api_pb2, jail_pb2
 from couchers.servicers import jail as servicers_jail
 from couchers.utils import create_coordinate, to_aware_datetime
 from tests.fixtures.db import generate_user
-from tests.fixtures.misc import PushCollector, email_fields, mock_notification_email
+from tests.fixtures.misc import EmailCollector, PushCollector, process_jobs
 from tests.fixtures.sessions import real_account_session, real_admin_session, real_api_session, real_jail_session
 
 
@@ -184,8 +184,7 @@ def test_MarkUserNeedsLocationUpdate(db):
         assert len(res.pending_mod_notes) == 0
 
     with real_admin_session(super_token) as admin:
-        with mock_notification_email() as mock:
-            admin.MarkUserNeedsLocationUpdate(admin_pb2.MarkUserNeedsLocationUpdateReq(user=user.username))
+        admin.MarkUserNeedsLocationUpdate(admin_pb2.MarkUserNeedsLocationUpdateReq(user=user.username))
 
     with real_jail_session(token) as jail:
         res = jail.JailInfo(empty_pb2.Empty())
@@ -263,7 +262,7 @@ def test_AcceptCommunityGuidelines(db):
         assert not res.has_not_accepted_community_guidelines
 
 
-def test_modnotes(db, push_collector: PushCollector):
+def test_modnotes(db, email_collector: EmailCollector, push_collector: PushCollector):
     user, token = generate_user()
     super_user, super_token = generate_user(is_superuser=True)
 
@@ -278,24 +277,20 @@ def test_modnotes(db, push_collector: PushCollector):
         assert len(res.mod_notes) == 0
 
     with real_admin_session(super_token) as admin:
-        with mock_notification_email() as mock:
-            admin.SendModNote(
-                admin_pb2.SendModNoteReq(
-                    user=user.username,
-                    content="# Important note\nThis is a sample mod note.",
-                    internal_id="sample_note",
-                )
+        admin.SendModNote(
+            admin_pb2.SendModNoteReq(
+                user=user.username,
+                content="# Important note\nThis is a sample mod note.",
+                internal_id="sample_note",
             )
-        mock.assert_called_once()
-        fields = email_fields(mock)
-
-        assert fields.subject == "[TEST] You have received a mod note"
-        push = push_collector.pop_for_user(user.id, last=True)
-        assert push.content.title == "New moderator note"
-        assert (
-            push.content.body
-            == "You received a moderator note. Read and acknowledge it to continue using the platform."
         )
+
+    email = email_collector.pop_for_recipient(user.email, last=True)
+    assert email.subject == "[TEST] You have received a mod note"
+
+    push = push_collector.pop_for_user(user.id, last=True)
+    assert push.content.title == "New moderator note"
+    assert push.content.body == "You received a moderator note. Read and acknowledge it to continue using the platform."
 
     with real_jail_session(token) as jail:
         res = jail.JailInfo(empty_pb2.Empty())
@@ -353,7 +348,7 @@ def test_modnotes(db, push_collector: PushCollector):
         assert to_aware_datetime(note.acknowledged) > to_aware_datetime(note.created)
 
 
-def test_modnotes_no_notify(db, push_collector: PushCollector):
+def test_modnotes_no_notify(db, email_collector: EmailCollector, push_collector: PushCollector):
     user, token = generate_user()
     super_user, super_token = generate_user(is_superuser=True)
 
@@ -368,16 +363,16 @@ def test_modnotes_no_notify(db, push_collector: PushCollector):
         assert len(res.mod_notes) == 0
 
     with real_admin_session(super_token) as admin:
-        with mock_notification_email() as mock:
-            admin.SendModNote(
-                admin_pb2.SendModNoteReq(
-                    user=user.username,
-                    content="# Important note\nThis is a sample mod note.",
-                    internal_id="sample_note",
-                    do_not_notify=True,
-                )
+        admin.SendModNote(
+            admin_pb2.SendModNoteReq(
+                user=user.username,
+                content="# Important note\nThis is a sample mod note.",
+                internal_id="sample_note",
+                do_not_notify=True,
             )
-        mock.assert_not_called()
+        )
+
+    assert email_collector.count_for_recipient(user.email) == 0
 
     with real_jail_session(token) as jail:
         res = jail.JailInfo(empty_pb2.Empty())

--- a/app/backend/src/tests/test_jail.py
+++ b/app/backend/src/tests/test_jail.py
@@ -8,7 +8,7 @@ from couchers.proto import admin_pb2, api_pb2, jail_pb2
 from couchers.servicers import jail as servicers_jail
 from couchers.utils import create_coordinate, to_aware_datetime
 from tests.fixtures.db import generate_user
-from tests.fixtures.misc import EmailCollector, PushCollector, process_jobs
+from tests.fixtures.misc import EmailCollector, PushCollector
 from tests.fixtures.sessions import real_account_session, real_admin_session, real_api_session, real_jail_session
 
 

--- a/app/backend/src/tests/test_moderation.py
+++ b/app/backend/src/tests/test_moderation.py
@@ -2258,6 +2258,7 @@ def test_host_request_message_notifications_suppressed_before_approval(
         )
 
     # Host should STILL have no notifications (messages sent while SHADOWED)
+    assert email_collector.count_for_recipient(host.email) == 0
     assert push_collector.count_for_user(host.id) == 0
 
     # Now approve the request

--- a/app/backend/src/tests/test_moderation.py
+++ b/app/backend/src/tests/test_moderation.py
@@ -32,7 +32,7 @@ from couchers.moderation.utils import create_moderation
 from couchers.proto import api_pb2, conversations_pb2, events_pb2, moderation_pb2, notifications_pb2, requests_pb2
 from couchers.utils import Timestamp_from_datetime, now, today
 from tests.fixtures.db import generate_user, make_friends
-from tests.fixtures.misc import PushCollector, mock_notification_email, process_jobs
+from tests.fixtures.misc import EmailCollector, PushCollector, process_jobs
 from tests.fixtures.sessions import (
     api_session,
     conversations_session,
@@ -1785,7 +1785,7 @@ def test_group_chat_moderation_shadow(db):
 # ============================================================================
 
 
-def test_auto_approve_moderation_queue_disabled_when_zero(db):
+def test_auto_approve_moderation_queue_disabled_when_zero(db, email_collector: EmailCollector):
     """Test that auto-approval is disabled when deadline is 0"""
     moderator, mod_token = generate_user(is_superuser=True)
     user1, token1 = generate_user()
@@ -1796,18 +1796,17 @@ def test_auto_approve_moderation_queue_disabled_when_zero(db):
 
     # Create a host request
     with requests_session(token1) as api:
-        with mock_notification_email() as mock:
-            host_request_id = api.CreateHostRequest(
-                requests_pb2.CreateHostRequestReq(
-                    host_user_id=user2.id,
-                    from_date=today_plus_2,
-                    to_date=today_plus_3,
-                    text=valid_request_text(),
-                )
-            ).host_request_id
+        host_request_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=user2.id,
+                from_date=today_plus_2,
+                to_date=today_plus_3,
+                text=valid_request_text(),
+            )
+        ).host_request_id
 
         # No email should have been sent (request is shadowed)
-        mock.assert_not_called()
+        assert email_collector.count_for_recipient(user2.email) == 0
 
         # Ensure deadline is 0 (disabled)
         config["MODERATION_AUTO_APPROVE_DEADLINE_SECONDS"] = 0
@@ -1850,7 +1849,9 @@ def test_auto_approve_moderation_queue_disabled_when_zero(db):
         assert state_res.moderation_state.visibility == moderation_pb2.MODERATION_VISIBILITY_SHADOWED
 
 
-def test_auto_approve_moderation_queue_approves_old_items(db, push_collector: PushCollector):
+def test_auto_approve_moderation_queue_approves_old_items(
+    db, email_collector: EmailCollector, push_collector: PushCollector
+):
     """Test that auto-approval approves items older than the deadline"""
     moderator, mod_token = generate_user(is_superuser=True)
     user1, token1 = generate_user()
@@ -1861,18 +1862,17 @@ def test_auto_approve_moderation_queue_approves_old_items(db, push_collector: Pu
 
     # Create a host request
     with requests_session(token1) as api:
-        with mock_notification_email() as mock:
-            host_request_id = api.CreateHostRequest(
-                requests_pb2.CreateHostRequestReq(
-                    host_user_id=user2.id,
-                    from_date=today_plus_2,
-                    to_date=today_plus_3,
-                    text=valid_request_text("Test request for auto-approval"),
-                )
-            ).host_request_id
+        host_request_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=user2.id,
+                from_date=today_plus_2,
+                to_date=today_plus_3,
+                text=valid_request_text("Test request for auto-approval"),
+            )
+        ).host_request_id
 
         # No email sent initially (shadowed)
-        mock.assert_not_called()
+        assert email_collector.count_for_recipient(user2.email) == 0
 
     # Host cannot see the request yet
     with requests_session(token2) as api:
@@ -1943,7 +1943,7 @@ def test_auto_approve_moderation_queue_approves_old_items(db, push_collector: Pu
         assert approve_entries[0].moderator_user_id == moderator.id
 
 
-def test_auto_approve_does_not_approve_recent_items(db):
+def test_auto_approve_does_not_approve_recent_items(db, email_collector: EmailCollector):
     """Test that auto-approval does not approve items that are newer than the deadline"""
     moderator, mod_token = generate_user(is_superuser=True)
     user1, token1 = generate_user()
@@ -1954,29 +1954,27 @@ def test_auto_approve_does_not_approve_recent_items(db):
 
     # Create a host request
     with requests_session(token1) as api:
-        with mock_notification_email() as mock:
-            host_request_id = api.CreateHostRequest(
-                requests_pb2.CreateHostRequestReq(
-                    host_user_id=user2.id,
-                    from_date=today_plus_2,
-                    to_date=today_plus_3,
-                    text=valid_request_text(),
-                )
-            ).host_request_id
+        host_request_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=user2.id,
+                from_date=today_plus_2,
+                to_date=today_plus_3,
+                text=valid_request_text(),
+            )
+        ).host_request_id
 
         # No email sent (shadowed)
-        mock.assert_not_called()
+        assert email_collector.count_for_recipient(user2.email) == 0
 
     # Set deadline to 1 hour (items older than 1 hour will be auto-approved)
     config["MODERATION_AUTO_APPROVE_DEADLINE_SECONDS"] = 3600
     config["MODERATION_BOT_USER_ID"] = moderator.id
 
     # Run the job - the item was just created, so it shouldn't be approved
-    with mock_notification_email() as mock:
-        auto_approve_moderation_queue(empty_pb2.Empty())
+    auto_approve_moderation_queue(empty_pb2.Empty())
 
-        # Still no email sent
-        mock.assert_not_called()
+    # Still no email sent
+    assert email_collector.count_for_recipient(user2.email) == 0
 
     # Host still cannot see the request
     with requests_session(token2) as api:
@@ -2216,7 +2214,9 @@ def test_auto_approve_skips_shadowed_user_authored_items(db):
 # ============================================================================
 
 
-def test_host_request_message_notifications_suppressed_before_approval(db, push_collector: PushCollector, moderator):
+def test_host_request_message_notifications_suppressed_before_approval(
+    db, email_collector: EmailCollector, push_collector: PushCollector, moderator
+):
     """
     Test that notifications are NOT sent for messages in host requests
     that haven't been approved yet.
@@ -2239,6 +2239,7 @@ def test_host_request_message_notifications_suppressed_before_approval(db, push_
         ).host_request_id
 
     # No notifications should have been sent to the host (request is SHADOWED)
+    assert email_collector.count_for_recipient(host.email) == 0
     assert push_collector.count_for_user(host.id) == 0
 
     # Send additional messages BEFORE approval - should NOT generate notifications
@@ -2260,8 +2261,8 @@ def test_host_request_message_notifications_suppressed_before_approval(db, push_
     assert push_collector.count_for_user(host.id) == 0
 
     # Now approve the request
-    with mock_notification_email():
-        moderator.approve_host_request(hr_id)
+    moderator.approve_host_request(hr_id)
+    email_collector.pop_for_recipient(host.email)
 
     # Host should now have 3 notifications (all deferred notifications are delivered on approval):
     # 1. host_request:create (the initial request)
@@ -2315,7 +2316,9 @@ def test_host_request_status_notifications_suppressed_before_approval(db, push_c
     assert push_collector.count_for_user(host.id) == 0
 
 
-def test_host_request_notifications_sent_after_approval(db, push_collector: PushCollector, moderator):
+def test_host_request_notifications_sent_after_approval(
+    db, email_collector: EmailCollector, push_collector: PushCollector, moderator
+):
     """
     Test that after a host request is approved, all notifications work normally.
     """
@@ -2336,39 +2339,39 @@ def test_host_request_notifications_sent_after_approval(db, push_collector: Push
             )
         ).host_request_id
 
-    with mock_notification_email():
-        moderator.approve_host_request(hr_id)
+    moderator.approve_host_request(hr_id)
 
     # Host should have received 1 notification (the approval notification)
+    email_collector.pop_for_recipient(host.email, last=True)
     push_collector.pop_for_user(host.id, last=True)
 
     # Host accepts the request - surfer should be notified
     with requests_session(host_token) as api:
-        with mock_notification_email():
-            api.RespondHostRequest(
-                requests_pb2.RespondHostRequestReq(
-                    host_request_id=hr_id,
-                    status=conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED,
-                    text="Sure, come on over!",
-                )
+        api.RespondHostRequest(
+            requests_pb2.RespondHostRequestReq(
+                host_request_id=hr_id,
+                status=conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED,
+                text="Sure, come on over!",
             )
+        )
 
     # Surfer should have 1 notification (the accept notification)
+    email_collector.pop_for_recipient(surfer.email, last=True)
     push = push_collector.pop_for_user(surfer.id, last=True)
     assert push.content.title == f"{host.name} accepted your host request"
 
     # Surfer confirms - host should be notified
     with requests_session(surfer_token) as api:
-        with mock_notification_email():
-            api.RespondHostRequest(
-                requests_pb2.RespondHostRequestReq(
-                    host_request_id=hr_id,
-                    status=conversations_pb2.HOST_REQUEST_STATUS_CONFIRMED,
-                    text="See you then!",
-                )
+        api.RespondHostRequest(
+            requests_pb2.RespondHostRequestReq(
+                host_request_id=hr_id,
+                status=conversations_pb2.HOST_REQUEST_STATUS_CONFIRMED,
+                text="See you then!",
             )
+        )
 
     # Host should now have received the confirmation notifications
+    email_collector.pop_for_recipient(host.email, last=True)
     push = push_collector.pop_for_user(host.id, last=True)
     assert push.content.title == f"{surfer.name} confirmed their host request"
 

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -49,7 +49,7 @@ from couchers.proto.internal import jobs_pb2, unsubscribe_pb2
 from couchers.servicers.api import user_model_to_pb
 from couchers.utils import not_none, now
 from tests.fixtures.db import generate_user
-from tests.fixtures.misc import PushCollector, email_fields, mock_notification_email, process_jobs
+from tests.fixtures.misc import EmailCollector, PushCollector, process_jobs
 from tests.fixtures.sessions import (
     api_session,
     auth_api_session,
@@ -139,7 +139,7 @@ def test_SetNotificationSettings_preferences_not_editable(db):
         assert e.value.details() == "That notification preference is not user editable."
 
 
-def test_unsubscribe(db):
+def test_unsubscribe(db, email_collector: EmailCollector):
     # this is the ugliest test i've written
 
     user, token = generate_user()
@@ -162,25 +162,24 @@ def test_unsubscribe(db):
             )
         )
 
-    with mock_notification_email() as mock:
-        with session_scope() as session:
-            notify(
-                session,
-                user_id=user.id,
-                topic_action=topic_action,
-                key="",
-                data=notification_data_pb2.BadgeAdd(
-                    badge_id="volunteer",
-                    badge_name="Active Volunteer",
-                    badge_description="This user is an active volunteer for Couchers.org",
-                ),
-            )
+    with session_scope() as session:
+        notify(
+            session,
+            user_id=user.id,
+            topic_action=topic_action,
+            key="",
+            data=notification_data_pb2.BadgeAdd(
+                badge_id="volunteer",
+                badge_name="Active Volunteer",
+                badge_description="This user is an active volunteer for Couchers.org",
+            ),
+        )
 
-    assert mock.call_count == 1
-    assert email_fields(mock).recipient == user.email
+    email = email_collector.pop_for_recipient(user.email, last=True)
+
     # very ugly
     # http://localhost:3000/quick-link?payload=CAEiGAoOZnJpZW5kX3JlcXVlc3QSBmFjY2VwdA==&sig=BQdk024NTATm8zlR0krSXTBhP5U9TlFv7VhJeIHZtUg=
-    for link in re.findall(r'<a href="(.*?)"', email_fields(mock).html):
+    for link in re.findall(r'<a href="(.*?)"', email.html):
         if "payload" not in link:
             continue
         print(link)
@@ -212,24 +211,23 @@ def test_unsubscribe(db):
                 if topic == topic_action.topic and item == topic_action.action:
                     assert not item.email
 
-    with mock_notification_email() as mock:
-        with session_scope() as session:
-            notify(
-                session,
-                user_id=user.id,
-                topic_action=topic_action,
-                key="",
-                data=notification_data_pb2.BadgeAdd(
-                    badge_id="volunteer",
-                    badge_name="Active Volunteer",
-                    badge_description="This user is an active volunteer for Couchers.org",
-                ),
-            )
+    with session_scope() as session:
+        notify(
+            session,
+            user_id=user.id,
+            topic_action=topic_action,
+            key="",
+            data=notification_data_pb2.BadgeAdd(
+                badge_id="volunteer",
+                badge_name="Active Volunteer",
+                badge_description="This user is an active volunteer for Couchers.org",
+            ),
+        )
 
-    assert mock.call_count == 0
+    assert email_collector.count_for_recipient(user.email) == 0
 
 
-def test_unsubscribe_do_not_email(db, moderator):
+def test_unsubscribe_do_not_email(db, email_collector: EmailCollector, moderator):
     user, token = generate_user()
 
     _, token2 = generate_user(complete_profile=True)
@@ -239,14 +237,13 @@ def test_unsubscribe_do_not_email(db, moderator):
         fr_id = res.sent[0].friend_request_id
 
     # Moderator approves the friend request, which triggers the notification email
-    with mock_notification_email() as mock:
-        moderator.approve_friend_request(fr_id)
+    moderator.approve_friend_request(fr_id)
 
-    assert mock.call_count == 1
-    assert email_fields(mock).recipient == user.email
+    email = email_collector.pop_for_recipient(user.email, last=True)
+    assert email.recipient == user.email
     # very ugly
     # http://localhost:3000/quick-link?payload=CAEiGAoOZnJpZW5kX3JlcXVlc3QSBmFjY2VwdA==&sig=BQdk024NTATm8zlR0krSXTBhP5U9TlFv7VhJeIHZtUg=
-    for link in re.findall(r'<a href="(.*?)"', email_fields(mock).html):
+    for link in re.findall(r'<a href="(.*?)"', email.html):
         if "payload" not in link:
             continue
         print(link)
@@ -276,10 +273,9 @@ def test_unsubscribe_do_not_email(db, moderator):
         fr_id3 = res.sent[0].friend_request_id
 
     # Approving this friend request should NOT send an email since user has do_not_email set
-    with mock_notification_email() as mock:
-        moderator.approve_friend_request(fr_id3)
+    moderator.approve_friend_request(fr_id3)
 
-    assert mock.call_count == 0
+    assert email_collector.count_for_recipient(user.email) == 0
 
     with session_scope() as session:
         user_ = session.execute(select(User).where(User.id == user.id)).scalar_one()
@@ -552,7 +548,7 @@ def test_SendTestPushNotification(db, push_collector: PushCollector):
     assert push.content.body == "If you see this, then it's working :)"
 
 
-def test_SendBlogPostNotification(db, push_collector: PushCollector):
+def test_SendBlogPostNotification(db, email_collector: EmailCollector, push_collector: PushCollector):
     super_user, super_token = generate_user(is_superuser=True)
 
     user1, user1_token = generate_user()
@@ -591,26 +587,23 @@ def test_SendBlogPostNotification(db, push_collector: PushCollector):
             )
         )
 
-    with mock_notification_email() as mock:
-        with real_editor_session(super_token) as editor_api:
-            editor_api.SendBlogPostNotification(
-                editor_pb2.SendBlogPostNotificationReq(
-                    title="Couchers.org v0.9.9 Release Notes",
-                    blurb="Read about last major updates before v1!",
-                    url="https://couchers.org/blog/2025/05/11/v0.9.9-release",
-                )
+    with real_editor_session(super_token) as editor_api:
+        editor_api.SendBlogPostNotification(
+            editor_pb2.SendBlogPostNotificationReq(
+                title="Couchers.org v0.9.9 Release Notes",
+                blurb="Read about last major updates before v1!",
+                url="https://couchers.org/blog/2025/05/11/v0.9.9-release",
             )
+        )
 
-    process_jobs()
-
-    assert mock.call_count == 1
-    assert email_fields(mock).recipient == user2.email
-    assert "Couchers.org v0.9.9 Release Notes" in email_fields(mock).html
-    assert "Couchers.org v0.9.9 Release Notes" in email_fields(mock).plain
-    assert "Read about last major updates before v1!" in email_fields(mock).html
-    assert "Read about last major updates before v1!" in email_fields(mock).plain
-    assert "https://couchers.org/blog/2025/05/11/v0.9.9-release" in email_fields(mock).html
-    assert "https://couchers.org/blog/2025/05/11/v0.9.9-release" in email_fields(mock).plain
+    email = email_collector.pop_for_recipient(user2.email, last=True)
+    assert email.recipient == user2.email
+    assert "Couchers.org v0.9.9 Release Notes" in email.html
+    assert "Couchers.org v0.9.9 Release Notes" in email.plain
+    assert "Read about last major updates before v1!" in email.html
+    assert "Read about last major updates before v1!" in email.plain
+    assert "https://couchers.org/blog/2025/05/11/v0.9.9-release" in email.html
+    assert "https://couchers.org/blog/2025/05/11/v0.9.9-release" in email.plain
 
     push = push_collector.pop_for_user(user1.id, last=True)
     assert push.content.title == "New blog post: Couchers.org v0.9.9 Release Notes"
@@ -665,39 +658,38 @@ def test_get_topic_actions_by_delivery_type(db):
         assert NotificationTopicAction.account_deletion__start in deliver
 
 
-def test_event_reminder_email_sent(db):
+def test_event_reminder_email_sent(db, email_collector: EmailCollector):
     user, token = generate_user()
     title = "Board Game Night"
     start_event_time = timestamp_pb2.Timestamp(seconds=1751690400)
 
     expected_time_str = LocalizationContext.from_user(user).localize_datetime(start_event_time)
 
-    with mock_notification_email() as mock:
-        with session_scope() as session:
-            user_in_session = session.get_one(User, user.id)
+    with session_scope() as session:
+        user_in_session = session.get_one(User, user.id)
 
-            notify(
-                session,
-                user_id=user.id,
-                topic_action=NotificationTopicAction.event__reminder,
-                key="",
-                data=notification_data_pb2.EventReminder(
-                    event=events_pb2.Event(
-                        event_id=1,
-                        slug="board-game-night",
-                        title=title,
-                        start_time=start_event_time,
-                    ),
-                    user=user_model_to_pb(user_in_session, session, make_background_user_context(user_id=user.id)),
+        notify(
+            session,
+            user_id=user.id,
+            topic_action=NotificationTopicAction.event__reminder,
+            key="",
+            data=notification_data_pb2.EventReminder(
+                event=events_pb2.Event(
+                    event_id=1,
+                    slug="board-game-night",
+                    title=title,
+                    start_time=start_event_time,
                 ),
-            )
+                user=user_model_to_pb(user_in_session, session, make_background_user_context(user_id=user.id)),
+            ),
+        )
 
-    assert mock.call_count == 1
-    assert email_fields(mock).recipient == user.email
-    assert title in email_fields(mock).html
-    assert title in email_fields(mock).plain
-    assert expected_time_str in email_fields(mock).html
-    assert expected_time_str in email_fields(mock).plain
+    email = email_collector.pop_for_recipient(user.email, last=True)
+    assert email.recipient == user.email
+    assert title in email.html
+    assert title in email.plain
+    assert expected_time_str in email.html
+    assert expected_time_str in email.plain
 
 
 def test_RegisterMobilePushNotificationSubscription(db):
@@ -1374,7 +1366,7 @@ def test_DebugRedeliverPushNotification_push_notifications_disabled(db, push_col
     assert push_collector.count_for_user(user.id) == 0
 
 
-def test_handle_notification_email_delivery(db):
+def test_handle_notification_email_delivery(db, email_collector: EmailCollector):
     """Test that email notifications are delivered when email preference is enabled."""
     user, token = generate_user()
 
@@ -1395,22 +1387,21 @@ def test_handle_notification_email_delivery(db):
             )
         )
 
-    with mock_notification_email() as mock:
-        with session_scope() as session:
-            notify(
-                session,
-                user_id=user.id,
-                topic_action=topic_action,
-                key="test-badge",
-                data=notification_data_pb2.BadgeAdd(
-                    badge_id="volunteer",
-                    badge_name="Active Volunteer",
-                    badge_description="This user is an active volunteer",
-                ),
-            )
+    with session_scope() as session:
+        notify(
+            session,
+            user_id=user.id,
+            topic_action=topic_action,
+            key="test-badge",
+            data=notification_data_pb2.BadgeAdd(
+                badge_id="volunteer",
+                badge_name="Active Volunteer",
+                badge_description="This user is an active volunteer",
+            ),
+        )
 
-    assert mock.call_count == 1
-    assert email_fields(mock).recipient == user.email
+    email = email_collector.pop_for_recipient(user.email, last=True)
+    assert email.recipient == user.email
 
     with session_scope() as session:
         delivery = session.execute(
@@ -1509,7 +1500,7 @@ def test_handle_notification_digest_delivery(db):
         assert delivery.delivered is None
 
 
-def test_handle_notification_banned_user_no_email(db):
+def test_handle_notification_banned_user_no_email(db, email_collector: EmailCollector):
     """Test that banned users don't receive email notifications."""
     user, token = generate_user()
 
@@ -1534,25 +1525,24 @@ def test_handle_notification_banned_user_no_email(db):
     with session_scope() as session:
         session.execute(update(User).where(User.id == user.id).values(banned_at=now()))
 
-    with mock_notification_email() as mock:
-        with session_scope() as session:
-            notify(
-                session,
-                user_id=user.id,
-                topic_action=topic_action,
-                key="test-badge",
-                data=notification_data_pb2.BadgeAdd(
-                    badge_id="volunteer",
-                    badge_name="Active Volunteer",
-                    badge_description="This user is an active volunteer",
-                ),
-            )
+    with session_scope() as session:
+        notify(
+            session,
+            user_id=user.id,
+            topic_action=topic_action,
+            key="test-badge",
+            data=notification_data_pb2.BadgeAdd(
+                badge_id="volunteer",
+                badge_name="Active Volunteer",
+                badge_description="This user is an active volunteer",
+            ),
+        )
 
     # Email should not be sent to the banned user
-    assert mock.call_count == 0
+    assert email_collector.count_for_recipient(user.email) == 0
 
 
-def test_handle_notification_deleted_user_no_regular_email(db):
+def test_handle_notification_deleted_user_no_regular_email(db, email_collector: EmailCollector):
     """Test that deleted users don't receive non-account-deletion email notifications."""
     user, token = generate_user()
 
@@ -1577,25 +1567,24 @@ def test_handle_notification_deleted_user_no_regular_email(db):
     with session_scope() as session:
         session.execute(update(User).where(User.id == user.id).values(deleted_at=now()))
 
-    with mock_notification_email() as mock:
-        with session_scope() as session:
-            notify(
-                session,
-                user_id=user.id,
-                topic_action=topic_action,
-                key="test-badge",
-                data=notification_data_pb2.BadgeAdd(
-                    badge_id="volunteer",
-                    badge_name="Active Volunteer",
-                    badge_description="This user is an active volunteer",
-                ),
-            )
+    with session_scope() as session:
+        notify(
+            session,
+            user_id=user.id,
+            topic_action=topic_action,
+            key="test-badge",
+            data=notification_data_pb2.BadgeAdd(
+                badge_id="volunteer",
+                badge_name="Active Volunteer",
+                badge_description="This user is an active volunteer",
+            ),
+        )
 
     # Email should not be sent to deleted user for non-account-deletion notification
-    assert mock.call_count == 0
+    assert email_collector.count_for_recipient(user.email) == 0
 
 
-def test_handle_notification_deleted_user_receives_account_deletion_email(db):
+def test_handle_notification_deleted_user_receives_account_deletion_email(db, email_collector: EmailCollector):
     """Test that deleted users CAN receive account deletion notifications."""
     user, token = generate_user()
 
@@ -1605,25 +1594,24 @@ def test_handle_notification_deleted_user_receives_account_deletion_email(db):
     with session_scope() as session:
         session.execute(update(User).where(User.id == user.id).values(deleted_at=now()))
 
-    with mock_notification_email() as mock:
-        with session_scope() as session:
-            notify(
-                session,
-                user_id=user.id,
-                topic_action=topic_action,
-                key="",
-                data=notification_data_pb2.AccountDeletionComplete(
-                    undelete_token="test-token",
-                    undelete_days=7,
-                ),
-            )
+    with session_scope() as session:
+        notify(
+            session,
+            user_id=user.id,
+            topic_action=topic_action,
+            key="",
+            data=notification_data_pb2.AccountDeletionComplete(
+                undelete_token="test-token",
+                undelete_days=7,
+            ),
+        )
 
     # Email SHOULD be sent to deleted user for account deletion notification
-    assert mock.call_count == 1
-    assert email_fields(mock).recipient == user.email
+    email = email_collector.pop_for_recipient(user.email, last=True)
+    assert email.recipient == user.email
 
 
-def test_handle_notification_do_not_email_respected(db):
+def test_handle_notification_do_not_email_respected(db, email_collector: EmailCollector):
     """Test that users with do_not_email set don't receive non-critical emails."""
     user, token = generate_user()
 
@@ -1656,25 +1644,24 @@ def test_handle_notification_do_not_email_respected(db):
             )
         )
 
-    with mock_notification_email() as mock:
-        with session_scope() as session:
-            notify(
-                session,
-                user_id=user.id,
-                topic_action=topic_action,
-                key="test-badge",
-                data=notification_data_pb2.BadgeAdd(
-                    badge_id="volunteer",
-                    badge_name="Active Volunteer",
-                    badge_description="This user is an active volunteer",
-                ),
-            )
+    with session_scope() as session:
+        notify(
+            session,
+            user_id=user.id,
+            topic_action=topic_action,
+            key="test-badge",
+            data=notification_data_pb2.BadgeAdd(
+                badge_id="volunteer",
+                badge_name="Active Volunteer",
+                badge_description="This user is an active volunteer",
+            ),
+        )
 
     # Email should not be sent when do_not_email is True
-    assert mock.call_count == 0
+    assert email_collector.count_for_recipient(user.email) == 0
 
 
-def test_handle_notification_critical_bypasses_do_not_email(db):
+def test_handle_notification_critical_bypasses_do_not_email(db, email_collector: EmailCollector):
     """Test that critical notifications bypass do_not_email setting."""
     user, token = generate_user()
 
@@ -1692,19 +1679,18 @@ def test_handle_notification_critical_bypasses_do_not_email(db):
             )
         )
 
-    with mock_notification_email() as mock:
-        with session_scope() as session:
-            notify(
-                session,
-                user_id=user.id,
-                topic_action=topic_action,
-                key="",
-                data=None,
-            )
+    with session_scope() as session:
+        notify(
+            session,
+            user_id=user.id,
+            topic_action=topic_action,
+            key="",
+            data=None,
+        )
 
     # Critical email SHOULD be sent even with do_not_email=True
-    assert mock.call_count == 1
-    assert email_fields(mock).recipient == user.email
+    email = email_collector.pop_for_recipient(user.email, last=True)
+    assert email.recipient == user.email
 
 
 def test_handle_notification_duplicate_delivery_skipped(db, push_collector: PushCollector):
@@ -1825,7 +1811,9 @@ def test_handle_notification_delivered_when_content_visible(db, moderator):
         assert len(deliveries) > 0
 
 
-def test_handle_notification_multiple_delivery_types(db, push_collector: PushCollector):
+def test_handle_notification_multiple_delivery_types(
+    db, email_collector: EmailCollector, push_collector: PushCollector
+):
     """Test that multiple delivery types are processed for a single notification."""
     user, token = generate_user()
 
@@ -1858,22 +1846,21 @@ def test_handle_notification_multiple_delivery_types(db, push_collector: PushCol
             )
         )
 
-    with mock_notification_email() as mock:
-        with session_scope() as session:
-            notify(
-                session,
-                user_id=user.id,
-                topic_action=topic_action,
-                key="test-badge",
-                data=notification_data_pb2.BadgeAdd(
-                    badge_id="volunteer",
-                    badge_name="Active Volunteer",
-                    badge_description="This user is an active volunteer",
-                ),
-            )
+    with session_scope() as session:
+        notify(
+            session,
+            user_id=user.id,
+            topic_action=topic_action,
+            key="test-badge",
+            data=notification_data_pb2.BadgeAdd(
+                badge_id="volunteer",
+                badge_name="Active Volunteer",
+                badge_description="This user is an active volunteer",
+            ),
+        )
 
     # Email should be sent
-    assert mock.call_count == 1
+    email_collector.pop_for_recipient(user.email, last=True)
 
     # Push should be sent
     push = push_collector.pop_for_user(user.id, last=True)

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -536,7 +536,9 @@ def test_WriteFriendReference_with_empty_text(db):
     assert e.value.details() == "The text of a reference must not be empty"
 
 
-def test_WriteFriendReference_with_private_text(db, email_collector: EmailCollector, push_collector: PushCollector, moderator):
+def test_WriteFriendReference_with_private_text(
+    db, email_collector: EmailCollector, push_collector: PushCollector, moderator
+):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
 
@@ -861,7 +863,9 @@ def test_WriteHostRequestReference(db, moderator):
         )
 
 
-def test_WriteHostRequestReference_private_text(db, email_collector: EmailCollector, push_collector: PushCollector, moderator):
+def test_WriteHostRequestReference_private_text(
+    db, email_collector: EmailCollector, push_collector: PushCollector, moderator
+):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
 

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -1,5 +1,4 @@
 from datetime import date, datetime, timedelta
-from unittest.mock import patch
 
 import grpc
 import pytest

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -557,7 +557,7 @@ def test_WriteFriendReference_with_private_text(db, email_collector: EmailCollec
         moderator.approve_reference(ref.reference_id)
 
     # make sure an email was sent to the user receiving the ref as well as the mods
-    email_collector.pop_for_mods(last=True)
+    email_collector.pop_for_reports(last=True)
     email = email_collector.pop_for_recipient(user2.email, last=True)
     assert email.subject == f"[TEST] You've received a friend reference from {user1.name}!"
     assert email.recipient == user2.email
@@ -883,7 +883,7 @@ def test_WriteHostRequestReference_private_text(db, email_collector: EmailCollec
         moderator.approve_reference(ref.reference_id)
 
     # make sure an email was sent to the user receiving the ref as well as the mods
-    email_collector.pop_for_mods(last=True)
+    email_collector.pop_for_reports(last=True)
     email = email_collector.pop_for_recipient(user2.email, last=True)
     assert email.subject == f"[TEST] You've received a reference from {user1.name}!"
     assert email.recipient == user2.email

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -28,7 +28,7 @@ from couchers.moderation.utils import create_moderation
 from couchers.proto import conversations_pb2, moderation_pb2, references_pb2, requests_pb2
 from couchers.utils import create_coordinate, now, to_aware_datetime, today
 from tests.fixtures.db import generate_user, make_friends, make_user_block
-from tests.fixtures.misc import PushCollector, email_fields, mock_notification_email
+from tests.fixtures.misc import EmailCollector, PushCollector
 from tests.fixtures.sessions import account_session, real_moderation_session, references_session, requests_session
 from tests.test_requests import valid_request_text
 
@@ -537,7 +537,7 @@ def test_WriteFriendReference_with_empty_text(db):
     assert e.value.details() == "The text of a reference must not be empty"
 
 
-def test_WriteFriendReference_with_private_text(db, push_collector: PushCollector, moderator):
+def test_WriteFriendReference_with_private_text(db, email_collector: EmailCollector, push_collector: PushCollector, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
 
@@ -545,26 +545,23 @@ def test_WriteFriendReference_with_private_text(db, push_collector: PushCollecto
     make_friends(user1, user2)
 
     with references_session(token1) as api:
-        with patch("couchers.email.queuing.queue_email") as mock1:
-            with mock_notification_email() as mock2:
-                ref = api.WriteFriendReference(
-                    references_pb2.WriteFriendReferenceReq(
-                        to_user_id=user2.id,
-                        text="They were nice!",
-                        was_appropriate=True,
-                        rating=0.6,
-                        private_text="A bit of an odd ball, but a nice person nonetheless.",
-                    )
-                )
-                # Approve before patches/jobs exit so the pending notification is delivered while mocked.
-                moderator.approve_reference(ref.reference_id)
+        ref = api.WriteFriendReference(
+            references_pb2.WriteFriendReferenceReq(
+                to_user_id=user2.id,
+                text="They were nice!",
+                was_appropriate=True,
+                rating=0.6,
+                private_text="A bit of an odd ball, but a nice person nonetheless.",
+            )
+        )
+        # Approve before patches/jobs exit so the pending notification is delivered while mocked.
+        moderator.approve_reference(ref.reference_id)
 
     # make sure an email was sent to the user receiving the ref as well as the mods
-    assert mock1.call_count == 1
-    assert mock2.call_count == 1
-    e = email_fields(mock2)
-    assert e.subject == f"[TEST] You've received a friend reference from {user1.name}!"
-    assert e.recipient == user2.email
+    email_collector.pop_for_mods(last=True)
+    email = email_collector.pop_for_recipient(user2.email, last=True)
+    assert email.subject == f"[TEST] You've received a friend reference from {user1.name}!"
+    assert email.recipient == user2.email
 
     push = push_collector.pop_for_user(user2.id, last=True)
     assert push.content.title == f"New friend reference from {user1.name}"
@@ -865,7 +862,7 @@ def test_WriteHostRequestReference(db, moderator):
         )
 
 
-def test_WriteHostRequestReference_private_text(db, push_collector: PushCollector, moderator):
+def test_WriteHostRequestReference_private_text(db, email_collector: EmailCollector, push_collector: PushCollector, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
 
@@ -874,27 +871,23 @@ def test_WriteHostRequestReference_private_text(db, push_collector: PushCollecto
     moderator.approve_host_request(hr)
 
     with references_session(token1) as api:
-        with patch("couchers.email.queuing.queue_email") as mock1:
-            with mock_notification_email() as mock2:
-                ref = api.WriteHostRequestReference(
-                    references_pb2.WriteHostRequestReferenceReq(
-                        host_request_id=hr,
-                        text="Should work!",
-                        was_appropriate=True,
-                        rating=0.9,
-                        private_text="Something",
-                    )
-                )
-                # Approve before patches/jobs exit so the pending notification is delivered while mocked.
-                moderator.approve_reference(ref.reference_id)
+        ref = api.WriteHostRequestReference(
+            references_pb2.WriteHostRequestReferenceReq(
+                host_request_id=hr,
+                text="Should work!",
+                was_appropriate=True,
+                rating=0.9,
+                private_text="Something",
+            )
+        )
+        # Approve before patches/jobs exit so the pending notification is delivered while mocked.
+        moderator.approve_reference(ref.reference_id)
 
     # make sure an email was sent to the user receiving the ref as well as the mods
-    assert mock1.call_count == 1
-    assert mock2.call_count == 1
-
-    e = email_fields(mock2)
-    assert e.subject == f"[TEST] You've received a reference from {user1.name}!"
-    assert e.recipient == user2.email
+    email_collector.pop_for_mods(last=True)
+    email = email_collector.pop_for_recipient(user2.email, last=True)
+    assert email.subject == f"[TEST] You've received a reference from {user1.name}!"
+    assert email.recipient == user2.email
 
     push = push_collector.pop_for_user(user2.id, last=True)
     assert push.content.title == f"New reference from {user1.name}"

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -331,7 +331,7 @@ def test_excessive_requests_are_reported(db, email_collector: EmailCollector):
                 )
             )
 
-        assert email_collector.count_for_mods() == 0
+        assert email_collector.count_for_reports() == 0
 
         host_user, _ = generate_user()
         with pytest.raises(grpc.RpcError) as exc_info:
@@ -349,7 +349,7 @@ def test_excessive_requests_are_reported(db, email_collector: EmailCollector):
             == "You have sent a lot of host requests in the past 24 hours. To avoid spam, you can't send any more for now."
         )
 
-        email = email_collector.pop_for_mods(last=True)
+        email = email_collector.pop_for_reports(last=True)
         assert email.plain.startswith(
             f"User {user.username} has sent {rate_limit_definition.hard_limit} host requests in the past {RATE_LIMIT_HOURS} hours."
         )

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -35,7 +35,7 @@ from couchers.proto.internal import unsubscribe_pb2
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_HOURS
 from couchers.utils import create_coordinate, create_polygon_lat_lng, now, to_multi, today
 from tests.fixtures.db import generate_user
-from tests.fixtures.misc import PushCollector, email_fields, mock_notification_email
+from tests.fixtures.misc import EmailCollector, PushCollector, process_jobs
 from tests.fixtures.sessions import api_session, auth_api_session, requests_session
 
 
@@ -284,7 +284,7 @@ def test_create_request_incomplete_profile(db):
     assert e.value.details() == "You have to complete your profile before you can send a request."
 
 
-def test_excessive_requests_are_reported(db):
+def test_excessive_requests_are_reported(db, email_collector: EmailCollector):
     """Test that excessive host requests are first reported in a warning email and finally lead blocking of further requests."""
     user, token = generate_user()
     today_plus_2 = today() + timedelta(days=2)
@@ -292,20 +292,49 @@ def test_excessive_requests_are_reported(db):
     rate_limit_definition = RATE_LIMIT_DEFINITIONS[RateLimitAction.host_request]
     with requests_session(token) as api:
         # Test warning email
-        with mock_notification_email() as mock_email:
-            for _ in range(rate_limit_definition.warning_limit):
-                host_user, _ = generate_user()
-                _ = api.CreateHostRequest(
-                    requests_pb2.CreateHostRequestReq(
-                        host_user_id=host_user.id,
-                        from_date=today_plus_2.isoformat(),
-                        to_date=today_plus_3.isoformat(),
-                        text=valid_request_text(),
-                    )
-                )
-
-            assert mock_email.call_count == 0
+        for _ in range(rate_limit_definition.warning_limit):
             host_user, _ = generate_user()
+            _ = api.CreateHostRequest(
+                requests_pb2.CreateHostRequestReq(
+                    host_user_id=host_user.id,
+                    from_date=today_plus_2.isoformat(),
+                    to_date=today_plus_3.isoformat(),
+                    text=valid_request_text(),
+                )
+            )
+
+        assert email_collector.count_for_mods() == 0
+        host_user, _ = generate_user()
+        _ = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=host_user.id,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
+                text=valid_request_text("Excessive test request"),
+            )
+        )
+
+        email = email_collector.pop_for_mods(last=True)
+        assert email.plain.startswith(
+            f"User {user.username} has sent {rate_limit_definition.warning_limit} host requests in the past {RATE_LIMIT_HOURS} hours."
+        )
+
+        # Test ban after exceeding HOST_REQUEST_HARD_LIMIT
+        for _ in range(rate_limit_definition.hard_limit - rate_limit_definition.warning_limit - 1):
+            host_user, _ = generate_user()
+            _ = api.CreateHostRequest(
+                requests_pb2.CreateHostRequestReq(
+                    host_user_id=host_user.id,
+                    from_date=today_plus_2.isoformat(),
+                    to_date=today_plus_3.isoformat(),
+                    text=valid_request_text(),
+                )
+            )
+
+        assert email_collector.count_for_mods() == 0
+
+        host_user, _ = generate_user()
+        with pytest.raises(grpc.RpcError) as exc_info:
             _ = api.CreateHostRequest(
                 requests_pb2.CreateHostRequestReq(
                     host_user_id=host_user.id,
@@ -314,48 +343,17 @@ def test_excessive_requests_are_reported(db):
                     text=valid_request_text("Excessive test request"),
                 )
             )
-            assert mock_email.call_count == 1
-            email = email_fields(mock_email).plain
-            assert email.startswith(
-                f"User {user.username} has sent {rate_limit_definition.warning_limit} host requests in the past {RATE_LIMIT_HOURS} hours."
-            )
+        assert exc_info.value.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
+        assert (
+            exc_info.value.details()
+            == "You have sent a lot of host requests in the past 24 hours. To avoid spam, you can't send any more for now."
+        )
 
-        # Test ban after exceeding HOST_REQUEST_HARD_LIMIT
-        with mock_notification_email() as mock_email:
-            for _ in range(rate_limit_definition.hard_limit - rate_limit_definition.warning_limit - 1):
-                host_user, _ = generate_user()
-                _ = api.CreateHostRequest(
-                    requests_pb2.CreateHostRequestReq(
-                        host_user_id=host_user.id,
-                        from_date=today_plus_2.isoformat(),
-                        to_date=today_plus_3.isoformat(),
-                        text=valid_request_text(),
-                    )
-                )
-
-            assert mock_email.call_count == 0
-            host_user, _ = generate_user()
-            with pytest.raises(grpc.RpcError) as exc_info:
-                _ = api.CreateHostRequest(
-                    requests_pb2.CreateHostRequestReq(
-                        host_user_id=host_user.id,
-                        from_date=today_plus_2.isoformat(),
-                        to_date=today_plus_3.isoformat(),
-                        text=valid_request_text("Excessive test request"),
-                    )
-                )
-            assert exc_info.value.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
-            assert (
-                exc_info.value.details()
-                == "You have sent a lot of host requests in the past 24 hours. To avoid spam, you can't send any more for now."
-            )
-
-            assert mock_email.call_count == 1
-            email = email_fields(mock_email).plain
-            assert email.startswith(
-                f"User {user.username} has sent {rate_limit_definition.hard_limit} host requests in the past {RATE_LIMIT_HOURS} hours."
-            )
-            assert "The user has been blocked from sending further host requests for now." in email
+        email = email_collector.pop_for_mods(last=True)
+        assert email.plain.startswith(
+            f"User {user.username} has sent {rate_limit_definition.hard_limit} host requests in the past {RATE_LIMIT_HOURS} hours."
+        )
+        assert "The user has been blocked from sending further host requests for now." in email.plain
 
 
 def add_message(db, text, author_id, conversation_id):
@@ -1408,7 +1406,7 @@ def test_response_rate(db, moderator):
         assert res.almost_all.response_time_p66.ToTimedelta() == timedelta(hours=35)
 
 
-def test_request_notifications(db, push_collector: PushCollector, moderator):
+def test_request_notifications(db, email_collector: EmailCollector, push_collector: PushCollector, moderator):
     host, host_token = generate_user(complete_profile=True)
     surfer, surfer_token = generate_user(complete_profile=True)
 
@@ -1428,62 +1426,59 @@ def test_request_notifications(db, push_collector: PushCollector, moderator):
             )
         ).host_request_id
 
-    with mock_notification_email() as mock:
-        moderator.approve_host_request(hr_id)
+    moderator.approve_host_request(hr_id)
 
-    mock.assert_called_once()
-    e = email_fields(mock)
-    assert e.recipient == host.email
-    assert "host request" in e.subject.lower()
-    assert host.name in e.plain
-    assert host.name in e.html
-    assert "quick decline" in e.plain.lower(), e.plain
-    assert "quick decline" in e.html.lower()
-    assert surfer.name in e.plain
-    assert surfer.name in e.html
-    assert host_loc_context.localize_date(today_plus_2, with_year=False) in e.plain
-    assert host_loc_context.localize_date(today_plus_2, with_year=False) in e.html
-    assert host_loc_context.localize_date(today_plus_3, with_year=False) in e.plain
-    assert host_loc_context.localize_date(today_plus_3, with_year=False) in e.html
-    assert "http://localhost:5001/img/thumbnail/" not in e.plain
-    assert "http://localhost:5001/img/thumbnail/" in e.html
-    assert f"http://localhost:3000/messages/request/{hr_id}" in e.plain
-    assert f"http://localhost:3000/messages/request/{hr_id}" in e.html
-    assert not e.attachments
+    email = email_collector.pop_for_recipient(host.email, last=True)
+    assert email.recipient == host.email
+    assert "host request" in email.subject.lower()
+    assert host.name in email.plain
+    assert host.name in email.html
+    assert "quick decline" in email.plain.lower(), email.plain
+    assert "quick decline" in email.html.lower()
+    assert surfer.name in email.plain
+    assert surfer.name in email.html
+    assert host_loc_context.localize_date(today_plus_2, with_year=False) in email.plain
+    assert host_loc_context.localize_date(today_plus_2, with_year=False) in email.html
+    assert host_loc_context.localize_date(today_plus_3, with_year=False) in email.plain
+    assert host_loc_context.localize_date(today_plus_3, with_year=False) in email.html
+    assert "http://localhost:5001/img/thumbnail/" not in email.plain
+    assert "http://localhost:5001/img/thumbnail/" in email.html
+    assert f"http://localhost:3000/messages/request/{hr_id}" in email.plain
+    assert f"http://localhost:3000/messages/request/{hr_id}" in email.html
+    assert not email.attachments
 
     assert push_collector.pop_for_user(host.id, last=True).content.title == f"New host request from {surfer.name}"
 
     with requests_session(host_token) as api:
-        with mock_notification_email() as mock:
-            api.RespondHostRequest(
-                requests_pb2.RespondHostRequestReq(
-                    host_request_id=hr_id,
-                    status=conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED,
-                    text="Accepting host request",
-                )
+        api.RespondHostRequest(
+            requests_pb2.RespondHostRequestReq(
+                host_request_id=hr_id,
+                status=conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED,
+                text="Accepting host request",
             )
+        )
 
-    e = email_fields(mock)
-    assert e.recipient == surfer.email
-    assert "host request" in e.subject.lower()
-    assert host.name in e.plain
-    assert host.name in e.html
-    assert surfer.name in e.plain
-    assert surfer.name in e.html
-    assert surfer_loc_context.localize_date(today_plus_2, with_year=False) in e.plain
-    assert surfer_loc_context.localize_date(today_plus_2, with_year=False) in e.html
-    assert surfer_loc_context.localize_date(today_plus_3, with_year=False) in e.plain
-    assert surfer_loc_context.localize_date(today_plus_3, with_year=False) in e.html
-    assert "http://localhost:5001/img/thumbnail/" not in e.plain
-    assert "http://localhost:5001/img/thumbnail/" in e.html
-    assert f"http://localhost:3000/messages/request/{hr_id}" in e.plain
-    assert f"http://localhost:3000/messages/request/{hr_id}" in e.html
-    assert len(e.attachments or []) == 1
+    email = email_collector.pop_for_recipient(surfer.email, last=True)
+    assert email.recipient == surfer.email
+    assert "host request" in email.subject.lower()
+    assert host.name in email.plain
+    assert host.name in email.html
+    assert surfer.name in email.plain
+    assert surfer.name in email.html
+    assert surfer_loc_context.localize_date(today_plus_2, with_year=False) in email.plain
+    assert surfer_loc_context.localize_date(today_plus_2, with_year=False) in email.html
+    assert surfer_loc_context.localize_date(today_plus_3, with_year=False) in email.plain
+    assert surfer_loc_context.localize_date(today_plus_3, with_year=False) in email.html
+    assert "http://localhost:5001/img/thumbnail/" not in email.plain
+    assert "http://localhost:5001/img/thumbnail/" in email.html
+    assert f"http://localhost:3000/messages/request/{hr_id}" in email.plain
+    assert f"http://localhost:3000/messages/request/{hr_id}" in email.html
+    assert len(email.attachments or []) == 1
 
     assert push_collector.pop_for_user(surfer.id, last=True).content.title == f"{host.name} accepted your host request"
 
 
-def test_quick_decline(db, push_collector: PushCollector, moderator):
+def test_quick_decline(db, email_collector: EmailCollector, push_collector: PushCollector, moderator):
     host, host_token = generate_user(complete_profile=True)
     surfer, surfer_token = generate_user(complete_profile=True)
 
@@ -1502,33 +1497,31 @@ def test_quick_decline(db, push_collector: PushCollector, moderator):
             )
         ).host_request_id
 
-    with mock_notification_email() as mock:
-        moderator.approve_host_request(hr_id)
+    moderator.approve_host_request(hr_id)
 
-    mock.assert_called_once()
-    e = email_fields(mock)
-    assert e.recipient == host.email
-    assert "host request" in e.subject.lower()
-    assert host.name in e.plain
-    assert host.name in e.html
-    assert "quick decline" in e.plain.lower(), e.plain
-    assert "quick decline" in e.html.lower()
-    assert surfer.name in e.plain
-    assert surfer.name in e.html
-    assert host_loc_context.localize_date(today_plus_2, with_year=False) in e.plain
-    assert host_loc_context.localize_date(today_plus_2, with_year=False) in e.html
-    assert host_loc_context.localize_date(today_plus_3, with_year=False) in e.plain
-    assert host_loc_context.localize_date(today_plus_3, with_year=False) in e.html
-    assert "http://localhost:5001/img/thumbnail/" not in e.plain
-    assert "http://localhost:5001/img/thumbnail/" in e.html
-    assert f"http://localhost:3000/messages/request/{hr_id}" in e.plain
-    assert f"http://localhost:3000/messages/request/{hr_id}" in e.html
+    email = email_collector.pop_for_recipient(host.email, last=True)
+    assert email.recipient == host.email
+    assert "host request" in email.subject.lower()
+    assert host.name in email.plain
+    assert host.name in email.html
+    assert "quick decline" in email.plain.lower(), email.plain
+    assert "quick decline" in email.html.lower()
+    assert surfer.name in email.plain
+    assert surfer.name in email.html
+    assert host_loc_context.localize_date(today_plus_2, with_year=False) in email.plain
+    assert host_loc_context.localize_date(today_plus_2, with_year=False) in email.html
+    assert host_loc_context.localize_date(today_plus_3, with_year=False) in email.plain
+    assert host_loc_context.localize_date(today_plus_3, with_year=False) in email.html
+    assert "http://localhost:5001/img/thumbnail/" not in email.plain
+    assert "http://localhost:5001/img/thumbnail/" in email.html
+    assert f"http://localhost:3000/messages/request/{hr_id}" in email.plain
+    assert f"http://localhost:3000/messages/request/{hr_id}" in email.html
 
     assert push_collector.pop_for_user(host.id, last=True).content.title == f"New host request from {surfer.name}"
 
     # very ugly
     # http://localhost:3000/quick-link?payload=CAEiGAoOZnJpZW5kX3JlcXVlc3QSBmFjY2VwdA==&sig=BQdk024NTATm8zlR0krSXTBhP5U9TlFv7VhJeIHZtUg=
-    for link in re.findall(r'<a href="(.*?)"', email_fields(mock).html):
+    for link in re.findall(r'<a href="(.*?)"', email.html):
         if "payload" not in link:
             continue
         print(link)

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -35,7 +35,7 @@ from couchers.proto.internal import unsubscribe_pb2
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_HOURS
 from couchers.utils import create_coordinate, create_polygon_lat_lng, now, to_multi, today
 from tests.fixtures.db import generate_user
-from tests.fixtures.misc import EmailCollector, PushCollector, process_jobs
+from tests.fixtures.misc import EmailCollector, PushCollector
 from tests.fixtures.sessions import api_session, auth_api_session, requests_session
 
 

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -303,7 +303,7 @@ def test_excessive_requests_are_reported(db, email_collector: EmailCollector):
                 )
             )
 
-        assert email_collector.count_for_mods() == 0
+        assert email_collector.count_for_reports() == 0
         host_user, _ = generate_user()
         _ = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
@@ -314,7 +314,7 @@ def test_excessive_requests_are_reported(db, email_collector: EmailCollector):
             )
         )
 
-        email = email_collector.pop_for_mods(last=True)
+        email = email_collector.pop_for_reports(last=True)
         assert email.plain.startswith(
             f"User {user.username} has sent {rate_limit_definition.warning_limit} host requests in the past {RATE_LIMIT_HOURS} hours."
         )


### PR DESCRIPTION
Test APIs for verifying emails and push notifications had different shapes, though they are conceptually the same. This changes unifies that to the richer and stronger-typed `PushCollector` model, with improvements. Changes:

- Make `PushCollector` call `process_jobs()` before every read, in case something needs to be flushed. Previously it implicitly depended on `process_jobs()` calls by neighboring email validation code.
- Make `PushCollector` support both test-scoped usage as a fixture and `with`-statement usage scopes.
- Add `EmailCollector` under the same model as `PushCollector` (including changes above)
- Update tests to use `EmailCollector`. 

## Testing
CI reran the tests.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
