### PR TITLE
Mobile: relay gRPC-web API calls through native code

### DIFF
--- a/app/mobile/components/WebEmbed.tsx
+++ b/app/mobile/components/WebEmbed.tsx
@@ -24,6 +24,7 @@ import { useAuthContext } from "@/features/auth/AuthContext";
 import { useImagePicker } from "@/hooks/useImagePicker";
 import { useWebNavigation } from "@/hooks/useWebNavigation";
 import errorGraphic from "@/resources/404graphic.png";
+import { relayApiRequest } from "@/service/apiRelay";
 import client from "@/service/client";
 import { dispatchEscapeRef, lastLoginTimeRef } from "@/state/webViewState";
 import { theme } from "@/theme";
@@ -369,6 +370,14 @@ export default function WebEmbed({
       } else if (payload?.type === "REQUEST_IMAGE_PICK") {
         // WebView file input crashes on mobile; use native picker instead.
         pickImage(sendImagePickResult);
+      } else if (payload?.type === "API_REQUEST") {
+        // The web app's gRPC-web client relays each call here so the request
+        // is performed by native code rather than the WebView's transport.
+        const response = await relayApiRequest(payload.data);
+        webviewRef.current?.injectJavaScript(`
+          window.postMessage(${JSON.stringify({ type: "API_RESPONSE", data: response })}, "*");
+          true;
+        `);
       }
     } catch (error) {
       // Ignore non-JSON messages from browser/WebView internals.
@@ -459,7 +468,7 @@ export default function WebEmbed({
             />
           </View>
         )}
-        injectedJavaScriptObject={{ isNativeEmbed: true }}
+        injectedJavaScriptObject={{ isNativeEmbed: true, apiRelay: true }}
         onLoad={() => {
           hasLoadedRef.current = true;
         }}

--- a/app/mobile/service/apiRelay.ts
+++ b/app/mobile/service/apiRelay.ts
@@ -1,0 +1,111 @@
+// Native side of the gRPC-web relay: the web app (running in the WebView)
+// hands us an already-framed gRPC-web request; we perform the actual HTTP call
+// from native code and hand the raw response back. See app/web/service/
+// nativeApiRelay.ts for the WebView side.
+
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL ?? "";
+
+export interface ApiRequestPayload {
+  id: string;
+  path: string;
+  headers: Record<string, string>;
+  bodyBase64: string;
+}
+
+export interface ApiResponsePayload {
+  id: string;
+  httpStatus?: number;
+  headers?: Record<string, string>;
+  bodyBase64?: string;
+  error?: string;
+}
+
+const B64_CHARS =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+const B64_LOOKUP = (() => {
+  const table = new Int16Array(128).fill(-1);
+  for (let i = 0; i < B64_CHARS.length; i += 1) {
+    table[B64_CHARS.charCodeAt(i)] = i;
+  }
+  return table;
+})();
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  let result = "";
+  for (let i = 0; i < bytes.length; i += 3) {
+    const hasByte1 = i + 1 < bytes.length;
+    const hasByte2 = i + 2 < bytes.length;
+    const b0 = bytes[i];
+    const b1 = hasByte1 ? bytes[i + 1] : 0;
+    const b2 = hasByte2 ? bytes[i + 2] : 0;
+    result += B64_CHARS[b0 >> 2];
+    result += B64_CHARS[((b0 & 0x03) << 4) | (b1 >> 4)];
+    result += hasByte1 ? B64_CHARS[((b1 & 0x0f) << 2) | (b2 >> 6)] : "=";
+    result += hasByte2 ? B64_CHARS[b2 & 0x3f] : "=";
+  }
+  return result;
+}
+
+export function base64ToBytes(value: string): Uint8Array {
+  const bytes: number[] = [];
+  let buffer = 0;
+  let bits = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    const sextet = code < 128 ? B64_LOOKUP[code] : -1;
+    if (sextet === -1) {
+      continue;
+    }
+    buffer = (buffer << 6) | sextet;
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      bytes.push((buffer >> bits) & 0xff);
+    }
+  }
+  return Uint8Array.from(bytes);
+}
+
+function parseResponseHeaders(raw: string): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const line of raw.split(/[\r\n]+/)) {
+    const idx = line.indexOf(":");
+    if (idx === -1) {
+      continue;
+    }
+    headers[line.slice(0, idx).trim().toLowerCase()] = line
+      .slice(idx + 1)
+      .trim();
+  }
+  return headers;
+}
+
+export function relayApiRequest(
+  request: ApiRequestPayload,
+): Promise<ApiResponsePayload> {
+  return new Promise((resolve) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", API_BASE_URL + request.path);
+    xhr.responseType = "arraybuffer";
+    xhr.withCredentials = true;
+    for (const [key, value] of Object.entries(request.headers)) {
+      xhr.setRequestHeader(key, value);
+    }
+    xhr.onload = () => {
+      resolve({
+        id: request.id,
+        httpStatus: xhr.status,
+        headers: parseResponseHeaders(xhr.getAllResponseHeaders()),
+        bodyBase64: bytesToBase64(new Uint8Array(xhr.response as ArrayBuffer)),
+      });
+    };
+    xhr.onerror = () => {
+      resolve({ id: request.id, error: "Network request failed" });
+    };
+    xhr.ontimeout = () => {
+      resolve({ id: request.id, error: "Request timed out" });
+    };
+    xhr.send(base64ToBytes(request.bodyBase64));
+  });
+}

