### PR TITLE
Backend: improve per-RPC and query-level perf observability

### DIFF
--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -343,9 +343,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                 timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
             )
 
-            setup_perf = read_perf()
-            if setup_perf is not None:
-                observe_in_servicer_setup_histogram(method, setup_perf.db_time_ms, setup_perf.cpu_ms)
+            observe_in_servicer_setup_histogram(method, read_perf())
         except Exception as e:
             observe_in_servicer_setup_errors_counter(method, type(e).__name__)
             sentry_sdk.set_tag("context", "servicer_setup")
@@ -393,10 +391,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                     )
                     observe_in_servicer_duration_histogram(method, couchers_context._user_id, "", "", duration / 1000)
                     observe_api_call(method, headers.client_platform)
-                    if perf is not None:
-                        observe_in_servicer_perf_histograms(
-                            method, perf.db_query_count, perf.db_write_query_count, perf.db_time_ms, perf.cpu_ms
-                        )
+                    observe_in_servicer_perf_histograms(method, perf)
                 except Exception as e:
                     perf = read_perf()
                     finished = perf_counter_ns()
@@ -428,10 +423,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                         method, couchers_context._user_id, code or "", type(e).__name__, duration / 1000
                     )
                     observe_api_call(method, headers.client_platform)
-                    if perf is not None:
-                        observe_in_servicer_perf_histograms(
-                            method, perf.db_query_count, perf.db_write_query_count, perf.db_time_ms, perf.cpu_ms
-                        )
+                    observe_in_servicer_perf_histograms(method, perf)
 
                     if not code:
                         sentry_sdk.set_tag("context", "servicer")

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -460,28 +460,21 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
 
             return res
 
-        wrapped_deserializer: Callable[[bytes], T] | None = None
-        if (request_deserializer := handler.request_deserializer) is not None:
-
-            def wrapped_deserializer(request_bytes: bytes) -> T:
+        def timed_serde[A, B](fn: Callable[[A], B], direction: str) -> Callable[[A], B]:
+            def wrapped(arg: A) -> B:
                 t0 = perf_counter_ns()
-                req = request_deserializer(request_bytes)
-                observe_in_servicer_serde_histogram(method, "deserialize", (perf_counter_ns() - t0) / 1e9)
-                return req
+                result = fn(arg)
+                observe_in_servicer_serde_histogram(method, direction, (perf_counter_ns() - t0) / 1e9)
+                return result
 
-        wrapped_serializer: Callable[[R], bytes] | None = None
-        if (response_serializer := handler.response_serializer) is not None:
+            return wrapped
 
-            def wrapped_serializer(response: R) -> bytes:
-                t0 = perf_counter_ns()
-                data = response_serializer(response)
-                observe_in_servicer_serde_histogram(method, "serialize", (perf_counter_ns() - t0) / 1e9)
-                return data
-
+        # always set for our generated-proto methods, but grpc types them as optional
+        assert handler.request_deserializer is not None and handler.response_serializer is not None
         return grpc.unary_unary_rpc_method_handler(
             function_without_couchers_stuff,
-            request_deserializer=wrapped_deserializer,
-            response_serializer=wrapped_serializer,
+            request_deserializer=timed_serde(handler.request_deserializer, "deserialize"),
+            response_serializer=timed_serde(handler.response_serializer, "serialize"),
         )
 
 

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -38,7 +38,10 @@ from couchers.metrics import (
     observe_api_call,
     observe_in_servicer_duration_histogram,
     observe_in_servicer_perf_histograms,
+    observe_in_servicer_pool_wait_histogram,
+    observe_in_servicer_serde_histogram,
     observe_in_servicer_setup_errors_counter,
+    observe_in_servicer_setup_histogram,
 )
 from couchers.models import APICall, ClientPlatform, User, UserActivity, UserSession
 from couchers.perf import PerfResult, read_perf, start_perf
@@ -295,6 +298,11 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
 
         method = handler_call_details.method
 
+        # Arm resource accounting across the auth/setup phase so its DB time (the user fetch + user_activity upsert)
+        # and CPU are attributed separately from the handler body; read back once setup succeeds, below. The handler
+        # re-arms its own accounting. Auth-failure early-returns just leave this to be overwritten by the next request.
+        start_perf()
+
         try:
             try:
                 auth_level = find_auth_level(self._pool, method)
