### PR TITLE
Mobile: preserve query params on email/QR deep links

### DIFF
--- a/app/mobile/app/(tabs)/[...slug].tsx
+++ b/app/mobile/app/(tabs)/[...slug].tsx
@@ -4,7 +4,7 @@ import WebEmbed from "@/components/WebEmbed";
 import { detailRouteOriginRef } from "@/state/webViewState";
 
 export default function CatchAllScreen() {
-  const { slug } = useLocalSearchParams<{ slug?: string[] }>();
+  const { slug, ...rest } = useLocalSearchParams<{ slug?: string[] }>();
   const router = useRouter();
 
   // slug is undefined/empty when nav state is restored without a valid path
@@ -14,7 +14,17 @@ export default function CatchAllScreen() {
     return <Redirect href="/(tabs)/dashboard" />;
   }
 
-  const path = `/${slug.join("/")}`;
+  // Forward query params the deep link carried (e.g. ?token=, ?code=); the slug
+  // segments only cover the path, so without this they'd be silently dropped.
+  const query = rest as Record<string, string | string[]>;
+  const queryString = Object.entries(query)
+    .flatMap(([key, value]) =>
+      (Array.isArray(value) ? value : [value]).map(
+        (v) => `${encodeURIComponent(key)}=${encodeURIComponent(v)}`,
+      ),
+    )
+    .join("&");
+  const path = `/${slug.join("/")}${queryString ? `?${queryString}` : ""}`;
   return (
     <WebEmbed
       key={path}

--- a/app/mobile/app/delete-account.tsx
+++ b/app/mobile/app/delete-account.tsx
@@ -1,0 +1,12 @@
+import { useLocalSearchParams } from "expo-router";
+
+import WebEmbed from "@/components/WebEmbed";
+
+export default function DeleteAccountScreen() {
+  const { token } = useLocalSearchParams<{ token?: string }>();
+  const path = token
+    ? `/delete-account?token=${encodeURIComponent(token)}`
+    : "/delete-account";
+
+  return <WebEmbed path={path} />;
+}

--- a/app/mobile/app/quick-link.tsx
+++ b/app/mobile/app/quick-link.tsx
@@ -1,0 +1,16 @@
+import { useLocalSearchParams } from "expo-router";
+
+import WebEmbed from "@/components/WebEmbed";
+
+export default function QuickLinkScreen() {
+  const { payload, sig } = useLocalSearchParams<{
+    payload?: string;
+    sig?: string;
+  }>();
+  const path =
+    payload && sig
+      ? `/quick-link?payload=${encodeURIComponent(payload)}&sig=${encodeURIComponent(sig)}`
+      : "/quick-link";
+
+  return <WebEmbed path={path} />;
+}

--- a/app/mobile/app/recover-account.tsx
+++ b/app/mobile/app/recover-account.tsx
@@ -1,0 +1,12 @@
+import { useLocalSearchParams } from "expo-router";
+
+import WebEmbed from "@/components/WebEmbed";
+
+export default function RecoverAccountScreen() {
+  const { token } = useLocalSearchParams<{ token?: string }>();
+  const path = token
+    ? `/recover-account?token=${encodeURIComponent(token)}`
+    : "/recover-account";
+
+  return <WebEmbed path={path} />;
+}

--- a/app/mobile/app/verify-postal.tsx
+++ b/app/mobile/app/verify-postal.tsx
@@ -1,0 +1,12 @@
+import { useLocalSearchParams } from "expo-router";
+
+import WebEmbed from "@/components/WebEmbed";
+
+export default function VerifyPostalScreen() {
+  const { c } = useLocalSearchParams<{ c?: string }>();
+  const path = c
+    ? `/verify-postal?c=${encodeURIComponent(c)}`
+    : "/verify-postal";
+
+  return <WebEmbed path={path} />;
+}


### PR DESCRIPTION
Closes Couchers-org/bugs#63
closes Couchers-org/couchers#8733

on app, the links don't get all the tokens correctly as the router ignores them, i think. this should fix it for many key routes?

---

Universal/app links cover the entire `couchers.org` domain (`applinks:couchers.org` / Android `pathPrefix: "/"`), so every link opened on a device with the app installed is handled in-app. The catch-all route (`app/(tabs)/[...slug].tsx`) rebuilt the path from the slug segments only and silently dropped the query string. Any token-bearing link therefore lost its token and the flow couldn't complete in-app.

This was originally reported as a broken account-deletion link: tapping the confirmation link in the email landed on `/delete-account` with no `?token=`, so deletion was never finalized (confirmed in logs — the deletion-confirmation API call never followed the email).

Changes:
- **`app/(tabs)/[...slug].tsx`**: forward the query string through the catch-all instead of dropping it. Fixes the logged-in flows: `complete-strong-verification?verification_attempt_token=`, `invite?code=`, and `donate?success=`.
- **`delete-account.tsx` / `recover-account.tsx`** (new): top-level routes that capture and forward the `?token=`, mirroring the existing `confirm-email` / `complete-password-reset` screens.
- **`quick-link.tsx`** (new): captures `payload` + `sig` for the unsubscribe / do-not-email / mute-chat / quick-decline links present in the footer of **every** notification email. Top-level (unprotected) so it works while logged out, since these links are signature-authenticated.
- **`verify-postal.tsx`** (new): captures `c` for the QR code printed on the physical verification postcard.

The new screens rely on expo-router auto-registration (no `_layout.tsx` declaration), consistent with how `delete-account`/`recover-account` were added; they're reachable regardless of auth state.

## Testing
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm test` — 128 passing
- Manual: needs in-app verification on a build that intercepts the universal links — tap a deletion-confirmation email link, an unsubscribe footer link, and scan a postal QR, and confirm the token/params reach the embedded web page.

**Mobile checklist**
- [ ] Ran the app locally and the deep links resolve with their params intact
- [ ] Verified both logged-in and logged-out link handling
- [x] Type check, lint, and unit tests pass

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._