--- a/app/mobile/tests/service/apiRelay.test.ts
+++ b/app/mobile/tests/service/apiRelay.test.ts
@@ -1,0 +1,31 @@
+import { base64ToBytes, bytesToBase64 } from "@/service/apiRelay";
+
+describe("apiRelay base64", () => {
+  it("encodes known vectors, including every padding length", () => {
+    expect(bytesToBase64(Uint8Array.from([]))).toBe("");
+    expect(bytesToBase64(Uint8Array.from([102]))).toBe("Zg==");
+    expect(bytesToBase64(Uint8Array.from([102, 111]))).toBe("Zm8=");
+    expect(bytesToBase64(Uint8Array.from([102, 111, 111]))).toBe("Zm9v");
+    expect(bytesToBase64(Uint8Array.from([102, 111, 111, 98, 97, 114]))).toBe(
+      "Zm9vYmFy",
+    );
+  });
+
+  it("decodes a known vector", () => {
+    expect(Array.from(base64ToBytes("Zm9vYmFy"))).toEqual([
+      102, 111, 111, 98, 97, 114,
+    ]);
+  });
+
+  it("round-trips arbitrary byte sequences", () => {
+    for (const length of [0, 1, 2, 3, 4, 255, 1000]) {
+      const bytes = new Uint8Array(length);
+      for (let i = 0; i < length; i += 1) {
+        bytes[i] = (i * 31 + 7) & 0xff;
+      }
+      expect(Array.from(base64ToBytes(bytesToBase64(bytes)))).toEqual(
+        Array.from(bytes),
+      );
+    }
+  });
+});

--- a/app/web/service/client.ts
+++ b/app/web/service/client.ts
@@ -24,6 +24,7 @@ import { SearchPromiseClient } from "proto/search_grpc_web_pb";
 import { ThreadsPromiseClient } from "proto/threads_grpc_web_pb";
 import { getClientPlatform } from "utils/clientPlatform";
 
