### PR TITLE
Backend: persist feature flags to a disk cache

### DIFF
--- a/app/backend.dev.env
+++ b/app/backend.dev.env
@@ -89,6 +89,7 @@ EXPERIMENTATION_ENABLED=0
 EXPERIMENTATION_PASS_ALL_GATES=1
 GROWTHBOOK_API_HOST=https://gbapi.couchershq.org
 GROWTHBOOK_CLIENT_KEY=sdk-cGmljeXu1BCzHffE
+GROWTHBOOK_CACHE_PATH=growthbook-features-cache.json
 
 # Moderation auto-approval deadline in seconds (0 to disable)
 MODERATION_AUTO_APPROVE_DEADLINE_SECONDS=10

--- a/app/backend/.gitignore
+++ b/app/backend/.gitignore
@@ -19,3 +19,6 @@ htmlcov/
 
 # test artifacts
 test_artifacts/
+
+# GrowthBook feature-flag disk cache (GROWTHBOOK_CACHE_PATH)
+growthbook-features-cache.json

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -122,6 +122,9 @@ CONFIG_OPTIONS: CONFIG_T = [
     # GrowthBook SDK configuration
     ("GROWTHBOOK_API_HOST", str, "https://cdn.growthbook.io"),
     ("GROWTHBOOK_CLIENT_KEY", str, ""),
+    # Disk path for the last-known-good feature payload, used as a cold-start fallback when GrowthBook
+    # is unreachable. Required when experimentation is enabled so we never start on in-code defaults.
+    ("GROWTHBOOK_CACHE_PATH", str, ""),
     # Moderation auto-approval deadline in seconds (0 to disable auto-approval)
     ("MODERATION_AUTO_APPROVE_DEADLINE_SECONDS", int),
     # User ID of the bot user for automated moderation actions
@@ -173,6 +176,8 @@ def check_config(cfg: dict[str, Any]) -> None:
     if cfg["EXPERIMENTATION_ENABLED"]:
         if not cfg["GROWTHBOOK_CLIENT_KEY"]:
             raise Exception("No GrowthBook client key but experimentation enabled")
+        if not cfg["GROWTHBOOK_CACHE_PATH"]:
+            raise Exception("No GrowthBook cache path but experimentation enabled")
 
 
 def make_config() -> dict[str, Any]:

--- a/app/backend/src/couchers/experimentation.py
+++ b/app/backend/src/couchers/experimentation.py
@@ -90,8 +90,7 @@ def _set_last_fetch_time(when: float) -> None:
 
 
 def seconds_since_last_fetch() -> float | None:
-    """Seconds since features were last successfully pulled from GrowthBook, or None if never pulled
-    (e.g. experimentation disabled). Drives the staleness metric so a stalled refresh is observable."""
+    """Seconds since the last successful pull, or None if never pulled. Drives the staleness metric."""
     when = _last_fetch_time
     if when is None:
         return None
@@ -99,18 +98,10 @@ def seconds_since_last_fetch() -> float | None:
 
 
 def _write_cache(response: dict[str, Any]) -> None:
-    """Persist a freshly fetched payload to disk for use as a cold-start fallback.
-
-    Written to a temp file in the same directory and then renamed (Path.replace is atomic), so a
-    concurrent reader never sees a partial file and concurrent writers from the api/worker/scheduler
-    processes resolve to a last-writer-wins of identical content. Failures are not swallowed: a disk
-    problem here is real and must surface.
-    """
     path = Path(config["GROWTHBOOK_CACHE_PATH"])
     data = json.dumps({"fetched_at": time.time(), "response": response})
-    # Write to a temp file in the same directory, then rename over the target: rename is atomic only
-    # within a filesystem, so the temp must live next to the target, and a reader either sees the whole
-    # old file or the whole new one - never a half-written cache that would fail our strict parse.
+    # Temp file alongside the target then rename: rename is atomic within a filesystem, so a reader
+    # never sees a half-written cache.
     with NamedTemporaryFile("w", dir=path.parent, prefix=".growthbook-cache-", suffix=".tmp", delete=False) as f:
         f.write(data)
         tmp = Path(f.name)
@@ -118,9 +109,7 @@ def _write_cache(response: dict[str, Any]) -> None:
 
 
 def _read_cache() -> tuple[dict[str, Any], float] | None:
-    """Load the persisted payload as (response, fetched_at). Returns None only when no cache file
-    exists yet (e.g. the very first deploy). A file that exists but can't be parsed raises - a corrupt
-    cache is a hard failure, not something to paper over by falling through to in-code defaults."""
+    """(response, fetched_at), or None if no cache file exists yet. A corrupt file raises."""
     path = Path(config["GROWTHBOOK_CACHE_PATH"])
     if not path.exists():
         return None
@@ -136,8 +125,7 @@ def _refresh_loop() -> None:
             _write_cache(response)
             _set_last_fetch_time(time.time())
             logger.debug("GrowthBook features refreshed")
-        # On a failed fetch, keep last-known-good state and try again next tick. seconds_since_last_fetch
-        # climbs until a fetch succeeds, so the degradation surfaces via the staleness metric.
+        # On a failed fetch, keep last-known-good state and retry next tick; the staleness metric climbs.
 
 
 def setup_experimentation() -> None:
@@ -168,8 +156,7 @@ def setup_experimentation() -> None:
         _set_last_fetch_time(time.time())
         logger.info("GrowthBook features loaded from API")
     else:
-        # GrowthBook is unreachable at startup. Fall back to the last-known-good snapshot from disk
-        # rather than coming up healthy on in-code defaults. With no usable cache either, fail loudly.
+        # Unreachable at startup: fall back to the disk cache rather than booting on in-code defaults.
         cached = _read_cache()
         if cached is None:
             raise GrowthBookUnavailableError(

--- a/app/backend/src/couchers/experimentation.py
+++ b/app/backend/src/couchers/experimentation.py
@@ -18,11 +18,11 @@ once at process startup.
 
 import json
 import logging
-import os
-import tempfile
 import threading
 import time
 from collections.abc import Callable
+from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import Any
 
 import urllib3
@@ -86,15 +86,13 @@ def _apply_response(response: dict[str, Any]) -> None:
 
 def _set_last_fetch_time(when: float) -> None:
     global _last_fetch_time
-    with _state_lock:
-        _last_fetch_time = when
+    _last_fetch_time = when
 
 
 def seconds_since_last_fetch() -> float | None:
     """Seconds since features were last successfully pulled from GrowthBook, or None if never pulled
     (e.g. experimentation disabled). Drives the staleness metric so a stalled refresh is observable."""
-    with _state_lock:
-        when = _last_fetch_time
+    when = _last_fetch_time
     if when is None:
         return None
     return max(0.0, time.time() - when)
@@ -103,36 +101,30 @@ def seconds_since_last_fetch() -> float | None:
 def _write_cache(response: dict[str, Any]) -> None:
     """Persist a freshly fetched payload to disk for use as a cold-start fallback.
 
-    Written atomically (temp file + os.replace) so a concurrent reader never sees a partial file, and
-    so concurrent writers from the api/worker/scheduler processes just resolve to a last-writer-wins of
-    identical content. Failures are not swallowed: a disk problem here is real and must surface.
+    Written to a temp file in the same directory and then renamed (Path.replace is atomic), so a
+    concurrent reader never sees a partial file and concurrent writers from the api/worker/scheduler
+    processes resolve to a last-writer-wins of identical content. Failures are not swallowed: a disk
+    problem here is real and must surface.
     """
-    path = config["GROWTHBOOK_CACHE_PATH"]
-    data = json.dumps({"fetched_at": time.time(), "response": response}).encode("utf-8")
-    directory = os.path.dirname(os.path.abspath(path))
-    fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=".growthbook-cache-", suffix=".json.tmp")
-    try:
-        with os.fdopen(fd, "wb") as f:
-            f.write(data)
-        os.replace(tmp_path, path)
-    except BaseException:
-        # Clean up the temp file, but never mask the underlying write error.
-        try:
-            os.unlink(tmp_path)
-        except FileNotFoundError:
-            pass
-        raise
+    path = Path(config["GROWTHBOOK_CACHE_PATH"])
+    data = json.dumps({"fetched_at": time.time(), "response": response})
+    # Write to a temp file in the same directory, then rename over the target: rename is atomic only
+    # within a filesystem, so the temp must live next to the target, and a reader either sees the whole
+    # old file or the whole new one - never a half-written cache that would fail our strict parse.
+    with NamedTemporaryFile("w", dir=path.parent, prefix=".growthbook-cache-", suffix=".tmp", delete=False) as f:
+        f.write(data)
+        tmp = Path(f.name)
+    tmp.replace(path)
 
 
 def _read_cache() -> tuple[dict[str, Any], float] | None:
     """Load the persisted payload as (response, fetched_at). Returns None only when no cache file
     exists yet (e.g. the very first deploy). A file that exists but can't be parsed raises - a corrupt
     cache is a hard failure, not something to paper over by falling through to in-code defaults."""
-    path = config["GROWTHBOOK_CACHE_PATH"]
-    if not os.path.exists(path):
+    path = Path(config["GROWTHBOOK_CACHE_PATH"])
+    if not path.exists():
         return None
-    with open(path, "rb") as f:
-        payload = json.loads(f.read().decode("utf-8"))
+    payload = json.loads(path.read_text())
     return payload["response"], payload["fetched_at"]
 
 

--- a/app/backend/src/couchers/experimentation.py
+++ b/app/backend/src/couchers/experimentation.py
@@ -18,7 +18,10 @@ once at process startup.
 
 import json
 import logging
+import os
+import tempfile
 import threading
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -42,10 +45,17 @@ _state: dict[str, Any] = {"features": {}, "savedGroups": {}}
 _state_lock = threading.Lock()
 _refresh_stop = threading.Event()
 _refresh_thread: threading.Thread | None = None
+# Unix time of the last successful pull from GrowthBook (None until the first success). Set when we
+# load from the API or seed from the disk cache; drives the staleness metric.
+_last_fetch_time: float | None = None
 
 
 class ExperimentationNotInitializedError(Exception):
     """Raised when experimentation functions are called before initialization."""
+
+
+class GrowthBookUnavailableError(Exception):
+    """Raised at startup when features can't be fetched and there's no usable disk cache to fall back on."""
 
 
 def _fetch_features() -> dict[str, Any] | None:
@@ -74,13 +84,68 @@ def _apply_response(response: dict[str, Any]) -> None:
         _state["savedGroups"] = response.get("savedGroups", {})
 
 
+def _set_last_fetch_time(when: float) -> None:
+    global _last_fetch_time
+    with _state_lock:
+        _last_fetch_time = when
+
+
+def seconds_since_last_fetch() -> float | None:
+    """Seconds since features were last successfully pulled from GrowthBook, or None if never pulled
+    (e.g. experimentation disabled). Drives the staleness metric so a stalled refresh is observable."""
+    with _state_lock:
+        when = _last_fetch_time
+    if when is None:
+        return None
+    return max(0.0, time.time() - when)
+
+
+def _write_cache(response: dict[str, Any]) -> None:
+    """Persist a freshly fetched payload to disk for use as a cold-start fallback.
+
+    Written atomically (temp file + os.replace) so a concurrent reader never sees a partial file, and
+    so concurrent writers from the api/worker/scheduler processes just resolve to a last-writer-wins of
+    identical content. Failures are not swallowed: a disk problem here is real and must surface.
+    """
+    path = config["GROWTHBOOK_CACHE_PATH"]
+    data = json.dumps({"fetched_at": time.time(), "response": response}).encode("utf-8")
+    directory = os.path.dirname(os.path.abspath(path))
+    fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=".growthbook-cache-", suffix=".json.tmp")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        os.replace(tmp_path, path)
+    except BaseException:
+        # Clean up the temp file, but never mask the underlying write error.
+        try:
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _read_cache() -> tuple[dict[str, Any], float] | None:
+    """Load the persisted payload as (response, fetched_at). Returns None only when no cache file
+    exists yet (e.g. the very first deploy). A file that exists but can't be parsed raises - a corrupt
+    cache is a hard failure, not something to paper over by falling through to in-code defaults."""
+    path = config["GROWTHBOOK_CACHE_PATH"]
+    if not os.path.exists(path):
+        return None
+    with open(path, "rb") as f:
+        payload = json.loads(f.read().decode("utf-8"))
+    return payload["response"], payload["fetched_at"]
+
+
 def _refresh_loop() -> None:
     while not _refresh_stop.wait(_REFRESH_INTERVAL_SECONDS):
         response = _fetch_features()
         if response is not None:
             _apply_response(response)
