### PR TITLE
Backend: fix feature-flag gating gaps for SMS and postal verification

### DIFF
--- a/app/backend/src/couchers/i18n/locales/en.json
+++ b/app/backend/src/couchers/i18n/locales/en.json
@@ -221,6 +221,7 @@
     "signup_flow_email_taken": "That email address is already associated with an account. Please log in instead!",
     "signup_flow_feedback_filled": "Feedback information already filled in.",
     "signup_flow_motivations_filled": "You've already told us about why you are signing up.",
+    "sms_disabled": "SMS verification is currently disabled.",
     "strong_verification_already_verified": "You already have strong verification.",
     "strong_verification_attempt_not_found": "Strong verification attempt not found.",
     "strong_verification_disabled": "Strong verification is currently disabled.",

--- a/app/backend/src/couchers/phone/sms.py
+++ b/app/backend/src/couchers/phone/sms.py
@@ -1,4 +1,3 @@
-import logging
 from typing import cast
 
 import boto3
@@ -6,11 +5,8 @@ import luhn
 
 from couchers import crypto
 from couchers.config import config
-from couchers.context import CouchersContext
 from couchers.db import session_scope
 from couchers.models import SMS
-
-logger = logging.getLogger(__name__)
 
 
 def generate_random_code() -> str:
@@ -26,16 +22,12 @@ def format_message(token: str) -> str:
     return f"{token} is your Couchers.org verification code. If you did not request this, please ignore this message. Best, the Couchers.org team."
 
 
-def send_sms(context: CouchersContext, number: str, message: str) -> str:
+def send_sms(number: str, message: str) -> str:
     """Send SMS to a E.164 formatted phone number with leading +. Return "success" on
     success, "unsupported operator" on unsupported operator, and any other
     string for any other error."""
 
     assert len(message) <= 140, "Message too long"
-
-    if not context.get_boolean_value("sms_enabled", default=False):
-        logger.info(f"SMS not enabled, need to send to {number}: {message}")
-        return "SMS not enabled."
 
     sns = boto3.client("sns")
     sender_id = config["SMS_SENDER_ID"]

--- a/app/backend/src/couchers/phone/sms.py
+++ b/app/backend/src/couchers/phone/sms.py
@@ -4,8 +4,9 @@ from typing import cast
 import boto3
 import luhn
 
-from couchers import crypto, experimentation
+from couchers import crypto
 from couchers.config import config
+from couchers.context import CouchersContext
 from couchers.db import session_scope
 from couchers.models import SMS
 
@@ -25,14 +26,14 @@ def format_message(token: str) -> str:
     return f"{token} is your Couchers.org verification code. If you did not request this, please ignore this message. Best, the Couchers.org team."
 
 
-def send_sms(number: str, message: str) -> str:
+def send_sms(context: CouchersContext, number: str, message: str) -> str:
     """Send SMS to a E.164 formatted phone number with leading +. Return "success" on
     success, "unsupported operator" on unsupported operator, and any other
     string for any other error."""
 
     assert len(message) <= 140, "Message too long"
 
-    if not experimentation.get_global_boolean_value("sms_enabled", default=False):
+    if not context.get_boolean_value("sms_enabled", default=False):
         logger.info(f"SMS not enabled, need to send to {number}: {message}")
         return "SMS not enabled."
 

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -349,7 +349,7 @@ class Account(account_pb2_grpc.AccountServicer):
             context.abort_with_error_code(grpc.StatusCode.RESOURCE_EXHAUSTED, "reverification_too_early")
 
         token = sms.generate_random_code()
-        result = sms.send_sms(phone, sms.format_message(token))
+        result = sms.send_sms(context, phone, sms.format_message(token))
 
         if result == "success":
             user.phone = phone

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -342,6 +342,10 @@ class Account(account_pb2_grpc.AccountServicer):
             user.phone_verification_attempts = 0
             return empty_pb2.Empty()
 
