### PR TITLE
mobile: add Bugs.CheckNativeStatus diagnostics ping

### DIFF
--- a/app/mobile/app/_layout.tsx
+++ b/app/mobile/app/_layout.tsx
@@ -31,6 +31,7 @@ import { SafeAreaProvider } from "react-native-safe-area-context";
 import DevSettingsButton from "@/components/DevSettingsButton";
 import { hydrateUrlOverrides } from "@/config/urls";
 import { AuthProvider, useAuthContext } from "@/features/auth/AuthContext";
+import { useNativeDiagnostics } from "@/features/diagnostics/useNativeDiagnostics";
 import { useRegisterPushNotifications } from "@/features/notifications/useRegisterPushNotifications";
 import { appVariant } from "@/service/buildInfo";
 import { reconfigureApiClient } from "@/service/client";
@@ -219,5 +220,6 @@ function useNotificationObserver() {
 function PushNotificationsRegistrar() {
   useRegisterPushNotifications();
   useNotificationObserver();
+  useNativeDiagnostics();
   return null;
 }

--- a/app/mobile/features/diagnostics/installId.ts
+++ b/app/mobile/features/diagnostics/installId.ts
@@ -1,0 +1,42 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Application from "expo-application";
+import * as Crypto from "expo-crypto";
+import { Platform } from "react-native";
+
+// 128-bit hex ID generated and persisted on first launch; survives restarts/OTA, resets on reinstall.
+const INSTALL_ID_KEY = "diagnostics.installId";
+
+function randomId(): string {
+  return Array.from(Crypto.getRandomBytes(16), (b) =>
+    b.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+export async function getInstallId(): Promise<string> {
+  const existing = await AsyncStorage.getItem(INSTALL_ID_KEY);
+  if (existing) {
+    return existing;
+  }
+  const id = randomId();
+  await AsyncStorage.setItem(INSTALL_ID_KEY, id);
+  return id;
+}
+
+// Best-effort platform identifiers for cross-install correlation (iOS IDFV, Android SSAID).
+export async function getPlatformDeviceIds(): Promise<{
+  idfv?: string;
+  androidId?: string;
+}> {
+  try {
+    if (Platform.OS === "ios") {
+      const idfv = await Application.getIosIdForVendorAsync();
+      return { idfv: idfv ?? undefined };
+    }
+    if (Platform.OS === "android") {
+      return { androidId: Application.getAndroidId() ?? undefined };
+    }
+  } catch {
+    // best-effort; never block a ping
+  }
+  return {};
+}

--- a/app/mobile/features/diagnostics/pushTokenStore.ts
+++ b/app/mobile/features/diagnostics/pushTokenStore.ts
@@ -1,0 +1,12 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+// The last Expo push token registered with the backend, persisted so diagnostics can report it.
+const PUSH_TOKEN_KEY = "diagnostics.pushToken";
+
+export async function setStoredPushToken(token: string): Promise<void> {
+  await AsyncStorage.setItem(PUSH_TOKEN_KEY, token);
+}
+
+export async function getStoredPushToken(): Promise<string | null> {
+  return AsyncStorage.getItem(PUSH_TOKEN_KEY);
+}

--- a/app/mobile/features/diagnostics/useNativeDiagnostics.ts
+++ b/app/mobile/features/diagnostics/useNativeDiagnostics.ts
@@ -1,0 +1,113 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Application from "expo-application";
+import Constants from "expo-constants";
+import * as Device from "expo-device";
+import * as Notifications from "expo-notifications";
+import * as Updates from "expo-updates";
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { AppState, AppStateStatus, Platform } from "react-native";
+
+import { useAuthContext } from "@/features/auth/AuthContext";
+import {
+  getInstallId,
+  getPlatformDeviceIds,
+} from "@/features/diagnostics/installId";
+import { getStoredPushToken } from "@/features/diagnostics/pushTokenStore";
+import { NativeUpdateAction } from "@/proto/bugs_pb";
+import { checkNativeStatus } from "@/service/checkNativeStatus";
+
+const LAST_OPEN_KEY = "diagnostics.lastOpenAt";
+const PING_THROTTLE_MS = 30 * 60 * 1000;
+
+// Reports a diagnostics snapshot to CheckNativeStatus on cold start and each foreground
+// transition, throttled to at most once per PING_THROTTLE_MS. Best-effort and fire-and-forget.
+export function useNativeDiagnostics(): void {
+  const { authenticated } = useAuthContext();
+  const { i18n } = useTranslation();
+
+  // Refs so the AppState listener sees current values without re-subscribing.
+  const authenticatedRef = useRef(authenticated);
+  authenticatedRef.current = authenticated;
+  const localeRef = useRef(i18n.language);
+  localeRef.current = i18n.language;
+
+  useEffect(() => {
+    async function maybeReport() {
+      try {
+        const now = Date.now();
+        const lastOpenRaw = await AsyncStorage.getItem(LAST_OPEN_KEY);
+        const lastOpenAt = lastOpenRaw ? Number(lastOpenRaw) : null;
+
+        if (lastOpenAt && now - lastOpenAt < PING_THROTTLE_MS) {
+          return;
+        }
+
+        const timeSinceLastOpenSeconds = lastOpenAt
+          ? (now - lastOpenAt) / 1000
+          : undefined;
+
+        const [installId, deviceIds, pushToken, permission] = await Promise.all(
+          [
+            getInstallId(),
+            getPlatformDeviceIds(),
+            getStoredPushToken(),
+            Notifications.getPermissionsAsync(),
+          ],
+        );
+
+        const result = await checkNativeStatus({
+          installId,
+          idfv: deviceIds.idfv,
+          androidId: deviceIds.androidId,
+          userState: authenticatedRef.current ? "authenticated" : "logged_out",
+          appVersion: Constants.expoConfig?.version ?? "unknown",
+          gitHash:
+            (Constants.expoConfig?.extra as { gitHash?: string } | undefined)
+              ?.gitHash ?? "unknown",
+          nativeBuild: Application.nativeBuildVersion ?? "unknown",
+          platform: Platform.OS,
+          osVersion: String(Platform.Version),
+          deviceName: Device.deviceName ?? undefined,
+          locale: localeRef.current,
+          otaUpdateId: Updates.updateId ?? undefined,
+          runtimeVersion: Updates.runtimeVersion ?? undefined,
+          otaChannel: Updates.channel ?? undefined,
+          isEmbedded: Updates.isEmbeddedLaunch,
+          otaCreatedAt: Updates.createdAt?.toISOString() ?? undefined,
+          pushPermission: permission.status,
+          pushToken: pushToken ?? undefined,
+          timeSinceLastOpenSeconds,
+          occurred: new Date(now).toISOString(),
+        });
+
+        await AsyncStorage.setItem(LAST_OPEN_KEY, String(now));
+
+        // TODO: act on result (fetch OTA, nag, or block) per action/required/actBy.
+        if (
+          result.action !== NativeUpdateAction.NATIVE_UPDATE_ACTION_NONE &&
+          result.action !== NativeUpdateAction.NATIVE_UPDATE_ACTION_UNSPECIFIED
+        ) {
+          console.log("Native status update prompt:", result);
+        }
+      } catch (error) {
+        console.warn("Failed to check native status:", error);
+      }
+    }
+
+    maybeReport();
+
+    const subscription = AppState.addEventListener(
+      "change",
+      (state: AppStateStatus) => {
+        if (state === "active") {
+          maybeReport();
+        }
+      },
+    );
+
+    return () => {
+      subscription.remove();
+    };
+  }, []);
+}

--- a/app/mobile/features/notifications/useRegisterPushNotifications.ts
+++ b/app/mobile/features/notifications/useRegisterPushNotifications.ts
@@ -1,10 +1,11 @@
-import { useEffect, useRef } from "react";
-import { Platform } from "react-native";
+import Constants from "expo-constants";
 import * as Device from "expo-device";
 import * as Notifications from "expo-notifications";
-import Constants from "expo-constants";
+import { useEffect, useRef } from "react";
+import { Platform } from "react-native";
 
 import { useAuthContext } from "@/features/auth/AuthContext";
+import { setStoredPushToken } from "@/features/diagnostics/pushTokenStore";
 import { registerMobilePushNotificationSubscription } from "@/service/notifications";
 
 async function ensureNotificationPermissions(): Promise<boolean> {
@@ -118,6 +119,7 @@ export function useRegisterPushNotifications() {
         });
 
         lastRegisteredTokenRef.current = token;
+        await setStoredPushToken(token);
         console.log("✅ Push notification registration complete");
       } catch (error) {
         console.error(

--- a/app/mobile/service/checkNativeStatus.ts
+++ b/app/mobile/service/checkNativeStatus.ts
@@ -1,0 +1,28 @@
+import { CheckNativeStatusReq, NativeUpdateAction } from "@/proto/bugs_pb";
+import client from "@/service/client";
+
+export interface NativeUpdateInfo {
+  action: NativeUpdateAction;
+  required: boolean;
+  actBy?: Date;
+  message: string;
+  linkUrl: string;
+}
+
+// JSON-encodes a diagnostics snapshot into debug_json and returns the backend's update decision.
+export async function checkNativeStatus(
+  debugInfo: Record<string, unknown>,
+): Promise<NativeUpdateInfo> {
+  const req = new CheckNativeStatusReq();
+  req.setDebugJson(JSON.stringify(debugInfo));
+
+  const res = await client.bugs.checkNativeStatus(req);
+  const info = res.getUpdateInfo();
+  return {
+    action: info?.getAction() ?? NativeUpdateAction.NATIVE_UPDATE_ACTION_NONE,
+    required: info?.getRequired() ?? false,
+    actBy: info?.getActBy()?.toDate(),
+    message: info?.getMessage() ?? "",
+    linkUrl: info?.getLinkUrl() ?? "",
+  };
+}

--- a/app/mobile/service/client.ts
+++ b/app/mobile/service/client.ts
@@ -3,6 +3,7 @@ import { Platform } from "react-native";
 
 import { getApiBaseUrl } from "@/config/urls";
 import { AuthPromiseClient } from "@/proto/auth_grpc_web_pb";
+import { BugsPromiseClient } from "@/proto/bugs_grpc_web_pb";
 import { NotificationsPromiseClient } from "@/proto/notifications_grpc_web_pb";
 import isGrpcError from "@/service/utils/isGrpcError";
 import { applicationNameForUserAgent } from "@/utils/userAgent";
@@ -104,6 +105,7 @@ function buildClients(url: string) {
   }
   return {
     auth: new AuthPromiseClient(url, null, opts),
+    bugs: new BugsPromiseClient(url, null, opts),
     notifications: new NotificationsPromiseClient(url, null, opts),
   };
 }
@@ -123,7 +125,7 @@ export function reconfigureApiClient(): void {
 if (!IS_PROD && typeof window !== "undefined") {
   // @ts-ignore
   const grpcWebTools = window.__GRPCWEB_DEVTOOLS__ || (() => {});
-  grpcWebTools([client.auth, client.notifications]);
+  grpcWebTools([client.auth, client.bugs, client.notifications]);
 }
 
 export default client;

--- a/app/mobile/tests/service/checkNativeStatus.test.ts
+++ b/app/mobile/tests/service/checkNativeStatus.test.ts
@@ -1,0 +1,101 @@
+import { NativeUpdateAction } from "@/proto/bugs_pb";
+import { checkNativeStatus } from "@/service/checkNativeStatus";
+import client from "@/service/client";
+
+jest.mock("@/service/client", () => ({
+  bugs: {
+    checkNativeStatus: jest.fn(),
+  },
+}));
+
+const mockCheckNativeStatus = client.bugs.checkNativeStatus as jest.Mock;
+
+function mockResponse(
+  info: Partial<{
+    action: NativeUpdateAction;
+    required: boolean;
+    actBy: Date;
+    message: string;
+    linkUrl: string;
+  }> | null = {},
+) {
+  return {
+    getUpdateInfo: () =>
+      info === null
+        ? undefined
+        : {
+            getAction: () =>
+              info.action ?? NativeUpdateAction.NATIVE_UPDATE_ACTION_NONE,
+            getRequired: () => info.required ?? false,
+            getActBy: () =>
+              info.actBy ? { toDate: () => info.actBy } : undefined,
+            getMessage: () => info.message ?? "",
+            getLinkUrl: () => info.linkUrl ?? "",
+          },
+  };
+}
+
+describe("checkNativeStatus", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("JSON-encodes the debug info into debug_json", async () => {
+    mockCheckNativeStatus.mockResolvedValue(mockResponse());
+
+    const debugInfo = {
+      installId: "install-1",
+      userState: "authenticated",
+      appVersion: "1.1.20",
+      platform: "ios",
+    };
+    await checkNativeStatus(debugInfo);
+
+    expect(mockCheckNativeStatus).toHaveBeenCalledTimes(1);
+    const req = mockCheckNativeStatus.mock.calls[0][0];
+    expect(JSON.parse(req.getDebugJson())).toEqual(debugInfo);
+  });
+
+  it("maps the backend's update info", async () => {
+    const actBy = new Date("2026-06-01T00:00:00.000Z");
+    mockCheckNativeStatus.mockResolvedValue(
+      mockResponse({
+        action: NativeUpdateAction.NATIVE_UPDATE_ACTION_STORE,
+        required: true,
+        actBy,
+        message: "Please update to continue.",
+        linkUrl: "https://apps.apple.com/app/id123",
+      }),
+    );
+
+    const result = await checkNativeStatus({ platform: "ios" });
+    expect(result).toEqual({
+      action: NativeUpdateAction.NATIVE_UPDATE_ACTION_STORE,
+      required: true,
+      actBy,
+      message: "Please update to continue.",
+      linkUrl: "https://apps.apple.com/app/id123",
+    });
+  });
+
+  it("defaults to NONE when the backend sends no update info", async () => {
+    mockCheckNativeStatus.mockResolvedValue(mockResponse(null));
+
+    const result = await checkNativeStatus({ platform: "ios" });
+    expect(result).toEqual({
+      action: NativeUpdateAction.NATIVE_UPDATE_ACTION_NONE,
+      required: false,
+      actBy: undefined,
+      message: "",
+      linkUrl: "",
+    });
+  });
+
+  it("propagates errors from the client", async () => {
+    mockCheckNativeStatus.mockRejectedValue(new Error("Network error"));
+
+    await expect(checkNativeStatus({ platform: "ios" })).rejects.toThrow(
+      "Network error",
+    );
+  });
+});


### PR DESCRIPTION
Adds the native mobile client for the `Bugs.CheckNativeStatus` diagnostics ping. On cold start and each foreground transition (throttled to once / 30 min) the app sends a `debug_json` snapshot — install id, platform ids, user state, app/build version, OTA bundle info, push permission/token, time since last open — and reads back a structured `NativeUpdateInfo`.

The backend RPC + servicer live in a **separate PR off `develop`** (#8856), since `develop` doesn't yet carry the mobile gRPC infrastructure this builds on. The `bugs.proto` change appears in both branches so each can generate its stubs; the content is identical and reconciles on merge. Acting on the update decision (fetch OTA / nag / block) is a follow-up — the hook currently just logs a non-`NONE` action.

## Testing
Mobile proto stubs regenerate cleanly. `npx jest checkNativeStatus` — 4 passing (field encoding, update-info mapping, the no-info default, error propagation). eslint clean on the changed files (the `@sentry/react-native` resolution error is pre-existing on `v1.1.20` and unrelated; the `Platform` unused-import warning comes from `v1.1.20`'s own `client.ts`). Still TODO before this leaves draft: on-device verification that pings reach the backend.

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._