### PR TITLE
Backend: instrument interceptor setup-phase failures

### DIFF
--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -33,7 +33,7 @@ from couchers.db import session_scope
 from couchers.descriptor_pool import get_descriptor_pool
 from couchers.i18n import LocalizationContext
 from couchers.i18n.locales import DEFAULT_LOCALE
-from couchers.metrics import observe_in_servicer_duration_histogram
+from couchers.metrics import observe_in_servicer_duration_histogram, observe_in_servicer_setup_errors_counter
 from couchers.models import APICall, ClientPlatform, User, UserActivity, UserSession
 from couchers.proto import annotations_pb2
 from couchers.proto.annotations_pb2 import AuthLevel
@@ -280,46 +280,58 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
 
         method = handler_call_details.method
 
+        # The setup phase below (auth, header parsing, the user-details DB call, permission checks, handler
+        # resolution, sofa generation, localization) runs *before* function_without_couchers_stuff, so the metric +
+        # logging + Sentry instrumentation inside that handler never sees failures here. The expected early-exit cases
+        # (AbortError, BadHeaders) return as before; any *unexpected* exception is caught below so it doesn't escape
+        # uninstrumented as an opaque UNKNOWN.
         try:
-            auth_level = find_auth_level(self._pool, method)
-        except AbortError as ae:
-            return abort_handler(ae.msg, ae.code)
+            try:
+                auth_level = find_auth_level(self._pool, method)
+            except AbortError as ae:
+                return abort_handler(ae.msg, ae.code)
 
-        try:
-            headers = parse_headers(dict(handler_call_details.invocation_metadata))
-        except BadHeaders:
-            return unauthenticated_handler(COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE)
+            try:
+                headers = parse_headers(dict(handler_call_details.invocation_metadata))
+            except BadHeaders:
+                return unauthenticated_handler(COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE)
 
-        auth_info = _try_get_and_update_user_details(
-            headers.token,
-            headers.is_api_key,
-            headers.ip_address,
-            headers.user_agent,
-            headers.sofa,
-            headers.client_platform,
-        )
+            auth_info = _try_get_and_update_user_details(
+                headers.token,
+                headers.is_api_key,
+                headers.ip_address,
+                headers.user_agent,
+                headers.sofa,
+                headers.client_platform,
+            )
 
-        try:
-            check_permissions(auth_info, auth_level)
-        except AbortError as ae:
-            return unauthenticated_handler(ae.msg, ae.code)
+            try:
+                check_permissions(auth_info, auth_level)
+            except AbortError as ae:
+                return unauthenticated_handler(ae.msg, ae.code)
 
-        if not (handler := continuation(handler_call_details)):
-            raise RuntimeError(f"No handler in '{method}'")
+            if not (handler := continuation(handler_call_details)):
+                raise RuntimeError(f"No handler in '{method}'")
 
-        if not (prev_function := handler.unary_unary):
-            raise RuntimeError(f"No prev_function in '{method}', {handler}")
+            if not (prev_function := handler.unary_unary):
+                raise RuntimeError(f"No prev_function in '{method}', {handler}")
 
-        if headers.sofa:
-            sofa = headers.sofa
-            new_sofa_cookie = None
-        else:
-            sofa, new_sofa_cookie = generate_sofa_cookie()
+            if headers.sofa:
+                sofa = headers.sofa
+                new_sofa_cookie = None
+            else:
+                sofa, new_sofa_cookie = generate_sofa_cookie()
 
