### PR TITLE
Backend/emails: from_notification factory methods

### DIFF
--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -95,6 +95,13 @@ class AccountDeletionStartedEmail(EmailBase):
         builder.security_warning_para()
 
     @classmethod
+    def from_notification(cls, data: notification_data_pb2.AccountDeletionStart, *, user_name: str) -> Self:
+        return cls(
+            user_name=user_name,
+            deletion_link=urls.delete_account_link(account_deletion_token=data.deletion_token),
+        )
+
+    @classmethod
     def dummy_data(cls) -> AccountDeletionStartedEmail:
         return AccountDeletionStartedEmail(
             user_name="Alice",
@@ -119,6 +126,14 @@ class AccountDeletionCompletedEmail(EmailBase):
         builder.para("recovery_instructions_days", {"count": self.days})
         builder.action(self.undelete_link, "recover_action")
         builder.security_warning_para()
+
+    @classmethod
+    def from_notification(cls, data: notification_data_pb2.AccountDeletionComplete, *, user_name: str) -> Self:
+        return cls(
+            user_name=user_name,
+            undelete_link=urls.recover_account_link(account_undelete_token=data.undelete_token),
+            days=data.undelete_days,
+        )
 
     @classmethod
     def dummy_data(cls) -> AccountDeletionCompletedEmail:
@@ -169,6 +184,10 @@ class APIKeyIssuedEmail(EmailBase):
         builder.security_warning_para()
 
     @classmethod
+    def from_notification(cls, data: notification_data_pb2.ApiKeyCreate, *, user_name: str) -> Self:
+        return cls(user_name=user_name, api_key=data.api_key, expiry=data.expiry.ToDatetime(tzinfo=UTC))
+
+    @classmethod
     def dummy_data(cls) -> APIKeyIssuedEmail:
         return APIKeyIssuedEmail(
             user_name="Alice", api_key="my_api_key_123", expiry=datetime(2099, 12, 31, 23, 59, 59, tzinfo=UTC)
@@ -193,6 +212,14 @@ class BadgeChangedEmail(EmailBase):
         builder.para("body", {"badge_name": self.badge_name})
 
     @classmethod
+    def from_add_notification(cls, data: notification_data_pb2.BadgeAdd, *, user_name: str) -> Self:
+        return cls(user_name=user_name, badge_name=data.badge_name, added=True)
+
+    @classmethod
+    def from_remove_notification(cls, data: notification_data_pb2.BadgeRemove, *, user_name: str) -> Self:
+        return cls(user_name=user_name, badge_name=data.badge_name, added=False)
+
+    @classmethod
     def dummy_data(cls) -> BadgeChangedEmail:
         return BadgeChangedEmail(user_name="Alice", badge_name="Founder", added=True)
 
@@ -210,6 +237,10 @@ class BirthdateChangedEmail(EmailBase):
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         builder.para("body", {"date": loc_context.localize_date(self.new_birthdate)})
         builder.security_warning_para()
+
+    @classmethod
+    def from_notification(cls, data: notification_data_pb2.BirthdateChange, *, user_name: str) -> Self:
+        return cls(user_name=user_name, new_birthdate=date.fromisoformat(data.birthdate))
 
     @classmethod
     def dummy_data(cls) -> BirthdateChangedEmail:
@@ -248,6 +279,18 @@ class DiscussionCreatedEmail(EmailBase):
         builder.user(self.author)
         builder.quote(self.markdown_text, markdown=True)
         builder.action(self.view_link, "view_action")
+
+    @classmethod
+    def from_notification(cls, data: notification_data_pb2.DiscussionCreate, *, user_name: str) -> Self:
+        discussion = data.discussion
+        return cls(
+            user_name=user_name,
+            author=UserInfo.from_protobuf(data.author),
+            title=discussion.title,
+            parent_context=discussion.owner_title,
+            markdown_text=discussion.content,
+            view_link=urls.discussion_link(discussion_id=discussion.discussion_id, slug=discussion.slug),
+        )
 
     @classmethod
     def dummy_data(cls) -> DiscussionCreatedEmail:
@@ -294,6 +337,18 @@ class DiscussionCommentEmail(EmailBase):
         builder.action(self.view_link, "view_action")
 
     @classmethod
+    def from_notification(cls, data: notification_data_pb2.DiscussionComment, *, user_name: str) -> Self:
+        discussion = data.discussion
+        return cls(
+            user_name=user_name,
+            author=UserInfo.from_protobuf(data.author),
+            discussion_title=discussion.title,
+            discussion_parent_context=discussion.owner_title,
+            markdown_text=data.reply.content,
+            view_link=urls.discussion_link(discussion_id=discussion.discussion_id, slug=discussion.slug),
+        )
+
+    @classmethod
     def dummy_data(cls) -> DiscussionCommentEmail:
         return DiscussionCommentEmail(
             user_name="Alice",
@@ -318,6 +373,10 @@ class EmailAddressChangedEmail(EmailBase):
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         builder.para("body", {"email_address": self.new_email})
         builder.security_warning_para()
+
+    @classmethod
+    def from_notification(cls, data: notification_data_pb2.EmailAddressChange, *, user_name: str) -> Self:
+        return cls(user_name=user_name, new_email=data.new_email)
 
     @classmethod
     def dummy_data(cls) -> EmailAddressChangedEmail:
@@ -365,6 +424,10 @@ class FriendRequestReceivedEmail(EmailBase):
         builder.do_not_reply_request_para()
 
     @classmethod
+    def from_notification(cls, data: notification_data_pb2.FriendRequestCreate, *, user_name: str) -> Self:
+        return cls(user_name=user_name, befriender=UserInfo.from_protobuf(data.other_user))
+
+    @classmethod
     def dummy_data(cls) -> FriendRequestReceivedEmail:
         return FriendRequestReceivedEmail(
             user_name="Alice",
@@ -395,6 +458,10 @@ class FriendRequestAcceptedEmail(EmailBase):
         builder.para("closing")
 
     @classmethod
+    def from_notification(cls, data: notification_data_pb2.FriendRequestAccept, *, user_name: str) -> Self:
+        return cls(user_name=user_name, new_friend=UserInfo.from_protobuf(data.other_user))
+
+    @classmethod
     def dummy_data(cls) -> FriendRequestAcceptedEmail:
         return FriendRequestAcceptedEmail(
             user_name="Alice",
@@ -415,6 +482,10 @@ class GenderChangedEmail(EmailBase):
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         builder.para("body", {"gender": self.new_gender})
         builder.security_warning_para()
+
+    @classmethod
+    def from_notification(cls, data: notification_data_pb2.GenderChange, *, user_name: str) -> Self:
+        return cls(user_name=user_name, new_gender=data.gender)
 
     @classmethod
     def dummy_data(cls) -> GenderChangedEmail:
@@ -491,6 +562,13 @@ class PasswordResetStartedEmail(EmailBase):
         builder.security_warning_para()
 
     @classmethod
+    def from_notification(cls, data: notification_data_pb2.PasswordResetStart, *, user_name: str) -> Self:
+        return cls(
+            user_name=user_name,
+            password_reset_link=urls.password_reset_link(password_reset_token=data.password_reset_token),
+        )
+
+    @classmethod
     def dummy_data(cls) -> PasswordResetStartedEmail:
         return PasswordResetStartedEmail(user_name="Alice", password_reset_link="https://couchers.org/reset-password")
 
@@ -509,6 +587,14 @@ class PhoneNumberChangeEmail(EmailBase):
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         builder.para("body", {"phone_number": format_phone_number(self.new_phone_number)})
         builder.security_warning_para()
+
+    @classmethod
+    def from_change_notification(cls, data: notification_data_pb2.PhoneNumberChange, *, user_name: str) -> Self:
+        return cls(user_name=user_name, new_phone_number=data.phone, completed=False)
+
+    @classmethod
+    def from_verify_notification(cls, data: notification_data_pb2.PhoneNumberVerify, *, user_name: str) -> Self:
+        return cls(user_name=user_name, new_phone_number=data.phone, completed=True)
 
     @classmethod
     def dummy_data(cls) -> PhoneNumberChangeEmail:
@@ -541,6 +627,10 @@ class PostalVerificationFailedEmail(EmailBase):
         builder.security_warning_para()
 
     @classmethod
+    def from_notification(cls, data: notification_data_pb2.PostalVerificationFailed, *, user_name: str) -> Self:
+        return cls(user_name=user_name, reason=data.reason)
+
+    @classmethod
     def dummy_data(cls) -> PostalVerificationFailedEmail:
         return PostalVerificationFailedEmail(
             user_name="Alice",
@@ -562,6 +652,10 @@ class PostalVerificationPostcardSentEmail(EmailBase):
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         builder.para("body", {"city": self.city, "country": self.country})
         builder.security_warning_para()
+
+    @classmethod
+    def from_notification(cls, data: notification_data_pb2.PostalVerificationPostcardSent, *, user_name: str) -> Self:
+        return cls(user_name=user_name, city=data.city, country=data.country)
 
     @classmethod
     def dummy_data(cls) -> PostalVerificationPostcardSentEmail:
@@ -607,6 +701,10 @@ class StrongVerificationFailedEmail(EmailBase):
                 raise Exception("Shouldn't get here")
         builder.para(reason_string_key)
         builder.security_warning_para()
+
+    @classmethod
+    def from_notification(cls, data: notification_data_pb2.VerificationSVFail, *, user_name: str) -> Self:
+        return cls(user_name=user_name, reason=data.reason)
 
     @classmethod
     def dummy_data(cls) -> StrongVerificationFailedEmail:
@@ -661,6 +759,25 @@ class ThreadReplyEmail(EmailBase):
         builder.user(self.author)
         builder.quote(self.markdown_text, markdown=True)
         builder.action(self.view_link, "view_action")
+
+    @classmethod
+    def from_notification(cls, data: notification_data_pb2.ThreadReply, *, user_name: str) -> Self:
+        parent = data.WhichOneof("reply_parent")
+        if parent == "event":
+            parent_context = data.event.title
+            view_link = urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug)
+        elif parent == "discussion":
+            parent_context = data.discussion.title
+            view_link = urls.discussion_link(discussion_id=data.discussion.discussion_id, slug=data.discussion.slug)
+        else:
+            raise Exception("Can only do replies to events and discussions")
+        return cls(
+            user_name=user_name,
+            author=UserInfo.from_protobuf(data.author),
+            parent_context=parent_context,
+            markdown_text=data.reply.content,
+            view_link=view_link,
+        )
 
     @classmethod
     def dummy_data(cls) -> ThreadReplyEmail:

--- a/app/backend/src/couchers/email/rendering.py
+++ b/app/backend/src/couchers/email/rendering.py
@@ -11,9 +11,11 @@ from typing import Any, Self
 
 from markupsafe import Markup
 
+from couchers import urls
 from couchers.i18n import LocalizationContext
 from couchers.i18n.i18next import I18Next, SubstitutionDict
 from couchers.i18n.locales import load_locales
+from couchers.proto import api_pb2
 from couchers.templating import Jinja2Template, _markdown, template_folder
 from couchers.utils import now
 
@@ -47,6 +49,16 @@ class UserInfo:
     city: str
     avatar_url: str
     profile_url: str
+
+    @classmethod
+    def from_protobuf(cls, user: api_pb2.User) -> Self:
+        return cls(
+            name=user.name,
+            age=user.age,
+            city=user.city,
+            avatar_url=user.avatar_thumbnail_url or urls.icon_url(),
+            profile_url=urls.user_link(username=user.username),
+        )
 
     @staticmethod
     def dummy_bob() -> UserInfo:

--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -1,6 +1,5 @@
 import logging
 from dataclasses import dataclass, field
-from datetime import date
 from typing import Any
 
 import couchers.email.emails as emails
@@ -11,7 +10,6 @@ from couchers.email.rendering import (
     EmailFooter,
     UnsubscribeInfo,
     UnsubscribeLink,
-    UserInfo,
     render_html_body,
     render_plaintext_body,
 )
@@ -107,111 +105,61 @@ def render_email_notification(
     )
 
 
-def _user_info(user: api_pb2.User) -> UserInfo:
-    return UserInfo(
-        name=user.name,
-        age=user.age,
-        city=user.city,
-        avatar_url=user.avatar_thumbnail_url or urls.icon_url(),
-        profile_url=urls.user_link(username=user.username),
-    )
-
-
 def _get_generic_templated_email(user_name: str, notification: Notification) -> emails.EmailBase | None:
     data = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
     match notification.topic_action:
         case NotificationTopicAction.account_deletion__start:
-            return emails.AccountDeletionStartedEmail(
-                user_name,
-                deletion_link=urls.delete_account_link(account_deletion_token=data.deletion_token),
-            )
+            return emails.AccountDeletionStartedEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.account_deletion__complete:
-            return emails.AccountDeletionCompletedEmail(
-                user_name,
-                undelete_link=urls.recover_account_link(account_undelete_token=data.undelete_token),
-                days=data.undelete_days,
-            )
+            return emails.AccountDeletionCompletedEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.account_deletion__recovered:
-            return emails.AccountDeletionRecoveredEmail(user_name)
+            return emails.AccountDeletionRecoveredEmail(user_name=user_name)
         case NotificationTopicAction.api_key__create:
-            return emails.APIKeyIssuedEmail(user_name, api_key=data.api_key, expiry=data.expiry)
+            return emails.APIKeyIssuedEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.badge__add:
-            return emails.BadgeChangedEmail(user_name, badge_name=data.badge_name, added=True)
+            return emails.BadgeChangedEmail.from_add_notification(data, user_name=user_name)
         case NotificationTopicAction.badge__remove:
-            return emails.BadgeChangedEmail(user_name, badge_name=data.badge_name, added=False)
+            return emails.BadgeChangedEmail.from_remove_notification(data, user_name=user_name)
         case NotificationTopicAction.birthdate__change:
-            return emails.BirthdateChangedEmail(user_name, new_birthdate=date.fromisoformat(data.birthdate))
+            return emails.BirthdateChangedEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.discussion__create:
-            discussion = data.discussion
-            return emails.DiscussionCreatedEmail(
-                user_name,
-                author=_user_info(data.author),
-                title=discussion.title,
-                parent_context=discussion.owner_title,
-                markdown_text=discussion.content,
-                view_link=urls.discussion_link(discussion_id=discussion.discussion_id, slug=discussion.slug),
-            )
+            return emails.DiscussionCreatedEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.discussion__comment:
-            discussion = data.discussion
-            return emails.DiscussionCommentEmail(
-                user_name,
-                author=_user_info(data.author),
-                discussion_title=discussion.title,
-                discussion_parent_context=discussion.owner_title,
-                markdown_text=data.reply.content,
-                view_link=urls.discussion_link(discussion_id=discussion.discussion_id, slug=discussion.slug),
-            )
+            return emails.DiscussionCommentEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.email_address__change:
-            return emails.EmailAddressChangedEmail(user_name, new_email=data.new_email)
+            return emails.EmailAddressChangedEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.email_address__verify:
-            return emails.EmailAddressVerifiedEmail(user_name)
+            return emails.EmailAddressVerifiedEmail(user_name=user_name)
         case NotificationTopicAction.friend_request__create:
-            return emails.FriendRequestReceivedEmail(user_name, befriender=_user_info(data.other_user))
+            return emails.FriendRequestReceivedEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.friend_request__accept:
-            return emails.FriendRequestAcceptedEmail(user_name, new_friend=_user_info(data.other_user))
+            return emails.FriendRequestAcceptedEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.gender__change:
-            return emails.GenderChangedEmail(user_name, new_gender=data.gender)
+            return emails.GenderChangedEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.modnote__create:
-            return emails.ModeratorNoteEmail(user_name)
+            return emails.ModeratorNoteEmail(user_name=user_name)
         case NotificationTopicAction.password__change:
-            return emails.PasswordChangedEmail(user_name)
+            return emails.PasswordChangedEmail(user_name=user_name)
         case NotificationTopicAction.password_reset__complete:
-            return emails.PasswordResetCompletedEmail(user_name)
+            return emails.PasswordResetCompletedEmail(user_name=user_name)
         case NotificationTopicAction.password_reset__start:
-            return emails.PasswordResetStartedEmail(
-                user_name, password_reset_link=urls.password_reset_link(password_reset_token=data.password_reset_token)
-            )
+            return emails.PasswordResetStartedEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.phone_number__change:
-            return emails.PhoneNumberChangeEmail(user_name, new_phone_number=data.phone, completed=False)
+            return emails.PhoneNumberChangeEmail.from_change_notification(data, user_name=user_name)
         case NotificationTopicAction.phone_number__verify:
-            return emails.PhoneNumberChangeEmail(user_name, new_phone_number=data.phone, completed=True)
+            return emails.PhoneNumberChangeEmail.from_verify_notification(data, user_name=user_name)
         case NotificationTopicAction.postal_verification__failed:
-            return emails.PostalVerificationFailedEmail(user_name, reason=data.reason)
+            return emails.PostalVerificationFailedEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.postal_verification__postcard_sent:
-            return emails.PostalVerificationPostcardSentEmail(user_name, city=data.city, country=data.country)
+            return emails.PostalVerificationPostcardSentEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.postal_verification__success:
-            return emails.PostalVerificationSucceededEmail(user_name)
+            return emails.PostalVerificationSucceededEmail(user_name=user_name)
         case NotificationTopicAction.thread__reply:
-            parent = data.WhichOneof("reply_parent")
-            if parent == "event":
-                parent_context = data.event.title
-                view_link = urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug)
-            elif parent == "discussion":
-                parent_context = data.discussion.title
-                view_link = urls.discussion_link(discussion_id=data.discussion.discussion_id, slug=data.discussion.slug)
-            else:
-                raise Exception("Can only do replies to events and discussions")
-            return emails.ThreadReplyEmail(
-                user_name,
-                author=_user_info(data.author),
-                parent_context=parent_context,
-                markdown_text=data.reply.content,
-                view_link=view_link,
-            )
+            return emails.ThreadReplyEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.verification__sv_fail:
-            return emails.StrongVerificationFailedEmail(user_name, reason=data.reason)
+            return emails.StrongVerificationFailedEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.verification__sv_success:
-            return emails.StrongVerificationSucceededEmail(user_name)
+            return emails.StrongVerificationSucceededEmail(user_name=user_name)
         case _:
             # Still implemented as a custom templated email
             return None


### PR DESCRIPTION
Moves converting the notification data into constructing an email object to static methods of each email class. Having separate methods keeps the match statement cleaner and allows typing each notification data to have mypy validate attribute accesses.

I'll rebase as needed to handle conflicts with my other PRs.

Fixes #8712

## Testing
`uv run dump-emails` still works and emails are still fine.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
