### PR TITLE
Backend: Update notification is_seen when viewing message or host request

### DIFF
--- a/app/backend/src/couchers/notifications/notify.py
+++ b/app/backend/src/couchers/notifications/notify.py
@@ -2,6 +2,7 @@ import logging
 
 from google.protobuf import empty_pb2
 from google.protobuf.message import Message
+from sqlalchemy import update
 from sqlalchemy.orm import Session
 
 from couchers.jobs.enqueue import queue_job
@@ -61,4 +62,23 @@ def notify(
         payload=jobs_pb2.HandleNotificationPayload(
             notification_id=notification.id,
         ),
+    )
+
+
+def mark_notifications_seen(
+    session: Session,
+    *,
+    user_id: int,
+    key: str,
+    topic_actions: list[NotificationTopicAction],
+) -> None:
+    """
+    Marks all unseen notifications for the given user, key, and topic actions as seen.
+    """
+    session.execute(
+        update(Notification)
+        .values(is_seen=True)
+        .where(Notification.user_id == user_id)
+        .where(Notification.key == key)
+        .where(Notification.topic_action.in_(topic_actions))
     )

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 
 import grpc
 from google.protobuf import empty_pb2
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.orm import Session, contains_eager
 from sqlalchemy.sql import func, not_, or_
 
@@ -24,6 +24,7 @@ from couchers.models import (
     Message,
     MessageType,
     ModerationObjectType,
+    Notification,
     RateLimitAction,
     User,
 )
@@ -612,6 +613,13 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "cant_unsee_messages")
 
         subscription.last_seen_message_id = request.last_seen_message_id
+
+        session.execute(
+            update(Notification)
+            .values(is_seen=True)
+            .where(Notification.user_id == context.user_id)
+            .where(Notification.key == str(request.group_chat_id))
+        )
 
         return empty_pb2.Empty()
 

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 
 import grpc
 from google.protobuf import empty_pb2
-from sqlalchemy import select, update
+from sqlalchemy import select
 from sqlalchemy.orm import Session, contains_eager
 from sqlalchemy.sql import func, not_, or_
 
@@ -24,13 +24,12 @@ from couchers.models import (
     Message,
     MessageType,
     ModerationObjectType,
-    Notification,
     RateLimitAction,
     User,
 )
 from couchers.models.notifications import NotificationTopicAction
 from couchers.moderation.utils import create_moderation
-from couchers.notifications.notify import notify
+from couchers.notifications.notify import mark_notifications_seen, notify
 from couchers.proto import conversations_pb2, conversations_pb2_grpc, notification_data_pb2
 from couchers.proto.internal import jobs_pb2
 from couchers.rate_limits.check import process_rate_limits_and_check_abort
@@ -614,11 +613,14 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
 
         subscription.last_seen_message_id = request.last_seen_message_id
 
-        session.execute(
-            update(Notification)
-            .values(is_seen=True)
-            .where(Notification.user_id == context.user_id)
-            .where(Notification.key == str(request.group_chat_id))
+        mark_notifications_seen(
+            session,
+            user_id=context.user_id,
+            key=str(request.group_chat_id),
+            topic_actions=[
+                NotificationTopicAction.chat__message,
+                NotificationTopicAction.chat__missed_messages,
+            ],
         )
 
         return empty_pb2.Empty()

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 import grpc
 from google.protobuf import empty_pb2
-from sqlalchemy import exists, select
+from sqlalchemy import exists, select, update
 from sqlalchemy.orm import Session, aliased
 from sqlalchemy.sql import and_, func, or_
 
@@ -29,6 +29,7 @@ from couchers.models import (
     Message,
     MessageType,
     ModerationObjectType,
+    Notification,
     RateLimitAction,
     User,
 )
@@ -938,6 +939,13 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             if not host_request.recipient_last_seen_message_id <= request.last_seen_message_id:
                 context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "cant_unsee_messages")
             host_request.recipient_last_seen_message_id = request.last_seen_message_id
+
+        session.execute(
+            update(Notification)
+            .values(is_seen=True)
+            .where(Notification.user_id == context.user_id)
+            .where(Notification.key == str(host_request.conversation_id))
+        )
 
         session.commit()
         return empty_pb2.Empty()

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 import grpc
 from google.protobuf import empty_pb2
-from sqlalchemy import exists, select, update
+from sqlalchemy import exists, select
 from sqlalchemy.orm import Session, aliased
 from sqlalchemy.sql import and_, func, or_
 
@@ -29,14 +29,13 @@ from couchers.models import (
     Message,
     MessageType,
     ModerationObjectType,
-    Notification,
     RateLimitAction,
     User,
 )
 from couchers.models.notifications import NotificationTopicAction
 from couchers.models.public_trips import PublicTrip, PublicTripStatus
 from couchers.moderation.utils import create_moderation
