### PR TITLE
Backend: sample traces via feature flag

### DIFF
--- a/app/backend/src/app.py
+++ b/app/backend/src/app.py
@@ -93,11 +93,12 @@ def main() -> None:
         for _ in range(config["BACKGROUND_WORKER_COUNT"]):
             start_jobs_worker()
 
-    setup_tracing()
-
     # Initialize the experimentation framework for feature flags in the main process.
     # Worker processes initialize their own instance in _run_forever().
+    # Must precede setup_tracing(), which reads the `trace_sample_ratio` flag.
     setup_experimentation()
+
+    setup_tracing()
 
     if config["ROLE"] in ["api", "all"]:
         server = create_main_server(port=1751)

--- a/app/backend/src/couchers/tracing.py
+++ b/app/backend/src/couchers/tracing.py
@@ -1,4 +1,7 @@
+from collections.abc import Sequence
+
 from opentelemetry import trace
+from opentelemetry.context import Context
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.instrumentation.grpc import GrpcInstrumentorServer
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
@@ -6,9 +9,39 @@ from opentelemetry.instrumentation.threading import ThreadingInstrumentor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.sampling import ParentBased, Sampler, SamplingResult, TraceIdRatioBased
+from opentelemetry.trace import Link, SpanKind
+from opentelemetry.trace.span import TraceState
+from opentelemetry.util.types import Attributes
 
 from couchers.config import config
 from couchers.db import _get_base_engine
+from couchers.experimentation import get_global_float_value
+
+
+class FeatureFlagRatioSampler(Sampler):
+    """
+    Samples the fraction of traces given by the `trace_sample_ratio` flag (default 0). Wired as the
+    ParentBased root, so it's consulted only for root spans - one flag read per RPC, not per span.
+    """
+
+    def should_sample(
+        self,
+        parent_context: Context | None,
+        trace_id: int,
+        name: str,
+        kind: SpanKind | None = None,
+        attributes: Attributes = None,
+        links: Sequence[Link] | None = None,
+        trace_state: TraceState | None = None,
+    ) -> SamplingResult:
+        ratio = get_global_float_value("trace_sample_ratio", 0.0)
+        return TraceIdRatioBased(ratio).should_sample(
+            parent_context, trace_id, name, kind, attributes, links, trace_state
+        )
+
+    def get_description(self) -> str:
+        return "FeatureFlagRatioSampler{flag=trace_sample_ratio}"
 
 
 def setup_tracing() -> None:
@@ -19,7 +52,10 @@ def setup_tracing() -> None:
         grpc_server_instrumentor.instrument()
         SQLAlchemyInstrumentor().instrument(engine=_get_base_engine(), enable_commenter=True, commenter_options={})
 
-        tracer = TracerProvider(resource=Resource(attributes={"service.name": "backend"}))
+        tracer = TracerProvider(
+            resource=Resource(attributes={"service.name": "backend"}),
+            sampler=ParentBased(root=FeatureFlagRatioSampler()),
+        )
         tracer.add_span_processor(
             BatchSpanProcessor(OTLPSpanExporter(endpoint=config["OPENTELEMETRY_ENDPOINT"], insecure=True))
         )


### PR DESCRIPTION
## Description

Drive the OpenTelemetry trace sample ratio from the `trace_sample_ratio` GrowthBook flag so it can be tuned in prod without a redeploy. `setup_tracing()` uses `ParentBased(root=FeatureFlagRatioSampler())`; because the sampler is the `ParentBased` root it is consulted only for root spans (one gRPC server span per RPC), so the flag is read once per RPC, not per span, and changes take effect without a restart. Default is `0.0` (no tracing) when the flag is unset. `setup_experimentation()` is reordered ahead of `setup_tracing()` so the evaluator is ready when the flag is first read.

Lowering the ratio in prod cuts per-RPC span construction overhead from the gRPC + SQLAlchemy instrumentors.

> Note: an earlier revision of this PR also swapped `pool_pre_ping` for `pool_recycle` on the DB engine. That was dropped — `pool_pre_ping` is the fix for #643 (stale pooled connections silently dropped by docker networking), which `pool_recycle` does not reliably cover, and the per-checkout `SELECT 1` is negligible on a co-located DB.

## Testing

- `make format` and `make mypy` pass.
- Exercised the sampler directly (root-span decision, `get_description`) and verified no import cycle (`couchers.tracing` ↔ `couchers.experimentation`).
- Default flag value leaves dev/test behavior unchanged (tracing off unless the flag is set).

## Backend checklist

- [x] Ran `make format`
- [x] Ran `make mypy`
- [ ] Added/updated tests where appropriate

## For maintainers

- [ ] Squash and merge

_This PR was created with the Couchers PR skill._