### PR TITLE
Fix reminder text host vs surf reference

### DIFF
--- a/app/web/features/dashboard/ReminderItem.test.tsx
+++ b/app/web/features/dashboard/ReminderItem.test.tsx
@@ -65,7 +65,7 @@ describe("ReminderItem", () => {
     ).toBeVisible();
     expect(
       screen.getByText(
-        t("dashboard:reminder.write_reference.description", {
+        t("dashboard:reminder.write_reference.description_hosted", {
           name: surferUser.name,
         }),
       ),

--- a/app/web/features/dashboard/ReminderItem.tsx
+++ b/app/web/features/dashboard/ReminderItem.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "i18n";
 import { DASHBOARD } from "i18n/namespaces";
 import Link from "next/link";
 import { Reminder } from "proto/account_pb";
+import { ReferenceType } from "proto/references_pb";
 import {
   referenceTypeRoute,
   routeToEditProfile,
@@ -44,9 +45,12 @@ export default function ReminderItem({
     const { hostRequestId, otherUser, referenceType } =
       reminder.writeReferenceReminder;
     title = t("reminder.write_reference.title");
-    description = t("reminder.write_reference.description", {
-      name: otherUser.name,
-    });
+    description = t(
+      referenceType === ReferenceType.REFERENCE_TYPE_SURFED
+        ? "reminder.write_reference.description_surfed"
+        : "reminder.write_reference.description_hosted",
+      { name: otherUser.name },
+    );
     buttonText = t("reminder.write_reference.button");
     href = routeToLeaveReference(
       referenceTypeRoute[referenceType],

--- a/app/web/features/dashboard/locales/en.json
+++ b/app/web/features/dashboard/locales/en.json
@@ -81,7 +81,8 @@
     },
     "write_reference": {
       "title": "Write a reference",
-      "description": "Leave a reference for {{name}}'s stay",
+      "description_surfed": "Leave a reference for your stay at {{name}}'s",
+      "description_hosted": "Leave a reference for {{name}}'s stay",
       "button": "Write reference"
     },
     "complete_profile": {


### PR DESCRIPTION
Closes #8710 

Host and surf were using the same reminder text. This fixes it to have different text for host vs surf reference reminder.

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