-from couchers.notifications.notify import notify
+from couchers.notifications.notify import mark_notifications_seen, notify
 from couchers.proto import conversations_pb2, notification_data_pb2, requests_pb2, requests_pb2_grpc
 from couchers.rate_limits.check import process_rate_limits_and_check_abort
 from couchers.rate_limits.definitions import RATE_LIMIT_HOURS
@@ -940,11 +939,20 @@ class Requests(requests_pb2_grpc.RequestsServicer):
                 context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "cant_unsee_messages")
             host_request.recipient_last_seen_message_id = request.last_seen_message_id
 
-        session.execute(
-            update(Notification)
-            .values(is_seen=True)
-            .where(Notification.user_id == context.user_id)
-            .where(Notification.key == str(host_request.conversation_id))
+        mark_notifications_seen(
+            session,
+            user_id=context.user_id,
+            key=str(host_request.conversation_id),
+            topic_actions=[
+                NotificationTopicAction.host_request__create,
+                NotificationTopicAction.host_request__accept,
+                NotificationTopicAction.host_request__reject,
+                NotificationTopicAction.host_request__confirm,
+                NotificationTopicAction.host_request__cancel,
+                NotificationTopicAction.host_request__message,
+                NotificationTopicAction.host_request__missed_messages,
+                NotificationTopicAction.host_request__reminder,
+            ],
         )
 
         session.commit()

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 import grpc
 import pytest
 from google.protobuf import wrappers_pb2
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from couchers.db import session_scope
 from couchers.jobs.worker import process_job
@@ -1312,6 +1312,42 @@ def test_last_seen(db, moderator):
 
         res = c.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=gcid))
         assert res.unseen_message_count == 0
+
+
+def test_mark_last_seen_clears_notifications(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    with conversations_session(token1) as c:
+        gcid = c.CreateGroupChat(
+            conversations_pb2.CreateGroupChatReq(
+                recipient_user_ids=[user2.id], title=wrappers_pb2.StringValue(value="Test chat")
+            )
+        ).group_chat_id
+
+    moderator.approve_group_chat(gcid)
+
+    with conversations_session(token1) as c:
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=gcid, text="Hello"))
+
+    process_jobs()
+
+    def unseen_notification_count(user_id):
+        with session_scope() as session:
+            return session.execute(
+                select(func.count())
+                .select_from(Notification)
+                .where(Notification.user_id == user_id)
+                .where(Notification.key == str(gcid))
+                .where(Notification.is_seen == False)
+            ).scalar_one()
+
+    assert unseen_notification_count(user2.id) > 0
+
+    with conversations_session(token2) as c:
+        c.MarkLastSeenGroupChat(conversations_pb2.MarkLastSeenGroupChatReq(group_chat_id=gcid, last_seen_message_id=1))
+
+    assert unseen_notification_count(user2.id) == 0
 
 
 def test_one_dm_per_pair(db, moderator):

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -5,7 +5,7 @@ from urllib.parse import parse_qs, urlparse
 
 import grpc
 import pytest
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy_utils import refresh_materialized_view
 
 from couchers.constants import HOST_REQUEST_MIN_LENGTH_UTF16
@@ -20,6 +20,7 @@ from couchers.models import (
     MessageType,
     Node,
     NodeType,
+    Notification,
     RateLimitAction,
 )
 from couchers.models.public_trips import PublicTrip, PublicTripStatus
@@ -1082,6 +1083,44 @@ def test_mark_last_seen(db, moderator):
     with api_session(token2) as api:
         assert api.Ping(api_pb2.PingReq()).unseen_received_host_request_count == 1
         assert api.Ping(api_pb2.PingReq()).unseen_sent_host_request_count == 1
+
+
+def test_mark_last_seen_clears_notifications(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
+
+    with requests_session(token1) as api:
+        host_request_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=user2.id,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
+                text=valid_request_text("Test message"),
+            )
+        ).host_request_id
+
+    moderator.approve_host_request(host_request_id)
+
+    def unseen_notification_count(user_id):
+        with session_scope() as session:
+            return session.execute(
+                select(func.count())
+                .select_from(Notification)
+                .where(Notification.user_id == user_id)
+                .where(Notification.key == str(host_request_id))
+                .where(Notification.is_seen == False)
+            ).scalar_one()
+
+    assert unseen_notification_count(user2.id) > 0
+
+    with requests_session(token2) as api:
+        api.MarkLastSeenHostRequest(
+            requests_pb2.MarkLastSeenHostRequestReq(host_request_id=host_request_id, last_seen_message_id=1)
+        )
+
+    assert unseen_notification_count(user2.id) == 0
 
 
 def test_response_rate(db, moderator):


### PR DESCRIPTION
Right now the notification feed item only gets marked read if they click it via the notification feed. We want the unread badge to also be updated by viewing the messages themselves via the messages section.


<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
