### PR TITLE
Backend: Ensure all datetimes are timezone-aware

### DIFF
--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -67,6 +67,9 @@ def is_valid_email(field: str) -> bool:
 
 
 def Timestamp_from_datetime(dt: datetime) -> Timestamp:
+    if dt.tzinfo is None:
+        raise ValueError("Cannot convert a naive datetime to a timestamp.")
+
     pb_ts = Timestamp()
     pb_ts.FromDatetime(dt)
     return pb_ts

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -1,5 +1,5 @@
 import json
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 import grpc
 import pytest
@@ -675,7 +675,8 @@ def test_ListUserIds(db):
     with real_admin_session(super_token) as api:
         res = api.ListUserIds(
             admin_pb2.ListUserIdsReq(
-                start_time=Timestamp_from_datetime(datetime(2000, 1, 1)), end_time=Timestamp_from_datetime(now())
+                start_time=Timestamp_from_datetime(datetime(2000, 1, 1, tzinfo=UTC)),
+                end_time=Timestamp_from_datetime(now()),
             )
         )
         assert len(res.user_ids) == 2

--- a/app/backend/src/tests/test_models.py
+++ b/app/backend/src/tests/test_models.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 
 import pytest
 from sqlalchemy import select
@@ -24,22 +24,30 @@ def test_user_age(db):
 
 
 def test_user_display_joined():
-    assert make_user(joined=datetime(2020, 7, 10, 16, 34, 1, 1)).display_joined == datetime(2020, 7, 10, 16, 0, 0, 0)
-    assert make_user(joined=datetime(2025, 7, 10, 16, 59, 1, 1)).display_joined == datetime(2025, 7, 10, 16, 0, 0, 0)
-    assert make_user(joined=datetime(2020, 7, 10, 16, 0, 1, 1)).display_joined == datetime(2020, 7, 10, 16, 0, 0, 0)
-    assert make_user(joined=datetime(2020, 7, 10, 0, 0, 0, 0)).display_joined == datetime(2020, 7, 10, 0, 0, 0, 0)
+    assert make_user(joined=datetime(2020, 7, 10, 16, 34, 1, 1, tzinfo=UTC)).display_joined == datetime(
+        2020, 7, 10, 16, 0, 0, 0, tzinfo=UTC
+    )
+    assert make_user(joined=datetime(2025, 7, 10, 16, 59, 1, 1, tzinfo=UTC)).display_joined == datetime(
+        2025, 7, 10, 16, 0, 0, 0, tzinfo=UTC
+    )
+    assert make_user(joined=datetime(2020, 7, 10, 16, 0, 1, 1, tzinfo=UTC)).display_joined == datetime(
+        2020, 7, 10, 16, 0, 0, 0, tzinfo=UTC
+    )
+    assert make_user(joined=datetime(2020, 7, 10, 0, 0, 0, 0, tzinfo=UTC)).display_joined == datetime(
+        2020, 7, 10, 0, 0, 0, 0, tzinfo=UTC
+    )
 
 
 def test_user_display_last_active():