+        # Removing a number is always allowed; sending a verification SMS is gated.
+        if not context.get_boolean_value("sms_enabled", default=False):
+            context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "sms_disabled")
+
         if not is_known_operator(phone):
             context.abort_with_error_code(grpc.StatusCode.UNIMPLEMENTED, "unrecognized_phone_number")
 
@@ -349,7 +353,7 @@ class Account(account_pb2_grpc.AccountServicer):
             context.abort_with_error_code(grpc.StatusCode.RESOURCE_EXHAUSTED, "reverification_too_early")
 
         token = sms.generate_random_code()
-        result = sms.send_sms(context, phone, sms.format_message(token))
+        result = sms.send_sms(phone, sms.format_message(token))
 
         if result == "success":
             user.phone = phone

--- a/app/backend/src/couchers/servicers/postal_verification.py
+++ b/app/backend/src/couchers/servicers/postal_verification.py
@@ -168,6 +168,11 @@ class PostalVerification(postal_verification_pb2_grpc.PostalVerificationServicer
         """
         Step 2: User confirms address, we generate code and send postcard.
         """
+        # Gate the step that actually commits to sending a (paid) postcard, not just the initial
+        # address validation - otherwise turning the flag off wouldn't stop postcards mid-flow.
+        if not context.get_boolean_value("postal_verification_enabled", default=False):
+            context.abort_with_error_code(grpc.StatusCode.UNAVAILABLE, "postal_verification_disabled")
+
         attempt = session.execute(
             select(PostalVerificationAttempt)
             .where(PostalVerificationAttempt.id == request.postal_verification_attempt_id)

--- a/app/backend/src/tests/test_postal_verification.py
+++ b/app/backend/src/tests/test_postal_verification.py
@@ -15,7 +15,7 @@ from couchers.db import session_scope
 from couchers.helpers.postal_verification import generate_postal_verification_code, has_postal_verification
 from couchers.jobs.worker import process_job
 from couchers.models import User
-from couchers.models.postal_verification import PostalVerificationAttempt
+from couchers.models.postal_verification import PostalVerificationAttempt, PostalVerificationStatus
 from couchers.postal.my_postcard import _generate_back_left_side_png
 from couchers.proto import postal_verification_pb2
 from couchers.resources import get_postcard_front_image
@@ -56,6 +56,32 @@ def test_postal_verification_disabled(db, feature_flags):
                         country_code="US",
                     )
                 )
+            )
+        assert e.value.code() == grpc.StatusCode.UNAVAILABLE
+
+
+def test_postal_verification_confirm_disabled(db, feature_flags):
+    """Confirming (which queues the paid postcard) must respect the flag, not just initiation."""
+    feature_flags.set("postal_verification_enabled", False)
+    user, token = generate_user()
+
+    # Seed a pending attempt directly, since initiation is gated by the same flag.
+    with session_scope() as session:
+        attempt = PostalVerificationAttempt(
+            user_id=user.id,
+            status=PostalVerificationStatus.pending_address_confirmation,
+            address_line_1="123 Main St",
+            city="Test City",
+            country_code="US",
+        )
+        session.add(attempt)
+        session.flush()
+        attempt_id = attempt.id
+
+    with postal_verification_session(token) as pv:
+        with pytest.raises(grpc.RpcError) as e:
+            pv.ConfirmPostalAddress(
+                postal_verification_pb2.ConfirmPostalAddressReq(postal_verification_attempt_id=attempt_id)
             )
         assert e.value.code() == grpc.StatusCode.UNAVAILABLE
 

--- a/app/backend/src/tests/test_verification.py
+++ b/app/backend/src/tests/test_verification.py
@@ -7,7 +7,6 @@ from sqlalchemy import select, update
 
 import couchers.phone.sms
 from couchers.config import config
-from couchers.context import make_background_user_context
 from couchers.crypto import random_hex
 from couchers.db import session_scope
 from couchers.models import SMS, User
@@ -44,7 +43,7 @@ def test_ChangePhone(db, monkeypatch, push_collector: PushCollector):
         assert e.value.code() == grpc.StatusCode.UNIMPLEMENTED
 
         # Test with operator not supported by SMS backend
