### PR TITLE
mobile: Dev Tool TestFlight build + in-app backend URL override

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -834,6 +834,79 @@ preview:web-next:
       changes:
       - app/web/**/*
 
+# Per-branch Dev Tool OTA preview: bundle the devtool variant and stage the Expo
+# Updates manifest (see docs/mobile-dev-tool-ota.md), then publish to the existing
+# dev-assets bucket under an immutable per-SHA prefix. The installed Dev Tool dev
+# client loads it via couchers-devtool://expo-development-client/?url=...
+build:mobile-ota:
+  needs: ["protos"]
+  stage: build
+  image: node:22
+  inherit:
+    default: false
+  variables:
+    # Must build the devtool variant so the fingerprint matches the installed
+    # Dev Tool dev client; a mismatch makes the client silently ignore the update.
+    APP_VARIANT: devtool
+    EXPO_PUBLIC_COUCHERS_ENV: preview
+    EXPO_PUBLIC_API_BASE_URL: https://dev-api.couchershq.org
+    EXPO_PUBLIC_WEB_BASE_URL: https://next.couchershq.org
+    # Add "android" once the iOS path is validated end-to-end.
+    OTA_PLATFORMS: "ios"
+  script:
+    - cd app/mobile
+    - npm ci
+    - npm run build:protos
+    - npx expo config --type public --json > ota-expo-config.json
+    - |
+      for P in $OTA_PLATFORMS; do
+        rm -rf dist
+        npx expo export --platform "$P"
+        RV=$(npx expo-updates fingerprint:generate --platform "$P" 2>/dev/null | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(JSON.parse(s).hash))')
+        echo "fingerprint($P) = $RV"
+        node scripts/ota-stage.mjs --platform "$P" --runtime-version "$RV" --base-url "https://$CI_COMMIT_SHORT_SHA--ota.$PREVIEW_DOMAIN" --dist dist --out ota-out --expo-config ota-expo-config.json
+      done
+  artifacts:
+    paths:
+      - app/mobile/ota-out/
+    expire_in: 1 week
+  rules:
+    - if: ($BUILD_MOBILE == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
+    - if: ($BUILD_MOBILE == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
+      changes:
+        - app/proto/**/*
+        - app/mobile/**/*
+
+preview:mobile-ota:
+  needs: ["build:mobile-ota"]
+  stage: preview
+  image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest
+  inherit:
+    # no docker login
+    default: false
+  variables:
+    OTA_PLATFORMS: "ios"
+  script:
+    - |
+      for P in $OTA_PLATFORMS; do
+        D="app/mobile/ota-out/$P"
+        CT="$(cat "$D/manifest.content-type")"
+        # manifest is the protocol-v1 multipart body; its content-type carries the
+        # boundary. The expo-protocol-version response header is injected by the
+        # preview-origin-response Lambda@Edge (S3 can't set it).
+        aws s3 cp "$D/manifest" "s3://$AWS_PREVIEW_BUCKET/ota/$CI_COMMIT_SHORT_SHA/$P/manifest" --content-type "$CT"
+        aws s3 cp "$D/bundle.hbc" "s3://$AWS_PREVIEW_BUCKET/ota/$CI_COMMIT_SHORT_SHA/$P/bundle.hbc" --content-type application/javascript
+        aws s3 cp "$D/assets/" "s3://$AWS_PREVIEW_BUCKET/ota/$CI_COMMIT_SHORT_SHA/$P/assets/" --recursive
+        echo "Done $P. Manifest: https://$CI_COMMIT_SHORT_SHA--ota.$PREVIEW_DOMAIN/$P/manifest"
+        echo "  deep link: couchers-devtool://expo-development-client/?url=https%3A%2F%2F$CI_COMMIT_SHORT_SHA--ota.$PREVIEW_DOMAIN%2F$P%2Fmanifest"
+      done
+  rules:
+    - if: ($BUILD_MOBILE == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
+    - if: ($BUILD_MOBILE == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
+      changes:
+        - app/proto/**/*
+        - app/mobile/**/*
+
 preview:protos:
   needs: ["protos"]
   stage: preview

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -851,8 +851,7 @@ build:mobile-ota:
     EXPO_PUBLIC_COUCHERS_ENV: preview
     EXPO_PUBLIC_API_BASE_URL: https://dev-api.couchershq.org
     EXPO_PUBLIC_WEB_BASE_URL: https://next.couchershq.org
-    # Add "android" once the iOS path is validated end-to-end.
-    OTA_PLATFORMS: "ios"
+    OTA_PLATFORMS: "ios android"
   script:
     - cd app/mobile
     - npm ci
@@ -889,7 +888,7 @@ preview:mobile-ota:
     # no docker login
     default: false
   variables:
-    OTA_PLATFORMS: "ios"
+    OTA_PLATFORMS: "ios android"
   script:
     - |
       for P in $OTA_PLATFORMS; do
@@ -902,6 +901,7 @@ preview:mobile-ota:
         aws s3 cp "$D/bundle.hbc" "s3://$AWS_PREVIEW_BUCKET/ota/$CI_COMMIT_SHORT_SHA/$P/bundle.hbc" --content-type application/javascript
         aws s3 cp "$D/assets/" "s3://$AWS_PREVIEW_BUCKET/ota/$CI_COMMIT_SHORT_SHA/$P/assets/" --recursive
         aws s3 cp "$D/qr.png" "s3://$AWS_PREVIEW_BUCKET/ota/$CI_COMMIT_SHORT_SHA/$P/qr.png" --content-type image/png
+        aws s3 cp "$D/open.html" "s3://$AWS_PREVIEW_BUCKET/ota/$CI_COMMIT_SHORT_SHA/$P/open.html" --content-type "text/html; charset=utf-8"
         echo "Done $P. Manifest: https://$CI_COMMIT_SHORT_SHA--ota.$PREVIEW_DOMAIN/$P/manifest"
         echo "  deep link: couchers-devtool://expo-development-client/?url=https%3A%2F%2F$CI_COMMIT_SHORT_SHA--ota.$PREVIEW_DOMAIN%2F$P%2Fmanifest"
       done
@@ -927,7 +927,7 @@ preview:pr-comment:
   inherit:
     default: false
   variables:
-    OTA_PLATFORMS: "ios"
+    OTA_PLATFORMS: "ios android"
   script:
     - pip install --quiet --no-cache-dir requests
     - python app/scripts/pr_preview_comment.py

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -865,6 +865,9 @@ build:mobile-ota:
         RV=$(npx expo-updates fingerprint:generate --platform "$P" 2>/dev/null | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(JSON.parse(s).hash))')
         echo "fingerprint($P) = $RV"
         node scripts/ota-stage.mjs --platform "$P" --runtime-version "$RV" --base-url "https://$CI_COMMIT_SHORT_SHA--ota.$PREVIEW_DOMAIN" --dist dist --out ota-out --expo-config ota-expo-config.json
+        # QR encodes the dev-launcher deep link so the PR comment can show a scannable image.
+        # npx (not a package.json dep) keeps it out of the fingerprint sources.
+        npx --yes qrcode -o "ota-out/$P/qr.png" "couchers-devtool://expo-development-client/?url=https%3A%2F%2F$CI_COMMIT_SHORT_SHA--ota.$PREVIEW_DOMAIN%2F$P%2Fmanifest" < /dev/null
       done
   artifacts:
     paths:
@@ -898,6 +901,7 @@ preview:mobile-ota:
         aws s3 cp "$D/manifest" "s3://$AWS_PREVIEW_BUCKET/ota/$CI_COMMIT_SHORT_SHA/$P/manifest" --content-type "$CT"
         aws s3 cp "$D/bundle.hbc" "s3://$AWS_PREVIEW_BUCKET/ota/$CI_COMMIT_SHORT_SHA/$P/bundle.hbc" --content-type application/javascript
         aws s3 cp "$D/assets/" "s3://$AWS_PREVIEW_BUCKET/ota/$CI_COMMIT_SHORT_SHA/$P/assets/" --recursive
+        aws s3 cp "$D/qr.png" "s3://$AWS_PREVIEW_BUCKET/ota/$CI_COMMIT_SHORT_SHA/$P/qr.png" --content-type image/png
         echo "Done $P. Manifest: https://$CI_COMMIT_SHORT_SHA--ota.$PREVIEW_DOMAIN/$P/manifest"
         echo "  deep link: couchers-devtool://expo-development-client/?url=https%3A%2F%2F$CI_COMMIT_SHORT_SHA--ota.$PREVIEW_DOMAIN%2F$P%2Fmanifest"
       done
@@ -925,7 +929,7 @@ preview:pr-comment:
   variables:
     OTA_PLATFORMS: "ios"
   script:
-    - pip install --quiet --no-cache-dir "qrcode[pil]" requests boto3
+    - pip install --quiet --no-cache-dir requests
     - python app/scripts/pr_preview_comment.py
   rules:
     - if: ($BUILD_MOBILE == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -876,6 +876,7 @@ build:mobile-ota:
       changes:
         - app/proto/**/*
         - app/mobile/**/*
+        - app/scripts/**/*
 
 preview:mobile-ota:
   needs: ["build:mobile-ota"]
@@ -906,6 +907,33 @@ preview:mobile-ota:
       changes:
         - app/proto/**/*
         - app/mobile/**/*
+        - app/scripts/**/*
+
+# Aggregate per-PR preview links into one sticky GitHub PR comment. Runs after the
+# upload jobs (needs) so every link/QR it posts is already live on CloudFront.
+# Currently surfaces the mobile Dev Tool OTA preview; add more sections (web,
+# coverage, ...) in app/scripts/pr_preview_comment.py as previews grow. No-ops when
+# GITHUB_PREVIEW_TOKEN is unset or there's no open PR, so it never reds the pipeline.
+preview:pr-comment:
+  needs:
+    - job: preview:mobile-ota
+      artifacts: false
+  stage: preview
+  image: python:3.12-slim
+  inherit:
+    default: false
+  variables:
+    OTA_PLATFORMS: "ios"
+  script:
+    - pip install --quiet --no-cache-dir "qrcode[pil]" requests boto3
+    - python app/scripts/pr_preview_comment.py
+  rules:
+    - if: ($BUILD_MOBILE == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
+    - if: ($BUILD_MOBILE == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
+      changes:
+        - app/proto/**/*
+        - app/mobile/**/*
+        - app/scripts/**/*
 
 preview:protos:
   needs: ["protos"]

--- a/app/mobile/.fingerprintignore
+++ b/app/mobile/.fingerprintignore
@@ -1,0 +1,9 @@
+# google-services.json is provided only as an EAS file env secret
+# (GOOGLE_SERVICES_JSON, preview environment), so it's present on EAS builds but
+# absent locally and in CI. Expo hashes it into the fingerprint by contents, which
+# makes the runtime version (fingerprint policy) differ between the EAS-built Dev
+# Tool client and our per-branch OTA bundles / local builds. Exclude it everywhere
+# so the fingerprint is reproducible; a Firebase/FCM config change needs a fresh
+# native build regardless.
+google-services.json
+**/eas-environment-secrets/**

--- a/app/mobile/.gitignore
+++ b/app/mobile/.gitignore
@@ -27,6 +27,10 @@ GoogleService-Info.plist
 # Metro
 .metro-health-check*
 
+# Per-branch OTA preview pipeline (scripts/ota-stage.mjs, expo export)
+/ota-out/
+/ota-expo-config.json
+
 # debug
 npm-debug.*
 yarn-debug.*

--- a/app/mobile/README.md
+++ b/app/mobile/README.md
@@ -1,6 +1,6 @@
 # Couchers Mobile App
 
-React Native mobile app built with [Expo](https://expo.dev). We maintain two separate apps (staging and production) that can coexist on the same device with different bundle IDs and API endpoints.
+React Native mobile app built with [Expo](https://expo.dev). We maintain three separate apps (staging, production, and a development tool) that can coexist on the same device with different bundle IDs and API endpoints.
 
 ## Table of Contents
 
@@ -10,8 +10,9 @@ React Native mobile app built with [Expo](https://expo.dev). We maintain two sep
 4. [Releasing Staging Build](#4-releasing-staging-build)
 5. [Releasing Production Build](#5-releasing-production-build)
 6. [App Variants](#app-variants)
-7. [Updating Dependencies](#updating-dependencies)
-8. [Learn More](#learn-more)
+7. [Dev Tool (TestFlight)](#dev-tool-testflight)
+8. [Updating Dependencies](#updating-dependencies)
+9. [Learn More](#learn-more)
 
 ## 1. First Time Setup
 
@@ -51,6 +52,12 @@ npx expo run:android --device
 ```
 
 On iOS: if you get issues about signing, try opening `app/mobile/ios` in Xcode and setting up app signing there.
+
+> **Tip:** If you only work on JavaScript/TypeScript, you can skip the local
+> native build (and Xcode/Android Studio) entirely — install the prebuilt
+> **Couchers (Dev Tool)** app from TestFlight and run `npx expo start` against it.
+> See [Dev Tool (TestFlight)](#dev-tool-testflight). You only
+> need a local native build when changing native dependencies or `app.config.js`.
 
 **After the initial build is installed, use this for daily development:**
 ```bash
@@ -170,16 +177,52 @@ npm run release:android:production
 
 ## App Variants
 
-We maintain **two separate apps** that can coexist on the same device:
+We maintain **three separate apps** that can coexist on the same device:
 
 | Variant | App Name | iOS Bundle ID | Android Package | API Server |
 |---------|----------|---------------|-----------------|------------|
+| **Dev Tool** | Couchers (Dev Tool) | `org.couchers.devtool.ios` | `org.couchers.devtool.android` | `dev-api.couchershq.org` |
 | **Staging** | Couchers (Staging) | `org.couchers.staging.ios` | `org.couchers.staging.android` | `dev-api.couchershq.org` |
 | **Production** | Couchers | `org.couchers.ios` | `org.couchers.android` | `api.couchers.org` |
 
-**Benefits:** Both apps can be installed simultaneously, separate push notification channels, test staging changes without affecting production users.
+**Benefits:** All apps can be installed simultaneously, separate push notification channels, test staging changes without affecting production users.
 
 **How it works:** Build profiles in `eas.json` set an `APP_VARIANT` environment variable, which `app.config.js` reads to configure bundle IDs, app names, and API endpoints dynamically.
+
+The **Dev Tool** variant is a [development build](#dev-tool-testflight) (it reuses the staging icons and backend). The **Dev Tool** and **Staging** apps both point at `dev-api.couchershq.org` but are distinct apps with separate bundle IDs.
+
+## Dev Tool (TestFlight)
+
+The **Couchers (Dev Tool)** variant is a [development build](https://docs.expo.dev/develop/development-builds/introduction/) — essentially "Expo Go, but with our own native modules." It bundles every native dependency in the project plus the Expo dev launcher, and points at the staging backend. Devs install it once from TestFlight and load JavaScript over the air, so they never need Xcode, CocoaPods, or a local native build for day-to-day JS/TS work. The "Dev Tool" name signals it's a developer utility, not another release flavor like staging or production.
+
+**Daily workflow (no Xcode needed):**
+
+```bash
+npx expo start
+```
+
+Open the **Couchers (Dev Tool)** app and connect to the Metro server (same network), or scan the QR code. JS/TS changes hot-reload exactly as they do with a locally built development build.
+
+**When a new Dev Tool build is required:** only when the set of native dependencies changes (adding/removing a native package, changing `app.config.js`, or bumping the Expo SDK). Pure JS/TS changes never need a rebuild — they load over the air.
+
+### Releasing a new Dev Tool build
+
+```bash
+npm run release:ios:devtool       # iOS → TestFlight
+npm run release:android:devtool   # Android → Play internal testing
+```
+
+Once submitted, the build appears in TestFlight after Apple's automated processing (no full App Review for internal testers). Invited devs update from the TestFlight app.
+
+### One-time setup (maintainers)
+
+Before the first release, the **Couchers (Dev Tool)** app records must exist:
+
+1. Create the app in [App Store Connect](https://appstoreconnect.apple.com) with bundle ID `org.couchers.devtool.ios`, and create the matching app in [Google Play Console](https://play.google.com/console) with package `org.couchers.devtool.android`.
+2. Replace `REPLACE_WITH_DEVTOOL_ASC_APP_ID` in `eas.json` (`submit.devtool.ios.ascAppId`) with the new App Store Connect app ID.
+3. Invite developers as internal TestFlight testers — no per-device UDID registration is required (unlike EAS internal/ad-hoc distribution).
+
+> **Coming next:** with the Dev Tool installed, we can wire up per-PR JavaScript previews — a CI job publishes each PR's bundle via `eas update` and posts a QR code on the PR. Scanning it in the Dev Tool loads that branch's changes, the mobile analog of our Vercel web previews. (JS-only; the `runtimeVersion: fingerprint` policy ensures a PR that changes native code won't load a mismatched bundle.)
 
 ## Updating Dependencies
 

--- a/app/mobile/app.config.js
+++ b/app/mobile/app.config.js
@@ -11,118 +11,106 @@ const getGitHash = () => {
   }
 };
 
-// Determine app variant from environment variable
+const ICON_SETS = {
+  default: {
+    icon: "./assets/images/icon.png",
+    ios: "./assets/images/icon_ios.png",
+    adaptiveForeground: "./assets/images/adaptive_icon_foreground.png",
+  },
+  staging: {
+    icon: "./assets/images/icon_staging.png",
+    ios: "./assets/images/icon_ios_staging.png",
+    adaptiveForeground: "./assets/images/adaptive_icon_foreground_staging.png",
+  },
+};
+
+// Per-variant configuration — add a new variant by adding an entry here.
+// `linkHost` is the https domain the app claims for universal/app links;
+// null means no claim (the Dev Tool build routes via its custom scheme only, so
+// it can't steal universal links from the staging app, which shares its backend).
+const VARIANTS = {
+  production: {
+    name: "Couchers",
+    bundleIdentifier: "org.couchers.ios",
+    androidPackage: "org.couchers.android",
+    scheme: "couchers",
+    iconSet: "default",
+    linkHost: "couchers.org",
+  },
+  staging: {
+    name: "Couchers (Staging)",
+    bundleIdentifier: "org.couchers.staging.ios",
+    androidPackage: "org.couchers.staging.android",
+    scheme: "couchers-staging",
+    iconSet: "staging",
+    linkHost: "next.couchershq.org",
+  },
+  devtool: {
+    name: "Couchers (Dev Tool)",
+    bundleIdentifier: "org.couchers.devtool.ios",
+    androidPackage: "org.couchers.devtool.android",
+    scheme: "couchers-devtool",
+    iconSet: "staging",
+    linkHost: null,
+  },
+};
+
 const APP_VARIANT = process.env.APP_VARIANT || "production";
-const IS_STAGING = APP_VARIANT === "staging";
+const variant = VARIANTS[APP_VARIANT] ?? VARIANTS.production;
+const icons = ICON_SETS[variant.iconSet];
 
-// Helper functions for dynamic configuration
-const getAppName = () => {
-  if (IS_STAGING) {
-    return "Couchers (Staging)";
-  }
-  return "Couchers";
-};
+const associatedDomains = variant.linkHost
+  ? [`applinks:${variant.linkHost}`]
+  : [];
 
-const getBundleIdentifier = () => {
-  if (IS_STAGING) {
-    return "org.couchers.staging.ios";
-  }
-  return "org.couchers.ios";
-};
-
-const getAndroidPackage = () => {
-  if (IS_STAGING) {
-    return "org.couchers.staging.android";
-  }
-  return "org.couchers.android";
-};
-
-const getAppScheme = () => {
-  if (IS_STAGING) {
-    return "couchers-staging";
-  }
-  return "couchers";
-};
-
-const getIcon = () => {
-  if (IS_STAGING) {
-    return "./assets/images/icon_staging.png";
-  }
-  return "./assets/images/icon.png";
-};
-
-const getIosIcon = () => {
-  if (IS_STAGING) {
-    return "./assets/images/icon_ios_staging.png";
-  }
-  return "./assets/images/icon_ios.png";
-};
+const intentFilters = variant.linkHost
+  ? [
+      {
+        action: "VIEW",
+        autoVerify: true,
+        data: [{ scheme: "https", host: variant.linkHost, pathPrefix: "/" }],
+        category: ["BROWSABLE", "DEFAULT"],
+      },
+    ]
+  : [];
 
 export default {
-  name: getAppName(),
+  name: variant.name,
   slug: "mobile",
   version: "1.1.20",
   orientation: "portrait",
-  icon: getIcon(),
-  scheme: getAppScheme(),
+  icon: icons.icon,
+  scheme: variant.scheme,
   userInterfaceStyle: "automatic",
   newArchEnabled: true,
+  runtimeVersion: { policy: "fingerprint" },
+  updates: {
+    url: "https://u.expo.dev/fb4fc9aa-d8b2-45a5-82aa-be05e99b0413",
+  },
   ios: {
     supportsTablet: true,
-    bundleIdentifier: getBundleIdentifier(),
-    icon: getIosIcon(),
-    associatedDomains: IS_STAGING
-      ? ["applinks:next.couchershq.org"]
-      : ["applinks:couchers.org"],
+    bundleIdentifier: variant.bundleIdentifier,
+    icon: icons.ios,
+    associatedDomains,
     infoPlist: {
       ITSAppUsesNonExemptEncryption: false,
     },
   },
   android: {
     edgeToEdgeEnabled: true,
-    package: getAndroidPackage(),
+    package: variant.androidPackage,
     googleServicesFile:
       process.env.GOOGLE_SERVICES_JSON ?? "./google-services.json",
     permissions: ["POST_NOTIFICATIONS"],
     adaptiveIcon: {
-      foregroundImage: IS_STAGING
-        ? "./assets/images/adaptive_icon_foreground_staging.png"
-        : "./assets/images/adaptive_icon_foreground.png",
+      foregroundImage: icons.adaptiveForeground,
       backgroundColor: "#E47701",
     },
     notification: {
       icon: "./assets/images/notification_icon.png",
       color: "#E47701",
     },
-    intentFilters: IS_STAGING
-      ? [
-          {
-            action: "VIEW",
-            autoVerify: true,
-            data: [
-              {
-                scheme: "https",
-                host: "next.couchershq.org",
-                pathPrefix: "/",
-              },
-            ],
-            category: ["BROWSABLE", "DEFAULT"],
-          },
-        ]
-      : [
-          {
-            action: "VIEW",
-            autoVerify: true,
-            data: [
-              {
-                scheme: "https",
-                host: "couchers.org",
-                pathPrefix: "/",
-              },
-            ],
-            category: ["BROWSABLE", "DEFAULT"],
-          },
-        ],
+    intentFilters,
   },
   web: {
     bundler: "metro",

--- a/app/mobile/app.config.js
+++ b/app/mobile/app.config.js
@@ -74,6 +74,15 @@ const intentFilters = variant.linkHost
     ]
   : [];
 
+// Dev Tool branches load OTA through the dev launcher's deep-link load path
+// (couchers-devtool://expo-development-client/?url=...), so no update URL is
+// baked in and manifests are served unsigned over HTTPS. Staging and production
+// stay on EAS Update.
+const updates =
+  APP_VARIANT === "devtool"
+    ? { enabled: true }
+    : { url: "https://u.expo.dev/fb4fc9aa-d8b2-45a5-82aa-be05e99b0413" };
+
 export default {
   name: variant.name,
   slug: "mobile",
@@ -84,9 +93,7 @@ export default {
   userInterfaceStyle: "automatic",
   newArchEnabled: true,
   runtimeVersion: { policy: "fingerprint" },
-  updates: {
-    url: "https://u.expo.dev/fb4fc9aa-d8b2-45a5-82aa-be05e99b0413",
-  },
+  updates,
   ios: {
     supportsTablet: true,
     bundleIdentifier: variant.bundleIdentifier,

--- a/app/mobile/app/_layout.tsx
+++ b/app/mobile/app/_layout.tsx
@@ -21,12 +21,15 @@ import * as Notifications from "expo-notifications";
 import { Href, router, Stack } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useColorScheme } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
+import DevSettingsButton from "@/components/DevSettingsButton";
+import { hydrateUrlOverrides } from "@/config/urls";
 import { AuthProvider, useAuthContext } from "@/features/auth/AuthContext";
 import { useRegisterPushNotifications } from "@/features/notifications/useRegisterPushNotifications";
+import { reconfigureApiClient } from "@/service/client";
 import { getNotificationPath } from "@/utils/getNotificationPath";
 
 // Module-level Set to track handled notification IDs (persists across component remounts)
@@ -80,6 +83,7 @@ function RootNavigator({ fontsLoaded }: { fontsLoaded: boolean }) {
       </Stack.Protected>
       {/* Accessible regardless of auth state */}
       <Stack.Screen name="confirm-email" />
+      <Stack.Screen name="dev-settings" options={{ presentation: "modal" }} />
     </Stack>
   );
 }
@@ -97,7 +101,17 @@ export default function RootLayout() {
     Ubuntu_700Bold_Italic,
   });
 
-  if (!fontsLoaded) {
+  // Load any persisted backend URL override and re-point the gRPC client before
+  // rendering, so the first auth check and webview loads hit the chosen backend.
+  const [configLoaded, setConfigLoaded] = useState(false);
+  useEffect(() => {
+    hydrateUrlOverrides().then(() => {
+      reconfigureApiClient();
+      setConfigLoaded(true);
+    });
+  }, []);
+
+  if (!fontsLoaded || !configLoaded) {
     return null;
   }
 
@@ -109,6 +123,7 @@ export default function RootLayout() {
         <AuthProvider>
           <PushNotificationsRegistrar />
           <RootNavigator fontsLoaded={fontsLoaded} />
+          <DevSettingsButton />
         </AuthProvider>
       </ThemeProvider>
     </SafeAreaProvider>

--- a/app/mobile/app/dev-settings.tsx
+++ b/app/mobile/app/dev-settings.tsx
@@ -1,3 +1,4 @@
+import * as Clipboard from "expo-clipboard";
 import Constants from "expo-constants";
 import { router, useLocalSearchParams } from "expo-router";
 import { useEffect, useState } from "react";
@@ -50,6 +51,8 @@ export default function DevSettingsScreen() {
   const [apiBaseUrl, setApiBaseUrl] = useState(paramApi ?? getApiBaseUrl());
   const [webBaseUrl, setWebBaseUrl] = useState(paramWeb ?? getWebBaseUrl());
   const [history, setHistory] = useState<UrlOverrides[]>([]);
+  const [linkExpanded, setLinkExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
 
   // Apply incoming deep-link params (e.g. a scanned QR opening the app while
   // this screen is already mounted).
@@ -72,6 +75,7 @@ export default function DevSettingsScreen() {
       : theme.palette.text.secondary,
     border: isDark ? theme.dark.grey[100] : theme.palette.grey[200],
     inputBackground: isDark ? theme.dark.background.default : "#fff",
+    muted: isDark ? theme.dark.grey[100] : theme.palette.grey[50],
     primary: isDark ? theme.dark.primary.main : theme.palette.primary.main,
   };
 
@@ -143,6 +147,13 @@ export default function DevSettingsScreen() {
 
   const handleClearHistory = () => {
     clearUrlHistory().then(() => setHistory([]));
+  };
+
+  const handleCopyLink = async () => {
+    if (!shareLink) return;
+    await Clipboard.setStringAsync(shareLink);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
   };
 
   return (
@@ -266,22 +277,35 @@ export default function DevSettingsScreen() {
 
           {shareLink && (
             <View style={styles.shareSection}>
-              <Text style={[styles.sectionTitle, { color: colors.text }]}>
-                Share via QR
-              </Text>
-              <Text style={[styles.hint, { color: colors.textSecondary }]}>
-                Make a QR of this link and scan it with a phone camera to open
-                another device with these URLs filled in.
-              </Text>
-              <Text
-                selectable
-                style={[
-                  styles.link,
-                  { color: colors.text, borderColor: colors.border },
-                ]}
+              <Pressable
+                onPress={() => setLinkExpanded((v) => !v)}
+                style={styles.shareHeader}
               >
-                {shareLink}
-              </Text>
+                <Text style={[styles.shareTitle, { color: colors.textSecondary }]}>
+                  {linkExpanded ? "▾" : "▸"} Share via link
+                </Text>
+              </Pressable>
+              {linkExpanded && (
+                <>
+                  <Pressable onPress={handleCopyLink}>
+                    <Text
+                      style={[
+                        styles.link,
+                        {
+                          color: colors.text,
+                          borderColor: colors.border,
+                          backgroundColor: colors.muted,
+                        },
+                      ]}
+                    >
+                      {shareLink}
+                    </Text>
+                  </Pressable>
+                  <Text style={[styles.hint, { color: colors.textSecondary }]}>
+                    {copied ? "Copied to clipboard" : "Tap the link to copy it"}
+                  </Text>
+                </>
+              )}
             </View>
           )}
         </ScrollView>
@@ -466,6 +490,13 @@ const styles = StyleSheet.create({
   },
   shareSection: {
     marginTop: 24,
+  },
+  shareHeader: {
+    paddingVertical: 8,
+  },
+  shareTitle: {
+    fontSize: 14,
+    fontWeight: "600",
   },
   link: {
     fontSize: 13,

--- a/app/mobile/app/dev-settings.tsx
+++ b/app/mobile/app/dev-settings.tsx
@@ -281,7 +281,9 @@ export default function DevSettingsScreen() {
                 onPress={() => setLinkExpanded((v) => !v)}
                 style={styles.shareHeader}
               >
-                <Text style={[styles.shareTitle, { color: colors.textSecondary }]}>
+                <Text
+                  style={[styles.shareTitle, { color: colors.textSecondary }]}
+                >
                   {linkExpanded ? "▾" : "▸"} Share via link
                 </Text>
               </Pressable>

--- a/app/mobile/app/dev-settings.tsx
+++ b/app/mobile/app/dev-settings.tsx
@@ -1,0 +1,478 @@
+import Constants from "expo-constants";
+import { router, useLocalSearchParams } from "expo-router";
+import { useEffect, useState } from "react";
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  useColorScheme,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import {
+  clearUrlHistory,
+  clearUrlOverrides,
+  getApiBaseUrl,
+  getDefaultApiBaseUrl,
+  getDefaultWebBaseUrl,
+  getUrlHistory,
+  getWebBaseUrl,
+  isDevUrlOverrideEnabled,
+  PRESETS,
+  setUrlOverrides,
+  UrlOverrides,
+} from "@/config/urls";
+import { theme } from "@/theme";
+import { reloadApp } from "@/utils/reloadApp";
+
+function asString(value: string | string[] | undefined): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function hostLabel(entry: UrlOverrides): string {
+  const url = entry.webBaseUrl || entry.apiBaseUrl || "";
+  return url.replace(/^https?:\/\//, "");
+}
+
+export default function DevSettingsScreen() {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === "dark";
+  const params = useLocalSearchParams<{ api?: string; web?: string }>();
+  const paramApi = asString(params.api);
+  const paramWeb = asString(params.web);
+
+  const [apiBaseUrl, setApiBaseUrl] = useState(paramApi ?? getApiBaseUrl());
+  const [webBaseUrl, setWebBaseUrl] = useState(paramWeb ?? getWebBaseUrl());
+  const [history, setHistory] = useState<UrlOverrides[]>([]);
+
+  // Apply incoming deep-link params (e.g. a scanned QR opening the app while
+  // this screen is already mounted).
+  useEffect(() => {
+    if (paramApi !== undefined) setApiBaseUrl(paramApi);
+    if (paramWeb !== undefined) setWebBaseUrl(paramWeb);
+  }, [paramApi, paramWeb]);
+
+  useEffect(() => {
+    getUrlHistory().then(setHistory);
+  }, []);
+
+  const colors = {
+    background: isDark
+      ? theme.dark.background.default
+      : theme.palette.background.default,
+    text: isDark ? theme.dark.text.primary : theme.palette.text.primary,
+    textSecondary: isDark
+      ? theme.dark.text.secondary
+      : theme.palette.text.secondary,
+    border: isDark ? theme.dark.grey[100] : theme.palette.grey[200],
+    inputBackground: isDark ? theme.dark.background.default : "#fff",
+    primary: isDark ? theme.dark.primary.main : theme.palette.primary.main,
+  };
+
+  if (!isDevUrlOverrideEnabled()) {
+    return (
+      <SafeAreaView
+        style={[styles.container, { backgroundColor: colors.background }]}
+      >
+        <View style={styles.centered}>
+          <Text style={{ color: colors.text }}>
+            Developer settings are not available in this build.
+          </Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const fill = (api: string, web: string) => {
+    setApiBaseUrl(api);
+    setWebBaseUrl(web);
+  };
+
+  const scheme = Array.isArray(Constants.expoConfig?.scheme)
+    ? Constants.expoConfig?.scheme[0]
+    : Constants.expoConfig?.scheme;
+  const shareLink =
+    scheme && (apiBaseUrl || webBaseUrl)
+      ? `${scheme}://dev-settings?api=${encodeURIComponent(
+          apiBaseUrl,
+        )}&web=${encodeURIComponent(webBaseUrl)}`
+      : null;
+
+  const applyAndReload = async (action: () => Promise<void>) => {
+    await action();
+    try {
+      await reloadApp();
+    } catch {
+      Alert.alert("Saved", "Restart the app for the new URLs to take effect.", [
+        { text: "OK", onPress: () => router.back() },
+      ]);
+    }
+  };
+
+  const handleSave = () => {
+    const invalid = [apiBaseUrl, webBaseUrl].some(
+      (url) => url && !/^https?:\/\//.test(url.trim()),
+    );
+    if (invalid) {
+      Alert.alert("Invalid URL", "URLs must start with http:// or https://");
+      return;
+    }
+    applyAndReload(() => setUrlOverrides({ apiBaseUrl, webBaseUrl }));
+  };
+
+  const handleReset = () => {
+    Alert.alert(
+      "Reset URLs",
+      "Clear overrides and restart with the build's default backend?",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Reset",
+          style: "destructive",
+          onPress: () => applyAndReload(clearUrlOverrides),
+        },
+      ],
+    );
+  };
+
+  const handleClearHistory = () => {
+    clearUrlHistory().then(() => setHistory([]));
+  };
+
+  return (
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: colors.background }]}
+    >
+      <KeyboardAvoidingView
+        style={styles.container}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <ScrollView
+          contentContainerStyle={styles.content}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View style={styles.header}>
+            <Text style={[styles.title, { color: colors.text }]}>
+              Developer settings
+            </Text>
+            <Pressable hitSlop={12} onPress={() => router.back()}>
+              <Text style={[styles.close, { color: colors.primary }]}>
+                Close
+              </Text>
+            </Pressable>
+          </View>
+
+          <Text style={[styles.description, { color: colors.textSecondary }]}>
+            Point the app at a different backend. Saving restarts the app so the
+            change takes effect.
+          </Text>
+
+          <Text style={[styles.sectionTitle, { color: colors.text }]}>
+            Presets
+          </Text>
+          <View style={styles.chips}>
+            {PRESETS.map((preset) => (
+              <Chip
+                key={preset.label}
+                label={preset.label}
+                onPress={() => fill(preset.apiBaseUrl, preset.webBaseUrl)}
+                colors={colors}
+              />
+            ))}
+            <Chip
+              label="Build default"
+              onPress={() =>
+                fill(getDefaultApiBaseUrl(), getDefaultWebBaseUrl())
+              }
+              colors={colors}
+            />
+          </View>
+
+          {history.length > 0 && (
+            <>
+              <View style={styles.sectionHeader}>
+                <Text style={[styles.sectionTitle, { color: colors.text }]}>
+                  Recent
+                </Text>
+                <Pressable hitSlop={8} onPress={handleClearHistory}>
+                  <Text style={[styles.clear, { color: colors.textSecondary }]}>
+                    Clear
+                  </Text>
+                </Pressable>
+              </View>
+              <View style={styles.chips}>
+                {history.map((entry, index) => (
+                  <Chip
+                    key={`${entry.apiBaseUrl}|${entry.webBaseUrl}|${index}`}
+                    label={hostLabel(entry)}
+                    onPress={() =>
+                      fill(entry.apiBaseUrl ?? "", entry.webBaseUrl ?? "")
+                    }
+                    colors={colors}
+                  />
+                ))}
+              </View>
+            </>
+          )}
+
+          <Field
+            label="API base URL"
+            value={apiBaseUrl}
+            onChangeText={setApiBaseUrl}
+            placeholder={getDefaultApiBaseUrl()}
+            defaultValue={getDefaultApiBaseUrl()}
+            colors={colors}
+          />
+          <Field
+            label="Web base URL"
+            value={webBaseUrl}
+            onChangeText={setWebBaseUrl}
+            placeholder={getDefaultWebBaseUrl()}
+            defaultValue={getDefaultWebBaseUrl()}
+            colors={colors}
+          />
+
+          <Pressable
+            accessibilityRole="button"
+            onPress={handleSave}
+            style={({ pressed }) => [
+              styles.button,
+              { backgroundColor: colors.primary },
+              pressed && styles.buttonPressed,
+            ]}
+          >
+            <Text style={styles.buttonText}>Save & restart</Text>
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            onPress={handleReset}
+            style={({ pressed }) => [
+              styles.button,
+              styles.resetButton,
+              { borderColor: colors.border },
+              pressed && styles.buttonPressed,
+            ]}
+          >
+            <Text style={[styles.resetButtonText, { color: colors.text }]}>
+              Reset to defaults
+            </Text>
+          </Pressable>
+
+          {shareLink && (
+            <View style={styles.shareSection}>
+              <Text style={[styles.sectionTitle, { color: colors.text }]}>
+                Share via QR
+              </Text>
+              <Text style={[styles.hint, { color: colors.textSecondary }]}>
+                Make a QR of this link and scan it with a phone camera to open
+                another device with these URLs filled in.
+              </Text>
+              <Text
+                selectable
+                style={[
+                  styles.link,
+                  { color: colors.text, borderColor: colors.border },
+                ]}
+              >
+                {shareLink}
+              </Text>
+            </View>
+          )}
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+type FieldColors = {
+  text: string;
+  textSecondary: string;
+  border: string;
+  inputBackground: string;
+};
+
+function Chip({
+  label,
+  onPress,
+  colors,
+}: {
+  label: string;
+  onPress: () => void;
+  colors: { text: string; border: string };
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.chip,
+        { borderColor: colors.border },
+        pressed && styles.buttonPressed,
+      ]}
+    >
+      <Text style={[styles.chipText, { color: colors.text }]}>{label}</Text>
+    </Pressable>
+  );
+}
+
+function Field({
+  label,
+  value,
+  onChangeText,
+  placeholder,
+  defaultValue,
+  colors,
+}: {
+  label: string;
+  value: string;
+  onChangeText: (text: string) => void;
+  placeholder: string;
+  defaultValue: string;
+  colors: FieldColors;
+}) {
+  return (
+    <View style={styles.field}>
+      <Text style={[styles.label, { color: colors.text }]}>{label}</Text>
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        placeholderTextColor={colors.textSecondary}
+        autoCapitalize="none"
+        autoCorrect={false}
+        keyboardType="url"
+        style={[
+          styles.input,
+          {
+            color: colors.text,
+            borderColor: colors.border,
+            backgroundColor: colors.inputBackground,
+          },
+        ]}
+      />
+      <Text style={[styles.hint, { color: colors.textSecondary }]}>
+        Default: {defaultValue}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  centered: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  content: {
+    padding: 24,
+    gap: 8,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: "700",
+  },
+  close: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  description: {
+    fontSize: 14,
+    marginBottom: 8,
+  },
+  sectionTitle: {
+    fontSize: 15,
+    fontWeight: "600",
+    marginTop: 8,
+  },
+  sectionHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  clear: {
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  chips: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+    marginBottom: 8,
+  },
+  chip: {
+    borderWidth: 1,
+    borderRadius: 16,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  chipText: {
+    fontSize: 13,
+    fontWeight: "500",
+  },
+  field: {
+    marginBottom: 16,
+  },
+  label: {
+    fontSize: 15,
+    fontWeight: "600",
+    marginBottom: 6,
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+  },
+  hint: {
+    fontSize: 12,
+    marginTop: 6,
+  },
+  button: {
+    borderRadius: 8,
+    paddingVertical: 14,
+    alignItems: "center",
+    marginTop: 8,
+  },
+  buttonPressed: {
+    opacity: 0.8,
+  },
+  buttonText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  resetButton: {
+    backgroundColor: "transparent",
+    borderWidth: 1,
+  },
+  resetButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  shareSection: {
+    marginTop: 24,
+  },
+  link: {
+    fontSize: 13,
+    fontFamily: Platform.OS === "ios" ? "Courier" : "monospace",
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    marginTop: 8,
+  },
+});

--- a/app/mobile/app/login.tsx
+++ b/app/mobile/app/login.tsx
@@ -2,7 +2,14 @@ import { useFocusEffect } from "@react-navigation/native";
 import { Href, useRouter } from "expo-router";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { useCallback, useState } from "react";
-import { Appearance, BackHandler, Linking, useColorScheme } from "react-native";
+import {
+  Appearance,
+  BackHandler,
+  Linking,
+  Text,
+  useColorScheme,
+  View,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { WebView } from "react-native-webview";
 
@@ -116,6 +123,32 @@ export default function LoginScreen() {
           }
         }}
       />
+      {/* TEMPORARY OTA pipeline test marker — remove before merge */}
+      <View
+        pointerEvents="none"
+        style={{
+          position: "absolute",
+          top: 60,
+          left: 0,
+          right: 0,
+          alignItems: "center",
+        }}
+      >
+        <Text
+          style={{
+            backgroundColor: "#E4017B",
+            color: "#fff",
+            fontSize: 16,
+            fontWeight: "700",
+            paddingVertical: 6,
+            paddingHorizontal: 14,
+            borderRadius: 8,
+            overflow: "hidden",
+          }}
+        >
+          OTA TEST BUNDLE — CI
+        </Text>
+      </View>
     </SafeAreaView>
   );
 }

--- a/app/mobile/app/login.tsx
+++ b/app/mobile/app/login.tsx
@@ -6,9 +6,7 @@ import {
   Appearance,
   BackHandler,
   Linking,
-  Text,
   useColorScheme,
-  View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { WebView } from "react-native-webview";
@@ -123,32 +121,6 @@ export default function LoginScreen() {
           }
         }}
       />
-      {/* TEMPORARY OTA pipeline test marker — remove before merge */}
-      <View
-        pointerEvents="none"
-        style={{
-          position: "absolute",
-          top: 60,
-          left: 0,
-          right: 0,
-          alignItems: "center",
-        }}
-      >
-        <Text
-          style={{
-            backgroundColor: "#E4017B",
-            color: "#fff",
-            fontSize: 16,
-            fontWeight: "700",
-            paddingVertical: 6,
-            paddingHorizontal: 14,
-            borderRadius: 8,
-            overflow: "hidden",
-          }}
-        >
-          OTA TEST BUNDLE — CI
-        </Text>
-      </View>
     </SafeAreaView>
   );
 }

--- a/app/mobile/app/login.tsx
+++ b/app/mobile/app/login.tsx
@@ -6,6 +6,7 @@ import { Appearance, BackHandler, Linking, useColorScheme } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { WebView } from "react-native-webview";
 
+import { getWebBaseUrl } from "@/config/urls";
 import { useAuthContext } from "@/features/auth/AuthContext";
 import { loginRoute } from "@/routes";
 import client from "@/service/client";
@@ -37,7 +38,7 @@ async function waitForSessionSync(
 }
 
 export default function LoginScreen() {
-  const WEB_BASE_URL = process.env.EXPO_PUBLIC_WEB_BASE_URL!;
+  const WEB_BASE_URL = getWebBaseUrl();
   const { markAuthenticated, markLoggedOut, setUserId, setJailed } =
     useAuthContext();
   const router = useRouter();

--- a/app/mobile/components/DevSettingsButton.tsx
+++ b/app/mobile/components/DevSettingsButton.tsx
@@ -1,0 +1,82 @@
+import { Ionicons } from "@expo/vector-icons";
+import { router } from "expo-router";
+import { useRef } from "react";
+import { Animated, PanResponder, StyleSheet } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { isDevUrlOverrideEnabled } from "@/config/urls";
+import { theme } from "@/theme";
+
+// Draggable floating button that opens the developer URL-override screen from
+// anywhere in the app. Rendered above the navigator (and its webviews) so it's
+// reachable on every screen, logged in or out. Non-prod builds only.
+export default function DevSettingsButton() {
+  const insets = useSafeAreaInsets();
+  const pan = useRef(new Animated.ValueXY()).current;
+  const draggedRef = useRef(false);
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: (_evt, gesture) =>
+        Math.abs(gesture.dx) > 4 || Math.abs(gesture.dy) > 4,
+      onPanResponderGrant: () => {
+        draggedRef.current = false;
+        pan.extractOffset();
+      },
+      onPanResponderMove: (evt, gesture) => {
+        if (Math.abs(gesture.dx) > 4 || Math.abs(gesture.dy) > 4) {
+          draggedRef.current = true;
+        }
+        Animated.event([null, { dx: pan.x, dy: pan.y }], {
+          useNativeDriver: false,
+        })(evt, gesture);
+      },
+      onPanResponderRelease: () => {
+        pan.flattenOffset();
+        // A press that didn't move is a tap → open the screen.
+        if (!draggedRef.current) {
+          router.navigate("/dev-settings");
+        }
+      },
+    }),
+  ).current;
+
+  if (!isDevUrlOverrideEnabled()) {
+    return null;
+  }
+
+  return (
+    <Animated.View
+      {...panResponder.panHandlers}
+      accessibilityRole="button"
+      accessibilityLabel="Open developer settings"
+      style={[
+        styles.button,
+        { bottom: insets.bottom + 96, transform: pan.getTranslateTransform() },
+      ]}
+    >
+      <Ionicons name="construct" size={20} color="#fff" />
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    position: "absolute",
+    right: 16,
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: theme.palette.secondary.main,
+    opacity: 0.85,
+    zIndex: 1000,
+    elevation: 8,
+    shadowColor: "#000",
+    shadowOpacity: 0.3,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 2 },
+  },
+});

--- a/app/mobile/components/WebEmbed.tsx
+++ b/app/mobile/components/WebEmbed.tsx
@@ -19,6 +19,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { WebView, WebViewMessageEvent } from "react-native-webview";
 
+import { getWebBaseUrl } from "@/config/urls";
 import { useAuthContext } from "@/features/auth/AuthContext";
 import { useImagePicker } from "@/hooks/useImagePicker";
 import { useWebNavigation } from "@/hooks/useWebNavigation";
@@ -38,7 +39,7 @@ export default function WebEmbed({
   path,
   onNativeBackFallback,
 }: WebEmbedProps) {
-  const WEB_BASE_URL = process.env.EXPO_PUBLIC_WEB_BASE_URL!;
+  const WEB_BASE_URL = getWebBaseUrl();
 
   const insets = useSafeAreaInsets();
   const colorScheme = useColorScheme();

--- a/app/mobile/config/urls.ts
+++ b/app/mobile/config/urls.ts
@@ -1,0 +1,156 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const STORAGE_KEY = "@couchers/devUrlOverrides";
+
+const DEFAULT_API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ||
+  process.env.EXPO_PUBLIC_API_BASE_URL ||
+  "http://localhost:8888"; // fallback for tests
+
+const DEFAULT_WEB_BASE_URL =
+  process.env.EXPO_PUBLIC_WEB_BASE_URL || "http://localhost:3000";
+
+const IS_PROD =
+  (process.env.NEXT_PUBLIC_COUCHERS_ENV ||
+    process.env.EXPO_PUBLIC_COUCHERS_ENV) === "prod";
+
+export type UrlOverrides = {
+  apiBaseUrl: string | null;
+  webBaseUrl: string | null;
+};
+
+export type Preset = {
+  label: string;
+  apiBaseUrl: string;
+  webBaseUrl: string;
+};
+
+// Known backends, offered as one-tap fills so common environments don't have
+// to be typed by hand.
+export const PRESETS: Preset[] = [
+  {
+    label: "Staging",
+    apiBaseUrl: "https://dev-api.couchershq.org",
+    webBaseUrl: "https://next.couchershq.org",
+  },
+  {
+    label: "Production",
+    apiBaseUrl: "https://api.couchers.org",
+    webBaseUrl: "https://couchers.org",
+  },
+];
+
+const HISTORY_KEY = "@couchers/devUrlHistory";
+const HISTORY_LIMIT = 8;
+
+let cache: UrlOverrides = { apiBaseUrl: null, webBaseUrl: null };
+
+// Overriding the backend URLs is only allowed in non-prod builds, so a
+// production app can never be pointed at a different backend, even if a
+// stale override somehow ends up in storage.
+export function isDevUrlOverrideEnabled(): boolean {
+  return !IS_PROD;
+}
+
+function normalize(url: string | null | undefined): string | null {
+  const trimmed = url?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.replace(/\/+$/, "");
+}
+
+export function getDefaultApiBaseUrl(): string {
+  return DEFAULT_API_BASE_URL;
+}
+
+export function getDefaultWebBaseUrl(): string {
+  return DEFAULT_WEB_BASE_URL;
+}
+
+export function getApiBaseUrl(): string {
+  if (isDevUrlOverrideEnabled() && cache.apiBaseUrl) {
+    return cache.apiBaseUrl;
+  }
+  return DEFAULT_API_BASE_URL;
+}
+
+export function getWebBaseUrl(): string {
+  if (isDevUrlOverrideEnabled() && cache.webBaseUrl) {
+    return cache.webBaseUrl;
+  }
+  return DEFAULT_WEB_BASE_URL;
+}
+
+export function getUrlOverrides(): UrlOverrides {
+  return { ...cache };
+}
+
+// Loads persisted overrides into the in-memory cache. Must run at startup
+// before the gRPC client and webviews read their URLs.
+export async function hydrateUrlOverrides(): Promise<void> {
+  if (!isDevUrlOverrideEnabled()) {
+    return;
+  }
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<UrlOverrides>;
+      cache = {
+        apiBaseUrl: normalize(parsed.apiBaseUrl),
+        webBaseUrl: normalize(parsed.webBaseUrl),
+      };
+    }
+  } catch {
+    cache = { apiBaseUrl: null, webBaseUrl: null };
+  }
+}
+
+export async function setUrlOverrides(overrides: UrlOverrides): Promise<void> {
+  cache = {
+    apiBaseUrl: normalize(overrides.apiBaseUrl),
+    webBaseUrl: normalize(overrides.webBaseUrl),
+  };
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(cache));
+  await addToHistory(cache);
+}
+
+export async function clearUrlOverrides(): Promise<void> {
+  cache = { apiBaseUrl: null, webBaseUrl: null };
+  await AsyncStorage.removeItem(STORAGE_KEY);
+}
+
+export async function getUrlHistory(): Promise<UrlOverrides[]> {
+  try {
+    const raw = await AsyncStorage.getItem(HISTORY_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed
+      .map((e) => ({
+        apiBaseUrl: normalize(e?.apiBaseUrl),
+        webBaseUrl: normalize(e?.webBaseUrl),
+      }))
+      .filter((e) => e.apiBaseUrl || e.webBaseUrl);
+  } catch {
+    return [];
+  }
+}
+
+export async function clearUrlHistory(): Promise<void> {
+  await AsyncStorage.removeItem(HISTORY_KEY);
+}
+
+async function addToHistory(entry: UrlOverrides): Promise<void> {
+  if (!entry.apiBaseUrl && !entry.webBaseUrl) {
+    return;
+  }
+  const history = await getUrlHistory();
+  const deduped = history.filter(
+    (e) =>
+      !(e.apiBaseUrl === entry.apiBaseUrl && e.webBaseUrl === entry.webBaseUrl),
+  );
+  const next = [entry, ...deduped].slice(0, HISTORY_LIMIT);
+  await AsyncStorage.setItem(HISTORY_KEY, JSON.stringify(next));
+}

--- a/app/mobile/dev-url-qr.html
+++ b/app/mobile/dev-url-qr.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Couchers dev URL QR generator</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+    <style>
+      body {
+        font-family: -apple-system, system-ui, sans-serif;
+        max-width: 520px;
+        margin: 40px auto;
+        padding: 0 16px;
+        color: #313539;
+      }
+      h1 {
+        font-size: 20px;
+      }
+      label {
+        display: block;
+        font-weight: 600;
+        margin: 16px 0 4px;
+      }
+      input,
+      select {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 8px;
+        font-size: 15px;
+      }
+      .presets {
+        margin-top: 12px;
+      }
+      button {
+        padding: 6px 12px;
+        margin: 4px 4px 0 0;
+        cursor: pointer;
+      }
+      #qr {
+        margin-top: 24px;
+        display: flex;
+        justify-content: center;
+      }
+      code {
+        display: block;
+        word-break: break-all;
+        background: #f3f3f3;
+        padding: 8px;
+        margin-top: 12px;
+        font-size: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Couchers dev URL QR</h1>
+    <p>
+      Generate a QR for the in-app developer settings. Scan it with a phone
+      camera to open the app with these URLs pre-filled.
+    </p>
+
+    <div class="presets">
+      <button
+        data-api="https://dev-api.couchershq.org"
+        data-web="https://next.couchershq.org"
+      >
+        Staging
+      </button>
+      <button
+        data-api="https://api.couchers.org"
+        data-web="https://couchers.org"
+      >
+        Production
+      </button>
+    </div>
+
+    <label for="scheme">App</label>
+    <select id="scheme">
+      <option value="couchers-devtool">Dev Tool (couchers-devtool)</option>
+      <option value="couchers-staging">Staging (couchers-staging)</option>
+    </select>
+
+    <label for="api">API base URL</label>
+    <input id="api" placeholder="https://dev-api.couchershq.org" />
+
+    <label for="web">Web base URL</label>
+    <input id="web" placeholder="https://next.couchershq.org" />
+
+    <code id="link"></code>
+    <div id="qr"></div>
+
+    <script>
+      const qrEl = document.getElementById("qr");
+      const linkEl = document.getElementById("link");
+      const apiEl = document.getElementById("api");
+      const webEl = document.getElementById("web");
+      const schemeEl = document.getElementById("scheme");
+      let qr = null;
+
+      function render() {
+        const scheme = schemeEl.value;
+        const api = encodeURIComponent(apiEl.value.trim());
+        const web = encodeURIComponent(webEl.value.trim());
+        const link = `${scheme}://dev-settings?api=${api}&web=${web}`;
+        linkEl.textContent = link;
+        qrEl.innerHTML = "";
+        qr = new QRCode(qrEl, { text: link, width: 240, height: 240 });
+      }
+
+      document.querySelectorAll(".presets button").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          apiEl.value = btn.dataset.api;
+          webEl.value = btn.dataset.web;
+          render();
+        });
+      });
+
+      [apiEl, webEl, schemeEl].forEach((el) =>
+        el.addEventListener("input", render),
+      );
+      render();
+    </script>
+  </body>
+</html>

