### PR TITLE
Backend: thread CouchersContext into urls helpers

### DIFF
--- a/app/backend/src/couchers/context.py
+++ b/app/backend/src/couchers/context.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, NoReturn, cast
 import grpc
 
 from couchers import experimentation
+from couchers.config import config
 from couchers.i18n import LocalizationContext
 
 if TYPE_CHECKING:
@@ -179,6 +180,11 @@ class CouchersContext:
     @property
     def localization(self) -> LocalizationContext:
         return self.__localization
+
+    @property
+    def base_url(self) -> str:
+        # Single choke point for the frontend base URL of links built (via couchers.urls) for this context.
+        return cast(str, config["BASE_URL"])
 
     # Feature-flag evaluation methods mirror the OpenFeature evaluation API, evaluating for this
     # context's user. The gating lives in experimentation; we just pass our cached per-request

--- a/app/backend/src/couchers/email/calendar_events.py
+++ b/app/backend/src/couchers/email/calendar_events.py
@@ -6,8 +6,8 @@ from ics.grammar.parse import ContentLine  # type: ignore[import-untyped]
 
 from couchers import urls
 from couchers.config import config
+from couchers.context import CouchersContext
 from couchers.email.rendering import get_emails_i18next
-from couchers.i18n import LocalizationContext
 from couchers.proto.internal.jobs_pb2 import EmailAttachment
 from couchers.proto.requests_pb2 import HostRequest
 
@@ -15,24 +15,22 @@ HOST_REQUEST_ICS_FILENAME = "host_request.ics"
 
 
 def create_host_request_attachment(
-    host_request: HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext
+    host_request: HostRequest, other_name: str, hosting: bool, context: CouchersContext
 ) -> EmailAttachment:
-    ics = create_host_request_ics(host_request, other_name, hosting, loc_context)
+    ics = create_host_request_ics(host_request, other_name, hosting, context)
     return ics_to_attachment(ics, HOST_REQUEST_ICS_FILENAME)
 
 
-def create_host_request_ics(
-    host_request: HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext
-) -> str:
-    event = create_host_request_event(host_request, other_name, hosting, loc_context)
+def create_host_request_ics(host_request: HostRequest, other_name: str, hosting: bool, context: CouchersContext) -> str:
+    event = create_host_request_event(host_request, other_name, hosting, context)
 
     # METHOD:PUBLISH means this is part of a stream of calendar event information.
     # It allows for later cancellation, and doesn't expose accept/decline functionality.
-    return event_to_ics(event, "PUBLISH", loc_context)
+    return event_to_ics(event, "PUBLISH", context)
 
 
 def create_host_request_event(
-    host_request: HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext, sequence: int = 0
+    host_request: HostRequest, other_name: str, hosting: bool, context: CouchersContext, sequence: int = 0
 ) -> Event:
     """Creates an ics event for a host request."""
 
@@ -44,11 +42,11 @@ def create_host_request_event(
 
     if hosting:
         event.name = get_emails_i18next().localize(
-            "calendar_events.host_requests.title_host", loc_context.locale, {"name": other_name}
+            "calendar_events.host_requests.title_host", context.localization.locale, {"name": other_name}
         )
     else:
         event.name = get_emails_i18next().localize(
-            "calendar_events.host_requests.title_surfer", loc_context.locale, {"name": other_name}
+            "calendar_events.host_requests.title_surfer", context.localization.locale, {"name": other_name}
         )
 
     # Our to_date is inclusive, iCalendar's DTEND is exclusive (for full-day events)
@@ -58,7 +56,7 @@ def create_host_request_event(
     event.make_all_day()
 
     event.location = host_request.hosting_city
-    event.url = urls.host_request(host_request_id=str(host_request.host_request_id))
+    event.url = urls.host_request(context, host_request_id=str(host_request.host_request_id))
 
     # Google Calendar™ will hide the URL if there is a location, so also include it in the description
     event.description = event.url
@@ -67,30 +65,30 @@ def create_host_request_event(
 
 
 def create_host_request_cancellation_attachment(
-    host_request: HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext
+    host_request: HostRequest, other_name: str, hosting: bool, context: CouchersContext
 ) -> EmailAttachment:
-    ics = create_host_request_cancellation_ics(host_request, other_name, hosting, loc_context)
+    ics = create_host_request_cancellation_ics(host_request, other_name, hosting, context)
     return ics_to_attachment(ics, HOST_REQUEST_ICS_FILENAME)
 
 
 def create_host_request_cancellation_ics(
-    host_request: HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext
+    host_request: HostRequest, other_name: str, hosting: bool, context: CouchersContext
 ) -> str:
-    event = create_host_request_event(host_request, other_name, hosting, loc_context, sequence=1)
+    event = create_host_request_event(host_request, other_name, hosting, context, sequence=1)
     event.name = get_emails_i18next().localize(
-        "calendar_events.title_cancelled", loc_context.locale, {"title": event.name}
+        "calendar_events.title_cancelled", context.localization.locale, {"title": event.name}
     )
     event.status = "CANCELLED"
 
     # METHOD:PUBLISH means this is part of a stream of calendar event information.
     # Gmail™ will immediately remove the event from the user's calendar.
     # METHOD:CANCEL might leave the event in cancelled state or not work.
-    return event_to_ics(event, "PUBLISH", loc_context)
+    return event_to_ics(event, "PUBLISH", context)
 
 
-def event_to_ics(event: Event, method: str | None, loc_context: LocalizationContext) -> str:
+def event_to_ics(event: Event, method: str | None, context: CouchersContext) -> str:
     # PRODID is mandatory and generally follows "-//[Organization]//[Product Name]//[Language]"
-    calendar = Calendar(creator=f"-//Couchers.org//Couchers//{loc_context.locale.upper()}")
+    calendar = Calendar(creator=f"-//Couchers.org//Couchers//{context.localization.locale.upper()}")
     if method:
         calendar.method = method
     calendar.events.add(event)

--- a/app/backend/src/couchers/email/dump_emails.py
+++ b/app/backend/src/couchers/email/dump_emails.py
@@ -11,6 +11,7 @@ from datetime import UTC
 from pathlib import Path
 
 import couchers.email.emails
+from couchers.context import CouchersContext, make_logged_out_context
 from couchers.email.emails import EmailBase
 from couchers.email.rendering import (
     EmailFooter,
@@ -43,7 +44,7 @@ class CommandLineArgs:
 
 def main() -> None:
     args = CommandLineArgs.parse(sys.argv[1:])
-    loc_context = LocalizationContext(locale=args.locale, timezone=UTC)
+    context = make_logged_out_context(LocalizationContext(locale=args.locale, timezone=UTC))
 
     footer = EmailFooter(
         timezone_name="UTC",
@@ -59,14 +60,14 @@ def main() -> None:
     for _, klass in inspect.getmembers(couchers.email.emails, lambda o: inspect.isclass(o) and o.__base__ == EmailBase):
         email_class: type[EmailBase] = klass
         if filter_regex.fullmatch(email_class.__name__):
-            dump_email(email_class.dummy_data(), footer, loc_context, args.outdir)
+            dump_email(email_class.dummy_data(), footer, context, args.outdir)
 
 
-def dump_email(email: EmailBase, footer: EmailFooter, loc_context: LocalizationContext, outdir: Path) -> None:
+def dump_email(email: EmailBase, footer: EmailFooter, context: CouchersContext, outdir: Path) -> None:
     """Dumps an email's subject and plaintext+html body to a file."""
-    subject_line = email.get_subject_line(loc_context)
-    preview_line = email.get_preview_line(loc_context)
-    blocks = email.get_body_blocks(loc_context)
+    subject_line = email.get_subject_line(context)
+    preview_line = email.get_preview_line(context)
+    blocks = email.get_body_blocks(context)
 
     outdir.mkdir(exist_ok=True)
 
@@ -76,13 +77,13 @@ def dump_email(email: EmailBase, footer: EmailFooter, loc_context: LocalizationC
     html_path = outdir / f"{email.__class__.__name__}.html"
     print(f"  Rendering html to {html_path}...")
     html = render_html_body(
-        subject=subject_line, preview=preview_line, blocks=blocks, footer=footer, loc_context=loc_context
+        subject=subject_line, preview=preview_line, blocks=blocks, footer=footer, loc_context=context.localization
     )
     html_path.write_text(html)
 
     plaintext_path = outdir / f"{email.__class__.__name__}.txt"
     print(f"  Rendering plaintext to {plaintext_path}...")
-    plaintext = render_plaintext_body(blocks=blocks, footer=footer, loc_context=loc_context)
+    plaintext = render_plaintext_body(blocks=blocks, footer=footer, loc_context=context.localization)
     plaintext_path.write_text(plaintext)
 
 

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -8,6 +8,7 @@ from datetime import UTC, date, datetime
 from typing import Self
 
 from couchers import urls
+from couchers.context import CouchersContext
 from couchers.email.rendering import (
     EmailBlock,
     EmailBlocksBuilder,
@@ -15,7 +16,6 @@ from couchers.email.rendering import (
     UserInfo,
     get_emails_i18next,
 )
-from couchers.i18n import LocalizationContext
 from couchers.i18n.i18next import SubstitutionDict
 from couchers.i18n.localize import format_phone_number
 from couchers.proto import notification_data_pb2
@@ -34,29 +34,31 @@ class EmailBase(ABC):
     @abstractmethod
     def string_key_prefix(self) -> str: ...
 
-    def get_subject_line(self, loc_context: LocalizationContext) -> str:
+    def get_subject_line(self, context: CouchersContext) -> str:
         """Gets the subject line header of the email."""
-        return self._localize(loc_context, "subject")
+        return self._localize(context, "subject")
 
-    def get_preview_line(self, loc_context: LocalizationContext) -> str | None:
+    def get_preview_line(self, context: CouchersContext) -> str | None:
         """Gets the line that gets shown as a preview next to the title in users' inboxes."""
         return None
 
-    def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
+    def get_body_blocks(self, context: CouchersContext) -> list[EmailBlock]:
         """Gets the blocks that form the body of the email."""
 
         # Delegate to build_body, but wrap with greetings and closing lines common to all emails.
         i18next = get_emails_i18next()
-        builder = EmailBlocksBuilder(locale=loc_context.locale, string_key_prefix=self.string_key_prefix)
+        builder = EmailBlocksBuilder(locale=context.localization.locale, string_key_prefix=self.string_key_prefix)
         builder.block(
-            ParaBlock(text=i18next.localize("generic.greeting_line", loc_context.locale, {"name": self.user_name}))
+            ParaBlock(
+                text=i18next.localize("generic.greeting_line", context.localization.locale, {"name": self.user_name})
+            )
         )
-        self.build_body(builder, loc_context)
-        builder.block(ParaBlock(text=i18next.localize("generic.closing_line", loc_context.locale)))
+        self.build_body(builder, context)
+        builder.block(ParaBlock(text=i18next.localize("generic.closing_line", context.localization.locale)))
         return builder.blocks
 
     @abstractmethod
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None: ...
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None: ...
 
     @classmethod
     @abstractmethod
@@ -65,14 +67,12 @@ class EmailBase(ABC):
         ...
 
     # Helpers for localizing email-specific strings
-    def _localize(
-        self, loc_context: LocalizationContext, key: str, substitutions: SubstitutionDict | None = None
-    ) -> str:
+    def _localize(self, context: CouchersContext, key: str, substitutions: SubstitutionDict | None = None) -> str:
         key = f"{self.string_key_prefix}.{key}"
-        return get_emails_i18next().localize(key, loc_context.locale, substitutions)
+        return get_emails_i18next().localize(key, context.localization.locale, substitutions)
 
-    def _body_builder(self, loc_context: LocalizationContext) -> EmailBlocksBuilder:
-        return EmailBlocksBuilder(locale=loc_context.locale, string_key_prefix=self.string_key_prefix)
+    def _body_builder(self, context: CouchersContext) -> EmailBlocksBuilder:
+        return EmailBlocksBuilder(locale=context.localization.locale, string_key_prefix=self.string_key_prefix)
 
 
 # Specific email definitions
@@ -88,17 +88,19 @@ class AccountDeletionStartedEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "account_deletion_started"
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("request_description")
         builder.para("confirmation_instructions")
         builder.action(self.deletion_link, "confirm_action")
         builder.security_warning_para()
 
     @classmethod
-    def from_notification(cls, data: notification_data_pb2.AccountDeletionStart, *, user_name: str) -> Self:
+    def from_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.AccountDeletionStart, *, user_name: str
+    ) -> Self:
         return cls(
             user_name=user_name,
-            deletion_link=urls.delete_account_link(account_deletion_token=data.deletion_token),
+            deletion_link=urls.delete_account_link(context, account_deletion_token=data.deletion_token),
         )
 
     @classmethod
@@ -120,7 +122,7 @@ class AccountDeletionCompletedEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "account_deletion_completed"
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("confirmation")
         builder.para("farewell")
         builder.para("recovery_instructions_days", {"count": self.days})
@@ -128,10 +130,12 @@ class AccountDeletionCompletedEmail(EmailBase):
         builder.security_warning_para()
 
     @classmethod
-    def from_notification(cls, data: notification_data_pb2.AccountDeletionComplete, *, user_name: str) -> Self:
+    def from_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.AccountDeletionComplete, *, user_name: str
+    ) -> Self:
         return cls(
             user_name=user_name,
-            undelete_link=urls.recover_account_link(account_undelete_token=data.undelete_token),
+            undelete_link=urls.recover_account_link(context, account_undelete_token=data.undelete_token),
             days=data.undelete_days,
         )
 
@@ -152,10 +156,10 @@ class AccountDeletionRecoveredEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "account_deletion_recovered"
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("confirmation")
         builder.para("login_instructions")
-        builder.action(urls.app_link(), "login_action")
+        builder.action(urls.app_link(context), "login_action")
         builder.para("redelete_instructions")
         builder.security_warning_para()
 
@@ -175,16 +179,18 @@ class APIKeyIssuedEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "api_key_issued"
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("header")
         builder.quote(self.api_key, markdown=False)
-        builder.para("expiry", {"datetime": loc_context.localize_datetime(self.expiry)})
+        builder.para("expiry", {"datetime": context.localization.localize_datetime(self.expiry)})
         builder.para("usage_warning")
         builder.para("policy_warning")
         builder.security_warning_para()
 
     @classmethod
-    def from_notification(cls, data: notification_data_pb2.ApiKeyCreate, *, user_name: str) -> Self:
+    def from_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.ApiKeyCreate, *, user_name: str
+    ) -> Self:
         return cls(user_name=user_name, api_key=data.api_key, expiry=data.expiry.ToDatetime(tzinfo=UTC))
 
     @classmethod
@@ -205,18 +211,22 @@ class BadgeChangedEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "badge_added" if self.added else "badge_removed"
 
-    def get_subject_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, "subject", {"badge_name": self.badge_name})
+    def get_subject_line(self, context: CouchersContext) -> str:
+        return self._localize(context, "subject", {"badge_name": self.badge_name})
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("body", {"badge_name": self.badge_name})
 
     @classmethod
-    def from_add_notification(cls, data: notification_data_pb2.BadgeAdd, *, user_name: str) -> Self:
+    def from_add_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.BadgeAdd, *, user_name: str
+    ) -> Self:
         return cls(user_name=user_name, badge_name=data.badge_name, added=True)
 
     @classmethod
-    def from_remove_notification(cls, data: notification_data_pb2.BadgeRemove, *, user_name: str) -> Self:
+    def from_remove_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.BadgeRemove, *, user_name: str
+    ) -> Self:
         return cls(user_name=user_name, badge_name=data.badge_name, added=False)
 
     @classmethod
@@ -234,12 +244,14 @@ class BirthdateChangedEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "birthdate_changed"
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body", {"date": loc_context.localize_date(self.new_birthdate)})
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
+        builder.para("body", {"date": context.localization.localize_date(self.new_birthdate)})
         builder.security_warning_para()
 
     @classmethod
-    def from_notification(cls, data: notification_data_pb2.BirthdateChange, *, user_name: str) -> Self:
+    def from_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.BirthdateChange, *, user_name: str
+    ) -> Self:
         return cls(user_name=user_name, new_birthdate=date.fromisoformat(data.birthdate))
 
     @classmethod
@@ -264,10 +276,10 @@ class DiscussionCreatedEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "discussion_created"
 
