### PR TITLE
Web: redirect /rules to Help Center community values category

### DIFF
--- a/app/web/redirects.js
+++ b/app/web/redirects.js
@@ -6,6 +6,12 @@ module.exports = {
       permanent: false,
     },
     {
+      source: "/rules",
+      destination:
+        "https://help.couchers.org/hc/couchersorg-help-center/en/categories/community-values-safety-and-trust",
+      permanent: false,
+    },
+    {
       source: "/volunteer/form",
       destination:
         "https://forms.monday.com/forms/0354e14aa52a37757e9b5ecf2419fef9?r=use1",


### PR DESCRIPTION
Adds a short-link redirect so `couchers.org/rules` redirects to the Help Center category listing our rules and guidelines (Community Values, Safety and Trust). Implemented as a Next.js redirect alongside the other `couchers.org` short links.

Closes #8775

## Testing
Verified the new entry matches the existing redirect convention in `app/web/redirects.js`. After deploy, visiting `couchers.org/rules` should return a 302 to `https://help.couchers.org/hc/couchersorg-help-center/en/categories/community-values-safety-and-trust`.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant (n/a — config-only redirect)
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._