### PR TITLE
Backend/i18n: Support relative string keys

### DIFF
--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -693,7 +693,7 @@ class HostRequestCreatedEmail(EmailBase):
             },
         )
         builder.quote(self.text, markdown=False)
-        builder.action(self.view_link, ".view_action")
+        builder.action(self.view_link, "host_request_generic.view_action")
         builder.action(self.quick_decline_link, ".quick_decline_action")
         builder.para(".respond_encouragement")
         builder.para(_do_not_reply_request_string_key)

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -17,7 +17,7 @@ from couchers.email.rendering import (
     get_emails_i18next,
 )
 from couchers.i18n import LocalizationContext
-from couchers.i18n.i18next import SubstitutionDict
+from couchers.i18n.i18next import SubstitutionDict, full_string_key
 from couchers.i18n.localize import format_phone_number
 from couchers.notifications.quick_links import generate_quick_decline_link
 from couchers.proto import conversations_pb2, notification_data_pb2
@@ -34,11 +34,11 @@ class EmailBase(ABC):
 
     @property
     @abstractmethod
-    def string_key_prefix(self) -> str: ...
+    def string_key_base(self) -> str: ...
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         """Gets the subject line header of the email."""
-        return self._localize(loc_context, "subject")
+        return self._localize(loc_context, ".subject")
 
     def get_preview_line(self, loc_context: LocalizationContext) -> str | None:
         """Gets the line that gets shown as a preview next to the title in users' inboxes."""
@@ -49,7 +49,7 @@ class EmailBase(ABC):
 
         # Delegate to build_body, but wrap with greetings and closing lines common to all emails.
         i18next = get_emails_i18next()
-        builder = EmailBlocksBuilder(locale=loc_context.locale, string_key_prefix=self.string_key_prefix)
+        builder = EmailBlocksBuilder(locale=loc_context.locale, string_key_base=self.string_key_base)
         builder.block(
             ParaBlock(text=i18next.localize("generic.greeting_line", loc_context.locale, {"name": self.user_name}))
         )
@@ -82,11 +82,11 @@ class EmailBase(ABC):
     def _localize(
         self, loc_context: LocalizationContext, key: str, substitutions: SubstitutionDict | None = None
     ) -> str:
-        key = f"{self.string_key_prefix}.{key}"
+        key = full_string_key(key, relative_base=self.string_key_base)
         return get_emails_i18next().localize(key, loc_context.locale, substitutions)
 
     def _body_builder(self, loc_context: LocalizationContext) -> EmailBlocksBuilder:
-        return EmailBlocksBuilder(locale=loc_context.locale, string_key_prefix=self.string_key_prefix)
+        return EmailBlocksBuilder(locale=loc_context.locale, string_key_base=self.string_key_base)
 
 
 # Specific email definitions
@@ -99,13 +99,13 @@ class AccountDeletionStartedEmail(EmailBase):
     deletion_link: str
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "account_deletion_started"
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("request_description")
-        builder.para("confirmation_instructions")
-        builder.action(self.deletion_link, "confirm_action")
+        builder.para(".request_description")
+        builder.para(".confirmation_instructions")
+        builder.action(self.deletion_link, ".confirm_action")
         builder.security_warning_para()
 
     @classmethod
@@ -131,14 +131,14 @@ class AccountDeletionCompletedEmail(EmailBase):
     days: int
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "account_deletion_completed"
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("confirmation")
-        builder.para("farewell")
-        builder.para("recovery_instructions_days", {"count": self.days})
-        builder.action(self.undelete_link, "recover_action")
+        builder.para(".confirmation")
+        builder.para(".farewell")
+        builder.para(".recovery_instructions_days", {"count": self.days})
+        builder.action(self.undelete_link, ".recover_action")
         builder.security_warning_para()
 
     @classmethod
@@ -163,14 +163,14 @@ class AccountDeletionRecoveredEmail(EmailBase):
     """Sent to a user after their account deletion has been cancelled."""
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "account_deletion_recovered"
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("confirmation")
-        builder.para("login_instructions")
-        builder.action(urls.app_link(), "login_action")
-        builder.para("redelete_instructions")
+        builder.para(".confirmation")
+        builder.para(".login_instructions")
+        builder.action(urls.app_link(), ".login_action")
+        builder.para(".redelete_instructions")
         builder.security_warning_para()
 
     @classmethod
@@ -186,15 +186,15 @@ class APIKeyIssuedEmail(EmailBase):
     expiry: datetime
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "api_key_issued"
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("header")
+        builder.para(".header")
         builder.quote(self.api_key, markdown=False)
