### PR TITLE
mobile: point staging at the self-hosted OTA backend

### DIFF
--- a/app/mobile/app.config.js
+++ b/app/mobile/app.config.js
@@ -76,12 +76,17 @@ const intentFilters = variant.linkHost
 
 // Dev Tool branches load OTA through the dev launcher's deep-link load path
 // (couchers-devtool://expo-development-client/?url=...), so no update URL is
-// baked in and manifests are served unsigned over HTTPS. Staging and production
-// stay on EAS Update.
+// baked in and manifests are served unsigned over HTTPS.
+//
+// Staging points at our self-hosted OTA backend (cut 1: validating the Expo
+// Updates protocol + native<->backend transport, unsigned). Production stays on
+// EAS Update until staging is proven, then flips here too.
 const updates =
   APP_VARIANT === "devtool"
     ? { enabled: true }
-    : { url: "https://u.expo.dev/fb4fc9aa-d8b2-45a5-82aa-be05e99b0413" };
+    : APP_VARIANT === "staging"
+      ? { url: "https://dev-api.couchershq.org/mobile/ota/manifest" }
+      : { url: "https://u.expo.dev/fb4fc9aa-d8b2-45a5-82aa-be05e99b0413" };
 
 export default {
   name: variant.name,


### PR DESCRIPTION
Points the **staging** Expo app variant at our self-hosted OTA manifest endpoint (`https://dev-api.couchershq.org/mobile/ota/manifest`) instead of EAS Update. This is cut 1 of validating the self-hosted Expo Updates protocol and the native↔backend transport (unsigned).

The Dev Tool variant keeps its dev-launcher deep-link path, and production stays on EAS Update until staging is proven — then production flips here too.

This branch is rebased onto `mobile/v1.1.20`; it is a single one-line config change on top of that base (the rest of the Dev Tool OTA work already landed in `v1.1.20`).

## Testing
Ran from `app/mobile`:
- `npm run lint` (expo lint) — clean
- `npx tsc --noEmit` — no type errors
- `npm test` (jest) — 129/129 tests pass

Still needs on-device validation: install a staging build and confirm it fetches/applies an update from the self-hosted manifest endpoint.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._