### PR TITLE
Correlate browser requests into envoy/backend traces

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -645,6 +645,8 @@ test:proxy:
   needs: ["build:proxy"]
   stage: test
   script:
+    # statically validate the config (fully loads/validates it without opening listeners)
+    - docker run --rm --entrypoint /usr/local/bin/envoy $PROXY_TAG -c /etc/envoy/envoy.yaml --mode validate
     - docker run --name envoy-config-test -d -p 8888:8888 -p 9901:9901 $PROXY_TAG
     - sleep 10
     - |

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -645,7 +645,6 @@ test:proxy:
   needs: ["build:proxy"]
   stage: test
   script:
-    # statically validate the config (fully loads/validates it without opening listeners)
     - docker run --rm --entrypoint /usr/local/bin/envoy $PROXY_TAG -c /etc/envoy/envoy.yaml --mode validate
     - docker run --name envoy-config-test -d -p 8888:8888 -p 9901:9901 $PROXY_TAG
     - sleep 10

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -601,7 +601,6 @@ test:proxy:
   needs: ["build:proxy"]
   stage: test
   script:
-    # statically validate the config (fully loads/validates it without opening listeners)
     - docker run --rm --entrypoint /usr/local/bin/envoy $PROXY_TAG -c /etc/envoy/envoy.yaml --mode validate
     - docker run --name envoy-config-test -d -p 8888:8888 -p 9901:9901 $PROXY_TAG
     - sleep 10

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -601,6 +601,8 @@ test:proxy:
   needs: ["build:proxy"]
   stage: test
   script:
+    # statically validate the config (fully loads/validates it without opening listeners)
+    - docker run --rm --entrypoint /usr/local/bin/envoy $PROXY_TAG -c /etc/envoy/envoy.yaml --mode validate
     - docker run --name envoy-config-test -d -p 8888:8888 -p 9901:9901 $PROXY_TAG
     - sleep 10
     - |

--- a/app/docker-compose.prod.yml
+++ b/app/docker-compose.prod.yml
@@ -71,6 +71,7 @@ services:
       - backend_envoy
       - envoy_nginx
       - envoy_prometheus
+      - envoy_jaeger
     dns_search: ""
   nginx:
     image: registry.gitlab.com/couchers/couchers/nginx
@@ -151,6 +152,7 @@ services:
       - COLLECTOR_OTLP_ENABLED=true
     networks:
       - backend_jaeger
+      - envoy_jaeger
 
 networks:
   backend_prometheus:
@@ -181,6 +183,9 @@ networks:
     driver: bridge
     enable_ipv6: true
   envoy_prometheus:
+    driver: bridge
+    enable_ipv6: true
+  envoy_jaeger:
     driver: bridge
     enable_ipv6: true
   backend_jaeger:

--- a/app/proxy/envoy.yaml
+++ b/app/proxy/envoy.yaml
@@ -19,10 +19,6 @@ static_resources:
           codec_type: auto
           stat_prefix: ingress_http
           tracing:
-            # continues the trace context coming in from the browser (traceparent
-            # header) and propagates it upstream to the backend, while emitting an
-            # envoy span. The gap between this span and the backend span is the
-            # dispatch/queue time that's otherwise invisible.
             provider:
               name: envoy.tracers.opentelemetry
               typed_config:
@@ -201,7 +197,6 @@ static_resources:
         "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicit_http_config:
           http2_protocol_options: {}
-  # OTLP/gRPC sink for envoy's own spans (jaeger all-in-one has COLLECTOR_OTLP_ENABLED)
   - name: jaeger
     connect_timeout: 1s
     type: logical_dns

--- a/app/proxy/envoy.yaml
+++ b/app/proxy/envoy.yaml
@@ -18,6 +18,23 @@ static_resources:
           "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
+          tracing:
+            # continues the trace context coming in from the browser (traceparent
+            # header) and propagates it upstream to the backend, while emitting an
+            # envoy span. The gap between this span and the backend span is the
+            # dispatch/queue time that's otherwise invisible.
+            provider:
+              name: envoy.tracers.opentelemetry
+              typed_config:
+                "@type": type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
+                grpc_service:
+                  envoy_grpc:
+                    cluster_name: jaeger
+                  timeout: 1s
+                service_name: envoy
+            # trace everything while we debug; dial down once the picture is clear
+            random_sampling:
+              value: 100.0
           access_log:
           - name: envoy.access_loggers.stdout
             typed_config:
