### PR TITLE
Backend: Per-request resource accounting on api_calls

### DIFF
--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -31,6 +31,7 @@ from couchers.models import (
     TimezoneArea,
     User,
 )
+from couchers.perf import register_perf_listeners
 from couchers.sql import where_users_column_visible
 
 if TYPE_CHECKING:
@@ -60,7 +61,7 @@ def apply_migrations() -> None:
 
 @functools.cache
 def _get_base_engine() -> Engine:
-    return create_engine(
+    engine = create_engine(
         config["DATABASE_CONNECTION_STRING"],
         # checks that the connections in the pool are alive before using them, which avoids the "server closed the
         # connection unexpectedly" errors
@@ -70,6 +71,8 @@ def _get_base_engine() -> Engine:
         # main threads + a few extra in case
         pool_size=SERVER_THREADS + WORKER_THREADS + 12,
     )
+    register_perf_listeners(engine)
+    return engine
 
 
 @contextmanager

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -35,6 +35,7 @@ from couchers.i18n import LocalizationContext
 from couchers.i18n.locales import DEFAULT_LOCALE
 from couchers.metrics import observe_in_servicer_duration_histogram, observe_in_servicer_setup_errors_counter
 from couchers.models import APICall, ClientPlatform, User, UserActivity, UserSession
+from couchers.perf import PerfResult, read_perf, start_perf
 from couchers.proto import annotations_pb2
 from couchers.proto.annotations_pb2 import AuthLevel
 from couchers.utils import (
@@ -219,6 +220,8 @@ def _store_log(
     response: Message | None,
     traceback: str | None = None,
     perf_report: str | None = None,
+    perf: PerfResult | None = None,
+    client_platform: ClientPlatform | None = None,
     ip_address: str | None,
     user_agent: str | None,
     sofa: str | None,
@@ -243,6 +246,11 @@ def _store_log(
                 response_truncated=response_truncated,
                 traceback=traceback,
                 perf_report=perf_report,
+                query_count=perf.query_count if perf else None,
+                write_query_count=perf.write_query_count if perf else None,
+                db_time_ms=perf.db_time_ms if perf else None,
+                cpu_ms=perf.cpu_ms if perf else None,
+                client_platform=client_platform,
                 ip_address=ip_address,
                 user_agent=user_agent,
                 sofa=sofa,
@@ -339,6 +347,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             )
 
             with session_scope() as session:
+                start_perf()
                 try:
                     _res = prev_function(req, couchers_context, session)  # type: ignore[call-arg, arg-type]
                     res = cast(Message, _res)
@@ -351,12 +360,15 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                         is_api_key=cast(bool, couchers_context._is_api_key),
                         request=req,
                         response=res,
+                        perf=read_perf(),
+                        client_platform=headers.client_platform,
                         ip_address=headers.ip_address,
                         user_agent=headers.user_agent,
                         sofa=sofa,
                     )
                     observe_in_servicer_duration_histogram(method, couchers_context._user_id, "", "", duration / 1000)
                 except Exception as e:
+                    perf = read_perf()
                     finished = perf_counter_ns()
                     duration = (finished - start) / 1e6  # ms
 
@@ -376,6 +388,8 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                         request=req,
                         response=None,
                         traceback=traceback,
+                        perf=perf,
+                        client_platform=headers.client_platform,
                         ip_address=headers.ip_address,
                         user_agent=headers.user_agent,
                         sofa=sofa,

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -34,6 +34,7 @@ from couchers.descriptor_pool import get_descriptor_pool
 from couchers.i18n import LocalizationContext
 from couchers.i18n.locales import DEFAULT_LOCALE
 from couchers.metrics import (
+    observe_api_call,
     observe_in_servicer_duration_histogram,
     observe_in_servicer_perf_histograms,
     observe_in_servicer_setup_errors_counter,
@@ -372,6 +373,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                         sofa=sofa,
                     )
                     observe_in_servicer_duration_histogram(method, couchers_context._user_id, "", "", duration / 1000)
+                    observe_api_call(method, headers.client_platform)
                     if perf is not None:
                         observe_in_servicer_perf_histograms(
                             method, perf.query_count, perf.write_query_count, perf.db_time_ms, perf.cpu_ms
@@ -406,6 +408,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                     observe_in_servicer_duration_histogram(
                         method, couchers_context._user_id, code or "", type(e).__name__, duration / 1000
                     )
+                    observe_api_call(method, headers.client_platform)
                     if perf is not None:
                         observe_in_servicer_perf_histograms(
                             method, perf.query_count, perf.write_query_count, perf.db_time_ms, perf.cpu_ms

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -356,6 +356,9 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                 try:
                     _res = prev_function(req, couchers_context, session)  # type: ignore[call-arg, arg-type]
                     res = cast(Message, _res)
+                    # flush so pending ORM writes execute (and are counted) before we snapshot; a handler that only
+                    # session.add(...)s and returns would otherwise flush at commit, after read_perf()
+                    session.flush()
                     perf = read_perf()
                     finished = perf_counter_ns()
                     duration = (finished - start) / 1e6  # ms

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -33,7 +33,11 @@ from couchers.db import session_scope
 from couchers.descriptor_pool import get_descriptor_pool
 from couchers.i18n import LocalizationContext
 from couchers.i18n.locales import DEFAULT_LOCALE
-from couchers.metrics import observe_in_servicer_duration_histogram, observe_in_servicer_setup_errors_counter
+from couchers.metrics import (
+    observe_in_servicer_duration_histogram,
+    observe_in_servicer_perf_histograms,
+    observe_in_servicer_setup_errors_counter,
+)
 from couchers.models import APICall, ClientPlatform, User, UserActivity, UserSession
 from couchers.perf import PerfResult, read_perf, start_perf
 from couchers.proto import annotations_pb2
@@ -351,6 +355,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                 try:
                     _res = prev_function(req, couchers_context, session)  # type: ignore[call-arg, arg-type]
                     res = cast(Message, _res)
+                    perf = read_perf()
                     finished = perf_counter_ns()
                     duration = (finished - start) / 1e6  # ms
                     _store_log(
@@ -360,13 +365,15 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                         is_api_key=cast(bool, couchers_context._is_api_key),
                         request=req,
                         response=res,
-                        perf=read_perf(),
+                        perf=perf,
                         client_platform=headers.client_platform,
                         ip_address=headers.ip_address,
                         user_agent=headers.user_agent,
                         sofa=sofa,
                     )
                     observe_in_servicer_duration_histogram(method, couchers_context._user_id, "", "", duration / 1000)
+                    if perf is not None:
+                        observe_in_servicer_perf_histograms(method, perf.query_count, perf.db_time_ms, perf.cpu_ms)
                 except Exception as e:
                     perf = read_perf()
                     finished = perf_counter_ns()
@@ -397,6 +404,8 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                     observe_in_servicer_duration_histogram(
                         method, couchers_context._user_id, code or "", type(e).__name__, duration / 1000
                     )
+                    if perf is not None:
+                        observe_in_servicer_perf_histograms(method, perf.query_count, perf.db_time_ms, perf.cpu_ms)
 
                     if not code:
                         sentry_sdk.set_tag("context", "servicer")

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -373,7 +373,9 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                     )
                     observe_in_servicer_duration_histogram(method, couchers_context._user_id, "", "", duration / 1000)
                     if perf is not None:
-                        observe_in_servicer_perf_histograms(method, perf.query_count, perf.db_time_ms, perf.cpu_ms)
+                        observe_in_servicer_perf_histograms(
+                            method, perf.query_count, perf.write_query_count, perf.db_time_ms, perf.cpu_ms
+                        )
                 except Exception as e:
                     perf = read_perf()
                     finished = perf_counter_ns()
@@ -405,7 +407,9 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                         method, couchers_context._user_id, code or "", type(e).__name__, duration / 1000
                     )
                     if perf is not None:
-                        observe_in_servicer_perf_histograms(method, perf.query_count, perf.db_time_ms, perf.cpu_ms)
+                        observe_in_servicer_perf_histograms(
+                            method, perf.query_count, perf.write_query_count, perf.db_time_ms, perf.cpu_ms
+                        )
 
                     if not code:
                         sentry_sdk.set_tag("context", "servicer")

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -251,8 +251,8 @@ def _store_log(
                 response_truncated=response_truncated,
                 traceback=traceback,
                 perf_report=perf_report,
-                query_count=perf.query_count if perf else None,
-                write_query_count=perf.write_query_count if perf else None,
+                db_query_count=perf.db_query_count if perf else None,
+                db_write_query_count=perf.db_write_query_count if perf else None,
                 db_time_ms=perf.db_time_ms if perf else None,
                 cpu_ms=perf.cpu_ms if perf else None,
                 client_platform=client_platform,
@@ -379,7 +379,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                     observe_api_call(method, headers.client_platform)
                     if perf is not None:
                         observe_in_servicer_perf_histograms(
-                            method, perf.query_count, perf.write_query_count, perf.db_time_ms, perf.cpu_ms
+                            method, perf.db_query_count, perf.db_write_query_count, perf.db_time_ms, perf.cpu_ms
                         )
                 except Exception as e:
                     perf = read_perf()
@@ -414,7 +414,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                     observe_api_call(method, headers.client_platform)
                     if perf is not None:
                         observe_in_servicer_perf_histograms(
-                            method, perf.query_count, perf.write_query_count, perf.db_time_ms, perf.cpu_ms
+                            method, perf.db_query_count, perf.db_write_query_count, perf.db_time_ms, perf.cpu_ms
                         )
 
                     if not code:

--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -132,14 +132,23 @@ servicer_query_count_histogram: Histogram = Histogram(
     "couchers_servicer_query_count",
     "Number of SQL statements executed per gRPC call",
     labelnames=["method"],
-    buckets=(1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, _INF),
+    buckets=(1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, _INF),
+)
+servicer_write_query_count_histogram: Histogram = Histogram(
+    "couchers_servicer_write_query_count",
+    "Number of INSERT/UPDATE/DELETE statements executed per gRPC call",
+    labelnames=["method"],
+    buckets=(1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, _INF),
 )
 
 
-def observe_in_servicer_perf_histograms(method: str, query_count: int, db_time_ms: float, cpu_ms: float) -> None:
+def observe_in_servicer_perf_histograms(
+    method: str, query_count: int, write_query_count: int, db_time_ms: float, cpu_ms: float
+) -> None:
     servicer_db_time_histogram.labels(method).observe(db_time_ms / 1000)
     servicer_cpu_time_histogram.labels(method).observe(cpu_ms / 1000)
     servicer_query_count_histogram.labels(method).observe(query_count)
+    servicer_write_query_count_histogram.labels(method).observe(write_query_count)
 
 
 # list of gauge names and function to execute to set value to

--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -151,6 +151,19 @@ def observe_in_servicer_perf_histograms(
     servicer_write_query_count_histogram.labels(method).observe(write_query_count)
 
 
+# Simple count of API calls, broken down by method and the client platform header. Cheap (a counter, no buckets) and
+# answers "how much traffic comes from each platform".
+api_calls_counter: Counter = Counter(
+    "couchers_api_calls_total",
+    "Number of gRPC API calls",
+    labelnames=["method", "platform"],
+)
+
+
+def observe_api_call(method: str, client_platform: ClientPlatform | None) -> None:
+    api_calls_counter.labels(method, client_platform.name if client_platform is not None else "unknown").inc()
+
+
 # list of gauge names and function to execute to set value to
 # the python prometheus client does not support Gauge.set_function, so instead we hack around it and set each gauge just
 # before collection with this

--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -128,14 +128,15 @@ servicer_cpu_time_histogram: Histogram = Histogram(
     "Backend thread CPU time per gRPC call",
     labelnames=["method"],
 )
-servicer_query_count_histogram: Histogram = Histogram(
-    "couchers_servicer_query_count",
+# Fibonacci bucket boundaries: roughly exponential, good resolution for an unbounded value
+servicer_db_query_count_histogram: Histogram = Histogram(
+    "couchers_servicer_db_query_count",
     "Number of SQL statements executed per gRPC call",
     labelnames=["method"],
     buckets=(1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, _INF),
 )
-servicer_write_query_count_histogram: Histogram = Histogram(
-    "couchers_servicer_write_query_count",
+servicer_db_write_query_count_histogram: Histogram = Histogram(
+    "couchers_servicer_db_write_query_count",
     "Number of INSERT/UPDATE/DELETE statements executed per gRPC call",
     labelnames=["method"],
     buckets=(1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, _INF),
@@ -143,12 +144,12 @@ servicer_write_query_count_histogram: Histogram = Histogram(
 
 
 def observe_in_servicer_perf_histograms(
-    method: str, query_count: int, write_query_count: int, db_time_ms: float, cpu_ms: float
+    method: str, db_query_count: int, db_write_query_count: int, db_time_ms: float, cpu_ms: float
 ) -> None:
     servicer_db_time_histogram.labels(method).observe(db_time_ms / 1000)
     servicer_cpu_time_histogram.labels(method).observe(cpu_ms / 1000)
-    servicer_query_count_histogram.labels(method).observe(query_count)
-    servicer_write_query_count_histogram.labels(method).observe(write_query_count)
+    servicer_db_query_count_histogram.labels(method).observe(db_query_count)
+    servicer_db_write_query_count_histogram.labels(method).observe(db_write_query_count)
 
 
 # Simple count of API calls, broken down by method and the client platform header. Cheap (a counter, no buckets) and

--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -115,6 +115,33 @@ def observe_in_servicer_setup_errors_counter(method: str, exception_type: str) -
     servicer_setup_errors_counter.labels(method, exception_type).inc()
 
 
+# Per-request resource accounting (see couchers/perf.py), labelled by method only to keep cardinality modest. The
+# histogram _sum gives the cost rate per endpoint via rate() (DB-seconds/sec, CPU-seconds/sec); the buckets give the
+# per-call distribution.
+servicer_db_time_histogram: Histogram = Histogram(
+    "couchers_servicer_db_time_seconds",
+    "Time spent in DB cursor execution per gRPC call",
+    labelnames=["method"],
+)
+servicer_cpu_time_histogram: Histogram = Histogram(
+    "couchers_servicer_cpu_seconds",
+    "Backend thread CPU time per gRPC call",
+    labelnames=["method"],
+)
+servicer_query_count_histogram: Histogram = Histogram(
+    "couchers_servicer_query_count",
+    "Number of SQL statements executed per gRPC call",
+    labelnames=["method"],
+    buckets=(1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, _INF),
+)
+
+
+def observe_in_servicer_perf_histograms(method: str, query_count: int, db_time_ms: float, cpu_ms: float) -> None:
+    servicer_db_time_histogram.labels(method).observe(db_time_ms / 1000)
+    servicer_cpu_time_histogram.labels(method).observe(cpu_ms / 1000)
+    servicer_query_count_histogram.labels(method).observe(query_count)
+
+
 # list of gauge names and function to execute to set value to
 # the python prometheus client does not support Gauge.set_function, so instead we hack around it and set each gauge just
 # before collection with this

--- a/app/backend/src/couchers/migrations/versions/0159_backend_per_request_resource_accounting_.py
+++ b/app/backend/src/couchers/migrations/versions/0159_backend_per_request_resource_accounting_.py
@@ -1,0 +1,40 @@
+"""Backend: Per-request resource accounting on api_calls
+
+Revision ID: 0159
+Revises: 0158
+Create Date: 2026-05-28 23:58:35.420486
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0159"
+down_revision = "0158"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("api_calls", sa.Column("query_count", sa.BigInteger(), nullable=True), schema="logging")
+    op.add_column("api_calls", sa.Column("write_query_count", sa.BigInteger(), nullable=True), schema="logging")
+    op.add_column("api_calls", sa.Column("db_time_ms", sa.Float(), nullable=True), schema="logging")
+    op.add_column("api_calls", sa.Column("cpu_ms", sa.Float(), nullable=True), schema="logging")
+    op.add_column(
+        "api_calls",
+        sa.Column(
+            "client_platform",
+            sa.Enum("web_desktop", "web_mobile", "app_ios", "app_android", name="clientplatform"),
+            nullable=True,
+        ),
+        schema="logging",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("api_calls", "client_platform", schema="logging")
+    op.drop_column("api_calls", "cpu_ms", schema="logging")
+    op.drop_column("api_calls", "db_time_ms", schema="logging")
+    op.drop_column("api_calls", "write_query_count", schema="logging")
+    op.drop_column("api_calls", "query_count", schema="logging")

--- a/app/backend/src/couchers/migrations/versions/0159_backend_per_request_resource_accounting_.py
+++ b/app/backend/src/couchers/migrations/versions/0159_backend_per_request_resource_accounting_.py
@@ -17,8 +17,8 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column("api_calls", sa.Column("query_count", sa.BigInteger(), nullable=True), schema="logging")
-    op.add_column("api_calls", sa.Column("write_query_count", sa.BigInteger(), nullable=True), schema="logging")
+    op.add_column("api_calls", sa.Column("db_query_count", sa.BigInteger(), nullable=True), schema="logging")
+    op.add_column("api_calls", sa.Column("db_write_query_count", sa.BigInteger(), nullable=True), schema="logging")
     op.add_column("api_calls", sa.Column("db_time_ms", sa.Float(), nullable=True), schema="logging")
     op.add_column("api_calls", sa.Column("cpu_ms", sa.Float(), nullable=True), schema="logging")
     op.add_column(
@@ -36,5 +36,5 @@ def downgrade() -> None:
     op.drop_column("api_calls", "client_platform", schema="logging")
     op.drop_column("api_calls", "cpu_ms", schema="logging")
     op.drop_column("api_calls", "db_time_ms", schema="logging")
-    op.drop_column("api_calls", "write_query_count", schema="logging")
-    op.drop_column("api_calls", "query_count", schema="logging")
+    op.drop_column("api_calls", "db_write_query_count", schema="logging")
+    op.drop_column("api_calls", "db_query_count", schema="logging")

--- a/app/backend/src/couchers/models/logging.py
+++ b/app/backend/src/couchers/models/logging.py
@@ -71,7 +71,6 @@ class APICall(Base, kw_only=True):
     db_time_ms: Mapped[float | None] = mapped_column(Float, default=None)
     cpu_ms: Mapped[float | None] = mapped_column(Float, default=None)
 
-    # client platform the call came from, from the x-couchers-client-platform header
     client_platform: Mapped[ClientPlatform | None] = mapped_column(Enum(ClientPlatform), default=None)
 
     # details of the browser, if available

--- a/app/backend/src/couchers/models/logging.py
+++ b/app/backend/src/couchers/models/logging.py
@@ -65,8 +65,7 @@ class APICall(Base, kw_only=True):
     # human readable perf report
     perf_report: Mapped[str | None] = mapped_column(String, default=None)
 
-    # per-request resource accounting, covering the handler span (see couchers/perf.py). Null for the rare row logged
-    # without accounting armed. Wall time is `duration`; residual wait = duration - cpu_ms - db_time_ms.
+    # per-request resource accounting, covering the handler span (see couchers/perf.py)
     query_count: Mapped[int | None] = mapped_column(BigInteger, default=None)
     write_query_count: Mapped[int | None] = mapped_column(BigInteger, default=None)
     db_time_ms: Mapped[float | None] = mapped_column(Float, default=None)

--- a/app/backend/src/couchers/models/logging.py
+++ b/app/backend/src/couchers/models/logging.py
@@ -10,6 +10,7 @@ from sqlalchemy.sql import expression
 
 from couchers.config import config
 from couchers.models.base import Base
+from couchers.models.rest import ClientPlatform
 
 
 class EventSource(enum.Enum):
@@ -63,6 +64,16 @@ class APICall(Base, kw_only=True):
 
     # human readable perf report
     perf_report: Mapped[str | None] = mapped_column(String, default=None)
+
+    # per-request resource accounting, covering the handler span (see couchers/perf.py). Null for the rare row logged
+    # without accounting armed. Wall time is `duration`; residual wait = duration - cpu_ms - db_time_ms.
+    query_count: Mapped[int | None] = mapped_column(BigInteger, default=None)
+    write_query_count: Mapped[int | None] = mapped_column(BigInteger, default=None)
+    db_time_ms: Mapped[float | None] = mapped_column(Float, default=None)
+    cpu_ms: Mapped[float | None] = mapped_column(Float, default=None)
+
+    # client platform the call came from, from the x-couchers-client-platform header
+    client_platform: Mapped[ClientPlatform | None] = mapped_column(Enum(ClientPlatform), default=None)
 
     # details of the browser, if available
     ip_address: Mapped[str | None] = mapped_column(String, default=None)

--- a/app/backend/src/couchers/models/logging.py
+++ b/app/backend/src/couchers/models/logging.py
@@ -66,8 +66,9 @@ class APICall(Base, kw_only=True):
     perf_report: Mapped[str | None] = mapped_column(String, default=None)
 
     # per-request resource accounting, covering the handler span (see couchers/perf.py)
-    query_count: Mapped[int | None] = mapped_column(BigInteger, default=None)
-    write_query_count: Mapped[int | None] = mapped_column(BigInteger, default=None)
+    db_query_count: Mapped[int | None] = mapped_column(BigInteger, default=None)
+    # counts only SQLAlchemy rendered insert/update/delete
+    db_write_query_count: Mapped[int | None] = mapped_column(BigInteger, default=None)
     db_time_ms: Mapped[float | None] = mapped_column(Float, default=None)
     cpu_ms: Mapped[float | None] = mapped_column(Float, default=None)
 

--- a/app/backend/src/couchers/perf.py
+++ b/app/backend/src/couchers/perf.py
@@ -46,9 +46,9 @@ def read_perf() -> PerfResult | None:
     )
 
 
-def _is_write(statement: str) -> bool:
-    # INSERT/UPDATE/DELETE are all 6 chars; OTel's SQL commenter appends comments at the end, so the leading token is
-    # still the verb.
+def _is_write_statement(statement: str) -> bool:
+    # Fallback for raw text() SQL, which SQLAlchemy doesn't compile and so leaves is_crud False. INSERT/UPDATE/DELETE
+    # are all 6 chars; OTel's SQL commenter appends comments at the end, so the leading token is still the verb.
     return statement.lstrip()[:6].upper().startswith(("INSERT", "UPDATE", "DELETE"))
 
 
@@ -68,7 +68,8 @@ def _after_cursor_execute(conn, cursor, statement, parameters, context, executem
         return
     acc.query_count += 1
     acc.db_time_ms += elapsed_ms
-    if _is_write(statement):
+    # is_crud is set by SQLAlchemy when it compiled an INSERT/UPDATE/DELETE; the statement sniff only catches raw text().
+    if context.is_crud or _is_write_statement(statement):
         acc.write_query_count += 1
 
 

--- a/app/backend/src/couchers/perf.py
+++ b/app/backend/src/couchers/perf.py
@@ -1,0 +1,77 @@
+import threading
+from dataclasses import dataclass
+from time import perf_counter_ns, thread_time_ns
+
+from sqlalchemy import Engine, event
+
+# Per-request resource accounting. The gRPC server is thread-per-request with synchronous psycopg, so the SQLAlchemy
+# cursor-execute listeners fire on the same thread that runs the handler. We keep a thread-local accumulator that the
+# interceptor arms (start_perf) right before invoking the handler and reads back (read_perf) right after, so the
+# captured numbers cover the handler span only (not auth lookup or the _store_log insert that runs afterwards).
+
+_local = threading.local()
+
+
+@dataclass
+class _PerfAccumulator:
+    cpu_start_ns: int
+    query_count: int = 0
+    write_query_count: int = 0
+    db_time_ms: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class PerfResult:
+    query_count: int
+    write_query_count: int
+    db_time_ms: float
+    cpu_ms: float
+
+
+def start_perf() -> None:
+    """Arm per-request resource accounting on the current thread."""
+    _local.acc = _PerfAccumulator(cpu_start_ns=thread_time_ns())
+
+
+def read_perf() -> PerfResult | None:
+    """Snapshot the current thread's accumulator, or None if accounting wasn't armed."""
+    acc: _PerfAccumulator | None = getattr(_local, "acc", None)
+    if acc is None:
+        return None
+    return PerfResult(
+        query_count=acc.query_count,
+        write_query_count=acc.write_query_count,
+        db_time_ms=acc.db_time_ms,
+        cpu_ms=(thread_time_ns() - acc.cpu_start_ns) / 1e6,
+    )
+
+
+def _is_write(statement: str) -> bool:
+    # INSERT/UPDATE/DELETE are all 6 chars; OTel's SQL commenter appends comments at the end, so the leading token is
+    # still the verb.
+    return statement.lstrip()[:6].upper().startswith(("INSERT", "UPDATE", "DELETE"))
+
+
+def _before_cursor_execute(conn, cursor, statement, parameters, context, executemany):  # type: ignore[no-untyped-def]
+    # A stack handles re-entrant/nested executes on the same connection.
+    conn.info.setdefault("_perf_query_starts", []).append(perf_counter_ns())
+
+
+def _after_cursor_execute(conn, cursor, statement, parameters, context, executemany):  # type: ignore[no-untyped-def]
+    starts = conn.info.get("_perf_query_starts")
+    if not starts:
+        return
+    elapsed_ms = (perf_counter_ns() - starts.pop()) / 1e6
+    acc: _PerfAccumulator | None = getattr(_local, "acc", None)
+    if acc is None:
+        # Query on a thread with no active request (background job, metrics scrape, etc.) - don't attribute it.
+        return
+    acc.query_count += 1
+    acc.db_time_ms += elapsed_ms
+    if _is_write(statement):
+        acc.write_query_count += 1
+
+
+def register_perf_listeners(engine: Engine) -> None:
+    event.listen(engine, "before_cursor_execute", _before_cursor_execute)
+    event.listen(engine, "after_cursor_execute", _after_cursor_execute)

--- a/app/backend/src/couchers/perf.py
+++ b/app/backend/src/couchers/perf.py
@@ -46,12 +46,6 @@ def read_perf() -> PerfResult | None:
     )
 
 
-def _is_write_statement(statement: str) -> bool:
-    # Fallback for raw text() SQL, which SQLAlchemy doesn't compile and so leaves is_crud False. INSERT/UPDATE/DELETE
-    # are all 6 chars; OTel's SQL commenter appends comments at the end, so the leading token is still the verb.
-    return statement.lstrip()[:6].upper().startswith(("INSERT", "UPDATE", "DELETE"))
-
-
 def _before_cursor_execute(conn, cursor, statement, parameters, context, executemany):  # type: ignore[no-untyped-def]
     # A stack handles re-entrant/nested executes on the same connection.
     conn.info.setdefault("_perf_query_starts", []).append(perf_counter_ns())
@@ -68,8 +62,8 @@ def _after_cursor_execute(conn, cursor, statement, parameters, context, executem
         return
     acc.query_count += 1
     acc.db_time_ms += elapsed_ms
-    # is_crud is set by SQLAlchemy when it compiled an INSERT/UPDATE/DELETE; the statement sniff only catches raw text().
-    if context.is_crud or _is_write_statement(statement):
+    # is_crud is set by SQLAlchemy when it compiled an INSERT/UPDATE/DELETE.
+    if context.is_crud:
         acc.write_query_count += 1
 
 

--- a/app/backend/src/couchers/perf.py
+++ b/app/backend/src/couchers/perf.py
@@ -12,18 +12,18 @@ from sqlalchemy import Engine, event
 _local = threading.local()
 
 
-@dataclass
+@dataclass(slots=True)
 class _PerfAccumulator:
     cpu_start_ns: int
-    query_count: int = 0
-    write_query_count: int = 0
+    db_query_count: int = 0
+    db_write_query_count: int = 0
     db_time_ms: float = 0.0
 
 
 @dataclass(frozen=True, slots=True)
 class PerfResult:
-    query_count: int
-    write_query_count: int
+    db_query_count: int
+    db_write_query_count: int
     db_time_ms: float
     cpu_ms: float
 
@@ -34,13 +34,18 @@ def start_perf() -> None:
 
 
 def read_perf() -> PerfResult | None:
-    """Snapshot the current thread's accumulator, or None if accounting wasn't armed."""
+    """Snapshot and clear the current thread's accumulator, or None if accounting wasn't armed.
+
+    Clearing means queries that run after this (e.g. the _store_log insert, or background work reusing the thread)
+    aren't attributed to the just-finished request.
+    """
     acc: _PerfAccumulator | None = getattr(_local, "acc", None)
     if acc is None:
         return None
+    _local.acc = None
     return PerfResult(
-        query_count=acc.query_count,
-        write_query_count=acc.write_query_count,
+        db_query_count=acc.db_query_count,
+        db_write_query_count=acc.db_write_query_count,
         db_time_ms=acc.db_time_ms,
         cpu_ms=(thread_time_ns() - acc.cpu_start_ns) / 1e6,
     )
@@ -60,11 +65,11 @@ def _after_cursor_execute(conn, cursor, statement, parameters, context, executem
     if acc is None:
         # Query on a thread with no active request (background job, metrics scrape, etc.) - don't attribute it.
         return
-    acc.query_count += 1
+    acc.db_query_count += 1
     acc.db_time_ms += elapsed_ms
-    # is_crud is set by SQLAlchemy when it compiled an INSERT/UPDATE/DELETE.
-    if context.is_crud:
-        acc.write_query_count += 1
+    # SQLAlchemy sets these when it compiled an INSERT/UPDATE/DELETE.
+    if context.isinsert or context.isupdate or context.isdelete:
+        acc.db_write_query_count += 1
 
 
 def register_perf_listeners(engine: Engine) -> None:

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -33,7 +33,6 @@ from couchers.interceptors import (
 )
 from couchers.metrics import servicer_duration_histogram, servicer_setup_errors_counter
 from couchers.models import APICall, ClientPlatform, User, UserActivity, UserSession
-from couchers.perf import _is_write_statement
 from couchers.proto import account_pb2, admin_pb2, annotations_pb2, api_pb2, auth_pb2
 from couchers.servicers.account import Account
 from couchers.servicers.api import API
@@ -230,24 +229,13 @@ def test_tracing_interceptor_ok_open(db):
     assert _get_histogram_labels_value("/org.couchers.auth.Auth/SignupFlow", "False", "", "") == val + 1
 
 
-def test_is_write_statement():
-    assert _is_write_statement("INSERT INTO foo VALUES (1)")
-    assert _is_write_statement("UPDATE foo SET a = 1")
-    assert _is_write_statement("DELETE FROM foo")
-    assert _is_write_statement("  \n  insert into foo values (1)")
-    assert not _is_write_statement("SELECT 1")
-    assert not _is_write_statement("  SELECT * FROM foo")
-    assert not _is_write_statement("WITH x AS (SELECT 1) SELECT * FROM x")
-
-
 def test_tracing_interceptor_perf_accounting(db):
-    # handler runs a known number of statements: three reads, one compiled write (caught via is_crud), and one raw
-    # text() write (caught via the statement-sniff fallback). Both writes match zero rows so they're side-effect free.
+    # handler runs a known number of statements: three reads and one compiled write (caught via is_crud). The write
+    # matches zero rows so it's side-effect free.
     def TestRpc(request, context, session):
         for _ in range(3):
             session.execute(text("SELECT 1"))
         session.execute(update(APICall).where(APICall.id == -1).values(method="x"))
-        session.execute(text("UPDATE logging.api_calls SET method = method WHERE false"))
         return empty_pb2.Empty()
 
     with interceptor_dummy_api(TestRpc, interceptors=[CouchersMiddlewareInterceptor()]) as call_rpc:
@@ -255,8 +243,8 @@ def test_tracing_interceptor_perf_accounting(db):
 
     with session_scope() as session:
         trace = session.execute(select(APICall)).scalar_one()
-        assert trace.query_count == 5
-        assert trace.write_query_count == 2
+        assert trace.query_count == 4
+        assert trace.write_query_count == 1
         assert trace.db_time_ms is not None and trace.db_time_ms >= 0
         assert trace.cpu_ms is not None and trace.cpu_ms >= 0
         # the handler's DB work can't exceed the whole-request wall time

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -10,7 +10,7 @@ import pytest
 from google.protobuf import empty_pb2
 from google.protobuf.descriptor import ServiceDescriptor
 from google.protobuf.descriptor_pool import DescriptorPool
-from sqlalchemy import select, update
+from sqlalchemy import select, text, update
 
 from couchers.constants import (
     MISSING_AUTH_LEVEL_ERROR_MESSAGE,
@@ -32,7 +32,8 @@ from couchers.interceptors import (
     validate_auth_level,
 )
 from couchers.metrics import servicer_duration_histogram, servicer_setup_errors_counter
-from couchers.models import APICall, User, UserActivity, UserSession
+from couchers.models import APICall, ClientPlatform, User, UserActivity, UserSession
+from couchers.perf import _is_write
 from couchers.proto import account_pb2, admin_pb2, annotations_pb2, api_pb2, auth_pb2
 from couchers.servicers.account import Account
 from couchers.servicers.api import API
@@ -227,6 +228,38 @@ def test_tracing_interceptor_ok_open(db):
         assert not trace.traceback
 
     assert _get_histogram_labels_value("/org.couchers.auth.Auth/SignupFlow", "False", "", "") == val + 1
+
+
+def test_is_write():
+    assert _is_write("INSERT INTO foo VALUES (1)")
+    assert _is_write("UPDATE foo SET a = 1")
+    assert _is_write("DELETE FROM foo")
+    assert _is_write("  \n  insert into foo values (1)")
+    assert not _is_write("SELECT 1")
+    assert not _is_write("  SELECT * FROM foo")
+    assert not _is_write("WITH x AS (SELECT 1) SELECT * FROM x")
+
+
+def test_tracing_interceptor_perf_accounting(db):
+    # handler runs a known number of statements - three reads, one write
+    def TestRpc(request, context, session):
+        for _ in range(3):
+            session.execute(text("SELECT 1"))
+        session.execute(text("UPDATE logging.api_calls SET method = method WHERE false"))
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(TestRpc, interceptors=[CouchersMiddlewareInterceptor()]) as call_rpc:
+        call_rpc(empty_pb2.Empty(), metadata=(("x-couchers-client-platform", "web_mobile"),))
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.query_count == 4
+        assert trace.write_query_count == 1
+        assert trace.db_time_ms is not None and trace.db_time_ms >= 0
+        assert trace.cpu_ms is not None and trace.cpu_ms >= 0
+        # the handler's DB work can't exceed the whole-request wall time
+        assert trace.db_time_ms <= trace.duration
+        assert trace.client_platform == ClientPlatform.web_mobile
 
 
 def test_tracing_interceptor_sensitive(db):

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -33,8 +33,8 @@ from couchers.interceptors import (
 )
 from couchers.metrics import (
     api_calls_counter,
+    servicer_db_query_count_histogram,
     servicer_duration_histogram,
-    servicer_query_count_histogram,
     servicer_setup_errors_counter,
 )
 from couchers.models import APICall, ClientPlatform, User, UserActivity, UserSession
@@ -234,12 +234,12 @@ def test_tracing_interceptor_ok_open(db):
     assert _get_histogram_labels_value("/org.couchers.auth.Auth/SignupFlow", "False", "", "") == val + 1
 
 
-def _get_query_count_histogram(method):
+def _get_db_query_count_histogram(method):
     return sum(
         s.value
-        for m in servicer_query_count_histogram.collect()
+        for m in servicer_db_query_count_histogram.collect()
         for s in m.samples
-        if s.name == "couchers_servicer_query_count_count" and s.labels.get("method") == method
+        if s.name == "couchers_servicer_db_query_count_count" and s.labels.get("method") == method
     )
 
 
@@ -256,11 +256,11 @@ def _get_api_call_count(method, platform):
 
 def test_tracing_interceptor_perf_accounting(db):
     method = "/org.couchers.auth.Auth/SignupFlow"
-    hist_count_before = _get_query_count_histogram(method)
+    hist_count_before = _get_db_query_count_histogram(method)
     api_call_count_before = _get_api_call_count(method, "web_mobile")
 
-    # handler runs a known number of statements: three reads and one compiled write (caught via is_crud). The write
-    # matches zero rows so it's side-effect free.
+    # handler runs a known number of statements: three reads and one compiled write. The write matches zero rows so
+    # it's side-effect free.
     def TestRpc(request, context, session):
         for _ in range(3):
             session.execute(text("SELECT 1"))
@@ -272,8 +272,8 @@ def test_tracing_interceptor_perf_accounting(db):
 
     with session_scope() as session:
         trace = session.execute(select(APICall)).scalar_one()
-        assert trace.query_count == 4
-        assert trace.write_query_count == 1
+        assert trace.db_query_count == 4
+        assert trace.db_write_query_count == 1
         assert trace.db_time_ms is not None and trace.db_time_ms >= 0
         assert trace.cpu_ms is not None and trace.cpu_ms >= 0
         # the handler's DB work can't exceed the whole-request wall time
@@ -281,7 +281,7 @@ def test_tracing_interceptor_perf_accounting(db):
         assert trace.client_platform == ClientPlatform.web_mobile
 
     # the call was also observed into the Prometheus per-request resource histograms and the per-platform call counter
-    assert _get_query_count_histogram(method) == hist_count_before + 1
+    assert _get_db_query_count_histogram(method) == hist_count_before + 1
     assert _get_api_call_count(method, "web_mobile") == api_call_count_before + 1
 
 
@@ -299,8 +299,8 @@ def test_tracing_interceptor_perf_accounting_orm_write(db):
 
     with session_scope() as session:
         log = session.execute(select(APICall).where(APICall.method == method)).scalar_one()
-        assert log.query_count == 1
-        assert log.write_query_count == 1
+        assert log.db_query_count == 1
+        assert log.db_write_query_count == 1
 
 
 def test_tracing_interceptor_sensitive(db):

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -32,6 +32,7 @@ from couchers.interceptors import (
     validate_auth_level,
 )
 from couchers.metrics import (
+    api_calls_counter,
     servicer_duration_histogram,
     servicer_query_count_histogram,
     servicer_setup_errors_counter,
@@ -234,18 +235,29 @@ def test_tracing_interceptor_ok_open(db):
 
 
 def _get_query_count_histogram(method):
-    samples = {
-        s.name: s.value
+    return sum(
+        s.value
         for m in servicer_query_count_histogram.collect()
         for s in m.samples
-        if s.labels.get("method") == method and s.name in ("couchers_servicer_query_count_count",)
-    }
-    return samples.get("couchers_servicer_query_count_count", 0)
+        if s.name == "couchers_servicer_query_count_count" and s.labels.get("method") == method
+    )
+
+
+def _get_api_call_count(method, platform):
+    return sum(
+        s.value
+        for m in api_calls_counter.collect()
+        for s in m.samples
+        if s.name == "couchers_api_calls_total"
+        and s.labels.get("method") == method
+        and s.labels.get("platform") == platform
+    )
 
 
 def test_tracing_interceptor_perf_accounting(db):
     method = "/org.couchers.auth.Auth/SignupFlow"
     hist_count_before = _get_query_count_histogram(method)
+    api_call_count_before = _get_api_call_count(method, "web_mobile")
 
     # handler runs a known number of statements: three reads and one compiled write (caught via is_crud). The write
     # matches zero rows so it's side-effect free.
@@ -268,8 +280,9 @@ def test_tracing_interceptor_perf_accounting(db):
         assert trace.db_time_ms <= trace.duration
         assert trace.client_platform == ClientPlatform.web_mobile
 
-    # the call was also observed into the Prometheus per-request resource histograms
+    # the call was also observed into the Prometheus per-request resource histograms and the per-platform call counter
     assert _get_query_count_histogram(method) == hist_count_before + 1
+    assert _get_api_call_count(method, "web_mobile") == api_call_count_before + 1
 
 
 def test_tracing_interceptor_sensitive(db):

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -285,6 +285,24 @@ def test_tracing_interceptor_perf_accounting(db):
     assert _get_api_call_count(method, "web_mobile") == api_call_count_before + 1
 
 
+def test_tracing_interceptor_perf_accounting_orm_write(db):
+    # a handler that only session.add(...)s and returns: the INSERT flushes at commit, after read_perf(), so without
+    # the interceptor's explicit flush it would be missed from the write/query counts
+    method = "/org.couchers.auth.Auth/SignupFlow"
+
+    def TestRpc(request, context, session):
+        session.add(APICall(method="handler-insert", duration=0.0, is_api_key=False, response_truncated=False))
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(TestRpc, interceptors=[CouchersMiddlewareInterceptor()]) as call_rpc:
+        call_rpc(empty_pb2.Empty())
+
+    with session_scope() as session:
+        log = session.execute(select(APICall).where(APICall.method == method)).scalar_one()
+        assert log.query_count == 1
+        assert log.write_query_count == 1
+
+
 def test_tracing_interceptor_sensitive(db):
     val = _get_histogram_labels_value("/org.couchers.auth.Auth/SignupFlow", "False", "", "")
 

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -31,7 +31,11 @@ from couchers.interceptors import (
     parse_headers,
     validate_auth_level,
 )
-from couchers.metrics import servicer_duration_histogram, servicer_setup_errors_counter
+from couchers.metrics import (
+    servicer_duration_histogram,
+    servicer_query_count_histogram,
+    servicer_setup_errors_counter,
+)
 from couchers.models import APICall, ClientPlatform, User, UserActivity, UserSession
 from couchers.proto import account_pb2, admin_pb2, annotations_pb2, api_pb2, auth_pb2
 from couchers.servicers.account import Account
@@ -229,7 +233,20 @@ def test_tracing_interceptor_ok_open(db):
     assert _get_histogram_labels_value("/org.couchers.auth.Auth/SignupFlow", "False", "", "") == val + 1
 
 
+def _get_query_count_histogram(method):
+    samples = {
+        s.name: s.value
+        for m in servicer_query_count_histogram.collect()
+        for s in m.samples
+        if s.labels.get("method") == method and s.name in ("couchers_servicer_query_count_count",)
+    }
+    return samples.get("couchers_servicer_query_count_count", 0)
+
+
 def test_tracing_interceptor_perf_accounting(db):
+    method = "/org.couchers.auth.Auth/SignupFlow"
+    hist_count_before = _get_query_count_histogram(method)
+
     # handler runs a known number of statements: three reads and one compiled write (caught via is_crud). The write
     # matches zero rows so it's side-effect free.
     def TestRpc(request, context, session):
@@ -250,6 +267,9 @@ def test_tracing_interceptor_perf_accounting(db):
         # the handler's DB work can't exceed the whole-request wall time
         assert trace.db_time_ms <= trace.duration
         assert trace.client_platform == ClientPlatform.web_mobile
+
+    # the call was also observed into the Prometheus per-request resource histograms
+    assert _get_query_count_histogram(method) == hist_count_before + 1
 
 
 def test_tracing_interceptor_sensitive(db):

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -33,7 +33,7 @@ from couchers.interceptors import (
 )
 from couchers.metrics import servicer_duration_histogram, servicer_setup_errors_counter
 from couchers.models import APICall, ClientPlatform, User, UserActivity, UserSession
-from couchers.perf import _is_write
+from couchers.perf import _is_write_statement
 from couchers.proto import account_pb2, admin_pb2, annotations_pb2, api_pb2, auth_pb2
 from couchers.servicers.account import Account
 from couchers.servicers.api import API
@@ -230,21 +230,23 @@ def test_tracing_interceptor_ok_open(db):
     assert _get_histogram_labels_value("/org.couchers.auth.Auth/SignupFlow", "False", "", "") == val + 1
 
 
-def test_is_write():
-    assert _is_write("INSERT INTO foo VALUES (1)")
-    assert _is_write("UPDATE foo SET a = 1")
-    assert _is_write("DELETE FROM foo")
-    assert _is_write("  \n  insert into foo values (1)")
-    assert not _is_write("SELECT 1")
-    assert not _is_write("  SELECT * FROM foo")
-    assert not _is_write("WITH x AS (SELECT 1) SELECT * FROM x")
+def test_is_write_statement():
+    assert _is_write_statement("INSERT INTO foo VALUES (1)")
+    assert _is_write_statement("UPDATE foo SET a = 1")
+    assert _is_write_statement("DELETE FROM foo")
+    assert _is_write_statement("  \n  insert into foo values (1)")
+    assert not _is_write_statement("SELECT 1")
+    assert not _is_write_statement("  SELECT * FROM foo")
+    assert not _is_write_statement("WITH x AS (SELECT 1) SELECT * FROM x")
 
 
 def test_tracing_interceptor_perf_accounting(db):
-    # handler runs a known number of statements - three reads, one write
+    # handler runs a known number of statements: three reads, one compiled write (caught via is_crud), and one raw
+    # text() write (caught via the statement-sniff fallback). Both writes match zero rows so they're side-effect free.
     def TestRpc(request, context, session):
         for _ in range(3):
             session.execute(text("SELECT 1"))
+        session.execute(update(APICall).where(APICall.id == -1).values(method="x"))
         session.execute(text("UPDATE logging.api_calls SET method = method WHERE false"))
         return empty_pb2.Empty()
 
@@ -253,8 +255,8 @@ def test_tracing_interceptor_perf_accounting(db):
 
     with session_scope() as session:
         trace = session.execute(select(APICall)).scalar_one()
-        assert trace.query_count == 4
-        assert trace.write_query_count == 1
+        assert trace.query_count == 5
+        assert trace.write_query_count == 2
         assert trace.db_time_ms is not None and trace.db_time_ms >= 0
         assert trace.cpu_ms is not None and trace.cpu_ms >= 0
         # the handler's DB work can't exceed the whole-request wall time


### PR DESCRIPTION
Adds per-request resource accounting to `logging.api_calls` so we can see *why* an endpoint is expensive, not just that it's slow.

Per RPC, over the handler span, we now capture: `query_count`, `write_query_count`, `db_time_ms`, `cpu_ms`, and `client_platform`. A thread-local accumulator in `couchers/perf.py` is fed by SQLAlchemy cursor-execute listeners (writes detected via `ExecutionContext.is_crud`); the interceptor arms it around the handler so the numbers exclude auth and the log insert.

Also surfaced in Prometheus (method-labelled): `db_time_seconds`, `cpu_seconds`, `query_count`, `write_query_count` histograms, plus a `couchers_api_calls_total` counter labelled by method + platform.

With these you can decompose latency into backend CPU vs Postgres vs residual wait, rank endpoints by DB cost, and spot N+1s.

## Testing
Unit + integration tests in `test_interceptors.py` (column population, write detection, histogram/counter observation). `make format` and `make mypy` clean.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes (autogenerated in CI)

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._