### PR TITLE
Backend/i18n: Ensure we deal with supported locales

### DIFF
--- a/app/backend/src/app.py
+++ b/app/backend/src/app.py
@@ -24,7 +24,7 @@ from couchers.config import check_config, config
 from couchers.constants import API_BASE_PORT, API_WORKER_COUNT, GRACEFUL_SHUTDOWN_TIMEOUT, MEDIA_PORT
 from couchers.db import apply_migrations, db_post_fork, session_scope
 from couchers.experimentation import setup_experimentation
-from couchers.i18n.localize import get_main_i18next
+from couchers.i18n.locales import get_main_i18next
 from couchers.jobs.worker import start_jobs_scheduler, start_jobs_worker
 from couchers.metrics import create_prometheus_server
 from couchers.server import create_main_server, create_media_server

--- a/app/backend/src/couchers/i18n/context.py
+++ b/app/backend/src/couchers/i18n/context.py
@@ -7,10 +7,14 @@ import babel
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from couchers.i18n.i18next import I18Next
-from couchers.i18n.locales import DEFAULT_LOCALE, get_locale_fallbacks
-from couchers.i18n.localize import (
+from couchers.i18n.locales import (
+    DEFAULT_LOCALE,
     get_babel_locale,
+    get_locale_fallbacks,
     get_main_i18next,
+    is_supported_locale,
+)
+from couchers.i18n.localize import (
     localize_date,
     localize_datetime,
     localize_time,
@@ -40,10 +44,13 @@ class LocalizationContext:
     babel_locale: babel.Locale
 
     def __init__(self, locale: str, timezone: tzinfo) -> None:
+        if not is_supported_locale(locale):
+            raise ValueError(f"Unsupported locale {locale}.")
+
         self.locale = locale
         self.locale_list = [self.locale] + get_locale_fallbacks(self.locale)
         self.timezone = timezone
-        self.babel_locale = get_babel_locale(self.locale_list)
+        self.babel_locale = get_babel_locale(locale)
 
     def __setattr__(self, name: str, value: Any) -> None:
         # Freeze after initialization. We can't use @dataclass(frozen=True) because then

--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -4,11 +4,11 @@ Implements localizing strings stored in the i18next json format.
 
 import re
 from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from html import escape, unescape
 from typing import Any
 
-from babel import Locale, UnknownLocaleError
+import babel
 from markupsafe import Markup
 
 PLURALIZABLE_VARIABLE_NAME = "count"
@@ -22,16 +22,17 @@ PLURALIZABLE_VARIABLE_NAME = "count"
 SubstitutionDict = Mapping[str, str | int | Markup]
 
 
-@dataclass
 class I18Next:
     """Retrieves translated strings from their keys based on the i18next format."""
 
-    translations_by_locale: dict[str, Translation] = field(default_factory=dict)
-    default_translation: Translation | None = None
-    """The translation used to look up strings in unsupported locales."""
+    def __init__(self) -> None:
+        self.translations_by_locale: dict[str, Translation] = dict()
+
+        # The translation used to look up strings in unsupported locales.
+        self.default_translation: Translation | None = None
 
     def add_translation(self, locale: str, *, json_dict: dict[str, Any] | None = None) -> Translation:
-        translation = Translation(locale)
+        translation = Translation(babel_locale=babel.Locale.parse(locale, sep="-"))
         self.translations_by_locale[locale] = translation
         if json_dict:
             translation.load_json_dict(json_dict)
@@ -68,14 +69,18 @@ class I18Next:
             raise LocalizationError(locale, string_key)
 
 
-@dataclass
 class Translation:
     """A set of translated strings for a locale."""
 
-    locale: str
-    """The locale, e.g. 'en' or 'fr-CA'"""
-    strings_by_key: dict[str, String] = field(default_factory=dict)
-    fallbacks: list[Translation] = field(default_factory=list)
+    def __init__(self, *, babel_locale: babel.Locale) -> None:
+        # The Babel library locale for this translation. Used to resolved plural forms.
+        self.babel_locale = babel_locale
+        self.strings_by_key: dict[str, String] = dict()
+        self.fallbacks: list[Translation] = []
+
+    @property
+    def locale(self) -> str:
+        return str(self.babel_locale).replace("_", "-")
 
     def load_json_dict(self, json_dict: Mapping[str, Any]) -> None:
         def add_strings(json_dict: Mapping[str, Any], key_prefix: str | None) -> None:
@@ -103,14 +108,7 @@ class Translation:
         if substitutions:
             if count := substitutions.get(PLURALIZABLE_VARIABLE_NAME):
                 if isinstance(count, int):
-                    try:
-                        # Babel resolves the locale name into a filename that uses underscores
-                        babel_locale_name = self.locale.replace("-", "_")
-                        plural_form = Locale(babel_locale_name).plural_form(count)
-                    except UnknownLocaleError:
-                        # Fallback to English-style plural rule.
-                        plural_form = "one" if 1 else "other"
-                    plural_key = key + "_" + plural_form
+                    plural_key = key + "_" + self.babel_locale.plural_form(count)
                     if string := self.strings_by_key.get(plural_key):
                         return string
         return self.strings_by_key.get(key)

--- a/app/backend/src/couchers/i18n/locales.py
+++ b/app/backend/src/couchers/i18n/locales.py
@@ -1,5 +1,8 @@
 import json
+from functools import lru_cache
 from pathlib import Path
+
+import babel
 
 from couchers.i18n.i18next import I18Next
 
@@ -19,6 +22,46 @@ _LOCALE_FALLBACKS: dict[str, str] = {
 }
 
 
+def get_supported_locales() -> list[str]:
+    """Gets the list of supported locales (i.e., for which we have translations)."""
+    return list(get_main_i18next().translations_by_locale.keys())
+
+
+def is_supported_locale(locale: str) -> bool:
+    """Checks if a locale is supported (i.e., if we have translations for it)."""
+    return locale in get_main_i18next().translations_by_locale.keys()
+
+
+def to_supported_locale(locale: str) -> str:
+    """Converts a locale to the closest supported one."""
+
+    if is_supported_locale(locale):
+        return locale
+
+    # Normalize casing in case that's why we don't have a match (e.g., "en-us" vs "en-US")
+    try:
+        # Locale.parse returns either a 4-tuple or a 5-tuple
+        result_tuple = babel.parse_locale(locale, sep="-")
+        if len(result_tuple) == 4:
+            result = (*result_tuple, None)  # Normalize to 5-tuple for unpacking
+        language, territory, script, _, _ = result
+    except ValueError:
+        return DEFAULT_LOCALE
+
+    language = language.lower()
+    territory = territory.upper() if territory else None  # pt-BR, fr-CA
+    script = script.title() if script else None  # zh-Hans, zh-Hant
+
+    normalized_locale = "-".join(filter(None, [language, territory, script]))
+    if is_supported_locale(normalized_locale):
+        return normalized_locale
+
+    if is_supported_locale(language):
+        return language
+
+    return DEFAULT_LOCALE
+
+
 def get_locale_fallbacks(locale: str) -> list[str]:
     """Gets the list of locales to which to fallback to if the given one is unavailable."""
     if fallback := _LOCALE_FALLBACKS.get(locale):
@@ -26,6 +69,14 @@ def get_locale_fallbacks(locale: str) -> list[str]:
     if locale == DEFAULT_LOCALE:
         return []
     return [DEFAULT_LOCALE]
+
+
+def get_babel_locale(locale: str) -> babel.Locale:
+    """
+    Returns the babel locale object for a given locale string.
+    Guaranteed by tests to succeed for supported locales.
+    """
+    return babel.Locale.parse(locale, sep="-")
 
 
 def load_locales(directory: Path) -> I18Next:
@@ -55,3 +106,9 @@ def load_locales(directory: Path) -> I18Next:
             translation.fallbacks.append(i18next.translations_by_locale[fallback_locale])
 
     return i18next
+
+
+@lru_cache(maxsize=1)
+def get_main_i18next() -> I18Next:
+    """Gets the I18Next instance for the main locales files."""
+    return load_locales(Path(__file__).parent / "locales")

--- a/app/backend/src/couchers/i18n/localize.py
+++ b/app/backend/src/couchers/i18n/localize.py
@@ -6,32 +6,13 @@ Most code should use the higher-level couchers.i18n.LocalizationContext object.
 import re
 from collections.abc import Mapping
 from datetime import date, datetime, time, tzinfo
-from functools import lru_cache
-from pathlib import Path
 from typing import cast
 
 import babel
 import phonenumbers
 from babel.dates import get_datetime_format, get_timezone_name, match_skeleton, parse_pattern
 
-from couchers.i18n.i18next import I18Next
-from couchers.i18n.locales import DEFAULT_LOCALE, load_locales
-
-
-@lru_cache(maxsize=1)
-def get_main_i18next() -> I18Next:
-    """Gets the I18Next instance for the main locales files."""
-    return load_locales(Path(__file__).parent / "locales")
-
-
-def get_babel_locale(locale_list: list[str]) -> babel.Locale:
-    """Resolves a babel.Locale object from a list of locale candidates."""
-    for locale in locale_list:
-        try:
-            return babel.Locale.parse(locale, sep="-")
-        except babel.UnknownLocaleError:
-            continue
-    raise LookupError(f"No babel locale found for locales {', '.join(locale_list)}")
+from couchers.i18n.locales import DEFAULT_LOCALE, get_main_i18next
 
 
 def localize_string(lang: str | None, key: str, *, substitutions: Mapping[str, str | int] | None = None) -> str:

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -33,7 +33,7 @@ from couchers.context import CouchersContext, make_interactive_context, make_med
 from couchers.db import session_scope
 from couchers.descriptor_pool import get_descriptor_pool
 from couchers.i18n import LocalizationContext
-from couchers.i18n.locales import DEFAULT_LOCALE
+from couchers.i18n.locales import to_supported_locale
 from couchers.metrics import (
     observe_api_call,
     observe_in_servicer_duration_histogram,
@@ -332,10 +332,11 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             else:
                 sofa, new_sofa_cookie = generate_sofa_cookie()
 
+            locale = to_supported_locale((auth_info.ui_language_preference if auth_info else headers.ui_lang) or "")
             loc_context = LocalizationContext(
-                locale=(auth_info.ui_language_preference if auth_info else headers.ui_lang) or DEFAULT_LOCALE,
-                timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
-            )
+                    locale=locale,
+                    timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
+                )
         except Exception as e:
             observe_in_servicer_setup_errors_counter(method, type(e).__name__)
             sentry_sdk.set_tag("context", "servicer_setup")

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -334,9 +334,9 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
 
             locale = to_supported_locale((auth_info.ui_language_preference if auth_info else headers.ui_lang) or "")
             loc_context = LocalizationContext(
-                    locale=locale,
-                    timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
-                )
+                locale=locale,
+                timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
+            )
         except Exception as e:
             observe_in_servicer_setup_errors_counter(method, type(e).__name__)
             sentry_sdk.set_tag("context", "servicer_setup")

--- a/app/backend/src/couchers/templating.py
+++ b/app/backend/src/couchers/templating.py
@@ -19,7 +19,7 @@ from markupsafe import Markup
 
 from couchers.i18n import LocalizationContext
 from couchers.i18n.i18next import I18Next
-from couchers.i18n.localize import get_main_i18next
+from couchers.i18n.locales import get_main_i18next
 
 logger = logging.getLogger(__name__)
 

--- a/app/backend/src/tests/test_i18n.py
+++ b/app/backend/src/tests/test_i18n.py
@@ -1,5 +1,4 @@
 import pytest
-from babel import Locale, UnknownLocaleError
 
 from couchers.i18n.localize import get_main_i18next
 
@@ -36,15 +35,3 @@ def test_fallback_chain():
     assert en.fallbacks == []
 
     assert i18next.default_translation == en
-
-
-def test_babel_locales():
-    """Documents which locales are not supported/recognized by the Babel library's CLDR."""
-    unknown_locales: set[str] = set()
-    i18next = get_main_i18next()
-    for locale in i18next.translations_by_locale.keys():
-        try:
-            Locale(locale.replace("-", "_"))
-        except UnknownLocaleError:
-            unknown_locales.add(locale)
-    assert unknown_locales == set()

--- a/app/backend/src/tests/test_i18n_locales.py
+++ b/app/backend/src/tests/test_i18n_locales.py
@@ -1,6 +1,12 @@
 import pytest
 
-from couchers.i18n.localize import get_main_i18next
+from couchers.i18n.locales import (
+    DEFAULT_LOCALE,
+    get_babel_locale,
+    get_main_i18next,
+    get_supported_locales,
+    to_supported_locale,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -19,6 +25,27 @@ def test_translations_loaded():
 
     # Other languages should also exist
     assert len(i18next.translations_by_locale) > 1
+
+
+def test_to_supported_locale():
+    # No-ops
+    assert to_supported_locale("en") == "en"
+    assert to_supported_locale("fr") == "fr"
+    assert to_supported_locale("fr-CA") == "fr-CA"
+    assert to_supported_locale("zh-Hans") == "zh-Hans"
+
+    # Normalization
+    assert to_supported_locale("") == DEFAULT_LOCALE
+    assert to_supported_locale("xx") == DEFAULT_LOCALE
+    assert to_supported_locale("FR-ca") == "fr-CA"
+    assert to_supported_locale("en-UK") == "en"
+    assert to_supported_locale("en-Shorthand") == "en"
+    assert to_supported_locale("fr-CA-Shorthand") == "fr-CA"
+
+
+def test_all_supported_locales_have_babel_locales():
+    for locale in get_supported_locales():
+        assert get_babel_locale(locale), f"Locale {locale} does not have a valid Babel locale"
 
 
 def test_fallback_chain():

--- a/app/backend/src/tests/test_i18n_locales.py
+++ b/app/backend/src/tests/test_i18n_locales.py
@@ -34,9 +34,12 @@ def test_to_supported_locale():
     assert to_supported_locale("fr-CA") == "fr-CA"
     assert to_supported_locale("zh-Hans") == "zh-Hans"
 
-    # Normalization
+    # Bogus locales
     assert to_supported_locale("") == DEFAULT_LOCALE
     assert to_supported_locale("xx") == DEFAULT_LOCALE
+    assert to_supported_locale("------------------") == DEFAULT_LOCALE
+
+    # Normalization
     assert to_supported_locale("FR-ca") == "fr-CA"
     assert to_supported_locale("en-UK") == "en"
     assert to_supported_locale("en-Shorthand") == "en"

--- a/app/backend/src/tests/test_i18next.py
+++ b/app/backend/src/tests/test_i18next.py
@@ -1,3 +1,4 @@
+import babel
 import pytest
 from markupsafe import Markup
 
@@ -80,13 +81,11 @@ def test_plural_no_count():
     assert i18next.localize("apples", "en", {"count": 2}) == "apples"
 
 
-def test_missing_plural_rules():
+def test_missing_babel_locale():
     i18next = I18Next()
-    piglatin = i18next.add_translation("piglatin", json_dict={"pigs": "igpays", "pigs_one": "igpay"})
-    en = i18next.add_translation("en", json_dict={"pigs": "pigs", "pigs_one": "pig"})
-    piglatin.fallbacks.append(en)
-    # Should resolve using the english plural rules since "piglatin" doesn't have its own.
-    assert i18next.localize("pigs", "piglatin", {"count": 1}) == "igpay"
+
+    with pytest.raises(babel.UnknownLocaleError):
+        i18next.add_translation("piglatin")
 
 
 def test_load_simple_json():


### PR DESCRIPTION
Tighten locale validity invariants to avoid late errors:

- Normalize locales coming from the frontend to a supported value.
- Add test to assert that every supported locale has a `babel.Locale`.
- Prevent creating a `LocalizationContext` with an unsupported locale.

Related to #8830 and following up to previous fix in #8831.

Fixes #8832

## Testing
Added tests

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