-        builder.para("expiry", {"datetime": loc_context.localize_datetime(self.expiry)})
-        builder.para("usage_warning")
-        builder.para("policy_warning")
+        builder.para(".expiry", {"datetime": loc_context.localize_datetime(self.expiry)})
+        builder.para(".usage_warning")
+        builder.para(".policy_warning")
         builder.security_warning_para()
 
     @classmethod
@@ -216,14 +216,14 @@ class BadgeChangedEmail(EmailBase):
     added: bool
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "badge_added" if self.added else "badge_removed"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, "subject", {"badge_name": self.badge_name})
+        return self._localize(loc_context, ".subject", {"badge_name": self.badge_name})
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body", {"badge_name": self.badge_name})
+        builder.para(".body", {"badge_name": self.badge_name})
 
     @classmethod
     def from_notification(
@@ -250,11 +250,11 @@ class BirthdateChangedEmail(EmailBase):
     new_birthdate: date
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "birthdate_changed"
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body", {"date": loc_context.localize_date(self.new_birthdate)})
+        builder.para(".body", {"date": loc_context.localize_date(self.new_birthdate)})
         builder.security_warning_para()
 
     @classmethod
@@ -279,19 +279,19 @@ class ChatMessageReceivedEmail(EmailBase):
     view_url: str
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return f"chat_message_received.{'direct' if self.group_chat_title is None else 'group'}"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(
-            loc_context, "subject", {"author": self.author.name, "group": self.group_chat_title or ""}
+            loc_context, ".subject", {"author": self.author.name, "group": self.group_chat_title or ""}
         )
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body", {"author": self.author.name, "group": self.group_chat_title or ""})
+        builder.para(".body", {"author": self.author.name, "group": self.group_chat_title or ""})
         builder.user(self.author)
         builder.quote(self.text, markdown=False)
-        builder.action(self.view_url, "view_action")
+        builder.action(self.view_url, ".view_action")
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.ChatMessage, *, user_name: str) -> Self:
@@ -348,21 +348,21 @@ class ChatMessagesMissedEmail(EmailBase):
     entries: list[Entry]
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "chat_messages_missed"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, "subject")
+        return self._localize(loc_context, ".subject")
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         for entry in self.entries:
             if entry.group_chat_title:
-                builder.para("in_group", {"count": entry.missed_count, "group": entry.group_chat_title})
+                builder.para(".in_group", {"count": entry.missed_count, "group": entry.group_chat_title})
             else:
-                builder.para("in_dm", {"count": entry.missed_count, "author": entry.latest_message_author.name})
+                builder.para(".in_dm", {"count": entry.missed_count, "author": entry.latest_message_author.name})
             builder.user(entry.latest_message_author)
             builder.quote(entry.latest_message_text, markdown=False)
-            builder.action(entry.view_url, "view_action")
+            builder.action(entry.view_url, ".view_action")
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.ChatMissedMessages, *, user_name: str) -> Self:
@@ -430,15 +430,15 @@ class DiscussionCreatedEmail(EmailBase):
     view_link: str
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "discussion_created"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, "subject", {"author": self.author.name, "title": self.title})
+        return self._localize(loc_context, ".subject", {"author": self.author.name, "title": self.title})
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         builder.para(
-            "body",
+            ".body",
             {
                 "author": self.author.name,
                 "title": self.title,
@@ -447,7 +447,7 @@ class DiscussionCreatedEmail(EmailBase):
         )
         builder.user(self.author)
         builder.quote(self.markdown_text, markdown=True)
-        builder.action(self.view_link, "view_action")
+        builder.action(self.view_link, ".view_action")
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.DiscussionCreate, *, user_name: str) -> Self:
@@ -484,17 +484,17 @@ class DiscussionCommentEmail(EmailBase):
     view_link: str
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "discussion_comment"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(
-            loc_context, "subject", {"author": self.author.name, "discussion_title": self.discussion_title}
+            loc_context, ".subject", {"author": self.author.name, "discussion_title": self.discussion_title}
         )
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         builder.para(
-            "body",
+            ".body",
             {
                 "author": self.author.name,
                 "discussion_title": self.discussion_title,
@@ -503,7 +503,7 @@ class DiscussionCommentEmail(EmailBase):
         )
         builder.user(self.author)
         builder.quote(self.markdown_text, markdown=True)
-        builder.action(self.view_link, "view_action")
+        builder.action(self.view_link, ".view_action")
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.DiscussionComment, *, user_name: str) -> Self:
@@ -536,11 +536,11 @@ class EmailAddressChangedEmail(EmailBase):
     new_email: str
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "email_address_change_initiated"
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body", {"email_address": self.new_email})
+        builder.para(".body", {"email_address": self.new_email})
         builder.security_warning_para()
 
     @classmethod