+import { NativeApiRelayInterceptor } from "./nativeApiRelay";
 import isGrpcError from "./utils/isGrpcError";
 
 const URL = (process.env.NEXT_PUBLIC_API_BASE_URL ||
@@ -90,9 +91,17 @@ class PlatformInterceptor {
 const authInterceptor = new AuthInterceptor();
 const timeoutInterceptor = new TimeoutInterceptor();
 const platformInterceptor = new PlatformInterceptor();
+// Innermost interceptor: stands in for the transport when running inside the
+// native mobile app, relaying the call to the native layer.
+const nativeApiRelayInterceptor = new NativeApiRelayInterceptor();
 
 const opts = {
-  unaryInterceptors: [authInterceptor, timeoutInterceptor, platformInterceptor],
+  unaryInterceptors: [
+    authInterceptor,
+    timeoutInterceptor,
+    platformInterceptor,
+    nativeApiRelayInterceptor,
+  ],
   // this modifies the behaviour on the API so that it will send cookies on the requests
   withCredentials: true,
   /// TODO: streaming interceptor for auth https://grpc.io/blog/grpc-web-interceptor/

--- a/app/web/service/nativeApiRelay.test.ts
+++ b/app/web/service/nativeApiRelay.test.ts
@@ -1,0 +1,168 @@
+import { MethodDescriptor, MethodType, Request, RpcError } from "grpc-web";
+
+import {
+  frameMessage,
+  NativeApiRelayInterceptor,
+  parseFrames,
+} from "./nativeApiRelay";
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+function trailerFrame(text: string): Uint8Array {
+  const payload = new TextEncoder().encode(text);
+  const frame = new Uint8Array(5 + payload.length);
+  frame[0] = 0x80;
+  new DataView(frame.buffer).setUint32(1, payload.length);
+  frame.set(payload, 5);
+  return frame;
+}
+
+function toBase64(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes));
+}
+
+function makeRequest(): Request<unknown, unknown> {
+  const descriptor = new MethodDescriptor(
+    "/org.couchers.test.Test/Echo",
+    MethodType.UNARY,
+    Object as never,
+    Object as never,
+    (message: never) => message,
+    (bytes: Uint8Array) => ({ echoed: Array.from(bytes) }),
+  );
+  return {
+    getMethodDescriptor: () => descriptor,
+    getRequestMessage: () => ({
+      serializeBinary: () => Uint8Array.from([9, 9, 9]),
+    }),
+    getMetadata: () => ({}),
+  } as unknown as Request<unknown, unknown>;
+}
+
+describe("gRPC-web framing helpers", () => {
+  it("frames a message with a 5-byte length prefix", () => {
+    const framed = frameMessage(Uint8Array.from([1, 2, 3, 4]));
+    expect(framed[0]).toBe(0);
+    expect(new DataView(framed.buffer).getUint32(1)).toBe(4);
+    expect(Array.from(framed.slice(5))).toEqual([1, 2, 3, 4]);
+  });
+
+  it("parses a data frame and a trailer frame", () => {
+    const body = concat(
+      frameMessage(Uint8Array.from([7, 8])),
+      trailerFrame("grpc-status:0\r\ngrpc-message:ok\r\n"),
+    );
+    const { message, trailers } = parseFrames(body);
+    expect(Array.from(message!)).toEqual([7, 8]);
+    expect(trailers["grpc-status"]).toBe("0");
+    expect(trailers["grpc-message"]).toBe("ok");
+  });
+});
+
+describe("NativeApiRelayInterceptor", () => {
+  afterEach(() => {
+    delete window.ReactNativeWebView;
+  });
+
+  it("passes through to the invoker when not in a native embed", async () => {
+    const invoker = jest.fn(async () => ({
+      getResponseMessage: () => "direct",
+    }));
+    const interceptor = new NativeApiRelayInterceptor();
+
+    const response = await interceptor.intercept(
+      makeRequest(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      invoker as any,
+    );
+
+    expect(invoker).toHaveBeenCalled();
+    expect(response.getResponseMessage()).toBe("direct");
+  });
+
+  it("relays the call to native and deserializes the response", async () => {
+    const postMessage = jest.fn();
+    window.ReactNativeWebView = {
+      postMessage,
+      injectedObjectJson: () => JSON.stringify({ apiRelay: true }),
+    };
+    const invoker = jest.fn();
+    const interceptor = new NativeApiRelayInterceptor();
+
+    const promise = interceptor.intercept(
+      makeRequest(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      invoker as any,
+    );
+
+    const sent = JSON.parse(postMessage.mock.calls[0][0]);
+    expect(sent.type).toBe("API_REQUEST");
+    expect(sent.data.path).toBe("/org.couchers.test.Test/Echo");
+
+    const body = concat(
+      frameMessage(Uint8Array.from([5, 6])),
+      trailerFrame("grpc-status:0\r\n"),
+    );
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: JSON.stringify({
+          type: "API_RESPONSE",
+          data: {
+            id: sent.data.id,
+            httpStatus: 200,
+            headers: {},
+            bodyBase64: toBase64(body),
+          },
+        }),
+      }),
+    );
+
+    const response = await promise;
+    expect(invoker).not.toHaveBeenCalled();
+    expect(response.getResponseMessage()).toEqual({ echoed: [5, 6] });
+  });
+
+  it("throws an RpcError when native returns a non-OK grpc-status", async () => {
+    const postMessage = jest.fn();
+    window.ReactNativeWebView = {
+      postMessage,
+      injectedObjectJson: () => JSON.stringify({ apiRelay: true }),
+    };
+    const interceptor = new NativeApiRelayInterceptor();
+
+    const promise = interceptor.intercept(
+      makeRequest(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      jest.fn() as any,
+    );
+
+    const sent = JSON.parse(postMessage.mock.calls[0][0]);
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: JSON.stringify({
+          type: "API_RESPONSE",
+          data: {
+            id: sent.data.id,
+            httpStatus: 200,
+            headers: {},
+            bodyBase64: toBase64(
+              trailerFrame("grpc-status:5\r\ngrpc-message:nope\r\n"),
+            ),
+          },
+        }),
+      }),
+    );
+
+    await expect(promise).rejects.toBeInstanceOf(RpcError);
+    await expect(promise).rejects.toMatchObject({ code: 5, message: "nope" });
+  });
+});

