### PR TITLE
Backend: Split quick_links for layering/avoiding circular module refs

### DIFF
--- a/app/backend/src/couchers/notifications/quick_links.py
+++ b/app/backend/src/couchers/notifications/quick_links.py
@@ -31,7 +31,7 @@ def _generate_quick_link(payload: Message) -> str:
     return urls.quick_link(payload=b64encode(msg), sig=b64encode(sig))
 
 
-def decode_quick_link(*, payload: bytes, sig: bytes, context: CouchersContext) -> unsubscribe_pb2.UnsubscribePayload:
+def decode_quick_link(payload: bytes, sig: bytes, context: CouchersContext) -> unsubscribe_pb2.UnsubscribePayload:
     if not verify_hash_signature(message=payload, key=get_secret(UNSUBSCRIBE_KEY_NAME), sig=sig):
         context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "wrong_signature")
 

--- a/app/backend/src/couchers/notifications/quick_links.py
+++ b/app/backend/src/couchers/notifications/quick_links.py
@@ -6,10 +6,12 @@ It is called "unsubscribe" in some places for historical reasons (it was the fir
 
 import logging
 
+import grpc
 from google.protobuf.message import Message
 
 from couchers import urls
-from couchers.crypto import UNSUBSCRIBE_KEY_NAME, b64encode, generate_hash_signature, get_secret
+from couchers.context import CouchersContext
+from couchers.crypto import UNSUBSCRIBE_KEY_NAME, b64encode, generate_hash_signature, get_secret, verify_hash_signature
 from couchers.models import (
     Notification,
     NotificationTopicAction,
@@ -27,6 +29,13 @@ def _generate_quick_link(payload: Message) -> str:
     msg = payload.SerializeToString()
     sig = generate_hash_signature(message=msg, key=get_secret(UNSUBSCRIBE_KEY_NAME))
     return urls.quick_link(payload=b64encode(msg), sig=b64encode(sig))
+
+
+def parse_quick_link(*, payload: str, sig: str, context: CouchersContext) -> unsubscribe_pb2.UnsubscribePayload:
+    if not verify_hash_signature(message=payload, key=get_secret(UNSUBSCRIBE_KEY_NAME), sig=sig):
+        context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "wrong_signature")
+
+    return unsubscribe_pb2.UnsubscribePayload.FromString(payload)
 
 
 def generate_do_not_email(user: User) -> str:

--- a/app/backend/src/couchers/notifications/quick_links.py
+++ b/app/backend/src/couchers/notifications/quick_links.py
@@ -31,7 +31,7 @@ def _generate_quick_link(payload: Message) -> str:
     return urls.quick_link(payload=b64encode(msg), sig=b64encode(sig))
 
 
-def parse_quick_link(*, payload: str, sig: str, context: CouchersContext) -> unsubscribe_pb2.UnsubscribePayload:
+def decode_quick_link(*, payload: bytes, sig: bytes, context: CouchersContext) -> unsubscribe_pb2.UnsubscribePayload:
     if not verify_hash_signature(message=payload, key=get_secret(UNSUBSCRIBE_KEY_NAME), sig=sig):
         context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "wrong_signature")
 