-        loc_context = LocalizationContext(
-            locale=(auth_info.ui_language_preference if auth_info else headers.ui_lang) or DEFAULT_LOCALE,
-            timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
-        )
+            loc_context = LocalizationContext(
+                locale=(auth_info.ui_language_preference if auth_info else headers.ui_lang) or DEFAULT_LOCALE,
+                timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
+            )
+        except Exception as e:
+            observe_in_servicer_setup_errors_counter(method, type(e).__name__)
+            sentry_sdk.set_tag("context", "servicer_setup")
+            sentry_sdk.set_tag("method", method)
+            sentry_sdk.capture_exception(e)
+            return abort_handler(UNKNOWN_ERROR_MESSAGE, grpc.StatusCode.INTERNAL)
 
         def function_without_couchers_stuff(req: Message, grpc_context: grpc.ServicerContext) -> Message | None:
             couchers_context = make_interactive_context(

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -280,11 +280,6 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
 
         method = handler_call_details.method
 
-        # The setup phase below (auth, header parsing, the user-details DB call, permission checks, handler
-        # resolution, sofa generation, localization) runs *before* function_without_couchers_stuff, so the metric +
-        # logging + Sentry instrumentation inside that handler never sees failures here. The expected early-exit cases
-        # (AbortError, BadHeaders) return as before; any *unexpected* exception is caught below so it doesn't escape
-        # uninstrumented as an opaque UNKNOWN.
         try:
             try:
                 auth_level = find_auth_level(self._pool, method)

--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -86,6 +86,20 @@ def observe_in_servicer_duration_histogram(
     servicer_duration_histogram.labels(method, user_id is not None, status_code, exception_type).observe(duration_s)
 
 
+# Unexpected errors raised during interceptor setup (auth, header parsing, handler resolution, localization, etc.)
+# happen *before* the handler runs, so they never reach the servicer_duration_histogram above. This counter makes
+# that otherwise-invisible class of failure observable.
+servicer_setup_errors_counter: Counter = Counter(
+    "couchers_servicer_setup_errors_total",
+    "Number of unexpected errors raised during gRPC interceptor setup, before the handler is invoked",
+    labelnames=["method", "exception"],
+)
+
+
+def observe_in_servicer_setup_errors_counter(method: str, exception_type: str) -> None:
+    servicer_setup_errors_counter.labels(method, exception_type).inc()
+
+
 # list of gauge names and function to execute to set value to
 # the python prometheus client does not support Gauge.set_function, so instead we hack around it and set each gauge just
 # before collection with this

--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -86,9 +86,6 @@ def observe_in_servicer_duration_histogram(
     servicer_duration_histogram.labels(method, user_id is not None, status_code, exception_type).observe(duration_s)
 
 
-# Unexpected errors raised during interceptor setup (auth, header parsing, handler resolution, localization, etc.)
-# happen *before* the handler runs, so they never reach the servicer_duration_histogram above. This counter makes
-# that otherwise-invisible class of failure observable.
 servicer_setup_errors_counter: Counter = Counter(
     "couchers_servicer_setup_errors_total",
     "Number of unexpected errors raised during gRPC interceptor setup, before the handler is invoked",

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -3,7 +3,7 @@ from concurrent import futures
 from contextlib import contextmanager
 from datetime import timedelta
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import grpc
 import pytest
@@ -15,6 +15,7 @@ from sqlalchemy import select, update
 from couchers.constants import (
     MISSING_AUTH_LEVEL_ERROR_MESSAGE,
     NONEXISTENT_API_CALL_ERROR_MESSAGE,
+    UNKNOWN_ERROR_MESSAGE,
 )
 from couchers.crypto import b64encode, random_hex, simple_encrypt
 from couchers.db import session_scope
@@ -30,7 +31,7 @@ from couchers.interceptors import (
     parse_headers,
     validate_auth_level,
 )
-from couchers.metrics import servicer_duration_histogram
+from couchers.metrics import servicer_duration_histogram, servicer_setup_errors_counter
 from couchers.models import APICall, User, UserActivity, UserSession
 from couchers.proto import account_pb2, admin_pb2, annotations_pb2, api_pb2, auth_pb2
 from couchers.servicers.account import Account
@@ -97,6 +98,21 @@ def _get_histogram_labels_value(method, logged_in, exception, code):
     if len(histogram_counts) == 0:
         return 0
     return histogram_counts[0].value
+
+
+def _get_setup_errors_value(method, exception):
+    metrics = servicer_setup_errors_counter.collect()
+    counter = [m for m in metrics if m.name == "couchers_servicer_setup_errors"][0]
+    samples = [
+        s
+        for s in counter.samples
+        if s.name == "couchers_servicer_setup_errors_total"
+        and s.labels["method"] == method
+        and s.labels["exception"] == exception
+    ]
+    if len(samples) == 0:
+        return 0
+    return samples[0].value
 
 
 def test_logging_interceptor_ok():
@@ -290,6 +306,31 @@ def test_tracing_interceptor_exception(db):
         assert not trace.response
 
     assert _get_histogram_labels_value("/org.couchers.auth.Auth/SignupFlow", "False", "Exception", "") == val + 1
+
+
+def test_setup_phase_exception_observed(db):
+    # An unexpected exception during the interceptor setup phase (here: building the LocalizationContext, the exact
+    # spot of the observed zh-hans crash) happens before function_without_couchers_stuff runs, so the handler-level
+    # instrumentation never sees it. It must instead bump the setup-errors counter, hit Sentry, and surface as a
+    # sanitized INTERNAL rather than escaping as an opaque UNKNOWN.
+    method = "/org.couchers.auth.Auth/SignupFlow"
+    val = _get_setup_errors_value(method, "ValueError")
+
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with (
+        patch("couchers.interceptors.LocalizationContext", side_effect=ValueError("expected only letters")),
+        patch("couchers.interceptors.sentry_sdk") as mock_sentry,
+        interceptor_dummy_api(TestRpc, interceptors=[CouchersMiddlewareInterceptor()]) as call_rpc,
+    ):
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty())
+        assert e.value.code() == grpc.StatusCode.INTERNAL
+        assert e.value.details() == UNKNOWN_ERROR_MESSAGE
+        mock_sentry.capture_exception.assert_called_once()
+
+    assert _get_setup_errors_value(method, "ValueError") == val + 1
 
 
 def test_tracing_interceptor_abort(db):

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -309,10 +309,6 @@ def test_tracing_interceptor_exception(db):
 
 
 def test_setup_phase_exception_observed(db):
-    # An unexpected exception during the interceptor setup phase (here: building the LocalizationContext, the exact
-    # spot of the observed zh-hans crash) happens before function_without_couchers_stuff runs, so the handler-level
-    # instrumentation never sees it. It must instead bump the setup-errors counter, hit Sentry, and surface as a
-    # sanitized INTERNAL rather than escaping as an opaque UNKNOWN.
     method = "/org.couchers.auth.Auth/SignupFlow"
     val = _get_setup_errors_value(method, "ValueError")
 


### PR DESCRIPTION
Exceptions during the gRPC interceptor setup phase (auth, header parsing, the user-details DB call, permission checks, handler resolution, sofa generation, `LocalizationContext`) happen before the handler runs, so they escaped all instrumentation: no metric, no Sentry, and they surfaced to clients as an opaque `UNKNOWN`. This was hit in production by a `ui_lang=zh-hans` value that crashed `LocalizationContext` (that parsing bug is already fixed; this closes the observability gap that hid it).

- New `couchers_servicer_setup_errors_total` counter (labeled `method`, `exception`).
- Wrap the setup phase in `intercept_service` so unexpected exceptions bump the counter, report to Sentry, and return a sanitized `INTERNAL`. The existing `AbortError`/`BadHeaders` early-returns are unchanged.

## Testing
Added `test_setup_phase_exception_observed`. `make format`/`make mypy` clean, all `test_interceptors.py` tests pass.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._