### PR TITLE
Backend: add experimental_features_enabled and is_volunteer to experiment evaluator

### DIFF
--- a/app/backend/src/couchers/context.py
+++ b/app/backend/src/couchers/context.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, NoReturn, cast
+from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 import grpc
 
@@ -72,6 +72,7 @@ class CouchersContext:
         token: str | None,
         localization: LocalizationContext,
         sofa: str | None = None,
+        experimentation_attributes: dict[str, Any] | None = None,
     ):
         """Don't ever construct directly, always use the `make_*_context_` functions!"""
         self._grpc_context = grpc_context
@@ -85,6 +86,9 @@ class CouchersContext:
         self.__cookies: list[str] = []
         self.__response_headers: list[tuple[str, str]] = []
         self._growthbook: GrowthBook | None = None
+        # Extra per-user GrowthBook targeting attributes (beyond the user id), sourced from the
+        # request's already-loaded auth info so the evaluator needs no DB query of its own.
+        self._experimentation_attributes = experimentation_attributes or {}
 
         if self.__is_interactive:
             if not self._grpc_context:
@@ -209,7 +213,7 @@ class CouchersContext:
     def _get_growthbook(self) -> GrowthBook:
         if self._growthbook is None:
             # _user_id is None when logged out: evaluate anonymously, falling through to defaults.
-            self._growthbook = experimentation._create_evaluator(self._user_id)
+            self._growthbook = experimentation._create_evaluator(self._user_id, self._experimentation_attributes)
         return self._growthbook
 
 
