### PR TITLE
Add complete my home reminder

### DIFF
--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -43,6 +43,7 @@ from couchers.models import (
     AccountDeletionToken,
     ContributeOption,
     ContributorForm,
+    HostingStatus,
     HostRequest,
     HostRequestStatus,
     InviteCode,
@@ -784,6 +785,9 @@ class Account(account_pb2_grpc.AccountServicer):
 
         if not has_completed_profile(session, user):
             reminders.append(account_pb2.Reminder(complete_profile_reminder=account_pb2.CompleteProfileReminder()))
+
+        if user.hosting_status in (HostingStatus.can_host, HostingStatus.maybe) and not user.has_completed_my_home:
+            reminders.append(account_pb2.Reminder(complete_my_home_reminder=account_pb2.CompleteMyHomeReminder()))
 
         return account_pb2.GetRemindersRes(reminders=reminders)
 

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -15,8 +15,10 @@ from couchers.models import (
     AccountDeletionReason,
     AccountDeletionToken,
     BackgroundJob,
+    HostingStatus,
     InviteCode,
     PhotoGalleryItem,
+    SleepingArrangement,
     Upload,
     User,
 )
@@ -1133,6 +1135,38 @@ def test_reminders(db, moderator):
         ]
         assert reminders[0].respond_to_host_request_reminder.host_request_id == host_request3_id
         assert reminders[0].respond_to_host_request_reminder.surfer_user.user_id == req_user1.id
+
+
+def test_my_home_reminder(db):
+    # can_host with incomplete my home (max_guests not set) → reminder shown
+    can_host_incomplete, token1 = generate_user(hosting_status=HostingStatus.can_host)
+    # maybe with incomplete my home → reminder shown
+    maybe_incomplete, token2 = generate_user(hosting_status=HostingStatus.maybe)
+    # cant_host → no reminder regardless of my home completion
+    cant_host, token3 = generate_user(hosting_status=HostingStatus.cant_host)
+    # can_host with fully completed my home → no reminder
+    can_host_complete, token4 = generate_user(
+        hosting_status=HostingStatus.can_host,
+        max_guests=2,
+        sleeping_arrangement=SleepingArrangement.private,
+        # about_place is set by default in make_user
+    )
+
+    with account_session(token1) as account:
+        assert [reminder.WhichOneof("reminder") for reminder in account.GetReminders(empty_pb2.Empty()).reminders] == [
+            "complete_my_home_reminder",
+        ]
+
+    with account_session(token2) as account:
+        assert [reminder.WhichOneof("reminder") for reminder in account.GetReminders(empty_pb2.Empty()).reminders] == [
+            "complete_my_home_reminder",
+        ]
+
+    with account_session(token3) as account:
+        assert [reminder.WhichOneof("reminder") for reminder in account.GetReminders(empty_pb2.Empty()).reminders] == []
+
+    with account_session(token4) as account:
+        assert [reminder.WhichOneof("reminder") for reminder in account.GetReminders(empty_pb2.Empty()).reminders] == []
 
 
 def test_volunteer_stuff(db):

