### PR TITLE
Prune images on staging deploy instead of full `down`

### DIFF
--- a/app/deployment/install.sh
+++ b/app/deployment/install.sh
@@ -5,12 +5,9 @@ set -e
 pushd ..
 git pull
 docker compose -f docker-compose.prod.yml pull
-
 docker ps -a --filter "label=com.docker.compose.project=app" --format '{{.Names}}' \
   | grep -E '^[0-9a-f]+_' \
   | xargs -r docker rm -f || true
-
 docker compose -f docker-compose.prod.yml up -d
-
 docker image prune -af --filter "until=24h"
 popd

--- a/app/deployment/install.sh
+++ b/app/deployment/install.sh
@@ -5,6 +5,16 @@ set -e
 pushd ..
 git pull
 docker compose -f docker-compose.prod.yml pull
-docker compose -f docker-compose.prod.yml down --timeout 60
+
+# Remove leftovers from a previously-interrupted recreate (named "<id>_<service>").
+# They squat the rename target and make `up` fail with a name conflict.
+docker ps -a --filter "label=com.docker.compose.project=app" --format '{{.Names}}' \
+  | grep -E '^[0-9a-f]+_' \
+  | xargs -r docker rm -f || true
+
 docker compose -f docker-compose.prod.yml up -d
+
+# Reclaim disk: drop images no longer referenced by a container. The new stack is
+# already up holding refs to the images it needs, so only stale ones are removed.
+docker image prune -af
 popd

--- a/app/deployment/install.sh
+++ b/app/deployment/install.sh
@@ -6,15 +6,11 @@ pushd ..
 git pull
 docker compose -f docker-compose.prod.yml pull
 
-# Remove leftovers from a previously-interrupted recreate (named "<id>_<service>").
-# They squat the rename target and make `up` fail with a name conflict.
 docker ps -a --filter "label=com.docker.compose.project=app" --format '{{.Names}}' \
   | grep -E '^[0-9a-f]+_' \
   | xargs -r docker rm -f || true
 
 docker compose -f docker-compose.prod.yml up -d
 
-# Reclaim disk: drop images no longer referenced by a container. The new stack is
-# already up holding refs to the images it needs, so only stale ones are removed.
-docker image prune -af
+docker image prune -af --filter "until=24h"
 popd


### PR DESCRIPTION
Staging deploys were occasionally failing because the server ran out of disk space — the staging install script never pruned old Docker images, so they accumulated across deploys until the disk filled and Docker operations started failing.

The earlier workaround was to run a full `docker compose down` before `up`, which incidentally cleared the broken state but caused ~30s of downtime on every deploy. This replaces that with the actual fix:

- **Drop the `down`** — `up` recreates only changed containers, so there's no need to take the whole stack down.
- **Prune unreferenced images after `up`** — reclaims disk from old deploys. Images backing running containers are reference-counted and never removed, so the live stack (and its layers) is untouched.
- **Sweep leftover renamed containers before `up`** — if a previous recreate was interrupted it can leave a `<id>_<service>` container that squats the rename target and makes `up` fail with a name conflict; this removes those best-effort. Live containers are named `app-<service>-N` and never match the pattern.

The prod deploy lambda already prunes after deploys; this brings staging in line.

## Testing
Shell-only change to the staging deploy script; verified the ghost-cleanup pattern matches `<id>_<service>` leftovers but not live `app-<service>-N` containers. Will confirm on the next staging deploy that the stack stays up (no full `down`) and old images are reclaimed.

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._