--- a/app/backend/src/couchers/notifications/quick_links.py
+++ b/app/backend/src/couchers/notifications/quick_links.py
@@ -6,31 +6,17 @@ It is called "unsubscribe" in some places for historical reasons (it was the fir
 
 import logging
 
-import grpc
 from google.protobuf.message import Message
-from sqlalchemy import select
-from sqlalchemy.orm import Session
 
 from couchers import urls
-from couchers.constants import DATETIME_INFINITY
-from couchers.context import CouchersContext, make_one_off_interactive_user_context
-from couchers.crypto import UNSUBSCRIBE_KEY_NAME, b64encode, generate_hash_signature, get_secret, verify_hash_signature
+from couchers.crypto import UNSUBSCRIBE_KEY_NAME, b64encode, generate_hash_signature, get_secret
 from couchers.models import (
-    GroupChat,
-    GroupChatSubscription,
-    HostingStatus,
-    MeetupStatus,
     Notification,
-    NotificationDeliveryType,
     NotificationTopicAction,
     User,
 )
-from couchers.notifications import settings
-from couchers.notifications.utils import enum_from_topic_action
-from couchers.proto import auth_pb2, conversations_pb2, requests_pb2
+from couchers.proto import requests_pb2
 from couchers.proto.internal import unsubscribe_pb2
-from couchers.servicers.requests import Requests
-from couchers.sql import where_moderated_content_visible
 from couchers.utils import now
 
 logger = logging.getLogger(__name__)
@@ -99,66 +85,3 @@ def can_unsubscribe_topic_key(topic_action: NotificationTopicAction) -> bool:
     """
     # Only chat__message has a meaningful key (the chat ID); chat__missed_messages is a summary with no specific chat
     return topic_action == NotificationTopicAction.chat__message
-
-
-def respond_quick_link(request: auth_pb2.UnsubscribeReq, context: CouchersContext, session: Session) -> str:
-    """
-    Returns a response string or uses context.abort upon error
-    """
-    if not verify_hash_signature(message=request.payload, key=get_secret(UNSUBSCRIBE_KEY_NAME), sig=request.sig):
-        context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "wrong_signature")
-    payload = unsubscribe_pb2.UnsubscribePayload.FromString(request.payload)
-    user = session.execute(select(User).where(User.id == payload.user_id)).scalar_one()
-    if payload.HasField("do_not_email"):
-        logger.info(f"User {user.name} turning of emails")
-        user.do_not_email = True
-        user.hosting_status = HostingStatus.cant_host
-        user.meetup_status = MeetupStatus.does_not_want_to_meetup
-        return context.localization.localize_string("quick_links.do_not_email")
-    if payload.HasField("topic_action"):
-        logger.info(f"User {user.name} unsubscribing from topic_action")
-        topic = payload.topic_action.topic
-        action = payload.topic_action.action
-        topic_action = enum_from_topic_action[topic, action]
-        # disable emails for this type
-        settings.set_preference(session, user.id, topic_action, NotificationDeliveryType.email, False)
-        return context.localization.localize_string("quick_links.topic_action")
-    if payload.HasField("topic_key"):
-        logger.info(f"User {user.name} unsubscribing from topic_key")
-        topic = payload.topic_key.topic
-        key = payload.topic_key.key
-        # a bunch of manual stuff
-        if topic == "chat":
-            group_chat_id = int(key)
-            subscription = session.execute(
-                where_moderated_content_visible(
-                    select(GroupChatSubscription).join(
-                        GroupChat, GroupChat.conversation_id == GroupChatSubscription.group_chat_id
-                    ),
-                    context,
-                    GroupChat,
-                    is_list_operation=False,
-                )
-                .where(GroupChatSubscription.group_chat_id == group_chat_id)
-                .where(GroupChatSubscription.user_id == user.id)
-                .where(GroupChatSubscription.left == None)
-            ).scalar_one_or_none()
-
-            if subscription is None:
-                context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "chat_not_found")
-
-            subscription.muted_until = DATETIME_INFINITY
-            return context.localization.localize_string("quick_links.chat_unsub")
-        else:
-            context.abort_with_error_code(grpc.StatusCode.UNIMPLEMENTED, "cant_unsub_topic")
-    if payload.HasField("host_request_quick_decline"):
-        Requests().RespondHostRequest(
-            request=requests_pb2.RespondHostRequestReq(
-                host_request_id=payload.host_request_quick_decline.host_request_id,
-                status=conversations_pb2.HOST_REQUEST_STATUS_REJECTED,
-            ),
-            context=make_one_off_interactive_user_context(couchers_context=context, user_id=payload.user_id),
-            session=session,
-        )
-        return context.localization.localize_string("quick_links.host_request_quick_decline")
-    raise Exception("Unhandled quick link type")

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -41,7 +41,7 @@ from couchers.models import (
 from couchers.models.notifications import NotificationTopicAction
 from couchers.models.uploads import get_avatar_upload
 from couchers.notifications.notify import notify
-from couchers.notifications.quick_links import parse_quick_link
+from couchers.notifications.quick_links import decode_quick_link
 from couchers.proto import auth_pb2, auth_pb2_grpc, notification_data_pb2
 from couchers.servicers.account import abort_on_invalid_password, contributeoption2sql
 from couchers.servicers.api import hostingstatus2sql
@@ -706,7 +706,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
     def Unsubscribe(
         self, request: auth_pb2.UnsubscribeReq, context: CouchersContext, session: Session
     ) -> auth_pb2.UnsubscribeRes:
-        payload = parse_quick_link(payload=request.payload, sig=request.sig, context=context)
+        payload = decode_quick_link(payload=request.payload, sig=request.sig, context=context)
         return auth_pb2.UnsubscribeRes(response=handle_unsubscribe(payload, context, session))
 
     def AntiBot(self, request: auth_pb2.AntiBotReq, context: CouchersContext, session: Session) -> auth_pb2.AntiBotRes:

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -706,7 +706,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
     def Unsubscribe(
         self, request: auth_pb2.UnsubscribeReq, context: CouchersContext, session: Session
     ) -> auth_pb2.UnsubscribeRes:
-        payload = decode_quick_link(payload=request.payload, sig=request.sig, context=context)
+        payload = decode_quick_link(request.payload, request.sig, context)
         return auth_pb2.UnsubscribeRes(response=handle_unsubscribe(payload, context, session))
 
     def AntiBot(self, request: auth_pb2.AntiBotReq, context: CouchersContext, session: Session) -> auth_pb2.AntiBotRes:

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -41,10 +41,10 @@ from couchers.models import (
 from couchers.models.notifications import NotificationTopicAction
 from couchers.models.uploads import get_avatar_upload
 from couchers.notifications.notify import notify
-from couchers.notifications.quick_links import respond_quick_link
 from couchers.proto import auth_pb2, auth_pb2_grpc, notification_data_pb2
 from couchers.servicers.account import abort_on_invalid_password, contributeoption2sql
 from couchers.servicers.api import hostingstatus2sql
+from couchers.servicers.auth_quick_links import respond_quick_link
 from couchers.sql import username_or_email
 from couchers.tasks import (
     enforce_community_memberships_for_user,

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -41,10 +41,11 @@ from couchers.models import (
 from couchers.models.notifications import NotificationTopicAction
 from couchers.models.uploads import get_avatar_upload
 from couchers.notifications.notify import notify
+from couchers.notifications.quick_links import parse_quick_link
 from couchers.proto import auth_pb2, auth_pb2_grpc, notification_data_pb2
 from couchers.servicers.account import abort_on_invalid_password, contributeoption2sql
 from couchers.servicers.api import hostingstatus2sql
-from couchers.servicers.auth_quick_links import respond_quick_link
+from couchers.servicers.auth_unsubscribe import handle_unsubscribe
 from couchers.sql import username_or_email
 from couchers.tasks import (
     enforce_community_memberships_for_user,
@@ -705,7 +706,8 @@ class Auth(auth_pb2_grpc.AuthServicer):
     def Unsubscribe(
         self, request: auth_pb2.UnsubscribeReq, context: CouchersContext, session: Session
     ) -> auth_pb2.UnsubscribeRes:
-        return auth_pb2.UnsubscribeRes(response=respond_quick_link(request, context, session))
+        payload = parse_quick_link(payload=request.payload, sig=request.sig, context=context)
+        return auth_pb2.UnsubscribeRes(response=handle_unsubscribe(payload, context, session))
 
     def AntiBot(self, request: auth_pb2.AntiBotReq, context: CouchersContext, session: Session) -> auth_pb2.AntiBotRes:
         if not context.get_boolean_value("recaptcha_enabled", default=False):

--- a/app/backend/src/couchers/servicers/auth_quick_links.py
+++ b/app/backend/src/couchers/servicers/auth_quick_links.py
@@ -1,0 +1,98 @@
+"""
+Implements the "quick links" that are included in emails, for unsubscribing without logging in.
+"""
+
+import logging
+
+import grpc
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from couchers.constants import DATETIME_INFINITY
+from couchers.context import CouchersContext, make_one_off_interactive_user_context
+from couchers.crypto import UNSUBSCRIBE_KEY_NAME, get_secret, verify_hash_signature
+from couchers.models import (
+    GroupChat,
+    GroupChatSubscription,
+    HostingStatus,
+    MeetupStatus,
+    NotificationDeliveryType,
+    User,
+)
+from couchers.notifications import settings
+from couchers.notifications.utils import enum_from_topic_action
+from couchers.proto import auth_pb2, conversations_pb2, requests_pb2
+from couchers.proto.internal import unsubscribe_pb2
+from couchers.servicers.requests import Requests
+from couchers.sql import where_moderated_content_visible
+
+logger = logging.getLogger(__name__)
+
+
+def respond_quick_link(request: auth_pb2.UnsubscribeReq, context: CouchersContext, session: Session) -> str:
+    """
+    Returns a response string or uses context.abort upon error
+    """
+    if not verify_hash_signature(message=request.payload, key=get_secret(UNSUBSCRIBE_KEY_NAME), sig=request.sig):
+        context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "wrong_signature")
+
+    payload = unsubscribe_pb2.UnsubscribePayload.FromString(request.payload)
+    user = session.execute(select(User).where(User.id == payload.user_id)).scalar_one()
+
+    if payload.HasField("do_not_email"):
+        logger.info(f"User {user.name} turning of emails")
+        user.do_not_email = True
+        user.hosting_status = HostingStatus.cant_host
+        user.meetup_status = MeetupStatus.does_not_want_to_meetup
+        return context.localization.localize_string("quick_links.do_not_email")
+
+    if payload.HasField("topic_action"):
+        logger.info(f"User {user.name} unsubscribing from topic_action")
+        topic = payload.topic_action.topic
+        action = payload.topic_action.action
+        topic_action = enum_from_topic_action[topic, action]
+        # disable emails for this type
+        settings.set_preference(session, user.id, topic_action, NotificationDeliveryType.email, False)
+        return context.localization.localize_string("quick_links.topic_action")
+
+    if payload.HasField("topic_key"):
+        logger.info(f"User {user.name} unsubscribing from topic_key")
+        topic = payload.topic_key.topic
+        key = payload.topic_key.key
+        # a bunch of manual stuff
+        if topic == "chat":
+            group_chat_id = int(key)
+            subscription = session.execute(
+                where_moderated_content_visible(
+                    select(GroupChatSubscription).join(
+                        GroupChat, GroupChat.conversation_id == GroupChatSubscription.group_chat_id
+                    ),
+                    context,
+                    GroupChat,
+                    is_list_operation=False,
+                )
+                .where(GroupChatSubscription.group_chat_id == group_chat_id)
+                .where(GroupChatSubscription.user_id == user.id)
+                .where(GroupChatSubscription.left == None)
+            ).scalar_one_or_none()
+
+            if subscription is None:
+                context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "chat_not_found")
+
+            subscription.muted_until = DATETIME_INFINITY
+            return context.localization.localize_string("quick_links.chat_unsub")
+        else:
+            context.abort_with_error_code(grpc.StatusCode.UNIMPLEMENTED, "cant_unsub_topic")
+
+    if payload.HasField("host_request_quick_decline"):
+        Requests().RespondHostRequest(
+            request=requests_pb2.RespondHostRequestReq(
+                host_request_id=payload.host_request_quick_decline.host_request_id,
+                status=conversations_pb2.HOST_REQUEST_STATUS_REJECTED,
+            ),
+            context=make_one_off_interactive_user_context(couchers_context=context, user_id=payload.user_id),
+            session=session,
+        )
+        return context.localization.localize_string("quick_links.host_request_quick_decline")
+
+    raise Exception("Unhandled quick link type")

--- a/app/backend/src/couchers/servicers/auth_unsubscribe.py
+++ b/app/backend/src/couchers/servicers/auth_unsubscribe.py
@@ -10,7 +10,6 @@ from sqlalchemy.orm import Session
 
 from couchers.constants import DATETIME_INFINITY
 from couchers.context import CouchersContext, make_one_off_interactive_user_context
-from couchers.crypto import UNSUBSCRIBE_KEY_NAME, get_secret, verify_hash_signature
 from couchers.models import (
     GroupChat,
     GroupChatSubscription,
@@ -21,7 +20,7 @@ from couchers.models import (
 )
 from couchers.notifications import settings
 from couchers.notifications.utils import enum_from_topic_action
-from couchers.proto import auth_pb2, conversations_pb2, requests_pb2
+from couchers.proto import conversations_pb2, requests_pb2
 from couchers.proto.internal import unsubscribe_pb2
 from couchers.servicers.requests import Requests
 from couchers.sql import where_moderated_content_visible
@@ -29,14 +28,10 @@ from couchers.sql import where_moderated_content_visible
 logger = logging.getLogger(__name__)
 
 
-def respond_quick_link(request: auth_pb2.UnsubscribeReq, context: CouchersContext, session: Session) -> str:
+def handle_unsubscribe(payload: unsubscribe_pb2.UnsubscribePayload, context: CouchersContext, session: Session) -> str:
     """
     Returns a response string or uses context.abort upon error
     """
-    if not verify_hash_signature(message=request.payload, key=get_secret(UNSUBSCRIBE_KEY_NAME), sig=request.sig):
-        context.abort_with_error_code(grpc.StatusCode.PERMISSION_DENIED, "wrong_signature")
-
-    payload = unsubscribe_pb2.UnsubscribePayload.FromString(request.payload)
     user = session.execute(select(User).where(User.id == payload.user_id)).scalar_one()
 
     if payload.HasField("do_not_email"):


### PR DESCRIPTION
`notifications.quick_links.py` included both the data-only link generation code and the database-manipulating servicer implementation. I've run into circular dependencies more than once due to this because we need to generate quick_links in email/notification logic that is lower level than servicers, so if they transitively import the Requests servicers, things blow up.

Fix this by raising the `respond_quick_link` function to the servicer layer, where it logically belongs.

For code organization, I preferred putting it in `servicers.auth_quick_links` than making `servicers.auth` bigger, though this the first example of this splitting up of a servicer's logic in two files.

Example of a circular reference if `quick_links` import servicers, and emails try to import `quick_links` (what I'm preparing in https://github.com/Couchers-org/couchers/pull/8827):

```
src/tests/conftest.py:25: in <module>
    from tests.fixtures.db import (  # noqa: E402
src/tests/fixtures/db.py:40: in <module>
    from couchers.servicers.auth import create_session
src/couchers/servicers/auth.py:44: in <module>
    from couchers.notifications.quick_links import respond_quick_link
src/couchers/notifications/quick_links.py:32: in <module>
    from couchers.servicers.requests import Requests
src/couchers/servicers/requests.py:40: in <module>
    from couchers.rate_limits.check import process_rate_limits_and_check_abort
src/couchers/rate_limits/check.py:9: in <module>
    from couchers.tasks import send_rate_limit_violation_report_email
src/couchers/tasks.py:8: in <module>
    import couchers.email.emails as emails
src/couchers/email/emails.py:22: in <module>
    from couchers.notifications.quick_links import generate_quick_decline_link
E   ImportError: cannot import name 'generate_quick_decline_link' from partially initialized module 'couchers.notifications.quick_links' (most likely due to a circular import) (/app/src/couchers/notifications/quick_links.py)
```

## Testing
N/A - No functional changes.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