--- a/app/proto/account.proto
+++ b/app/proto/account.proto
@@ -309,6 +309,8 @@ message ListInviteCodesRes {
 
 message CompleteProfileReminder {}
 
+message CompleteMyHomeReminder {}
+
 message CompleteVerificationReminder {}
 
 message RespondToHostRequestReminder {
@@ -328,6 +330,7 @@ message Reminder {
     CompleteVerificationReminder complete_verification_reminder = 2;
     RespondToHostRequestReminder respond_to_host_request_reminder = 3;
     WriteReferenceReminder write_reference_reminder  = 4;
+    CompleteMyHomeReminder complete_my_home_reminder = 5;
   }
 }
 

--- a/app/web/features/dashboard/ReminderCarousel.tsx
+++ b/app/web/features/dashboard/ReminderCarousel.tsx
@@ -17,7 +17,7 @@ import { remindersKey } from "../queryKeys";
 import ReminderItem from "./ReminderItem";
 
 const CARD_WIDTH_DESKTOP = 280;
-const CARD_WIDTH_MOBILE = 240;
+const CARD_WIDTH_MOBILE = 200;
 const CARD_GAP = 16;
 
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
@@ -36,6 +36,9 @@ function getReminderId(reminder: Reminder.AsObject): string | null {
   }
   if (reminder.completeProfileReminder) {
     return "complete_profile";
+  }
+  if (reminder.completeMyHomeReminder) {
+    return "complete_my_home";
   }
   if (reminder.completeVerificationReminder) {
     return "complete_verification";
@@ -174,7 +177,15 @@ export default function ReminderCarousel() {
         <ChevronLeftIcon />
       </StyledArrow>
 
-      <StyledScroller ref={scrollerRef} onScroll={updateScrollState}>
+      <StyledScroller
+        ref={scrollerRef}
+        onScroll={updateScrollState}
+        sx={
+          isMobile && visibleReminders.length === 1
+            ? { justifyContent: "center" }
+            : undefined
+        }
+      >
         {visibleReminders.map(({ id, reminder }) => (
           <StyledCardSlot key={id}>
             <ReminderItem

--- a/app/web/features/dashboard/ReminderItem.test.tsx
+++ b/app/web/features/dashboard/ReminderItem.test.tsx
@@ -80,6 +80,24 @@ describe("ReminderItem", () => {
     );
   });
 
+  it("renders a 'complete my home' card with a link to the home edit tab", () => {
+    render(<ReminderItem reminder={{ completeMyHomeReminder: {} }} />, {
+      wrapper,
+    });
+
+    expect(
+      screen.getByText(t("dashboard:reminder.complete_my_home.title")),
+    ).toBeVisible();
+    expect(
+      screen.getByText(t("dashboard:reminder.complete_my_home.description")),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("link", {
+        name: t("dashboard:reminder.complete_my_home.button"),
+      }),
+    ).toHaveAttribute("href", "/profile/edit/home");
+  });
+
   it("renders a 'complete profile' card with a link to edit the profile", () => {
     render(<ReminderItem reminder={{ completeProfileReminder: {} }} />, {
       wrapper,

--- a/app/web/features/dashboard/ReminderItem.tsx
+++ b/app/web/features/dashboard/ReminderItem.tsx
@@ -53,6 +53,11 @@ export default function ReminderItem({
       otherUser.userId,
       hostRequestId,
     );
+  } else if (reminder.completeMyHomeReminder) {
+    title = t("reminder.complete_my_home.title");
+    description = t("reminder.complete_my_home.description");
+    buttonText = t("reminder.complete_my_home.button");
+    href = routeToEditProfile("home");
   } else if (reminder.completeProfileReminder) {
     title = t("reminder.complete_profile.title");
     description = t("reminder.complete_profile.description");
@@ -70,49 +75,48 @@ export default function ReminderItem({
   return (
     <Box
       sx={(theme) => ({
-        position: "relative",
         backgroundColor: alpha(theme.palette.secondary.main, 0.08),
-        padding: isMobile ? "20px" : "24px",
+        padding: isMobile ? "14px" : "24px",
         display: "flex",
         flexDirection: "column",
         height: "100%",
       })}
     >
-      {onDismiss && (
-        <IconButton
-          aria-label={t("reminder.carousel_dismiss_button_a11y")}
-          onClick={onDismiss}
-          size="small"
-          sx={(theme) => ({
-            position: "absolute",
-            top: theme.spacing(1),
-            right: theme.spacing(1),
-          })}
-        >
-          <CloseIcon />
-        </IconButton>
-      )}
-
-      <Box sx={{ flexGrow: 1 }}>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "flex-start",
+          marginBottom: isMobile ? "8px" : "16px",
+        }}
+      >
         <Typography
-          variant="h3"
-          sx={{
-            fontWeight: 800,
-            marginBottom: isMobile ? "12px" : "16px",
-          }}
+          variant={isMobile ? "h4" : "h3"}
+          sx={{ fontWeight: 800, flexGrow: 1 }}
         >
           {title}
         </Typography>
-
-        <Typography
-          sx={{
-            marginBottom: isMobile ? "14px" : "18px",
-            fontSize: ".85rem",
-          }}
-        >
-          {description}
-        </Typography>
+        {onDismiss && (
+          <IconButton
+            aria-label={t("reminder.carousel_dismiss_button_a11y")}
+            onClick={onDismiss}
+            size="small"
+            sx={{ marginTop: "-4px", marginRight: "-4px", flexShrink: 0 }}
+          >
+            <CloseIcon />
+          </IconButton>
+        )}
       </Box>
+
+      <Typography
+        sx={{
+          flexGrow: 1,
+          marginBottom: isMobile ? "10px" : "18px",
+          fontSize: isMobile ? ".75rem" : ".85rem",
+        }}
+      >
+        {description}
+      </Typography>
 
       <Button
         component={Link}

--- a/app/web/features/dashboard/locales/en.json
+++ b/app/web/features/dashboard/locales/en.json
@@ -84,6 +84,11 @@
       "description": "Leave a reference for {{name}}'s stay",
       "button": "Write reference"
     },
+    "complete_my_home": {
+      "title": "Complete your profile \"My Home\" section",
+      "description": "Fill in your sleeping arrangements, house rules, and a description of your place",
+      "button": "Edit your home"
+    },
     "complete_profile": {
       "title": "Complete your profile",
       "description": "Fill in your \"Who I Am\" section and upload a profile photo",


### PR DESCRIPTION
As discussed in the last meeting, adds a complete "My Home" section reminder.

I also made the mobile card a bit smaller, less wide and centered it on mobile when there's only one (based on various comments over the last weeks on Slack).

Closes #8744 

<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

## Testing
- Run app locally
- Clear your my home section
- Reminder should appear on dashboard

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