@@ -336,6 +344,10 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                 locale=(auth_info.ui_language_preference if auth_info else headers.ui_lang) or DEFAULT_LOCALE,
                 timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
             )
+
+            setup_perf = read_perf()
+            if setup_perf is not None:
+                observe_in_servicer_setup_histogram(method, setup_perf.db_time_ms, setup_perf.cpu_ms)
         except Exception as e:
             observe_in_servicer_setup_errors_counter(method, type(e).__name__)
             sentry_sdk.set_tag("context", "servicer_setup")
@@ -354,6 +366,11 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             )
 
             with session_scope() as session:
+                # Force the pool checkout now and time it, so connection-acquisition wait is a distinct bucket rather
+                # than hiding inside the handler's first query. start_perf() arms after, so this isn't counted as DB.
+                pool_wait_start = perf_counter_ns()
+                session.connection()
+                observe_in_servicer_pool_wait_histogram(method, (perf_counter_ns() - pool_wait_start) / 1e9)
                 start_perf()
                 try:
                     _res = prev_function(req, couchers_context, session)  # type: ignore[call-arg, arg-type]
@@ -454,10 +471,28 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
 
             return res
 
+        wrapped_deserializer: Callable[[bytes], T] | None = None
+        if (request_deserializer := handler.request_deserializer) is not None:
+
+            def wrapped_deserializer(request_bytes: bytes) -> T:
+                t0 = perf_counter_ns()
+                req = request_deserializer(request_bytes)
+                observe_in_servicer_serde_histogram(method, "deserialize", (perf_counter_ns() - t0) / 1e9)
+                return req
+
+        wrapped_serializer: Callable[[R], bytes] | None = None
+        if (response_serializer := handler.response_serializer) is not None:
+
+            def wrapped_serializer(response: R) -> bytes:
+                t0 = perf_counter_ns()
+                data = response_serializer(response)
+                observe_in_servicer_serde_histogram(method, "serialize", (perf_counter_ns() - t0) / 1e9)
+                return data
+
         return grpc.unary_unary_rpc_method_handler(
             function_without_couchers_stuff,
-            request_deserializer=handler.request_deserializer,
-            response_serializer=handler.response_serializer,
+            request_deserializer=wrapped_deserializer,
+            response_serializer=wrapped_serializer,
         )
 
 

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -298,9 +298,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
 
         method = handler_call_details.method
 
-        # Arm resource accounting across the auth/setup phase so its DB time (the user fetch + user_activity upsert)
-        # and CPU are attributed separately from the handler body; read back once setup succeeds, below. The handler
-        # re-arms its own accounting. Auth-failure early-returns just leave this to be overwritten by the next request.
+        # accounting for the auth/setup phase; the handler re-arms its own below
         start_perf()
 
         try:
@@ -366,8 +364,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             )
 
             with session_scope() as session:
-                # Force the pool checkout now and time it, so connection-acquisition wait is a distinct bucket rather
-                # than hiding inside the handler's first query. start_perf() arms after, so this isn't counted as DB.
+                # force the checkout now so its wait is timed here rather than hiding in the handler's first query
                 pool_wait_start = perf_counter_ns()
                 session.connection()
                 observe_in_servicer_pool_wait_histogram(method, (perf_counter_ns() - pool_wait_start) / 1e9)

--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -57,6 +57,45 @@ multiprocess.MultiProcessCollector(registry)  # type: ignore[no-untyped-call]
 
 _INF: float = float("inf")
 
