### PR TITLE
Backend: Fix host request rejected email + add email localization guardrail

### DIFF
--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -912,7 +912,7 @@ class HostRequestStatusChangedEmail(EmailBase):
             case conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED:
                 return f"{base_key}.accepted_by_host"
             case conversations_pb2.HOST_REQUEST_STATUS_REJECTED:
-                return f"{base_key}.rejected_by_host"
+                return f"{base_key}.declined_by_host"
             case conversations_pb2.HOST_REQUEST_STATUS_CONFIRMED:
                 return f"{base_key}.confirmed_by_surfer"
             case conversations_pb2.HOST_REQUEST_STATUS_CANCELLED:

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -877,7 +877,7 @@ class HostRequestStatusChangedEmail(EmailBase):
             case conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED:
                 return f"{base_key}.accepted_by_host"
             case conversations_pb2.HOST_REQUEST_STATUS_REJECTED:
-                return f"{base_key}.declined_by_host"
+                return f"{base_key}.rejected_by_host"
             case conversations_pb2.HOST_REQUEST_STATUS_CONFIRMED:
                 return f"{base_key}.confirmed_by_surfer"
             case conversations_pb2.HOST_REQUEST_STATUS_CANCELLED:

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -4,7 +4,7 @@ Defines data models for each email we sent out to users.
 
 import re
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, date, datetime
 from typing import Self, assert_never
 
@@ -65,6 +65,18 @@ class EmailBase(ABC):
     def dummy_data(cls) -> Self:
         """Returns an instance filled with dummy data that can be used for testing."""
         ...
+
+    @classmethod
+    def dummy_variants(cls) -> list[Self]:
+        """
+        Returns dummy instances covering every distinct rendering variant of this email.
+
+        Emails whose subject or body depends on internal state (e.g. a status enum or a
+        boolean) build their localization keys dynamically, so a single dummy instance only
+        exercises one branch. Such emails override this to return one instance per branch,
+        ensuring the rendering tests resolve every localization key the class can produce.
+        """
+        return [cls.dummy_data()]
 
     # Helpers for localizing email-specific strings
     def _localize(
@@ -225,6 +237,11 @@ class BadgeChangedEmail(EmailBase):
     def dummy_data(cls) -> BadgeChangedEmail:
         return BadgeChangedEmail(user_name="Alice", badge_name="Founder", added=True)
 
+    @classmethod
+    def dummy_variants(cls) -> list[BadgeChangedEmail]:
+        base = cls.dummy_data()
+        return [replace(base, added=True), replace(base, added=False)]
+
 
 @dataclass(kw_only=True, slots=True)
 class BirthdateChangedEmail(EmailBase):
@@ -304,6 +321,14 @@ class ChatMessageReceivedEmail(EmailBase):
             text="Hi Alice!",
             view_url="https://couchers.org/messages/chats/123",
         )
+
+    @classmethod
+    def dummy_variants(cls) -> list[ChatMessageReceivedEmail]:
+        base = cls.dummy_data()
+        return [
+            replace(base, group_chat_title=None),
+            replace(base, group_chat_title="Best friends"),
+        ]
 
 
 @dataclass(kw_only=True, slots=True)
@@ -805,6 +830,11 @@ class HostRequestMessageEmail(EmailBase):
             view_link="https://couchers.org/requests/123",
         )
 
+    @classmethod
+    def dummy_variants(cls) -> list[HostRequestMessageEmail]:
+        base = cls.dummy_data()
+        return [replace(base, from_host=True), replace(base, from_host=False)]
+
 
 @dataclass(kw_only=True, slots=True)
 class HostRequestMissedMessagesEmail(EmailBase):
@@ -858,6 +888,11 @@ class HostRequestMissedMessagesEmail(EmailBase):
             from_host=True,
             view_link="https://couchers.org/requests/123",
         )
+
+    @classmethod
+    def dummy_variants(cls) -> list[HostRequestMissedMessagesEmail]:
+        base = cls.dummy_data()
+        return [replace(base, from_host=True), replace(base, from_host=False)]
 
 
 @dataclass(kw_only=True, slots=True)
@@ -949,6 +984,16 @@ class HostRequestStatusChangedEmail(EmailBase):
             new_status=conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED,
             view_link="https://couchers.org/requests/123",
         )
+
+    @classmethod
+    def dummy_variants(cls) -> list[HostRequestStatusChangedEmail]:
+        base = cls.dummy_data()
+        return [
+            replace(base, new_status=conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED),
+            replace(base, new_status=conversations_pb2.HOST_REQUEST_STATUS_REJECTED),
+            replace(base, new_status=conversations_pb2.HOST_REQUEST_STATUS_CONFIRMED),
+            replace(base, new_status=conversations_pb2.HOST_REQUEST_STATUS_CANCELLED),
+        ]
 
 
 @dataclass(kw_only=True, slots=True)
@@ -1060,6 +1105,11 @@ class PhoneNumberChangeEmail(EmailBase):
             completed=False,
         )
 
+    @classmethod
+    def dummy_variants(cls) -> list[PhoneNumberChangeEmail]:
+        base = cls.dummy_data()
+        return [replace(base, completed=False), replace(base, completed=True)]
+
 
 @dataclass(kw_only=True, slots=True)
 class PostalVerificationFailedEmail(EmailBase):
@@ -1092,6 +1142,15 @@ class PostalVerificationFailedEmail(EmailBase):
             user_name="Alice",
             reason=notification_data_pb2.POSTAL_VERIFICATION_FAIL_REASON_CODE_EXPIRED,
         )
