### PR TITLE
Devex: Restore CODEOWNERS (autoreviewers still has a bug)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
-# Deprecated in favor of autoreviewers.yml since CODEOWNERS can only match one rule.
+# Only the last matching line's owners are added to the PR
+* @aapeliv
+/app/**/locales/*.json @tristanlabelle # Watch Weblate integrations
+/app/web/ @nabramow
+/docs/ @aapeliv @nabramow

--- a/.github/workflows/add-reviewers.yml
+++ b/.github/workflows/add-reviewers.yml
@@ -1,11 +1,12 @@
+# [WIP] Currently fails to add team reviewers
 # Adds reviewers upon publishing a PR based on changed files.
 # Works around limitations of GitHub's CODEOWNERS, which can only match one rule,
 # whereas our changes can straddle frontend and backend, for example.
 name: Add reviewers
 
-on:
-  pull_request:
-    types: [opened, ready_for_review, reopened]
+# on:
+#   pull_request:
+#     types: [opened, ready_for_review, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}


### PR DESCRIPTION
Even though the `gh pr edit --add-reviewers` call was correct, the default GITHUB_TOKEN doesn't have permissions to add team reviewers to a PR, and neither does the bot token. I think there's a way around this but while I experiment, let's bring back CODEOWNERS.

I'm not deleting the `add-reviewers.yml` workflow because I need the file to exist to be able to experiment with it. GH won't run new workflows added in a PR.

## Testing
N/A

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