@@ -69,7 +86,7 @@ static_resources:
                   - suffix: -couchers-org.vercel.app
                   - suffix: vercel.couchershq.org
                   allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                  allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,authorization,cookie,accept-language,x-couchers-client-platform
+                  allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,authorization,cookie,accept-language,x-couchers-client-platform,traceparent,tracestate
                   max_age: "1728000"
                   expose_headers: grpc-status,grpc-message,set-cookie
                   allow_credentials: true
@@ -179,6 +196,21 @@ static_resources:
       interval: 5s
       base_ejection_time: 30s
       max_ejection_percent: 50
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
+  # OTLP/gRPC sink for envoy's own spans (jaeger all-in-one has COLLECTOR_OTLP_ENABLED)
+  - name: jaeger
+    connect_timeout: 1s
+    type: logical_dns
+    load_assignment:
+      cluster_name: jaeger
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address: { socket_address: { address: jaeger, port_value: 4317 }}
     typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/app/proxy/envoy.yaml
+++ b/app/proxy/envoy.yaml
@@ -19,10 +19,6 @@ static_resources:
           codec_type: auto
           stat_prefix: ingress_http
           tracing:
-            # continues the trace context coming in from the browser (traceparent
-            # header) and propagates it upstream to the backend, while emitting an
-            # envoy span. The gap between this span and the backend span is the
-            # dispatch/queue time that's otherwise invisible.
             provider:
               name: envoy.tracers.opentelemetry
               typed_config:
@@ -171,7 +167,6 @@ static_resources:
         "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicit_http_config:
           http2_protocol_options: {}
-  # OTLP/gRPC sink for envoy's own spans (jaeger all-in-one has COLLECTOR_OTLP_ENABLED)
   - name: jaeger
     connect_timeout: 1s
     type: logical_dns

--- a/app/proxy/envoy.yaml
+++ b/app/proxy/envoy.yaml
@@ -18,6 +18,23 @@ static_resources:
           "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
+          tracing:
+            # continues the trace context coming in from the browser (traceparent
+            # header) and propagates it upstream to the backend, while emitting an
+            # envoy span. The gap between this span and the backend span is the
+            # dispatch/queue time that's otherwise invisible.
+            provider:
+              name: envoy.tracers.opentelemetry
+              typed_config:
+                "@type": type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
+                grpc_service:
+                  envoy_grpc:
+                    cluster_name: jaeger
+                  timeout: 1s
+                service_name: envoy
+            # trace everything while we debug; dial down once the picture is clear
+            random_sampling:
+              value: 100.0
           access_log:
           - name: envoy.access_loggers.stdout
             typed_config:
@@ -59,7 +76,7 @@ static_resources:
                   - suffix: -couchers-org.vercel.app
                   - suffix: vercel.couchershq.org
                   allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                  allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,authorization,cookie,accept-language,x-couchers-client-platform
+                  allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,authorization,cookie,accept-language,x-couchers-client-platform,traceparent,tracestate
                   max_age: "1728000"
                   expose_headers: grpc-status,grpc-message,set-cookie
                   allow_credentials: true
@@ -149,6 +166,21 @@ static_resources:
       - lb_endpoints:
         - endpoint:
             address: { socket_address: { address: backend, port_value: 1751 }}
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
+  # OTLP/gRPC sink for envoy's own spans (jaeger all-in-one has COLLECTOR_OTLP_ENABLED)
+  - name: jaeger
+    connect_timeout: 1s
+    type: logical_dns
+    load_assignment:
+      cluster_name: jaeger
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address: { socket_address: { address: jaeger, port_value: 4317 }}
     typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/app/web/service/client.ts
