### PR TITLE
feat: dismissible reminders

### DIFF
--- a/app/web/features/auth/useAuthStore.test.ts
+++ b/app/web/features/auth/useAuthStore.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { StatusCode } from "grpc-web";
-import { usePersistedState } from "platform/usePersistedState";
+import { useClearablePersistedState } from "platform/usePersistedState";
 import { service } from "service";
 
 import wrapper from "../../test/hookWrapper";
@@ -15,22 +15,26 @@ const getIsJailedMock = service.jail.getIsJailed as jest.Mock;
 const logoutMock = service.user.logout as jest.Mock;
 const getAccountInfoMock = service.account.getAccountInfo as jest.Mock;
 
-describe("usePersistedState hook", () => {
+describe("useClearablePersistedState hook", () => {
   it("uses a default value", () => {
     const defaultValue = "Test string";
-    const { result } = renderHook(() => usePersistedState("key", defaultValue));
+    const { result } = renderHook(() =>
+      useClearablePersistedState("key", defaultValue),
+    );
     expect(result.current[0]).toBe(defaultValue);
   });
 
   it("saves then loads a value", () => {
     const value = { test: "Test string" };
-    const { result } = renderHook(() => usePersistedState("key", { test: "" }));
+    const { result } = renderHook(() =>
+      useClearablePersistedState("key", { test: "" }),
+    );
     expect(result.current[0]).toStrictEqual({ test: "" });
     act(() => result.current[1](value));
     expect(result.current[0]).toStrictEqual(value);
     expect(localStorage.getItem("key")).toBe(JSON.stringify(value));
     const { result: result2 } = renderHook(() =>
-      usePersistedState("key", { test: "" }),
+      useClearablePersistedState("key", { test: "" }),
     );
     expect(result2.current[0]).toStrictEqual(value);
   });
@@ -38,21 +42,21 @@ describe("usePersistedState hook", () => {
   it("saves then loads a value from sessionStorage", () => {
     const value = { test: "session test" };
     const { result } = renderHook(() =>
-      usePersistedState("key", { test: "" }, "sessionStorage"),
+      useClearablePersistedState("key", { test: "" }, "sessionStorage"),
     );
     expect(result.current[0]).toStrictEqual({ test: "" });
     act(() => result.current[1](value));
     expect(result.current[0]).toStrictEqual(value);
     expect(sessionStorage.getItem("key")).toBe(JSON.stringify(value));
     const { result: result2 } = renderHook(() =>
-      usePersistedState("key", { test: "" }, "sessionStorage"),
+      useClearablePersistedState("key", { test: "" }, "sessionStorage"),
     );
     expect(result2.current[0]).toStrictEqual(value);
   });
 
   it("clears a value", () => {
     const { result } = renderHook(() =>
-      usePersistedState("key", { test: "" }, "sessionStorage"),
+      useClearablePersistedState("key", { test: "" }, "sessionStorage"),
     );
     expect(result.current[0]).toStrictEqual({ test: "" });
     act(() => result.current[2]());

--- a/app/web/features/dashboard/ReminderCarousel.test.tsx
+++ b/app/web/features/dashboard/ReminderCarousel.test.tsx
@@ -1,10 +1,15 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { service } from "service";
+import liteUsers from "test/fixtures/liteUsers.json";
 import wrapper from "test/hookWrapper";
 import i18n from "test/i18n";
 import { assertErrorAlert, mockConsoleError } from "test/utils";
 
 import ReminderCarousel from "./ReminderCarousel";
+
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+const DISMISSED_REMINDERS_KEY = "dismissedReminders";
 
 const { t } = i18n;
 
@@ -13,6 +18,10 @@ const getReminders = service.account.getReminders as jest.MockedFunction<
 >;
 
 describe("ReminderCarousel", () => {
+  beforeEach(() => {
+    localStorage.removeItem(DISMISSED_REMINDERS_KEY);
+  });
+
   it("renders nothing when backend returns no reminders", async () => {
     getReminders.mockResolvedValue({ remindersList: [] });
 
@@ -47,5 +56,143 @@ describe("ReminderCarousel", () => {
     render(<ReminderCarousel />, { wrapper });
 
     await assertErrorAlert("Failed to fetch reminders");
+  });
+
+  it("dismisses a reminder via the dismiss control and persists the choice", async () => {
+    const user = userEvent.setup();
+    getReminders.mockResolvedValue({
+      remindersList: [{ completeProfileReminder: {} }],
+    });
+
+    render(<ReminderCarousel />, { wrapper });
+
+    expect(
+      await screen.findByText(t("dashboard:reminder.complete_profile.title")),
+    ).toBeVisible();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: t("dashboard:reminder.carousel_dismiss_button_a11y"),
+      }),
+    );
+
+    expect(
+      screen.queryByText(t("dashboard:reminder.complete_profile.title")),
+    ).not.toBeInTheDocument();
+
+    const stored: Record<string, number> = JSON.parse(
+      localStorage.getItem(DISMISSED_REMINDERS_KEY) ?? "{}",
+    );
+    expect(typeof stored.complete_profile).toBe("number");
+  });
+
+  it("does not show a reminder that was dismissed within the last week", async () => {
+    const now = 1_700_000_000_000;
+    jest.spyOn(Date, "now").mockReturnValue(now);
+    localStorage.setItem(
+      DISMISSED_REMINDERS_KEY,
+      JSON.stringify({
+        complete_profile: now - 24 * 60 * 60 * 1000,
+      }),
+    );
+
+    getReminders.mockResolvedValue({
+      remindersList: [{ completeProfileReminder: {} }],
+    });
+
+    const { container } = render(<ReminderCarousel />, { wrapper });
+
+    await waitFor(() => expect(getReminders).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows a reminder again once the dismiss is older than one week", async () => {
+    const now = 1_700_000_000_000;
+    jest.spyOn(Date, "now").mockReturnValue(now);
+    localStorage.setItem(
+      DISMISSED_REMINDERS_KEY,
+      JSON.stringify({
+        complete_profile: now - ONE_WEEK_MS - 1,
+      }),
+    );
+
+    getReminders.mockResolvedValue({
+      remindersList: [{ completeProfileReminder: {} }],
+    });
+
+    render(<ReminderCarousel />, { wrapper });
+
+    expect(
+      await screen.findByText(t("dashboard:reminder.complete_profile.title")),
+    ).toBeVisible();
+  });
+
+  it("prunes stale dismiss entries from storage when a reminder is dismissed", async () => {
+    const user = userEvent.setup();
+    const now = 2_000_000_000_000;
+    jest.spyOn(Date, "now").mockReturnValue(now);
+    localStorage.setItem(
+      DISMISSED_REMINDERS_KEY,
+      JSON.stringify({
+        "write_reference:7": now - ONE_WEEK_MS - 1000,
+      }),
+    );
+
+    getReminders.mockResolvedValue({
+      remindersList: [{ completeProfileReminder: {} }],
+    });
+
+    render(<ReminderCarousel />, { wrapper });
+    await screen.findByText(t("dashboard:reminder.complete_profile.title"));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: t("dashboard:reminder.carousel_dismiss_button_a11y"),
+      }),
+    );
+
+    const stored: Record<string, number> = JSON.parse(
+      localStorage.getItem(DISMISSED_REMINDERS_KEY) ?? "{}",
+    );
+    expect(stored["write_reference:7"]).toBeUndefined();
+    expect(stored.complete_profile).toBe(now);
+  });
+
+  it("dismissing one host request reminder does not dismiss another", async () => {
+    const user = userEvent.setup();
+    const [alice, bob] = liteUsers;
+    getReminders.mockResolvedValue({
+      remindersList: [
+        {
+          respondToHostRequestReminder: {
+            hostRequestId: 42,
+            surferUser: alice,
+          },
+        },
+        {
+          respondToHostRequestReminder: { hostRequestId: 99, surferUser: bob },
+        },
+      ],
+    });
+
+    render(<ReminderCarousel />, { wrapper });
+
+    const aliceTitle = t("dashboard:reminder.respond_to_host_request.title", {
+      name: alice.name,
+    });
+    const bobTitle = t("dashboard:reminder.respond_to_host_request.title", {
+      name: bob.name,
+    });
+
+    expect(await screen.findByText(aliceTitle)).toBeVisible();
+    expect(screen.getByText(bobTitle)).toBeVisible();
+
+    const dismissButtons = screen.getAllByRole("button", {
+      name: t("dashboard:reminder.carousel_dismiss_button_a11y"),
+    });
+    await user.click(dismissButtons[0]);
+
+    expect(screen.queryByText(aliceTitle)).not.toBeInTheDocument();
+    expect(screen.getByText(bobTitle)).toBeVisible();
   });
 });

--- a/app/web/features/dashboard/ReminderCarousel.tsx
+++ b/app/web/features/dashboard/ReminderCarousel.tsx
@@ -7,7 +7,8 @@ import { useQuery } from "@tanstack/react-query";
 import Alert from "components/Alert";
 import IconButton from "components/IconButton";
 import { RpcError } from "grpc-web";
-import { GetRemindersRes } from "proto/account_pb";
+import { usePersistedState } from "platform/usePersistedState";
+import { GetRemindersRes, Reminder } from "proto/account_pb";
 import { useEffect, useRef, useState } from "react";
 import { service } from "service";
 
@@ -18,6 +19,54 @@ import ReminderItem from "./ReminderItem";
 const CARD_WIDTH_DESKTOP = 280;
 const CARD_WIDTH_MOBILE = 240;
 const CARD_GAP = 16;
+
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface ReminderWithId {
+  id: string;
+  reminder: Reminder.AsObject;
+}
+
+function getReminderId(reminder: Reminder.AsObject): string | null {
+  if (reminder.respondToHostRequestReminder?.hostRequestId != null) {
+    return `respond_host_request:${reminder.respondToHostRequestReminder.hostRequestId}`;
+  }
+  if (reminder.writeReferenceReminder?.hostRequestId != null) {
+    return `write_reference:${reminder.writeReferenceReminder.hostRequestId}`;
+  }
+  if (reminder.completeProfileReminder) {
+    return "complete_profile";
+  }
+  if (reminder.completeVerificationReminder) {
+    return "complete_verification";
+  }
+  return null;
+}
+
+function pruneStaleEntries(
+  dismissedReminders: Record<string, number>,
+  currentDismissalTime: number,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const [reminderId, dismissalTime] of Object.entries(
+    dismissedReminders,
+  )) {
+    if (currentDismissalTime - dismissalTime < ONE_WEEK_MS) {
+      out[reminderId] = dismissalTime;
+    }
+  }
+  return out;
+}
+
+function isStillDismissed(
+  dismissedReminders: Record<string, number>,
+  key: string,
+): boolean {
+  const now = Date.now();
+  const ts = dismissedReminders[key];
+  if (ts === undefined) return false;
+  return now - ts < ONE_WEEK_MS;
+}
 
 const StyledContainer = styled(Box)(({ theme }) => ({
   display: "flex",
@@ -64,6 +113,10 @@ export default function ReminderCarousel() {
     queryFn: () => service.account.getReminders(),
   });
 
+  const [dismissedReminders, setDismissedReminders] = usePersistedState<
+    Record<string, number>
+  >("dismissedReminders", {});
+
   const scrollerRef = useRef<HTMLDivElement>(null);
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
@@ -71,6 +124,20 @@ export default function ReminderCarousel() {
   const [canScrollRight, setCanScrollRight] = useState(false);
 
   const reminders = data?.remindersList ?? [];
+
+  const visibleReminders = reminders.reduce<ReminderWithId[]>((acc, r) => {
+    const id = getReminderId(r);
+    if (id && !isStillDismissed(dismissedReminders, id)) {
+      acc.push({ id, reminder: r });
+    }
+    return acc;
+  }, []);
+
+  const handleDismiss = (id: string) => {
+    const dismissTime = Date.now();
+    const pruned = pruneStaleEntries(dismissedReminders, dismissTime);
+    setDismissedReminders({ ...pruned, [id]: dismissTime });
+  };
 
   const updateScrollState = () => {
     const el = scrollerRef.current;
@@ -81,21 +148,21 @@ export default function ReminderCarousel() {
 
   useEffect(() => {
     updateScrollState();
-  }, [reminders.length]);
+  }, [visibleReminders.length]);
 
   const scrollByCard = (direction: 1 | -1) => {
     scrollerRef.current?.scrollBy({
       left:
         direction *
         (isMobile
-          ? CARD_WIDTH_DESKTOP + CARD_GAP
-          : CARD_WIDTH_MOBILE + CARD_GAP),
+          ? CARD_WIDTH_MOBILE + CARD_GAP
+          : CARD_WIDTH_DESKTOP + CARD_GAP),
       behavior: "smooth",
     });
   };
 
   if (error) return <Alert severity="error">{error.message}</Alert>;
-  if (!reminders.length) return null;
+  if (!visibleReminders.length) return null;
 
   return (
     <StyledContainer>
@@ -108,9 +175,12 @@ export default function ReminderCarousel() {
       </StyledArrow>
 
       <StyledScroller ref={scrollerRef} onScroll={updateScrollState}>
-        {reminders.map((reminder, i) => (
-          <StyledCardSlot key={i}>
-            <ReminderItem reminder={reminder} />
+        {visibleReminders.map(({ id, reminder }) => (
+          <StyledCardSlot key={id}>
+            <ReminderItem
+              reminder={reminder}
+              onDismiss={() => handleDismiss(id)}
+            />
           </StyledCardSlot>
         ))}
       </StyledScroller>

--- a/app/web/features/dashboard/ReminderItem.test.tsx
+++ b/app/web/features/dashboard/ReminderItem.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ReferenceType } from "proto/references_pb";
 import liteUsers from "test/fixtures/liteUsers.json";
 import wrapper from "test/hookWrapper";
@@ -119,5 +120,25 @@ describe("ReminderItem", () => {
     const { container } = render(<ReminderItem reminder={{}} />, { wrapper });
 
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("calls onDismiss when the dismiss button is clicked", async () => {
+    const user = userEvent.setup();
+    const onDismiss = jest.fn();
+    render(
+      <ReminderItem
+        reminder={{ completeProfileReminder: {} }}
+        onDismiss={onDismiss}
+      />,
+      { wrapper },
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: t("dashboard:reminder.carousel_dismiss_button_a11y"),
+      }),
+    );
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/web/features/dashboard/ReminderItem.tsx
+++ b/app/web/features/dashboard/ReminderItem.tsx
@@ -1,6 +1,8 @@
 import { alpha, Box, Typography } from "@mui/material";
 import { useMediaQuery } from "@mui/system";
 import Button from "components/Button";
+import IconButton from "components/IconButton";
+import { CloseIcon } from "components/Icons";
 import { useTranslation } from "i18n";
 import { DASHBOARD } from "i18n/namespaces";
 import Link from "next/link";
@@ -17,8 +19,10 @@ import { theme } from "../../theme";
 
 export default function ReminderItem({
   reminder,
+  onDismiss,
 }: {
   reminder: Reminder.AsObject;
+  onDismiss?: () => void;
 }) {
   const { t } = useTranslation([DASHBOARD]);
 
@@ -66,6 +70,7 @@ export default function ReminderItem({
   return (
     <Box
       sx={(theme) => ({
+        position: "relative",
         backgroundColor: alpha(theme.palette.secondary.main, 0.08),
         padding: isMobile ? "20px" : "24px",
         display: "flex",
@@ -73,6 +78,21 @@ export default function ReminderItem({
         height: "100%",
       })}
     >
+      {onDismiss && (
+        <IconButton
+          aria-label={t("reminder.carousel_dismiss_button_a11y")}
+          onClick={onDismiss}
+          size="small"
+          sx={(theme) => ({
+            position: "absolute",
+            top: theme.spacing(1),
+            right: theme.spacing(1),
+          })}
+        >
+          <CloseIcon />
+        </IconButton>
+      )}
+
       <Box sx={{ flexGrow: 1 }}>
         <Typography
           variant="h3"

--- a/app/web/features/dashboard/locales/en.json
+++ b/app/web/features/dashboard/locales/en.json
@@ -86,6 +86,7 @@
       "title": "Strong verification",
       "description": "Verify your identity for a safer community",
       "button": "Verify your account"
-    }
+    },
+    "carousel_dismiss_button_a11y": "Dismiss reminder"
   }
 }

--- a/app/web/features/messages/groupchats/GroupChatSendField.tsx
+++ b/app/web/features/messages/groupchats/GroupChatSendField.tsx
@@ -6,7 +6,7 @@ import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { RpcError } from "grpc-web";
 import { useTranslation } from "i18n";
 import { GLOBAL, MESSAGES } from "i18n/namespaces";
-import { usePersistedState } from "platform/usePersistedState";
+import { useClearablePersistedState } from "platform/usePersistedState";
 import React from "react";
 import { useForm } from "react-hook-form";
 
@@ -43,7 +43,7 @@ export default function GroupChatSendField({
   const { register, handleSubmit, reset, watch } = useForm<MessageFormData>();
 
   const [persistedMessage, setPersistedMessage, clearPersistedMessage] =
-    usePersistedState(
+    useClearablePersistedState(
       `messages.${currentUserId}.${chatId}`,
       "",
       "sessionStorage",

--- a/app/web/platform/usePersistedState.ts
+++ b/app/web/platform/usePersistedState.ts
@@ -6,7 +6,7 @@ import {
 
 type StorageType = "localStorage" | "sessionStorage";
 
-export function usePersistedState<T>(
+export function useClearablePersistedState<T>(
   key: string,
   defaultValue: T,
   storage: StorageType = "localStorage",
@@ -35,6 +35,15 @@ export function usePersistedState<T>(
     _setState(undefined);
   }, [key, storage]);
   return [_state, setState, clearState];
+}
+
+export function usePersistedState<T>(
+  key: string,
+  defaultValue: T,
+  storage: StorageType = "localStorage",
+) {
+  const [state, setState] = useClearablePersistedState(key, defaultValue, storage);
+  return [state as T, setState] as const;
 }
 
 export function clearStorage() {

--- a/app/web/platform/usePersistedState.ts
+++ b/app/web/platform/usePersistedState.ts
@@ -14,9 +14,15 @@ export function useClearablePersistedState<T>(
   // in ssr, window doesn't exist, just use default
   const saved =
     typeof window !== "undefined" ? window[storage].getItem(key) : null;
-  const [_state, _setState] = useState<T | undefined>(
-    saved !== null ? JSON.parse(saved) : defaultValue,
-  );
+  const [_state, _setState] = useState<T | undefined>(() => {
+    let initialValue: T | undefined;
+    try {
+      initialValue = saved !== null ? JSON.parse(saved) : defaultValue;
+    } catch {
+      initialValue = defaultValue;
+    }
+    return initialValue;
+  });
   const setState = useCallback(
     (value: T) => {
       if (value === undefined) {
@@ -37,12 +43,20 @@ export function useClearablePersistedState<T>(
   return [_state, setState, clearState];
 }
 
+/**
+ * @todo Consolidate all usage to this hook eventually - the clearable version should be doable via this hook only so the
+ * state has stronger typing and doesn't need to be type casted.
+ */
 export function usePersistedState<T>(
   key: string,
   defaultValue: T,
   storage: StorageType = "localStorage",
 ) {
-  const [state, setState] = useClearablePersistedState(key, defaultValue, storage);
+  const [state, setState] = useClearablePersistedState(
+    key,
+    defaultValue,
+    storage,
+  );
   return [state as T, setState] as const;
 }
 


### PR DESCRIPTION
*Describe briefly what this PR is doing and why.*

<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

Closes #8430

I went with a localStorage implementation in the end as we already have an existing `usePersistedStorage` hook, which makes reading/writing values a lot easier than manual cookie manipulation.

The return type on it was bothering me though, as values returned can never be `undefined` unless you call `clearValue` (the 3rd destructured value of the tuple). Or explicitly pass `undefined` as a default value, but in that case, that would be captured by the generic T type. This wrong typing made the consuming code more complex - you either need to write fallbacks that are unnecessary, extra code to check for undefinedness, or lie with assertions... and none of those feel great!

So I went ahead and refactored it into a new hook called `useClearablePersistedStorage`, which has the same implementation before, and `usePersistedStorage` now wraps that except with the `undefined` typing on the value removed. I figured it's fine as part of this since the change is relatively small and only a handful of tests and a single consumer got affected.

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

Have two profiles ready. One should have an incomplete profile, the other should be complete so you can send host requests to the incomplete profile.

Once you sent a host request to the incomplete profile, you should see two reminders in the account's dashboard.

Click on the new X button on either of them to dismiss it.

Refresh the page and check that only the reminder you didn't dismiss is shown.

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->


https://github.com/user-attachments/assets/6474952c-3a03-48c5-ae18-bc4b01d4c4f7


https://github.com/user-attachments/assets/bb6eade1-edbb-4bc8-9614-1bd5159b2ba3



**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