@@ -557,11 +557,11 @@ class EmailAddressVerifiedEmail(EmailBase):
     """Sent to a user to notify them that their new email address has been verified."""
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "email_address_verified"
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body")
+        builder.para(".body")
         builder.security_warning_para()
 
     @classmethod
@@ -576,20 +576,20 @@ class FriendRequestReceivedEmail(EmailBase):
     befriender: UserInfo
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "friend_request_received"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, "subject", {"name": self.befriender.name})
+        return self._localize(loc_context, ".subject", {"name": self.befriender.name})
 
     def get_preview_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, "body", {"name": self.befriender.name})
+        return self._localize(loc_context, ".body", {"name": self.befriender.name})
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body", {"name": self.befriender.name})
+        builder.para(".body", {"name": self.befriender.name})
         builder.user(self.befriender)
-        builder.action(urls.friend_requests_link(), "view_action")
-        builder.para("closing")
+        builder.action(urls.friend_requests_link(), ".view_action")
+        builder.para(".closing")
         builder.do_not_reply_request_para()
 
     @classmethod
@@ -611,20 +611,20 @@ class FriendRequestAcceptedEmail(EmailBase):
     new_friend: UserInfo
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "friend_request_accepted"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, "subject", {"name": self.new_friend.name})
+        return self._localize(loc_context, ".subject", {"name": self.new_friend.name})
 
     def get_preview_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, "body", {"name": self.new_friend.name})
+        return self._localize(loc_context, ".body", {"name": self.new_friend.name})
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body", {"name": self.new_friend.name})
+        builder.para(".body", {"name": self.new_friend.name})
         builder.user(self.new_friend)
-        builder.action(self.new_friend.profile_url, "view_action")
-        builder.para("closing")
+        builder.action(self.new_friend.profile_url, ".view_action")
+        builder.para(".closing")
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.FriendRequestAccept, *, user_name: str) -> Self:
@@ -645,11 +645,11 @@ class GenderChangedEmail(EmailBase):
     new_gender: str
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "gender_changed"
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body", {"gender": self.new_gender})
+        builder.para(".body", {"gender": self.new_gender})
         builder.security_warning_para()
 
     @classmethod
@@ -676,14 +676,14 @@ class HostRequestCreatedEmail(EmailBase):
     view_link: str
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "host_request_created"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, "subject", {"surfer_name": self.surfer.name})
+        return self._localize(loc_context, ".subject", {"surfer_name": self.surfer.name})
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body", {"surfer_name": self.surfer.name})
+        builder.para(".body", {"surfer_name": self.surfer.name})
         builder.user(
             self.surfer,
             "date_range",
@@ -693,9 +693,9 @@ class HostRequestCreatedEmail(EmailBase):
             },
         )
         builder.quote(self.text, markdown=False)
-        builder.action(self.view_link, "view_action")
-        builder.action(self.quick_decline_link, "quick_decline_action")
-        builder.para("respond_encouragement")
+        builder.action(self.view_link, ".view_action")
+        builder.action(self.quick_decline_link, ".quick_decline_action")
+        builder.para(".respond_encouragement")
         builder.do_not_reply_request_para()
 
     @classmethod
@@ -733,23 +733,23 @@ class HostRequestReminderEmail(EmailBase):
     view_link: str
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "host_request_reminder"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, "subject", {"surfer_name": self.surfer.name})
+        return self._localize(loc_context, ".subject", {"surfer_name": self.surfer.name})
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body")
+        builder.para(".body")
         builder.user(
             self.surfer,
-            ".host_request_generic.date_range",
+            "host_request_generic.date_range",
             {
                 "from_date": _localize_host_request_date(self.from_date, loc_context),
                 "to_date": _localize_host_request_date(self.to_date, loc_context),
             },
         )
-        builder.action(self.view_link, ".host_request_generic.view_action")
+        builder.action(self.view_link, "host_request_generic.view_action")
         builder.do_not_reply_request_para()
 
     @classmethod
@@ -785,25 +785,25 @@ class HostRequestMessageEmail(EmailBase):
     view_link: str
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         variant = "from_host" if self.from_host else "from_surfer"
         return f"host_request_message.{variant}"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, "subject", {"other_name": self.other_user.name})
+        return self._localize(loc_context, ".subject", {"other_name": self.other_user.name})
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body", {"other_name": self.other_user.name})
+        builder.para(".body", {"other_name": self.other_user.name})
         builder.user(
             self.other_user,
-            ".host_request_generic.date_range",
+            "host_request_generic.date_range",
             {
                 "from_date": _localize_host_request_date(self.from_date, loc_context),
                 "to_date": _localize_host_request_date(self.to_date, loc_context),
             },
         )
         builder.quote(self.text, markdown=False)