--- a/app/mobile/eas.json
+++ b/app/mobile/eas.json
@@ -31,6 +31,19 @@
         "EXPO_PUBLIC_WEB_BASE_URL": "https://couchers.org",
         "EXPO_PUBLIC_COUCHERS_ENV": "prod"
       }
+    },
+    "devtool": {
+      "developmentClient": true,
+      "distribution": "store",
+      "autoIncrement": true,
+      "channel": "development",
+      "environment": "preview",
+      "env": {
+        "APP_VARIANT": "devtool",
+        "EXPO_PUBLIC_API_BASE_URL": "https://dev-api.couchershq.org",
+        "EXPO_PUBLIC_WEB_BASE_URL": "https://next.couchershq.org",
+        "EXPO_PUBLIC_COUCHERS_ENV": "preview"
+      }
     }
   },
   "submit": {
@@ -51,6 +64,16 @@
       "android": {
         "track": "internal",
         "releaseStatus": "completed"
+      }
+    },
+    "devtool": {
+      "ios": {
+        "ascAppId": "REPLACE_WITH_DEVTOOL_ASC_APP_ID"
+      },
+      "android": {
+        "track": "internal",
+        "releaseStatus": "completed",
+        "changesNotSentForReview": true
       }
     }
   }

--- a/app/mobile/eas.json
+++ b/app/mobile/eas.json
@@ -68,7 +68,7 @@
     },
     "devtool": {
       "ios": {
-        "ascAppId": "REPLACE_WITH_DEVTOOL_ASC_APP_ID"
+        "ascAppId": "6772371797"
       },
       "android": {
         "track": "internal",

--- a/app/mobile/eas.json
+++ b/app/mobile/eas.json
@@ -35,9 +35,6 @@
     "devtool": {
       "developmentClient": true,
       "distribution": "store",
-      "android": {
-        "buildType": "app-bundle"
-      },
       "autoIncrement": true,
       "channel": "development",
       "environment": "preview",

--- a/app/mobile/eas.json
+++ b/app/mobile/eas.json
@@ -35,6 +35,9 @@
     "devtool": {
       "developmentClient": true,
       "distribution": "store",
+      "android": {
+        "buildType": "app-bundle"
+      },
       "autoIncrement": true,
       "channel": "development",
       "environment": "preview",

--- a/app/mobile/jest.setup.ts
+++ b/app/mobile/jest.setup.ts
@@ -6,6 +6,11 @@ jest.useFakeTimers();
 // Common environment variables
 process.env.EXPO_PUBLIC_WEB_BASE_URL = "https://couchers.org";
 
+// Mock AsyncStorage with the library-provided in-memory implementation
+jest.mock("@react-native-async-storage/async-storage", () =>
+  require("@react-native-async-storage/async-storage/jest/async-storage-mock"),
+);
+
 // Mock expo-constants globally
 jest.mock("expo-constants", () => ({
   expoConfig: {

--- a/app/mobile/metro.config.js
+++ b/app/mobile/metro.config.js
@@ -1,0 +1,6 @@
+// Learn more https://docs.expo.dev/guides/customizing-metro
+const { getDefaultConfig } = require("expo/metro-config");
+
+const config = getDefaultConfig(__dirname);
+
+module.exports = config;

--- a/app/mobile/package-lock.json
+++ b/app/mobile/package-lock.json
@@ -12,6 +12,7 @@
         "@expo/cli": "^55.0.0-canary-20260105-6b962e6",
         "@expo/vector-icons": "^15.0.3",
         "@expo/xcpretty": "^4.3.2",
+        "@react-native-async-storage/async-storage": "2.2.0",
         "@react-navigation/drawer": "^7.3.9",
         "@react-navigation/native": "^7.1.6",
         "expo": "~54.0.34",
@@ -3788,6 +3789,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -10438,6 +10451,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -12589,6 +12611,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/app/mobile/package-lock.json
+++ b/app/mobile/package-lock.json
@@ -17,6 +17,7 @@
         "@react-navigation/native": "^7.1.6",
         "expo": "~54.0.34",
         "expo-build-properties": "^1.0.10",
+        "expo-clipboard": "~8.0.8",
         "expo-constants": "~18.0.11",
         "expo-dev-client": "~6.0.21",
         "expo-device": "~8.0.10",
@@ -7881,6 +7882,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-clipboard": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-8.0.8.tgz",
+      "integrity": "sha512-VKoBkHIpZZDJTB0jRO4/PZskHdMNOEz3P/41tmM6fDuODMpqhvyWK053X0ebspkxiawJX9lX33JXHBCvVsTTOA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-constants": {

--- a/app/mobile/package.json
+++ b/app/mobile/package.json
@@ -13,8 +13,10 @@
     "lint": "expo lint",
     "format": "expo lint --fix && prettier --write .",
     "test": "jest",
+    "release:ios:devtool": "eas build --platform ios --profile devtool --auto-submit",
     "release:ios:staging": "eas build --platform ios --profile staging --auto-submit",
     "release:ios:production": "eas build --platform ios --profile production --auto-submit",
+    "release:android:devtool": "eas build --platform android --profile devtool --auto-submit",
     "release:android:staging": "eas build --platform android --profile staging --auto-submit",
     "release:android:production": "eas build --platform android --profile production --auto-submit"
   },

--- a/app/mobile/package.json
+++ b/app/mobile/package.json
@@ -4,6 +4,7 @@
   "version": "1.1.20",
   "scripts": {
     "start": "expo start",
+    "start:devtool": "APP_VARIANT=devtool expo start --dev-client --scheme couchers-devtool",
     "start:localhost": "expo start --localhost",
     "build:protos": "bash ./ci-build-protos.sh",
     "eas-build-pre-install": "npm run build:protos",
@@ -36,6 +37,7 @@
     "@react-navigation/native": "^7.1.6",
     "expo": "~54.0.34",
     "expo-build-properties": "^1.0.10",
+    "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.11",
     "expo-dev-client": "~6.0.21",
     "expo-device": "~8.0.10",

--- a/app/mobile/package.json
+++ b/app/mobile/package.json
@@ -31,6 +31,7 @@
     "@expo/cli": "^55.0.0-canary-20260105-6b962e6",
     "@expo/vector-icons": "^15.0.3",
     "@expo/xcpretty": "^4.3.2",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/drawer": "^7.3.9",
     "@react-navigation/native": "^7.1.6",
     "expo": "~54.0.34",

--- a/app/mobile/scripts/ota-serve.mjs
+++ b/app/mobile/scripts/ota-serve.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+// Phase-2 local test harness for Dev Tool OTA.
+//
+// Serves a staged `ota-out/<platform>/` (from ota-stage.mjs) to a real device on
+// the LAN so we can confirm, on-device, whether the dev launcher loads our
+// manifest and in which framing (plain JSON vs multipart/mixed). It:
+//   - logs every request + the expo-* headers the launcher actually sends,
+//   - content-negotiates the manifest framing (override with ?framing=json|multipart),
+//   - rewrites launchAsset/asset URLs to its own host, so no regen on IP change,
+//   - serves a landing page with a tappable deep link + QR (open it in Safari on
+//     the phone, or scan the QR) to trigger the launcher load.
+//
+// Usage: node scripts/ota-serve.mjs [--dir ota-out] [--port 8099] [--scheme couchers-devtool]
+
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+
+const args = Object.fromEntries(
+  process.argv.slice(2).reduce((acc, cur, i, a) => {
+    if (cur.startsWith("--")) acc.push([cur.slice(2), a[i + 1]]);
+    return acc;
+  }, [])
+);
+const DIR = path.resolve(args.dir ?? "ota-out");
+const PORT = parseInt(args.port ?? "8099", 10);
+const SCHEME = args.scheme ?? "couchers-devtool";
+
+const LOG_HEADERS = [
+  "accept",
+  "expo-platform",
+  "expo-protocol-version",
+  "expo-runtime-version",
+  "expo-current-update-id",
+  "expo-embedded-update-id",
+  "expo-expect-signature",
+  "expo-dev-client-id",
+  "expo-updates-environment",
+  "eas-client-id",
+  "user-agent",
+];
+
+function platforms() {
+  return fs
+    .readdirSync(DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && fs.existsSync(path.join(DIR, d.name, "manifest.json")))
+    .map((d) => d.name);
+}
+
+function loadManifest(platform, host) {
+  const raw = JSON.parse(fs.readFileSync(path.join(DIR, platform, "manifest.json"), "utf8"));
+  const rewrite = (u) => `http://${host}${new URL(u).pathname}`;
+  raw.launchAsset.url = rewrite(raw.launchAsset.url);
+  raw.assets = raw.assets.map((a) => ({ ...a, url: rewrite(a.url) }));
+  return raw;
+}
+
+function contentTypeMap(platform) {
+  const m = JSON.parse(fs.readFileSync(path.join(DIR, platform, "manifest.json"), "utf8"));
+  const map = new Map();
+  for (const a of m.assets) map.set(a.key, a.contentType);
+  map.set(path.basename(new URL(m.launchAsset.url).pathname), m.launchAsset.contentType);
+  return map;
+}
+
+function multipartBody(manifest) {
+  const boundary = `----ota${Date.now().toString(16)}`;
+  const part = (name, body, contentType) =>
+    `--${boundary}\r\n` +
+    `content-disposition: form-data; name="${name}"\r\n` +
+    `content-type: ${contentType}\r\n\r\n` +
+    `${body}\r\n`;
+  const body =
+    part("manifest", JSON.stringify(manifest), "application/json; charset=utf-8") +
+    part("extensions", JSON.stringify({ assetRequestHeaders: {} }), "application/json") +
+    `--${boundary}--\r\n`;
+  return { body, contentType: `multipart/mixed; boundary=${boundary}` };
+}
+
+function logReq(req) {
+  const hdrs = LOG_HEADERS.filter((h) => req.headers[h] != null)
+    .map((h) => `${h}=${req.headers[h]}`)
+    .join("  ");
+  console.log(`${new Date().toISOString()}  ${req.method} ${req.url}`);
+  if (hdrs) console.log(`    ${hdrs}`);
+}
+
+function chooseFraming(req, url) {
+  const q = url.searchParams.get("framing");
+  if (q === "json" || q === "multipart") return q;
+  const accept = req.headers["accept"] ?? "";
+  if (accept.includes("multipart/mixed") || req.headers["expo-protocol-version"]) return "multipart";
+  return "json";
+}
+
+function landingPage(host) {
+  const links = platforms()
+    .map((p) => {
+      const manifestUrl = `http://${host}/${p}/manifest`;
+      const deepLink = `${SCHEME}://expo-development-client/?url=${encodeURIComponent(manifestUrl)}`;
+      return `
+      <section>
+        <h2>${p}</h2>
+        <p><a href="${deepLink}">Open ${p} branch in Dev Tool &rarr;</a></p>
+        <div class="qr" data-link="${deepLink.replace(/"/g, "&quot;")}"></div>
+        <code>${deepLink}</code>
+        <p style="font-size:12px;color:#888">manifest: ${manifestUrl}</p>
+      </section>`;
+    })
+    .join("");
+  return `<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>OTA test</title>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+<style>body{font-family:-apple-system,system-ui,sans-serif;max-width:520px;margin:32px auto;padding:0 16px;color:#313539}
+h2{font-size:18px;margin-top:32px}a{font-size:17px}code{display:block;word-break:break-all;background:#f3f3f3;padding:8px;margin-top:8px;font-size:11px}
+.qr{margin:16px 0;display:flex;justify-content:center}</style></head>
+<body><h1>Dev Tool OTA test</h1>
+<p>Open this page in Safari <b>on the phone</b> and tap the link, or scan the QR.</p>
+${links}
+<script>document.querySelectorAll(".qr").forEach(function(el){new QRCode(el,{text:el.dataset.link,width:220,height:220});});</script>
+</body></html>`;
+}
+
+const server = http.createServer((req, res) => {
+  logReq(req);
+  const host = req.headers.host ?? `localhost:${PORT}`;
+  const url = new URL(req.url, `http://${host}`);
+  const parts = url.pathname.split("/").filter(Boolean);
+
+  // landing page
+  if (url.pathname === "/") {
+    res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    res.end(landingPage(host));
+    return;
+  }
+
+  const platform = parts[0];
+  if (!platforms().includes(platform)) {
+    res.writeHead(404).end("unknown platform");
+    return;
+  }
+
+  // manifest
+  if (parts[1] === "manifest" || parts[1] === "manifest.json") {
+    if (req.method === "HEAD") {
+      // mirror the reference server: GET-only. Non-2xx HEAD lets the launcher
+      // classify this as a published-manifest URL rather than a Metro server.
+      res.writeHead(405).end();
+      return;
+    }
+    const manifest = loadManifest(platform, host);
+    const framing = chooseFraming(req, url);
+    if (framing === "multipart") {
+      const { body, contentType } = multipartBody(manifest);
+      // OTA_NO_PROTO_HEADERS mimics raw S3, which can set content-type but not
+      // arbitrary response headers like expo-protocol-version / expo-sfv-version.
+      const headers = { "content-type": contentType, "cache-control": "private, max-age=0" };
+      if (!process.env.OTA_NO_PROTO_HEADERS) {
+        headers["expo-protocol-version"] = "1";
+        headers["expo-sfv-version"] = "0";
+      }
+      res.writeHead(200, headers);
+      console.log(
+        `    -> 200 multipart (${body.length} bytes)${process.env.OTA_NO_PROTO_HEADERS ? " [no proto headers / S3-mimic]" : ""}`
+      );
+      res.end(body);
+    } else {
+      const body = JSON.stringify(manifest);
+      res.writeHead(200, {
+        "content-type": "application/json; charset=utf-8",
+        "expo-protocol-version": "0",
+        "cache-control": "private, max-age=0",
+      });
+      console.log(`    -> 200 json (${body.length} bytes)`);
+      res.end(body);
+    }
+    return;
+  }
+
+  // bundle / assets
+  let filePath = null;
+  if (parts[1] === "bundle.hbc") filePath = path.join(DIR, platform, "bundle.hbc");
+  else if (parts[1] === "assets" && parts[2]) filePath = path.join(DIR, platform, "assets", parts[2]);
+
+  if (filePath && fs.existsSync(filePath)) {
+    const name = path.basename(filePath);
+    const ct = contentTypeMap(platform).get(name) ?? "application/octet-stream";
+    const buf = fs.readFileSync(filePath);
+    res.writeHead(200, { "content-type": ct, "content-length": buf.length });
+    console.log(`    -> 200 ${ct} (${buf.length} bytes)`);
+    res.end(buf);
+    return;
+  }
+
+  res.writeHead(404).end("not found");
+});
+
+server.listen(PORT, "0.0.0.0", () => {
+  console.log(`OTA test server on http://0.0.0.0:${PORT}  (platforms: ${platforms().join(", ") || "none"})`);
+  console.log(`Open on the phone:  http://<this-mac-LAN-ip>:${PORT}/`);
+});

--- a/app/mobile/scripts/ota-stage.mjs
+++ b/app/mobile/scripts/ota-stage.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+// Stage an `expo export` output into the layout we serve for per-branch Dev Tool
+// OTA previews, and generate the Expo Updates manifest for it.
+//
+// The manifest content (asset key/hash/contentType, launchAsset, id derivation)
+// mirrors Expo's reference `custom-expo-updates-server` exactly, so it loads on a
+// stock expo-updates client. The wire framing (plain JSON vs multipart/mixed) is
+// the one thing still confirmed on-device in Phase 2 — this script emits the
+// manifest object as JSON; packaging is applied at serve/upload time.
+//
+// Usage:
+//   node scripts/ota-stage.mjs \
+//     --platform ios \
+//     --runtime-version <fingerprint> \
+//     --base-url https://<sha>--ota.preview.couchershq.org \
+//     [--dist dist] [--out ota-out] [--expo-config expo-config.json] [--created-at <iso>]
+//
+// Produces <out>/<platform>/{manifest.json, bundle.hbc, assets/<key>}, ready to
+// `aws s3 cp --recursive` to s3://couchers-dev-assets/ota/<sha>/<platform>/.
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const CONTENT_TYPES = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  ttf: "font/ttf",
+  otf: "font/otf",
+  woff: "font/woff",
+  woff2: "font/woff2",
+  json: "application/json",
+  js: "application/javascript",
+};
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i];
+    if (!key.startsWith("--")) throw new Error(`Unexpected argument: ${key}`);
+    args[key.slice(2)] = argv[i + 1];
+  }
+  return args;
+}
+
+function sha256Base64Url(buf) {
+  return crypto
+    .createHash("sha256")
+    .update(buf)
+    .digest("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function md5Hex(buf) {
+  return crypto.createHash("md5").update(buf).digest("hex");
+}
+
+// sha256 hex of metadata.json -> deterministic UUID, exactly as the reference does.
+function sha256HexToUuid(buf) {
+  const h = crypto.createHash("sha256").update(buf).digest("hex");
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20, 32)}`;
+}
+
+function assetMetadata({ distDir, filePath, ext, isLaunchAsset, baseUrl, platform, outDir, staged }) {
+  const abs = path.join(distDir, filePath);
+  const buf = fs.readFileSync(abs);
+  const key = md5Hex(buf);
+  const contentType = isLaunchAsset
+    ? "application/javascript"
+    : (CONTENT_TYPES[ext] ?? "application/octet-stream");
+  const fileExtension = `.${isLaunchAsset ? "bundle" : ext}`;
+
+  const servedName = isLaunchAsset ? "bundle.hbc" : path.join("assets", key);
+  const dest = path.join(outDir, servedName);
+  if (!staged.has(dest)) {
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.writeFileSync(dest, buf);
+    staged.add(dest);
+  }
+
+  return {
+    hash: sha256Base64Url(buf),
+    key,
+    fileExtension,
+    contentType,
+    url: `${baseUrl}/${platform}/${servedName.split(path.sep).join("/")}`,
+  };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const platform = args.platform;
+  const runtimeVersion = args["runtime-version"];
+  const baseUrl = (args["base-url"] ?? "").replace(/\/$/, "");
+  if (!["ios", "android"].includes(platform)) {
+    throw new Error(`--platform must be ios or android (got ${platform})`);
+  }
+  if (!runtimeVersion) throw new Error("--runtime-version is required");
+  if (!baseUrl) throw new Error("--base-url is required");
+
+  const distDir = path.resolve(args.dist ?? "dist");
+  const outRoot = path.resolve(args.out ?? "ota-out");
+  const outDir = path.join(outRoot, platform);
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const metadataBuf = fs.readFileSync(path.join(distDir, "metadata.json"));
+  const metadata = JSON.parse(metadataBuf.toString("utf8"));
+  const pf = metadata.fileMetadata?.[platform];
+  if (!pf) throw new Error(`No fileMetadata for platform ${platform} in metadata.json`);
+
+  let expoClient = {};
+  if (args["expo-config"]) {
+    expoClient = JSON.parse(fs.readFileSync(path.resolve(args["expo-config"]), "utf8"));
+  } else {
+    console.warn("WARN: no --expo-config given; extra.expoClient will be empty {}");
+  }
+
+  const staged = new Set();
+  const assets = pf.assets.map((a) =>
+    assetMetadata({
+      distDir,
+      filePath: a.path,
+      ext: a.ext,
+      isLaunchAsset: false,
+      baseUrl,
+      platform,
+      outDir,
+      staged,
+    })
+  );
+  const launchAsset = assetMetadata({
+    distDir,
+    filePath: pf.bundle,
+    ext: null,
+    isLaunchAsset: true,
+    baseUrl,
+    platform,
+    outDir,
+    staged,
+  });
+
+  const manifest = {
+    id: sha256HexToUuid(metadataBuf),
+    createdAt: args["created-at"] ?? new Date().toISOString(),
+    runtimeVersion,
+    launchAsset,
+    assets,
+    metadata: {},
+    extra: { expoClient },
+  };
+
+  fs.writeFileSync(path.join(outDir, "manifest.json"), JSON.stringify(manifest, null, 2));
+
+  // Emit the protocol-v1 multipart/mixed framing that the dev client requires, as
+  // a static file S3 can serve verbatim, plus the content-type (with the matching
+  // boundary) for the uploader to set. Framing matches the on-device-verified
+  // local server (a `manifest` part + an `extensions` part).
+  const boundary = "COUCHERS_OTA_BOUNDARY";
+  const part = (name, body, ct) =>
+    `--${boundary}\r\n` +
+    `content-disposition: form-data; name="${name}"\r\n` +
+    `content-type: ${ct}\r\n\r\n` +
+    `${body}\r\n`;
+  const multipart =
+    part("manifest", JSON.stringify(manifest), "application/json; charset=utf-8") +
+    part("extensions", JSON.stringify({ assetRequestHeaders: {} }), "application/json") +
+    `--${boundary}--\r\n`;
+  fs.writeFileSync(path.join(outDir, "manifest"), multipart);
+  fs.writeFileSync(path.join(outDir, "manifest.content-type"), `multipart/mixed; boundary=${boundary}`);
+
+  console.log(`staged ${platform} -> ${outDir}`);
+  console.log(`  id              ${manifest.id}`);
+  console.log(`  runtimeVersion  ${runtimeVersion}`);
+  console.log(`  launchAsset     ${launchAsset.key} (${launchAsset.contentType})`);
+  console.log(`  assets          ${assets.length} entries, ${staged.size - 1} unique files`);
+  console.log(`  manifest.json   ${path.join(outDir, "manifest.json")} (object, for local server)`);
+  console.log(`  manifest        ${path.join(outDir, "manifest")} (multipart body, for S3)`);
+}
+
+main();

--- a/app/mobile/scripts/ota-stage.mjs
+++ b/app/mobile/scripts/ota-stage.mjs
@@ -174,6 +174,27 @@ function main() {
   fs.writeFileSync(path.join(outDir, "manifest"), multipart);
   fs.writeFileSync(path.join(outDir, "manifest.content-type"), `multipart/mixed; boundary=${boundary}`);
 
+  // GitHub strips custom-scheme (couchers-devtool://) links from comments, so the PR
+  // comment links to this https page, which redirects to the dev-launcher deep link
+  // once opened on the device.
+  const manifestUrl = `${baseUrl}/${platform}/manifest`;
+  const deepLink =
+    "couchers-devtool://expo-development-client/?url=" + encodeURIComponent(manifestUrl);
+  const openHtml = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Open in Dev Tool</title>
+<script>location.replace(${JSON.stringify(deepLink)})</script>
+</head>
+<body style="font-family: sans-serif; text-align: center; margin-top: 3em">
+<p>Opening this branch in the Dev Tool… <a href="${deepLink}">tap here if nothing happens</a>.</p>
+</body>
+</html>
+`;
+  fs.writeFileSync(path.join(outDir, "open.html"), openHtml);
+
   console.log(`staged ${platform} -> ${outDir}`);
   console.log(`  id              ${manifest.id}`);
   console.log(`  runtimeVersion  ${runtimeVersion}`);
@@ -181,6 +202,7 @@ function main() {
   console.log(`  assets          ${assets.length} entries, ${staged.size - 1} unique files`);
   console.log(`  manifest.json   ${path.join(outDir, "manifest.json")} (object, for local server)`);
   console.log(`  manifest        ${path.join(outDir, "manifest")} (multipart body, for S3)`);
+  console.log(`  open.html       ${path.join(outDir, "open.html")} (https -> deep link redirect)`);
 }
 
 main();

--- a/app/mobile/service/client.ts
+++ b/app/mobile/service/client.ts
@@ -2,21 +2,12 @@ import { Request, RpcError, StatusCode } from "grpc-web";
 import { AuthPromiseClient } from "@/proto/auth_grpc_web_pb";
 import { NotificationsPromiseClient } from "@/proto/notifications_grpc_web_pb";
 
+import { getApiBaseUrl } from "@/config/urls";
 import isGrpcError from "@/service/utils/isGrpcError";
 
-const URL =
-  process.env.NEXT_PUBLIC_API_BASE_URL ||
-  process.env.EXPO_PUBLIC_API_BASE_URL ||
-  "http://localhost:8888"; // fallback for tests
 const IS_PROD =
   (process.env.NEXT_PUBLIC_COUCHERS_ENV ||
     process.env.EXPO_PUBLIC_COUCHERS_ENV)! === "prod";
-
-// Debug: Log the API URL being used
-if (!IS_PROD) {
-  console.log("🔧 Mobile API URL:", URL);
-  console.log("🔧 Environment:", process.env.EXPO_PUBLIC_COUCHERS_ENV);
-}
 
 const grpcTimeout = 10000; //milliseconds
 
@@ -36,7 +27,7 @@ export class AuthInterceptor {
       response = await invoker(request);
     } catch (e) {
       console.error("🔴 API Request Error:", e);
-      console.error("🔴 Using API URL:", URL);
+      console.error("🔴 Using API URL:", getApiBaseUrl());
       if (isGrpcError(e) && e.code === StatusCode.UNAUTHENTICATED) {
         _unauthenticatedErrorHandler(e);
       } else {
@@ -70,10 +61,28 @@ const opts = {
   /// TODO: streaming interceptor for auth https://grpc.io/blog/grpc-web-interceptor/
 };
 
-const client = {
-  auth: new AuthPromiseClient(URL, null, opts),
-  notifications: new NotificationsPromiseClient(URL, null, opts),
-};
+function buildClients(url: string) {
+  if (!IS_PROD) {
+    console.log("🔧 Mobile API URL:", url);
+    console.log("🔧 Environment:", process.env.EXPO_PUBLIC_COUCHERS_ENV);
+  }
+  return {
+    auth: new AuthPromiseClient(url, null, opts),
+    notifications: new NotificationsPromiseClient(url, null, opts),
+  };
+}
+
+// Mutable so reconfigureApiClient() can re-point it after the persisted URL
+// override is hydrated at startup. Callers reference client.auth/.notifications
+// at call time, so they always see the latest clients.
+const client = buildClients(getApiBaseUrl());
+
+// Rebuilds the gRPC clients against the currently-resolved API URL. Call after
+// hydrating the URL override at startup; the initial clients above are created
+// at import time, before the override is read from storage.
+export function reconfigureApiClient(): void {
+  Object.assign(client, buildClients(getApiBaseUrl()));
+}
 
 if (!IS_PROD && typeof window !== "undefined") {
   // @ts-ignore

--- a/app/mobile/utils/reloadApp.ts
+++ b/app/mobile/utils/reloadApp.ts
@@ -1,0 +1,14 @@
+import * as Updates from "expo-updates";
+import { DevSettings } from "react-native";
+
+// Restarts the JS bundle so freshly-saved URL overrides are picked up by the
+// gRPC client and webviews. DevSettings.reload() is the path that works when
+// running over a dev server (the Dev Tool build); Updates.reloadAsync() covers
+// release-mode builds (e.g. staging) where DevSettings is unavailable.
+export async function reloadApp(): Promise<void> {
+  if (__DEV__) {
+    DevSettings.reload();
+    return;
+  }
+  await Updates.reloadAsync();
+}

--- a/app/scripts/pr_preview_comment.py
+++ b/app/scripts/pr_preview_comment.py
@@ -43,15 +43,15 @@ def mobile_ota_section(short_sha, domain, platforms):
     lines = [
         "### Mobile Dev Tool preview",
         "",
-        "Scan with your phone camera (or tap the deep link on the device) to open this "
-        "branch in the installed **Dev Tool** dev client.",
+        "Scan the QR with your phone camera, or tap **Open in Dev Tool** on the device, "
+        "to open this branch in the installed **Dev Tool** dev client.",
     ]
     for platform in platforms:
         base = f"https://{short_sha}--ota.{domain}/{platform}"
         link = deep_link(f"{base}/manifest")
         lines += [
             "",
-            f"**{platform}**",
+            f"**{platform}** — [Open in Dev Tool]({base}/open.html)",
             "",
             f'<img src="{base}/qr.png" alt="QR to open the {platform} build" width="180" height="180" />',
             "",

--- a/app/scripts/pr_preview_comment.py
+++ b/app/scripts/pr_preview_comment.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Post (or update) a sticky preview comment on the GitHub PR for this pipeline.
+
+Runs in GitLab CI after the preview/upload jobs so every link it posts is already
+live. Currently surfaces the per-branch mobile Dev Tool OTA preview (QR + deep
+link); each preview is a section, so web/coverage/etc. can be appended as the
+pipeline grows. No-ops (exit 0) when there is no token or no open PR, so it never
+turns a pipeline red.
+"""
+
+import io
+import os
+import sys
+import urllib.parse
+
+import boto3
+import qrcode
+import requests
+
+MARKER = "<!-- couchers-preview-bot -->"
+GITHUB_API = "https://api.github.com"
+
+
+def env(name, default=None, *, required=False):
+    value = os.environ.get(name, default)
+    if required and not value:
+        sys.exit(f"missing required env var {name}")
+    return value
+
+
+def gh_headers(token):
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def deep_link(manifest_url):
+    return "couchers-devtool://expo-development-client/?url=" + urllib.parse.quote(
+        manifest_url, safe=""
+    )
+
+
+def make_qr_png(data):
+    qr = qrcode.QRCode(
+        border=2, box_size=8, error_correction=qrcode.constants.ERROR_CORRECT_M
+    )
+    qr.add_data(data)
+    qr.make(fit=True)
+    buf = io.BytesIO()
+    qr.make_image(fill_color="black", back_color="white").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def mobile_ota_section(s3, bucket, short_sha, domain, platforms):
+    lines = [
+        "### Mobile Dev Tool preview",
+        "",
+        "Scan with your phone camera (or tap the deep link on the device) to open this "
+        "branch in the installed **Dev Tool** dev client.",
+    ]
+    for platform in platforms:
+        manifest_url = f"https://{short_sha}--ota.{domain}/{platform}/manifest"
+        link = deep_link(manifest_url)
+        s3.put_object(
+            Bucket=bucket,
+            Key=f"ota/{short_sha}/{platform}/qr.png",
+            Body=make_qr_png(link),
+            ContentType="image/png",
+        )
+        qr_url = f"https://{short_sha}--ota.{domain}/{platform}/qr.png"
+        lines += [
+            "",
+            f"**{platform}**",
+            "",
+            f'<img src="{qr_url}" alt="QR to open the {platform} build" width="180" height="180" />',
+            "",
+            "<details><summary>Deep link</summary>",
+            "",
+            "```",
+            link,
+            "```",
+            "</details>",
+        ]
+    return "\n".join(lines)
+
+
+def build_body(sections, sha, pipeline_url):
+    parts = [MARKER, "## Preview builds", ""]
+    parts += [section for section in sections if section]
+    footer = f"commit `{sha[:8]}`"
+    if pipeline_url:
+        footer += f" · [pipeline]({pipeline_url})"
+    parts += ["", "---", f"<sub>{footer}</sub>"]
+    return "\n".join(parts)
+
+
+def find_open_pr(repo, sha, token):
+    resp = requests.get(
+        f"{GITHUB_API}/repos/{repo}/commits/{sha}/pulls",
+        headers=gh_headers(token),
+        timeout=30,
+    )
+    resp.raise_for_status()
+    for pr in resp.json():
+        if pr.get("state") == "open":
+            return pr["number"]
+    return None
+
+
+def upsert_comment(repo, pr, body, token):
+    resp = requests.get(
+        f"{GITHUB_API}/repos/{repo}/issues/{pr}/comments",
+        headers=gh_headers(token),
+        params={"per_page": 100},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    existing = next((c for c in resp.json() if MARKER in (c.get("body") or "")), None)
+    if existing:
+        resp = requests.patch(
+            f"{GITHUB_API}/repos/{repo}/issues/comments/{existing['id']}",
+            headers=gh_headers(token),
+            json={"body": body},
+            timeout=30,
+        )
+    else:
+        resp = requests.post(
+            f"{GITHUB_API}/repos/{repo}/issues/{pr}/comments",
+            headers=gh_headers(token),
+            json={"body": body},
+            timeout=30,
+        )
+    resp.raise_for_status()
+    return resp.json().get("html_url")
+
+
+def main():
+    token = env("GITHUB_PREVIEW_TOKEN")
+    if not token:
+        print("GITHUB_PREVIEW_TOKEN not set - skipping preview comment.")
+        return
+
+    repo = env("GITHUB_REPO", "Couchers-org/couchers")
+    sha = env("CI_COMMIT_SHA", required=True)
+    short_sha = env("CI_COMMIT_SHORT_SHA", required=True)
+    domain = env("PREVIEW_DOMAIN", required=True)
+    pipeline_url = env("CI_PIPELINE_URL", "")
+    platforms = env("OTA_PLATFORMS", "ios").split()
+
+    pr = find_open_pr(repo, sha, token)
+    if not pr:
+        print(f"No open PR for {sha} - skipping preview comment.")
+        return
+
+    s3 = boto3.client("s3")
+    bucket = env("AWS_PREVIEW_BUCKET", required=True)
+
+    sections = [mobile_ota_section(s3, bucket, short_sha, domain, platforms)]
+    url = upsert_comment(repo, pr, build_body(sections, sha, pipeline_url), token)
+    print(f"Posted preview comment to PR #{pr}: {url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/app/scripts/pr_preview_comment.py
+++ b/app/scripts/pr_preview_comment.py
@@ -1,20 +1,17 @@
 #!/usr/bin/env python3
 """Post (or update) a sticky preview comment on the GitHub PR for this pipeline.
 
-Runs in GitLab CI after the preview/upload jobs so every link it posts is already
-live. Currently surfaces the per-branch mobile Dev Tool OTA preview (QR + deep
-link); each preview is a section, so web/coverage/etc. can be appended as the
-pipeline grows. No-ops (exit 0) when there is no token or no open PR, so it never
-turns a pipeline red.
+Runs in GitLab CI after the upload jobs so every link it posts is already live.
+Each preview is a section, so web/coverage/etc. can be appended as the pipeline
+grows. The mobile QR PNG is generated and uploaded by the OTA build/upload jobs;
+this script only assembles markdown and talks to the GitHub API. No-ops (exit 0)
+when there is no token or no open PR, so it never turns a pipeline red.
 """
 
-import io
 import os
 import sys
 import urllib.parse
 
-import boto3
-import qrcode
 import requests
 
 MARKER = "<!-- couchers-preview-bot -->"
@@ -42,18 +39,7 @@ def deep_link(manifest_url):
     )
 
 
-def make_qr_png(data):
-    qr = qrcode.QRCode(
-        border=2, box_size=8, error_correction=qrcode.constants.ERROR_CORRECT_M
-    )
-    qr.add_data(data)
-    qr.make(fit=True)
-    buf = io.BytesIO()
-    qr.make_image(fill_color="black", back_color="white").save(buf, format="PNG")
-    return buf.getvalue()
-
-
-def mobile_ota_section(s3, bucket, short_sha, domain, platforms):
+def mobile_ota_section(short_sha, domain, platforms):
     lines = [
         "### Mobile Dev Tool preview",
         "",
@@ -61,20 +47,13 @@ def mobile_ota_section(s3, bucket, short_sha, domain, platforms):
         "branch in the installed **Dev Tool** dev client.",
     ]
     for platform in platforms:
-        manifest_url = f"https://{short_sha}--ota.{domain}/{platform}/manifest"
-        link = deep_link(manifest_url)
-        s3.put_object(
-            Bucket=bucket,
-            Key=f"ota/{short_sha}/{platform}/qr.png",
-            Body=make_qr_png(link),
-            ContentType="image/png",
-        )
-        qr_url = f"https://{short_sha}--ota.{domain}/{platform}/qr.png"
+        base = f"https://{short_sha}--ota.{domain}/{platform}"
+        link = deep_link(f"{base}/manifest")
         lines += [
             "",
             f"**{platform}**",
             "",
-            f'<img src="{qr_url}" alt="QR to open the {platform} build" width="180" height="180" />',
+            f'<img src="{base}/qr.png" alt="QR to open the {platform} build" width="180" height="180" />',
             "",
             "<details><summary>Deep link</summary>",
             "",
@@ -154,10 +133,7 @@ def main():
         print(f"No open PR for {sha} - skipping preview comment.")
         return
 
-    s3 = boto3.client("s3")
-    bucket = env("AWS_PREVIEW_BUCKET", required=True)
-
-    sections = [mobile_ota_section(s3, bucket, short_sha, domain, platforms)]
+    sections = [mobile_ota_section(short_sha, domain, platforms)]
     url = upsert_comment(repo, pr, build_body(sections, sha, pipeline_url), token)
     print(f"Posted preview comment to PR #{pr}: {url}")
 

--- a/docs/mobile-dev-tool-ota.md
+++ b/docs/mobile-dev-tool-ota.md
@@ -1,0 +1,330 @@
+# Mobile Dev Tool — per-branch OTA previews
+
+How we let anyone open a specific mobile branch on a phone by scanning a QR in
+the PR, **without** an App Store / TestFlight build per branch, and without
+paying for EAS Update.
+
+**Status:** design decided, implementation in progress. Scope is the **Dev Tool
+build only** — never production.
+
+This supersedes the earlier exploration in `tools/lambdas/expo-ota.md` (which
+weighed a hand-rolled edge function vs. the `expo-open-ota` server). We evaluated
+deploying `expo-open-ota` at `ota.couchershq.org`, then concluded a **static**
+serve off our existing S3 + CloudFront is simpler for a dev-only tool. The
+reasoning and the source-level findings that justify it are recorded below.
+
+---
+
+## 1. What the Dev Tool has to do
+
+The Dev Tool (`devtool` variant in `app/mobile/app.config.js`, `devtool` profile
+in `app/mobile/eas.json`) is one installed app that must do **all** of the
+following at once, because that's how it earns its keep across the whole team:
+
+| Workflow | Share of work | How it's served |
+| --- | --- | --- |
+| **Local Metro live-reload** — point the installed app at a dev's `expo start` for instant reload, no per-device native build | ~95% of dev work | dev launcher loads a Metro URL |
+| **Web preview** — repoint the in-app WebView at a Vercel branch URL | ~65% of PRs | in-app dev settings (`config/urls.ts` override) |
+| **RN-shell OTA** — load a branch's prebuilt JS shell (Expo Router screens, `WebEmbed`, nav) | ~30% of PRs | dev launcher loads our manifest URL ← **this doc** |
+| **Native change** — new native module / dep | ~5% | full native build by senior staff (they build anyway) |
+
+Two consequences drive the whole design:
+
+1. **It must stay a dev client** (`developmentClient: true`). The live-reload
+   workflow is the Dev Tool's main reason to exist; that requires the dev
+   launcher. So the OTA mechanism has to work *inside a dev client*, not assume a
+   release build.
+2. **The web axis and the RN-shell axis are orthogonal.** The RN shell is the
+   native-JS bundle (delivered OTA); the web/API target the WebView loads is set
+   separately at runtime via the existing dev-settings override. A QR can carry
+   one, the other, or both.
+
+---
+
+## 2. Key finding: how OTA reaches a dev client
+
+A dev client **hard-disables the programmatic Updates API**. In
+`expo-updates`, `UpdatesDevLauncherController` throws
+`NotAvailableInDevClientException` for `fetchUpdateAsync`, `checkForUpdateAsync`,
+`setUpdateURLAndRequestHeadersOverride`, and `setUpdateRequestHeadersOverride`.
+So we **cannot** swap branches by calling those at runtime.
+
+Instead, branches load through the **dev launcher's own load path**
+(`EXDevLauncherController.loadApp`) — the *same* machinery that loads a Metro
+server. You hand it a URL via the deep link:
+
+```
+couchers-devtool://expo-development-client/?url=<url-encoded target>
+```
+
+where the target is **either** a Metro URL (live reload) **or** one of our
+manifest URLs (branch OTA). The launcher probes the URL
+(`EXDevLauncherManifestParser`): a `HEAD` to classify it, then a `GET` to read
+the manifest, then it loads the update via `fetchUpdateWithConfiguration`.
+
+**What the launcher sends on those requests** (from
+`EXDevLauncherUpdatesHelper.m` / `DevLauncherUpdatesHelper.kt` /
+`EXDevLauncherManifestParser.m`):
+
+- `expo-platform: ios|android`
+- `Expo-Updates-Environment: DEVELOPMENT`
+- `Expo-Dev-Client-ID: <installation id>`
+- `expo-runtime-version: <the installed build's fingerprint>`
+- `accept: application/expo+json,application/json`
+
+**What it does NOT send:** `expo-channel-name`. It also does **not** forward the
+`updates.requestHeaders` configured in `app.config.js`. Therefore **the branch
+must be fully identified by the URL itself** — we cannot rely on a channel
+header or on channel→branch resolution. This is *why* a static per-URL serve fits
+the dev-client model perfectly: every branch is just a distinct, immutable URL.
+
+> This is also why deploying `expo-open-ota` as-is did not work for the dev
+> client: its `/manifest` handler reads the channel **only** from the
+> `expo-channel-name` header (no path/query fallback) and 400s without it, and
+> the launcher never sends that header. We'd have had to patch the server.
+
+---
+
+## 3. Why static — no OTA server, no code signing
+
+- **The wire format is frozen.** The Expo Updates protocol is a published,
+  versioned spec ("v1", pinned by the `expo-protocol-version` header). The
+  manifest shape, the `multipart/mixed` framing, the request headers, and the
+  signing scheme don't drift with Expo SDK upgrades. Multiple independent servers
+  (`expo-open-ota`, `xavia-ota`, Expo's own `custom-expo-updates-server` example)
+  interoperate with shipping apps precisely because it's stable. So generating
+  the manifest ourselves is not a moving-target maintenance burden.
+- **What *is* SDK-coupled isn't ours to write.** The fingerprint
+  (`runtimeVersion`) and the JS bundle are produced by `expo export` /
+  `@expo/fingerprint`, which we invoke from the same repo+lockfile that built the
+  app — so both sides agree by construction. We call a CLI; we don't reimplement
+  it.
+- **Signing is the easy part, and unnecessary here.** Code signing only kicks in
+  when `app.config.js` sets `codeSigningCertificate`. Its job is to stop a
+  compromised server injecting malicious JS into a *production-signed* app. For an
+  internally distributed dev/QA tool fetching branch bundles over HTTPS, TLS
+  already covers that threat. So we **drop signing for the Dev Tool** and serve
+  plain manifests. (Signing comes back if/when prod OTA is on the table — see §10.)
+
+Net: the OTA server's value was convenience (`eoas publish`, channel mapping,
+dashboard, rollback), not protocol correctness. For one dev-only flow, a small CI
+script + the S3/CloudFront we already run is fewer moving parts.
+
+---
+
+## 4. The Expo Updates protocol, minimally
+
+**Request:** `GET <url>` with the headers in §2.
+
+**Response — the manifest** (protocol v1, served as one `multipart/mixed` part;
+the JSON body shape):
+
+```json
+{
+  "id": "<uuid for this update>",
+  "createdAt": "2026-05-23T12:00:00.000Z",
+  "runtimeVersion": "<fingerprint — must match the request>",
+  "launchAsset": {
+    "key": "bundle-<hash>",
+    "contentType": "application/javascript",
+    "url": "https://<sha>--ota.preview.couchershq.org/ios/bundle.hbc"
+  },
+  "assets": [
+    { "key": "<hash>", "contentType": "image/png",
+      "url": "https://<sha>--ota.preview.couchershq.org/ios/assets/<hash>" }
+  ],
+  "metadata": {},
+  "extra": { "expoClient": { "...": "from dist/expoConfig.json" } }
+}
+```
+
+The update is **content-addressed**: the client compares the manifest `id`
+against what it's running and no-ops if equal. Crucially, if
+`runtimeVersion` does **not** match the installed build's fingerprint, the client
+**ignores the update**. That is our safety net — a branch that changed native
+deps has a different fingerprint and simply won't load OTA (it needs a native
+build, the 5% case).
+
+---
+
+## 5. Reusing the dev-assets infra
+
+We already serve web previews from S3 + CloudFront via two Lambda@Edge functions
+(must stay in `us-east-1`, where the bucket and functions already live):
+
+- `tools/lambdas/preview-viewer-request.js` — **host → S3 key prefix.**
+  `resolvePath(host)` maps `next.couchershq.org → /web/develop`, and
+  `<a>--<b>.preview.couchershq.org → /<b>/<a>`, then prepends that folder to the
+  request URI.
+- `tools/lambdas/preview-origin-response.js` — SPA 404 → `index.html` fallback.
+
+**OTA slots into the existing viewer-request with zero changes.** Pick the host
+pattern `<sha>--ota.preview.couchershq.org`:
+
+- `resolvePath("<sha>--ota.preview.couchershq.org")` → `db1=<sha>`, `db2=ota` →
+  `/ota/<sha>`.
+- A request for `/ios/manifest` becomes S3 key `/ota/<sha>/ios/manifest`.
+- The web-SPA special-case (`folder.startsWith("/web/")`) doesn't fire for
+  `/ota/...`, and root→`preview.txt` doesn't apply. So it just works.
+
+`<sha>` is the **git commit SHA** the CI job published (URL-safe; branch names
+with slashes are not). Humans never type it — the PR comment encodes the full URL
+in a QR.
+
+**Per-SHA content is immutable** → CloudFront can cache forever and **no
+invalidation is ever needed**. (This is the big simplification over a mutable
+`latest.json` pointer.)
+
+### Platform: one URL or two?
+
+A manifest is per-platform (one `launchAsset`). Two options:
+
+- **No Lambda change (start here):** publish both platforms and use
+  platform-specific URLs — `/ios/manifest` and `/android/manifest`. The PR
+  comment renders an iOS QR and an Android QR.
+- **One-URL nicety (optional):** extend the viewer-request Lambda so that when
+  `db2 === "ota"` it reads the `expo-platform` request header and rewrites to
+  `/ota/<sha>/<platform>/manifest`. Then a single QR works on both. Small, isolated
+  change (gated on the `ota` host), but requires CloudFront to forward
+  `expo-platform` to the function.
+
+### Manifest response headers / framing
+
+Target protocol v1: store the manifest object as a `multipart/mixed` body with
+`Content-Type: multipart/mixed; boundary=<b>` (set at upload via
+`aws s3 cp --content-type`). S3 cannot emit a real `expo-protocol-version: 1`
+response header on its own — if the client requires it, add a tiny
+**origin-response Lambda@Edge** that injects it, mirroring
+`preview-origin-response.js`.
+
+> ⚠️ **Empirical check (do this on-device before finalizing):** confirm what
+> `expo-updates ~29` (SDK 54) actually requires from the dev-launcher load path.
+> If it accepts a protocol-0 `application/expo+json` JSON manifest, we can skip
+> the origin-response Lambda entirely. If it demands v1 multipart + the response
+> header, add the one-function origin-response Lambda. The failure mode is a
+> generic "Couldn't parse the manifest" alert with no detail, so test early.
+
+---
+
+## 6. S3 layout (in the existing `couchers-dev-assets` bucket)
+
+```
+ota/
+  <sha>/                      # git commit SHA — immutable
+    ios/
+      manifest                # multipart/mixed body, no signature
+      bundle.hbc
+      assets/<hash>
+    android/
+      manifest
+      bundle.hbc
+      assets/<hash>
+```
+
+All asset/bundle URLs baked into the manifest point back at
+`https://<sha>--ota.preview.couchershq.org/<platform>/...`, served as plain files.
+
+---
+
+## 7. CI publish job
+
+A job (GitLab CI, gated on `app/mobile/**` changes; or a GitHub Action under
+`tools/.github/workflows/` reusing the existing Lambda-deploy AWS creds pattern)
+that, per mobile PR:
+
+1. For each platform: `APP_VARIANT=devtool npx expo export --platform <p>` →
+   `dist/` (bundle at `dist/_expo/static/js/<p>/index-<hash>.hbc`,
+   `dist/assets/<hash>`, `dist/metadata.json`, `dist/expoConfig.json`).
+2. Compute the fingerprint `runtimeVersion` (`npx @expo/fingerprint` /
+   `npx expo-updates fingerprint:generate --platform <p>` — verify the exact
+   invocation for our toolchain). It must equal the installed Dev Tool build's
+   fingerprint.
+3. Generate the manifest from `metadata.json` + `expoConfig.json`: mint a UUID
+   `id`, set `runtimeVersion`, compute each asset's base64url SHA-256, and rewrite
+   every path to its `<sha>--ota.preview.couchershq.org` URL. Wrap as
+   `multipart/mixed`.
+4. `aws s3 cp` the bundle, assets, and manifest under `ota/<sha>/<platform>/`,
+   with correct `--content-type` on each.
+5. No CloudFront invalidation needed (immutable keys).
+6. Post / update the PR comment with the QR(s) — see §9.
+
+---
+
+## 8. App-config (launcher) changes
+
+In `app/mobile/app.config.js`, **devtool variant only**:
+
+- **Keep** `runtimeVersion: { policy: "fingerprint" }` and `updates.enabled: true`
+  (the launcher uses the fingerprint to gate updates).
+- **Remove** `codeSigningCertificate` + `codeSigningMetadata` (no signing — §3).
+  Correspondingly revert the `.gitignore` exception and the committed
+  `certs/certificate.pem`; they were for the server approach.
+- The per-branch update URL is supplied **at load time** via the deep link, not
+  baked into config. An embedded `updates.url` is only the launch-time default;
+  for the Dev Tool we want it to boot to the launcher/menu, and branch loads come
+  from the QR.
+- **Stay a dev client** (`developmentClient: true`) — do not flip to a release
+  build.
+
+`eas.json`'s `channel: "development"` on the devtool profile is vestigial for the
+static approach (channels only matter for EAS Update) but harmless.
+
+Production and staging stay on EAS Update (`u.expo.dev`) untouched.
+
+---
+
+## 9. PR comment + QR
+
+The phone camera opens a custom-scheme deep link; the existing
+`app/mobile/dev-url-qr.html` already proves this pattern for the web/API axis.
+Per PR, the comment renders QR(s) by change type:
+
+- **Web-only PR** → set the WebView target, no OTA:
+  `couchers-devtool://dev-settings?api=<dev-api>&web=<vercel preview url>`
+  (handled by `app/mobile/app/dev-settings.tsx` → `config/urls.ts` override,
+  persisted in AsyncStorage).
+- **RN-shell PR** → load the branch bundle:
+  `couchers-devtool://expo-development-client/?url=<encoded manifest url>`
+  (`https://<sha>--ota.preview.couchershq.org/<platform>/manifest`), one QR per
+  platform unless the one-URL Lambda nicety (§5) is in place.
+
+The two axes compose: scanning the RN-shell QR loads the branch's native shell;
+the WebView inside it uses whatever web/API override is persisted (or the
+devtool's configured `EXPO_PUBLIC_WEB_BASE_URL`). To pin both, set the
+dev-settings link first, then load the bundle.
+
+---
+
+## 10. Constraints, gotchas, open items
+
+- **Fingerprint match is the #1 failure cause.** The exported `runtimeVersion`
+  must equal the installed Dev Tool build's, or the client silently ignores the
+  update. JS-only branches built from the same native config match
+  deterministically; native changes don't (by design — the safety net).
+- **CloudFront must forward the `expo-*` headers** to origin/function as needed,
+  and not cache the manifest keyed in a way that ignores platform. Per-SHA keys
+  are immutable, so caching is otherwise free.
+- **Empirical checks remaining:** (a) the protocol/response-header question in §5;
+  (b) confirm the launcher accepts our static manifest end-to-end on a real
+  device against the bucket; (c) the exact `@expo/fingerprint` invocation for our
+  toolchain.
+- **Going to production (out of scope now):** would add code signing (private key
+  signs manifests, build embeds the public cert), staged rollouts, and instant
+  rollback (protocol v1 directives). At that point reconsider `expo-open-ota`
+  rather than growing the edge functions — it provides channels, rollouts,
+  rollback, and signing out of the box and can use the same bucket.
+
+---
+
+## References
+
+- Expo Updates protocol spec: https://docs.expo.dev/technical-specs/expo-updates-1/
+- Custom updates server guide: https://docs.expo.dev/distribution/custom-updates-server/
+- `expo-open-ota` (evaluated, not adopted for the dev tool): https://github.com/axelmarciano/expo-open-ota
+- Earlier exploration: `tools/lambdas/expo-ota.md`
+- Existing edge functions: `tools/lambdas/preview-viewer-request.js`, `tools/lambdas/preview-origin-response.js`
+- App config / channels: `app/mobile/app.config.js`, `app/mobile/eas.json`
+- In-app web/API override: `app/mobile/config/urls.ts`, `app/mobile/app/dev-settings.tsx`
+- QR pattern precedent: `app/mobile/dev-url-qr.html`
+- Dev-launcher load path (source): `app/mobile/node_modules/expo-dev-launcher/ios/EXDevLauncherController.m`, `.../EXDevLauncherUpdatesHelper.m`, `.../Manifest/EXDevLauncherManifestParser.m`, `.../android/.../helpers/DevLauncherUpdatesHelper.kt`
+- Dev-client API disablement (source): `app/mobile/node_modules/expo-updates/.../UpdatesDevLauncherController.kt`

--- a/docs/mobile-dev-tool-ota.md
+++ b/docs/mobile-dev-tool-ota.md
@@ -134,7 +134,7 @@ the JSON body shape):
       "url": "https://<sha>--ota.preview.couchershq.org/ios/assets/<hash>" }
   ],
   "metadata": {},
-  "extra": { "expoClient": { "...": "from dist/expoConfig.json" } }
+  "extra": { "expoClient": { "...": "from `npx expo config --type public --json`" } }
 }
 ```
 
@@ -190,19 +190,44 @@ A manifest is per-platform (one `launchAsset`). Two options:
 
 ### Manifest response headers / framing
 
-Target protocol v1: store the manifest object as a `multipart/mixed` body with
-`Content-Type: multipart/mixed; boundary=<b>` (set at upload via
-`aws s3 cp --content-type`). S3 cannot emit a real `expo-protocol-version: 1`
-response header on its own — if the client requires it, add a tiny
-**origin-response Lambda@Edge** that injects it, mirroring
-`preview-origin-response.js`.
+**CONFIRMED on-device** (SDK 54 / `expo-updates ~29`, iOS dev client, 2026-05-23,
+served from a local static-mimicking server over plain HTTP):
 
-> ⚠️ **Empirical check (do this on-device before finalizing):** confirm what
-> `expo-updates ~29` (SDK 54) actually requires from the dev-launcher load path.
-> If it accepts a protocol-0 `application/expo+json` JSON manifest, we can skip
-> the origin-response Lambda entirely. If it demands v1 multipart + the response
-> header, add the one-function origin-response Lambda. The failure mode is a
-> generic "Couldn't parse the manifest" alert with no detail, so test early.
+The dev launcher load is a two-step request to the manifest URL:
+
+1. `HEAD <url>` — classification probe. Sends `accept: application/expo+json,application/json`,
+   `expo-platform`, `Expo-Dev-Client-ID`. We answer non-2xx (`405`) so it's treated
+   as a published-manifest URL, not a Metro dev server.
+2. `GET <url>` — the actual update fetch. Sends
+   `accept: multipart/mixed,application/expo+json,application/json`,
+   `expo-protocol-version: 1`, `expo-platform`, `expo-runtime-version: <fingerprint>`,
+   `Expo-Updates-Environment: DEVELOPMENT`, `Expo-Dev-Client-ID`, `eas-client-id`.
+   No `expo-channel-name`. No `expo-expect-signature`.
+
+So the client wants **protocol v1 `multipart/mixed`** (a `manifest` part + an
+`extensions` part) — *not* plain JSON. We serve it with
+`content-type: multipart/mixed; boundary=<b>`, `expo-protocol-version: 1`,
+`expo-sfv-version: 0`. The fingerprint in `expo-runtime-version` must equal the
+manifest's `runtimeVersion` or the update is silently ignored. No signature is
+requested, so unsigned manifests load. Cleartext HTTP is accepted by the dev
+client (no ATS block) — production uses HTTPS via CloudFront anyway.
+
+For S3: the multipart body is a static file uploaded with
+`--content-type "multipart/mixed; boundary=<b>"` (boundary baked in CI, matching
+the body). S3 cannot emit the `expo-protocol-version: 1` *response header* on its
+own, and **that header is required** — CONFIRMED on-device: serving the exact same
+multipart body with only the content-type (no `expo-protocol-version` /
+`expo-sfv-version`) makes the client reject the manifest before fetching anything
+("failed to load app from …"); it does not infer the protocol from the content-type.
+
+So the manifest response needs the header injected at the edge. **Extend the
+existing `preview-origin-response.js` Lambda@Edge** to add `expo-protocol-version: 1`
+(and `expo-sfv-version: 0`) on responses whose key is the OTA manifest
+(`/ota/<sha>/<platform>/manifest`) — scoped by path, mirroring its current `/web/`
+branch, so web previews are unaffected. This reuses infra we already deploy; no new
+function. (A CloudFront response-headers policy also works but attaches per cache
+behavior, so it can't scope by path/host as cleanly given the host→prefix routing
+lives in the viewer-request Lambda.)
 
 ---
 
@@ -233,16 +258,20 @@ A job (GitLab CI, gated on `app/mobile/**` changes; or a GitHub Action under
 that, per mobile PR:
 
 1. For each platform: `APP_VARIANT=devtool npx expo export --platform <p>` →
-   `dist/` (bundle at `dist/_expo/static/js/<p>/index-<hash>.hbc`,
-   `dist/assets/<hash>`, `dist/metadata.json`, `dist/expoConfig.json`).
+   `dist/` (bundle at `dist/_expo/static/js/<p>/entry-<hash>.hbc`, assets at
+   `dist/assets/<metro-hash>`, and `dist/metadata.json` which lists the bundle +
+   each asset's `{path, ext}`). NOTE: SDK 54's export does **not** emit a
+   `dist/expoConfig.json`; get the public config from
+   `APP_VARIANT=devtool npx expo config --type public --json` for `extra.expoClient`.
 2. Compute the fingerprint `runtimeVersion` (`npx @expo/fingerprint` /
    `npx expo-updates fingerprint:generate --platform <p>` — verify the exact
    invocation for our toolchain). It must equal the installed Dev Tool build's
    fingerprint.
-3. Generate the manifest from `metadata.json` + `expoConfig.json`: mint a UUID
-   `id`, set `runtimeVersion`, compute each asset's base64url SHA-256, and rewrite
-   every path to its `<sha>--ota.preview.couchershq.org` URL. Wrap as
-   `multipart/mixed`.
+3. Generate the manifest from `metadata.json` + `expo config --type public --json`:
+   mint a UUID `id`, set `runtimeVersion`, compute each asset's base64url SHA-256
+   (this is its manifest `key`), and rewrite every path to its
+   `<sha>--ota.preview.couchershq.org` URL. Wrap as `multipart/mixed` (Phase 2
+   confirms whether the dev launcher requires this or accepts plain JSON).
 4. `aws s3 cp` the bundle, assets, and manifest under `ota/<sha>/<platform>/`,
    with correct `--content-type` on each.
 5. No CloudFront invalidation needed (immutable keys).
@@ -304,10 +333,18 @@ dev-settings link first, then load the bundle.
 - **CloudFront must forward the `expo-*` headers** to origin/function as needed,
   and not cache the manifest keyed in a way that ignores platform. Per-SHA keys
   are immutable, so caching is otherwise free.
-- **Empirical checks remaining:** (a) the protocol/response-header question in §5;
-  (b) confirm the launcher accepts our static manifest end-to-end on a real
-  device against the bucket; (c) the exact `@expo/fingerprint` invocation for our
-  toolchain.
+- **Empirical checks — mostly resolved (2026-05-23, on a real iOS dev client):**
+  (a) framing is v1 `multipart/mixed` — see §5 (resolved); (b) end-to-end load
+  confirmed against a static-mimicking local server: manifest → bundle → all assets
+  downloaded, the JS bundle ran and rendered, and a JS edit re-exported with a new
+  manifest `id` hot-reloaded onto the device (only `bundle.hbc` re-downloaded,
+  unchanged assets stayed cached) (resolved); (c) fingerprint command is
+  `npx expo-updates fingerprint:generate --platform <p>` → `.hash`; the device's
+  `expo-runtime-version` matched the value computed from the tree (resolved).
+  The `expo-protocol-version: 1` *response header* is **required** (§5 — confirmed:
+  without it the client rejects the manifest before fetching). Remaining: the same
+  end-to-end run against the real S3 bucket + CloudFront with the header injected by
+  an extended `preview-origin-response.js`.
 - **Going to production (out of scope now):** would add code signing (private key
   signs manifests, build embeds the public cert), staged rollouts, and instant
   rollback (protocol v1 directives). At that point reconsider `expo-open-ota`

--- a/docs/mobile-dev-tool-ota.md
+++ b/docs/mobile-dev-tool-ota.md
@@ -4,8 +4,10 @@ How we let anyone open a specific mobile branch on a phone by scanning a QR in
 the PR, **without** an App Store / TestFlight build per branch, and without
 paying for EAS Update.
 
-**Status:** design decided, implementation in progress. Scope is the **Dev Tool
-build only** — never production.
+**Status:** implemented. iOS validated end-to-end on a real device against the
+real S3 + CloudFront (2026-05-24); the Android publish pipeline is live, with
+on-device Android validation still pending. Scope is the **Dev Tool build only** —
+never production.
 
 This supersedes the earlier exploration in `tools/lambdas/expo-ota.md` (which
 weighed a hand-rolled edge function vs. the `expo-open-ota` server). We evaluated
@@ -179,9 +181,9 @@ invalidation is ever needed**. (This is the big simplification over a mutable
 
 A manifest is per-platform (one `launchAsset`). Two options:
 
-- **No Lambda change (start here):** publish both platforms and use
+- **No Lambda change (implemented):** publish both platforms and use
   platform-specific URLs — `/ios/manifest` and `/android/manifest`. The PR
-  comment renders an iOS QR and an Android QR.
+  comment renders an iOS section and an Android section, each with its own QR.
 - **One-URL nicety (optional):** extend the viewer-request Lambda so that when
   `db2 === "ota"` it reads the `expo-platform` request header and rewrites to
   `/ota/<sha>/<platform>/manifest`. Then a single QR works on both. Small, isolated
@@ -220,14 +222,14 @@ multipart body with only the content-type (no `expo-protocol-version` /
 `expo-sfv-version`) makes the client reject the manifest before fetching anything
 ("failed to load app from …"); it does not infer the protocol from the content-type.
 
-So the manifest response needs the header injected at the edge. **Extend the
-existing `preview-origin-response.js` Lambda@Edge** to add `expo-protocol-version: 1`
-(and `expo-sfv-version: 0`) on responses whose key is the OTA manifest
-(`/ota/<sha>/<platform>/manifest`) — scoped by path, mirroring its current `/web/`
-branch, so web previews are unaffected. This reuses infra we already deploy; no new
-function. (A CloudFront response-headers policy also works but attaches per cache
-behavior, so it can't scope by path/host as cleanly given the host→prefix routing
-lives in the viewer-request Lambda.)
+So the manifest response needs the header injected at the edge. The existing
+`tools/lambdas/preview-origin-response.js` Lambda@Edge now adds
+`expo-protocol-version: 1` (and `expo-sfv-version: 0`) on responses whose key is
+the OTA manifest (`/ota/<sha>/<platform>/manifest`) — scoped by path, mirroring its
+`/web/` branch, so web previews are unaffected. This reuses infra we already
+deploy; no new function. (A CloudFront response-headers policy also works but
+attaches per cache behavior, so it can't scope by path/host as cleanly given the
+host→prefix routing lives in the viewer-request Lambda.)
 
 ---
 
@@ -251,31 +253,43 @@ All asset/bundle URLs baked into the manifest point back at
 
 ---
 
-## 7. CI publish job
+## 7. CI publish jobs
 
-A job (GitLab CI, gated on `app/mobile/**` changes; or a GitHub Action under
-`tools/.github/workflows/` reusing the existing Lambda-deploy AWS creds pattern)
-that, per mobile PR:
+Implemented as three GitLab CI jobs in `app/.gitlab-ci.yml`, gated on
+`app/proto/**`, `app/mobile/**`, `app/scripts/**` changes (and always on the
+`develop` release branch). The GitHub Action option was dropped in favour of
+keeping everything in the existing GitLab pipeline, so the comment job can `needs:`
+the upload job and only post once the links are live.
 
-1. For each platform: `APP_VARIANT=devtool npx expo export --platform <p>` →
-   `dist/` (bundle at `dist/_expo/static/js/<p>/entry-<hash>.hbc`, assets at
-   `dist/assets/<metro-hash>`, and `dist/metadata.json` which lists the bundle +
-   each asset's `{path, ext}`). NOTE: SDK 54's export does **not** emit a
-   `dist/expoConfig.json`; get the public config from
-   `APP_VARIANT=devtool npx expo config --type public --json` for `extra.expoClient`.
-2. Compute the fingerprint `runtimeVersion` (`npx @expo/fingerprint` /
-   `npx expo-updates fingerprint:generate --platform <p>` — verify the exact
-   invocation for our toolchain). It must equal the installed Dev Tool build's
-   fingerprint.
-3. Generate the manifest from `metadata.json` + `expo config --type public --json`:
-   mint a UUID `id`, set `runtimeVersion`, compute each asset's base64url SHA-256
-   (this is its manifest `key`), and rewrite every path to its
-   `<sha>--ota.preview.couchershq.org` URL. Wrap as `multipart/mixed` (Phase 2
-   confirms whether the dev launcher requires this or accepts plain JSON).
-4. `aws s3 cp` the bundle, assets, and manifest under `ota/<sha>/<platform>/`,
-   with correct `--content-type` on each.
-5. No CloudFront invalidation needed (immutable keys).
-6. Post / update the PR comment with the QR(s) — see §9.
+**`build:mobile-ota`** (`node:22`) — for each platform in `OTA_PLATFORMS`
+(`ios android`):
+
+1. `APP_VARIANT=devtool npx expo export --platform <p>` → `dist/` (bundle, assets,
+   and `dist/metadata.json` listing the bundle + each asset's `{path, ext}`). SDK
+   54's export does **not** emit `dist/expoConfig.json`, so the public config comes
+   from `npx expo config --type public --json` (`ota-expo-config.json`) for
+   `extra.expoClient`.
+2. `npx expo-updates fingerprint:generate --platform <p>` → `.hash` for
+   `runtimeVersion`. Must equal the installed Dev Tool build's fingerprint — see §8
+   on `.fingerprintignore`.
+3. `node scripts/ota-stage.mjs` builds the manifest from `metadata.json` +
+   `ota-expo-config.json`: content-addressed asset keys (base64url SHA-256),
+   rewrites every URL to `<sha>--ota.preview.couchershq.org/<platform>/…`, and
+   writes both the `manifest.json` object and the protocol-v1 `multipart/mixed`
+   `manifest` body (+ its `manifest.content-type`). It also writes `open.html`, an
+   https redirect to the dev-launcher deep link (see §9).
+4. `npx --yes qrcode` renders `qr.png` encoding the deep link. Using `npx` (not a
+   `package.json` dep) keeps `qrcode` out of the fingerprint sources.
+
+**`preview:mobile-ota`** (`aws-base`) — `aws s3 cp` the `manifest` (with its
+multipart content-type), `bundle.hbc`, `assets/`, `qr.png`, and `open.html` to
+`s3://couchers-dev-assets/ota/<sha>/<platform>/`. No CloudFront invalidation
+(immutable keys).
+
+**`preview:pr-comment`** (`python:3.12-slim`) — `needs:` the upload job so every
+link is already live, then runs `app/scripts/pr_preview_comment.py` to post/update
+the sticky PR comment (§9). No-ops if `GITHUB_PREVIEW_TOKEN` is unset or there's no
+open PR, so it never reds the pipeline.
 
 ---
 
@@ -285,6 +299,18 @@ In `app/mobile/app.config.js`, **devtool variant only**:
 
 - **Keep** `runtimeVersion: { policy: "fingerprint" }` and `updates.enabled: true`
   (the launcher uses the fingerprint to gate updates).
+- **Add `app/mobile/.fingerprintignore`** excluding `google-services.json` and
+  `**/eas-environment-secrets/**`. The devtool build receives `google-services.json`
+  only as an EAS file env secret (`GOOGLE_SERVICES_JSON`, preview environment), so
+  it's present on EAS builds but absent locally and in CI. Expo hashes it into the
+  fingerprint by **contents** (`@expo/fingerprint` tags it
+  `expoConfigExternalFile:contentsOnly`), which made the runtime version diverge
+  between the EAS-built client and our local/CI computation — the client would then
+  ignore every OTA. The ignore drops it everywhere (ignored sources get a null hash
+  and are skipped entirely), so the fingerprint is reproducible without the secret.
+  The native build still uses the file normally; a Firebase/FCM config change needs
+  a fresh native build regardless. The secret is write-only on EAS, so it can't be
+  pulled to reproduce locally — exclusion is the only no-secret-distribution fix.
 - **Remove** `codeSigningCertificate` + `codeSigningMetadata` (no signing — §3).
   Correspondingly revert the `.gitignore` exception and the committed
   `certs/certificate.pem`; they were for the server approach.
@@ -304,23 +330,31 @@ Production and staging stay on EAS Update (`u.expo.dev`) untouched.
 
 ## 9. PR comment + QR
 
-The phone camera opens a custom-scheme deep link; the existing
-`app/mobile/dev-url-qr.html` already proves this pattern for the web/API axis.
-Per PR, the comment renders QR(s) by change type:
+`preview:pr-comment` posts one **sticky** comment per PR (marked with the HTML
+comment `<!-- couchers-preview-bot -->`; `app/scripts/pr_preview_comment.py`
+resolves the PR from the commit SHA via the GitHub API, then upserts the comment).
+It's assembled from **sections**, so more previews (web, coverage, …) can be
+appended as the pipeline grows.
 
-- **Web-only PR** → set the WebView target, no OTA:
-  `couchers-devtool://dev-settings?api=<dev-api>&web=<vercel preview url>`
-  (handled by `app/mobile/app/dev-settings.tsx` → `config/urls.ts` override,
-  persisted in AsyncStorage).
-- **RN-shell PR** → load the branch bundle:
+**Implemented today — the RN-shell OTA section**, one block per platform with:
+
+- a **QR** (`qr.png`) encoding the dev-launcher deep link
   `couchers-devtool://expo-development-client/?url=<encoded manifest url>`
-  (`https://<sha>--ota.preview.couchershq.org/<platform>/manifest`), one QR per
-  platform unless the one-URL Lambda nicety (§5) is in place.
+  (`https://<sha>--ota.preview.couchershq.org/<platform>/manifest`) — scan with the
+  phone camera to open the branch directly in the installed Dev Tool;
+- a clickable **Open in Dev Tool** link. GitHub's comment sanitiser strips
+  custom-scheme (`couchers-devtool://`) hrefs, so the link targets the hosted
+  `open.html` (https), which `location.replace`s to the deep link on the device;
+- the raw deep link in a `<details>` block for copy/paste.
 
-The two axes compose: scanning the RN-shell QR loads the branch's native shell;
-the WebView inside it uses whatever web/API override is persisted (or the
-devtool's configured `EXPO_PUBLIC_WEB_BASE_URL`). To pin both, set the
-dev-settings link first, then load the bundle.
+**Designed, not yet wired in — the web/API axis.** The Dev Tool also supports
+repointing its WebView via
+`couchers-devtool://dev-settings?api=<dev-api>&web=<vercel preview url>`
+(`app/mobile/app/dev-settings.tsx` → `config/urls.ts`, persisted in AsyncStorage;
+the `app/mobile/dev-url-qr.html` precedent proves the pattern). It's orthogonal to
+the OTA shell and can be added as another section. The two axes compose: load the
+RN-shell bundle, and the WebView inside uses whatever web/API override is persisted
+(or the devtool's configured `EXPO_PUBLIC_WEB_BASE_URL`).
 
 ---
 
@@ -329,7 +363,10 @@ dev-settings link first, then load the bundle.
 - **Fingerprint match is the #1 failure cause.** The exported `runtimeVersion`
   must equal the installed Dev Tool build's, or the client silently ignores the
   update. JS-only branches built from the same native config match
-  deterministically; native changes don't (by design — the safety net).
+  deterministically; native changes don't (by design — the safety net). One real
+  trap hit in practice: config files supplied only as EAS file env secrets (e.g.
+  `google-services.json`) are hashed into the fingerprint on EAS but absent
+  locally/in CI — handled by `.fingerprintignore` (§8).
 - **CloudFront must forward the `expo-*` headers** to origin/function as needed,
   and not cache the manifest keyed in a way that ignores platform. Per-SHA keys
   are immutable, so caching is otherwise free.
@@ -342,9 +379,11 @@ dev-settings link first, then load the bundle.
   `npx expo-updates fingerprint:generate --platform <p>` → `.hash`; the device's
   `expo-runtime-version` matched the value computed from the tree (resolved).
   The `expo-protocol-version: 1` *response header* is **required** (§5 — confirmed:
-  without it the client rejects the manifest before fetching). Remaining: the same
-  end-to-end run against the real S3 bucket + CloudFront with the header injected by
-  an extended `preview-origin-response.js`.
+  without it the client rejects the manifest before fetching). The full iOS
+  end-to-end run against the real S3 bucket + CloudFront, with the header injected
+  by the deployed `preview-origin-response.js`, also succeeded (2026-05-24).
+  **Remaining:** the same on-device validation for **Android** — the publish
+  pipeline is live, but no Android Dev Tool client has loaded a branch OTA yet.
 - **Going to production (out of scope now):** would add code signing (private key
   signs manifests, build embeds the public cert), staged rollouts, and instant
   rollback (protocol v1 directives). At that point reconsider `expo-open-ota`
@@ -363,5 +402,9 @@ dev-settings link first, then load the bundle.
 - App config / channels: `app/mobile/app.config.js`, `app/mobile/eas.json`
 - In-app web/API override: `app/mobile/config/urls.ts`, `app/mobile/app/dev-settings.tsx`
 - QR pattern precedent: `app/mobile/dev-url-qr.html`
+- CI publish jobs: `app/.gitlab-ci.yml` (`build:mobile-ota`, `preview:mobile-ota`, `preview:pr-comment`)
+- Manifest/QR/open.html staging: `app/mobile/scripts/ota-stage.mjs`
+- PR comment generator: `app/scripts/pr_preview_comment.py`
+- Fingerprint exclusion: `app/mobile/.fingerprintignore`
 - Dev-launcher load path (source): `app/mobile/node_modules/expo-dev-launcher/ios/EXDevLauncherController.m`, `.../EXDevLauncherUpdatesHelper.m`, `.../Manifest/EXDevLauncherManifestParser.m`, `.../android/.../helpers/DevLauncherUpdatesHelper.kt`
 - Dev-client API disablement (source): `app/mobile/node_modules/expo-updates/.../UpdatesDevLauncherController.kt`


### PR DESCRIPTION
Builds out the **Dev Tool** mobile variant, lets developers point it at any backend without rebuilding, and adds a per-branch OTA preview so any mobile branch can be opened on a phone straight from its PR.

**Dev Tool TestFlight build** (`wip` commit)
- New `devtool` app variant (separate bundle ID / scheme / icon) and an EAS `devtool` build+submit profile (`developmentClient`, store distribution).
- `release:*:devtool` scripts and README instructions for the install-once / load-JS-over-the-air workflow.

**In-app backend URL override** (this is the main new code)
- A floating dev button (non-prod builds only) opens a **Developer settings** screen to override the API and web base URLs at runtime.
- Overrides persist in `AsyncStorage` and are applied on a JS reload; the gRPC client and webviews now resolve their URLs through a single `config/urls.ts` module instead of reading `process.env` directly. Production builds ignore overrides entirely.
- Quality-of-life so URLs don't have to be typed each time: **presets** (Staging / Production / build default), a **recents** list, and **deep-link prefill** — scanning a QR of `couchers-devtool://dev-settings?api=…&web=…` with the phone camera opens the app with the fields filled. A small `dev-url-qr.html` generator page is included.

**Per-branch Dev Tool OTA preview**
- Lets anyone open a specific mobile branch on a phone by scanning a QR / tapping a link in the PR — no per-branch TestFlight build and no paid EAS Update. The installed Dev Tool dev client loads the branch's JS bundle over the air through the dev-launcher deep link; a fresh native build is only needed when native deps change.
- Self-hosted on the existing S3 (`couchers-dev-assets`) + CloudFront + Lambda@Edge. `expo export` is staged into an Expo Updates v1 `multipart/mixed` manifest (`app/mobile/scripts/ota-stage.mjs`) and uploaded under an immutable `ota/<sha>/<platform>/` prefix; the origin-response Lambda injects the required `expo-protocol-version` header (S3 can't).
- Three GitLab CI jobs — `build:mobile-ota` → `preview:mobile-ota` → `preview:pr-comment` — build/stage, upload, and post a sticky PR comment with a scannable QR plus a clickable **Open in Dev Tool** link per platform (`app/scripts/pr_preview_comment.py`; the link targets a hosted `open.html` redirect because GitHub strips custom-scheme hrefs). iOS and Android.
- `.fingerprintignore` excludes `google-services.json` (provided only as an EAS file secret, so absent locally and in CI) so the fingerprint runtime version is reproducible across the EAS build and CI.
- Design and on-device findings: `docs/mobile-dev-tool-ota.md`.

## Testing
- `npx tsc --noEmit`, `expo lint`, and `npm test` pass; the GitLab CI OTA chain (`build`/`preview:mobile-ota`, `preview:pr-comment`) is green.
- The OTA preview was validated end-to-end on a real iOS device (manifest → bundle → assets load; a JS edit re-exported and hot-reloaded). Android export/upload/comment run in CI; on-device Android validation is pending a Dev Tool client install.
- In-app backend URL override not yet exercised on a device/simulator — it adds the `@react-native-async-storage/async-storage` native module, so a fresh dev-client build is required first. After rebuilding, worth a manual check of: the floating button on every screen, save → reload re-points the backend, presets/recents fill the fields, and the deep-link/QR round-trip.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._