+
+    @classmethod
+    def dummy_variants(cls) -> list[PostalVerificationFailedEmail]:
+        base = cls.dummy_data()
+        return [
+            replace(base, reason=notification_data_pb2.POSTAL_VERIFICATION_FAIL_REASON_CODE_EXPIRED),
+            replace(base, reason=notification_data_pb2.POSTAL_VERIFICATION_FAIL_REASON_TOO_MANY_ATTEMPTS),
+            replace(base, reason=notification_data_pb2.POSTAL_VERIFICATION_FAIL_REASON_UNKNOWN),
+        ]
 
 
 @dataclass(kw_only=True, slots=True)
@@ -1168,6 +1227,15 @@ class StrongVerificationFailedEmail(EmailBase):
             user_name="Alice",
             reason=notification_data_pb2.SV_FAIL_REASON_NOT_A_PASSPORT,
         )
+
+    @classmethod
+    def dummy_variants(cls) -> list[StrongVerificationFailedEmail]:
+        base = cls.dummy_data()
+        return [
+            replace(base, reason=notification_data_pb2.SV_FAIL_REASON_WRONG_BIRTHDATE_OR_GENDER),
+            replace(base, reason=notification_data_pb2.SV_FAIL_REASON_NOT_A_PASSPORT),
+            replace(base, reason=notification_data_pb2.SV_FAIL_REASON_DUPLICATE),
+        ]
 
 
 @dataclass(kw_only=True, slots=True)

--- a/app/backend/src/tests/test_email_localization.py
+++ b/app/backend/src/tests/test_email_localization.py
@@ -1,0 +1,69 @@
+"""
+Guardrail tests that every email fully renders in English.
+
+These emails build their localization keys at runtime (sometimes dynamically from internal
+state, e.g. a host request status), so a missing or mistyped key only blows up when that
+specific email is sent in production. Here we render every email -- and every variant of
+emails whose output depends on internal state -- and assert that no localization key is
+missing. See `EmailBase.dummy_variants`.
+"""
+
+import inspect
+from datetime import UTC
+
+import pytest
+
+import couchers.email.emails
+from couchers.email.emails import EmailBase
+from couchers.email.rendering import (
+    EmailFooter,
+    UnsubscribeInfo,
+    UnsubscribeLink,
+    render_html_body,
+    render_plaintext_body,
+)
+from couchers.i18n import LocalizationContext
+
+
+def _all_email_variants() -> list[tuple[str, EmailBase]]:
+    variants: list[tuple[str, EmailBase]] = []
+    for _, email_class in inspect.getmembers(
+        couchers.email.emails, lambda o: inspect.isclass(o) and o.__base__ == EmailBase
+    ):
+        instances = email_class.dummy_variants()
+        for i, instance in enumerate(instances):
+            variant_id = email_class.__name__ if len(instances) == 1 else f"{email_class.__name__}-{i}"
+            variants.append((variant_id, instance))
+    return variants
+
+
+_VARIANTS = _all_email_variants()
+
+_FOOTER = EmailFooter(
+    timezone_name="UTC",
+    unsubscribe_info=UnsubscribeInfo(
+        manage_notifications_url="https://example.com/manage-notifications",
+        do_not_email_url="https://example.com/do-not-email",
+        topic_action_link=UnsubscribeLink(text="topic-action", url="https://example.com/unsubscribe"),
+    ),
+)
+
+
+@pytest.fixture(autouse=True)
+def _(testconfig):
+    pass
+
+
+@pytest.mark.parametrize("email", [v for _, v in _VARIANTS], ids=[i for i, _ in _VARIANTS])
+def test_email_renders_in_english(email: EmailBase):
+    loc_context = LocalizationContext(locale="en", timezone=UTC)
+
+    subject = email.get_subject_line(loc_context)
+    assert subject
+
+    preview = email.get_preview_line(loc_context)
+    blocks = email.get_body_blocks(loc_context)
+
+    # Render both the html and plaintext bodies end-to-end, since each resolves its own keys.
+    render_html_body(subject=subject, preview=preview, blocks=blocks, footer=_FOOTER, loc_context=loc_context)
+    render_plaintext_body(blocks=blocks, footer=_FOOTER, loc_context=loc_context)


### PR DESCRIPTION
Adds some tests to safeguard for and closes https://github.com/Couchers-org/couchers/issues/8825 (already hotfixed in 543a20f46d32ae0cffe4750d2b81339667b3db59)

---

Fixes a production `LocalizationError` and adds a guardrail so this class of bug can't recur.

`HostRequestStatusChangedEmail` built its i18next key as `host_request_status_changed.rejected_by_host` for the `REJECTED` status, but `email/locales/en.json` defines `declined_by_host`. Any rejected-host-request notification therefore crashed when rendering its subject line. The same band-aid was already hotfixed on `develop` (#543a20f46); this PR redoes it properly behind a regression test.

How it slipped through: emails build their localization keys at runtime (often dynamically from internal state), and nothing rendered them in a test. Even the existing `dump_emails.py` would have missed it, since `dummy_data()` only covers a single status — the rejected branch was never exercised.

This PR is structured as three commits so CI demonstrates the gap:
1. **Revert the hotfix** — reintroduces the bug.
2. **Add the guardrail test** — renders every email and every variant in English, asserting no missing localization key. `EmailBase.dummy_variants()` lets multi-variant emails enumerate all their branches. CI is **red** here, failing only on the rejected-by-host variant.
3. **Re-fix the key** — `rejected_by_host` → `declined_by_host`. CI goes **green**.

## Testing

`uv run pytest src/tests/test_email_localization.py` — 42 variants pass, and (before the fix) the rejected-by-host variant reproduces the exact production `LocalizationError`.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
