### PR TITLE
Fix native app User-Agent reporting on iOS and Android

### DIFF
--- a/app/mobile/jest.setup.ts
+++ b/app/mobile/jest.setup.ts
@@ -20,6 +20,10 @@ jest.mock("expo-constants", () => ({
       gitHash: "abc12345",
     },
   },
+}));
+
+// Mock expo-application globally
+jest.mock("expo-application", () => ({
   nativeBuildVersion: "42",
 }));
 

--- a/app/mobile/package-lock.json
+++ b/app/mobile/package-lock.json
@@ -16,6 +16,7 @@
         "@react-navigation/drawer": "^7.3.9",
         "@react-navigation/native": "^7.1.6",
         "expo": "~54.0.34",
+        "expo-application": "~7.0.8",
         "expo-build-properties": "^1.0.10",
         "expo-clipboard": "~8.0.8",
         "expo-constants": "~18.0.11",

--- a/app/mobile/package.json
+++ b/app/mobile/package.json
@@ -36,6 +36,7 @@
     "@react-navigation/drawer": "^7.3.9",
     "@react-navigation/native": "^7.1.6",
     "expo": "~54.0.34",
+    "expo-application": "~7.0.8",
     "expo-build-properties": "^1.0.10",
     "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.11",

--- a/app/mobile/service/client.ts
+++ b/app/mobile/service/client.ts
@@ -4,6 +4,7 @@ import { NotificationsPromiseClient } from "@/proto/notifications_grpc_web_pb";
 
 import { getApiBaseUrl } from "@/config/urls";
 import isGrpcError from "@/service/utils/isGrpcError";
+import { applicationNameForUserAgent } from "@/utils/userAgent";
 
 const IS_PROD =
   (process.env.NEXT_PUBLIC_COUCHERS_ENV ||
@@ -51,11 +52,26 @@ class TimeoutInterceptor {
   }
 }
 
+// Sets an explicit User-Agent on API requests. Without this, native requests
+// go out with the platform HTTP stack's default UA (okhttp's "okhttp/4.12.0"
+// on Android, CFNetwork/Darwin on iOS), making API traffic indistinguishable
+// from generic clients.
+export class UserAgentInterceptor {
+  async intercept(
+    request: Request<unknown, unknown>,
+    invoker: (request: unknown) => unknown,
+  ) {
+    request.getMetadata()["User-Agent"] = applicationNameForUserAgent;
+    return invoker(request);
+  }
+}
+
 const authInterceptor = new AuthInterceptor();
 const timeoutInterceptor = new TimeoutInterceptor();
+const userAgentInterceptor = new UserAgentInterceptor();
 
 const opts = {
-  unaryInterceptors: [authInterceptor, timeoutInterceptor],
+  unaryInterceptors: [authInterceptor, timeoutInterceptor, userAgentInterceptor],
   // this modifies the behaviour on the API so that it will send cookies on the requests
   withCredentials: true,
   /// TODO: streaming interceptor for auth https://grpc.io/blog/grpc-web-interceptor/

--- a/app/mobile/tests/service/client.test.ts
+++ b/app/mobile/tests/service/client.test.ts
@@ -1,8 +1,9 @@
-import { StatusCode } from "grpc-web";
+import { Request, StatusCode } from "grpc-web";
 
 import {
   AuthInterceptor,
   setUnauthenticatedErrorHandler,
+  UserAgentInterceptor,
 } from "@/service/client";
 
 describe("AuthInterceptor", () => {
@@ -35,5 +36,21 @@ describe("AuthInterceptor", () => {
       interceptor.intercept(null, invokerMock),
     ).rejects.toMatchObject({ code: StatusCode.NOT_FOUND });
     expect(errorHandler).not.toHaveBeenCalled();
+  });
+});
+
+describe("UserAgentInterceptor", () => {
+  it("sets a CouchersNative User-Agent on the request metadata", async () => {
+    const metadata: Record<string, string> = {};
+    const request = {
+      getMetadata: () => metadata,
+    } as unknown as Request<unknown, unknown>;
+    const invokerMock = jest.fn(() => ({ test: "test" }));
+    const interceptor = new UserAgentInterceptor();
+
+    const response = await interceptor.intercept(request, invokerMock);
+
+    expect(response).toMatchObject({ test: "test" });
+    expect(metadata["User-Agent"]).toContain("CouchersNative/");
   });
 });

--- a/app/mobile/utils/userAgent.ts
+++ b/app/mobile/utils/userAgent.ts
@@ -1,8 +1,12 @@
+import * as Application from "expo-application";
 import Constants from "expo-constants";
 import { Platform } from "react-native";
 
 const appVersion = Constants.expoConfig?.version ?? "unknown";
 const gitHash = Constants.expoConfig?.extra?.gitHash ?? "unknown";
-const nativeVersion = Constants.nativeBuildVersion ?? "unknown";
+// Constants.nativeBuildVersion was removed in recent Expo SDKs; expo-application
+// reads the build number from the native build at runtime, so it works even
+// with EAS remote/auto-incremented version codes.
+const nativeBuildVersion = Application.nativeBuildVersion ?? "unknown";
 
-export const applicationNameForUserAgent = `CouchersNative/${appVersion} (${Platform.OS}; build ${nativeVersion}; ${gitHash})`;
+export const applicationNameForUserAgent = `CouchersNative/${appVersion} (${Platform.OS}; build ${nativeBuildVersion}; ${gitHash})`;


### PR DESCRIPTION
Native gRPC-web API requests from the mobile app went out with the platform HTTP stack's default User-Agent — `okhttp/4.12.0` on Android and the generic CFNetwork/Darwin UA on iOS — instead of a recognisable `CouchersNative` identifier. This adds a `UserAgentInterceptor` that sets an explicit `User-Agent` on every unary API request.

It also fixes the `build unknown` segment: `nativeBuildVersion` is now read from `expo-application` instead of the no-longer-populated `Constants.nativeBuildVersion`, and `expo-application` is promoted to a direct dependency.

This combines the work from three Claude branches addressing the same area into one PR.

closes #8689
closes #8692

## Testing
- Added a test for `UserAgentInterceptor` and a global `expo-application` jest mock.
- Mobile dependencies aren't installed locally, so lint/jest weren't run here — CI (`test:mobile`, `test:mobile-linting`, `test:mobile-expo-doctor`) should validate.
- Should be verified on a real release build: native API requests report `CouchersNative/...` with a real build number.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._