-        builder.action(self.view_link, ".host_request_generic.view_action")
+        builder.action(self.view_link, "host_request_generic.view_action")
         builder.do_not_reply_request_para()
 
     @classmethod
@@ -847,24 +847,24 @@ class HostRequestMissedMessagesEmail(EmailBase):
     view_link: str
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         variant = "from_host" if self.from_host else "from_surfer"
         return f"host_request_missed_messages.{variant}"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, "subject", {"other_name": self.other_user.name})
+        return self._localize(loc_context, ".subject", {"other_name": self.other_user.name})
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body", {"other_name": self.other_user.name})
+        builder.para(".body", {"other_name": self.other_user.name})
         builder.user(
             self.other_user,
-            ".host_request_generic.date_range",
+            "host_request_generic.date_range",
             {
                 "from_date": _localize_host_request_date(self.from_date, loc_context),
                 "to_date": _localize_host_request_date(self.to_date, loc_context),
             },
         )
-        builder.action(self.view_link, ".host_request_generic.view_action")
+        builder.action(self.view_link, "host_request_generic.view_action")
         builder.do_not_reply_request_para()
 
     @classmethod
@@ -906,7 +906,7 @@ class HostRequestStatusChangedEmail(EmailBase):
     view_link: str
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         base_key = "host_request_status_changed"
         match self.new_status:
             case conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED:
@@ -921,19 +921,19 @@ class HostRequestStatusChangedEmail(EmailBase):
                 raise ValueError(f"Unexpected host request status: {self.new_status}")
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, "subject", {"other_name": self.other_user.name})
+        return self._localize(loc_context, ".subject", {"other_name": self.other_user.name})
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body", {"other_name": self.other_user.name})
+        builder.para(".body", {"other_name": self.other_user.name})
         builder.user(
             self.other_user,
-            ".host_request_generic.date_range",
+            "host_request_generic.date_range",
             {
                 "from_date": _localize_host_request_date(self.from_date, loc_context),
                 "to_date": _localize_host_request_date(self.to_date, loc_context),
             },
         )
-        builder.action(self.view_link, ".host_request_generic.view_action")
+        builder.action(self.view_link, "host_request_generic.view_action")
         builder.do_not_reply_request_para()
 
     @classmethod
@@ -1001,11 +1001,11 @@ class ModeratorNoteEmail(EmailBase):
     """Sent to a user to notify them they have received a moderator note."""
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "moderator_note"
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body")
+        builder.para(".body")
 
     @classmethod
     def dummy_data(cls) -> ModeratorNoteEmail:
@@ -1017,11 +1017,11 @@ class PasswordChangedEmail(EmailBase):
     """Sent to a user to notify them that their login password was changed."""
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "password_changed"
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body")
+        builder.para(".body")
         builder.security_warning_para()
 
     @classmethod
@@ -1034,11 +1034,11 @@ class PasswordResetCompletedEmail(EmailBase):
     """Sent to a user to confirm their password was successfully reset."""
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "password_reset_completed"
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body")
+        builder.para(".body")
         builder.security_warning_para()
 
     @classmethod
@@ -1053,13 +1053,13 @@ class PasswordResetStartedEmail(EmailBase):
     password_reset_link: str
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "password_reset_started"
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("request_description")
-        builder.para("confirmation_instructions")
-        builder.action(self.password_reset_link, "reset_action")
+        builder.para(".request_description")
+        builder.para(".confirmation_instructions")
+        builder.action(self.password_reset_link, ".reset_action")
         builder.security_warning_para()
 
     @classmethod
@@ -1082,11 +1082,11 @@ class PhoneNumberChangeEmail(EmailBase):
     completed: bool  # False = started, True = completed
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "phone_number_verified" if self.completed else "phone_number_verification_started"
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body", {"phone_number": format_phone_number(self.new_phone_number)})
+        builder.para(".body", {"phone_number": format_phone_number(self.new_phone_number)})
         builder.security_warning_para()
 
     @classmethod
@@ -1118,17 +1118,17 @@ class PostalVerificationFailedEmail(EmailBase):
     reason: notification_data_pb2.PostalVerificationFailReason.ValueType
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "postal_verification_failed"
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         match self.reason:
             case notification_data_pb2.POSTAL_VERIFICATION_FAIL_REASON_CODE_EXPIRED:
-                reason_string_key = "reason_code_expired"
+                reason_string_key = ".reason_code_expired"
             case notification_data_pb2.POSTAL_VERIFICATION_FAIL_REASON_TOO_MANY_ATTEMPTS:
-                reason_string_key = "reason_too_many_attempts"
+                reason_string_key = ".reason_too_many_attempts"
             case _:
-                reason_string_key = "reason_unknown"
+                reason_string_key = ".reason_unknown"
         builder.para(reason_string_key)
         builder.security_warning_para()
 
