### PR TITLE
Add ListUserUploads admin RPC

### DIFF
--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 import grpc
 from google.protobuf import empty_pb2
-from sqlalchemy import select
+from sqlalchemy import select, tuple_
 from sqlalchemy.orm import Session, aliased, selectinload
 from sqlalchemy.sql import and_, func, or_
 from user_agents import parse as user_agents_parse
@@ -43,7 +43,7 @@ from couchers.models import (
     UserBadge,
 )
 from couchers.models.notifications import NotificationTopicAction
-from couchers.models.uploads import has_avatar_photo_expression
+from couchers.models.uploads import Upload, has_avatar_photo_expression
 from couchers.notifications.notify import notify
 from couchers.proto import admin_pb2, admin_pb2_grpc, api_pb2, notification_data_pb2
 from couchers.proto.internal import jobs_pb2
@@ -1193,4 +1193,41 @@ class Admin(admin_pb2_grpc.AdminServicer):
         return admin_pb2.ListAdminActionsRes(
             admin_actions=action_pbs,
             next_page_token=str(rows[page_size - 1][0].id) if len(rows) > page_size else None,
+        )
+
+    def ListUserUploads(
+        self, request: admin_pb2.ListUserUploadsReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.ListUserUploadsRes:
+        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
+        if not user:
+            context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
+
+        page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
+
+        statement = select(Upload).where(Upload.creator_user_id == user.id)
+        if request.page_token:
+            cursor_created = session.execute(
+                select(Upload.created).where(Upload.key == request.page_token)
+            ).scalar_one()
+            statement = statement.where(tuple_(Upload.created, Upload.key) < (cursor_created, request.page_token))
+
+        uploads = (
+            session.execute(statement.order_by(Upload.created.desc(), Upload.key.desc()).limit(page_size + 1))
+            .scalars()
+            .all()
+        )
+
+        return admin_pb2.ListUserUploadsRes(
+            uploads=[
+                admin_pb2.UserUpload(
+                    key=upload.key,
+                    filename=upload.filename,
+                    full_url=upload.full_url,
+                    thumbnail_url=upload.thumbnail_url,
+                    credit=upload.credit or "",
+                    created=Timestamp_from_datetime(upload.created),
+                )
+                for upload in uploads[:page_size]
+            ],
+            next_page_token=uploads[page_size - 1].key if len(uploads) > page_size else None,
         )

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -18,6 +18,7 @@ from couchers.models import (
     ModerationUserList,
     ModerationVisibility,
     Reference,
+    Upload,
     User,
     UserActivity,
     UserSession,
@@ -1509,6 +1510,70 @@ def test_ListAdminActions_pagination(db):
 
     all_notes = first_page_notes + [a.note for a in res2.admin_actions]
     assert set(all_notes) == {"note 0", "note 1", "note 2"}
+
+
+def test_ListUserUploads(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    user, _ = generate_user(complete_profile=False)
+    other_user, _ = generate_user()
+
+    with session_scope() as session:
+        for i in range(3):
+            session.add(
+                Upload(
+                    key=f"key{i}",
+                    filename=f"photo{i}.jpg",
+                    creator_user_id=user.id,
+                    credit=f"credit {i}" if i == 0 else None,
+                )
+            )
+        session.add(Upload(key="other_key", filename="other.jpg", creator_user_id=other_user.id))
+
+    with real_admin_session(super_token) as api:
+        res = api.ListUserUploads(admin_pb2.ListUserUploadsReq(user=user.username))
+
+    assert len(res.uploads) == 3
+    assert res.next_page_token == ""
+    assert {u.filename for u in res.uploads} == {"photo0.jpg", "photo1.jpg", "photo2.jpg"}
+
+    upload0 = next(u for u in res.uploads if u.key == "key0")
+    assert upload0.credit == "credit 0"
+    assert upload0.full_url.endswith("/img/full/photo0.jpg")
+    assert upload0.thumbnail_url.endswith("/img/thumbnail/photo0.jpg")
+    assert upload0.HasField("created")
+
+
+def test_ListUserUploads_pagination(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    user, _ = generate_user(complete_profile=False)
+
+    with session_scope() as session:
+        for i in range(3):
+            session.add(Upload(key=f"key{i}", filename=f"photo{i}.jpg", creator_user_id=user.id))
+
+    with real_admin_session(super_token) as api:
+        res = api.ListUserUploads(admin_pb2.ListUserUploadsReq(user=user.username, page_size=2))
+        assert len(res.uploads) == 2
+        assert res.next_page_token != ""
+        first_page_keys = [u.key for u in res.uploads]
+
+        res2 = api.ListUserUploads(
+            admin_pb2.ListUserUploadsReq(user=user.username, page_size=2, page_token=res.next_page_token)
+        )
+        assert len(res2.uploads) == 1
+        assert res2.next_page_token == ""
+
+    all_keys = first_page_keys + [u.key for u in res2.uploads]
+    assert set(all_keys) == {"key0", "key1", "key2"}
+
+
+def test_ListUserUploads_not_found(db):
+    super_user, super_token = generate_user(is_superuser=True)
+
+    with real_admin_session(super_token) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.ListUserUploads(admin_pb2.ListUserUploadsReq(user="nonexistent"))
+        assert e.value.code() == grpc.StatusCode.NOT_FOUND
 
 
 # community invite feature tested in test_events.py

--- a/app/proto/admin.proto
+++ b/app/proto/admin.proto
@@ -105,6 +105,8 @@ service Admin {
   rpc SetModScore(SetModScoreReq) returns (UserDetails) {}
 
   rpc ListAdminActions(ListAdminActionsReq) returns (ListAdminActionsRes) {}
+
+  rpc ListUserUploads(ListUserUploadsReq) returns (ListUserUploadsRes) {}
 }
 
 message AdminActionLog {
@@ -572,5 +574,27 @@ message ListAdminActionsReq {
 
 message ListAdminActionsRes {
   repeated AdminActionLog admin_actions = 1;
+  string next_page_token = 2;
+}
+
+message ListUserUploadsReq {
+  // username, email, or user id
+  string user = 1;
+
+  uint32 page_size = 2;
+  string page_token = 3;
+}
+
+message UserUpload {
+  string key = 1;
+  string filename = 2;
+  string full_url = 3;
+  string thumbnail_url = 4;
+  string credit = 5;
+  google.protobuf.Timestamp created = 6;
+}
+
+message ListUserUploadsRes {
+  repeated UserUpload uploads = 1;
   string next_page_token = 2;
 }


### PR DESCRIPTION
Adds a new `ListUserUploads` RPC to the Admin gRPC service so admins can fetch all photo uploads created by a given user (identified by username, email, or user id). Results are ordered newest-first with cursor-based pagination on `(created, key)`, so identical timestamps still paginate deterministically. Each `UserUpload` includes the key, filename, full/thumbnail URLs, credit, and creation time.

## Testing
- Added backend tests in `test_admin.py`: basic listing (verifying fields, URLs, and credit), pagination across pages, and the user-not-found case.
- Ran `make protos`, `make format`, and `make mypy` (admin.py clean; only 2 pre-existing errors in unrelated files).
- `uv run pytest src/tests/test_admin.py -k ListUserUploads` passes.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._