### PR TITLE
Backend/bugs: Add locale to bug reporting

### DIFF
--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -58,6 +58,7 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
             f"**Backend version**: `{self._version()}`\n"
             f"**Frontend version**: `{request.frontend_version}`\n"
             f"**User Agent**: `{request.user_agent}`\n"
+            f"**Locale**: `{context.localization.locale}`\n"
             f"**Screen resolution**: {request.screen_resolution.width}x{request.screen_resolution.height}\n"
             f"**Page**: {request.page}\n"
             f"**User**: {user_details}"

--- a/app/backend/src/tests/test_bugs.py
+++ b/app/backend/src/tests/test_bugs.py
@@ -54,6 +54,7 @@ results
 **Backend version**: `{config["VERSION"]}`
 **Frontend version**: `frontend_version`
 **User Agent**: `user_agent`
+**Locale**: `en`
 **Screen resolution**: 1920x1080
 **Page**: page
 **User**: <not logged in>""".strip()
@@ -114,6 +115,7 @@ results
 **Backend version**: `{config["VERSION"]}`
 **Frontend version**: `frontend_version`
 **User Agent**: `user_agent`
+**Locale**: `en`
 **Screen resolution**: 390x844
 **Page**: page
 **User**: [@testing_user](http://localhost:3000/user/testing_user) (1)""".strip()


### PR DESCRIPTION
The locale is a piece of global state that impacts a lot of the website, so it's useful to log as part of bug reports. I've seen several bad date formats and similar bugs that would have benefited from this.

## Testing
Updated tests.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
