### PR TITLE
Remove EXPERIMENTATION_PASS_ALL_GATES

### DIFF
--- a/app/backend.dev.env
+++ b/app/backend.dev.env
@@ -78,7 +78,6 @@ ACTIVENESS_PROBES_ENABLED=1
 
 # Experimentation (feature flags)
 EXPERIMENTATION_ENABLED=0
-EXPERIMENTATION_PASS_ALL_GATES=1
 GROWTHBOOK_API_HOST=https://gbapi.couchershq.org
 GROWTHBOOK_CLIENT_KEY=sdk-cGmljeXu1BCzHffE
 GROWTHBOOK_CACHE_PATH=growthbook-features-cache.json

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -110,8 +110,6 @@ CONFIG_OPTIONS: CONFIG_T = [
     ("IN_TEST", bool, "0"),
     # Experimentation (feature flags via GrowthBook)
     ("EXPERIMENTATION_ENABLED", bool, "0"),
-    # When enabled, all feature gates return True (useful for development/testing)
-    ("EXPERIMENTATION_PASS_ALL_GATES", bool, "0"),
     # GrowthBook SDK configuration
     ("GROWTHBOOK_API_HOST", str, "https://cdn.growthbook.io"),
     ("GROWTHBOOK_CLIENT_KEY", str, ""),

--- a/app/backend/src/couchers/context.py
+++ b/app/backend/src/couchers/context.py
@@ -192,7 +192,7 @@ class CouchersContext:
     # context's user. The gating lives in experimentation; we just pass our cached per-request
     # evaluator. The in-code default is honored even for flags not yet set up in GrowthBook.
     def get_boolean_value(self, flag_key: str, default: bool) -> bool:
-        return experimentation._boolean_value(flag_key, default, self._get_growthbook)
+        return experimentation._feature_value(flag_key, default, self._get_growthbook)
 
     def get_string_value(self, flag_key: str, default: str) -> str:
         return experimentation._feature_value(flag_key, default, self._get_growthbook)

--- a/app/backend/src/couchers/experimentation.py
+++ b/app/backend/src/couchers/experimentation.py
@@ -12,8 +12,7 @@ Two ways to evaluate a flag:
     to vary per user. Whenever a user is (or could reasonably be) available, use the context: only the
     per-user path can do percentage rollouts, experiments, and feature-usage tracking.
 
-Both paths share the enabled / pass-all-gates gating helpers here. setup_experimentation() is called
-once at process startup.
+Both paths share the gating helper here. setup_experimentation() is called once at process startup.
 """
 
 import json
@@ -258,19 +257,13 @@ def _global_evaluator() -> GrowthBook:
     return _create_evaluator(None)
 
 
-# These two helpers are the single home of the gating logic, shared by the global functions below
-# and by CouchersContext (which passes its own cached per-request evaluator). get_evaluator is only
-# invoked once gating passes, so it stays lazy.
+# The single home of the gating logic, shared by the global functions below and by CouchersContext
+# (which passes its own cached per-request evaluator). get_evaluator is only invoked once gating
+# passes, so it stays lazy.
 def _feature_value[T](flag_key: str, default: T, get_evaluator: Callable[[], GrowthBook]) -> T:
     if not config["EXPERIMENTATION_ENABLED"]:
         return default
     return get_evaluator().get_feature_value(flag_key, default)  # type: ignore[no-any-return]
-
-
-def _boolean_value(flag_key: str, default: bool, get_evaluator: Callable[[], GrowthBook]) -> bool:
-    if config["EXPERIMENTATION_PASS_ALL_GATES"]:
-        return True
-    return _feature_value(flag_key, default, get_evaluator)
 
 
 # Global (no-user) flag evaluation. Use these ONLY when there is genuinely no user to evaluate for and
@@ -280,7 +273,7 @@ def _boolean_value(flag_key: str, default: bool, get_evaluator: Callable[[], Gro
 # feature-usage tracking. With no user to bucket, rollouts and experiments are skipped and flags fall
 # through to their in-code defaults unless a rule forces a value globally.
 def get_global_boolean_value(flag_key: str, default: bool) -> bool:
-    return _boolean_value(flag_key, default, _global_evaluator)
+    return _feature_value(flag_key, default, _global_evaluator)
 
 
 def get_global_string_value(flag_key: str, default: str) -> str:

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -225,7 +225,6 @@ def testconfig():
     config["RECAPTHCA_SITE_KEY"] = "..."
 
     config["EXPERIMENTATION_ENABLED"] = False
-    config["EXPERIMENTATION_PASS_ALL_GATES"] = True
     config["GROWTHBOOK_API_HOST"] = "https://cdn.growthbook.io"
     config["GROWTHBOOK_CLIENT_KEY"] = ""
     config["GROWTHBOOK_CACHE_PATH"] = ""
@@ -279,7 +278,6 @@ def feature_flags(monkeypatch) -> FeatureFlags:
     monkeypatch.setattr(experimentation, "_initialized", True)
     monkeypatch.setattr(experimentation, "_state", {"features": features, "savedGroups": {}})
     monkeypatch.setitem(config, "EXPERIMENTATION_ENABLED", True)
-    monkeypatch.setitem(config, "EXPERIMENTATION_PASS_ALL_GATES", False)
     return FeatureFlags(features)
 
 

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -1370,7 +1370,6 @@ def test_update_badges_skips_moderator_when_flag_off(db, monkeypatch):
         {"features": {"show_moderator_badge": {"defaultValue": True, "rules": [{"force": False}]}}, "savedGroups": {}},
     )
     monkeypatch.setitem(config, "EXPERIMENTATION_ENABLED", True)
-    monkeypatch.setitem(config, "EXPERIMENTATION_PASS_ALL_GATES", False)
 
     superuser, _ = generate_user(is_superuser=True, last_donated=None)
 

--- a/app/backend/src/tests/test_calendar_events.py
+++ b/app/backend/src/tests/test_calendar_events.py
@@ -92,7 +92,8 @@ def _normalize_ics(ics: str) -> str:
     return ics
 
 
-def test_host_request_attachments(db, email_collector: EmailCollector, moderator: Moderator):
+def test_host_request_attachments(db, email_collector: EmailCollector, feature_flags, moderator: Moderator):
+    feature_flags.set("email_ics_attachments_enabled", True)
     host, host_token = generate_user(complete_profile=True)
     surfer, surfer_token = generate_user(complete_profile=True)
 

--- a/app/backend/src/tests/test_donations.py
+++ b/app/backend/src/tests/test_donations.py
@@ -18,8 +18,8 @@ from tests.fixtures.sessions import donations_session, real_stripe_session
 
 
 @pytest.fixture(autouse=True)
-def _(testconfig):
-    pass
+def _(testconfig, feature_flags):
+    feature_flags.set("donations_enabled", True)
 
 
 def test_donations_disabled(db, feature_flags):

--- a/app/backend/src/tests/test_postal_verification.py
+++ b/app/backend/src/tests/test_postal_verification.py
@@ -25,8 +25,8 @@ from tests.fixtures.sessions import postal_verification_session
 
 
 @pytest.fixture(autouse=True)
-def _(testconfig):
-    pass
+def _(testconfig, feature_flags):
+    feature_flags.set("postal_verification_enabled", True)
 
 
 def test_generate_postal_verification_code():

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -1406,7 +1406,10 @@ def test_response_rate(db, moderator):
         assert res.almost_all.response_time_p66.ToTimedelta() == timedelta(hours=35)
 
 
-def test_request_notifications(db, email_collector: EmailCollector, push_collector: PushCollector, moderator):
+def test_request_notifications(
+    db, email_collector: EmailCollector, push_collector: PushCollector, feature_flags, moderator
+):
+    feature_flags.set("email_ics_attachments_enabled", True)
     host, host_token = generate_user(complete_profile=True)
     surfer, surfer_token = generate_user(complete_profile=True)
 

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -32,8 +32,8 @@ from tests.fixtures.sessions import account_session, api_session, real_admin_ses
 
 
 @pytest.fixture(autouse=True)
-def _(testconfig):
-    pass
+def _(testconfig, feature_flags):
+    feature_flags.set("strong_verification_enabled", True)
 
 
 def _emulate_iris_callback(session_id, session_state, reference):

--- a/app/backend/src/tests/test_verification.py
+++ b/app/backend/src/tests/test_verification.py
@@ -22,7 +22,8 @@ def _(testconfig):
     pass
 
 
-def test_ChangePhone(db, monkeypatch, push_collector: PushCollector):
+def test_ChangePhone(db, monkeypatch, feature_flags, push_collector: PushCollector):
+    feature_flags.set("sms_enabled", True)
     user, token = generate_user()
     user_id = user.id
 
@@ -89,7 +90,8 @@ def test_ChangePhone(db, monkeypatch, push_collector: PushCollector):
             assert user.phone_verification_token is None
 
 
-def test_ChangePhone_ratelimit(db, monkeypatch):
+def test_ChangePhone_ratelimit(db, monkeypatch, feature_flags):
+    feature_flags.set("sms_enabled", True)
     user, token = generate_user()
     user_id = user.id
     with account_session(token) as account:
@@ -161,7 +163,8 @@ def test_VerifyPhone_antibrute():
         assert e.value.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
 
 
-def test_phone_uniqueness(monkeypatch):
+def test_phone_uniqueness(monkeypatch, feature_flags):
+    feature_flags.set("sms_enabled", True)
     user1, token1 = generate_user()
     user2, token2 = generate_user()
     with account_session(token1) as account1, account_session(token2) as account2:

--- a/app/web/.env.development
+++ b/app/web/.env.development
@@ -6,5 +6,3 @@ NEXT_PUBLIC_CONSOLE_BASE_URL="https://next-console.couchershq.org"
 NEXT_PUBLIC_NOMINATIM_URL="https://nominatim.openstreetmap.org/"
 NEXT_PUBLIC_STRIPE_KEY="pk_test_51KEzByIfR5z29g5khFE5samD8XKOGLcCrM1lhCkfOomGPUFAEYOw8uAqI2Nkv33wYdPM2FgTQNTC07IiNfHY1kLJ00Jqm8Ppai"
 NEXT_PUBLIC_GLOBAL_MESSAGE_URL="https://gm.couchershq.org/next.json"
-# When enabled, all feature gates return true (useful for development/testing)
-NEXT_PUBLIC_EXPERIMENTATION_PASS_ALL_GATES="1"

--- a/app/web/experimentation.ts
+++ b/app/web/experimentation.ts
@@ -18,14 +18,6 @@ import { useBooleanFlagValue, useFlag } from "@openfeature/react-sdk";
 import { ConstrainedFlagKey, JsonValue } from "@openfeature/web-sdk";
 
 /**
- * Whether all gates should pass (for development/testing). Applied to boolean resolutions by the
- * remote-evaluation provider, mirroring the backend's boolean-only pass-all-gates behavior.
- */
-export function shouldPassAllGates(): boolean {
-  return process.env.NEXT_PUBLIC_EXPERIMENTATION_PASS_ALL_GATES === "1";
-}
-
-/**
  * Whether a feature gate is enabled for the current user. Gates default to off.
  */
 export function useGate(gateName: string): boolean {

--- a/app/web/features/experimentation/CouchersFlagProvider.ts
+++ b/app/web/features/experimentation/CouchersFlagProvider.ts
@@ -6,7 +6,6 @@ import {
   ResolutionDetails,
   StandardResolutionReasons,
 } from "@openfeature/web-sdk";
-import { shouldPassAllGates } from "experimentation";
 import { evaluateFlag } from "service/experiments";
 
 /**
@@ -75,9 +74,6 @@ export class CouchersFlagProvider implements Provider {
     flagKey: string,
     defaultValue: boolean,
   ): ResolutionDetails<boolean> {
-    if (shouldPassAllGates()) {
-      return { value: true, reason: StandardResolutionReasons.STATIC };
-    }
     return this.resolve(flagKey, defaultValue, "boolean");
   }
 


### PR DESCRIPTION
Removes the `EXPERIMENTATION_PASS_ALL_GATES` override entirely (backend + web).

## Why
The override forced **every** boolean feature gate to `True`, including on the global/background evaluation path. In dev this force-enabled flag-gated background jobs that call live external APIs with placeholder credentials — e.g. `check_mypostcard_jobs` (MyPostcard) and `add_users_to_email_list` (Listmonk) — producing recurring `401 Unauthorized` / connection errors in the logs. It was also the implicit test default, so the whole suite ran with all flags on regardless of each flag's real in-code default.

## What
- **Backend**: drop the `EXPERIMENTATION_PASS_ALL_GATES` config var (`config.py`) and the short-circuit in `experimentation._boolean_value` (which became identical to `_feature_value`, so it's folded in). `CouchersContext.get_boolean_value` and `get_global_boolean_value` now go straight through `_feature_value`. Removed from `backend.dev.env`.
- **Web**: remove `shouldPassAllGates()` and its use in `CouchersFlagProvider.resolveBooleanEvaluation`, plus `NEXT_PUBLIC_EXPERIMENTATION_PASS_ALL_GATES` from `.env.development`.
- **Tests**: flags now evaluate to their real value (in-code default when experimentation is disabled, which is the test default). Tests that exercised a flag-gated feature and previously relied on the global default-on now opt in explicitly via the existing `feature_flags` fixture: feature-dedicated files (`postal_verification`, `donations`, `strong_verification`) enable their flag in the module's autouse fixture; mixed files (`requests`, `verification`, `calendar_events`) opt in per-test.

Net effect: in dev, flag-gated features (and their background jobs) are now off by default unless turned on via GrowthBook, instead of being silently force-enabled.

## Testing
- `uv run pytest` — **1058 passed**, 4 deselected. The 4 deselected (`test_create_servers`, `test_job_retry`, two `test_check_native_status_*`) fail identically on clean `develop` — port binds from a locally-running backend and a stale local `bugs_pb2` stub — and are unrelated to this change.
- `make format` clean; `make mypy` shows only pre-existing errors (stale local `bugs_pb2` / missing `ics` stubs), identical on `develop`.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._