### PR TITLE
nginx: cache immutable /_next/static build assets

### DIFF
--- a/app/nginx/nginx.conf
+++ b/app/nginx/nginx.conf
@@ -57,6 +57,14 @@ http {
         # gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
         ##
+        # Proxy cache
+        ##
+
+        # Only used for immutable, content-hashed Next.js build assets (/_next/static/).
+        # Ephemeral storage is fine: a cold cache just re-warms from the web upstream.
+        proxy_cache_path /var/cache/nginx/next_static levels=1:2 keys_zone=next_static:10m max_size=1g inactive=7d use_temp_path=off;
+
+        ##
         # Virtual Host Configs
         ##
 

--- a/app/nginx/sites-enabled/web.conf
+++ b/app/nginx/sites-enabled/web.conf
@@ -18,6 +18,17 @@ server {
         proxy_pass http://envoy_backend/;
     }
 
+    # Immutable, content-hashed build assets. Safe to cache hard: a new build emits new
+    # filenames, so cached entries can never be stale. ^~ keeps these out of the catch-all
+    # below, so personalized SSR / _next/data responses are never cached.
+    location ^~ /_next/static/ {
+        proxy_pass http://web:3000;
+        proxy_cache next_static;
+        proxy_cache_lock on;
+        proxy_cache_valid 200 7d;
+        add_header X-Cache-Status $upstream_cache_status;
+    }
+
     location / {
         proxy_pass http://web:3000;
     }


### PR DESCRIPTION
Serves Next.js content-hashed build assets (`/_next/static/`) from an nginx `proxy_cache` instead of proxying every request to the single Next.js Node process.

The web tier runs as one Node process (standalone `server.js`), so every request for an immutable JS/CSS chunk competes for that single event loop along with real SSR work. These build assets are safe to cache hard: filenames are content-hashed (e.g. `chunks/2617.84f93ac2e31020ac.js`) and there is no `generateBuildId` override, so every build produces fresh paths and a cached entry can never go stale across a deploy. `proxy_cache_lock` collapses concurrent cold-cache misses into a single upstream fetch.

Scoping notes:
- The `^~ /_next/static/` modifier keeps these requests out of the catch-all `location /`, so personalized SSR pages and `/_next/data/*.json` are **never** cached.
- `proxy_ignore_headers` is not set, so nginx still honors upstream `Cache-Control` and refuses to cache any `Set-Cookie` response — backstops in case an asset is ever served with unexpected headers.

## Testing

Ships when the nginx image is rebuilt (config is baked in via the `{WEB_DOMAIN}` substitution); `run.sh` reloads nginx after deploy. To verify in an environment:

```bash
nginx -t            # config is valid
# immutable asset: MISS then HIT
curl -sI https://<web-domain>/_next/static/<chunk>.js | grep -i x-cache
curl -sI https://<web-domain>/_next/static/<chunk>.js | grep -i x-cache
# boundary holds — these must show NO X-Cache-Status header:
curl -sI https://<web-domain>/
curl -sI 'https://<web-domain>/_next/data/<...>.json'
```

Note: if `ASSET_PREFIX` is set in the prod web env, these assets are served from that host and this cache is a harmless no-op.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._