### PR TITLE
Backend/requests: More useful date formats

### DIFF
--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -688,8 +688,8 @@ class HostRequestCreatedEmail(EmailBase):
             self.surfer,
             "date_range",
             {
-                "from_date": loc_context.localize_date(self.from_date),
-                "to_date": loc_context.localize_date(self.to_date),
+                "from_date": _localize_host_request_date(self.from_date, loc_context),
+                "to_date": _localize_host_request_date(self.to_date, loc_context),
             },
         )
         builder.quote(self.text, markdown=False)
@@ -745,8 +745,8 @@ class HostRequestReminderEmail(EmailBase):
             self.surfer,
             ".host_request_generic.date_range",
             {
-                "from_date": loc_context.localize_date(self.from_date),
-                "to_date": loc_context.localize_date(self.to_date),
+                "from_date": _localize_host_request_date(self.from_date, loc_context),
+                "to_date": _localize_host_request_date(self.to_date, loc_context),
             },
         )
         builder.action(self.view_link, ".host_request_generic.view_action")
@@ -798,8 +798,8 @@ class HostRequestMessageEmail(EmailBase):
             self.other_user,
             ".host_request_generic.date_range",
             {
-                "from_date": loc_context.localize_date(self.from_date),
-                "to_date": loc_context.localize_date(self.to_date),
+                "from_date": _localize_host_request_date(self.from_date, loc_context),
+                "to_date": _localize_host_request_date(self.to_date, loc_context),
             },
         )
         builder.quote(self.text, markdown=False)
@@ -860,8 +860,8 @@ class HostRequestMissedMessagesEmail(EmailBase):
             self.other_user,
             ".host_request_generic.date_range",
             {
-                "from_date": loc_context.localize_date(self.from_date),
-                "to_date": loc_context.localize_date(self.to_date),
+                "from_date": _localize_host_request_date(self.from_date, loc_context),
+                "to_date": _localize_host_request_date(self.to_date, loc_context),
             },
         )
         builder.action(self.view_link, ".host_request_generic.view_action")
@@ -929,8 +929,8 @@ class HostRequestStatusChangedEmail(EmailBase):
             self.other_user,
             ".host_request_generic.date_range",
             {
-                "from_date": loc_context.localize_date(self.from_date),
-                "to_date": loc_context.localize_date(self.to_date),
+                "from_date": _localize_host_request_date(self.from_date, loc_context),
+                "to_date": _localize_host_request_date(self.to_date, loc_context),
             },
         )
         builder.action(self.view_link, ".host_request_generic.view_action")
@@ -1312,3 +1312,7 @@ class ThreadReplyEmail(EmailBase):
             markdown_text="I agree, the Grünewald is **amazing**!",
             view_link="https://couchers.org/discussions/123",
         )
+
+
+def _localize_host_request_date(value: date, loc_context: LocalizationContext) -> str:
+    return loc_context.localize_date(value, with_year=False, with_day_of_week=True)

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -1441,10 +1441,10 @@ def test_request_notifications(db, push_collector: PushCollector, moderator):
     assert "quick decline" in e.html.lower()
     assert surfer.name in e.plain
     assert surfer.name in e.html
-    assert host_loc_context.localize_date(today_plus_2) in e.plain
-    assert host_loc_context.localize_date(today_plus_2) in e.html
-    assert host_loc_context.localize_date(today_plus_3) in e.plain
-    assert host_loc_context.localize_date(today_plus_3) in e.html
+    assert host_loc_context.localize_date(today_plus_2, with_year=False) in e.plain
+    assert host_loc_context.localize_date(today_plus_2, with_year=False) in e.html
+    assert host_loc_context.localize_date(today_plus_3, with_year=False) in e.plain
+    assert host_loc_context.localize_date(today_plus_3, with_year=False) in e.html
     assert "http://localhost:5001/img/thumbnail/" not in e.plain
     assert "http://localhost:5001/img/thumbnail/" in e.html
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.plain
@@ -1515,10 +1515,10 @@ def test_quick_decline(db, push_collector: PushCollector, moderator):
     assert "quick decline" in e.html.lower()
     assert surfer.name in e.plain
     assert surfer.name in e.html
-    assert host_loc_context.localize_date(today_plus_2) in e.plain
-    assert host_loc_context.localize_date(today_plus_2) in e.html
-    assert host_loc_context.localize_date(today_plus_3) in e.plain
-    assert host_loc_context.localize_date(today_plus_3) in e.html
+    assert host_loc_context.localize_date(today_plus_2, with_year=False) in e.plain
+    assert host_loc_context.localize_date(today_plus_2, with_year=False) in e.html
+    assert host_loc_context.localize_date(today_plus_3, with_year=False) in e.plain
+    assert host_loc_context.localize_date(today_plus_3, with_year=False) in e.html
     assert "http://localhost:5001/img/thumbnail/" not in e.plain
     assert "http://localhost:5001/img/thumbnail/" in e.html
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.plain

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -1470,10 +1470,10 @@ def test_request_notifications(db, push_collector: PushCollector, moderator):
     assert host.name in e.html
     assert surfer.name in e.plain
     assert surfer.name in e.html
-    assert surfer_loc_context.localize_date(today_plus_2) in e.plain
-    assert surfer_loc_context.localize_date(today_plus_2) in e.html
-    assert surfer_loc_context.localize_date(today_plus_3) in e.plain
-    assert surfer_loc_context.localize_date(today_plus_3) in e.html
+    assert surfer_loc_context.localize_date(today_plus_2, with_year=False) in e.plain
+    assert surfer_loc_context.localize_date(today_plus_2, with_year=False) in e.html
+    assert surfer_loc_context.localize_date(today_plus_3, with_year=False) in e.plain
+    assert surfer_loc_context.localize_date(today_plus_3, with_year=False) in e.html
     assert "http://localhost:5001/img/thumbnail/" not in e.plain
     assert "http://localhost:5001/img/thumbnail/" in e.html
     assert f"http://localhost:3000/messages/request/{hr_id}" in e.plain


### PR DESCRIPTION
#8574 added support for localized date format variants. We can use it with requests to make them more useful: we don't need to show the year since requests are within 365 days (and typically within a month), and we can add the day of the week since that's useful info (hosting weekend vs day of week).

Updates tests accordingly. Which makes me think we should rather mock the system clock: #8854

## Testing
After this change:
<img width="1061" height="551" alt="image" src="https://github.com/user-attachments/assets/bd437943-3ce1-42be-b229-4d4f0ea18d08" />

Before:
<img width="1041" height="547" alt="image" src="https://github.com/user-attachments/assets/e831f3f6-df01-4e6c-b76f-c99a85b12c91" />

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me