-        def deny_operator(context, phone, message):
+        def deny_operator(phone, message):
             assert phone == "+46701740605"
             return "unsupported operator"
 
@@ -55,7 +54,7 @@ def test_ChangePhone(db, monkeypatch, push_collector: PushCollector):
         assert e.value.code() == grpc.StatusCode.UNIMPLEMENTED
 
         # Test with successfully sent SMS
-        def succeed(context, phone, message):
+        def succeed(phone, message):
             assert phone == "+46701740605"
             return "success"
 
@@ -95,7 +94,7 @@ def test_ChangePhone_ratelimit(db, monkeypatch):
     user_id = user.id
     with account_session(token) as account:
 
-        def succeed(context, phone, message):
+        def succeed(phone, message):
             return "success"
 
         monkeypatch.setattr(couchers.phone.sms, "send_sms", succeed)
@@ -167,7 +166,7 @@ def test_phone_uniqueness(monkeypatch):
     user2, token2 = generate_user()
     with account_session(token1) as account1, account_session(token2) as account2:
 
-        def succeed(context, phone, message):
+        def succeed(phone, message):
             return "success"
 
         monkeypatch.setattr(couchers.phone.sms, "send_sms", succeed)
@@ -218,10 +217,7 @@ def test_send_sms(db, monkeypatch):
         sns.publish.return_value = {"MessageId": msg_id}
         mock.client.return_value = sns
 