@@ -220,6 +224,7 @@ def make_interactive_context(
     token: str | None,
     localization: LocalizationContext,
     sofa: str | None = None,
+    experimentation_attributes: dict[str, Any] | None = None,
 ) -> CouchersContext:
     return CouchersContext(
         is_interactive=True,
@@ -229,6 +234,7 @@ def make_interactive_context(
         token=token,
         localization=localization,
         sofa=sofa,
+        experimentation_attributes=experimentation_attributes,
     )
 
 

--- a/app/backend/src/couchers/experimentation.py
+++ b/app/backend/src/couchers/experimentation.py
@@ -28,14 +28,11 @@ from typing import Any
 import urllib3
 from growthbook import GrowthBook
 from growthbook.common_types import Experiment, FeatureResult, Result
-from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
 
 from couchers.config import config
 from couchers.db import session_scope
 from couchers.models.logging import ExperimentExposure, FeatureUsage
-from couchers.models.rest import Volunteer
-from couchers.models.users import User
 
 logger = logging.getLogger(__name__)
 
@@ -218,13 +215,18 @@ def _record_feature_usage(user_id: int, key: str, result: FeatureResult, **_: An
         session.add(FeatureUsage(user_id=user_id, feature_key=key, value=result.value))
 
 
-def _create_evaluator(user_id: int | None) -> GrowthBook:
+def _create_evaluator(user_id: int | None, user_attributes: dict[str, Any] | None = None) -> GrowthBook:
     """
     Build a per-request GrowthBook evaluator over the current feature snapshot.
 
     Pass user_id=None for an anonymous (logged-out) evaluation: with no `id` attribute GrowthBook
     can't bucket the user, so experiments and percentage rollouts are skipped and flags fall
     through to their defaults. No exposure or usage is recorded without a user.
+
+    `user_attributes` are extra GrowthBook targeting attributes for the user (e.g.
+    experimental_features_enabled, is_volunteer); the caller supplies them - typically from the
+    request's already-loaded auth info - so this never queries the database. Ignored when user_id
+    is None.
 
     Reads the in-memory snapshot maintained by the background refresh thread - never does HTTP
     from the request path. Constructing without `client_key` keeps the GrowthBook a pure
@@ -239,19 +241,7 @@ def _create_evaluator(user_id: int | None) -> GrowthBook:
         features = _state["features"]
         saved_groups = _state["savedGroups"]
 
-    attributes: dict[str, Any] = {}
-    if user_id is not None:
-        attributes = {"id": str(user_id)}
-        with session_scope() as session:
-            row = session.execute(
-                select(User.enable_experimental_features, Volunteer.id)
-                .outerjoin(Volunteer, Volunteer.user_id == User.id)
-                .where(User.id == user_id)
-            ).one_or_none()
-        if row is not None:
-            enable_experimental_features, volunteer_id = row
-            attributes["experimental_features_enabled"] = enable_experimental_features
-            attributes["is_volunteer"] = volunteer_id is not None
+    attributes: dict[str, Any] = {"id": str(user_id), **(user_attributes or {})} if user_id is not None else {}
 
     def on_experiment_viewed(experiment: Experiment, result: Result, **kwargs: Any) -> None:
         if user_id is not None:

--- a/app/backend/src/couchers/experimentation.py
+++ b/app/backend/src/couchers/experimentation.py
@@ -28,11 +28,14 @@ from typing import Any
 import urllib3
 from growthbook import GrowthBook
 from growthbook.common_types import Experiment, FeatureResult, Result
+from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
 
 from couchers.config import config
 from couchers.db import session_scope
 from couchers.models.logging import ExperimentExposure, FeatureUsage
+from couchers.models.rest import Volunteer
+from couchers.models.users import User
 
 logger = logging.getLogger(__name__)
 
@@ -236,6 +239,20 @@ def _create_evaluator(user_id: int | None) -> GrowthBook:
         features = _state["features"]
         saved_groups = _state["savedGroups"]
 
+    attributes: dict[str, Any] = {}
+    if user_id is not None:
+        attributes = {"id": str(user_id)}
+        with session_scope() as session:
+            row = session.execute(
+                select(User.enable_experimental_features, Volunteer.id)
+                .outerjoin(Volunteer, Volunteer.user_id == User.id)
+                .where(User.id == user_id)
+            ).one_or_none()
+        if row is not None:
+            enable_experimental_features, volunteer_id = row
+            attributes["experimental_features_enabled"] = enable_experimental_features
+            attributes["is_volunteer"] = volunteer_id is not None
+
     def on_experiment_viewed(experiment: Experiment, result: Result, **kwargs: Any) -> None:
         if user_id is not None:
             _record_exposure(user_id, experiment, result)
@@ -245,7 +262,7 @@ def _create_evaluator(user_id: int | None) -> GrowthBook:
             _record_feature_usage(user_id, key, result)
 
     return GrowthBook(
-        attributes={"id": str(user_id)} if user_id is not None else {},
+        attributes=attributes,
         features=features,
         savedGroups=saved_groups,
         on_experiment_viewed=on_experiment_viewed,

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -34,7 +34,7 @@ from couchers.descriptor_pool import get_descriptor_pool
 from couchers.i18n import LocalizationContext
 from couchers.i18n.locales import DEFAULT_LOCALE
 from couchers.metrics import observe_in_servicer_duration_histogram
-from couchers.models import APICall, User, UserActivity, UserSession
+from couchers.models import APICall, User, UserActivity, UserSession, Volunteer
 from couchers.proto import annotations_pb2
 from couchers.proto.annotations_pb2 import AuthLevel
 from couchers.utils import (
@@ -63,6 +63,8 @@ class UserAuthInfo:
     token_expiry: datetime
     ui_language_preference: str | None
     timezone: str | None
+    enable_experimental_features: bool
+    is_volunteer: bool
     token: str = field(repr=False)
     is_api_key: bool
 
@@ -89,8 +91,9 @@ def _try_get_and_update_user_details(
         return None
 
     with session_scope() as session:
+        is_volunteer_col = select(Volunteer.id).where(Volunteer.user_id == User.id).exists().label("is_volunteer")
         result = session.execute(
-            select(User, UserSession, UserActivity)
+            select(User, UserSession, UserActivity, is_volunteer_col)
             .select_from(UserSession)
             .join(User, User.id == UserSession.user_id)
             .outerjoin(
@@ -111,7 +114,7 @@ def _try_get_and_update_user_details(
         if not result:
             return None
 
-        user, user_session, user_activity = result._tuple()
+        user, user_session, user_activity, is_volunteer = result._tuple()
 
         # update user last active time if it's been a while
         if now() - user.last_active > timedelta(minutes=5):
@@ -144,9 +147,21 @@ def _try_get_and_update_user_details(
             token_expiry=user_session.expiry,
             ui_language_preference=user.ui_language_preference,
             timezone=user.timezone,
+            enable_experimental_features=user.enable_experimental_features,
+            is_volunteer=is_volunteer,
             token=token,
             is_api_key=is_api_key,
         )
+
+
+def _experimentation_attributes(auth_info: UserAuthInfo | None) -> dict[str, Any]:
+    """Per-user GrowthBook targeting attributes, taken from the request's already-loaded auth info."""
+    if auth_info is None:
+        return {}
+    return {
+        "experimental_features_enabled": auth_info.enable_experimental_features,
+        "is_volunteer": auth_info.is_volunteer,
+    }
 
 
 def abort_handler[T, R](
@@ -314,6 +329,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                 token=auth_info.token if auth_info else None,
                 localization=loc_context,
                 sofa=sofa,
+                experimentation_attributes=_experimentation_attributes(auth_info),
             )
 
             with session_scope() as session:

--- a/app/backend/src/couchers/migrations/versions/0158_backend_add_experimental_features_.py
+++ b/app/backend/src/couchers/migrations/versions/0158_backend_add_experimental_features_.py
@@ -1,0 +1,27 @@
+"""Backend: add experimental_features_enabled and is_volunteer to experiment evaluator
+
+Revision ID: 0158
+Revises: 0157
+Create Date: 2026-05-24 18:41:23.257685
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0158"
+down_revision = "0157"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("enable_experimental_features", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "enable_experimental_features")

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -234,6 +234,9 @@ class User(Base, kw_only=True):
     # whether the user has filled in the contributor form
     filled_contributor_form: Mapped[bool] = mapped_column(Boolean, server_default=expression.false(), init=False)
 
+    # whether the user has opted into experimental/preview features
+    enable_experimental_features: Mapped[bool] = mapped_column(Boolean, server_default=expression.false(), init=False)
+
     # number of onboarding emails sent
     onboarding_emails_sent: Mapped[int] = mapped_column(Integer, server_default="0", init=False)
     last_onboarding_email_sent: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)

--- a/app/backend/src/tests/fixtures/sessions.py
+++ b/app/backend/src/tests/fixtures/sessions.py
@@ -14,6 +14,7 @@ from couchers.i18n import LocalizationContext
 from couchers.i18n.locales import DEFAULT_LOCALE
 from couchers.interceptors import (
     CouchersMiddlewareInterceptor,
+    _experimentation_attributes,
     _try_get_and_update_user_details,
     check_permissions,
     find_auth_level,
@@ -183,6 +184,7 @@ class FakeChannel:
                         locale=(auth_info and auth_info.ui_language_preference) or DEFAULT_LOCALE,
                         timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
                     ),
+                    experimentation_attributes=_experimentation_attributes(auth_info),
                 )
 
                 response = handler.unary_unary(request, context, session)

--- a/app/backend/src/tests/test_experimentation.py
+++ b/app/backend/src/tests/test_experimentation.py
@@ -1,8 +1,9 @@
 import json
+from datetime import date
 
 import pytest
 from growthbook.common_types import FeatureResult
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from couchers import experimentation
 from couchers.config import config
@@ -11,7 +12,9 @@ from couchers.db import session_scope
 from couchers.experimentation import GrowthBookUnavailableError, _record_feature_usage, setup_experimentation
 from couchers.i18n import LocalizationContext
 from couchers.models.logging import ExperimentExposure, FeatureUsage
+from couchers.models.users import User
 from couchers.proto import bugs_pb2
+from tests.fixtures.db import generate_user, make_volunteer
 from tests.fixtures.sessions import bugs_session
 
 # Raw GrowthBook feature definitions for exercising the framework's own bucketing/exposure mechanics.
@@ -26,12 +29,54 @@ _EXPERIMENT_FLAG = {
     "defaultValue": "control",
     "rules": [{"key": "my_experiment", "variations": ["control", "treatment"], "coverage": 1.0}],
 }
+# Flags that only force "on" when the matching per-user evaluator attribute is set - used to assert
+# that experimental_features_enabled and is_volunteer actually reach the GrowthBook evaluator.
+_EXPERIMENTAL_FEATURES_FLAG = {
+    "defaultValue": "off",
+    "rules": [{"condition": {"experimental_features_enabled": True}, "force": "on"}],
+}
+_VOLUNTEER_FLAG = {
+    "defaultValue": "off",
+    "rules": [{"condition": {"is_volunteer": True}, "force": "on"}],
+}
 
 
 def test_logged_in_user_is_bucketed_into_rollout(db, feature_flags):
     feature_flags.set_definition("rollout_flag", _ROLLOUT_FLAG)
     context = make_background_user_context(123)
     assert context.get_string_value("rollout_flag", "fallback") == "treatment"
+
+
+def test_experimental_features_enabled_attribute_reaches_evaluator(db, feature_flags):
+    feature_flags.set_definition("experimental_features_flag", _EXPERIMENTAL_FEATURES_FLAG)
+    user, _ = generate_user()
+    with session_scope() as session:
+        session.execute(update(User).where(User.id == user.id).values(enable_experimental_features=True))
+    context = make_background_user_context(user.id)
+    assert context.get_string_value("experimental_features_flag", "fallback") == "on"
+
+
+def test_experimental_features_disabled_by_default(db, feature_flags):
+    feature_flags.set_definition("experimental_features_flag", _EXPERIMENTAL_FEATURES_FLAG)
+    user, _ = generate_user()
+    context = make_background_user_context(user.id)
+    assert context.get_string_value("experimental_features_flag", "fallback") == "off"
+
+
+def test_is_volunteer_attribute_reaches_evaluator(db, feature_flags):
+    feature_flags.set_definition("volunteer_flag", _VOLUNTEER_FLAG)
+    user, _ = generate_user()
+    with session_scope() as session:
+        session.add(make_volunteer(user_id=user.id, role="Tester", started_volunteering=date(2020, 6, 1)))
+    context = make_background_user_context(user.id)
+    assert context.get_string_value("volunteer_flag", "fallback") == "on"
+
+
+def test_is_volunteer_false_for_non_volunteer(db, feature_flags):
+    feature_flags.set_definition("volunteer_flag", _VOLUNTEER_FLAG)
+    user, _ = generate_user()
+    context = make_background_user_context(user.id)
+    assert context.get_string_value("volunteer_flag", "fallback") == "off"
 
 
 def test_anonymous_user_excluded_from_rollout_gets_feature_default(feature_flags):

--- a/app/backend/src/tests/test_experimentation.py
+++ b/app/backend/src/tests/test_experimentation.py
@@ -49,34 +49,38 @@ def test_logged_in_user_is_bucketed_into_rollout(db, feature_flags):
 
 def test_experimental_features_enabled_attribute_reaches_evaluator(db, feature_flags):
     feature_flags.set_definition("experimental_features_flag", _EXPERIMENTAL_FEATURES_FLAG)
-    user, _ = generate_user()
+    user, token = generate_user()
     with session_scope() as session:
         session.execute(update(User).where(User.id == user.id).values(enable_experimental_features=True))
-    context = make_background_user_context(user.id)
-    assert context.get_string_value("experimental_features_flag", "fallback") == "on"
+    with bugs_session(token) as bugs:
+        res = bugs.EvaluateFeatureFlag(bugs_pb2.EvaluateFeatureFlagReq(flag_key="experimental_features_flag"))
+    assert res.value.string_value == "on"
 
 
 def test_experimental_features_disabled_by_default(db, feature_flags):
     feature_flags.set_definition("experimental_features_flag", _EXPERIMENTAL_FEATURES_FLAG)
-    user, _ = generate_user()
-    context = make_background_user_context(user.id)
-    assert context.get_string_value("experimental_features_flag", "fallback") == "off"
+    _, token = generate_user()
+    with bugs_session(token) as bugs:
+        res = bugs.EvaluateFeatureFlag(bugs_pb2.EvaluateFeatureFlagReq(flag_key="experimental_features_flag"))
+    assert res.value.string_value == "off"
 
 
 def test_is_volunteer_attribute_reaches_evaluator(db, feature_flags):
     feature_flags.set_definition("volunteer_flag", _VOLUNTEER_FLAG)
-    user, _ = generate_user()
+    user, token = generate_user()
     with session_scope() as session:
         session.add(make_volunteer(user_id=user.id, role="Tester", started_volunteering=date(2020, 6, 1)))
-    context = make_background_user_context(user.id)
-    assert context.get_string_value("volunteer_flag", "fallback") == "on"
+    with bugs_session(token) as bugs:
+        res = bugs.EvaluateFeatureFlag(bugs_pb2.EvaluateFeatureFlagReq(flag_key="volunteer_flag"))
+    assert res.value.string_value == "on"
 
 
 def test_is_volunteer_false_for_non_volunteer(db, feature_flags):
     feature_flags.set_definition("volunteer_flag", _VOLUNTEER_FLAG)
-    user, _ = generate_user()
-    context = make_background_user_context(user.id)
-    assert context.get_string_value("volunteer_flag", "fallback") == "off"
+    _, token = generate_user()
+    with bugs_session(token) as bugs:
+        res = bugs.EvaluateFeatureFlag(bugs_pb2.EvaluateFeatureFlagReq(flag_key="volunteer_flag"))
+    assert res.value.string_value == "off"
 
 
 def test_anonymous_user_excluded_from_rollout_gets_feature_default(feature_flags):

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -812,6 +812,8 @@ def test_check_auth_open_service_with_auth():
         token_expiry=now(),
         ui_language_preference="en",
         timezone="Etc/UTC",
+        enable_experimental_features=False,
+        is_volunteer=False,
         token="abc123",
         is_api_key=False,
     )
@@ -832,6 +834,8 @@ def test_check_auth_secure_service_with_normal_auth():
         token_expiry=now(),
         ui_language_preference="en",
         timezone="Etc/UTC",
+        enable_experimental_features=False,
+        is_volunteer=False,
         token="abc123",
         is_api_key=False,
     )
@@ -847,6 +851,8 @@ def test_check_auth_secure_service_with_jailed_user():
         token_expiry=now(),
         ui_language_preference="en",
         timezone="Etc/UTC",
+        enable_experimental_features=False,
+        is_volunteer=False,
         token="abc123",
         is_api_key=False,
     )
@@ -863,6 +869,8 @@ def test_check_auth_jailed_service_with_jailed_user():
         token_expiry=now(),
         ui_language_preference="en",
         timezone="Etc/UTC",
+        enable_experimental_features=False,
+        is_volunteer=False,
         token="abc123",
         is_api_key=False,
     )
@@ -883,6 +891,8 @@ def test_check_auth_editor_service_without_editor():
         token_expiry=now(),
         ui_language_preference="en",
         timezone="Etc/UTC",
+        enable_experimental_features=False,
+        is_volunteer=False,
         token="abc123",
         is_api_key=False,
     )
@@ -899,6 +909,8 @@ def test_check_auth_editor_service_with_editor():
         token_expiry=now(),
         ui_language_preference="en",
         timezone="Etc/UTC",
+        enable_experimental_features=False,
+        is_volunteer=False,
         token="abc123",
         is_api_key=False,
     )
@@ -914,6 +926,8 @@ def test_check_auth_admin_service_without_superuser():
         token_expiry=now(),
         ui_language_preference="en",
         timezone="Etc/UTC",
+        enable_experimental_features=False,
+        is_volunteer=False,
         token="abc123",
         is_api_key=False,
     )
@@ -930,6 +944,8 @@ def test_check_auth_admin_service_with_superuser():
         token_expiry=now(),
         ui_language_preference="en",
         timezone="Etc/UTC",
+        enable_experimental_features=False,
+        is_volunteer=False,
         token="abc123",
         is_api_key=False,
     )


### PR DESCRIPTION
Adds two per-user attributes to the GrowthBook experiment evaluator so feature flags and experiments can target on them when a user is signed in:

- `experimental_features_enabled` — backed by a new `enable_experimental_features` opt-in boolean column on `User` (default `false`).
- `is_volunteer` — whether the user has a row in the `volunteers` table (same definition `GetAccountInfo` already uses).

The evaluator still always sets `id` for bucketing; the two attributes are attached only when the user row exists, so logged-out evaluation is unchanged and flag evaluation won't crash for a since-deleted user.

## Testing
- Added 4 tests in `test_experimentation.py` using condition-gated flags that force `"on"` only when the matching attribute is set, covering both the enabled/volunteer and default cases.
- `uv run pytest src/tests/test_experimentation.py` — all 24 pass.
- `make format` clean; `make mypy` shows only pre-existing unrelated errors.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._