+            _write_cache(response)
+            _set_last_fetch_time(time.time())
             logger.debug("GrowthBook features refreshed")
-        # On failure, keep last-known-good state and try again next tick.
+        # On a failed fetch, keep last-known-good state and try again next tick. seconds_since_last_fetch
+        # climbs until a fetch succeeds, so the degradation surfaces via the staleness metric.
 
 
 def setup_experimentation() -> None:
@@ -107,6 +172,25 @@ def setup_experimentation() -> None:
     response = _fetch_features()
     if response is not None:
         _apply_response(response)
+        _write_cache(response)
+        _set_last_fetch_time(time.time())
+        logger.info("GrowthBook features loaded from API")
+    else:
+        # GrowthBook is unreachable at startup. Fall back to the last-known-good snapshot from disk
+        # rather than coming up healthy on in-code defaults. With no usable cache either, fail loudly.
+        cached = _read_cache()
+        if cached is None:
+            raise GrowthBookUnavailableError(
+                "Could not fetch features from GrowthBook and no disk cache is available - refusing to "
+                "start on in-code feature-flag defaults"
+            )
+        cached_response, fetched_at = cached
+        _apply_response(cached_response)
+        _set_last_fetch_time(fetched_at)
+        logger.warning(
+            "GrowthBook unavailable at startup; loaded features from disk cache (%.0fs old)",
+            max(0.0, time.time() - fetched_at),
+        )
 
     with _state_lock:
         smoke_gb = GrowthBook(features=_state["features"], savedGroups=_state["savedGroups"])