@@ -1161,11 +1161,11 @@ class PostalVerificationPostcardSentEmail(EmailBase):
     country: str
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "postal_verification_postcard_sent"
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body", {"city": self.city, "country": self.country})
+        builder.para(".body", {"city": self.city, "country": self.country})
         builder.security_warning_para()
 
     @classmethod
@@ -1182,11 +1182,11 @@ class PostalVerificationSucceededEmail(EmailBase):
     """Sent to a user when their postal verification has succeeded."""
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "postal_verification_succeeded"
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body")
+        builder.para(".body")
         builder.security_warning_para()
 
     @classmethod
@@ -1201,17 +1201,17 @@ class StrongVerificationFailedEmail(EmailBase):
     reason: notification_data_pb2.SVFailReason.ValueType
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "strong_verification_failed"
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         match self.reason:
             case notification_data_pb2.SV_FAIL_REASON_WRONG_BIRTHDATE_OR_GENDER:
-                reason_string_key = "reason_wrong_birthdate_or_gender"
+                reason_string_key = ".reason_wrong_birthdate_or_gender"
             case notification_data_pb2.SV_FAIL_REASON_NOT_A_PASSPORT:
-                reason_string_key = "reason_not_a_passport"
+                reason_string_key = ".reason_not_a_passport"
             case notification_data_pb2.SV_FAIL_REASON_DUPLICATE:
-                reason_string_key = "reason_duplicate"
+                reason_string_key = ".reason_duplicate"
             case _:
                 raise Exception("Shouldn't get here")
         builder.para(reason_string_key)
@@ -1243,16 +1243,16 @@ class StrongVerificationSucceededEmail(EmailBase):
     """Sent to a user when their strong verification has succeeded."""
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "strong_verification_succeeded"
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("success_message")
-        builder.para("thanks_message")
-        builder.para("cost_explanation")
-        builder.para("donation_request")
+        builder.para(".success_message")
+        builder.para(".thanks_message")
+        builder.para(".cost_explanation")
+        builder.para(".donation_request")
         donate_link = urls.donation_url() + "?utm_source=strong-verification-email"
-        builder.action(donate_link, "donate_action")
+        builder.action(donate_link, ".donate_action")
         builder.security_warning_para()
 
     @classmethod
@@ -1270,19 +1270,19 @@ class ThreadReplyEmail(EmailBase):
     view_link: str
 
     @property
-    def string_key_prefix(self) -> str:
+    def string_key_base(self) -> str:
         return "thread_reply"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(
-            loc_context, "subject", {"author": self.author.name, "parent_context": self.parent_context}
+            loc_context, ".subject", {"author": self.author.name, "parent_context": self.parent_context}
         )
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
-        builder.para("body", {"author": self.author.name, "parent_context": self.parent_context})
+        builder.para(".body", {"author": self.author.name, "parent_context": self.parent_context})
         builder.user(self.author)
         builder.quote(self.markdown_text, markdown=True)
-        builder.action(self.view_link, "view_action")
+        builder.action(self.view_link, ".view_action")
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.ThreadReply, *, user_name: str) -> Self:

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -686,7 +686,7 @@ class HostRequestCreatedEmail(EmailBase):
         builder.para(".body", {"surfer_name": self.surfer.name})
         builder.user(
             self.surfer,
-            "date_range",
+            "host_request_generic.date_range",
             {
                 "from_date": _localize_host_request_date(self.from_date, loc_context),
                 "to_date": _localize_host_request_date(self.to_date, loc_context),

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -12,7 +12,6 @@ from couchers import urls
 from couchers.email.rendering import (
     EmailBlock,
     EmailBlocksBuilder,
-    ParaBlock,
     UserInfo,
     get_emails_i18next,
 )
@@ -48,13 +47,10 @@ class EmailBase(ABC):
         """Gets the blocks that form the body of the email."""
 
         # Delegate to build_body, but wrap with greetings and closing lines common to all emails.
-        i18next = get_emails_i18next()
         builder = EmailBlocksBuilder(locale=loc_context.locale, string_key_base=self.string_key_base)
-        builder.block(
-            ParaBlock(text=i18next.localize("generic.greeting_line", loc_context.locale, {"name": self.user_name}))
-        )
+        builder.para("generic.greeting_line", {"name": self.user_name})
         self.build_body(builder, loc_context)
-        builder.block(ParaBlock(text=i18next.localize("generic.closing_line", loc_context.locale)))
+        builder.para("generic.closing_line")
         return builder.blocks
 
     @abstractmethod
@@ -89,6 +85,10 @@ class EmailBase(ABC):
         return EmailBlocksBuilder(locale=loc_context.locale, string_key_base=self.string_key_base)
 
 
+# Common string keys
+_do_not_reply_request_string_key = "generic.do_not_reply_request"
+_security_warning_string_key = "generic.security_warning_contact_support"
+
 # Specific email definitions
 
 
@@ -106,7 +106,7 @@ class AccountDeletionStartedEmail(EmailBase):
         builder.para(".request_description")
         builder.para(".confirmation_instructions")
         builder.action(self.deletion_link, ".confirm_action")
-        builder.security_warning_para()
+        builder.para(_security_warning_string_key)
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.AccountDeletionStart, *, user_name: str) -> Self:
@@ -139,7 +139,7 @@ class AccountDeletionCompletedEmail(EmailBase):
         builder.para(".farewell")
         builder.para(".recovery_instructions_days", {"count": self.days})
         builder.action(self.undelete_link, ".recover_action")
-        builder.security_warning_para()
+        builder.para(_security_warning_string_key)
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.AccountDeletionComplete, *, user_name: str) -> Self:
@@ -171,7 +171,7 @@ class AccountDeletionRecoveredEmail(EmailBase):
         builder.para(".login_instructions")
         builder.action(urls.app_link(), ".login_action")
         builder.para(".redelete_instructions")
