### PR TITLE
Clean up native OTA manifest endpoint (rename RPC, simplify header reads)

### DIFF
--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -116,18 +116,14 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
             data=get_descriptors_pb(),
         )
 
-    def GetMobileUpdateManifest(
+    def GetNativeUpdateManifest(
         self, request: httpbody_pb2.HttpBody, context: CouchersContext, session: Session
     ) -> httpbody_pb2.HttpBody:
-        def header(name: str) -> str:
-            value = context.headers.get(name, "")
-            return value.decode() if isinstance(value, bytes) else value
-
         # Expo rejects the manifest without these; Envoy forwards them as HTTP response headers.
         context.set_response_headers([("expo-protocol-version", "1"), ("expo-sfv-version", "0")])
 
-        platform = header("expo-platform") or "ios"
-        runtime_version = header("expo-runtime-version")
+        platform = cast(str, context.headers.get("expo-platform", "")) or "ios"
+        runtime_version = cast(str, context.headers.get("expo-runtime-version", ""))
 
         bundles: dict[str, Any] = context.get_object_value("native_ota_bundles", {})
         bundle = bundles.get(platform)

--- a/app/backend/src/tests/test_bugs.py
+++ b/app/backend/src/tests/test_bugs.py
@@ -417,10 +417,10 @@ _OTA_BUNDLES = {
 }
 
 
-def test_mobile_update_manifest(db, feature_flags):
+def test_native_update_manifest(db, feature_flags):
     feature_flags.set("native_ota_bundles", _OTA_BUNDLES)
     with real_bugs_session() as (bugs, metadata_interceptor):
-        res = bugs.GetMobileUpdateManifest(
+        res = bugs.GetNativeUpdateManifest(
             httpbody_pb2.HttpBody(),
             metadata=(("expo-platform", "ios"), ("expo-runtime-version", "my-fingerprint")),
         )
@@ -440,10 +440,10 @@ def test_mobile_update_manifest(db, feature_flags):
     assert metadata_interceptor.latest_headers["expo-sfv-version"] == "0"
 
 
-def test_mobile_update_manifest_android(db, feature_flags):
+def test_native_update_manifest_android(db, feature_flags):
     feature_flags.set("native_ota_bundles", _OTA_BUNDLES)
     with real_bugs_session() as (bugs, _metadata_interceptor):
-        res = bugs.GetMobileUpdateManifest(
+        res = bugs.GetNativeUpdateManifest(
             httpbody_pb2.HttpBody(),
             metadata=(("expo-platform", "android"), ("expo-runtime-version", "fp")),
         )
@@ -452,9 +452,9 @@ def test_mobile_update_manifest_android(db, feature_flags):
     assert manifest["launchAsset"]["url"].endswith("/android/bundle.hbc")
 
 
-def test_mobile_update_manifest_without_runtime_version_returns_directive(db):
+def test_native_update_manifest_without_runtime_version_returns_directive(db):
     with real_bugs_session() as (bugs, metadata_interceptor):
-        res = bugs.GetMobileUpdateManifest(
+        res = bugs.GetNativeUpdateManifest(
             httpbody_pb2.HttpBody(),
             metadata=(("expo-platform", "ios"),),
         )

--- a/app/proto/bugs.proto
+++ b/app/proto/bugs.proto
@@ -38,8 +38,8 @@ service Bugs {
     };
   }
 
-  rpc GetMobileUpdateManifest(google.api.HttpBody) returns (google.api.HttpBody) {
-    // Serves the Expo Updates protocol (v1) manifest for the mobile app
+  rpc GetNativeUpdateManifest(google.api.HttpBody) returns (google.api.HttpBody) {
+    // Serves the Expo Updates protocol (v1) manifest for the native app
     option (google.api.http) = {
       get : "/native/ota/manifest"
     };

--- a/docs/native-prod-ota.md
+++ b/docs/native-prod-ota.md
@@ -132,7 +132,7 @@ delivers `set-cookie`).
 > **Note — the route-scoped Envoy approach does NOT work here.** A `match: { path:
 > "/native/ota/manifest" }` route with `response_headers_to_add` never matches,
 > because `grpc_json_transcoder` rewrites the request `:path` to the gRPC method
-> path (`/org.couchers.bugs.Bugs/GetMobileUpdateManifest`) *before* route
+> path (`/org.couchers.bugs.Bugs/GetNativeUpdateManifest`) *before* route
 > selection, so the request falls through to the catch-all `prefix: "/"` route.
 > The servicer-metadata path sidesteps this entirely and needs no `envoy.yaml`
 > change — only the regenerated `descriptors.pb` (so the route transcodes at all).
@@ -219,7 +219,7 @@ check would bucket every install on `id="None"` — no per-user rollout split.
 
 ---
 
-## 6. The manifest endpoint (`Bugs.GetMobileUpdateManifest`)
+## 6. The manifest endpoint (`Bugs.GetNativeUpdateManifest`)
 
 Add to `app/proto/bugs.proto` (the `Bugs` service is already `AUTH_LEVEL_OPEN`
 and already Envoy-allowlisted):
@@ -227,7 +227,7 @@ and already Envoy-allowlisted):
 ```proto
 import "google/api/httpbody.proto";
 
-rpc GetMobileUpdateManifest(google.api.HttpBody) returns (google.api.HttpBody) {
+rpc GetNativeUpdateManifest(google.api.HttpBody) returns (google.api.HttpBody) {
   option (google.api.http) = { get : "/native/ota/manifest" };
 }
 ```


### PR DESCRIPTION
Follow-up cleanups to #8791 (already merged).

## Summary
- Rename the RPC `GetMobileUpdateManifest` → `GetNativeUpdateManifest`, for consistency with the `/native/ota/manifest` route.
- Drop the per-RPC `header()` helper: its `bytes` branch was dead code (the `expo-*` headers are never binary gRPC metadata), so read `context.headers` directly with a `cast(str, ...)`, matching the convention in `auth.py`.
- Update the proto, tests (calls + test names), and the design doc references accordingly.

No behaviour change to the endpoint.

## Test plan
- [x] `pytest src/tests/test_bugs.py` (18 passed)
- [x] `make format` clean
- [x] protos regenerated