### PR TITLE
Frontend/i18n: Honor locale when searching places

### DIFF
--- a/app/web/utils/hooks.ts
+++ b/app/web/utils/hooks.ts
@@ -11,6 +11,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { useTranslation } from "react-i18next";
 import { service } from "service";
 import {
   filterDuplicatePlaces,
@@ -85,6 +86,9 @@ const NOMINATIM_URL = process.env.NEXT_PUBLIC_NOMINATIM_URL;
 
 const useGeocodeQuery = () => {
   const isMounted = useIsMounted();
+  const {
+    i18n: { languages: locales },
+  } = useTranslation();
   const [isLoading, setIsLoading] = useSafeState(isMounted, false);
   const [error, setError] = useSafeState<string | undefined>(
     isMounted,
@@ -103,9 +107,16 @@ const useGeocodeQuery = () => {
       setIsLoading(true);
       setError(undefined);
       setResults(undefined);
-      const url = `${NOMINATIM_URL!}search?format=jsonv2&q=${encodeURIComponent(
-        value,
-      )}&addressdetails=1`;
+
+      // Refer to https://nominatim.org/release-docs/latest/api/Search/
+      const queryArgs = new URLSearchParams({
+        format: "jsonv2",
+        q: value,
+        addressdetails: "1", // include a breakdown of the address into elements
+        "accept-language": locales.join(","),
+      });
+
+      const url = `${NOMINATIM_URL!}search?${queryArgs}`;
       const fetchOptions = {
         headers: {
           Accept: "application/json",
@@ -160,7 +171,7 @@ const useGeocodeQuery = () => {
       }
       setIsLoading(false);
     },
-    [setError, setIsLoading, setResults],
+    [locales, setError, setIsLoading, setResults],
   );
 
   return { isLoading, error, results, query };


### PR DESCRIPTION
By default Nominatim will guess the locale from the Accept-Language header, but we can tell it to follow the language selected on Couchers (and its fallbacks).

Thanks to @HankAviator for locating where this needed fixing in code.

Fixes #6212

## Testing
Ran locally and searched for "Mexico" in English vs Spanish (navigation also works once selecting a result):

<img width="1244" height="564" alt="image" src="https://github.com/user-attachments/assets/349b8870-b99d-4ad8-8be3-4e491546bb2c" />

<img width="1292" height="556" alt="image" src="https://github.com/user-attachments/assets/b3fd4f35-68df-4cef-abc6-99ccbcfe8bd9" />

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