-        builder.security_warning_para()
+        builder.para(_security_warning_string_key)
 
     @classmethod
     def dummy_data(cls) -> AccountDeletionRecoveredEmail:
@@ -195,7 +195,7 @@ class APIKeyIssuedEmail(EmailBase):
         builder.para(".expiry", {"datetime": loc_context.localize_datetime(self.expiry)})
         builder.para(".usage_warning")
         builder.para(".policy_warning")
-        builder.security_warning_para()
+        builder.para(_security_warning_string_key)
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.ApiKeyCreate, *, user_name: str) -> Self:
@@ -255,7 +255,7 @@ class BirthdateChangedEmail(EmailBase):
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         builder.para(".body", {"date": loc_context.localize_date(self.new_birthdate)})
-        builder.security_warning_para()
+        builder.para(_security_warning_string_key)
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.BirthdateChange, *, user_name: str) -> Self:
@@ -541,7 +541,7 @@ class EmailAddressChangedEmail(EmailBase):
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         builder.para(".body", {"email_address": self.new_email})
-        builder.security_warning_para()
+        builder.para(_security_warning_string_key)
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.EmailAddressChange, *, user_name: str) -> Self:
@@ -562,7 +562,7 @@ class EmailAddressVerifiedEmail(EmailBase):
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         builder.para(".body")
-        builder.security_warning_para()
+        builder.para(_security_warning_string_key)
 
     @classmethod
     def dummy_data(cls) -> EmailAddressVerifiedEmail:
@@ -590,7 +590,7 @@ class FriendRequestReceivedEmail(EmailBase):
         builder.user(self.befriender)
         builder.action(urls.friend_requests_link(), ".view_action")
         builder.para(".closing")
-        builder.do_not_reply_request_para()
+        builder.para(_do_not_reply_request_string_key)
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.FriendRequestCreate, *, user_name: str) -> Self:
@@ -650,7 +650,7 @@ class GenderChangedEmail(EmailBase):
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         builder.para(".body", {"gender": self.new_gender})
-        builder.security_warning_para()
+        builder.para(_security_warning_string_key)
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.GenderChange, *, user_name: str) -> Self:
@@ -696,7 +696,7 @@ class HostRequestCreatedEmail(EmailBase):
         builder.action(self.view_link, ".view_action")
         builder.action(self.quick_decline_link, ".quick_decline_action")
         builder.para(".respond_encouragement")
-        builder.do_not_reply_request_para()
+        builder.para(_do_not_reply_request_string_key)
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.HostRequestCreate, *, user_name: str) -> Self:
@@ -750,7 +750,7 @@ class HostRequestReminderEmail(EmailBase):
             },
         )
         builder.action(self.view_link, "host_request_generic.view_action")
-        builder.do_not_reply_request_para()
+        builder.para(_do_not_reply_request_string_key)
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.HostRequestReminder, *, user_name: str) -> Self:
@@ -804,7 +804,7 @@ class HostRequestMessageEmail(EmailBase):
         )
         builder.quote(self.text, markdown=False)
         builder.action(self.view_link, "host_request_generic.view_action")
-        builder.do_not_reply_request_para()
+        builder.para(_do_not_reply_request_string_key)
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.HostRequestMessage, *, user_name: str) -> Self:
@@ -865,7 +865,7 @@ class HostRequestMissedMessagesEmail(EmailBase):
             },
         )
         builder.action(self.view_link, "host_request_generic.view_action")
