### PR TITLE
Backend/bugs: Use markdown to format GitHub issues

### DIFF
--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -47,19 +47,20 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
 
         issue_title = request.subject
         issue_body = (
-            f"Subject: {request.subject}\n"
-            f"Description:\n"
+            f"# {request.subject}\n"
+            f"## Description\n"
             f"{request.description}\n"
             f"\n"
-            f"Results:\n"
+            f"## Results\n"
             f"{request.results}\n"
             f"\n"
-            f"Backend version: {self._version()}\n"
-            f"Frontend version: {request.frontend_version}\n"
-            f"User Agent: {request.user_agent}\n"
-            f"Screen resolution: {request.screen_resolution.width}x{request.screen_resolution.height}\n"
-            f"Page: {request.page}\n"
-            f"User: {user_details}"
+            f"## Diagnostics\n"
+            f"**Backend version**: `{self._version()}`\n"
+            f"**Frontend version**: `{request.frontend_version}`\n"
+            f"**User Agent**: `{request.user_agent}`\n"
+            f"**Screen resolution**: {request.screen_resolution.width}x{request.screen_resolution.height}\n"
+            f"**Page**: {request.page}\n"
+            f"**User**: {user_details}"
         )
         issue_labels = ["bug tool", "bug: triage needed"]
 

--- a/app/backend/src/tests/test_bugs.py
+++ b/app/backend/src/tests/test_bugs.py
@@ -56,7 +56,7 @@ results
 **User Agent**: `user_agent`
 **Screen resolution**: 1920x1080
 **Page**: page
-**User**: <not logged in>""".strip(),
+**User**: <not logged in>""".strip()
 
             assert json == {
                 "title": "subject",
@@ -116,7 +116,7 @@ results
 **User Agent**: `user_agent`
 **Screen resolution**: 390x844
 **Page**: page
-**User**: [@testing_user](http://localhost:3000/user/testing_user) (1)""".strip(),
+**User**: [@testing_user](http://localhost:3000/user/testing_user) (1)""".strip()
 
             assert json == {
                 "title": "subject",

--- a/app/backend/src/tests/test_bugs.py
+++ b/app/backend/src/tests/test_bugs.py
@@ -41,13 +41,26 @@ def test_bugs(db):
         def dud_post(url, auth, json):
             assert url == "https://api.github.com/repos/org/repo/issues"
             assert auth == ("user", "token")
+
+            expected_body = f"""
+# subject
+## Description
+description
+
+## Results
+results
+
+## Diagnostics
+**Backend version**: `{config["VERSION"]}`
+**Frontend version**: `frontend_version`
+**User Agent**: `user_agent`
+**Screen resolution**: 1920x1080
+**Page**: page
+**User**: <not logged in>""".strip(),
+
             assert json == {
                 "title": "subject",
-                "body": (
-                    "Subject: subject\nDescription:\ndescription\n\nResults:\nresults\n\nBackend version: "
-                    + config["VERSION"]
-                    + "\nFrontend version: frontend_version\nUser Agent: user_agent\nScreen resolution: 1920x1080\nPage: page\nUser: <not logged in>"
-                ),
+                "body": expected_body,
                 "labels": ["bug tool", "bug: triage needed"],
             }
 
@@ -88,13 +101,26 @@ def test_bugs_with_user(db):
         def dud_post(url, auth, json):
             assert url == "https://api.github.com/repos/org/repo/issues"
             assert auth == ("user", "token")
+
+            expected_body = f"""
+# subject
+## Description
+description
+
+## Results
+results
+
+## Diagnostics
+**Backend version**: `{config["VERSION"]}`
+**Frontend version**: `frontend_version`
+**User Agent**: `user_agent`
+**Screen resolution**: 390x844
+**Page**: page
+**User**: [@testing_user](http://localhost:3000/user/testing_user) (1)""".strip(),
+
             assert json == {
                 "title": "subject",
-                "body": (
-                    "Subject: subject\nDescription:\ndescription\n\nResults:\nresults\n\nBackend version: "
-                    + config["VERSION"]
-                    + "\nFrontend version: frontend_version\nUser Agent: user_agent\nScreen resolution: 390x844\nPage: page\nUser: [@testing_user](http://localhost:3000/user/testing_user) (1)"
-                ),
+                "body": expected_body,
                 "labels": ["bug tool", "bug: triage needed"],
             }
 


### PR DESCRIPTION
Adds formatting to GitHub issues for readability.

## Testing
Replicated the formatting in a comment to preview it (see pics below). Used `gh api --method POST` to validate that "body" can contain markdown.

Before:
<img width="1744" height="718" alt="image" src="https://github.com/user-attachments/assets/84978fa8-5aff-4fb5-9ff6-f84d7b3dcd36" />

After:
<img width="1868" height="1166" alt="image" src="https://github.com/user-attachments/assets/f70700d3-fabc-4b10-89ad-9e790d44e76c" />

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
