### PR TITLE
Devops: serialize staging deploys with resource_group

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -1073,6 +1073,9 @@ deploy:deploy-info:
 deploy:staging:
   needs: ["release:web-next", "release:backend"]
   stage: deploy
+  # serialize staging deploys: two concurrent install.sh runs race during container
+  # recreate and leave orphaned renamed containers behind, breaking the next deploy
+  resource_group: staging
   image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest
   inherit:
     # no docker login


### PR DESCRIPTION
Two concurrent `deploy:staging` jobs race during `docker compose` container recreate. Compose renames the existing container aside (e.g. `2f0c4e9ef229_app-envoy-1`) before recreating it, and when two deploys overlap, the renamed leftovers are not cleaned up and collide by name on the next deploy with `Conflict. The container name ... is already in use`. This is what the `docker compose down` workaround in #7595 was papering over.

Unlike the prod deploy path (which holds a lock via the deploy lambda), the staging job had no concurrency guard, so two pipelines on the release branch could deploy simultaneously.

This adds `resource_group: staging` to the `deploy:staging` job. GitLab serializes jobs sharing a resource group, so only one staging deploy runs at a time and the recreate race can no longer happen.

## Testing

CI-only change; no application code affected. Verified the YAML edit is scoped to the `deploy:staging` job. After this merges and one staging deploy runs (which creates the resource group), the process mode stays the default `unordered`, which is fine for staging since `check_deployment.sh` verifies the landed version. `newest_first` can optionally be set later via the resource groups API if desired.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._