### PR TITLE
Default notification email feature flags to off

### DIFF
--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -44,14 +44,14 @@ def _send_email_notification(session: Session, user: User, notification: Notific
     context = make_background_user_context(user.id)
 
     loc_context = LocalizationContext.from_user(user)
-    if not context.get_boolean_value("notification_translations_enabled", default=True):
+    if not context.get_boolean_value("notification_translations_enabled", default=False):
         loc_context = dataclasses.replace(loc_context, locale="en")
 
     rendered = render_email_notification(
         user,
         notification,
         loc_context,
-        include_ics_attachments=context.get_boolean_value("email_ics_attachments_enabled", default=True),
+        include_ics_attachments=context.get_boolean_value("email_ics_attachments_enabled", default=False),
     )
 
     queue_email(


### PR DESCRIPTION
PR #8783 migrated `ENABLE_NOTIFICATION_TRANSLATIONS` and `ENABLE_EMAIL_ICS_ATTACHMENTS` from env config to GrowthBook feature flags, but evaluated both with `default=True`. That leaves both features ON whenever the flag is absent from GrowthBook (or experimentation is disabled), whereas every other feature gate in the codebase (`sms_enabled`, `donations_enabled`, `strong_verification_enabled`, `postal_verification_enabled`, `recaptcha_enabled`) defaults to `False`. This flips `notification_translations_enabled` and `email_ics_attachments_enabled` to `default=False` so the features are off unless explicitly enabled.

## Testing
- `uv run pytest src/tests/test_calendar_events.py` passes (4/4). The existing attachment test still produces attachments because normal tests run with `EXPERIMENTATION_PASS_ALL_GATES=True`, and the new disabled-test forces the flag off explicitly.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._