### PR TITLE
Backend/emails: Fix line break in closing

### DIFF
--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -1,7 +1,7 @@
 {
   "generic": {
     "greeting_line": "Hi {{name}},",
-    "closing_line": "Best,\nThe Couchers.org Team",
+    "closing_line": "Best,<br>The Couchers.org Team",
     "security_warning_contact_support": "If you did not initiate this action, please contact us by emailing <a href=\"mailto:support@couchers.org\">support@couchers.org</a> so we can sort this out as soon as possible!",
     "do_not_reply_request": "<b>Do not reply to this email.</b> Use one of the buttons above to reply to this request."
   },


### PR DESCRIPTION
Email localized strings are considered to be html so `<br>` is a line break, not `\n`.

## Testing
`uv run dump-emails`

<img width="334" height="108" alt="image" src="https://github.com/user-attachments/assets/6a143f8c-f2f6-41f7-b11b-13813879f4fc" />

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
