### PR TITLE
Remove event maybeGoing

### DIFF
--- a/app/backend/src/couchers/migrations/versions/0154_remove_maybe_from_attendeestatus.py
+++ b/app/backend/src/couchers/migrations/versions/0154_remove_maybe_from_attendeestatus.py
@@ -15,6 +15,8 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # backfill any remaining maybe rows to going before dropping the enum value
+    op.execute("UPDATE event_occurrence_attendees SET attendee_status = 'going' WHERE attendee_status = 'maybe'")
     op.execute("ALTER TYPE attendeestatus RENAME TO attendeestatus_old")
     op.execute("CREATE TYPE attendeestatus AS ENUM ('going')")
     op.execute("""

--- a/app/backend/src/couchers/migrations/versions/0154_remove_maybe_from_attendeestatus.py
+++ b/app/backend/src/couchers/migrations/versions/0154_remove_maybe_from_attendeestatus.py
@@ -1,0 +1,36 @@
+"""Events: Remove maybe from AttendeeStatus enum
+
+Revision ID: 0154
+Revises: 0153
+Create Date: 2026-05-17
+
+"""
+
+from alembic import op
+
+revision = "0154"
+down_revision = "0153"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE attendeestatus RENAME TO attendeestatus_old")
+    op.execute("CREATE TYPE attendeestatus AS ENUM ('going')")
+    op.execute("""
+        ALTER TABLE event_occurrence_attendees
+        ALTER COLUMN attendee_status TYPE attendeestatus
+        USING attendee_status::text::attendeestatus
+    """)
+    op.execute("DROP TYPE attendeestatus_old")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TYPE attendeestatus RENAME TO attendeestatus_old")
+    op.execute("CREATE TYPE attendeestatus AS ENUM ('going', 'maybe')")
+    op.execute("""
+        ALTER TABLE event_occurrence_attendees
+        ALTER COLUMN attendee_status TYPE attendeestatus
+        USING attendee_status::text::attendeestatus
+    """)
+    op.execute("DROP TYPE attendeestatus_old")

--- a/app/backend/src/couchers/models/events.py
+++ b/app/backend/src/couchers/models/events.py
@@ -241,7 +241,6 @@ class EventOrganizer(Base, kw_only=True):
 
 class AttendeeStatus(enum.Enum):
     going = enum.auto()
-    maybe = enum.auto()
 
 
 class EventOccurrenceAttendee(Base, kw_only=True):

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -56,13 +56,11 @@ logger = logging.getLogger(__name__)
 attendancestate2sql = {
     events_pb2.AttendanceState.ATTENDANCE_STATE_NOT_GOING: None,
     events_pb2.AttendanceState.ATTENDANCE_STATE_GOING: AttendeeStatus.going,
-    events_pb2.AttendanceState.ATTENDANCE_STATE_MAYBE: AttendeeStatus.maybe,
 }
 
 attendancestate2api = {
     None: events_pb2.AttendanceState.ATTENDANCE_STATE_NOT_GOING,
     AttendeeStatus.going: events_pb2.AttendanceState.ATTENDANCE_STATE_GOING,
-    AttendeeStatus.maybe: events_pb2.AttendanceState.ATTENDANCE_STATE_MAYBE,
 }
 
 MAX_PAGINATION_LENGTH = 25
@@ -136,17 +134,6 @@ def event_to_pb(session: Session, occurrence: EventOccurrence, context: Couchers
             EventOccurrenceAttendee.user_id,
         )
     ).scalar_one()
-    maybe_count = session.execute(
-        where_users_column_visible(
-            select(func.count())
-            .select_from(EventOccurrenceAttendee)
-            .where(EventOccurrenceAttendee.occurrence_id == occurrence.id)
-            .where(EventOccurrenceAttendee.attendee_status == AttendeeStatus.maybe),
-            context,
-            EventOccurrenceAttendee.user_id,
-        )
-    ).scalar_one()
-
     organizer_count = session.execute(
         where_users_column_visible(
             select(func.count()).select_from(EventOrganizer).where(EventOrganizer.event_id == event.id),
@@ -198,7 +185,6 @@ def event_to_pb(session: Session, occurrence: EventOccurrence, context: Couchers
         organizer=event.organizers.where(EventOrganizer.user_id == context.user_id).one_or_none() is not None,
         subscriber=event.subscribers.where(EventSubscription.user_id == context.user_id).one_or_none() is not None,
         going_count=going_count,
-        maybe_count=maybe_count,
         organizer_count=organizer_count,
         subscriber_count=subscriber_count,
         owner_user_id=event.owner_user_id,

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -96,7 +96,6 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
         assert res.organizer
         assert res.subscriber
         assert res.going_count == 1
-        assert res.maybe_count == 0
         assert res.organizer_count == 1
         assert res.subscriber_count == 1
         assert res.owner_user_id == user1.id
@@ -133,7 +132,6 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
         assert not res.organizer
         assert not res.subscriber
         assert res.going_count == 1
-        assert res.maybe_count == 0
         assert res.organizer_count == 1
         assert res.subscriber_count == 1
         assert res.owner_user_id == user1.id
@@ -165,7 +163,6 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
         assert not res.organizer
         assert not res.subscriber
         assert res.going_count == 1
-        assert res.maybe_count == 0
         assert res.organizer_count == 1
         assert res.subscriber_count == 1
         assert res.owner_user_id == user1.id
@@ -209,7 +206,6 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
         assert res.organizer
         assert res.subscriber
         assert res.going_count == 1
-        assert res.maybe_count == 0
         assert res.organizer_count == 1
         assert res.subscriber_count == 1
         assert res.owner_user_id == user1.id
@@ -244,7 +240,6 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
         assert not res.organizer
         assert not res.subscriber
         assert res.going_count == 1
-        assert res.maybe_count == 0
         assert res.organizer_count == 1
         assert res.subscriber_count == 1
         assert res.owner_user_id == user1.id
@@ -274,7 +269,6 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
         assert not res.organizer
         assert not res.subscriber
         assert res.going_count == 1
-        assert res.maybe_count == 0
         assert res.organizer_count == 1
         assert res.subscriber_count == 1
         assert res.owner_user_id == user1.id
@@ -576,7 +570,6 @@ def test_ScheduleEvent(db):
         assert res.organizer
         assert res.subscriber
         assert res.going_count == 1
-        assert res.maybe_count == 0
         assert res.organizer_count == 1
         assert res.subscriber_count == 1
         assert res.owner_user_id == user.id
@@ -742,9 +735,6 @@ def test_UpdateEvent_single(db, moderator: Moderator):
 
     with events_session(token6) as api:
         api.SetEventSubscription(events_pb2.SetEventSubscriptionReq(event_id=event_id, subscribe=True))
-        api.SetEventAttendance(
-            events_pb2.SetEventAttendanceReq(event_id=event_id, attendance_state=events_pb2.ATTENDANCE_STATE_MAYBE)
-        )
 
     time_before_update = now()
 
@@ -777,7 +767,6 @@ def test_UpdateEvent_single(db, moderator: Moderator):
         assert res.organizer
         assert res.subscriber
         assert res.going_count == 2
-        assert res.maybe_count == 1
         assert res.organizer_count == 1
         assert res.subscriber_count == 3
         assert res.owner_user_id == user1.id
@@ -809,7 +798,6 @@ def test_UpdateEvent_single(db, moderator: Moderator):
         assert not res.organizer
         assert not res.subscriber
         assert res.going_count == 2
-        assert res.maybe_count == 1
         assert res.organizer_count == 1
         assert res.subscriber_count == 3
         assert res.owner_user_id == user1.id
@@ -841,7 +829,6 @@ def test_UpdateEvent_single(db, moderator: Moderator):
         assert not res.organizer
         assert not res.subscriber
         assert res.going_count == 2
-        assert res.maybe_count == 1
         assert res.organizer_count == 1
         assert res.subscriber_count == 3
         assert res.owner_user_id == user1.id
@@ -881,7 +868,6 @@ def test_UpdateEvent_single(db, moderator: Moderator):
         assert res.organizer
         assert res.subscriber
         assert res.going_count == 2
-        assert res.maybe_count == 1
         assert res.organizer_count == 1
         assert res.subscriber_count == 3
         assert res.owner_user_id == user1.id
@@ -913,7 +899,6 @@ def test_UpdateEvent_single(db, moderator: Moderator):
         assert not res.organizer
         assert not res.subscriber
         assert res.going_count == 2
-        assert res.maybe_count == 1
         assert res.organizer_count == 1
         assert res.subscriber_count == 3
         assert res.owner_user_id == user1.id
@@ -943,7 +928,6 @@ def test_UpdateEvent_single(db, moderator: Moderator):
         assert not res.organizer
         assert not res.subscriber
         assert res.going_count == 2
-        assert res.maybe_count == 1
         assert res.organizer_count == 1
         assert res.subscriber_count == 3
         assert res.owner_user_id == user1.id
@@ -1025,9 +1009,6 @@ def test_UpdateEvent_all(db, moderator: Moderator):
 
     with events_session(token6) as api:
         api.SetEventSubscription(events_pb2.SetEventSubscriptionReq(event_id=event_id, subscribe=True))
-        api.SetEventAttendance(
-            events_pb2.SetEventAttendanceReq(event_id=event_id, attendance_state=events_pb2.ATTENDANCE_STATE_MAYBE)
-        )
 
     with events_session(token1) as api:
         for i in range(5):
@@ -1128,9 +1109,6 @@ def test_GetEvent(db, moderator: Moderator):
 
     with events_session(token6) as api:
         api.SetEventSubscription(events_pb2.SetEventSubscriptionReq(event_id=event_id, subscribe=True))
-        api.SetEventAttendance(
-            events_pb2.SetEventAttendanceReq(event_id=event_id, attendance_state=events_pb2.ATTENDANCE_STATE_MAYBE)
-        )
 
     with events_session(token1) as api:
         res = api.GetEvent(events_pb2.GetEventReq(event_id=event_id))
@@ -1154,7 +1132,6 @@ def test_GetEvent(db, moderator: Moderator):
         assert res.organizer
         assert res.subscriber
         assert res.going_count == 2
-        assert res.maybe_count == 1
         assert res.organizer_count == 1
         assert res.subscriber_count == 3
         assert res.owner_user_id == user1.id
@@ -1186,7 +1163,6 @@ def test_GetEvent(db, moderator: Moderator):
         assert not res.organizer
         assert not res.subscriber
         assert res.going_count == 2
-        assert res.maybe_count == 1
         assert res.organizer_count == 1
         assert res.subscriber_count == 3
         assert res.owner_user_id == user1.id
@@ -1218,7 +1194,6 @@ def test_GetEvent(db, moderator: Moderator):
         assert not res.organizer
         assert not res.subscriber
         assert res.going_count == 2
-        assert res.maybe_count == 1
         assert res.organizer_count == 1
         assert res.subscriber_count == 3
         assert res.owner_user_id == user1.id
@@ -1276,9 +1251,6 @@ def test_CancelEvent(db, moderator: Moderator):
 
     with events_session(token6) as api:
         api.SetEventSubscription(events_pb2.SetEventSubscriptionReq(event_id=event_id, subscribe=True))
-        api.SetEventAttendance(
-            events_pb2.SetEventAttendanceReq(event_id=event_id, attendance_state=events_pb2.ATTENDANCE_STATE_MAYBE)
-        )
 
     with events_session(token1) as api:
         res = api.CancelEvent(
@@ -1670,13 +1642,6 @@ def test_SetEventAttendance(db, moderator: Moderator):
             == events_pb2.ATTENDANCE_STATE_GOING
         )
         api.SetEventAttendance(
-            events_pb2.SetEventAttendanceReq(event_id=event_id, attendance_state=events_pb2.ATTENDANCE_STATE_MAYBE)
-        )
-        assert (
-            api.GetEvent(events_pb2.GetEventReq(event_id=event_id)).attendance_state
-            == events_pb2.ATTENDANCE_STATE_MAYBE
-        )
-        api.SetEventAttendance(
             events_pb2.SetEventAttendanceReq(event_id=event_id, attendance_state=events_pb2.ATTENDANCE_STATE_NOT_GOING)
         )
         assert (
@@ -1875,7 +1840,7 @@ def test_ListMyEvents(db, moderator: Moderator):
 
     with events_session(token1) as api:
         api.SetEventAttendance(
-            events_pb2.SetEventAttendanceReq(event_id=e1, attendance_state=events_pb2.ATTENDANCE_STATE_MAYBE)
+            events_pb2.SetEventAttendanceReq(event_id=e1, attendance_state=events_pb2.ATTENDANCE_STATE_GOING)
         )
         api.SetEventSubscription(events_pb2.SetEventSubscriptionReq(event_id=e4, subscribe=True))
 

--- a/app/proto/events.proto
+++ b/app/proto/events.proto
@@ -97,7 +97,6 @@ message OfflineEventInformation {
 
 enum AttendanceState {
   ATTENDANCE_STATE_NOT_GOING = 0;
-  ATTENDANCE_STATE_MAYBE = 1;
   ATTENDANCE_STATE_GOING = 2;
 }
 
@@ -146,7 +145,6 @@ message Event {
   bool subscriber = 23;
 
   uint32 going_count = 24;
-  uint32 maybe_count = 25;
   uint32 organizer_count = 26;
   uint32 subscriber_count = 27;
 

--- a/app/proto/events.proto
+++ b/app/proto/events.proto
@@ -97,6 +97,7 @@ message OfflineEventInformation {
 
 enum AttendanceState {
   ATTENDANCE_STATE_NOT_GOING = 0;
+  // ATTENDANCE_STATE_MAYBE = 1; -- removed, maybe attendance is no longer supported
   ATTENDANCE_STATE_GOING = 2;
 }
 
@@ -145,6 +146,8 @@ message Event {
   bool subscriber = 23;
 
   uint32 going_count = 24;
+  reserved 25;
+  reserved "maybe_count";
   uint32 organizer_count = 26;
   uint32 subscriber_count = 27;
 

--- a/app/web/features/communities/events/EventCard.test.tsx
+++ b/app/web/features/communities/events/EventCard.test.tsx
@@ -27,7 +27,7 @@ describe("Event card", () => {
     expect(
       screen.getByText(
         t("communities:attendees_count", {
-          count: firstEvent.goingCount + firstEvent.maybeCount,
+          count: firstEvent.goingCount,
         }),
       ),
     ).toBeVisible();
@@ -61,7 +61,7 @@ describe("Event card", () => {
     expect(
       screen.getByText(
         t("communities:attendees_count", {
-          count: thirdEvent.goingCount + thirdEvent.maybeCount,
+          count: thirdEvent.goingCount,
         }),
       ),
     ).toBeVisible();
@@ -92,7 +92,7 @@ describe("Event card", () => {
     expect(
       screen.getByText(
         t("communities:attendees_count", {
-          count: secondEvent.goingCount + secondEvent.maybeCount,
+          count: secondEvent.goingCount,
         }),
       ),
     ).toBeVisible();

--- a/app/web/features/communities/events/EventCard.tsx
+++ b/app/web/features/communities/events/EventCard.tsx
@@ -123,14 +123,11 @@ export const EVENT_CARD_TEST_ID = "event-card";
 interface EventCardProps {
   event: Event.AsObject;
   className?: string;
-  // Optional formatter to override attendees count text (used by dashboard to avoid loading COMMUNITIES)
-  attendeesCountFormatter?: (count: number) => string;
 }
 
 export default function EventCard({
   event,
   className,
-  attendeesCountFormatter,
 }: EventCardProps) {
   const {
     t,
@@ -224,11 +221,9 @@ export default function EventCard({
 
             <ActivityStatsWrapper>
               <Typography variant="body2" color="textSecondary">
-                {attendeesCountFormatter
-                  ? attendeesCountFormatter(event.goingCount + event.maybeCount)
-                  : t("communities:attendees_count", {
-                      count: event.goingCount + event.maybeCount,
-                    })}
+                {t("communities:attendees_count", {
+                  count: event.goingCount,
+                })}
               </Typography>
               <StyledCommentsCount variant="body2">
                 {t("communities:comments_count", {

--- a/app/web/features/communities/events/EventCard.tsx
+++ b/app/web/features/communities/events/EventCard.tsx
@@ -125,10 +125,7 @@ interface EventCardProps {
   className?: string;
 }
 
-export default function EventCard({
-  event,
-  className,
-}: EventCardProps) {
+export default function EventCard({ event, className }: EventCardProps) {
   const {
     t,
     i18n: { language: locale },

--- a/app/web/features/communities/events/LongEventCard.tsx
+++ b/app/web/features/communities/events/LongEventCard.tsx
@@ -201,7 +201,7 @@ const LongEventCard = ({
             <ActivityStatsWrapper>
               <Attendees>
                 {t("communities:attendees_count", {
-                  count: event.goingCount + event.maybeCount,
+                  count: event.goingCount,
                 })}
               </Attendees>
               <StyledCommentsCount variant="body2">

--- a/app/web/features/dashboard/EventListRow.tsx
+++ b/app/web/features/dashboard/EventListRow.tsx
@@ -177,8 +177,6 @@ export default function EventListRow({ event }: EventListRowProps) {
     ? event.offlineInformation.address
     : t("dashboard:events.location_online_label");
 
-  const attendeeCount = event.goingCount + event.maybeCount;
-
   return (
     <RowLink href={routeToEvent(event.eventId, event.slug)}>
       <DateChip>
@@ -191,7 +189,7 @@ export default function EventListRow({ event }: EventListRowProps) {
           <AttendeeTag>
             <Group sx={{ fontSize: "11px" }} />
             {t("dashboard:events.attendees_count_label", {
-              count: attendeeCount,
+              count: event.goingCount,
             })}
           </AttendeeTag>
           <ChevronRight


### PR DESCRIPTION
I checked the prod database and there are no "maybe_going" in. `event_occurrance_attendees` hence why I opted to just remove rather than migrate to going.

This PR removes all the references to `maybeGoing` since it's not used nor planned to be used on the frontend.

<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*
- Run backend
- In another terminal in backend folder, run `make downgrade` and then `make upgrade` and `make downgrade` again to make sure no errors
- EventPage attendees count should still look good.

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
