### PR TITLE
Backend: fix couchers_start_time_seconds exporting 0 in multiprocess mode

### DIFF
--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -58,7 +58,7 @@ _INF: float = float("inf")
 start_time_gauge: Gauge = Gauge(
     "couchers_start_time_seconds",
     "Unix timestamp of when the process started",
-    multiprocess_mode="min",
+    multiprocess_mode="max",
 )
 start_time_gauge.set(time.time())
 


### PR DESCRIPTION
`couchers_start_time_seconds` (added in #8847) was exporting `0` instead of the process start timestamp.

In Prometheus multiprocess mode, forked worker processes reset every gauge value to `0` in their own mmap file when prometheus_client detects the pid change. `start_time_gauge` is only `.set()` at module import, which forked children never re-run, so each worker leaves a stray `0` in its file. With `multiprocess_mode="min"` that `0` won the aggregation and the metric exported `0`.

Switching to `multiprocess_mode="max"` discards the stray `0`s and keeps the real timestamp written by the main process (the one that imported the module and serves `/metrics`). Since that process's pid never changes, its value is stable for the life of the container. This also matches `couchers_commit_timestamp_seconds`, which already uses `max`.

## Testing

Reproduced and verified against the installed `prometheus_client 0.25.0` by simulating the fork-based worker model: a parent sets the gauge, then forks workers that touch other metrics (triggering the pid-change reset).
- With `min`: aggregated output is `couchers_start_time_seconds 0.0`.
- With `max`: aggregated output is the real timestamp, and it stays stable across repeated waves of forked workers (12 workers, each leaving a `0` file).

**Backend checklist**
- [x] Run the backend locally and it works
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._