-        builder.do_not_reply_request_para()
+        builder.para(_do_not_reply_request_string_key)
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.HostRequestMissedMessages, *, user_name: str) -> Self:
@@ -934,7 +934,7 @@ class HostRequestStatusChangedEmail(EmailBase):
             },
         )
         builder.action(self.view_link, "host_request_generic.view_action")
-        builder.do_not_reply_request_para()
+        builder.para(_do_not_reply_request_string_key)
 
     @classmethod
     def from_notification(
@@ -1022,7 +1022,7 @@ class PasswordChangedEmail(EmailBase):
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         builder.para(".body")
-        builder.security_warning_para()
+        builder.para(_security_warning_string_key)
 
     @classmethod
     def dummy_data(cls) -> PasswordChangedEmail:
@@ -1039,7 +1039,7 @@ class PasswordResetCompletedEmail(EmailBase):
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         builder.para(".body")
-        builder.security_warning_para()
+        builder.para(_security_warning_string_key)
 
     @classmethod
     def dummy_data(cls) -> PasswordResetCompletedEmail:
@@ -1060,7 +1060,7 @@ class PasswordResetStartedEmail(EmailBase):
         builder.para(".request_description")
         builder.para(".confirmation_instructions")
         builder.action(self.password_reset_link, ".reset_action")
-        builder.security_warning_para()
+        builder.para(_security_warning_string_key)
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.PasswordResetStart, *, user_name: str) -> Self:
@@ -1087,7 +1087,7 @@ class PhoneNumberChangeEmail(EmailBase):
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         builder.para(".body", {"phone_number": format_phone_number(self.new_phone_number)})
-        builder.security_warning_para()
+        builder.para(_security_warning_string_key)
 
     @classmethod
     def from_change_notification(cls, data: notification_data_pb2.PhoneNumberChange, *, user_name: str) -> Self:
@@ -1130,7 +1130,7 @@ class PostalVerificationFailedEmail(EmailBase):
             case _:
                 reason_string_key = ".reason_unknown"
         builder.para(reason_string_key)
-        builder.security_warning_para()
+        builder.para(_security_warning_string_key)
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.PostalVerificationFailed, *, user_name: str) -> Self:
@@ -1166,7 +1166,7 @@ class PostalVerificationPostcardSentEmail(EmailBase):
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         builder.para(".body", {"city": self.city, "country": self.country})
-        builder.security_warning_para()
+        builder.para(_security_warning_string_key)
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.PostalVerificationPostcardSent, *, user_name: str) -> Self:
@@ -1187,7 +1187,7 @@ class PostalVerificationSucceededEmail(EmailBase):
 
     def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
         builder.para(".body")
-        builder.security_warning_para()
+        builder.para(_security_warning_string_key)
 
     @classmethod
     def dummy_data(cls) -> PostalVerificationSucceededEmail:
@@ -1215,7 +1215,7 @@ class StrongVerificationFailedEmail(EmailBase):
             case _:
                 raise Exception("Shouldn't get here")
         builder.para(reason_string_key)
-        builder.security_warning_para()
+        builder.para(_security_warning_string_key)
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.VerificationSVFail, *, user_name: str) -> Self:
@@ -1253,7 +1253,7 @@ class StrongVerificationSucceededEmail(EmailBase):
         builder.para(".donation_request")
         donate_link = urls.donation_url() + "?utm_source=strong-verification-email"
         builder.action(donate_link, ".donate_action")
-        builder.security_warning_para()
+        builder.para(_security_warning_string_key)
 
     @classmethod
     def dummy_data(cls) -> StrongVerificationSucceededEmail:

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -113,8 +113,6 @@
   "host_request_created": {
     "subject": "{{surfer_name}} sent you a host request",
     "body": "<b>{{surfer_name}}</b> sent you a host request:",
-    "date_range": "From <b>{{from_date}}</b> to <b>{{to_date}}</b>.",
-    "view_action": "View host request",
     "quick_decline_action": "Quick decline (no login needed)",
     "respond_encouragement": "Please respond to this request, even a quick decline is better than no response!"
   },

--- a/app/backend/src/couchers/email/rendering.py
+++ b/app/backend/src/couchers/email/rendering.py
@@ -99,7 +99,7 @@ class TwoButtonHTMLBlock(EmailBlock):
 
 class EmailBlocksBuilder:
     """
-    Builder object for constructing a list of EmailBlock's to form the body of an email.
+    Builder object for constructing a list of localized EmailBlock's to form the body of an email.
     """
 
     _locale: str
@@ -128,14 +128,6 @@ class EmailBlocksBuilder:
 
     def action(self, url: str, text_key: str, substitutions: SubstitutionDict | None = None) -> Self:
         return self.block(ActionBlock(text=self._text(text_key, substitutions), target_url=url))
