### PR TITLE
Frontend: Invalidate ping query to update message badges

### DIFF
--- a/app/web/features/messages/groupchats/GroupChatView.tsx
+++ b/app/web/features/messages/groupchats/GroupChatView.tsx
@@ -17,6 +17,7 @@ import {
   groupChatKey,
   groupChatMessagesKey,
   groupChatsListKey,
+  pingQueryKey,
 } from "features/queryKeys";
 import { useLiteUsers } from "features/userQueries/useLiteUsers";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
@@ -153,6 +154,7 @@ export default function GroupChatView({
       service.conversations.markLastSeenGroupChat(chatId, messageId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: groupChatKey(chatId) });
+      queryClient.invalidateQueries({ queryKey: [pingQueryKey] });
     },
   });
   const { markLastSeen } = useMarkLastSeen(

--- a/app/web/features/messages/requests/HostRequestView.tsx
+++ b/app/web/features/messages/requests/HostRequestView.tsx
@@ -19,6 +19,7 @@ import {
   hostRequestKey,
   hostRequestMessagesKey,
   hostRequestsListKey,
+  pingQueryKey,
 } from "features/queryKeys";
 import { useLiteUser } from "features/userQueries/useLiteUsers";
 import { RpcError } from "grpc-web";
@@ -214,6 +215,7 @@ export default function HostRequestView({
       queryClient.invalidateQueries({
         queryKey: hostRequestKey(hostRequestId),
       });
+      queryClient.invalidateQueries({ queryKey: [pingQueryKey] });
     },
   });
   const { markLastSeen } = useMarkLastSeen(


### PR DESCRIPTION
Frontend pingQueryKey invalidation: makes the UI update immediately. Without it, the frontend won't refetch the ping query until its natural 10-second polling interval fires — so the bell badge would still show the old stale count for up to 10 seconds, even though the backend data is already correct.

Closes #8312 

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