--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -19,6 +19,7 @@ from sqlalchemy import and_, case, select
 from sqlalchemy.sql import distinct, func
 from sqlalchemy.sql.selectable import Select
 
+from couchers import experimentation
 from couchers.db import session_scope
 from couchers.helpers.completed_profile import has_completed_profile_expression
 from couchers.materialized_views import ClusterSubscriptionCount
@@ -631,6 +632,22 @@ postcards_sent_counter: Counter = Counter(
     "Number of postcards sent via MyPostcard",
     labelnames=["country_code"],
 )
+
+
+# Seconds since feature flags were last successfully pulled from GrowthBook. Recomputed at scrape time
+# via the hacky-gauge mechanism so it reflects live age, not the value at the last refresh. 0 when
+# experimentation is disabled or flags have never been pulled.
+def _feature_flags_staleness_seconds() -> float:
+    age = experimentation.seconds_since_last_fetch()
+    return age if age is not None else 0.0
+
+
+feature_flags_staleness_gauge: Gauge = Gauge(
+    "couchers_feature_flags_staleness_seconds",
+    "Seconds since feature flags were last successfully fetched from GrowthBook",
+    multiprocess_mode="mostrecent",
+)
+_set_hacky_gauges_funcs.append((feature_flags_staleness_gauge, _feature_flags_staleness_seconds))
 
 
 def create_prometheus_server(port: int) -> Any:

