### PR TITLE
Backend: create proper moderation records for dummy references

### DIFF
--- a/app/backend/src/dummy_data.py
+++ b/app/backend/src/dummy_data.py
@@ -28,7 +28,6 @@ from couchers.models import (
     Message,
     MessageType,
     ModerationObjectType,
-    ModerationState,
     ModerationVisibility,
     Node,
     Page,
@@ -171,26 +170,31 @@ def add_dummy_users() -> None:
             from_user_id = session.execute(select(User).where(User.username == reference["from"])).scalar_one().id
             to_user_id = session.execute(select(User).where(User.username == reference["to"])).scalar_one().id
 
-            moderation_state = ModerationState(
-                object_type=ModerationObjectType.reference,
-                object_id=0,
-                visibility=ModerationVisibility.visible,
-            )
-            session.add(moderation_state)
-            session.flush()
+            def create_reference(
+                moderation_state_id: int,
+                from_user_id: int = from_user_id,
+                to_user_id: int = to_user_id,
+                reference: dict[str, Any] = reference,
+                reference_type: ReferenceType = reference_type,
+            ) -> int:
+                new_reference = Reference(
+                    from_user_id=from_user_id,
+                    to_user_id=to_user_id,
+                    reference_type=reference_type,
+                    text=reference["text"],
+                    rating=reference["rating"],
+                    was_appropriate=reference["was_appropriate"],
+                    moderation_state_id=moderation_state_id,
+                )
+                session.add(new_reference)
+                session.flush()
+                return new_reference.id
 
-            new_reference = Reference(
-                from_user_id=from_user_id,
-                to_user_id=to_user_id,
-                reference_type=reference_type,
-                text=reference["text"],
-                rating=reference["rating"],
-                was_appropriate=reference["was_appropriate"],
-                moderation_state_id=moderation_state.id,
+            moderation_state = create_moderation(
+                session, ModerationObjectType.reference, create_reference, from_user_id
             )
-            session.add(new_reference)
+            moderation_state.visibility = ModerationVisibility.visible
             session.flush()
-            moderation_state.object_id = new_reference.id
 
         session.commit()
 

--- a/app/backend/src/tests/test_dummy_data.py
+++ b/app/backend/src/tests/test_dummy_data.py
@@ -1,4 +1,7 @@
+from google.protobuf import empty_pb2
+
 from couchers.db import session_scope
+from couchers.jobs.handlers import check_database_consistency
 from couchers.resources import copy_resources_to_database
 from dummy_data import add_dummy_data
 
@@ -11,3 +14,6 @@ def test_add_dummy_data(db, caplog, testconfig):
 
     add_dummy_data()
     assert len(caplog.records) == 0
+
+    # dummy data must not leave the database in an inconsistent state (raises DatabaseInconsistencyError otherwise)
+    check_database_consistency(empty_pb2.Empty())


### PR DESCRIPTION
Fixes a `DatabaseInconsistencyError` raised by the `check_database_consistency` job on fresh checkouts.

The dummy data loader built reference `ModerationState`s by hand, skipping the `CREATE` log entry and `INITIAL_REVIEW` queue item that `create_moderation()` adds (the friend-relationship and group-chat dummy blocks already use it). As a result the seeded references failed the moderation consistency checks on every run. This routes reference creation through `create_moderation()` via the callback pattern, matching the other dummy objects.

## Testing
`test_add_dummy_data` now calls `check_database_consistency()` after loading dummy data, so the inconsistency would surface as a test failure. Run:

```
cd app/backend && uv run pytest src/tests/test_dummy_data.py
```

Passes with the fix; fails (raises `DatabaseInconsistencyError`) without it.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._