-
-    def do_not_reply_request_para(self) -> Self:
-        line = get_emails_i18next().localize_with_markup("generic.do_not_reply_request", self._locale)
-        return self.block(ParaBlock(text=line))
-
-    def security_warning_para(self) -> Self:
-        line = get_emails_i18next().localize_with_markup("generic.security_warning_contact_support", self._locale)
-        return self.block(ParaBlock(text=line))
 
     def block(self, block: EmailBlock) -> Self:
         self.blocks.append(block)

--- a/app/backend/src/couchers/email/rendering.py
+++ b/app/backend/src/couchers/email/rendering.py
@@ -13,7 +13,7 @@ from markupsafe import Markup
 
 from couchers import urls
 from couchers.i18n import LocalizationContext
-from couchers.i18n.i18next import I18Next, SubstitutionDict
+from couchers.i18n.i18next import I18Next, SubstitutionDict, full_string_key
 from couchers.i18n.locales import load_locales
 from couchers.proto import api_pb2
 from couchers.templating import Jinja2Template, _markdown, template_folder
@@ -103,13 +103,13 @@ class EmailBlocksBuilder:
     """
 
     _locale: str
-    _string_key_prefix: str
+    _string_key_base: str
     blocks: list[EmailBlock]
 
-    def __init__(self, locale: str, string_key_prefix: str):
+    def __init__(self, locale: str, string_key_base: str):
         self.blocks = []
         self._locale = locale
-        self._string_key_prefix = string_key_prefix
+        self._string_key_base = string_key_base
 
     def para(self, key: str, substitutions: SubstitutionDict | None = None) -> Self:
         return self.block(ParaBlock(text=self._markup(key, substitutions)))
@@ -142,20 +142,12 @@ class EmailBlocksBuilder:
         return self
 
     def _text(self, key: str, substitutions: SubstitutionDict | None = None) -> str:
-        full_key = self._to_full_string_key(key)
-        return get_emails_i18next().localize(full_key, self._locale, substitutions)
+        key = full_string_key(key, relative_base=self._string_key_base)
+        return get_emails_i18next().localize(key, self._locale, substitutions)
 
     def _markup(self, key: str, substitutions: SubstitutionDict | None = None) -> Markup:
-        full_key = self._to_full_string_key(key)
-        return get_emails_i18next().localize_with_markup(full_key, self._locale, substitutions)
-
-    def _to_full_string_key(self, key: str) -> str:
-        # It's convenient to have a default key prefix,
-        # but sometimes we need to access something outside of it.
-        if key.startswith("."):  # Escape hatch. Think rooted '/dir/file' paths in unix.
-            return key[1:]
-        else:
-            return f"{self._string_key_prefix}.{key}"
+        key = full_string_key(key, relative_base=self._string_key_base)
+        return get_emails_i18next().localize_with_markup(key, self._locale, substitutions)
 
 
 @dataclass(kw_only=True)

--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -211,3 +211,12 @@ class LocalizationError(Exception):
         self.locale = locale
         self.string_key = string_key
         super().__init__(f"Could not localize string {string_key} for locale {locale}")
+
+
+def full_string_key(key: str, *, relative_base: str | None) -> str:
+    """Resolves any relative string key (starting with '.') into a full string key."""
+    if key.startswith("."):
+        if relative_base is None:
+            raise ValueError("Relative string key requires a relative base.")
+        return relative_base + key
+    return key

--- a/app/backend/src/tests/test_i18next.py
+++ b/app/backend/src/tests/test_i18next.py
@@ -1,7 +1,7 @@
 import pytest
 from markupsafe import Markup
 
-from couchers.i18n.i18next import I18Next, LocalizationError
+from couchers.i18n.i18next import I18Next, LocalizationError, full_string_key
 
 
 def test_lookup():
@@ -192,3 +192,11 @@ def test_escaping():
     assert (
         i18next.localize_with_markup("greeting", "en", substitutions={"name": Markup("<script/>")}) == "hello <script/>"
     )
+
+
+def test_full_string_key():
+    assert full_string_key("key", relative_base=None) == "key"
+    assert full_string_key("key", relative_base="base") == "key"
+    assert full_string_key(".key", relative_base="base") == "base.key"
+    with pytest.raises(ValueError):
+        assert full_string_key(".key", relative_base=None)


### PR DESCRIPTION
Often several strings in a chunk of code will all be under the same key prefix. The frontend's `useTranslation` supports scoping to avoid repeating the prefix. This PR adds a similar mechanism on the backend, simplifying sharing strings between multiple emails.

I chose a syntax that makes it obvious when we our string keys are relative:

- `.key` -> implies that it is relative to some base string key, will throw if no base key is specified.
- `key` -> full string key, which ignores the base string key if any is specified.

## Testing
Added a test.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me