--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -634,12 +634,10 @@ postcards_sent_counter: Counter = Counter(
 )
 
 
-# Seconds since feature flags were last successfully pulled from GrowthBook. Recomputed at scrape time
-# via the hacky-gauge mechanism so it reflects live age, not the value at the last refresh. 0 when
-# experimentation is disabled or flags have never been pulled.
+# Recomputed at scrape time via the hacky-gauge mechanism, so it reflects live age. 0 when disabled
+# or never pulled.
 def _feature_flags_staleness_seconds() -> float:
-    age = experimentation.seconds_since_last_fetch()
-    return age if age is not None else 0.0
+    return experimentation.seconds_since_last_fetch() or 0.0
 
 
 feature_flags_staleness_gauge: Gauge = Gauge(

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -235,6 +235,7 @@ def testconfig():
     config["EXPERIMENTATION_PASS_ALL_GATES"] = True
     config["GROWTHBOOK_API_HOST"] = "https://cdn.growthbook.io"
     config["GROWTHBOOK_CLIENT_KEY"] = ""
+    config["GROWTHBOOK_CACHE_PATH"] = ""
 
     # Moderation auto-approval deadline - 0 disables, set in tests that need it
     config["MODERATION_AUTO_APPROVE_DEADLINE_SECONDS"] = 0

--- a/app/backend/src/tests/test_experimentation.py
+++ b/app/backend/src/tests/test_experimentation.py
@@ -1,3 +1,6 @@
+import json
+
+import pytest
 from growthbook.common_types import FeatureResult
 from sqlalchemy import select
 
@@ -5,7 +8,7 @@ from couchers import experimentation
 from couchers.config import config
 from couchers.context import make_background_user_context, make_logged_out_context
 from couchers.db import session_scope
-from couchers.experimentation import _record_feature_usage
+from couchers.experimentation import GrowthBookUnavailableError, _record_feature_usage, setup_experimentation
 from couchers.i18n import LocalizationContext
 from couchers.models.logging import ExperimentExposure, FeatureUsage
 from couchers.proto import bugs_pb2
@@ -145,3 +148,68 @@ def test_global_evaluation_gets_global_force_on_flag(feature_flags):
 
 def test_global_evaluation_unknown_feature_returns_in_code_default(feature_flags):
     assert experimentation.get_global_string_value("does_not_exist", "my_default") == "my_default"
+
+
+@pytest.fixture
+def setup_isolation(monkeypatch, tmp_path):
+    """Run setup_experimentation() against a clean module state and a tmp cache path, and make sure the
+    background refresh thread it starts is stopped afterwards."""
+    monkeypatch.setattr(experimentation, "_initialized", False)
+    monkeypatch.setattr(experimentation, "_last_fetch_time", None)
+    monkeypatch.setattr(experimentation, "_state", {"features": {}, "savedGroups": {}})
+    monkeypatch.setitem(config, "EXPERIMENTATION_ENABLED", True)
+    monkeypatch.setitem(config, "GROWTHBOOK_CACHE_PATH", str(tmp_path / "cache.json"))
+    yield tmp_path / "cache.json"
+    experimentation._refresh_stop.set()
+    if experimentation._refresh_thread is not None:
+        experimentation._refresh_thread.join(timeout=5)
+    experimentation._refresh_stop.clear()
+    experimentation._refresh_thread = None
+
+
+def test_setup_writes_cache_and_records_fetch_time(setup_isolation, monkeypatch):
+    cache = setup_isolation
+    payload = {"features": {"f": {"defaultValue": True}}, "savedGroups": {}}
+    monkeypatch.setattr(experimentation, "_fetch_features", lambda: payload)
+
+    setup_experimentation()
+
+    assert experimentation._state["features"] == {"f": {"defaultValue": True}}
+    assert experimentation.seconds_since_last_fetch() is not None
+    written = json.loads(cache.read_text())
+    assert written["response"] == payload
+    assert "fetched_at" in written
+
+
+def test_setup_falls_back_to_disk_cache_when_fetch_fails(setup_isolation, monkeypatch):
+    cache = setup_isolation
+    cached_payload = {"features": {"cached": {"defaultValue": "x"}}, "savedGroups": {}}
+    cache.write_text(json.dumps({"fetched_at": 1000.0, "response": cached_payload}))
+    monkeypatch.setattr(experimentation, "_fetch_features", lambda: None)
+
+    setup_experimentation()
+
+    assert experimentation._state["features"] == {"cached": {"defaultValue": "x"}}
+    # fetch time reflects the cached pull time, so staleness is large immediately
+    staleness = experimentation.seconds_since_last_fetch()
+    assert staleness is not None and staleness > 0
+
+
+def test_setup_raises_when_fetch_fails_and_no_cache(setup_isolation, monkeypatch):
+    monkeypatch.setattr(experimentation, "_fetch_features", lambda: None)
+
+    with pytest.raises(GrowthBookUnavailableError):
+        setup_experimentation()
+
+
+def test_setup_raises_on_corrupt_cache(setup_isolation, monkeypatch):
+    cache = setup_isolation
+    cache.write_text("this is not json")
+    monkeypatch.setattr(experimentation, "_fetch_features", lambda: None)
+
+    with pytest.raises(json.JSONDecodeError):
+        setup_experimentation()
+
+
+def test_seconds_since_last_fetch_none_when_never_fetched(setup_isolation):
+    assert experimentation.seconds_since_last_fetch() is None

--- a/app/docker-compose.prod.yml
+++ b/app/docker-compose.prod.yml
@@ -29,6 +29,8 @@ services:
     volumes:
       # auxiliary resources
       - "./data/aux/:/app/aux/:ro"
+      # persistent GrowthBook feature-flag cache (GROWTHBOOK_CACHE_PATH), survives deploys
+      - "./data/cache/:/data/cache/"
     expose:
       - 1751
       - 1753


### PR DESCRIPTION
Persists the GrowthBook feature payload to disk so the backend never cold-starts on in-code feature-flag defaults when GrowthBook is unreachable.

Previously, if GrowthBook was down when the backend started, the synchronous fetch failed silently and the process came up healthy with an empty feature set — every flag fell through to its in-code default. This is dangerous in prod where a flag's safe state may differ from its default.

What this changes:
- On every successful fetch (startup **and** the 60s refresh loop), the payload is written to disk atomically (temp file + `os.replace`) with a `fetched_at` timestamp.
- At startup: try a fresh fetch; on failure, fall back to the last-known-good disk cache. If there is neither a fresh fetch nor a usable cache, startup **fails loudly** (`GrowthBookUnavailableError`) rather than booting on defaults. A corrupt cache also raises.
- Cache read/write failures are never swallowed.
- New `GROWTHBOOK_CACHE_PATH` config, **required** by `check_config` when `EXPERIMENTATION_ENABLED` is set.
- New `couchers_feature_flags_staleness_seconds` Prometheus gauge — seconds since the last successful pull — so a stalled refresh (e.g. GrowthBook down while running) is observable. Seeded from the cache's timestamp on a cold start, so it reflects true age immediately.
- `docker-compose.prod.yml`: added a writable `./data/cache/:/data/cache/` mount so the cache survives container recreation on deploy.

**Operator note:** prod needs `GROWTHBOOK_CACHE_PATH=/data/cache/growthbook-features-cache.json` set in `backend.prod.env` (not committed). Without it the backend will refuse to start when experimentation is enabled.

## Testing
- `make format` and `make mypy` clean on changed files.
- Added unit tests in `test_experimentation.py`: cache write + fetch-time recorded on a successful fetch; fallback to disk cache when the fetch fails; raises when fetch fails and no cache exists; raises on a corrupt cache; staleness is `None` when never fetched.
- All new tests pass (`uv run pytest src/tests/test_experimentation.py`); the 2 pre-existing failures in that file are unrelated (require `make protos`).

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history (n/a — no DB changes)

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._