--- a/app/web/service/nativeApiRelay.ts
+++ b/app/web/service/nativeApiRelay.ts
@@ -1,0 +1,292 @@
+import {
+  type Metadata,
+  MethodDescriptor,
+  MethodType,
+  type Request,
+  RpcError,
+  StatusCode,
+  type UnaryResponse,
+} from "grpc-web";
+import { getInjectedValue } from "utils/nativeLink";
+
+// When the web app runs inside the native mobile WebView, gRPC-web calls are
+// relayed to the native layer (which performs the actual HTTP request) instead
+// of going out through the WebView's own XHR transport. This is wired in as the
+// innermost unary interceptor, so it stands in for the transport itself.
+
+// Ceiling for a relayed call when the request carries no gRPC deadline.
+const RELAY_TIMEOUT_MS = 30_000;
+
+interface ProtoMessage {
+  serializeBinary(): Uint8Array;
+}
+
+type DeserializeFn = (bytes: Uint8Array) => unknown;
+
+// The relay is only used when the native app explicitly advertises support via
+// the injected `apiRelay` flag. Older native builds lack the flag, so the web
+// app keeps using its own transport and is never bricked by a web-only deploy.
+function isApiRelayEnabled(): boolean {
+  return getInjectedValue("apiRelay") === true;
+}
+
+// grpc-web's MethodDescriptor stores the response deserializer under a minified
+// property name. Rather than hard-code it, probe a descriptor we construct
+// ourselves to discover which key holds it.
+let deserializeKey: string | null = null;
+function getDeserializeKey(): string {
+  if (deserializeKey !== null) {
+    return deserializeKey;
+  }
+  const marker: DeserializeFn = (bytes) => bytes;
+  const probe = new MethodDescriptor(
+    "probe",
+    MethodType.UNARY,
+    Object as never,
+    Object as never,
+    (message: never) => message,
+    marker,
+  );
+  const key = Object.keys(probe).find(
+    (k) => (probe as unknown as Record<string, unknown>)[k] === marker,
+  );
+  if (!key) {
+    throw new Error(
+      "nativeApiRelay: unable to locate grpc-web response deserializer",
+    );
+  }
+  deserializeKey = key;
+  return key;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+// Wrap a serialized message in a gRPC-web data frame: 1 flag byte + 4-byte
+// big-endian length prefix.
+export function frameMessage(payload: Uint8Array): Uint8Array {
+  const frame = new Uint8Array(5 + payload.length);
+  new DataView(frame.buffer).setUint32(1, payload.length);
+  frame.set(payload, 5);
+  return frame;
+}
+
+interface ParsedResponse {
+  message?: Uint8Array;
+  trailers: Record<string, string>;
+}
+
+function parseHeaderBlock(text: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const idx = line.indexOf(":");
+    if (idx === -1) {
+      continue;
+    }
+    out[line.slice(0, idx).trim().toLowerCase()] = line.slice(idx + 1).trim();
+  }
+  return out;
+}
+
+// Walk the gRPC-web framed response body: data frames carry the message, the
+// trailer frame (high bit of the flag byte set) carries grpc-status.
+export function parseFrames(body: Uint8Array): ParsedResponse {
+  const view = new DataView(body.buffer, body.byteOffset, body.byteLength);
+  let offset = 0;
+  let message: Uint8Array | undefined;
+  let trailers: Record<string, string> = {};
+  while (offset + 5 <= body.length) {
+    const flag = body[offset];
+    const length = view.getUint32(offset + 1);
+    const payload = body.subarray(offset + 5, offset + 5 + length);
+    offset += 5 + length;
+    if ((flag & 0x80) !== 0) {
+      trailers = parseHeaderBlock(new TextDecoder().decode(payload));
+    } else {
+      message = payload;
+    }
+  }
+  return { message, trailers };
+}
+
+function decodeGrpcMessage(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+interface RelayResponse {
+  httpStatus: number;
+  headers: Record<string, string>;
+  body: Uint8Array;
+}
+
+interface PendingCall {
+  resolve: (response: RelayResponse) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const pendingCalls = new Map<string, PendingCall>();
+let callCounter = 0;
+
+if (typeof window !== "undefined") {
+  window.addEventListener("message", (event) => {
+    let payload;
+    try {
+      payload =
+        typeof event.data === "string" ? JSON.parse(event.data) : event.data;
+    } catch {
+      return;
+    }
+    if (payload?.type !== "API_RESPONSE" || !payload.data) {
+      return;
+    }
+    const { id, error, httpStatus, headers, bodyBase64 } = payload.data;
+    const pending = pendingCalls.get(id);
+    if (!pending) {
+      return;
+    }
+    pendingCalls.delete(id);
+    clearTimeout(pending.timer);
+    if (error) {
+      pending.reject(new RpcError(StatusCode.UNAVAILABLE, error, {}));
+      return;
+    }
+    pending.resolve({
+      httpStatus: httpStatus ?? 0,
+      headers: headers ?? {},
+      body: base64ToBytes(bodyBase64 ?? ""),
+    });
+  });
+}
+
+function relayToNative(
+  path: string,
+  headers: Record<string, string>,
+  framedBody: Uint8Array,
+  timeoutMs: number,
+): Promise<RelayResponse> {
+  callCounter += 1;
+  const id = `api-${callCounter}`;
+  return new Promise<RelayResponse>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      pendingCalls.delete(id);
+      reject(
+        new RpcError(
+          StatusCode.DEADLINE_EXCEEDED,
+          "Native API relay timed out",
+          {},
+        ),
+      );
+    }, timeoutMs);
+    pendingCalls.set(id, { resolve, reject, timer });
+    window.ReactNativeWebView!.postMessage(
+      JSON.stringify({
+        type: "API_REQUEST",
+        data: { id, path, headers, bodyBase64: bytesToBase64(framedBody) },
+      }),
+    );
+  });
+}
+
+function buildHeaders(metadata: Metadata): {
+  headers: Record<string, string>;
+  timeoutMs: number;
+} {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/grpc-web+proto",
+    "X-Grpc-Web": "1",
+    "X-User-Agent": "grpc-web-javascript/0.1",
+    Accept: "application/grpc-web+proto",
+  };
+  let timeoutMs = RELAY_TIMEOUT_MS;
+  for (const [key, value] of Object.entries(metadata)) {
+    if (key === "deadline") {
+      timeoutMs = Math.max(0, Number(value) - Date.now());
+      headers["grpc-timeout"] = `${Math.ceil(timeoutMs)}m`;
+    } else {
+      headers[key] = value;
+    }
+  }
+  return { headers, timeoutMs };
+}
+
+export class NativeApiRelayInterceptor {
+  async intercept(
+    request: Request<unknown, unknown>,
+    invoker: (
+      request: Request<unknown, unknown>,
+    ) => Promise<UnaryResponse<unknown, unknown>>,
+  ): Promise<UnaryResponse<unknown, unknown>> {
+    if (!isApiRelayEnabled()) {
+      return invoker(request);
+    }
+
+    const descriptor = request.getMethodDescriptor();
+    const requestMessage = request.getRequestMessage() as ProtoMessage;
+    const { headers, timeoutMs } = buildHeaders(request.getMetadata());
+    const framed = frameMessage(requestMessage.serializeBinary());
+
+    const {
+      httpStatus,
+      headers: responseHeaders,
+      body,
+    } = await relayToNative(descriptor.getName(), headers, framed, timeoutMs);
+
+    const { message, trailers } = parseFrames(body);
+
+    const rawStatus = trailers["grpc-status"] ?? responseHeaders["grpc-status"];
+    const grpcStatus = rawStatus !== undefined ? Number(rawStatus) : null;
+    const grpcMessage = decodeGrpcMessage(
+      trailers["grpc-message"] ?? responseHeaders["grpc-message"] ?? "",
+    );
+
+    if (grpcStatus !== null && grpcStatus !== StatusCode.OK) {
+      throw new RpcError(grpcStatus, grpcMessage, trailers);
+    }
+    if (grpcStatus === null && httpStatus !== 200) {
+      throw new RpcError(
+        StatusCode.UNKNOWN,
+        `Native API relay HTTP ${httpStatus}`,
+        {},
+      );
+    }
+    if (!message) {
+      throw new RpcError(
+        StatusCode.UNKNOWN,
+        "Native API relay returned an empty response",
+        {},
+      );
+    }
+
+    const deserialize = (
+      descriptor as unknown as Record<string, DeserializeFn>
+    )[getDeserializeKey()];
+    const responseMessage = deserialize(message);
+
+    return {
+      getResponseMessage: () => responseMessage,
+      getMetadata: () => ({}),
+      getMethodDescriptor: () => descriptor,
+      getStatus: () => ({ code: StatusCode.OK, details: "", metadata: {} }),
+    } as UnaryResponse<unknown, unknown>;
+  }
+}

