### PR TITLE
Add Bugs.CheckNativeStatus diagnostics endpoint

### DIFF
--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -202,6 +202,19 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
 
         return empty_pb2.Empty()
 
+    def CheckNativeStatus(
+        self, request: bugs_pb2.CheckNativeStatusReq, context: CouchersContext, session: Session
+    ) -> bugs_pb2.CheckNativeStatusRes:
+        # Stub: log the ping for now. TODO: persist it and decide whether to force-update.
+        logger.info("CheckNativeStatus: user_id=%s debug=%s", context._user_id, request.debug_json)
+
+        return bugs_pb2.CheckNativeStatusRes(
+            update_info=bugs_pb2.NativeUpdateInfo(
+                action=bugs_pb2.NATIVE_UPDATE_ACTION_NONE,
+                required=False,
+            )
+        )
+
     def GeolocationSearchInfo(
         self, request: bugs_pb2.GeolocationSearchInfoReq, context: CouchersContext, session: Session
     ) -> empty_pb2.Empty:

--- a/app/backend/src/tests/test_bugs.py
+++ b/app/backend/src/tests/test_bugs.py
@@ -396,6 +396,31 @@ def test_report_diagnostics_frontend_version(db):
         assert events[0].version == "abc-def-123"
 
 
+def test_check_native_status_anonymous(db):
+    with bugs_session() as bugs:
+        res = bugs.CheckNativeStatus(
+            bugs_pb2.CheckNativeStatusReq(
+                debug_json=json.dumps({"app_version": "1.1.20", "platform": "ios", "user_state": "logged_out"})
+            )
+        )
+
+    # Stub backend: the ping is logged and the response asks for no update for now.
+    assert res.update_info.action == bugs_pb2.NATIVE_UPDATE_ACTION_NONE
+    assert res.update_info.required is False
+
+
+def test_check_native_status_authenticated(db):
+    _, token = generate_user()
+
+    with bugs_session(token) as bugs:
+        res = bugs.CheckNativeStatus(
+            bugs_pb2.CheckNativeStatusReq(debug_json=json.dumps({"platform": "android", "user_state": "authenticated"}))
+        )
+
+    assert res.update_info.action == bugs_pb2.NATIVE_UPDATE_ACTION_NONE
+    assert res.update_info.required is False
+
+
 def _multipart_part_json(body, name):
     """Extract and parse the JSON body of a named part from a multipart/mixed body."""
     marker = f'name="{name}"'

--- a/app/proto/bugs.proto
+++ b/app/proto/bugs.proto
@@ -51,6 +51,10 @@ service Bugs {
 
   rpc ReportDiagnostics(ReportDiagnosticsReq) returns (google.protobuf.Empty) {}
 
+  rpc CheckNativeStatus(CheckNativeStatusReq) returns (CheckNativeStatusRes) {
+    // Diagnostics ping from the native mobile apps.
+  }
+
   rpc EvaluateFeatureFlag(EvaluateFeatureFlagReq) returns (EvaluateFeatureFlagRes) {
     // Remotely evaluate a single feature flag for the current session's user (anonymously when
     // logged out) and return the resolved value. Evaluated one flag at a time, on demand, so the
@@ -118,6 +122,37 @@ message DiagnosticInfo {
 message ReportDiagnosticsReq {
   string frontend_version = 1;
   repeated DiagnosticInfo infos = 2;
+}
+
+message CheckNativeStatusReq {
+  string debug_json = 1;
+}
+
+enum NativeUpdateAction {
+  NATIVE_UPDATE_ACTION_UNSPECIFIED = 0;
+  // No update needed.
+  NATIVE_UPDATE_ACTION_NONE = 1;
+  // Fetch and reload an OTA bundle; the client can apply this itself.
+  NATIVE_UPDATE_ACTION_OTA = 2;
+  // Update via the App Store / Play Store.
+  NATIVE_UPDATE_ACTION_STORE = 3;
+  // Delete and reinstall the app (worst case).
+  NATIVE_UPDATE_ACTION_REINSTALL = 4;
+}
+
+message NativeUpdateInfo {
+  NativeUpdateAction action = 1;
+  // Advisory when false; when true the client must act by act_by (in the past = block now).
+  bool required = 2;
+  google.protobuf.Timestamp act_by = 3;
+  // Shown on the nag/block screen.
+  string message = 4;
+  // Where to send the user to update (store listing, or a different app for reinstall).
+  string link_url = 5;
+}
+
+message CheckNativeStatusRes {
+  NativeUpdateInfo update_info = 1;
 }
 
 message EvaluateFeatureFlagReq {

--- a/app/proto/bugs.proto
+++ b/app/proto/bugs.proto
@@ -4,6 +4,7 @@ package org.couchers.bugs;
 
 import "google/api/annotations.proto";
 import "google/api/httpbody.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
@@ -145,10 +146,15 @@ message NativeUpdateInfo {
   // Advisory when false; when true the client must act by act_by (in the past = block now).
   bool required = 2;
   google.protobuf.Timestamp act_by = 3;
+  // For advisory updates (required == false): after showing the nag, the client waits at least this
+  // long before showing it again. Ignored when required. Unset/zero = show once per app session.
+  google.protobuf.Duration nag_interval = 4;
   // Shown on the nag/block screen.
-  string message = 4;
+  string message = 5;
   // Where to send the user to update (store listing, or a different app for reinstall).
-  string link_url = 5;
+  string link_url = 6;
+  // Label for the link_url button (e.g. "Update now", "Get the new app").
+  string link_text = 7;
 }
 
 message CheckNativeStatusRes {


### PR DESCRIPTION
Adds a `CheckNativeStatus` RPC to the open `Bugs` service. The native mobile apps send a free-form `debug_json` diagnostics snapshot (app/build version, OTA bundle, push state, etc.); for now the backend just logs it.

The response is a structured `NativeUpdateInfo` so the server can later drive a force-update flow without another proto change:
- `action` — `NONE` / `OTA` / `STORE` / `REINSTALL`
- `required` — advisory vs. mandatory
- `act_by` — deadline (in the past = block now; in the future = nag with countdown; server owns the decision, client uses it only to render)
- `message`, `link_url`

The servicer is a **stub**: it logs the ping and always returns "no update". Persistence and the force-update decision logic are follow-ups.

The matching mobile client (the gRPC call + the diagnostics ping hook) is in a separate PR off `mobile/v1.1.20` (#8834), since `develop` doesn't yet carry the mobile gRPC infrastructure. The `bugs.proto` change appears in both so each side can generate its stubs; the content is identical and reconciles on merge.

## Testing
`make protos`, `make format` clean. `uv run pytest src/tests/test_bugs.py` — 22 passing, including two new tests covering the anonymous and authenticated ping returning `NATIVE_UPDATE_ACTION_NONE`. (`make mypy` has 2 pre-existing errors in unrelated files — `tests/fixtures/misc.py` and `test_calendar_events.py` — untouched here.)

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history — n/a, no DB changes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._