### PR TITLE
Backend/i18n: Fix error looking up pt-br babel locale

### DIFF
--- a/app/backend/src/couchers/i18n/localize.py
+++ b/app/backend/src/couchers/i18n/localize.py
@@ -33,6 +33,7 @@ def get_babel_locale(locale_list: list[str]) -> babel.Locale:
             continue
     raise LookupError(f"No babel locale found for locales {', '.join(locale_list)}")
 
+
 def localize_string(lang: str | None, key: str, *, substitutions: Mapping[str, str | int] | None = None) -> str:
     """
     Retrieves a translated string and performs substitutions.

--- a/app/backend/src/couchers/i18n/localize.py
+++ b/app/backend/src/couchers/i18n/localize.py
@@ -28,11 +28,10 @@ def get_babel_locale(locale_list: list[str]) -> babel.Locale:
     """Resolves a babel.Locale object from a list of locale candidates."""
     for locale in locale_list:
         try:
-            return babel.Locale.parse(locale)
+            return babel.Locale.parse(locale, sep="-")
         except babel.UnknownLocaleError:
             continue
     raise LookupError(f"No babel locale found for locales {', '.join(locale_list)}")
-
 
 def localize_string(lang: str | None, key: str, *, substitutions: Mapping[str, str | int] | None = None) -> str:
     """


### PR DESCRIPTION
Babel expects `pt_BR`, not `pt-BR` by default.

This is a hotfix. I'll improve this further in https://github.com/Couchers-org/couchers/pull/8828

Fixes #8830

## Testing
Called `Locale.parse("pt-BR", sep="-")` locally

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