+++ b/app/web/service/client.ts
@@ -85,17 +85,14 @@ function randomHex(bytes: number): string {
   return Array.from(arr, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-// Injects a W3C Trace Context header so each call can be correlated end-to-end
-// (browser -> envoy -> backend -> DB) in a single Jaeger trace. We only inject the
-// header here; the browser doesn't export spans of its own. The trailing "-01" flag
-// marks the trace as sampled so envoy records it.
+// Injects a W3C Trace Context header so calls can be correlated end-to-end in Jaeger.
 class TraceInterceptor {
   async intercept(
     request: Request<unknown, unknown>,
     invoker: (request: unknown) => unknown,
   ) {
-    const traceId = randomHex(16); // 32 hex chars
-    const spanId = randomHex(8); // 16 hex chars
+    const traceId = randomHex(16);
+    const spanId = randomHex(8);
     request.getMetadata()["traceparent"] = `00-${traceId}-${spanId}-01`;
     return invoker(request);
   }

--- a/app/web/service/client.ts
+++ b/app/web/service/client.ts
@@ -75,12 +75,44 @@ class PlatformInterceptor {
   }
 }
 
+function randomHex(bytes: number): string {
+  const arr = new Uint8Array(bytes);
+  if (typeof crypto !== "undefined" && crypto.getRandomValues) {
+    crypto.getRandomValues(arr);
+  } else {
+    for (let i = 0; i < bytes; i++) arr[i] = Math.floor(Math.random() * 256);
+  }
+  return Array.from(arr, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+// Injects a W3C Trace Context header so each call can be correlated end-to-end
+// (browser -> envoy -> backend -> DB) in a single Jaeger trace. We only inject the
+// header here; the browser doesn't export spans of its own. The trailing "-01" flag
+// marks the trace as sampled so envoy records it.
+class TraceInterceptor {
+  async intercept(
+    request: Request<unknown, unknown>,
+    invoker: (request: unknown) => unknown,
+  ) {
+    const traceId = randomHex(16); // 32 hex chars
+    const spanId = randomHex(8); // 16 hex chars
+    request.getMetadata()["traceparent"] = `00-${traceId}-${spanId}-01`;
+    return invoker(request);
+  }
+}
+
 const authInterceptor = new AuthInterceptor();
 const timeoutInterceptor = new TimeoutInterceptor();
 const platformInterceptor = new PlatformInterceptor();
+const traceInterceptor = new TraceInterceptor();
 
 const opts = {
-  unaryInterceptors: [authInterceptor, timeoutInterceptor, platformInterceptor],
+  unaryInterceptors: [
+    traceInterceptor,
+    authInterceptor,
+    timeoutInterceptor,
+    platformInterceptor,
+  ],
   // this modifies the behaviour on the API so that it will send cookies on the requests
   withCredentials: true,
   /// TODO: streaming interceptor for auth https://grpc.io/blog/grpc-web-interceptor/

--- a/app/web/service/client.ts
+++ b/app/web/service/client.ts
@@ -87,10 +87,7 @@ function randomHex(bytes: number): string {
 
 // Injects a W3C Trace Context header so calls can be correlated end-to-end in Jaeger.
 class TraceInterceptor {
-  async intercept(
-    request: Request<unknown, unknown>,
-    invoker: (request: unknown) => unknown,
-  ) {
+  async intercept(request: Request<unknown, unknown>, invoker: (request: unknown) => unknown) {
     const traceId = randomHex(16);
     const spanId = randomHex(8);
     request.getMetadata()["traceparent"] = `00-${traceId}-${spanId}-01`;
@@ -104,12 +101,7 @@ const platformInterceptor = new PlatformInterceptor();
 const traceInterceptor = new TraceInterceptor();
 
 const opts = {
-  unaryInterceptors: [
-    traceInterceptor,
-    authInterceptor,
-    timeoutInterceptor,
-    platformInterceptor,
-  ],
+  unaryInterceptors: [traceInterceptor, authInterceptor, timeoutInterceptor, platformInterceptor],
   // this modifies the behaviour on the API so that it will send cookies on the requests
   withCredentials: true,
   /// TODO: streaming interceptor for auth https://grpc.io/blog/grpc-web-interceptor/

--- a/app/web/service/client.ts
+++ b/app/web/service/client.ts
@@ -97,17 +97,14 @@ function randomHex(bytes: number): string {
   return Array.from(arr, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-// Injects a W3C Trace Context header so each call can be correlated end-to-end
-// (browser -> envoy -> backend -> DB) in a single Jaeger trace. We only inject the
-// header here; the browser doesn't export spans of its own. The trailing "-01" flag
-// marks the trace as sampled so envoy records it.
+// Injects a W3C Trace Context header so calls can be correlated end-to-end in Jaeger.
 class TraceInterceptor {
   async intercept(
     request: Request<unknown, unknown>,
     invoker: (request: unknown) => unknown,
   ) {
-    const traceId = randomHex(16); // 32 hex chars
-    const spanId = randomHex(8); // 16 hex chars
+    const traceId = randomHex(16);
+    const spanId = randomHex(8);
     request.getMetadata()["traceparent"] = `00-${traceId}-${spanId}-01`;
     return invoker(request);
   }

--- a/app/web/service/client.ts
+++ b/app/web/service/client.ts
@@ -87,12 +87,44 @@ class PlatformInterceptor {
   }
 }
 
+function randomHex(bytes: number): string {
+  const arr = new Uint8Array(bytes);
+  if (typeof crypto !== "undefined" && crypto.getRandomValues) {
+    crypto.getRandomValues(arr);
+  } else {
+    for (let i = 0; i < bytes; i++) arr[i] = Math.floor(Math.random() * 256);
+  }
+  return Array.from(arr, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+// Injects a W3C Trace Context header so each call can be correlated end-to-end
+// (browser -> envoy -> backend -> DB) in a single Jaeger trace. We only inject the
+// header here; the browser doesn't export spans of its own. The trailing "-01" flag
+// marks the trace as sampled so envoy records it.
+class TraceInterceptor {
+  async intercept(
+    request: Request<unknown, unknown>,
+    invoker: (request: unknown) => unknown,
+  ) {
+    const traceId = randomHex(16); // 32 hex chars
+    const spanId = randomHex(8); // 16 hex chars
+    request.getMetadata()["traceparent"] = `00-${traceId}-${spanId}-01`;
+    return invoker(request);
+  }
+}
+
 const authInterceptor = new AuthInterceptor();
 const timeoutInterceptor = new TimeoutInterceptor();
 const platformInterceptor = new PlatformInterceptor();
+const traceInterceptor = new TraceInterceptor();
 
 const opts = {
-  unaryInterceptors: [authInterceptor, timeoutInterceptor, platformInterceptor],
+  unaryInterceptors: [
+    traceInterceptor,
+    authInterceptor,
+    timeoutInterceptor,
+    platformInterceptor,
+  ],
   // this modifies the behaviour on the API so that it will send cookies on the requests
   withCredentials: true,
   /// TODO: streaming interceptor for auth https://grpc.io/blog/grpc-web-interceptor/


### PR DESCRIPTION
Wires up end-to-end trace correlation so a single user request shows up as one Jaeger trace spanning browser → envoy → backend → DB, instead of isolated backend-only traces. This makes the dispatch/queue time between envoy and the backend (currently invisible) show up as a gap in one waterfall — useful for diagnosing why a fan-out of simultaneous calls (e.g. the messages page firing many `GetLiteUser` calls) returns with increasing latency even though each backend span looks fast.

What it does:
- **Web client**: a new `TraceInterceptor` injects a W3C `traceparent` header (sampled) on every gRPC-web call. Header-only — the browser doesn't export spans of its own, this is purely for correlation.
- **Envoy**: enables the OpenTelemetry tracer (exporting OTLP/gRPC to Jaeger via a new `jaeger` cluster). Envoy now continues the incoming `traceparent`, emits its own span, and propagates context upstream to the backend (which already extracts it via its gRPC instrumentor). Adds `traceparent,tracestate` to the CORS `allow_headers` so the cross-origin preflight doesn't strip the header.
- **Compose**: adds an `envoy_jaeger` network so envoy can reach Jaeger's OTLP port (they previously shared none).
- **CI**: adds `envoy --mode validate` to `test:proxy` for a fast, direct static config check.

Note: `random_sampling` is set to 100% deliberately for debugging. Jaeger is in-memory (`MEMORY_MAX_TRACES=10000`), so this should be dialed down (or moved behind a collector with tail-sampling) once the picture is clear.

## Testing
- `envoy --mode validate` passes against the edited config locally (loads tracing config, both clusters, instantiates the `envoy.tracers.opentelemetry` tracer, `configuration OK`). This same check now runs in CI.
- `eslint` and `prettier --check` pass on `service/client.ts`.
- Not yet exercised end-to-end on a live deployment. To verify: deploy, open the messages page, and confirm in Jaeger that a single trace contains the envoy span with the backend span nested under it, and that the envoy→backend start gap fans out across the burst.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._