+# Dense from 1ms to ~300ms where most calls land, sparse out to 10min for long background jobs.
+MACHINE_DURATION_SECONDS: tuple[float, ...] = (
+    0.001,
+    0.0025,
+    0.005,
+    0.0075,
+    0.01,
+    0.015,
+    0.02,
+    0.03,
+    0.04,
+    0.05,
+    0.06,
+    0.075,
+    0.1,
+    0.125,
+    0.15,
+    0.2,
+    0.25,
+    0.3,
+    0.4,
+    0.5,
+    0.75,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    5.0,
+    7.5,
+    10.0,
+    15.0,
+    30.0,
+    60,
+    120,
+    300,
+    600,
+    _INF,
+)
+
 start_time_gauge: Gauge = Gauge(
     "couchers_start_time_seconds",
     "Unix timestamp of when the process started",
@@ -77,6 +116,7 @@ jobs_duration_histogram: Histogram = Histogram(
     "couchers_background_jobs_seconds",
     "Durations of background jobs",
     labelnames=["job", "status", "attempt", "exception"],
+    buckets=MACHINE_DURATION_SECONDS,
 )
 
 
@@ -97,6 +137,7 @@ servicer_duration_histogram: Histogram = Histogram(
     "couchers_servicer_duration_seconds",
     "Durations of processing gRPC calls",
     labelnames=["method", "logged_in", "code", "exception"],
+    buckets=MACHINE_DURATION_SECONDS,
 )
 
 
@@ -124,11 +165,13 @@ servicer_db_time_histogram: Histogram = Histogram(
     "couchers_servicer_db_time_seconds",
     "Time spent in DB cursor execution per gRPC call",
     labelnames=["method"],
+    buckets=MACHINE_DURATION_SECONDS,
 )
 servicer_cpu_time_histogram: Histogram = Histogram(
     "couchers_servicer_cpu_seconds",
     "Backend thread CPU time per gRPC call",
     labelnames=["method"],
+    buckets=MACHINE_DURATION_SECONDS,
 )
 # Fibonacci bucket boundaries: roughly exponential, good resolution for an unbounded value
 servicer_db_query_count_histogram: Histogram = Histogram(

--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -197,9 +197,7 @@ def observe_in_servicer_perf_histograms(
     servicer_db_write_query_count_histogram.labels(method).observe(db_write_query_count)
 
 
-# Auth/setup phase (everything before the handler body: find_auth_level, header parsing, the user fetch +
-# user_activity upsert, permission checks). Same db-vs-cpu split as the handler-body histograms above, so the
-# dashboard can attribute the per-call fixed cost that would otherwise hide in the duration "other" bucket.
+# Auth/setup phase (everything before the handler body), same db-vs-cpu split as the handler-body histograms above.
 servicer_setup_db_time_histogram: Histogram = Histogram(
     "couchers_servicer_setup_db_time_seconds",
     "Time spent in DB cursor execution during the auth/setup phase per gRPC call",
@@ -219,8 +217,6 @@ def observe_in_servicer_setup_histogram(method: str, setup_db_ms: float, setup_c
     servicer_setup_cpu_time_histogram.labels(method).observe(setup_cpu_ms / 1000)
 
 
-# Wall-clock blocked acquiring a DB connection from the pool, per gRPC call. Distinguishes "DB is slow" (db_time)
-# from "we're out of connections / threads are queuing" (this). Complements the couchers_db_pool_checked_out gauge.
 servicer_pool_wait_histogram: Histogram = Histogram(
     "couchers_servicer_pool_wait_seconds",
     "Time spent waiting to check out a DB connection from the pool per gRPC call",
@@ -233,8 +229,7 @@ def observe_in_servicer_pool_wait_histogram(method: str, pool_wait_s: float) -> 
     servicer_pool_wait_histogram.labels(method).observe(pool_wait_s)
 
 
-# Protobuf (de)serialization CPU per gRPC call. A separate diagnostic, not part of the additive duration pie:
-# "deserialize" lands in duration's residual, "serialize" runs after the duration window closes.
+# Separate diagnostic, not part of the additive duration pie: "serialize" runs after the duration window closes.
 servicer_serde_histogram: Histogram = Histogram(
     "couchers_servicer_serde_seconds",
     "Protobuf request deserialization / response serialization time per gRPC call",

--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -49,6 +49,7 @@ from couchers.models.moderation import (
     ModerationTrigger,
     ModerationVisibility,
 )
+from couchers.perf import PerfResult
 
 tracer = trace.get_tracer(__name__)
 
@@ -188,13 +189,13 @@ servicer_db_write_query_count_histogram: Histogram = Histogram(
 )
 
 
-def observe_in_servicer_perf_histograms(
-    method: str, db_query_count: int, db_write_query_count: int, db_time_ms: float, cpu_ms: float
-) -> None:
-    servicer_db_time_histogram.labels(method).observe(db_time_ms / 1000)
-    servicer_cpu_time_histogram.labels(method).observe(cpu_ms / 1000)
-    servicer_db_query_count_histogram.labels(method).observe(db_query_count)
-    servicer_db_write_query_count_histogram.labels(method).observe(db_write_query_count)
+def observe_in_servicer_perf_histograms(method: str, perf: PerfResult | None) -> None:
+    if perf is None:
+        return
+    servicer_db_time_histogram.labels(method).observe(perf.db_time_ms / 1000)
+    servicer_cpu_time_histogram.labels(method).observe(perf.cpu_ms / 1000)
+    servicer_db_query_count_histogram.labels(method).observe(perf.db_query_count)
+    servicer_db_write_query_count_histogram.labels(method).observe(perf.db_write_query_count)
 
 
 # Auth/setup phase (everything before the handler body), same db-vs-cpu split as the handler-body histograms above.
@@ -212,9 +213,11 @@ servicer_setup_cpu_time_histogram: Histogram = Histogram(
 )
 
 
-def observe_in_servicer_setup_histogram(method: str, setup_db_ms: float, setup_cpu_ms: float) -> None:
-    servicer_setup_db_time_histogram.labels(method).observe(setup_db_ms / 1000)
-    servicer_setup_cpu_time_histogram.labels(method).observe(setup_cpu_ms / 1000)
+def observe_in_servicer_setup_histogram(method: str, perf: PerfResult | None) -> None:
+    if perf is None:
+        return
+    servicer_setup_db_time_histogram.labels(method).observe(perf.db_time_ms / 1000)
+    servicer_setup_cpu_time_histogram.labels(method).observe(perf.cpu_ms / 1000)
 
 
 servicer_pool_wait_histogram: Histogram = Histogram(

--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -197,6 +197,56 @@ def observe_in_servicer_perf_histograms(
     servicer_db_write_query_count_histogram.labels(method).observe(db_write_query_count)
 
 
+# Auth/setup phase (everything before the handler body: find_auth_level, header parsing, the user fetch +
+# user_activity upsert, permission checks). Same db-vs-cpu split as the handler-body histograms above, so the
+# dashboard can attribute the per-call fixed cost that would otherwise hide in the duration "other" bucket.
+servicer_setup_db_time_histogram: Histogram = Histogram(
+    "couchers_servicer_setup_db_time_seconds",
+    "Time spent in DB cursor execution during the auth/setup phase per gRPC call",
+    labelnames=["method"],
+    buckets=MACHINE_DURATION_SECONDS,
+)
+servicer_setup_cpu_time_histogram: Histogram = Histogram(
+    "couchers_servicer_setup_cpu_seconds",
+    "Backend thread CPU time during the auth/setup phase per gRPC call",
+    labelnames=["method"],
+    buckets=MACHINE_DURATION_SECONDS,
+)
+
+
+def observe_in_servicer_setup_histogram(method: str, setup_db_ms: float, setup_cpu_ms: float) -> None:
+    servicer_setup_db_time_histogram.labels(method).observe(setup_db_ms / 1000)
+    servicer_setup_cpu_time_histogram.labels(method).observe(setup_cpu_ms / 1000)
+
+
+# Wall-clock blocked acquiring a DB connection from the pool, per gRPC call. Distinguishes "DB is slow" (db_time)
+# from "we're out of connections / threads are queuing" (this). Complements the couchers_db_pool_checked_out gauge.
+servicer_pool_wait_histogram: Histogram = Histogram(
+    "couchers_servicer_pool_wait_seconds",
+    "Time spent waiting to check out a DB connection from the pool per gRPC call",
+    labelnames=["method"],
+    buckets=MACHINE_DURATION_SECONDS,
+)
+
+
+def observe_in_servicer_pool_wait_histogram(method: str, pool_wait_s: float) -> None:
+    servicer_pool_wait_histogram.labels(method).observe(pool_wait_s)
+
+
+# Protobuf (de)serialization CPU per gRPC call. A separate diagnostic, not part of the additive duration pie:
+# "deserialize" lands in duration's residual, "serialize" runs after the duration window closes.
+servicer_serde_histogram: Histogram = Histogram(
+    "couchers_servicer_serde_seconds",
+    "Protobuf request deserialization / response serialization time per gRPC call",
+    labelnames=["method", "direction"],
+    buckets=MACHINE_DURATION_SECONDS,
+)
+
+
+def observe_in_servicer_serde_histogram(method: str, direction: str, serde_s: float) -> None:
+    servicer_serde_histogram.labels(method, direction).observe(serde_s)
+
+
 # liveall keeps one series per worker pid (and drops dead workers), so these also show load balance across workers.
 # Updated from inside each worker since the /metrics scrape runs in the parent, which has neither pool.
 grpc_in_flight_gauge: Gauge = Gauge(

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -299,8 +299,7 @@ def _get_histogram_count(histogram, count_name, **labels):
 
 
 def test_tracing_interceptor_phase_histograms(db):
-    # setup-phase (auth) db/cpu, pool-checkout wait, and protobuf de/serialization are each observed into their own
-    # Prometheus histogram, one observation per call. These are prometheus-only (not written into the APICall row).
+    # setup db/cpu, pool-wait, and de/serialization are each observed once per call into their own histogram
     method = "/org.couchers.auth.Auth/SignupFlow"
     setup_db_before = _get_histogram_count(
         servicer_setup_db_time_histogram, "couchers_servicer_setup_db_time_seconds_count", method=method

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -35,6 +35,10 @@ from couchers.metrics import (
     api_calls_counter,
     servicer_db_query_count_histogram,
     servicer_duration_histogram,
+    servicer_pool_wait_histogram,
+    servicer_serde_histogram,
+    servicer_setup_cpu_time_histogram,
+    servicer_setup_db_time_histogram,
     servicer_setup_errors_counter,
 )
 from couchers.models import APICall, ClientPlatform, User, UserActivity, UserSession
@@ -283,6 +287,71 @@ def test_tracing_interceptor_perf_accounting(db):
     # the call was also observed into the Prometheus per-request resource histograms and the per-platform call counter
     assert _get_db_query_count_histogram(method) == hist_count_before + 1
     assert _get_api_call_count(method, "web_mobile") == api_call_count_before + 1
+
+
+def _get_histogram_count(histogram, count_name, **labels):
+    return sum(
+        s.value
+        for m in histogram.collect()
+        for s in m.samples
+        if s.name == count_name and all(s.labels.get(k) == v for k, v in labels.items())
+    )
+
+
+def test_tracing_interceptor_phase_histograms(db):
+    # setup-phase (auth) db/cpu, pool-checkout wait, and protobuf de/serialization are each observed into their own
+    # Prometheus histogram, one observation per call. These are prometheus-only (not written into the APICall row).
+    method = "/org.couchers.auth.Auth/SignupFlow"
+    setup_db_before = _get_histogram_count(
+        servicer_setup_db_time_histogram, "couchers_servicer_setup_db_time_seconds_count", method=method
+    )
+    setup_cpu_before = _get_histogram_count(
+        servicer_setup_cpu_time_histogram, "couchers_servicer_setup_cpu_seconds_count", method=method
+    )
+    pool_wait_before = _get_histogram_count(
+        servicer_pool_wait_histogram, "couchers_servicer_pool_wait_seconds_count", method=method
+    )
+    deserialize_before = _get_histogram_count(
+        servicer_serde_histogram, "couchers_servicer_serde_seconds_count", method=method, direction="deserialize"
+    )
+    serialize_before = _get_histogram_count(
+        servicer_serde_histogram, "couchers_servicer_serde_seconds_count", method=method, direction="serialize"
+    )
+
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(TestRpc, interceptors=[CouchersMiddlewareInterceptor()]) as call_rpc:
+        call_rpc(empty_pb2.Empty())
+
+    assert (
+        _get_histogram_count(
+            servicer_setup_db_time_histogram, "couchers_servicer_setup_db_time_seconds_count", method=method
+        )
+        == setup_db_before + 1
+    )
+    assert (
+        _get_histogram_count(
+            servicer_setup_cpu_time_histogram, "couchers_servicer_setup_cpu_seconds_count", method=method
+        )
+        == setup_cpu_before + 1
+    )
+    assert (
+        _get_histogram_count(servicer_pool_wait_histogram, "couchers_servicer_pool_wait_seconds_count", method=method)
+        == pool_wait_before + 1
+    )
+    assert (
+        _get_histogram_count(
+            servicer_serde_histogram, "couchers_servicer_serde_seconds_count", method=method, direction="deserialize"
+        )
+        == deserialize_before + 1
+    )
+    assert (
+        _get_histogram_count(
+            servicer_serde_histogram, "couchers_servicer_serde_seconds_count", method=method, direction="serialize"
+        )
+        == serialize_before + 1
+    )
 
 
 def test_tracing_interceptor_perf_accounting_orm_write(db):

--- a/app/docker-compose.prod.yml
+++ b/app/docker-compose.prod.yml
@@ -103,10 +103,17 @@ services:
     dns_search: ""
   # generates prometheus metrics for the database
   pgprom:
-    image: quay.io/prometheuscommunity/postgres-exporter:v0.15.0
+    image: quay.io/prometheuscommunity/postgres-exporter:v0.18.0
     restart: always
     stop_grace_period: 5s
     env_file: pgprom.prod.env
+    # stat_statements collector is disabled by default; it surfaces per-query pg_stat_statements metrics.
+    # include_query emits the queryid->text mapping (normalized SQL, no literals); query_length raises the
+    # default 120-char truncation so our long multi-join statements aren't cut off.
+    command:
+      - "--collector.stat_statements"
+      - "--collector.stat_statements.include_query"
+      - "--collector.stat_statements.query_length=2048"
     expose:
       - 9187
     networks:

--- a/app/docker-compose.prod.yml
+++ b/app/docker-compose.prod.yml
@@ -107,12 +107,12 @@ services:
     restart: always
     stop_grace_period: 5s
     env_file: pgprom.prod.env
-    # stat_statements collector is disabled by default; it surfaces per-query pg_stat_statements metrics.
-    # include_query emits the queryid->text mapping (normalized SQL, no literals); query_length raises the
-    # default 120-char truncation so our long multi-join statements aren't cut off.
     command:
+      # per-query pg_stat_statements metrics
       - "--collector.stat_statements"
+      # emit the queryid->text mapping (normalized SQL, no literals)
       - "--collector.stat_statements.include_query"
+      # raise the 120-char default so long statements aren't cut off
       - "--collector.stat_statements.query_length=2048"
     expose:
       - 9187

--- a/app/postgis/postgresql.conf
+++ b/app/postgis/postgresql.conf
@@ -26,6 +26,8 @@ effective_io_concurrency = 200
 # Query statistics
 shared_preload_libraries = 'pg_stat_statements'
 pg_stat_statements.track = all
+# Splits query time into CPU vs block I/O wait (pg_stat_statements blk_read_time/blk_write_time)
+track_io_timing = on
 
 # JIT slows down PostGIS operations significantly
 jit = off


### PR DESCRIPTION
Improves backend performance observability on two fronts:

- **Finer histogram buckets**: adds a shared `MACHINE_DURATION_SECONDS` bucket layout (dense from 1ms to ~300ms where most calls land, sparse out to 10min) and applies it to the servicer duration/db-time/cpu histograms and the background-jobs histogram, so the per-call latency distribution is actually legible instead of falling into the default coarse buckets.
- **Per-query DB visibility**: enables the postgres-exporter `stat_statements` collector so `pg_stat_statements` data finally reaches Prometheus/VictoriaMetrics. The extension was already loaded (`shared_preload_libraries` + migration `0141`) but the exporter was never scraping it. Includes `--collector.stat_statements.include_query` (emits the normalized `queryid`→text mapping; literals are stripped, so no secrets) with `query_length=2048` to avoid truncating long multi-join statements. Also bumps the exporter `v0.15.0`→`v0.18.0` (the old version's stat_statements collector is broken against PG17+/18) and turns on `track_io_timing` so the block read/write timing columns are populated.

This lets us decompose the existing db/cpu/other latency breakdown and see which specific queries dominate DB time.

## Testing
- `make format` — clean.
- `make mypy` — passes for changed code (one pre-existing, unrelated `ics` missing-stub error in `test_calendar_events.py` remains).
- Config-only changes for the exporter/Postgres; verified flag names and metric/label shapes against the postgres-exporter v0.18.0 collector source.

**Post-deploy verification (operational):**
- Reload Postgres (`SELECT pg_reload_conf();`) for `track_io_timing`; redeploy `pgprom` for the image + flags.
- Grant the exporter's DB role `pg_read_all_stats` so it can read query text and other roles' statements.
- Confirm `pg_stat_statements_seconds_total` and `pg_stat_statements_query_id` series appear in Prometheus/VM.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._