-    assert make_user(last_active=datetime(2020, 7, 10, 16, 34, 1, 1)).display_last_active == datetime(
-        2020, 7, 10, 16, 0, 0, 0
+    assert make_user(last_active=datetime(2020, 7, 10, 16, 34, 1, 1, tzinfo=UTC)).display_last_active == datetime(
+        2020, 7, 10, 16, 0, 0, 0, tzinfo=UTC
     )
-    assert make_user(last_active=datetime(2025, 7, 10, 17, 59, 1, 1)).display_last_active == datetime(
-        2025, 7, 10, 17, 0, 0, 0
+    assert make_user(last_active=datetime(2025, 7, 10, 17, 59, 1, 1, tzinfo=UTC)).display_last_active == datetime(
+        2025, 7, 10, 17, 0, 0, 0, tzinfo=UTC
     )
-    assert make_user(last_active=datetime(2020, 7, 10, 16, 0, 1, 1)).display_last_active == datetime(
-        2020, 7, 10, 16, 0, 0, 0
+    assert make_user(last_active=datetime(2020, 7, 10, 16, 0, 1, 1, tzinfo=UTC)).display_last_active == datetime(
+        2020, 7, 10, 16, 0, 0, 0, tzinfo=UTC
     )
-    assert make_user(last_active=datetime(2020, 7, 10, 0, 0, 0, 0)).display_last_active == datetime(
-        2020, 7, 10, 0, 0, 0, 0
+    assert make_user(last_active=datetime(2020, 7, 10, 0, 0, 0, 0, tzinfo=UTC)).display_last_active == datetime(
+        2020, 7, 10, 0, 0, 0, 0, tzinfo=UTC
     )

--- a/app/backend/src/tests/test_public.py
+++ b/app/backend/src/tests/test_public.py
@@ -1,5 +1,5 @@
 import json
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from math import sqrt
 from unittest.mock import patch
 
@@ -241,30 +241,30 @@ def test_GetVolunteers_mixed_current_and_past(db):
             make_volunteer(
                 user_id=current1.id,
                 role="Current Role 1",
-                started_volunteering=datetime(2023, 1, 1).date(),
+                started_volunteering=date(2023, 1, 1),
             )
         )
         session.add(
             make_volunteer(
                 user_id=current2.id,
                 role="Current Role 2",
-                started_volunteering=datetime(2024, 1, 1).date(),
+                started_volunteering=date(2024, 1, 1),
             )
         )
         session.add(
             make_volunteer(
                 user_id=past1.id,
                 role="Past Role 1",
-                started_volunteering=datetime(2020, 1, 1).date(),
-                stopped_volunteering=datetime(2022, 6, 1).date(),
+                started_volunteering=date(2020, 1, 1),
+                stopped_volunteering=date(2022, 6, 1),
             )
         )
         session.add(
             make_volunteer(
                 user_id=past2.id,
                 role="Past Role 2",
-                started_volunteering=datetime(2021, 1, 1).date(),
-                stopped_volunteering=datetime(2023, 12, 31).date(),
+                started_volunteering=date(2021, 1, 1),
+                stopped_volunteering=date(2023, 12, 31),
             )
         )
 
@@ -295,7 +295,7 @@ def test_GetVolunteers_custom_sort_key(db):
             make_volunteer(
                 user_id=user2.id,
                 role="Role 2",
-                started_volunteering=datetime(2023, 3, 1).date(),
+                started_volunteering=date(2023, 3, 1),
                 sort_key=1.0,
             )
         )
@@ -304,7 +304,7 @@ def test_GetVolunteers_custom_sort_key(db):
             make_volunteer(
                 user_id=user3.id,
                 role="Role 3",
-                started_volunteering=datetime(2023, 1, 1).date(),
+                started_volunteering=date(2023, 1, 1),
                 sort_key=2.0,
             )
         )
@@ -313,7 +313,7 @@ def test_GetVolunteers_custom_sort_key(db):
             make_volunteer(
                 user_id=user1.id,
                 role="Role 1",
-                started_volunteering=datetime(2023, 2, 1).date(),
+                started_volunteering=date(2023, 2, 1),
             )
         )
 
@@ -340,14 +340,14 @@ def test_GetVolunteers_excludes_hidden(db):
             make_volunteer(
                 user_id=user1.id,
                 role="Visible Role",
-                started_volunteering=datetime(2023, 1, 1).date(),
+                started_volunteering=date(2023, 1, 1),
             )
         )
         session.add(
             make_volunteer(
                 user_id=user2.id,
                 role="Hidden Role",
-                started_volunteering=datetime(2023, 1, 1).date(),
+                started_volunteering=date(2023, 1, 1),
                 show_on_team_page=False,
             )
         )
@@ -374,7 +374,7 @@ def test_GetVolunteers_link_types(db):
             make_volunteer(
                 user_id=user_default.id,
                 role="Default Link",
-                started_volunteering=datetime(2023, 1, 1).date(),
+                started_volunteering=date(2023, 1, 1),
             )
         )
         # Volunteer with custom link
@@ -382,7 +382,7 @@ def test_GetVolunteers_link_types(db):
             make_volunteer(
                 user_id=user_custom.id,
                 role="Custom Link",
-                started_volunteering=datetime(2023, 1, 1).date(),
+                started_volunteering=date(2023, 1, 1),
                 link_type="email",
                 link_text="contact@example.com",
                 link_url="mailto:contact@example.com",
@@ -421,14 +421,14 @@ def test_GetVolunteers_board_member_flag(db):
             make_volunteer(
                 user_id=board_member.id,
                 role="Board Member Role",
-                started_volunteering=datetime(2023, 1, 1).date(),
+                started_volunteering=date(2023, 1, 1),
             )
         )
         session.add(
             make_volunteer(
                 user_id=regular_volunteer.id,
                 role="Regular Role",
-                started_volunteering=datetime(2023, 1, 1).date(),
+                started_volunteering=date(2023, 1, 1),
             )
         )
 


### PR DESCRIPTION
We shouldn't use Python naive datetimes, aka non-timezone-aware datetimes, to represent an instant in time, since that depends on the server's system timezone which should be irrelevant. Remove the few instances of them and throw if we encounter them.

## Testing
CI ran tests

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me