-    def get_subject_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, "subject", {"author": self.author.name, "title": self.title})
+    def get_subject_line(self, context: CouchersContext) -> str:
+        return self._localize(context, "subject", {"author": self.author.name, "title": self.title})
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para(
             "body",
             {
@@ -281,15 +293,17 @@ class DiscussionCreatedEmail(EmailBase):
         builder.action(self.view_link, "view_action")
 
     @classmethod
-    def from_notification(cls, data: notification_data_pb2.DiscussionCreate, *, user_name: str) -> Self:
+    def from_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.DiscussionCreate, *, user_name: str
+    ) -> Self:
         discussion = data.discussion
         return cls(
             user_name=user_name,
-            author=UserInfo.from_protobuf(data.author),
+            author=UserInfo.from_protobuf(context, data.author),
             title=discussion.title,
             parent_context=discussion.owner_title,
             markdown_text=discussion.content,
-            view_link=urls.discussion_link(discussion_id=discussion.discussion_id, slug=discussion.slug),
+            view_link=urls.discussion_link(context, discussion_id=discussion.discussion_id, slug=discussion.slug),
         )
 
     @classmethod
@@ -318,12 +332,12 @@ class DiscussionCommentEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "discussion_comment"
 
-    def get_subject_line(self, loc_context: LocalizationContext) -> str:
+    def get_subject_line(self, context: CouchersContext) -> str:
         return self._localize(
-            loc_context, "subject", {"author": self.author.name, "discussion_title": self.discussion_title}
+            context, "subject", {"author": self.author.name, "discussion_title": self.discussion_title}
         )
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para(
             "body",
             {
@@ -337,15 +351,17 @@ class DiscussionCommentEmail(EmailBase):
         builder.action(self.view_link, "view_action")
 
     @classmethod
-    def from_notification(cls, data: notification_data_pb2.DiscussionComment, *, user_name: str) -> Self:
+    def from_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.DiscussionComment, *, user_name: str
+    ) -> Self:
         discussion = data.discussion
         return cls(
             user_name=user_name,
-            author=UserInfo.from_protobuf(data.author),
+            author=UserInfo.from_protobuf(context, data.author),
             discussion_title=discussion.title,
             discussion_parent_context=discussion.owner_title,
             markdown_text=data.reply.content,
-            view_link=urls.discussion_link(discussion_id=discussion.discussion_id, slug=discussion.slug),
+            view_link=urls.discussion_link(context, discussion_id=discussion.discussion_id, slug=discussion.slug),
         )
 
     @classmethod
@@ -370,12 +386,14 @@ class EmailAddressChangedEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "email_address_change_initiated"
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("body", {"email_address": self.new_email})
         builder.security_warning_para()
 
     @classmethod
-    def from_notification(cls, data: notification_data_pb2.EmailAddressChange, *, user_name: str) -> Self:
+    def from_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.EmailAddressChange, *, user_name: str
+    ) -> Self:
         return cls(user_name=user_name, new_email=data.new_email)
 
     @classmethod
@@ -391,7 +409,7 @@ class EmailAddressVerifiedEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "email_address_verified"
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("body")
         builder.security_warning_para()
 
@@ -410,22 +428,24 @@ class FriendRequestReceivedEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "friend_request_received"
 
-    def get_subject_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, "subject", {"name": self.befriender.name})
+    def get_subject_line(self, context: CouchersContext) -> str:
+        return self._localize(context, "subject", {"name": self.befriender.name})
 
-    def get_preview_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, "body", {"name": self.befriender.name})
+    def get_preview_line(self, context: CouchersContext) -> str:
+        return self._localize(context, "body", {"name": self.befriender.name})
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("body", {"name": self.befriender.name})
         builder.user(self.befriender)
-        builder.action(urls.friend_requests_link(), "view_action")
+        builder.action(urls.friend_requests_link(context), "view_action")
         builder.para("closing")
         builder.do_not_reply_request_para()
 
     @classmethod
-    def from_notification(cls, data: notification_data_pb2.FriendRequestCreate, *, user_name: str) -> Self:
-        return cls(user_name=user_name, befriender=UserInfo.from_protobuf(data.other_user))
+    def from_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.FriendRequestCreate, *, user_name: str
+    ) -> Self:
+        return cls(user_name=user_name, befriender=UserInfo.from_protobuf(context, data.other_user))
 
     @classmethod
     def dummy_data(cls) -> FriendRequestReceivedEmail:
@@ -445,21 +465,23 @@ class FriendRequestAcceptedEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "friend_request_accepted"
 
-    def get_subject_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, "subject", {"name": self.new_friend.name})
+    def get_subject_line(self, context: CouchersContext) -> str:
+        return self._localize(context, "subject", {"name": self.new_friend.name})
 
-    def get_preview_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, "body", {"name": self.new_friend.name})
+    def get_preview_line(self, context: CouchersContext) -> str:
+        return self._localize(context, "body", {"name": self.new_friend.name})
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("body", {"name": self.new_friend.name})
         builder.user(self.new_friend)
         builder.action(self.new_friend.profile_url, "view_action")
         builder.para("closing")
 
     @classmethod
-    def from_notification(cls, data: notification_data_pb2.FriendRequestAccept, *, user_name: str) -> Self:
-        return cls(user_name=user_name, new_friend=UserInfo.from_protobuf(data.other_user))
+    def from_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.FriendRequestAccept, *, user_name: str
+    ) -> Self:
+        return cls(user_name=user_name, new_friend=UserInfo.from_protobuf(context, data.other_user))
 
     @classmethod
     def dummy_data(cls) -> FriendRequestAcceptedEmail:
@@ -479,12 +501,14 @@ class GenderChangedEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "gender_changed"
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("body", {"gender": self.new_gender})
         builder.security_warning_para()
 
     @classmethod
-    def from_notification(cls, data: notification_data_pb2.GenderChange, *, user_name: str) -> Self:
+    def from_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.GenderChange, *, user_name: str
+    ) -> Self:
         return cls(user_name=user_name, new_gender=data.gender)
 
     @classmethod
@@ -503,7 +527,7 @@ class ModeratorNoteEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "moderator_note"
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("body")
 
     @classmethod
@@ -519,7 +543,7 @@ class PasswordChangedEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "password_changed"
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("body")
         builder.security_warning_para()
 
@@ -536,7 +560,7 @@ class PasswordResetCompletedEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "password_reset_completed"
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("body")
         builder.security_warning_para()
 
@@ -555,17 +579,19 @@ class PasswordResetStartedEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "password_reset_started"
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("request_description")
         builder.para("confirmation_instructions")
         builder.action(self.password_reset_link, "reset_action")
         builder.security_warning_para()
 
     @classmethod
-    def from_notification(cls, data: notification_data_pb2.PasswordResetStart, *, user_name: str) -> Self:
+    def from_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.PasswordResetStart, *, user_name: str
+    ) -> Self:
         return cls(
             user_name=user_name,
-            password_reset_link=urls.password_reset_link(password_reset_token=data.password_reset_token),
+            password_reset_link=urls.password_reset_link(context, password_reset_token=data.password_reset_token),
         )
 
     @classmethod
@@ -584,16 +610,20 @@ class PhoneNumberChangeEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "phone_number_verified" if self.completed else "phone_number_verification_started"
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("body", {"phone_number": format_phone_number(self.new_phone_number)})
         builder.security_warning_para()
 
     @classmethod
-    def from_change_notification(cls, data: notification_data_pb2.PhoneNumberChange, *, user_name: str) -> Self:
+    def from_change_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.PhoneNumberChange, *, user_name: str
+    ) -> Self:
         return cls(user_name=user_name, new_phone_number=data.phone, completed=False)
 
     @classmethod
-    def from_verify_notification(cls, data: notification_data_pb2.PhoneNumberVerify, *, user_name: str) -> Self:
+    def from_verify_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.PhoneNumberVerify, *, user_name: str
+    ) -> Self:
         return cls(user_name=user_name, new_phone_number=data.phone, completed=True)
 
     @classmethod
@@ -615,7 +645,7 @@ class PostalVerificationFailedEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "postal_verification_failed"
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         match self.reason:
             case notification_data_pb2.POSTAL_VERIFICATION_FAIL_REASON_CODE_EXPIRED:
                 reason_string_key = "reason_code_expired"
@@ -627,7 +657,9 @@ class PostalVerificationFailedEmail(EmailBase):
         builder.security_warning_para()
 
     @classmethod
-    def from_notification(cls, data: notification_data_pb2.PostalVerificationFailed, *, user_name: str) -> Self:
+    def from_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.PostalVerificationFailed, *, user_name: str
+    ) -> Self:
         return cls(user_name=user_name, reason=data.reason)
 
     @classmethod
@@ -649,12 +681,14 @@ class PostalVerificationPostcardSentEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "postal_verification_postcard_sent"
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("body", {"city": self.city, "country": self.country})
         builder.security_warning_para()
 
     @classmethod
-    def from_notification(cls, data: notification_data_pb2.PostalVerificationPostcardSent, *, user_name: str) -> Self:
+    def from_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.PostalVerificationPostcardSent, *, user_name: str
+    ) -> Self:
         return cls(user_name=user_name, city=data.city, country=data.country)
 
     @classmethod
@@ -670,7 +704,7 @@ class PostalVerificationSucceededEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "postal_verification_succeeded"
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("body")
         builder.security_warning_para()
 
@@ -689,7 +723,7 @@ class StrongVerificationFailedEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "strong_verification_failed"
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         match self.reason:
             case notification_data_pb2.SV_FAIL_REASON_WRONG_BIRTHDATE_OR_GENDER:
                 reason_string_key = "reason_wrong_birthdate_or_gender"
@@ -703,7 +737,9 @@ class StrongVerificationFailedEmail(EmailBase):
         builder.security_warning_para()
 
     @classmethod
-    def from_notification(cls, data: notification_data_pb2.VerificationSVFail, *, user_name: str) -> Self:
+    def from_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.VerificationSVFail, *, user_name: str
+    ) -> Self:
         return cls(user_name=user_name, reason=data.reason)
 
     @classmethod
@@ -722,12 +758,12 @@ class StrongVerificationSucceededEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "strong_verification_succeeded"
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("success_message")
         builder.para("thanks_message")
         builder.para("cost_explanation")
         builder.para("donation_request")
-        donate_link = urls.donation_url() + "?utm_source=strong-verification-email"
+        donate_link = urls.donation_url(context) + "?utm_source=strong-verification-email"
         builder.action(donate_link, "donate_action")
         builder.security_warning_para()
 
@@ -749,31 +785,33 @@ class ThreadReplyEmail(EmailBase):
     def string_key_prefix(self) -> str:
         return "thread_reply"
 
-    def get_subject_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(
-            loc_context, "subject", {"author": self.author.name, "parent_context": self.parent_context}
-        )
+    def get_subject_line(self, context: CouchersContext) -> str:
+        return self._localize(context, "subject", {"author": self.author.name, "parent_context": self.parent_context})
 
-    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+    def build_body(self, builder: EmailBlocksBuilder, context: CouchersContext) -> None:
         builder.para("body", {"author": self.author.name, "parent_context": self.parent_context})
         builder.user(self.author)
         builder.quote(self.markdown_text, markdown=True)
         builder.action(self.view_link, "view_action")
 
     @classmethod
-    def from_notification(cls, data: notification_data_pb2.ThreadReply, *, user_name: str) -> Self:
+    def from_notification(
+        cls, context: CouchersContext, data: notification_data_pb2.ThreadReply, *, user_name: str
+    ) -> Self:
         parent = data.WhichOneof("reply_parent")
         if parent == "event":
             parent_context = data.event.title
-            view_link = urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug)
+            view_link = urls.event_link(context, occurrence_id=data.event.event_id, slug=data.event.slug)
         elif parent == "discussion":
             parent_context = data.discussion.title