-        assert (
-            couchers.phone.sms.send_sms(make_background_user_context(1), "+46701740605", "Testing SMS message")
-            == "success"
-        )
+        assert couchers.phone.sms.send_sms("+46701740605", "Testing SMS message") == "success"
 
         mock.client.assert_called_once_with("sns")
         sns.publish.assert_called_once_with(
@@ -241,12 +237,17 @@ def test_send_sms(db, monkeypatch):
         assert sms.message == "Testing SMS message"
 
 
-def test_send_sms_disabled(db, feature_flags):
+def test_ChangePhone_sms_disabled(db, feature_flags):
     feature_flags.set("sms_enabled", False)
-    assert (
-        couchers.phone.sms.send_sms(make_background_user_context(1), "+46701740605", "Testing SMS message")
-        == "SMS not enabled."
-    )
+    user, token = generate_user()
+    with account_session(token) as account:
+        # Setting a new number requires sending an SMS, which is gated.
+        with pytest.raises(grpc.RpcError) as e:
+            account.ChangePhone(account_pb2.ChangePhoneReq(phone="+46701740605"))
+        assert e.value.code() == grpc.StatusCode.UNAVAILABLE
+
+        # Removing a number doesn't send an SMS, so it's still allowed.
+        account.ChangePhone(account_pb2.ChangePhoneReq(phone=""))
 
 
 def test_sms_verification_no_donation():

--- a/app/backend/src/tests/test_verification.py
+++ b/app/backend/src/tests/test_verification.py
@@ -7,6 +7,7 @@ from sqlalchemy import select, update
 
 import couchers.phone.sms
 from couchers.config import config
+from couchers.context import make_background_user_context
 from couchers.crypto import random_hex
 from couchers.db import session_scope
 from couchers.models import SMS, User
@@ -43,7 +44,7 @@ def test_ChangePhone(db, monkeypatch, push_collector: PushCollector):
         assert e.value.code() == grpc.StatusCode.UNIMPLEMENTED
 
         # Test with operator not supported by SMS backend
-        def deny_operator(phone, message):
+        def deny_operator(context, phone, message):
             assert phone == "+46701740605"
             return "unsupported operator"
 
@@ -54,7 +55,7 @@ def test_ChangePhone(db, monkeypatch, push_collector: PushCollector):
         assert e.value.code() == grpc.StatusCode.UNIMPLEMENTED
 
         # Test with successfully sent SMS
-        def succeed(phone, message):
+        def succeed(context, phone, message):
             assert phone == "+46701740605"
             return "success"
 
@@ -94,7 +95,7 @@ def test_ChangePhone_ratelimit(db, monkeypatch):
     user_id = user.id
     with account_session(token) as account:
 
-        def succeed(phone, message):
+        def succeed(context, phone, message):
             return "success"
 
         monkeypatch.setattr(couchers.phone.sms, "send_sms", succeed)
@@ -166,7 +167,7 @@ def test_phone_uniqueness(monkeypatch):
     user2, token2 = generate_user()
     with account_session(token1) as account1, account_session(token2) as account2:
 
-        def succeed(phone, message):
+        def succeed(context, phone, message):
             return "success"
 
         monkeypatch.setattr(couchers.phone.sms, "send_sms", succeed)
@@ -217,7 +218,10 @@ def test_send_sms(db, monkeypatch):
         sns.publish.return_value = {"MessageId": msg_id}
         mock.client.return_value = sns
 
-        assert couchers.phone.sms.send_sms("+46701740605", "Testing SMS message") == "success"
+        assert (
+            couchers.phone.sms.send_sms(make_background_user_context(1), "+46701740605", "Testing SMS message")
+            == "success"
+        )
 
         mock.client.assert_called_once_with("sns")
         sns.publish.assert_called_once_with(
@@ -239,7 +243,10 @@ def test_send_sms(db, monkeypatch):
 
 def test_send_sms_disabled(db, feature_flags):
     feature_flags.set("sms_enabled", False)
-    assert couchers.phone.sms.send_sms("+46701740605", "Testing SMS message") == "SMS not enabled."
+    assert (
+        couchers.phone.sms.send_sms(make_background_user_context(1), "+46701740605", "Testing SMS message")
+        == "SMS not enabled."
+    )
 
 
 def test_sms_verification_no_donation():


### PR DESCRIPTION
Follow-up to #8774, tightening up two places where the recently-migrated feature flags weren't gating things correctly.

## What & why

**1. `sms_enabled` now gated at the `ChangePhone` RPC.** Previously the flag was read globally (anonymous) inside `send_sms`, even though its only caller always has a user context. Two problems: global evaluation skips per-user feature-usage tracking and would silently fall through to `default=False` if the flag ever became a rollout/experiment; and gating deep in a util was inconsistent with every other flag. Now `ChangePhone` checks `sms_enabled` per-user and aborts `UNAVAILABLE` + translatable `sms_disabled`, matching `donations`/`postal_verification`/`strong_verification`. `send_sms` is back to a pure sender. Removing a phone number stays ungated (it sends no SMS).

**2. `postal_verification_enabled` only gated the free step.** Only `InitiatePostalVerification` (address validation) checked the flag. `ConfirmPostalAddress` — the step that queues the actual (paid) postcard — did not, so a user already past step 1 could still trigger a postcard with the flag turned off. Now `ConfirmPostalAddress` is gated too, consistent with initiation.

## Deliberately left as-is
- **`recaptcha_enabled` (per-user, but `AntiBot`/`AntiBotPolicy` serve logged-out signup traffic):** per-user is already the most-correct choice; anonymous users can't be bucketed, so this is a config concern (use an unconditional force rule, not a % rollout, to cover logged-out users) rather than a code bug.
- **`check_mypostcard_jobs` (global eval):** it's a fleet-wide monitoring job with genuinely no per-user context, so global is the documented-correct path.

## Testing
- New `test_postal_verification_confirm_disabled` asserts `ConfirmPostalAddress` aborts `UNAVAILABLE` when the flag is off (seeds a pending attempt directly, since initiation is gated by the same flag).
- New `test_ChangePhone_sms_disabled` asserts setting a number aborts `UNAVAILABLE` when `sms_enabled` is off, and that removing a number is still allowed.
- `uv run pytest src/tests/test_verification.py src/tests/test_postal_verification.py src/tests/test_experimentation.py src/tests/test_account.py` — all pass.
- `make format` clean. `make mypy` has two pre-existing errors in untouched files (`tests/fixtures/misc.py`, `test_calendar_events.py`), unrelated to this change.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

🤖 Generated with [Claude Code](https://claude.com/claude-code)