--- a/app/web/utils/nativeLink.ts
+++ b/app/web/utils/nativeLink.ts
@@ -6,20 +6,26 @@ function getReactNativeWebView(): typeof window.ReactNativeWebView {
   }
 }
 
+// Read a single flag the native app injects into the WebView via
+// injectedObjectJson(). Returns undefined when not running in a native embed or
+// the value is absent/unparseable.
+export function getInjectedValue(key: string): unknown {
+  const webview = getReactNativeWebView();
+  if (!webview?.injectedObjectJson) return undefined;
+  try {
+    return JSON.parse(webview.injectedObjectJson())?.[key];
+  } catch {
+    return undefined;
+  }
+}
+
 function isNativeEmbed(): boolean {
   const webview = getReactNativeWebView();
   if (!webview) return false;
 
-  // Android-reliable detection: Check injectedObjectJson() which is more reliable than
-  // just checking for ReactNativeWebView existence due to timing issues on Android
-  try {
-    if (webview.injectedObjectJson) {
-      const injectedData = JSON.parse(webview.injectedObjectJson());
-      if (injectedData?.isNativeEmbed) return true;
-    }
-  } catch {
-    // Parsing failed or method not available - fall through to default behavior
-  }
+  // Android-reliable detection: the injected flag is more reliable than just
+  // checking for ReactNativeWebView existence due to timing issues on Android.
+  if (getInjectedValue("isNativeEmbed")) return true;
 
   // iOS and fallback: If ReactNativeWebView exists, assume we're in native embed
   return true;


### PR DESCRIPTION
Routes the mobile app's gRPC-web API calls through native code instead of the WebView's own HTTP transport.

A new gRPC-web unary interceptor (`nativeApiRelay.ts`) is wired in as the innermost interceptor in the web client. When the page is running inside the native mobile WebView, it bypasses the built-in transport: it serializes and gRPC-web-frames the request, relays it to native over `postMessage` with a correlation id, then unframes/deserializes the reply and surfaces non-OK `grpc-status` as an `RpcError`. On regular web it's a pass-through. The native side (`apiRelay.ts`) performs the real request via `XMLHttpRequest` (binary via `arraybuffer`) and only ever relays to the configured API host.

The relay activates only when the native app advertises support via the injected `apiRelay` flag, so a web-only deploy can never brick already-installed native builds (they keep using their own transport).

## Testing
- Web: `yarn typecheck` (clean for these files), `yarn test service/nativeApiRelay.test.ts` — 5 tests pass (framing helpers, pass-through, relay round-trip, non-OK status → RpcError)
- Mobile: `tsc --noEmit` clean, `jest tests/service/apiRelay.test.ts` — 3 base64 tests pass
- Lint clean for all changed files on both sides

Not yet done: an end-to-end smoke test of a relayed call against a running backend through a real device WebView. The protocol logic is unit-covered, but the live native fetch path has not been exercised on-device.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._