-            view_link = urls.discussion_link(discussion_id=data.discussion.discussion_id, slug=data.discussion.slug)
+            view_link = urls.discussion_link(
+                context, discussion_id=data.discussion.discussion_id, slug=data.discussion.slug
+            )
         else:
             raise Exception("Can only do replies to events and discussions")
         return cls(
             user_name=user_name,
-            author=UserInfo.from_protobuf(data.author),
+            author=UserInfo.from_protobuf(context, data.author),
             parent_context=parent_context,
             markdown_text=data.reply.content,
             view_link=view_link,

--- a/app/backend/src/couchers/email/rendering.py
+++ b/app/backend/src/couchers/email/rendering.py
@@ -12,6 +12,7 @@ from typing import Any, Self
 from markupsafe import Markup
 
 from couchers import urls
+from couchers.context import CouchersContext
 from couchers.i18n import LocalizationContext
 from couchers.i18n.i18next import I18Next, SubstitutionDict
 from couchers.i18n.locales import load_locales
@@ -51,13 +52,13 @@ class UserInfo:
     profile_url: str
 
     @classmethod
-    def from_protobuf(cls, user: api_pb2.User) -> Self:
+    def from_protobuf(cls, context: CouchersContext, user: api_pb2.User) -> Self:
         return cls(
             name=user.name,
             age=user.age,
             city=user.city,
-            avatar_url=user.avatar_thumbnail_url or urls.icon_url(),
-            profile_url=urls.user_link(username=user.username),
+            avatar_url=user.avatar_thumbnail_url or urls.icon_url(context),
+            profile_url=urls.user_link(context, username=user.username),
         )
 
     @staticmethod

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -1263,7 +1263,9 @@ def send_postal_verification_postcard(payload: jobs_pb2.SendPostalVerificationPo
 
         user_name = session.execute(select(User.name).where(User.id == attempt.user_id)).scalar_one()
 
+        context = make_background_user_context(attempt.user_id)
         job_id = send_postcard(
+            context,
             recipient_name=user_name,
             address_line_1=attempt.address_line_1,
             address_line_2=attempt.address_line_2,
@@ -1280,7 +1282,6 @@ def send_postal_verification_postcard(payload: jobs_pb2.SendPostalVerificationPo
 
         postcards_sent_counter.labels(country_code=attempt.country_code).inc()
 
-        context = make_background_user_context(attempt.user_id)
         log_event(
             context,
             session,

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -41,16 +41,15 @@ def _send_email_notification(session: Session, user: User, notification: Notific
         logger.info(f"Tried emailing {user} based on notification {notification.topic_action} but user is deleted")
         return
 
-    context = make_background_user_context(user.id)
-
     loc_context = LocalizationContext.from_user(user)
+    context = make_background_user_context(user.id, loc_context)
     if not context.get_boolean_value("notification_translations_enabled", default=False):
-        loc_context = dataclasses.replace(loc_context, locale="en")
+        context = make_background_user_context(user.id, dataclasses.replace(loc_context, locale="en"))
 
     rendered = render_email_notification(
         user,
         notification,
-        loc_context,
+        context,
         include_ics_attachments=context.get_boolean_value("email_ics_attachments_enabled", default=False),
     )
 
@@ -73,9 +72,11 @@ def _send_email_notification(session: Session, user: User, notification: Notific
 def _send_push_notification(session: Session, user: User, notification: Notification) -> None:
     logger.debug(f"Formatting push notification for {user}")
 
-    content = render_push_notification(notification, LocalizationContext.from_user(user))
+    context = make_background_user_context(user.id, LocalizationContext.from_user(user))
+    content = render_push_notification(notification, context)
     push_to_user(
         session,
+        context=context,
         user_id=user.id,
         topic_action=notification.topic_action.display,
         content=content,

--- a/app/backend/src/couchers/notifications/push.py
+++ b/app/backend/src/couchers/notifications/push.py
@@ -7,6 +7,7 @@ from sqlalchemy.sql import func
 
 from couchers import urls
 from couchers.config import config
+from couchers.context import CouchersContext
 from couchers.jobs.enqueue import queue_job
 from couchers.models import PushNotificationSubscription
 from couchers.notifications.send_raw_push_notification import send_raw_push_notification_v2
@@ -108,6 +109,7 @@ class PushNotificationContent:
 def push_to_subscription(
     session: Session,
     *,
+    context: CouchersContext,
     push_notification_subscription_id: int,
     user_id: int,
     topic_action: str,
@@ -118,7 +120,7 @@ def push_to_subscription(
     # TODO(#7617): Support iOS-style title/subtitles
     title = config["NOTIFICATION_PREFIX"] + content.title[: PushNotificationContent.MAX_TITLE_LENGTH]
     body = content.body[: PushNotificationContent.MAX_BODY_LENGTH]
-    icon_url = content.icon_url or urls.icon_url()
+    icon_url = content.icon_url or urls.icon_url(context)
     action_url = content.action_url or ""
     queue_job(
         session,
@@ -142,6 +144,7 @@ def push_to_subscription(
 
 def _push_to_user(
     session: Session,
+    context: CouchersContext,
     user_id: int,
     topic_action: str,
     content: PushNotificationContent,
@@ -163,6 +166,7 @@ def _push_to_user(
     for sub_id in sub_ids:
         push_to_subscription(
             session,
+            context=context,
             push_notification_subscription_id=sub_id,
             user_id=user_id,
             topic_action=topic_action,
@@ -175,6 +179,7 @@ def _push_to_user(
 def push_to_user(
     session: Session,
     *,
+    context: CouchersContext,
     user_id: int,
     topic_action: str,
     content: PushNotificationContent,
@@ -186,6 +191,7 @@ def push_to_user(
     """
     _push_to_user(
         session,
+        context,
         user_id=user_id,
         topic_action=topic_action,
         content=content,

--- a/app/backend/src/couchers/notifications/quick_links.py
+++ b/app/backend/src/couchers/notifications/quick_links.py
@@ -36,59 +36,63 @@ from couchers.utils import now
 logger = logging.getLogger(__name__)
 
 
-def _generate_quick_link(payload: Message) -> str:
+def _generate_quick_link(context: CouchersContext, payload: Message) -> str:
     payload.created.FromDatetime(now())  # type: ignore[attr-defined]
     msg = payload.SerializeToString()
     sig = generate_hash_signature(message=msg, key=get_secret(UNSUBSCRIBE_KEY_NAME))
-    return urls.quick_link(payload=b64encode(msg), sig=b64encode(sig))
+    return urls.quick_link(context, payload=b64encode(msg), sig=b64encode(sig))
 
 
-def generate_do_not_email(user: User) -> str:
+def generate_do_not_email(context: CouchersContext, user: User) -> str:
     return _generate_quick_link(
+        context,
         unsubscribe_pb2.UnsubscribePayload(
             user_id=user.id,
             do_not_email=unsubscribe_pb2.DoNotEmail(),
-        )
+        ),
     )
 
 
-def generate_unsub_topic_key(notification: Notification) -> str:
+def generate_unsub_topic_key(context: CouchersContext, notification: Notification) -> str:
     if not notification.key:
         raise ValueError(
             f"Cannot generate topic_key unsubscribe link for notification with empty key "
             f"(topic_action={notification.topic_action})"
         )
     return _generate_quick_link(
+        context,
         unsubscribe_pb2.UnsubscribePayload(
             user_id=notification.user_id,
             topic_key=unsubscribe_pb2.UnsubscribeTopicKey(
                 topic=notification.topic,
                 key=notification.key,
             ),
-        )
+        ),
     )
 
 
-def generate_unsub_topic_action(notification: Notification) -> str:
+def generate_unsub_topic_action(context: CouchersContext, notification: Notification) -> str:
     return _generate_quick_link(
+        context,
         unsubscribe_pb2.UnsubscribePayload(
             user_id=notification.user_id,
             topic_action=unsubscribe_pb2.UnsubscribeTopicAction(
                 topic=notification.topic,
                 action=notification.action,
             ),
-        )
+        ),
     )
 
 
-def generate_quick_decline_link(host_request: requests_pb2.HostRequest) -> str:
+def generate_quick_decline_link(context: CouchersContext, host_request: requests_pb2.HostRequest) -> str:
     return _generate_quick_link(
+        context,
         unsubscribe_pb2.UnsubscribePayload(
             user_id=host_request.host_user_id,
             host_request_quick_decline=unsubscribe_pb2.HostRequestQuickDecline(
                 host_request_id=host_request.host_request_id,
             ),
-        )
+        ),
     )
 
 

--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -5,6 +5,7 @@ from typing import Any
 import couchers.email.emails as emails
 from couchers import urls
 from couchers.config import config
+from couchers.context import CouchersContext
 from couchers.email.calendar_events import create_host_request_attachment, create_host_request_cancellation_attachment
 from couchers.email.rendering import (
     EmailFooter,
@@ -13,7 +14,6 @@ from couchers.email.rendering import (
     render_html_body,
     render_plaintext_body,
 )
-from couchers.i18n import LocalizationContext
 from couchers.models import Notification, NotificationTopicAction, User
 from couchers.notifications.quick_links import (
     can_unsubscribe_topic_key,
@@ -41,9 +41,9 @@ class RenderedEmailNotification:
 
 
 def render_email_notification(
-    user: User, notification: Notification, loc_context: LocalizationContext, *, include_ics_attachments: bool
+    user: User, notification: Notification, context: CouchersContext, *, include_ics_attachments: bool
 ) -> RenderedEmailNotification:
-    footer = get_email_footer(user, notification, loc_context)
+    footer = get_email_footer(user, notification, context)
 
     subject: str
     body_plaintext: str
@@ -51,18 +51,18 @@ def render_email_notification(
     source_data: str | None = None
     # Progressively migrate to the new email templating system in couchers.email.emails,
     # which supports localization and uses a single generic html template.
-    if email := _get_generic_templated_email(user.name, notification):
-        subject = email.get_subject_line(loc_context)
-        preview = email.get_preview_line(loc_context)
-        body_blocks = email.get_body_blocks(loc_context)
-        body_plaintext = render_plaintext_body(blocks=body_blocks, footer=footer, loc_context=loc_context)
+    if email := _get_generic_templated_email(user.name, notification, context):
+        subject = email.get_subject_line(context)
+        preview = email.get_preview_line(context)
+        body_blocks = email.get_body_blocks(context)
+        body_plaintext = render_plaintext_body(blocks=body_blocks, footer=footer, loc_context=context.localization)
         body_html = render_html_body(
-            subject=subject, preview=preview, blocks=body_blocks, footer=footer, loc_context=loc_context
+            subject=subject, preview=preview, blocks=body_blocks, footer=footer, loc_context=context.localization
         )
         source_data = f"notification; topic-action={notification.topic_action}; version={config['VERSION']}"
     else:
         # Email is still a custom-templated, nonlocalizable email.
-        custom_templated = _get_custom_templated_email(notification, loc_context)
+        custom_templated = _get_custom_templated_email(notification, context)
         subject = custom_templated.subject
 
         template_args = {
@@ -78,20 +78,20 @@ def render_email_notification(
         plain_tmplt_body = (template_folder / f"{custom_templated.template_name}.txt").read_text()
         plain_tmplt_footer = (template_folder / "_footer.txt").read_text()
         plain_tmplt = Jinja2Template(source=plain_tmplt_body + plain_tmplt_footer, html=False)
-        body_plaintext = plain_tmplt.render(template_args, loc_context)
+        body_plaintext = plain_tmplt.render(template_args, context.localization)
 
         # Format html template
         html_tmplt = Jinja2Template(
             source=(template_folder / "generated_html" / f"{custom_templated.template_name}.html").read_text(),
             html=True,
         )
-        body_html = html_tmplt.render(template_args, loc_context)
+        body_html = html_tmplt.render(template_args, context.localization)
 
         source_data = config["VERSION"] + f"/{custom_templated.template_name}"
 
-    list_unsubscribe_header = get_list_unsubscribe_header(notification)
+    list_unsubscribe_header = get_list_unsubscribe_header(context, notification)
     if include_ics_attachments:
-        attachment = get_ics_attachment(notification, loc_context)
+        attachment = get_ics_attachment(notification, context)
     else:
         attachment = None
 
@@ -105,37 +105,39 @@ def render_email_notification(
     )
 
 
-def _get_generic_templated_email(user_name: str, notification: Notification) -> emails.EmailBase | None:
+def _get_generic_templated_email(
+    user_name: str, notification: Notification, context: CouchersContext
+) -> emails.EmailBase | None:
     data = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
     match notification.topic_action:
         case NotificationTopicAction.account_deletion__start:
-            return emails.AccountDeletionStartedEmail.from_notification(data, user_name=user_name)
+            return emails.AccountDeletionStartedEmail.from_notification(context, data, user_name=user_name)
         case NotificationTopicAction.account_deletion__complete:
-            return emails.AccountDeletionCompletedEmail.from_notification(data, user_name=user_name)
+            return emails.AccountDeletionCompletedEmail.from_notification(context, data, user_name=user_name)
         case NotificationTopicAction.account_deletion__recovered:
             return emails.AccountDeletionRecoveredEmail(user_name=user_name)
         case NotificationTopicAction.api_key__create:
-            return emails.APIKeyIssuedEmail.from_notification(data, user_name=user_name)
+            return emails.APIKeyIssuedEmail.from_notification(context, data, user_name=user_name)
         case NotificationTopicAction.badge__add:
-            return emails.BadgeChangedEmail.from_add_notification(data, user_name=user_name)
+            return emails.BadgeChangedEmail.from_add_notification(context, data, user_name=user_name)
         case NotificationTopicAction.badge__remove:
-            return emails.BadgeChangedEmail.from_remove_notification(data, user_name=user_name)
+            return emails.BadgeChangedEmail.from_remove_notification(context, data, user_name=user_name)
         case NotificationTopicAction.birthdate__change:
-            return emails.BirthdateChangedEmail.from_notification(data, user_name=user_name)
+            return emails.BirthdateChangedEmail.from_notification(context, data, user_name=user_name)
         case NotificationTopicAction.discussion__create:
-            return emails.DiscussionCreatedEmail.from_notification(data, user_name=user_name)
+            return emails.DiscussionCreatedEmail.from_notification(context, data, user_name=user_name)
         case NotificationTopicAction.discussion__comment:
-            return emails.DiscussionCommentEmail.from_notification(data, user_name=user_name)
+            return emails.DiscussionCommentEmail.from_notification(context, data, user_name=user_name)
         case NotificationTopicAction.email_address__change:
-            return emails.EmailAddressChangedEmail.from_notification(data, user_name=user_name)
+            return emails.EmailAddressChangedEmail.from_notification(context, data, user_name=user_name)
         case NotificationTopicAction.email_address__verify:
             return emails.EmailAddressVerifiedEmail(user_name=user_name)
         case NotificationTopicAction.friend_request__create:
-            return emails.FriendRequestReceivedEmail.from_notification(data, user_name=user_name)
+            return emails.FriendRequestReceivedEmail.from_notification(context, data, user_name=user_name)
         case NotificationTopicAction.friend_request__accept:
-            return emails.FriendRequestAcceptedEmail.from_notification(data, user_name=user_name)
+            return emails.FriendRequestAcceptedEmail.from_notification(context, data, user_name=user_name)
         case NotificationTopicAction.gender__change:
-            return emails.GenderChangedEmail.from_notification(data, user_name=user_name)
+            return emails.GenderChangedEmail.from_notification(context, data, user_name=user_name)
         case NotificationTopicAction.modnote__create:
             return emails.ModeratorNoteEmail(user_name=user_name)
         case NotificationTopicAction.password__change:
@@ -143,21 +145,21 @@ def _get_generic_templated_email(user_name: str, notification: Notification) -> 
         case NotificationTopicAction.password_reset__complete:
             return emails.PasswordResetCompletedEmail(user_name=user_name)
         case NotificationTopicAction.password_reset__start:
-            return emails.PasswordResetStartedEmail.from_notification(data, user_name=user_name)
+            return emails.PasswordResetStartedEmail.from_notification(context, data, user_name=user_name)
         case NotificationTopicAction.phone_number__change:
-            return emails.PhoneNumberChangeEmail.from_change_notification(data, user_name=user_name)
+            return emails.PhoneNumberChangeEmail.from_change_notification(context, data, user_name=user_name)
         case NotificationTopicAction.phone_number__verify:
-            return emails.PhoneNumberChangeEmail.from_verify_notification(data, user_name=user_name)
+            return emails.PhoneNumberChangeEmail.from_verify_notification(context, data, user_name=user_name)
         case NotificationTopicAction.postal_verification__failed:
-            return emails.PostalVerificationFailedEmail.from_notification(data, user_name=user_name)
+            return emails.PostalVerificationFailedEmail.from_notification(context, data, user_name=user_name)
         case NotificationTopicAction.postal_verification__postcard_sent:
-            return emails.PostalVerificationPostcardSentEmail.from_notification(data, user_name=user_name)
+            return emails.PostalVerificationPostcardSentEmail.from_notification(context, data, user_name=user_name)
         case NotificationTopicAction.postal_verification__success:
             return emails.PostalVerificationSucceededEmail(user_name=user_name)
         case NotificationTopicAction.thread__reply:
-            return emails.ThreadReplyEmail.from_notification(data, user_name=user_name)
+            return emails.ThreadReplyEmail.from_notification(context, data, user_name=user_name)
         case NotificationTopicAction.verification__sv_fail:
-            return emails.StrongVerificationFailedEmail.from_notification(data, user_name=user_name)
+            return emails.StrongVerificationFailedEmail.from_notification(context, data, user_name=user_name)
         case NotificationTopicAction.verification__sv_success:
             return emails.StrongVerificationSucceededEmail(user_name=user_name)
         case _:
@@ -179,10 +181,10 @@ class CustomTemplatedEmail:
 
 # Gets the data necessary to template an email for which we have a custom template,
 # e.g. not yet using couchers.email.emails.
-def _get_custom_templated_email(notification: Notification, loc_context: LocalizationContext) -> CustomTemplatedEmail:
+def _get_custom_templated_email(notification: Notification, context: CouchersContext) -> CustomTemplatedEmail:
     data = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
     if notification.topic == "host_request":
-        view_link = urls.host_request(host_request_id=data.host_request.host_request_id)
+        view_link = urls.host_request(context, host_request_id=data.host_request.host_request_id)
         if notification.action == "missed_messages":
             their_your = "their" if data.am_host else "your"
             other = data.user
@@ -196,7 +198,7 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
                     "view_link": view_link,
                     "host_request": data.host_request,
                     "message": message,
-                    "other": UserTemplateArgs.from_protobuf_user(other),
+                    "other": UserTemplateArgs.from_protobuf_user(context, other),
                 },
             )
         elif notification.action == "create":
@@ -208,10 +210,10 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
                 template_name="host_request__new",
                 template_args={
                     "view_link": view_link,
-                    "quick_decline_link": generate_quick_decline_link(data.host_request),
+                    "quick_decline_link": generate_quick_decline_link(context, data.host_request),
                     "host_request": data.host_request,
                     "message": message,
-                    "other": UserTemplateArgs.from_protobuf_user(other),
+                    "other": UserTemplateArgs.from_protobuf_user(context, other),
                     "text": data.text,
                 },
             )
@@ -229,7 +231,7 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
                     "view_link": view_link,
                     "host_request": data.host_request,
                     "message": message,
-                    "other": UserTemplateArgs.from_protobuf_user(other),
+                    "other": UserTemplateArgs.from_protobuf_user(context, other),
                     "text": data.text,
                 },
             )
@@ -256,7 +258,7 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
                     "view_link": view_link,
                     "host_request": data.host_request,
                     "message": message,
-                    "other": UserTemplateArgs.from_protobuf_user(other),
+                    "other": UserTemplateArgs.from_protobuf_user(context, other),
                 },
             )
         elif notification.action == "reminder":
@@ -270,12 +272,12 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
                     "view_link": view_link,
                     "host_request": data.host_request,
                     "message": description,
-                    "other": UserTemplateArgs.from_protobuf_user(data.surfer),
+                    "other": UserTemplateArgs.from_protobuf_user(context, data.surfer),
                 },
             )
     elif notification.topic_action == NotificationTopicAction.donation__received:
-        title = loc_context.localize_string("notifications.donation_received.title")
-        message = loc_context.localize_string(
+        title = context.localization.localize_string("notifications.donation_received.title")
+        message = context.localization.localize_string(
             "notifications.donation_received.thanks_amount",
             substitutions={
                 "amount": data.amount,
@@ -296,10 +298,10 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
             preview="You received a message on Couchers.org!",
             template_name="chat_message",
             template_args={
-                "author": UserTemplateArgs.from_protobuf_user(data.author),
+                "author": UserTemplateArgs.from_protobuf_user(context, data.author),
                 "message": data.message,
                 "text": data.text,
-                "view_link": urls.chat_link(chat_id=data.group_chat_id),
+                "view_link": urls.chat_link(context, chat_id=data.group_chat_id),
             },
         )
     elif notification.topic_action == NotificationTopicAction.chat__missed_messages:
@@ -310,10 +312,10 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
             template_args={
                 "items": [
                     {
-                        "author": UserTemplateArgs.from_protobuf_user(item.author),
+                        "author": UserTemplateArgs.from_protobuf_user(context, item.author),
                         "message": item.message,
                         "text": item.text,
-                        "view_link": urls.chat_link(chat_id=item.group_chat_id),
+                        "view_link": urls.chat_link(context, chat_id=item.group_chat_id),
                     }
                     for item in data.messages
                 ]
@@ -321,10 +323,10 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
         )
     elif notification.topic == "event":
         event = data.event
-        start_time = loc_context.localize_datetime(event.start_time)
-        end_time = loc_context.localize_datetime(event.end_time)
+        start_time = context.localization.localize_datetime(event.start_time)
+        end_time = context.localization.localize_datetime(event.end_time)
         time_display = f"{start_time} - {end_time}"
-        event_link = urls.event_link(occurrence_id=event.event_id, slug=event.slug)
+        event_link = urls.event_link(context, occurrence_id=event.event_id, slug=event.slug)
         if notification.action in ["create_approved", "create_any"]:
             # create_approved = invitation, approved by mods
             # create_any = new event created by anyone (no need for approval) -- off by default
@@ -335,7 +337,7 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
                 subject = f'{data.inviting_user.name} created an event called "{event.title}"'
                 start_text = "A new event was created"
             community_link = (
-                urls.community_link(node_id=data.in_community.community_id, slug=data.in_community.slug)
+                urls.community_link(context, node_id=data.in_community.community_id, slug=data.in_community.slug)
                 if data.in_community
                 else None
             )
@@ -344,7 +346,7 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
                 preview=f"{start_text} on Couchers.org!",
                 template_name="event_create",
                 template_args={
-                    "inviting_user": UserTemplateArgs.from_protobuf_user(data.inviting_user),
+                    "inviting_user": UserTemplateArgs.from_protobuf_user(context, data.inviting_user),
                     "time_display": time_display,
                     "start_text": start_text,
                     "nearby": "nearby" if data.nearby else None,
@@ -361,7 +363,7 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
                 preview="An event you are subscribed to was updated.",
                 template_name="event_update",
                 template_args={
-                    "updating_user": UserTemplateArgs.from_protobuf_user(data.updating_user),
+                    "updating_user": UserTemplateArgs.from_protobuf_user(context, data.updating_user),
                     "time_display": time_display,
                     "event": event,
                     "updated_text": updated_text,
@@ -374,7 +376,7 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
                 preview="An event you are subscribed to has been cancelled.",
                 template_name="event_cancel",
                 template_args={
-                    "cancelling_user": UserTemplateArgs.from_protobuf_user(data.cancelling_user),
+                    "cancelling_user": UserTemplateArgs.from_protobuf_user(context, data.cancelling_user),
                     "time_display": time_display,
                     "event": event,
                     "view_link": event_link,
@@ -396,7 +398,7 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
                 preview="You were invited to co-organize an event on Couchers.org.",
                 template_name="event_invite_organizer",
                 template_args={
-                    "inviting_user": UserTemplateArgs.from_protobuf_user(data.inviting_user),
+                    "inviting_user": UserTemplateArgs.from_protobuf_user(context, data.inviting_user),
                     "time_display": time_display,
                     "event": event,
                     "view_link": event_link,
@@ -408,7 +410,7 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
                 preview="Someone commented on an event you are attending.",
                 template_name="event_comment",
                 template_args={
-                    "author": UserTemplateArgs.from_protobuf_user(data.author),
+                    "author": UserTemplateArgs.from_protobuf_user(context, data.author),
                     "time_display": time_display,
                     "event": event,
                     "content": data.reply.content,
@@ -434,8 +436,8 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
                 preview=data.text,
                 template_name="friend_reference",
                 template_args={
-                    "from_user": UserTemplateArgs.from_protobuf_user(data.from_user),
-                    "profile_references_link": urls.profile_references_link(),
+                    "from_user": UserTemplateArgs.from_protobuf_user(context, data.from_user),
+                    "profile_references_link": urls.profile_references_link(context),
                     "text": data.text,
                 },
             )
@@ -444,11 +446,12 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
             # what was my type? i surfed with them if i received a "hosted" request
             surfed = notification.action == "receive_hosted"
             leave_reference_link = urls.leave_reference_link(
+                context,
                 reference_type="surfed" if surfed else "hosted",
                 to_user_id=data.from_user.user_id,
                 host_request_id=data.host_request_id,
             )
-            profile_references_link = urls.profile_references_link()
+            profile_references_link = urls.profile_references_link(context)
             if data.text:
                 preview = data.text
             else:
@@ -458,7 +461,7 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
                 preview=preview,
                 template_name="host_reference",
                 template_args={
-                    "from_user": UserTemplateArgs.from_protobuf_user(data.from_user),
+                    "from_user": UserTemplateArgs.from_protobuf_user(context, data.from_user),
                     "leave_reference_link": leave_reference_link,
                     "profile_references_link": profile_references_link,
                     "text": data.text,
@@ -470,6 +473,7 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
             # what was my type? i surfed with them if i get a surfed reminder
             surfed = notification.action == "reminder_surfed"
             leave_reference_link = urls.leave_reference_link(
+                context,
                 reference_type="surfed" if surfed else "hosted",
                 to_user_id=data.other_user.user_id,
                 host_request_id=data.host_request_id,
@@ -481,7 +485,7 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
                 preview=preview,
                 template_name="reference_reminder",
                 template_args={
-                    "other_user": UserTemplateArgs.from_protobuf_user(data.other_user),
+                    "other_user": UserTemplateArgs.from_protobuf_user(context, data.other_user),
                     "leave_reference_link": leave_reference_link,
                     "days_left": str(data.days_left),
                     "surfed": surfed,
@@ -494,8 +498,8 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
                 preview="We are so excited to have you join our community!",
                 template_name="onboarding1",
                 template_args={
-                    "app_link": urls.app_link(),
-                    "edit_profile_link": urls.edit_profile_link(),
+                    "app_link": urls.app_link(context),
+                    "edit_profile_link": urls.edit_profile_link(context),
                 },
             )
         elif notification.key == "2":
@@ -504,7 +508,7 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
                 preview="We would ask one big favour of you: please fill out your profile by adding a photo and some text.",
                 template_name="onboarding2",
                 template_args={
-                    "edit_profile_link": urls.edit_profile_link(),
+                    "edit_profile_link": urls.edit_profile_link(context),
                 },
             )
     elif notification.topic_action == NotificationTopicAction.activeness__probe:
@@ -514,7 +518,7 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
             preview=title,
             template_name="activeness_probe",
             template_args={
-                "app_link": urls.app_link(),
+                "app_link": urls.app_link(context),
                 "days_left": (to_aware_datetime(data.deadline) - now()).days,
             },
         )
@@ -534,29 +538,29 @@ def _get_custom_templated_email(notification: Notification, loc_context: Localiz
     raise NotImplementedError(f"Unknown topic-action: {notification.topic}:{notification.action}")
 
 
-def get_ics_attachment(notification: Notification, loc_context: LocalizationContext) -> EmailAttachment | None:
+def get_ics_attachment(notification: Notification, context: CouchersContext) -> EmailAttachment | None:
     data = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
     if notification.topic_action == NotificationTopicAction.host_request__accept:
         # Caveat: The surfer technically still hasn't confirmed, but when they do they don't receive an email,
         # so the accept notification is our last opportunity to provide them with a calendar event.
         return create_host_request_attachment(
-            data.host_request, other_name=data.host.name, hosting=False, loc_context=loc_context
+            data.host_request, other_name=data.host.name, hosting=False, context=context
         )
     elif notification.topic_action == NotificationTopicAction.host_request__confirm:
         return create_host_request_attachment(
-            data.host_request, other_name=data.surfer.name, hosting=True, loc_context=loc_context
+            data.host_request, other_name=data.surfer.name, hosting=True, context=context
         )
     elif notification.topic_action == NotificationTopicAction.host_request__cancel:
         # Caveat: only the party getting cancelled receives this notification,
         # we have no opportunity to provide the cancelling party with a cancelled ics attachment.
         return create_host_request_cancellation_attachment(
-            data.host_request, other_name=data.surfer.name, hosting=True, loc_context=loc_context
+            data.host_request, other_name=data.surfer.name, hosting=True, context=context
         )
     else:
         return None
 
 
-def get_list_unsubscribe_header(notification: Notification) -> str | None:
+def get_list_unsubscribe_header(context: CouchersContext, notification: Notification) -> str | None:
     if notification.topic_action.is_critical:
         return None
 
@@ -564,9 +568,9 @@ def get_list_unsubscribe_header(notification: Notification) -> str | None:
     # Prefer topic-key unsubscription as it is more specific than topic-action (e.g. current chat, not all chats).
     list_unsubscribe_url: str
     if can_unsubscribe_topic_key(notification.topic_action):
-        list_unsubscribe_url = generate_unsub_topic_key(notification)
+        list_unsubscribe_url = generate_unsub_topic_key(context, notification)
     else:
-        list_unsubscribe_url = generate_unsub_topic_action(notification)
+        list_unsubscribe_url = generate_unsub_topic_action(context, notification)
 
     return f"<{list_unsubscribe_url}>"
 
@@ -659,20 +663,20 @@ def get_topic_key_unsubscribe_text(topic_action: NotificationTopicAction) -> str
             raise NotImplementedError(f"No topic-key unsubscribe text for {topic_action}.")
 
 
-def get_email_footer(user: User, notification: Notification, loc_context: LocalizationContext) -> EmailFooter:
+def get_email_footer(user: User, notification: Notification, context: CouchersContext) -> EmailFooter:
     return EmailFooter(
-        timezone_name=loc_context.localized_timezone,
+        timezone_name=context.localization.localized_timezone,
         copyright_year=now().year,
         unsubscribe_info=UnsubscribeInfo(
-            manage_notifications_url=urls.notification_settings_link(),
-            do_not_email_url=generate_do_not_email(user),
+            manage_notifications_url=urls.notification_settings_link(context),
+            do_not_email_url=generate_do_not_email(context, user),
             topic_action_link=UnsubscribeLink(
                 text=get_topic_action_unsubscribe_text(notification.topic_action),
-                url=generate_unsub_topic_action(notification),
+                url=generate_unsub_topic_action(context, notification),
             ),
             topic_key_link=UnsubscribeLink(
                 text=get_topic_key_unsubscribe_text(notification.topic_action),
-                url=generate_unsub_topic_key(notification),
+                url=generate_unsub_topic_key(context, notification),
             )
             if can_unsubscribe_topic_key(notification.topic_action)
             else None,
@@ -696,11 +700,11 @@ class UserTemplateArgs:
     profile_url: str
 
     @staticmethod
-    def from_protobuf_user(user: api_pb2.User) -> UserTemplateArgs:
+    def from_protobuf_user(context: CouchersContext, user: api_pb2.User) -> UserTemplateArgs:
         return UserTemplateArgs(
             name=user.name,
             age=user.age,
             city=user.city,
-            avatar_url=user.avatar_thumbnail_url or urls.icon_url(),
-            profile_url=urls.user_link(username=user.username),
+            avatar_url=user.avatar_thumbnail_url or urls.icon_url(context),
+            profile_url=urls.user_link(context, username=user.username),
         )

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -7,7 +7,7 @@ from datetime import date
 from typing import Any, assert_never
 
 from couchers import urls
-from couchers.i18n import LocalizationContext
+from couchers.context import CouchersContext
 from couchers.i18n.i18next import LocalizationError
 from couchers.i18n.localize import format_phone_number
 from couchers.models import Notification, NotificationTopicAction
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 # See PushNotificationContent's documentation for notification writing guidelines.
 
 
-def render_push_notification(notification: Notification, loc_context: LocalizationContext) -> PushNotificationContent:
+def render_push_notification(notification: Notification, context: CouchersContext) -> PushNotificationContent:
     data: Any = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
 
     match notification.topic_action:
@@ -29,124 +29,124 @@ def render_push_notification(notification: Notification, loc_context: Localizati
         # as mypy wouldn't allow that in a single function.
         # Keep topics sorted (actions can follow logical ordering)
         case NotificationTopicAction.account_deletion__start:
-            return _render_account_deletion__start(data, loc_context)
+            return _render_account_deletion__start(data, context)
         case NotificationTopicAction.account_deletion__complete:
-            return _render_account_deletion__complete(data, loc_context)
+            return _render_account_deletion__complete(data, context)
         case NotificationTopicAction.account_deletion__recovered:
-            return _render_account_deletion__recovered(loc_context)
+            return _render_account_deletion__recovered(context)
         case NotificationTopicAction.activeness__probe:
-            return _render_activeness__probe(data, loc_context)
+            return _render_activeness__probe(data, context)
         case NotificationTopicAction.api_key__create:
-            return _render_api_key__create(data, loc_context)
+            return _render_api_key__create(data, context)
         case NotificationTopicAction.badge__add:
-            return _render_badge__add(data, loc_context)
+            return _render_badge__add(data, context)
         case NotificationTopicAction.badge__remove:
-            return _render_badge__remove(data, loc_context)
+            return _render_badge__remove(data, context)
         case NotificationTopicAction.birthdate__change:
-            return _render_birthdate__change(data, loc_context)
+            return _render_birthdate__change(data, context)
         case NotificationTopicAction.chat__message:
-            return _render_chat__message(data, loc_context)
+            return _render_chat__message(data, context)
         case NotificationTopicAction.chat__missed_messages:
-            return _render_chat__missed_messages(data, loc_context)
+            return _render_chat__missed_messages(data, context)
         case NotificationTopicAction.donation__received:
-            return _render_donation__received(data, loc_context)
+            return _render_donation__received(data, context)
         case NotificationTopicAction.discussion__create:
-            return _render_discussion__create(data, loc_context)
+            return _render_discussion__create(data, context)
         case NotificationTopicAction.discussion__comment:
-            return _render_discussion__comment(data, loc_context)
+            return _render_discussion__comment(data, context)
         case NotificationTopicAction.email_address__change:
-            return _render_email_address__change(data, loc_context)
+            return _render_email_address__change(data, context)
         case NotificationTopicAction.email_address__verify:
-            return _render_email_address__verify(loc_context)
+            return _render_email_address__verify(context)
         case NotificationTopicAction.event__create_any:
-            return _render_event__create_any(data, loc_context)
+            return _render_event__create_any(data, context)
         case NotificationTopicAction.event__create_approved:
-            return _render_event__create_approved(data, loc_context)
+            return _render_event__create_approved(data, context)
         case NotificationTopicAction.event__update:
-            return _render_event__update(data, loc_context)
+            return _render_event__update(data, context)
         case NotificationTopicAction.event__invite_organizer:
-            return _render_event__invite_organizer(data, loc_context)
+            return _render_event__invite_organizer(data, context)
         case NotificationTopicAction.event__comment:
-            return _render_event__comment(data, loc_context)
+            return _render_event__comment(data, context)
         case NotificationTopicAction.event__reminder:
-            return _render_event__reminder(data, loc_context)
+            return _render_event__reminder(data, context)
         case NotificationTopicAction.event__cancel:
-            return _render_event__cancel(data, loc_context)
+            return _render_event__cancel(data, context)
         case NotificationTopicAction.event__delete:
-            return _render_event__delete(data, loc_context)
+            return _render_event__delete(data, context)
         case NotificationTopicAction.friend_request__create:
-            return _render_friend_request__create(data, loc_context)
+            return _render_friend_request__create(data, context)
         case NotificationTopicAction.friend_request__accept:
-            return _render_friend_request__accept(data, loc_context)
+            return _render_friend_request__accept(data, context)
         case NotificationTopicAction.gender__change:
-            return _render_gender__change(data, loc_context)
+            return _render_gender__change(data, context)
         case NotificationTopicAction.general__new_blog_post:
-            return _render_general__new_blog_post(data, loc_context)
+            return _render_general__new_blog_post(data, context)
         case NotificationTopicAction.host_request__create:
-            return _render_host_request__create(data, loc_context)
+            return _render_host_request__create(data, context)
         case NotificationTopicAction.host_request__message:
-            return _render_host_request__message(data, loc_context)
+            return _render_host_request__message(data, context)
         case NotificationTopicAction.host_request__missed_messages:
-            return _render_host_request__missed_messages(data, loc_context)
+            return _render_host_request__missed_messages(data, context)
         case NotificationTopicAction.host_request__reminder:
-            return _render_host_request__reminder(data, loc_context)
+            return _render_host_request__reminder(data, context)
         case NotificationTopicAction.host_request__accept:
-            return _render_host_request__accept(data, loc_context)
+            return _render_host_request__accept(data, context)
         case NotificationTopicAction.host_request__reject:
-            return _render_host_request__reject(data, loc_context)
+            return _render_host_request__reject(data, context)
         case NotificationTopicAction.host_request__cancel:
-            return _render_host_request__cancel(data, loc_context)
+            return _render_host_request__cancel(data, context)
         case NotificationTopicAction.host_request__confirm:
-            return _render_host_request__confirm(data, loc_context)
+            return _render_host_request__confirm(data, context)
         case NotificationTopicAction.modnote__create:
-            return _render_modnote__create(loc_context)
+            return _render_modnote__create(context)
         case NotificationTopicAction.onboarding__reminder:
-            return _render_onboarding__reminder(notification.key, loc_context)
+            return _render_onboarding__reminder(notification.key, context)
         case NotificationTopicAction.password__change:
-            return _render_password__change(loc_context)
+            return _render_password__change(context)
         case NotificationTopicAction.password_reset__start:
-            return _render_password_reset__start(data, loc_context)
+            return _render_password_reset__start(data, context)
         case NotificationTopicAction.password_reset__complete:
-            return _render_password_reset__complete(loc_context)
+            return _render_password_reset__complete(context)
         case NotificationTopicAction.phone_number__change:
-            return _render_phone_number__change(data, loc_context)
+            return _render_phone_number__change(data, context)
         case NotificationTopicAction.phone_number__verify:
-            return _render_phone_number__verify(data, loc_context)
+            return _render_phone_number__verify(data, context)
         case NotificationTopicAction.postal_verification__postcard_sent:
-            return _render_postal_verification__postcard_sent(data, loc_context)
+            return _render_postal_verification__postcard_sent(data, context)
         case NotificationTopicAction.postal_verification__success:
-            return _render_postal_verification__success(loc_context)
+            return _render_postal_verification__success(context)
         case NotificationTopicAction.postal_verification__failed:
-            return _render_postal_verification__failed(data, loc_context)
+            return _render_postal_verification__failed(data, context)
         case NotificationTopicAction.reference__receive_friend:
-            return _render_reference__receive_friend(data, loc_context)
+            return _render_reference__receive_friend(data, context)
         case NotificationTopicAction.reference__receive_hosted:
-            return _render_reference__receive_hosted(data, loc_context)
+            return _render_reference__receive_hosted(data, context)
         case NotificationTopicAction.reference__receive_surfed:
-            return _render_reference__receive_surfed(data, loc_context)
+            return _render_reference__receive_surfed(data, context)
         case NotificationTopicAction.reference__reminder_hosted:
-            return _render_reference__reminder_hosted(data, loc_context)
+            return _render_reference__reminder_hosted(data, context)
         case NotificationTopicAction.reference__reminder_surfed:
-            return _render_reference__reminder_surfed(data, loc_context)
+            return _render_reference__reminder_surfed(data, context)
         case NotificationTopicAction.thread__reply:
-            return _render_thread__reply(data, loc_context)
+            return _render_thread__reply(data, context)
         case NotificationTopicAction.verification__sv_success:
-            return _render_verification__sv_success(loc_context)
+            return _render_verification__sv_success(context)
         case NotificationTopicAction.verification__sv_fail:
-            return _render_verification__sv_fail(data, loc_context)
+            return _render_verification__sv_fail(data, context)
         case _:
             # Enables mypy's exhaustiveness checking for the cases above.
             assert_never(notification.topic_action)
 
 
-def render_adhoc_push_notification(name: str, loc_context: LocalizationContext) -> PushNotificationContent:
+def render_adhoc_push_notification(name: str, context: CouchersContext) -> PushNotificationContent:
     """Renders a push notification that doesn't have an assigned topic-action."""
-    return _get_content(string_group=f"_adhoc.{name}.push", loc_context=loc_context)
+    return _get_content(string_group=f"_adhoc.{name}.push", context=context)
 
 
 def _get_content(
     string_group: NotificationTopicAction | str,
-    loc_context: LocalizationContext,
+    context: CouchersContext,
     title: str | None = None,
     ios_title: str | None = None,
     ios_subtitle: str | None = None,
@@ -164,19 +164,19 @@ def _get_content(
     """
     # Look up the localized string for any string that was not provided
     if title is None:
-        title = _get_string(string_group, "title", loc_context, substitutions)
+        title = _get_string(string_group, "title", context, substitutions)
     if ios_title is None:
-        ios_title = _get_string(string_group, "ios_title", loc_context, substitutions)
+        ios_title = _get_string(string_group, "ios_title", context, substitutions)
     if ios_subtitle is None:
         try:
-            ios_subtitle = _get_string(string_group, "ios_subtitle", loc_context, substitutions)
+            ios_subtitle = _get_string(string_group, "ios_subtitle", context, substitutions)
         except LocalizationError:
             # Not all notifications have subtitles
             pass
     if body is None:
-        body = _get_string(string_group, "body", loc_context, substitutions)
+        body = _get_string(string_group, "body", context, substitutions)
 
-    icon_url = _avatar_url_or_default(icon_user) if icon_user else None
+    icon_url = _avatar_url_or_default(context, icon_user) if icon_user else None
 
     return PushNotificationContent(
         title=title, ios_title=ios_title, ios_subtitle=ios_subtitle, body=body, icon_url=icon_url, action_url=action_url
@@ -186,113 +186,107 @@ def _get_content(
 def _get_string(
     string_group: NotificationTopicAction | str,
     key: str,
-    loc_context: LocalizationContext,
+    context: CouchersContext,
     substitutions: dict[str, str | int] | None = None,
 ) -> str:
     if isinstance(string_group, NotificationTopicAction):
         full_key = f"{string_group.topic}.{string_group.action}.push.{key}"
     else:
         full_key = f"{string_group}.{key}"
-    return get_notifs_i18next().localize(full_key, loc_context.locale, substitutions)
+    return get_notifs_i18next().localize(full_key, context.localization.locale, substitutions)
 
 
-def _avatar_url_or_default(user: api_pb2.User) -> str:
-    return user.avatar_thumbnail_url or urls.icon_url()
+def _avatar_url_or_default(context: CouchersContext, user: api_pb2.User) -> str:
+    return user.avatar_thumbnail_url or urls.icon_url(context)
 
 
 def _render_account_deletion__start(
-    data: notification_data_pb2.AccountDeletionStart, loc_context: LocalizationContext
+    data: notification_data_pb2.AccountDeletionStart, context: CouchersContext
 ) -> PushNotificationContent:
-    return _get_content(NotificationTopicAction.account_deletion__start, loc_context)
+    return _get_content(NotificationTopicAction.account_deletion__start, context)
 
 
 def _render_account_deletion__complete(
-    data: notification_data_pb2.AccountDeletionComplete, loc_context: LocalizationContext
+    data: notification_data_pb2.AccountDeletionComplete, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
-        NotificationTopicAction.account_deletion__complete, loc_context, substitutions={"count": data.undelete_days}
+        NotificationTopicAction.account_deletion__complete, context, substitutions={"count": data.undelete_days}
     )
 
 
-def _render_account_deletion__recovered(loc_context: LocalizationContext) -> PushNotificationContent:
-    return _get_content(NotificationTopicAction.account_deletion__recovered, loc_context)
+def _render_account_deletion__recovered(context: CouchersContext) -> PushNotificationContent:
+    return _get_content(NotificationTopicAction.account_deletion__recovered, context)
 
 
 def _render_activeness__probe(
-    data: notification_data_pb2.ActivenessProbe, loc_context: LocalizationContext
+    data: notification_data_pb2.ActivenessProbe, context: CouchersContext
 ) -> PushNotificationContent:
-    return _get_content(NotificationTopicAction.activeness__probe, loc_context)
+    return _get_content(NotificationTopicAction.activeness__probe, context)
 
 
 def _render_api_key__create(
-    data: notification_data_pb2.ApiKeyCreate, loc_context: LocalizationContext
+    data: notification_data_pb2.ApiKeyCreate, context: CouchersContext
 ) -> PushNotificationContent:
-    return _get_content(NotificationTopicAction.api_key__create, loc_context)
+    return _get_content(NotificationTopicAction.api_key__create, context)
 
 
-def _render_badge__add(
-    data: notification_data_pb2.BadgeAdd, loc_context: LocalizationContext
-) -> PushNotificationContent:
+def _render_badge__add(data: notification_data_pb2.BadgeAdd, context: CouchersContext) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.badge__add,
-        loc_context,
+        context,
         substitutions={"badge_name": data.badge_name},
-        action_url=urls.profile_link(),
+        action_url=urls.profile_link(context),
     )
 
 
-def _render_badge__remove(
-    data: notification_data_pb2.BadgeRemove, loc_context: LocalizationContext
-) -> PushNotificationContent:
+def _render_badge__remove(data: notification_data_pb2.BadgeRemove, context: CouchersContext) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.badge__remove,
-        loc_context,
+        context,
         substitutions={"badge_name": data.badge_name},
-        action_url=urls.profile_link(),
+        action_url=urls.profile_link(context),
     )
 
 
 def _render_birthdate__change(
-    data: notification_data_pb2.BirthdateChange, loc_context: LocalizationContext
+    data: notification_data_pb2.BirthdateChange, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.birthdate__change,
-        loc_context,
-        substitutions={"birthdate": loc_context.localize_date_from_iso(data.birthdate)},
-        action_url=urls.account_settings_link(),
+        context,
+        substitutions={"birthdate": context.localization.localize_date_from_iso(data.birthdate)},
+        action_url=urls.account_settings_link(context),
     )
 
 
-def _render_chat__message(
-    data: notification_data_pb2.ChatMessage, loc_context: LocalizationContext
-) -> PushNotificationContent:
+def _render_chat__message(data: notification_data_pb2.ChatMessage, context: CouchersContext) -> PushNotificationContent:
     # All strings are dynamic, no need to use _get_content
     return PushNotificationContent(
         title=data.author.name,
         ios_title=data.author.name,
         body=data.text,
-        icon_url=_avatar_url_or_default(data.author),
-        action_url=urls.chat_link(chat_id=data.group_chat_id),
+        icon_url=_avatar_url_or_default(context, data.author),
+        action_url=urls.chat_link(context, chat_id=data.group_chat_id),
     )
 
 
 def _render_chat__missed_messages(
-    data: notification_data_pb2.ChatMissedMessages, loc_context: LocalizationContext
+    data: notification_data_pb2.ChatMissedMessages, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.chat__missed_messages,
-        loc_context,
+        context,
         substitutions={"count": len(data.messages)},
-        action_url=urls.messages_link(),
+        action_url=urls.messages_link(context),
     )
 
 
 def _render_donation__received(
-    data: notification_data_pb2.DonationReceived, loc_context: LocalizationContext
+    data: notification_data_pb2.DonationReceived, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.donation__received,
-        loc_context,
+        context,
         # Other currencies are not yet supported
         substitutions={"amount_with_currency": f"${data.amount}"},
         action_url=data.receipt_url,
@@ -300,206 +294,204 @@ def _render_donation__received(
 
 
 def _render_discussion__create(
-    data: notification_data_pb2.DiscussionCreate, loc_context: LocalizationContext
+    data: notification_data_pb2.DiscussionCreate, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.discussion__create,
-        loc_context,
+        context,
         substitutions={
             "title": data.discussion.title,
             "user": data.author.name,
             "group_or_community": data.discussion.owner_title,
         },
         icon_user=data.author,
-        action_url=urls.discussion_link(discussion_id=data.discussion.discussion_id, slug=data.discussion.slug),
+        action_url=urls.discussion_link(
+            context, discussion_id=data.discussion.discussion_id, slug=data.discussion.slug
+        ),
     )
 
 
 def _render_discussion__comment(
-    data: notification_data_pb2.DiscussionComment, loc_context: LocalizationContext
+    data: notification_data_pb2.DiscussionComment, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.discussion__comment,
-        loc_context,
+        context,
         ios_title=data.author.name,
         ios_subtitle=data.discussion.title,
         body=data.reply.content,
         substitutions={"user": data.author.name, "title": data.discussion.title},
         icon_user=data.author,
-        action_url=urls.discussion_link(discussion_id=data.discussion.discussion_id, slug=data.discussion.slug),
+        action_url=urls.discussion_link(
+            context, discussion_id=data.discussion.discussion_id, slug=data.discussion.slug
+        ),
     )
 
 
 def _render_email_address__change(
-    data: notification_data_pb2.EmailAddressChange, loc_context: LocalizationContext
+    data: notification_data_pb2.EmailAddressChange, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.email_address__change,
-        loc_context,
+        context,
         substitutions={"email": data.new_email},
-        action_url=urls.account_settings_link(),
+        action_url=urls.account_settings_link(context),
     )
 
 
-def _render_email_address__verify(loc_context: LocalizationContext) -> PushNotificationContent:
+def _render_email_address__verify(context: CouchersContext) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.email_address__verify,
-        loc_context,
-        action_url=urls.account_settings_link(),
+        context,
+        action_url=urls.account_settings_link(context),
     )
 
 
 def _render_event__create_any(
-    data: notification_data_pb2.EventCreate, loc_context: LocalizationContext
+    data: notification_data_pb2.EventCreate, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.event__create_any,
-        loc_context,
+        context,
         substitutions={
             "title": data.event.title,
             "user": data.inviting_user.name,
-            "date_and_time": loc_context.localize_datetime(data.event.start_time),
+            "date_and_time": context.localization.localize_datetime(data.event.start_time),
         },
-        action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
+        action_url=urls.event_link(context, occurrence_id=data.event.event_id, slug=data.event.slug),
     )
 
 
 def _render_event__create_approved(
-    data: notification_data_pb2.EventCreate, loc_context: LocalizationContext
+    data: notification_data_pb2.EventCreate, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.event__create_approved,
-        loc_context,
+        context,
         substitutions={
             "title": data.event.title,
             "user": data.inviting_user.name,
-            "date_and_time": loc_context.localize_datetime(data.event.start_time),
+            "date_and_time": context.localization.localize_datetime(data.event.start_time),
         },
-        action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
+        action_url=urls.event_link(context, occurrence_id=data.event.event_id, slug=data.event.slug),
     )
 
 
-def _render_event__update(
-    data: notification_data_pb2.EventUpdate, loc_context: LocalizationContext
-) -> PushNotificationContent:
+def _render_event__update(data: notification_data_pb2.EventUpdate, context: CouchersContext) -> PushNotificationContent:
     # updated_items can include: title, content, start_time, end_time, location,
     # but a list like that is tricky to localize.
     return _get_content(
         NotificationTopicAction.event__update,
-        loc_context,
+        context,
         substitutions={
             "title": data.event.title,
             "user": data.updating_user.name,
         },
-        action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
+        action_url=urls.event_link(context, occurrence_id=data.event.event_id, slug=data.event.slug),
     )
 
 
 def _render_event__invite_organizer(
-    data: notification_data_pb2.EventInviteOrganizer, loc_context: LocalizationContext
+    data: notification_data_pb2.EventInviteOrganizer, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.event__invite_organizer,
-        loc_context,
+        context,
         substitutions={
             "title": data.event.title,
             "user": data.inviting_user.name,
         },
-        action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
+        action_url=urls.event_link(context, occurrence_id=data.event.event_id, slug=data.event.slug),
     )
 
 
 def _render_event__comment(
-    data: notification_data_pb2.EventComment, loc_context: LocalizationContext
+    data: notification_data_pb2.EventComment, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.event__comment,
-        loc_context,
+        context,
         substitutions={
             "title": data.event.title,
             "user": data.author.name,
         },
         body=data.reply.content,
         icon_user=data.author,
-        action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
+        action_url=urls.event_link(context, occurrence_id=data.event.event_id, slug=data.event.slug),
     )
 
 
 def _render_event__reminder(
-    data: notification_data_pb2.EventReminder, loc_context: LocalizationContext
+    data: notification_data_pb2.EventReminder, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.event__reminder,
-        loc_context,
+        context,
         substitutions={
             "title": data.event.title,
-            "date_and_time": loc_context.localize_datetime(data.event.start_time),
+            "date_and_time": context.localization.localize_datetime(data.event.start_time),
         },
-        action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
+        action_url=urls.event_link(context, occurrence_id=data.event.event_id, slug=data.event.slug),
     )
 
 
-def _render_event__cancel(
-    data: notification_data_pb2.EventCancel, loc_context: LocalizationContext
-) -> PushNotificationContent:
+def _render_event__cancel(data: notification_data_pb2.EventCancel, context: CouchersContext) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.event__cancel,
-        loc_context,
+        context,
         substitutions={
             "title": data.event.title,
             "user": data.cancelling_user.name,
         },
-        action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
+        action_url=urls.event_link(context, occurrence_id=data.event.event_id, slug=data.event.slug),
     )
 
 
-def _render_event__delete(
-    data: notification_data_pb2.EventDelete, loc_context: LocalizationContext
-) -> PushNotificationContent:
-    return _get_content(NotificationTopicAction.event__delete, loc_context, substitutions={"title": data.event.title})
+def _render_event__delete(data: notification_data_pb2.EventDelete, context: CouchersContext) -> PushNotificationContent:
+    return _get_content(NotificationTopicAction.event__delete, context, substitutions={"title": data.event.title})
 
 
 def _render_friend_request__create(
-    data: notification_data_pb2.FriendRequestCreate, loc_context: LocalizationContext
+    data: notification_data_pb2.FriendRequestCreate, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.friend_request__create,
-        loc_context,
+        context,
         substitutions={"from_user": data.other_user.name},
         icon_user=data.other_user,
-        action_url=urls.friend_requests_link(),
+        action_url=urls.friend_requests_link(context),
     )
 
 
 def _render_friend_request__accept(
-    data: notification_data_pb2.FriendRequestAccept, loc_context: LocalizationContext
+    data: notification_data_pb2.FriendRequestAccept, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.friend_request__accept,
-        loc_context,
+        context,
         substitutions={"friend": data.other_user.name},
         icon_user=data.other_user,
-        action_url=urls.user_link(username=data.other_user.username),
+        action_url=urls.user_link(context, username=data.other_user.username),
     )
 
 
 def _render_gender__change(
-    data: notification_data_pb2.GenderChange, loc_context: LocalizationContext
+    data: notification_data_pb2.GenderChange, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.gender__change,
-        loc_context,
+        context,
         substitutions={"gender": data.gender},
-        action_url=urls.account_settings_link(),
+        action_url=urls.account_settings_link(context),
     )
 
 
 def _render_general__new_blog_post(
-    data: notification_data_pb2.GeneralNewBlogPost, loc_context: LocalizationContext
+    data: notification_data_pb2.GeneralNewBlogPost, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.general__new_blog_post,
-        loc_context,
+        context,
         body=data.blurb,
         substitutions={"title": data.title},
         action_url=data.url,
@@ -507,197 +499,199 @@ def _render_general__new_blog_post(
 
 
 def _render_host_request__create(
-    data: notification_data_pb2.HostRequestCreate, loc_context: LocalizationContext
+    data: notification_data_pb2.HostRequestCreate, context: CouchersContext
 ) -> PushNotificationContent:
     night_count = (date.fromisoformat(data.host_request.to_date) - date.fromisoformat(data.host_request.from_date)).days
     return _get_content(
         NotificationTopicAction.host_request__create,
-        loc_context,
+        context,
         substitutions={
             "user": data.surfer.name,
-            "start_date": loc_context.localize_date_from_iso(data.host_request.from_date),
+            "start_date": context.localization.localize_date_from_iso(data.host_request.from_date),
             "count": night_count,
         },
         icon_user=data.surfer,
-        action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
+        action_url=urls.host_request(context, host_request_id=data.host_request.host_request_id),
     )
 
 
 def _render_host_request__message(
-    data: notification_data_pb2.HostRequestMessage, loc_context: LocalizationContext
+    data: notification_data_pb2.HostRequestMessage, context: CouchersContext
 ) -> PushNotificationContent:
     # All strings are dynamic, no need to use _get_content
     return PushNotificationContent(
         title=data.user.name,
         ios_title=data.user.name,
         body=data.text,
-        action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
-        icon_url=_avatar_url_or_default(data.user),
+        action_url=urls.host_request(context, host_request_id=data.host_request.host_request_id),
+        icon_url=_avatar_url_or_default(context, data.user),
     )
 
 
 def _render_host_request__missed_messages(
-    data: notification_data_pb2.HostRequestMissedMessages, loc_context: LocalizationContext
+    data: notification_data_pb2.HostRequestMissedMessages, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.host_request__missed_messages,
-        loc_context,
+        context,
         substitutions={"user": data.user.name},
         icon_user=data.user,
-        action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
+        action_url=urls.host_request(context, host_request_id=data.host_request.host_request_id),
     )
 
 
 def _render_host_request__reminder(
-    data: notification_data_pb2.HostRequestReminder, loc_context: LocalizationContext
+    data: notification_data_pb2.HostRequestReminder, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.host_request__reminder,
-        loc_context,
+        context,
         substitutions={"user": data.surfer.name},
         icon_user=data.surfer,
-        action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
+        action_url=urls.host_request(context, host_request_id=data.host_request.host_request_id),
     )
 
 
 def _render_host_request__accept(
-    data: notification_data_pb2.HostRequestAccept, loc_context: LocalizationContext
+    data: notification_data_pb2.HostRequestAccept, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.host_request__accept,
-        loc_context,
+        context,
         substitutions={
             "user": data.host.name,
-            "date": loc_context.localize_date_from_iso(data.host_request.from_date),
+            "date": context.localization.localize_date_from_iso(data.host_request.from_date),
         },
         icon_user=data.host,
-        action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
+        action_url=urls.host_request(context, host_request_id=data.host_request.host_request_id),
     )
 
 
 def _render_host_request__reject(
-    data: notification_data_pb2.HostRequestReject, loc_context: LocalizationContext
+    data: notification_data_pb2.HostRequestReject, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.host_request__reject,
-        loc_context,
+        context,
         substitutions={
             "user": data.host.name,
-            "date": loc_context.localize_date_from_iso(data.host_request.from_date),
+            "date": context.localization.localize_date_from_iso(data.host_request.from_date),
         },
         icon_user=data.host,
-        action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
+        action_url=urls.host_request(context, host_request_id=data.host_request.host_request_id),
     )
 
 
 def _render_host_request__cancel(
-    data: notification_data_pb2.HostRequestCancel, loc_context: LocalizationContext
+    data: notification_data_pb2.HostRequestCancel, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.host_request__cancel,
-        loc_context,
+        context,
         substitutions={
             "user": data.surfer.name,
-            "date": loc_context.localize_date_from_iso(data.host_request.from_date),
+            "date": context.localization.localize_date_from_iso(data.host_request.from_date),
         },
         icon_user=data.surfer,
-        action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
+        action_url=urls.host_request(context, host_request_id=data.host_request.host_request_id),
     )
 
 
 def _render_host_request__confirm(
-    data: notification_data_pb2.HostRequestConfirm, loc_context: LocalizationContext
+    data: notification_data_pb2.HostRequestConfirm, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.host_request__confirm,
-        loc_context,
+        context,
         substitutions={
             "user": data.surfer.name,
-            "date": loc_context.localize_date_from_iso(data.host_request.from_date),
+            "date": context.localization.localize_date_from_iso(data.host_request.from_date),
         },
         icon_user=data.surfer,
-        action_url=urls.host_request(host_request_id=data.host_request.host_request_id),
+        action_url=urls.host_request(context, host_request_id=data.host_request.host_request_id),
     )
 
 
-def _render_modnote__create(loc_context: LocalizationContext) -> PushNotificationContent:
-    return _get_content(NotificationTopicAction.modnote__create, loc_context)
+def _render_modnote__create(context: CouchersContext) -> PushNotificationContent:
+    return _get_content(NotificationTopicAction.modnote__create, context)
 
 
-def _render_onboarding__reminder(key: str, loc_context: LocalizationContext) -> PushNotificationContent:
+def _render_onboarding__reminder(key: str, context: CouchersContext) -> PushNotificationContent:
     variant = "first" if key == "1" else "subsequent"
     return _get_content(
         f"onboarding.reminder.push.{variant}",
-        loc_context,
-        action_url=urls.edit_profile_link(),
+        context,
+        action_url=urls.edit_profile_link(context),
     )
 
 
-def _render_password__change(loc_context: LocalizationContext) -> PushNotificationContent:
-    return _get_content(NotificationTopicAction.password__change, loc_context, action_url=urls.account_settings_link())
+def _render_password__change(context: CouchersContext) -> PushNotificationContent:
+    return _get_content(
+        NotificationTopicAction.password__change, context, action_url=urls.account_settings_link(context)
+    )
 
 
 def _render_password_reset__start(
-    data: notification_data_pb2.PasswordResetStart, loc_context: LocalizationContext
+    data: notification_data_pb2.PasswordResetStart, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.password_reset__start,
-        loc_context,
-        action_url=urls.account_settings_link(),
+        context,
+        action_url=urls.account_settings_link(context),
     )
 
 
-def _render_password_reset__complete(loc_context: LocalizationContext) -> PushNotificationContent:
+def _render_password_reset__complete(context: CouchersContext) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.password_reset__complete,
-        loc_context,
-        action_url=urls.account_settings_link(),
+        context,
+        action_url=urls.account_settings_link(context),
     )
 
 
 def _render_phone_number__change(
-    data: notification_data_pb2.PhoneNumberChange, loc_context: LocalizationContext
+    data: notification_data_pb2.PhoneNumberChange, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.phone_number__change,
-        loc_context,
+        context,
         substitutions={"phone_number": format_phone_number(data.phone)},
-        action_url=urls.account_settings_link(),
+        action_url=urls.account_settings_link(context),
     )
 
 
 def _render_phone_number__verify(
-    data: notification_data_pb2.PhoneNumberVerify, loc_context: LocalizationContext
+    data: notification_data_pb2.PhoneNumberVerify, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.phone_number__verify,
-        loc_context,
+        context,
         substitutions={"phone_number": format_phone_number(data.phone)},
-        action_url=urls.account_settings_link(),
+        action_url=urls.account_settings_link(context),
     )
 
 
 def _render_postal_verification__postcard_sent(
-    data: notification_data_pb2.PostalVerificationPostcardSent, loc_context: LocalizationContext
+    data: notification_data_pb2.PostalVerificationPostcardSent, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.postal_verification__postcard_sent,
-        loc_context,
+        context,
         substitutions={"city": data.city, "country": data.country},
-        action_url=urls.account_settings_link(),
+        action_url=urls.account_settings_link(context),
     )
 
 
-def _render_postal_verification__success(loc_context: LocalizationContext) -> PushNotificationContent:
+def _render_postal_verification__success(context: CouchersContext) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.postal_verification__success,
-        loc_context,
-        action_url=urls.account_settings_link(),
+        context,
+        action_url=urls.account_settings_link(context),
     )
 
 
 def _render_postal_verification__failed(
-    data: notification_data_pb2.PostalVerificationFailed, loc_context: LocalizationContext
+    data: notification_data_pb2.PostalVerificationFailed, context: CouchersContext
 ) -> PushNotificationContent:
     body_key: str
     match data.reason:
@@ -710,47 +704,48 @@ def _render_postal_verification__failed(
 
     return _get_content(
         NotificationTopicAction.postal_verification__failed,
-        loc_context,
-        body=_get_string(NotificationTopicAction.postal_verification__failed, body_key, loc_context),
-        action_url=urls.account_settings_link(),
+        context,
+        body=_get_string(NotificationTopicAction.postal_verification__failed, body_key, context),
+        action_url=urls.account_settings_link(context),
     )
 
 
 def _render_reference__receive_friend(
-    data: notification_data_pb2.ReferenceReceiveFriend, loc_context: LocalizationContext
+    data: notification_data_pb2.ReferenceReceiveFriend, context: CouchersContext
 ) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.reference__receive_friend,
-        loc_context,
+        context,
         body=data.text,
         substitutions={"user": data.from_user.name},
         icon_user=data.from_user,
-        action_url=urls.profile_references_link(),
+        action_url=urls.profile_references_link(context),
     )
 
 
 def _render_reference__receive(
-    data: notification_data_pb2.ReferenceReceiveHostRequest, leave_reference_type: str, loc_context: LocalizationContext
+    data: notification_data_pb2.ReferenceReceiveHostRequest, leave_reference_type: str, context: CouchersContext
 ) -> PushNotificationContent:
     body: str
     if data.text:
         body = data.text
-        action_url = urls.profile_references_link()
+        action_url = urls.profile_references_link(context)
     else:
         body = _get_string(
             "reference._receive_any.push",
             "body_must_write_yours",
-            loc_context,
+            context,
             substitutions={"user": data.from_user.name},
         )
         action_url = urls.leave_reference_link(
+            context,
             reference_type=leave_reference_type,
             to_user_id=data.from_user.user_id,
             host_request_id=str(data.host_request_id),
         )
     return _get_content(
         string_group="reference._receive_any.push",
-        loc_context=loc_context,
+        context=context,
         body=body,
         substitutions={"user": data.from_user.name},
         icon_user=data.from_user,
@@ -759,29 +754,30 @@ def _render_reference__receive(
 
 
 def _render_reference__receive_hosted(
-    data: notification_data_pb2.ReferenceReceiveHostRequest, loc_context: LocalizationContext
+    data: notification_data_pb2.ReferenceReceiveHostRequest, context: CouchersContext
 ) -> PushNotificationContent:
     # Receiving a hosted reminder means I need to leave a surfed reference
-    return _render_reference__receive(data, leave_reference_type="surfed", loc_context=loc_context)
+    return _render_reference__receive(data, leave_reference_type="surfed", context=context)
 
 
 def _render_reference__receive_surfed(
-    data: notification_data_pb2.ReferenceReceiveHostRequest, loc_context: LocalizationContext
+    data: notification_data_pb2.ReferenceReceiveHostRequest, context: CouchersContext
 ) -> PushNotificationContent:
-    return _render_reference__receive(data, leave_reference_type="hosted", loc_context=loc_context)
+    return _render_reference__receive(data, leave_reference_type="hosted", context=context)
 
 
 def _render_reference__reminder(
-    data: notification_data_pb2.ReferenceReminder, leave_reference_type: str, loc_context: LocalizationContext
+    data: notification_data_pb2.ReferenceReminder, leave_reference_type: str, context: CouchersContext
 ) -> PushNotificationContent:
     leave_reference_link = urls.leave_reference_link(
+        context,
         reference_type=leave_reference_type,
         to_user_id=data.other_user.user_id,
         host_request_id=str(data.host_request_id),
     )
     return _get_content(
         string_group="reference._reminder_any.push",
-        loc_context=loc_context,
+        context=context,
         substitutions={"count": data.days_left, "user": data.other_user.name},
         icon_user=data.other_user,
         action_url=leave_reference_link,
@@ -789,36 +785,36 @@ def _render_reference__reminder(
 
 
 def _render_reference__reminder_surfed(
-    data: notification_data_pb2.ReferenceReminder, loc_context: LocalizationContext
+    data: notification_data_pb2.ReferenceReminder, context: CouchersContext
 ) -> PushNotificationContent:
     # Surfed reminder means I need to leave a surfed reference
-    return _render_reference__reminder(data, leave_reference_type="surfed", loc_context=loc_context)
+    return _render_reference__reminder(data, leave_reference_type="surfed", context=context)
 
 
 def _render_reference__reminder_hosted(
-    data: notification_data_pb2.ReferenceReminder, loc_context: LocalizationContext
+    data: notification_data_pb2.ReferenceReminder, context: CouchersContext
 ) -> PushNotificationContent:
-    return _render_reference__reminder(data, leave_reference_type="hosted", loc_context=loc_context)
+    return _render_reference__reminder(data, leave_reference_type="hosted", context=context)
 
 
-def _render_thread__reply(
-    data: notification_data_pb2.ThreadReply, loc_context: LocalizationContext
-) -> PushNotificationContent:
+def _render_thread__reply(data: notification_data_pb2.ThreadReply, context: CouchersContext) -> PushNotificationContent:
     parent_title: str
     view_link: str
     match data.WhichOneof("reply_parent"):
         case "event":
             parent_title = data.event.title
-            view_link = urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug)
+            view_link = urls.event_link(context, occurrence_id=data.event.event_id, slug=data.event.slug)
         case "discussion":
             parent_title = data.discussion.title
-            view_link = urls.discussion_link(discussion_id=data.discussion.discussion_id, slug=data.discussion.slug)
+            view_link = urls.discussion_link(
+                context, discussion_id=data.discussion.discussion_id, slug=data.discussion.slug
+            )
         case _:
             raise Exception("Can only do replies to events and discussions")
 
     return _get_content(
         NotificationTopicAction.thread__reply,
-        loc_context=loc_context,
+        context=context,
         body=data.reply.content,
         substitutions={"user": data.author.name, "title": parent_title},
         icon_user=data.author,
@@ -826,16 +822,16 @@ def _render_thread__reply(
     )
 
 
-def _render_verification__sv_success(loc_context: LocalizationContext) -> PushNotificationContent:
+def _render_verification__sv_success(context: CouchersContext) -> PushNotificationContent:
     return _get_content(
         NotificationTopicAction.verification__sv_success,
-        loc_context,
-        action_url=urls.account_settings_link(),
+        context,
+        action_url=urls.account_settings_link(context),
     )
 
 
 def _render_verification__sv_fail(
-    data: notification_data_pb2.VerificationSVFail, loc_context: LocalizationContext
+    data: notification_data_pb2.VerificationSVFail, context: CouchersContext
 ) -> PushNotificationContent:
     body_key: str
     match data.reason:
@@ -850,7 +846,7 @@ def _render_verification__sv_fail(
 
     return _get_content(
         NotificationTopicAction.verification__sv_fail,
-        loc_context,
-        body=_get_string(NotificationTopicAction.verification__sv_fail, body_key, loc_context),
-        action_url=urls.account_settings_link(),
+        context,
+        body=_get_string(NotificationTopicAction.verification__sv_fail, body_key, context),
+        action_url=urls.account_settings_link(context),
     )

--- a/app/backend/src/couchers/postal/my_postcard.py
+++ b/app/backend/src/couchers/postal/my_postcard.py
@@ -10,6 +10,7 @@ from PIL import Image, ImageDraw, ImageFont
 
 from couchers import urls
 from couchers.config import config
+from couchers.context import CouchersContext
 from couchers.resources import (
     get_postcard_back_left_template,
     get_postcard_font,
@@ -22,7 +23,7 @@ logger = logging.getLogger(__name__)
 API_BASE = "https://www.mypostcard.com/api/v1"
 
 
-def _generate_back_left_side_png(verification_code: str) -> bytes:
+def _generate_back_left_side_png(context: CouchersContext, verification_code: str) -> bytes:
     """
     Generates the back left side image (780x1016 px PNG at 300 DPI).
 
@@ -37,7 +38,7 @@ def _generate_back_left_side_png(verification_code: str) -> bytes:
 
     # Generate QR code
     qr = qrcode.QRCode(box_size=10, border=0)
-    qr.add_data(urls.postal_verification_link(code=verification_code))
+    qr.add_data(urls.postal_verification_link(context, code=verification_code))
     qr.make(fit=True)
     qr_img: Image.Image = qr.make_image(fill_color="black", back_color="white").get_image().convert("RGBA")
 
@@ -126,6 +127,7 @@ def _place_order(
 
 
 def send_postcard(
+    context: CouchersContext,
     recipient_name: str,
     address_line_1: str,
     address_line_2: str | None,
@@ -166,7 +168,7 @@ def send_postcard(
         recipient["state"] = state
 
     result = _place_order(
-        _authenticate(), recipient, get_postcard_front_image(), _generate_back_left_side_png(verification_code)
+        _authenticate(), recipient, get_postcard_front_image(), _generate_back_left_side_png(context, verification_code)
     )
     logger.info(f"MyPostcard order placed successfully: {result}")
     return int(result["job_id"])

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -147,7 +147,9 @@ def abort_on_invalid_password(password: str, context: CouchersContext) -> None:
         context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "insecure_password")
 
 
-def _volunteer_info_to_pb(volunteer: Volunteer, username: str) -> account_pb2.GetMyVolunteerInfoRes:
+def _volunteer_info_to_pb(
+    volunteer: Volunteer, username: str, context: CouchersContext
+) -> account_pb2.GetMyVolunteerInfoRes:
     return account_pb2.GetMyVolunteerInfoRes(
         display_name=volunteer.display_name,
         display_location=volunteer.display_location,
@@ -155,7 +157,7 @@ def _volunteer_info_to_pb(volunteer: Volunteer, username: str) -> account_pb2.Ge
         started_volunteering=date_to_api(volunteer.started_volunteering),
         stopped_volunteering=date_to_api(volunteer.stopped_volunteering) if volunteer.stopped_volunteering else None,
         show_on_team_page=volunteer.show_on_team_page,
-        **format_volunteer_link(volunteer, username),
+        **format_volunteer_link(context, volunteer, username),
     )
 
 
@@ -259,7 +261,7 @@ class Account(account_pb2_grpc.AccountServicer):
         user.new_email_token_created = now()
         user.new_email_token_expiry = now() + timedelta(hours=2)
 
-        send_email_changed_confirmation_to_new_email(session, user)
+        send_email_changed_confirmation_to_new_email(context, session, user)
 
         # will still go into old email
         notify(
@@ -489,7 +491,7 @@ class Account(account_pb2_grpc.AccountServicer):
         redirect_params = {
             "token": token,
             "redirect_url": urls.complete_strong_verification_url(
-                verification_attempt_token=verification_attempt_token
+                context, verification_attempt_token=verification_attempt_token
             ),
         }
         redirect_url = "https://passportreader.app/open?" + urlencode(redirect_params)
@@ -697,7 +699,7 @@ class Account(account_pb2_grpc.AccountServicer):
 
         return account_pb2.CreateInviteCodeRes(
             code=code,
-            url=urls.invite_code_link(code=code),
+            url=urls.invite_code_link(context, code=code),
         )
 
     def DisableInviteCode(
@@ -738,7 +740,7 @@ class Account(account_pb2_grpc.AccountServicer):
                     created=Timestamp_from_datetime(created),
                     disabled=Timestamp_from_datetime(disabled) if disabled else None,
                     uses=len_users,
-                    url=urls.invite_code_link(code=code_id),
+                    url=urls.invite_code_link(context, code=code_id),
                 )
                 for code_id, created, disabled, len_users in results
             ]
@@ -803,7 +805,7 @@ class Account(account_pb2_grpc.AccountServicer):
         ).one()
         if not volunteer:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "not_a_volunteer")
-        return _volunteer_info_to_pb(volunteer, user.username)
+        return _volunteer_info_to_pb(volunteer, user.username, context)
 
     def UpdateMyVolunteerInfo(
         self, request: account_pb2.UpdateMyVolunteerInfoReq, context: CouchersContext, session: Session
@@ -851,7 +853,7 @@ class Account(account_pb2_grpc.AccountServicer):
 
         session.flush()
 
-        return _volunteer_info_to_pb(volunteer, user.username)
+        return _volunteer_info_to_pb(volunteer, user.username, context)
 
 
 class Iris(iris_pb2_grpc.IrisServicer):

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -1000,7 +1000,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
         session.add(token)
         log_admin_action(session, context, user, "create_account_deletion_link", level=AdminActionLevel.high)
         return admin_pb2.CreateAccountDeletionLinkRes(
-            account_deletion_confirm_url=urls.delete_account_link(account_deletion_token=token.token)
+            account_deletion_confirm_url=urls.delete_account_link(context, account_deletion_token=token.token)
         )
 
     def AccessStats(

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -215,7 +215,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                     select(SignupFlow).where(SignupFlow.email == request.basic.email)
                 ).scalar_one_or_none()
                 if existing_flow:
-                    send_signup_email(session, existing_flow)
+                    send_signup_email(context, session, existing_flow)
                     session.commit()
                     context.abort_with_error_code(
                         grpc.StatusCode.FAILED_PRECONDITION, "signup_flow_email_started_signup"
@@ -330,7 +330,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
             # send verification email if needed
             if not flow.email_sent or request.resend_verification_email:
-                send_signup_email(session, flow)
+                send_signup_email(context, session, flow)
 
             session.flush()
 
@@ -472,7 +472,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 select(SignupFlow).where(username_or_email(request.user, table=SignupFlow))
             ).scalar_one_or_none()
             if signup_flow:
-                send_signup_email(session, signup_flow)
+                send_signup_email(context, session, signup_flow)
                 session.commit()
                 context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "signup_flow_email_started_signup")
             logger.debug("Didn't find user")
@@ -784,5 +784,5 @@ class Auth(auth_pb2_grpc.AuthServicer):
             name=user.name,
             username=user.username,
             avatar_url=avatar_upload.thumbnail_url if avatar_upload else None,
-            url=urls.invite_code_link(code=request.code),
+            url=urls.invite_code_link(context, code=request.code),
         )

--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -41,7 +41,7 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
 
         if context.is_logged_in():
             username = session.execute(select(User.username).where(User.id == context.user_id)).scalar_one()
-            user_details = f"[@{username}]({urls.user_link(username=username)}) ({context.user_id})"
+            user_details = f"[@{username}]({urls.user_link(context, username=username)}) ({context.user_id})"
         else:
             user_details = "<not logged in>"
 

--- a/app/backend/src/couchers/servicers/donations.py
+++ b/app/backend/src/couchers/servicers/donations.py
@@ -76,8 +76,8 @@ class Donations(donations_pb2_grpc.DonationsServicer):
             # Stripe actually allows None, but the signature says it's either a string or not passed.
             submit_type="donate" if not request.recurring else None,  # type: ignore[arg-type]
             customer=not_none(user.stripe_customer_id),
-            success_url=urls.donation_success_url(),
-            cancel_url=urls.donation_cancelled_url(),
+            success_url=urls.donation_success_url(context),
+            cancel_url=urls.donation_cancelled_url(context),
             payment_method_types=["card"],
             mode="subscription" if request.recurring else "payment",
             line_items=[item],  # type: ignore[list-item]
@@ -118,7 +118,7 @@ class Donations(donations_pb2_grpc.DonationsServicer):
 
         stripe_session = stripe.billing_portal.Session.create(
             customer=not_none(user.stripe_customer_id),
-            return_url=urls.donation_url(),
+            return_url=urls.donation_url(context),
             api_key=config["STRIPE_API_KEY"],
         )
 
@@ -155,7 +155,7 @@ class Stripe(stripe_pb2_grpc.StripeServicer):
                 user = session.execute(select(User).where(User.email == customer_email)).scalar_one_or_none()
                 if user:
                     user_add_badge(session, user.id, "swagster")
-                    user_link = urls.user_link(username=user.username)
+                    user_link = urls.user_link(context, username=user.username)
                     customer_info = f"<{user_link}|{user.name}>"
                 else:
                     customer_info = customer_email
@@ -199,7 +199,7 @@ class Stripe(stripe_pb2_grpc.StripeServicer):
                 # Recurring donations go through Stripe invoices, one-time don't
                 is_recurring = data_object.get("invoice") is not None
                 donation_type = "recurring" if is_recurring else "one-time"
-                user_link = urls.user_link(username=user.username)
+                user_link = urls.user_link(context, username=user.username)
                 try:
                     send_slack_message(
                         config["SLACK_DONATIONS_CHANNEL"],

--- a/app/backend/src/couchers/servicers/editor.py
+++ b/app/backend/src/couchers/servicers/editor.py
@@ -44,7 +44,7 @@ def load_community_geom(geojson: str, context: CouchersContext) -> BaseGeometry:
     return geom
 
 
-def volunteer_to_pb(session: Session, volunteer: Volunteer) -> editor_pb2.Volunteer:
+def volunteer_to_pb(session: Session, volunteer: Volunteer, context: CouchersContext) -> editor_pb2.Volunteer:
     """Convert a Volunteer model to the editor protobuf message."""
     lite_user = session.execute(select(LiteUser).where(LiteUser.id == volunteer.user_id)).scalar_one()
     board_members = set(get_static_badge_dict()["board_member"])
@@ -61,7 +61,7 @@ def volunteer_to_pb(session: Session, volunteer: Volunteer) -> editor_pb2.Volunt
         started_volunteering=date_to_api(volunteer.started_volunteering),
         stopped_volunteering=date_to_api(volunteer.stopped_volunteering) if volunteer.stopped_volunteering else None,
         show_on_team_page=volunteer.show_on_team_page,
-        **format_volunteer_link(volunteer, lite_user.username),
+        **format_volunteer_link(context, volunteer, lite_user.username),
     )
 
 
@@ -150,7 +150,9 @@ class Editor(editor_pb2_grpc.EditorServicer):
             return editor_pb2.EventCommunityInviteRequest(
                 event_community_invite_request_id=request.id,
                 user_id=request.user_id,
-                event_url=urls.event_link(occurrence_id=request.occurrence.id, slug=request.occurrence.event.slug),
+                event_url=urls.event_link(
+                    context, occurrence_id=request.occurrence.id, slug=request.occurrence.event.slug
+                ),
                 approx_users_to_notify=len(users_to_notify),
                 community_id=node_id,
             )
@@ -251,7 +253,7 @@ class Editor(editor_pb2_grpc.EditorServicer):
         session.add(volunteer)
         session.flush()
 
-        return volunteer_to_pb(session, volunteer)
+        return volunteer_to_pb(session, volunteer, context)
 
     def UpdateVolunteer(
         self, request: editor_pb2.UpdateVolunteerReq, context: CouchersContext, session: Session
@@ -293,7 +295,7 @@ class Editor(editor_pb2_grpc.EditorServicer):
 
         session.flush()
 
-        return volunteer_to_pb(session, volunteer)
+        return volunteer_to_pb(session, volunteer, context)
 
     def ListVolunteers(
         self, request: editor_pb2.ListVolunteersReq, context: CouchersContext, session: Session
@@ -315,7 +317,7 @@ class Editor(editor_pb2_grpc.EditorServicer):
         volunteers = session.execute(query).scalars().all()
 
         return editor_pb2.ListVolunteersRes(
-            volunteers=[volunteer_to_pb(session, volunteer) for volunteer in volunteers]
+            volunteers=[volunteer_to_pb(session, volunteer, context) for volunteer in volunteers]
         )
 
     def ListPostcards(

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -868,7 +868,7 @@ class Events(events_pb2_grpc.EventsServicer):
         session.add(req)
         session.flush()
 
-        send_event_community_invite_request_email(session, req)
+        send_event_community_invite_request_email(context, session, req)
 
         return empty_pb2.Empty()
 

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -10,7 +10,7 @@ from sqlalchemy.sql import or_
 
 from couchers.config import config
 from couchers.constants import DATETIME_INFINITY
-from couchers.context import CouchersContext
+from couchers.context import CouchersContext, make_background_user_context
 from couchers.i18n import LocalizationContext
 from couchers.models import (
     DeviceType,
@@ -47,7 +47,8 @@ def get_vapid_public_key() -> str:
 
 
 def notification_to_pb(user: User, notification: Notification) -> notifications_pb2.Notification:
-    content = render_push_notification(notification, LocalizationContext.from_user(user))
+    context = make_background_user_context(user.id, LocalizationContext.from_user(user))
+    content = render_push_notification(notification, context)
     return notifications_pb2.Notification(
         notification_id=notification.id,
         created=Timestamp_from_datetime(notification.created),
@@ -190,6 +191,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         session.flush()
         push_to_subscription(
             session,
+            context=context,
             push_notification_subscription_id=subscription.id,
             user_id=context.user_id,
             topic_action="adhoc:setup",
@@ -210,6 +212,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
 
         push_to_user(
             session,
+            context=context,
             user_id=context.user_id,
             topic_action="adhoc:testing",
             content=PushNotificationContent(
@@ -258,9 +261,10 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         session.add(subscription)
         session.flush()
 
-        push_content = render_adhoc_push_notification("push_enabled", context.localization)
+        push_content = render_adhoc_push_notification("push_enabled", context)
         push_to_subscription(
             session,
+            context=context,
             push_notification_subscription_id=subscription.id,
             user_id=context.user_id,
             topic_action="adhoc:push_enabled",
@@ -277,6 +281,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
 
         push_to_user(
             session,
+            context=context,
             user_id=context.user_id,
             topic_action="adhoc:testing",
             content=PushNotificationContent(
@@ -299,6 +304,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
 
         push_to_user(
             session,
+            context=context,
             user_id=context.user_id,
             topic_action="adhoc:testing",
             content=PushNotificationContent(
@@ -337,11 +343,13 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         if not notification:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "notification_not_found")
 
+        render_context = make_background_user_context(user.id, LocalizationContext.from_user(user))
         push_to_user(
             session,
+            context=context,
             user_id=context.user_id,
             topic_action=notification.topic_action.display,
-            content=render_push_notification(notification, LocalizationContext.from_user(user)),
+            content=render_push_notification(notification, render_context),
             key=notification.key,
         )
 

--- a/app/backend/src/couchers/servicers/public.py
+++ b/app/backend/src/couchers/servicers/public.py
@@ -10,6 +10,7 @@ from sqlalchemy.sql import func, union_all
 
 from couchers import experimentation, urls
 from couchers.context import CouchersContext, make_logged_out_context
+from couchers.i18n import LocalizationContext
 from couchers.materialized_views import LiteUser
 from couchers.models import (
     Cluster,
@@ -32,7 +33,7 @@ from couchers.utils import Timestamp_from_datetime, not_none, now
 logger = logging.getLogger(__name__)
 
 
-def format_volunteer_link(volunteer: Volunteer, username: str) -> dict[str, str]:
+def format_volunteer_link(context: CouchersContext, volunteer: Volunteer, username: str) -> dict[str, str]:
     """Format volunteer link information into a dict with link_type, link_text, and link_url."""
     if volunteer.link_type:
         return dict(
@@ -44,7 +45,7 @@ def format_volunteer_link(volunteer: Volunteer, username: str) -> dict[str, str]
         return dict(
             link_type="couchers",
             link_text=f"@{username}",
-            link_url=urls.user_link(username=username),
+            link_url=urls.user_link(context, username=username),
         )
 
 
@@ -142,6 +143,9 @@ def _get_volunteers(session: Session) -> public_pb2.GetVolunteersRes:
 
     board_members = set(get_static_badge_dict()["board_member"])
 
+    # The team page is public and cached identically for everyone, so links use the canonical base URL.
+    context = make_logged_out_context(LocalizationContext.en_utc())
+
     def format_volunteer(volunteer: Volunteer, lite_user: LiteUser) -> public_pb2.Volunteer:
         return public_pb2.Volunteer(
             name=volunteer.display_name or lite_user.name,
@@ -152,7 +156,7 @@ def _get_volunteers(session: Session) -> public_pb2.GetVolunteersRes:
             img=urls.media_url(filename=lite_user.avatar_filename, size="thumbnail")
             if lite_user.avatar_filename
             else None,
-            **format_volunteer_link(volunteer, lite_user.username),
+            **format_volunteer_link(context, volunteer, lite_user.username),
         )
 
     return public_pb2.GetVolunteersRes(

--- a/app/backend/src/couchers/tasks.py
+++ b/app/backend/src/couchers/tasks.py
@@ -8,6 +8,7 @@ from sqlalchemy.sql import func
 from couchers import urls
 from couchers.config import config
 from couchers.constants import SIGNUP_EMAIL_TOKEN_VALIDITY
+from couchers.context import CouchersContext
 from couchers.crypto import urlsafe_secure_token
 from couchers.db import session_scope
 from couchers.email.queuing import queue_system_email, queue_userless_email
@@ -33,24 +34,24 @@ from couchers.utils import now
 logger = logging.getLogger(__name__)
 
 
-def send_signup_email(session: Session, flow: SignupFlow) -> None:
+def send_signup_email(context: CouchersContext, session: Session, flow: SignupFlow) -> None:
     logger.info(f"Sending signup email to {flow.email=}:")
 
     # whether we've sent an email at all yet
     email_sent_before = flow.email_sent
     if flow.email_verified:
         # we just send a link to continue, not a verification link
-        signup_link = urls.signup_link(token=flow.flow_token)
+        signup_link = urls.signup_link(context, token=flow.flow_token)
     elif flow.email_token and flow.token_is_valid:
         # if the verification email was sent and still is not expired, just resend the verification email
-        signup_link = urls.signup_link(token=flow.email_token)
+        signup_link = urls.signup_link(context, token=flow.email_token)
     else:
         # otherwise send a fresh email with a new token
         token = urlsafe_secure_token()
         flow.email_verified = False
         flow.email_token = token
         flow.email_token_expiry = now() + SIGNUP_EMAIL_TOKEN_VALIDITY
-        signup_link = urls.signup_link(token=flow.email_token)
+        signup_link = urls.signup_link(context, token=flow.email_token)
 
     flow.email_sent = True
 
@@ -63,7 +64,7 @@ def send_signup_email(session: Session, flow: SignupFlow) -> None:
     )
 
 
-def send_email_changed_confirmation_to_new_email(session: Session, user: User) -> None:
+def send_email_changed_confirmation_to_new_email(context: CouchersContext, session: Session, user: User) -> None:
     """
     Send an email to the user's new email address requesting confirmation of email change
     """
@@ -77,7 +78,7 @@ def send_email_changed_confirmation_to_new_email(session: Session, user: User) -
     elif not user.new_email:
         raise ValueError(f"No new email for {user.id}")
 
-    confirmation_link = urls.change_email_link(confirmation_token=user.new_email_token)
+    confirmation_link = urls.change_email_link(context, confirmation_token=user.new_email_token)
     queue_userless_email(
         session,
         user.new_email,
@@ -161,14 +162,18 @@ def maybe_send_contributor_form_email(session: Session, form: ContributorForm) -
         )
 
 
-def send_event_community_invite_request_email(session: Session, request: EventCommunityInviteRequest) -> None:
+def send_event_community_invite_request_email(
+    context: CouchersContext, session: Session, request: EventCommunityInviteRequest
+) -> None:
     queue_system_email(
         session,
         config["MODS_EMAIL_RECIPIENT"],
         "event_community_invite_request",
         template_args={
-            "event_link": urls.event_link(occurrence_id=request.occurrence.id, slug=request.occurrence.event.slug),
-            "user_link": urls.user_link(username=request.user.username),
+            "event_link": urls.event_link(
+                context, occurrence_id=request.occurrence.id, slug=request.occurrence.event.slug
+            ),
+            "user_link": urls.user_link(context, username=request.user.username),
             "view_link": urls.console_link(page="tools/community-invites"),
         },
     )

--- a/app/backend/src/couchers/urls.py
+++ b/app/backend/src/couchers/urls.py
@@ -4,135 +4,142 @@
 # //app/web/src/routes.ts
 
 
+from typing import TYPE_CHECKING
+
 from couchers.config import config
 
-
-def app_link() -> str:
-    return f"{config['BASE_URL']}/"
-
-
-def icon_url() -> str:
-    return f"{config['BASE_URL']}/logo512.png"
+if TYPE_CHECKING:
+    from couchers.context import CouchersContext
 
 
-def profile_link() -> str:
-    return f"{config['BASE_URL']}/profile"
+def app_link(context: CouchersContext) -> str:
+    return f"{context.base_url}/"
 
 
-def user_link(*, username: str) -> str:
-    return f"{config['BASE_URL']}/user/{username}"
+def icon_url(context: CouchersContext) -> str:
+    return f"{context.base_url}/logo512.png"
 
 
-def edit_profile_link() -> str:
-    return f"{config['BASE_URL']}/profile/edit"
+def profile_link(context: CouchersContext) -> str:
+    return f"{context.base_url}/profile"
 
 
-def signup_link(*, token: str) -> str:
-    return f"{config['BASE_URL']}/signup?token={token}"
+def user_link(context: CouchersContext, *, username: str) -> str:
+    return f"{context.base_url}/user/{username}"
 
 
-def account_settings_link() -> str:
-    return f"{config['BASE_URL']}/account-settings"
+def edit_profile_link(context: CouchersContext) -> str:
+    return f"{context.base_url}/profile/edit"
 
 
-def notification_settings_link() -> str:
-    return f"{config['BASE_URL']}/account-settings/notifications"
+def signup_link(context: CouchersContext, *, token: str) -> str:
+    return f"{context.base_url}/signup?token={token}"
 
 
-def feature_preview_link() -> str:
-    return f"{config['BASE_URL']}/preview"
+def account_settings_link(context: CouchersContext) -> str:
+    return f"{context.base_url}/account-settings"
 
 
-def password_reset_link(*, password_reset_token: str) -> str:
-    return f"{config['BASE_URL']}/complete-password-reset?token={password_reset_token}"
+def notification_settings_link(context: CouchersContext) -> str:
+    return f"{context.base_url}/account-settings/notifications"
 
 
-def host_request_link_host() -> str:
-    return f"{config['BASE_URL']}/messages/hosting/"
+def feature_preview_link(context: CouchersContext) -> str:
+    return f"{context.base_url}/preview"
 
 
-def host_request_link_guest() -> str:
-    return f"{config['BASE_URL']}/messages/surfing/"
+def password_reset_link(context: CouchersContext, *, password_reset_token: str) -> str:
+    return f"{context.base_url}/complete-password-reset?token={password_reset_token}"
 
 
-def host_request(*, host_request_id: str) -> str:
-    return f"{config['BASE_URL']}/messages/request/{host_request_id}"
+def host_request_link_host(context: CouchersContext) -> str:
+    return f"{context.base_url}/messages/hosting/"
 
 
-def messages_link() -> str:
-    return f"{config['BASE_URL']}/messages/"
+def host_request_link_guest(context: CouchersContext) -> str:
+    return f"{context.base_url}/messages/surfing/"
 
 
-def chat_link(*, chat_id: int) -> str:
-    return f"{config['BASE_URL']}/messages/chats/{chat_id}"
+def host_request(context: CouchersContext, *, host_request_id: str) -> str:
+    return f"{context.base_url}/messages/request/{host_request_id}"
 
 
-def event_link(*, occurrence_id: int, slug: str = "e") -> str:
-    return f"{config['BASE_URL']}/event/{occurrence_id}/{slug}"
+def messages_link(context: CouchersContext) -> str:
+    return f"{context.base_url}/messages/"
 
 
-def community_link(*, node_id: int, slug: str = "e") -> str:
-    return f"{config['BASE_URL']}/community/{node_id}/{slug}"
+def chat_link(context: CouchersContext, *, chat_id: int) -> str:
+    return f"{context.base_url}/messages/chats/{chat_id}"
 
 
-def discussion_link(*, discussion_id: str, slug: str = "e") -> str:
-    return f"{config['BASE_URL']}/discussion/{discussion_id}/{slug}"
+def event_link(context: CouchersContext, *, occurrence_id: int, slug: str = "e") -> str:
+    return f"{context.base_url}/event/{occurrence_id}/{slug}"
 
 
-def leave_reference_link(*, reference_type: str, to_user_id: str, host_request_id: str | None = None) -> str:
+def community_link(context: CouchersContext, *, node_id: int, slug: str = "e") -> str:
+    return f"{context.base_url}/community/{node_id}/{slug}"
+
+
+def discussion_link(context: CouchersContext, *, discussion_id: str, slug: str = "e") -> str:
+    return f"{context.base_url}/discussion/{discussion_id}/{slug}"
+
+
+def leave_reference_link(
+    context: CouchersContext, *, reference_type: str, to_user_id: str, host_request_id: str | None = None
+) -> str:
     assert reference_type in ["friend", "surfed", "hosted"]
     if host_request_id:
-        return f"{config['BASE_URL']}/leave-reference/{reference_type}/{to_user_id}/{host_request_id}"
+        return f"{context.base_url}/leave-reference/{reference_type}/{to_user_id}/{host_request_id}"
     else:
-        return f"{config['BASE_URL']}/leave-reference/{reference_type}/{to_user_id}"
+        return f"{context.base_url}/leave-reference/{reference_type}/{to_user_id}"
 
 
-def profile_references_link() -> str:
-    return f"{config['BASE_URL']}/profile/references"
+def profile_references_link(context: CouchersContext) -> str:
+    return f"{context.base_url}/profile/references"
 
 
-def friend_requests_link() -> str:
-    return f"{config['BASE_URL']}/connections/friends/"
+def friend_requests_link(context: CouchersContext) -> str:
+    return f"{context.base_url}/connections/friends/"
 
 
 def media_upload_url(*, path: str) -> str:
     return f"{config['MEDIA_SERVER_UPLOAD_BASE_URL']}/{path}"
 
 
-def change_email_link(*, confirmation_token: str) -> str:
-    return f"{config['BASE_URL']}/confirm-email?token={confirmation_token}"
+def change_email_link(context: CouchersContext, *, confirmation_token: str) -> str:
+    return f"{context.base_url}/confirm-email?token={confirmation_token}"
 
 
-def donation_url() -> str:
-    return f"{config['BASE_URL']}/donate"
+def donation_url(context: CouchersContext) -> str:
+    return f"{context.base_url}/donate"
 
 
-def donation_cancelled_url() -> str:
-    return f"{config['BASE_URL']}/donate?cancelled=true"
+def donation_cancelled_url(context: CouchersContext) -> str:
+    return f"{context.base_url}/donate?cancelled=true"
 
 
-def donation_success_url() -> str:
-    return f"{config['BASE_URL']}/donate?success=true"
+def donation_success_url(context: CouchersContext) -> str:
+    return f"{context.base_url}/donate?success=true"
 
 
-def complete_strong_verification_url(*, verification_attempt_token: str) -> str:
-    return f"{config['BASE_URL']}/complete-strong-verification?verification_attempt_token={verification_attempt_token}"
+def complete_strong_verification_url(context: CouchersContext, *, verification_attempt_token: str) -> str:
+    return f"{context.base_url}/complete-strong-verification?verification_attempt_token={verification_attempt_token}"
 
 
-def delete_account_link(*, account_deletion_token: str) -> str:
-    return f"{config['BASE_URL']}/delete-account?token={account_deletion_token}"
+def delete_account_link(context: CouchersContext, *, account_deletion_token: str) -> str:
+    return f"{context.base_url}/delete-account?token={account_deletion_token}"
 
 
-def recover_account_link(*, account_undelete_token: str) -> str:
-    return f"{config['BASE_URL']}/recover-account?token={account_undelete_token}"
+def recover_account_link(context: CouchersContext, *, account_undelete_token: str) -> str:
+    return f"{context.base_url}/recover-account?token={account_undelete_token}"
 
 
-def unsubscribe_link(*, payload: str, sig: str) -> str:
-    return f"{config['BASE_URL']}/quick-link?payload={payload}&sig={sig}"
+def unsubscribe_link(context: CouchersContext, *, payload: str, sig: str) -> str:
+    return f"{context.base_url}/quick-link?payload={payload}&sig={sig}"
 
 
-def quick_link(*, payload: str, sig: str) -> str:
-    return f"{config['BASE_URL']}/quick-link?payload={payload}&sig={sig}"
+def quick_link(context: CouchersContext, *, payload: str, sig: str) -> str:
+    return f"{context.base_url}/quick-link?payload={payload}&sig={sig}"
 
 
 def media_url(*, filename: str, size: str) -> str:
@@ -143,9 +150,9 @@ def console_link(*, page: str) -> str:
     return f"{config['CONSOLE_BASE_URL']}/{page}"
 
 
-def invite_code_link(*, code: str) -> str:
-    return f"{config['BASE_URL']}/invite?code={code}"
+def invite_code_link(context: CouchersContext, *, code: str) -> str:
+    return f"{context.base_url}/invite?code={code}"
 
 
-def postal_verification_link(*, code: str) -> str:
-    return f"{config['BASE_URL']}/verify-postal?c={code}"
+def postal_verification_link(context: CouchersContext, *, code: str) -> str:
+    return f"{context.base_url}/verify-postal?c={code}"

--- a/app/backend/src/tests/fixtures/misc.py
+++ b/app/backend/src/tests/fixtures/misc.py
@@ -45,7 +45,7 @@ class PushCollector:
         self.by_user: dict[int, list[Push]] = {}
         """Collected notifications by user id, chronologically."""
 
-    def push_to_user(self, session: Session, user_id: int, **kwargs: Any) -> None:
+    def push_to_user(self, session: Session, context: Any, user_id: int, **kwargs: Any) -> None:
         if user_id not in self.by_user:
             self.by_user[user_id] = []
         self.by_user[user_id].append(Push(**kwargs))

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -8,8 +8,10 @@ from sqlalchemy import select, update
 from sqlalchemy.sql import func
 
 from couchers import urls
+from couchers.context import make_logged_out_context
 from couchers.crypto import hash_password, random_hex
 from couchers.db import session_scope
+from couchers.i18n import LocalizationContext
 from couchers.materialized_views import refresh_materialized_views_rapid
 from couchers.models import (
     AccountDeletionReason,
@@ -960,7 +962,7 @@ def test_CreateInviteCode(db):
         invite = session.execute(select(InviteCode).where(InviteCode.id == code)).scalar_one()
         assert invite.creator_user_id == user.id
         assert invite.disabled is None
-        assert res.url == urls.invite_code_link(code=res.code)
+        assert res.url == urls.invite_code_link(make_logged_out_context(LocalizationContext.en_utc()), code=res.code)
 
 
 def test_DisableInviteCode(db):
@@ -991,7 +993,9 @@ def test_ListInviteCodes(db):
         assert len(res.invite_codes) == 1
         assert res.invite_codes[0].code == code
         assert res.invite_codes[0].uses == 1
-        assert res.invite_codes[0].url == urls.invite_code_link(code=code)
+        assert res.invite_codes[0].url == urls.invite_code_link(
+            make_logged_out_context(LocalizationContext.en_utc()), code=code
+        )
 
 
 def test_reminders(db, moderator):

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -8,8 +8,10 @@ from sqlalchemy import select, update
 from sqlalchemy.sql import delete, func
 
 from couchers import urls
+from couchers.context import make_logged_out_context
 from couchers.crypto import hash_password, random_hex
 from couchers.db import session_scope
+from couchers.i18n import LocalizationContext
 from couchers.models import (
     ContributeOption,
     ContributorForm,
@@ -1196,7 +1198,7 @@ def test_GetInviteCodeInfo(db):
         assert res.avatar_url.endswith(".jpg")
         # Verify the hashed filename looks correct (64 char hex hash)
         assert len(res.avatar_url.split("/")[-1].replace(".jpg", "")) == 64
-        assert res.url == urls.invite_code_link(code=code)
+        assert res.url == urls.invite_code_link(make_logged_out_context(LocalizationContext.en_utc()), code=code)
 
 
 def test_GetInviteCodeInfo_no_avatar(db):
@@ -1210,7 +1212,7 @@ def test_GetInviteCodeInfo_no_avatar(db):
         assert res.name == user.name
         assert res.username == user.username
         assert res.avatar_url == ""
-        assert res.url == urls.invite_code_link(code=code)
+        assert res.url == urls.invite_code_link(make_logged_out_context(LocalizationContext.en_utc()), code=code)
 
 
 def test_GetInviteCodeInfo_not_found(db):

--- a/app/backend/src/tests/test_calendar_events.py
+++ b/app/backend/src/tests/test_calendar_events.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import ics
 import pytest
 
+from couchers.context import make_logged_out_context
 from couchers.email.calendar_events import create_host_request_cancellation_ics, create_host_request_ics
 from couchers.i18n.context import LocalizationContext
 from couchers.proto import conversations_pb2, requests_pb2
@@ -26,7 +27,7 @@ def test_initial_ics_content():
     )
 
     ics = create_host_request_ics(
-        host_request, other_name="Bob", hosting=True, loc_context=LocalizationContext.en_utc()
+        host_request, other_name="Bob", hosting=True, context=make_logged_out_context(LocalizationContext.en_utc())
     )
     assert _normalize_ics(ics) == _normalize_ics("""
 BEGIN:VCALENDAR
@@ -53,7 +54,7 @@ def test_cancellation_ics_content():
     )
 
     ics = create_host_request_cancellation_ics(
-        host_request, other_name="Bob", hosting=True, loc_context=LocalizationContext.en_utc()
+        host_request, other_name="Bob", hosting=True, context=make_logged_out_context(LocalizationContext.en_utc())
     )
     assert _normalize_ics(ics) == _normalize_ics("""
 BEGIN:VCALENDAR

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -8,8 +8,10 @@ from sqlalchemy import func, select, update
 import couchers.email
 import couchers.jobs.handlers
 from couchers.config import config
+from couchers.context import make_logged_out_context
 from couchers.crypto import b64decode, random_hex, urlsafe_secure_token
 from couchers.db import session_scope
+from couchers.i18n import LocalizationContext
 from couchers.models import (
     ContentReport,
     Email,
@@ -56,7 +58,7 @@ def test_signup_verification_email(db):
 
     with session_scope() as session:
         with mock_notification_email() as mock:
-            send_signup_email(session, flow)
+            send_signup_email(make_logged_out_context(LocalizationContext.en_utc()), session, flow)
 
     assert mock.call_count == 1
     e = email_fields(mock)
@@ -232,7 +234,9 @@ def test_email_changed_confirmation_sent_to_new_email(db):
     user.new_email_token = confirmation_token
     with session_scope() as session:
         with mock_notification_email() as mock:
-            send_email_changed_confirmation_to_new_email(session, user)
+            send_email_changed_confirmation_to_new_email(
+                make_logged_out_context(LocalizationContext.en_utc()), session, user
+            )
 
     assert mock.call_count == 1
     e = email_fields(mock)

--- a/app/backend/src/tests/test_postal_verification.py
+++ b/app/backend/src/tests/test_postal_verification.py
@@ -11,8 +11,10 @@ from couchers.constants import (
     POSTAL_VERIFICATION_MAX_ATTEMPTS,
     POSTAL_VERIFICATION_RATE_LIMIT,
 )
+from couchers.context import make_logged_out_context
 from couchers.db import session_scope
 from couchers.helpers.postal_verification import generate_postal_verification_code, has_postal_verification
+from couchers.i18n import LocalizationContext
 from couchers.jobs.worker import process_job
 from couchers.models import User
 from couchers.models.postal_verification import PostalVerificationAttempt, PostalVerificationStatus
@@ -690,7 +692,7 @@ def test_generate_postcard_images():
     """
     code = "ABC123"
     front = get_postcard_front_image()
-    back = _generate_back_left_side_png(code)
+    back = _generate_back_left_side_png(make_logged_out_context(LocalizationContext.en_utc()), code)
 
     assert len(front) > 0
     assert len(back) > 0

--- a/app/backend/src/tests/test_postcard_service.py
+++ b/app/backend/src/tests/test_postcard_service.py
@@ -3,6 +3,8 @@ from unittest.mock import patch
 import pytest
 from requests import RequestException
 
+from couchers.context import make_logged_out_context
+from couchers.i18n import LocalizationContext
 from couchers.postal.my_postcard import send_postcard
 from couchers.resources import get_postcard_front_image
 
@@ -10,6 +12,9 @@ from couchers.resources import get_postcard_front_image
 @pytest.fixture(autouse=True)
 def _(testconfig):
     pass
+
+
+_context = make_logged_out_context(LocalizationContext.en_utc())
 
 
 def test_get_postcard_front_image_returns_png():
@@ -30,6 +35,7 @@ def test_send_postcard_success():
         mock_order.return_value = {"job_id": 12345}
 
         job_id = send_postcard(
+            _context,
             recipient_name="Test User",
             address_line_1="123 Main St",
             address_line_2="Apt 4",
@@ -56,6 +62,7 @@ def test_send_postcard_builds_recipient_correctly():
         mock_order.return_value = {"job_id": 123}
 
         send_postcard(
+            _context,
             recipient_name="Test User",
             address_line_1="123 Main St",
             address_line_2="Apt 4",
@@ -86,6 +93,7 @@ def test_send_postcard_excludes_none_optional_fields():
         mock_order.return_value = {"job_id": 123}
 
         send_postcard(
+            _context,
             recipient_name="Test User",
             address_line_1="123 Main St",
             address_line_2=None,
@@ -112,6 +120,7 @@ def test_send_postcard_auth_failure():
 
         with pytest.raises(RequestException, match="Connection refused"):
             send_postcard(
+                _context,
                 recipient_name="Test User",
                 address_line_1="123 Main St",
                 address_line_2=None,
@@ -135,6 +144,7 @@ def test_send_postcard_order_failure():
 
         with pytest.raises(RequestException, match="500 Server Error"):
             send_postcard(
+                _context,
                 recipient_name="Test User",
                 address_line_1="123 Main St",
                 address_line_2=None,


### PR DESCRIPTION
Refactor `couchers.urls` so that base_url-derived link helpers take an explicit `CouchersContext` instead of implicitly reading `config["BASE_URL"]`.

Each base_url-derived helper now takes `context: CouchersContext` as its first positional arg and builds from a new `context.base_url` property (which currently just returns `config["BASE_URL"]`). Context is threaded through the servicer, notification-render, email, tasks and postal layers. The non-base_url helpers (`media_url`, `media_upload_url`, `console_link`) are left unchanged.

This is a pure plumbing refactor with no behavioural change — it sets the table so a later per-request / per-recipient BASE_URL override (for dev/preview testing) becomes a small change localized to the `context.base_url` property, rather than an ambient contextvar.

Notes:
- Pure-localization leaf renderers keep taking `LocalizationContext`; only url-building functions take `context`.
- The cached public team page builds a canonical logged-out context (its links are global and identical for everyone).
- The notification servicer's render paths build a `from_user`-localized context to preserve notification language.

## Testing
- `make format` and `make mypy` are clean (no new errors introduced; the two remaining mypy errors in `tests/fixtures/misc.py` and `tests/test_calendar_events.py` are pre-existing on `develop`).
- Ran the affected backend test suites: notifications, email, calendar events, postcard service, postal verification, donations, public, bugs, strong verification, events, admin, and the invite-code/volunteer paths — all passing.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._