### PR TITLE
Add GrowthBook-controlled Pyroscope continuous profiling

### DIFF
--- a/app/backend.dev.env
+++ b/app/backend.dev.env
@@ -83,6 +83,10 @@ GROWTHBOOK_API_HOST=https://gbapi.couchershq.org
 GROWTHBOOK_CLIENT_KEY=sdk-cGmljeXu1BCzHffE
 GROWTHBOOK_CACHE_PATH=growthbook-features-cache.json
 
+# Continuous profiling (Pyroscope). Empty server disables it; left off in dev.
+PYROSCOPE_SERVER=
+PYROSCOPE_AUTH_TOKEN=
+
 # Moderation auto-approval deadline in seconds (0 to disable)
 MODERATION_AUTO_APPROVE_DEADLINE_SECONDS=10
 # User ID of the bot user for automated moderation actions

--- a/app/backend.dev.env
+++ b/app/backend.dev.env
@@ -83,9 +83,10 @@ GROWTHBOOK_API_HOST=https://gbapi.couchershq.org
 GROWTHBOOK_CLIENT_KEY=sdk-cGmljeXu1BCzHffE
 GROWTHBOOK_CACHE_PATH=growthbook-features-cache.json
 
-# Continuous profiling (Pyroscope). Empty server disables it; left off in dev.
-PYROSCOPE_SERVER=
-PYROSCOPE_AUTH_TOKEN=
+# Continuous profiling (Pyroscope; gated at runtime by the profiling_enabled flag)
+PYROSCOPE_ENABLED=0
+PYROSCOPE_SERVER=https://pyroscope.couchershq.org
+PYROSCOPE_AUTH_TOKEN=...
 
 # Moderation auto-approval deadline in seconds (0 to disable)
 MODERATION_AUTO_APPROVE_DEADLINE_SECONDS=10

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "ua-parser>=1.0.1",
     "user-agents>=2.2.0",
     "growthbook>=1.2.0",
+    "pyroscope-io>=1.0.9",
 ]
 
 [project.scripts]
@@ -136,7 +137,7 @@ module = ["couchers.migrations.versions.*"]
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = ["http_ece", "py_vapid", "luhn", "sqlalchemy_utils.*", "growthbook", "user_agents"]
+module = ["http_ece", "py_vapid", "luhn", "sqlalchemy_utils.*", "growthbook", "user_agents", "pyroscope"]
 # These libraries don't have type stubs or py.typed markers
 ignore_missing_imports = true
 

--- a/app/backend/src/app.py
+++ b/app/backend/src/app.py
@@ -27,6 +27,7 @@ from couchers.experimentation import setup_experimentation
 from couchers.i18n.locales import get_main_i18next
 from couchers.jobs.worker import start_jobs_scheduler, start_jobs_worker
 from couchers.metrics import create_prometheus_server
+from couchers.profiling import setup_profiling
 from couchers.server import create_main_server, create_media_server
 from couchers.supervisor import supervise
 from couchers.tracing import setup_tracing
@@ -45,6 +46,7 @@ def _run_api_server(port: int) -> None:
         db_post_fork()
         setup_experimentation()
         setup_tracing()
+        setup_profiling(role="api", instance=f"api-{port}")
 
         server = create_main_server(port=port, start_resource_sampler=True)
         server.start()
@@ -128,7 +130,7 @@ def main() -> None:
 
     if config["ROLE"] in ["worker", "all"]:
         for i in range(config["BACKGROUND_WORKER_COUNT"]):
-            worker = start_jobs_worker()
+            worker = start_jobs_worker(i)
             worker.name = f"worker-{i}"
             children.append(worker)
 

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -119,9 +119,10 @@ CONFIG_OPTIONS: CONFIG_T = [
     # is unreachable. Required when experimentation is enabled so we never start on in-code defaults.
     ("GROWTHBOOK_CACHE_PATH", str, ""),
     # Continuous profiling (Pyroscope). Profiling is gated at runtime by the `profiling_enabled` feature
-    # flag; these provide the ingest endpoint and its bearer token. Empty PYROSCOPE_SERVER disables it.
-    ("PYROSCOPE_SERVER", str, ""),
-    ("PYROSCOPE_AUTH_TOKEN", str, ""),
+    # flag; PYROSCOPE_ENABLED is the per-deployment master switch.
+    ("PYROSCOPE_ENABLED", bool),
+    ("PYROSCOPE_SERVER", str),
+    ("PYROSCOPE_AUTH_TOKEN", str),
     # Moderation auto-approval deadline in seconds (0 to disable auto-approval)
     ("MODERATION_AUTO_APPROVE_DEADLINE_SECONDS", int),
     # User ID of the bot user for automated moderation actions
@@ -186,6 +187,10 @@ def check_config(cfg: dict[str, Any]) -> None:
             raise Exception("No GrowthBook client key but experimentation enabled")
         if not cfg["GROWTHBOOK_CACHE_PATH"]:
             raise Exception("No GrowthBook cache path but experimentation enabled")
+
+    if cfg["PYROSCOPE_ENABLED"]:
+        if not cfg["PYROSCOPE_SERVER"] or not cfg["PYROSCOPE_AUTH_TOKEN"]:
+            raise Exception("No Pyroscope server or auth token but profiling enabled")
 
 
 def make_config() -> dict[str, Any]:

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -118,6 +118,10 @@ CONFIG_OPTIONS: CONFIG_T = [
     # Disk path for the last-known-good feature payload, used as a cold-start fallback when GrowthBook
     # is unreachable. Required when experimentation is enabled so we never start on in-code defaults.
     ("GROWTHBOOK_CACHE_PATH", str, ""),
+    # Continuous profiling (Pyroscope). Profiling is gated at runtime by the `profiling_enabled` feature
+    # flag; these provide the ingest endpoint and its bearer token. Empty PYROSCOPE_SERVER disables it.
+    ("PYROSCOPE_SERVER", str, ""),
+    ("PYROSCOPE_AUTH_TOKEN", str, ""),
     # Moderation auto-approval deadline in seconds (0 to disable auto-approval)
     ("MODERATION_AUTO_APPROVE_DEADLINE_SECONDS", int),
     # User ID of the bot user for automated moderation actions

--- a/app/backend/src/couchers/jobs/worker.py
+++ b/app/backend/src/couchers/jobs/worker.py
@@ -30,6 +30,7 @@ from couchers.metrics import (
     observe_in_jobs_duration_histogram,
 )
 from couchers.models import BackgroundJob, BackgroundJobState
+from couchers.profiling import setup_profiling
 from couchers.tracing import setup_tracing
 from couchers.utils import now
 
@@ -171,12 +172,14 @@ def run_scheduler() -> None:
     sched.run()
 
 
-def _run_forever(func: Callable[[], None]) -> None:
+def _run_forever(func: Callable[[], None], profile_instance: str | None = None) -> None:
     # Post-fork initialization: these services use threading/async internals that
     # don't survive fork() and must be initialized fresh in each child process
     db_post_fork()
     setup_tracing()
     setup_experimentation()
+    if profile_instance is not None:
+        setup_profiling(role="worker", instance=profile_instance)
 
     while True:
         try:
@@ -197,7 +200,7 @@ def start_jobs_scheduler() -> Process:
     return scheduler
 
 
-def start_jobs_worker() -> Process:
-    worker = Process(target=_run_forever, args=(service_jobs,))
+def start_jobs_worker(index: int) -> Process:
+    worker = Process(target=_run_forever, args=(service_jobs,), kwargs={"profile_instance": f"worker-{index}"})
     worker.start()
     return worker

--- a/app/backend/src/couchers/profiling.py
+++ b/app/backend/src/couchers/profiling.py
@@ -1,0 +1,139 @@
+"""
+Continuous profiling via Grafana Pyroscope, using the pyroscope-io in-process agent (py-spy under
+the hood).
+
+Controlled entirely by GrowthBook flags so profiling can be turned on/off and retuned in prod
+without a redeploy:
+  - profiling_enabled      (bool)   master on/off
+  - profiling_sample_rate  (int)    samples per second
+  - profiling_mode         (string) "wall" or "cpu"
+
+Each profiled process (API workers, background-job workers) calls setup_profiling() once during its
+own per-process init - the agent is per-process, so this can't be inherited across the forkserver
+boundary. A daemon reconcile thread then polls the flags every RECONCILE_INTERVAL_SECONDS and
+(re)configures or shuts the agent down to match the desired state.
+
+Two hard requirements learned the hard way from the agent's internals:
+  - The container needs CAP_SYS_PTRACE (see docker-compose.prod.yml). Without it the agent silently
+    samples nothing.
+  - enable_logging must NEVER be passed True on a re-configure: the agent's Rust global logger can
+    only be initialised once per process, and a second attempt is a non-unwinding panic that aborts
+    the whole process. We pass enable_logging=False unconditionally.
+"""
+
+import logging
+import threading
+
+import pyroscope
+
+from couchers import experimentation
+from couchers.config import config
+
+logger = logging.getLogger(__name__)
+
+RECONCILE_INTERVAL_SECONDS = 30
+
+FLAG_ENABLED = "profiling_enabled"
+FLAG_SAMPLE_RATE = "profiling_sample_rate"
+FLAG_MODE = "profiling_mode"
+
+_DEFAULT_ENABLED = False
+_DEFAULT_SAMPLE_RATE = 20
+_DEFAULT_MODE = "wall"
+
+# Guard rails on the remotely-controlled sample rate.
+_MIN_SAMPLE_RATE = 1
+_MAX_SAMPLE_RATE = 250
+
+_APPLICATION_NAME = "couchers-backend"
+
+_started = False
+_stop_event = threading.Event()
+
+
+def _clamp_rate(rate: int) -> int:
+    return max(_MIN_SAMPLE_RATE, min(_MAX_SAMPLE_RATE, rate))
+
+
+def _start_agent(sample_rate: int, oncpu: bool, tags: dict[str, str]) -> None:
+    logger.info("Starting profiler: sample_rate=%d mode=%s", sample_rate, "cpu" if oncpu else "wall")
+    token = config["PYROSCOPE_AUTH_TOKEN"]
+    pyroscope.configure(
+        application_name=_APPLICATION_NAME,
+        server_address=config["PYROSCOPE_SERVER"],
+        sample_rate=sample_rate,
+        oncpu=oncpu,
+        tags=tags,
+        # The agent has no bearer-token option; the auth header is how our nginx ingest gate authenticates.
+        http_headers={"Authorization": f"Bearer {token}"} if token else None,
+        # Must stay False forever: re-initialising the agent's global logger panics and aborts the process.
+        enable_logging=False,
+    )
+
+
+def _reconcile_once(state: dict[str, object], tags: dict[str, str]) -> None:
+    enabled = experimentation.get_global_boolean_value(FLAG_ENABLED, _DEFAULT_ENABLED)
+    sample_rate = _clamp_rate(experimentation.get_global_integer_value(FLAG_SAMPLE_RATE, _DEFAULT_SAMPLE_RATE))
+    oncpu = experimentation.get_global_string_value(FLAG_MODE, _DEFAULT_MODE) == "cpu"
+
+    if not enabled:
+        if state["running"]:
+            logger.info("Stopping profiler")
+            pyroscope.shutdown()
+            state.update(running=False, sample_rate=None, oncpu=None)
+        return
+
+    if state["running"] and state["sample_rate"] == sample_rate and state["oncpu"] == oncpu:
+        return
+
+    if state["running"]:
+        # sample_rate/oncpu are baked in at agent creation, so a change means a full stop + restart
+        logger.info(
+            "Reconfiguring profiler: sample_rate %s->%d, mode %s->%s",
+            state["sample_rate"],
+            sample_rate,
+            "cpu" if state["oncpu"] else "wall",
+            "cpu" if oncpu else "wall",
+        )
+        pyroscope.shutdown()
+
+    _start_agent(sample_rate, oncpu, tags)
+    state.update(running=True, sample_rate=sample_rate, oncpu=oncpu)
+
+
+def _reconcile_loop(tags: dict[str, str]) -> None:
+    state: dict[str, object] = {"running": False, "sample_rate": None, "oncpu": None}
+    # Poll immediately, then every interval. A failed reconcile must not kill the thread.
+    while True:
+        try:
+            _reconcile_once(state, tags)
+        except Exception:
+            logger.exception("Profiling reconcile failed")
+        if _stop_event.wait(RECONCILE_INTERVAL_SECONDS):
+            return
+
+
+def setup_profiling(role: str, instance: str) -> None:
+    """
+    Start the per-process profiling reconcile thread. Call once per process, after
+    setup_experimentation(). No-op unless a Pyroscope server is configured.
+    """
+    global _started
+
+    if not config["PYROSCOPE_SERVER"]:
+        return
+
+    if _started:
+        logger.warning("setup_profiling() called more than once in a process; ignoring")
+        return
+    _started = True
+
+    tags = {
+        "role": role,
+        "instance": instance,
+        "environment": config["COOKIE_DOMAIN"],
+        "version": config["VERSION"],
+    }
+    thread = threading.Thread(target=_reconcile_loop, args=(tags,), name="profiling-reconcile", daemon=True)
+    thread.start()
+    logger.info("Profiling reconcile thread started (instance=%s)", instance)

--- a/app/backend/src/couchers/profiling.py
+++ b/app/backend/src/couchers/profiling.py
@@ -26,8 +26,6 @@ from couchers.config import config
 logger = logging.getLogger(__name__)
 
 _RECONCILE_INTERVAL_SECONDS = 30
-_MIN_SAMPLE_RATE = 1
-_MAX_SAMPLE_RATE = 250
 
 _initialized = False
 _stop = threading.Event()
@@ -49,10 +47,8 @@ def _reconcile() -> None:
             _running, _sample_rate, _oncpu = False, None, None
         return
 
-    sample_rate = max(
-        _MIN_SAMPLE_RATE,
-        min(_MAX_SAMPLE_RATE, experimentation.get_global_integer_value("profiling_sample_rate", 20)),
-    )
+    # clamp to 1..250: 0 divides by zero in the agent, and a runaway flag value shouldn't pin CPU
+    sample_rate = max(1, min(250, experimentation.get_global_integer_value("profiling_sample_rate", 20)))
     oncpu = experimentation.get_global_string_value("profiling_mode", "wall") == "cpu"
 
     if _running and (sample_rate, oncpu) == (_sample_rate, _oncpu):

--- a/app/backend/src/couchers/profiling.py
+++ b/app/backend/src/couchers/profiling.py
@@ -1,24 +1,18 @@
 """
-Continuous profiling via Grafana Pyroscope, using the pyroscope-io in-process agent (py-spy under
-the hood).
+Continuous profiling via Grafana Pyroscope.
 
-Controlled entirely by GrowthBook flags so profiling can be turned on/off and retuned in prod
-without a redeploy:
-  - profiling_enabled      (bool)   master on/off
-  - profiling_sample_rate  (int)    samples per second
-  - profiling_mode         (string) "wall" or "cpu"
+Each API and background-worker process runs an in-process pyroscope-io agent (py-spy under the
+hood). Profiling is controlled at runtime by GrowthBook flags, so it can be turned on, off, and
+retuned in production without a redeploy:
 
-Each profiled process (API workers, background-job workers) calls setup_profiling() once during its
-own per-process init - the agent is per-process, so this can't be inherited across the forkserver
-boundary. A daemon reconcile thread then polls the flags every RECONCILE_INTERVAL_SECONDS and
-(re)configures or shuts the agent down to match the desired state.
+    profiling_enabled      whether to profile at all
+    profiling_sample_rate  samples per second
+    profiling_mode         "wall" or "cpu"
 
-Two hard requirements learned the hard way from the agent's internals:
-  - The container needs CAP_SYS_PTRACE (see docker-compose.prod.yml). Without it the agent silently
-    samples nothing.
-  - enable_logging must NEVER be passed True on a re-configure: the agent's Rust global logger can
-    only be initialised once per process, and a second attempt is a non-unwinding panic that aborts
-    the whole process. We pass enable_logging=False unconditionally.
+A per-process reconcile thread polls these and (re)starts or stops the agent to match. The agent is
+per-process (it can't survive the forkserver boundary), needs CAP_SYS_PTRACE in the container, and
+its logging may only be initialised once per process - a second attempt aborts the process, so we
+never enable it.
 """
 
 import logging
@@ -31,109 +25,76 @@ from couchers.config import config
 
 logger = logging.getLogger(__name__)
 
-RECONCILE_INTERVAL_SECONDS = 30
-
-FLAG_ENABLED = "profiling_enabled"
-FLAG_SAMPLE_RATE = "profiling_sample_rate"
-FLAG_MODE = "profiling_mode"
-
-_DEFAULT_ENABLED = False
-_DEFAULT_SAMPLE_RATE = 20
-_DEFAULT_MODE = "wall"
-
-# Guard rails on the remotely-controlled sample rate.
+_RECONCILE_INTERVAL_SECONDS = 30
 _MIN_SAMPLE_RATE = 1
 _MAX_SAMPLE_RATE = 250
 
-_APPLICATION_NAME = "couchers-backend"
+_initialized = False
+_stop = threading.Event()
 
-_started = False
-_stop_event = threading.Event()
+# Owned exclusively by the single reconcile thread, so no locking.
+_tags: dict[str, str] = {}
+_running = False
+_sample_rate: int | None = None
+_oncpu: bool | None = None
 
 
-def _clamp_rate(rate: int) -> int:
-    return max(_MIN_SAMPLE_RATE, min(_MAX_SAMPLE_RATE, rate))
+def _reconcile() -> None:
+    global _running, _sample_rate, _oncpu
 
+    if not experimentation.get_global_boolean_value("profiling_enabled", False):
+        if _running:
+            logger.info("Stopping profiler")
+            pyroscope.shutdown()
+            _running, _sample_rate, _oncpu = False, None, None
+        return
 
-def _start_agent(sample_rate: int, oncpu: bool, tags: dict[str, str]) -> None:
-    logger.info("Starting profiler: sample_rate=%d mode=%s", sample_rate, "cpu" if oncpu else "wall")
-    token = config["PYROSCOPE_AUTH_TOKEN"]
+    sample_rate = max(
+        _MIN_SAMPLE_RATE,
+        min(_MAX_SAMPLE_RATE, experimentation.get_global_integer_value("profiling_sample_rate", 20)),
+    )
+    oncpu = experimentation.get_global_string_value("profiling_mode", "wall") == "cpu"
+
+    if _running and (sample_rate, oncpu) == (_sample_rate, _oncpu):
+        return
+
+    # The sample rate and mode are fixed when the agent starts, so a change means a full restart.
+    if _running:
+        pyroscope.shutdown()
+
+    logger.info("Starting profiler at %d Hz (%s)", sample_rate, "cpu" if oncpu else "wall")
     pyroscope.configure(
-        application_name=_APPLICATION_NAME,
+        application_name="couchers-backend",
         server_address=config["PYROSCOPE_SERVER"],
         sample_rate=sample_rate,
         oncpu=oncpu,
-        tags=tags,
-        # The agent has no bearer-token option; the auth header is how our nginx ingest gate authenticates.
-        http_headers={"Authorization": f"Bearer {token}"} if token else None,
-        # Must stay False forever: re-initialising the agent's global logger panics and aborts the process.
+        tags=_tags,
+        # The agent has no bearer-token option; this is what our nginx ingest gate authenticates against.
+        http_headers={"Authorization": f"Bearer {config['PYROSCOPE_AUTH_TOKEN']}"},
         enable_logging=False,
     )
+    _running, _sample_rate, _oncpu = True, sample_rate, oncpu
 
 
-def _reconcile_once(state: dict[str, object], tags: dict[str, str]) -> None:
-    enabled = experimentation.get_global_boolean_value(FLAG_ENABLED, _DEFAULT_ENABLED)
-    sample_rate = _clamp_rate(experimentation.get_global_integer_value(FLAG_SAMPLE_RATE, _DEFAULT_SAMPLE_RATE))
-    oncpu = experimentation.get_global_string_value(FLAG_MODE, _DEFAULT_MODE) == "cpu"
-
-    if not enabled:
-        if state["running"]:
-            logger.info("Stopping profiler")
-            pyroscope.shutdown()
-            state.update(running=False, sample_rate=None, oncpu=None)
-        return
-
-    if state["running"] and state["sample_rate"] == sample_rate and state["oncpu"] == oncpu:
-        return
-
-    if state["running"]:
-        # sample_rate/oncpu are baked in at agent creation, so a change means a full stop + restart
-        logger.info(
-            "Reconfiguring profiler: sample_rate %s->%d, mode %s->%s",
-            state["sample_rate"],
-            sample_rate,
-            "cpu" if state["oncpu"] else "wall",
-            "cpu" if oncpu else "wall",
-        )
-        pyroscope.shutdown()
-
-    _start_agent(sample_rate, oncpu, tags)
-    state.update(running=True, sample_rate=sample_rate, oncpu=oncpu)
-
-
-def _reconcile_loop(tags: dict[str, str]) -> None:
-    state: dict[str, object] = {"running": False, "sample_rate": None, "oncpu": None}
-    # Poll immediately, then every interval. A failed reconcile must not kill the thread.
-    while True:
-        try:
-            _reconcile_once(state, tags)
-        except Exception:
-            logger.exception("Profiling reconcile failed")
-        if _stop_event.wait(RECONCILE_INTERVAL_SECONDS):
-            return
+def _reconcile_loop() -> None:
+    _reconcile()
+    while not _stop.wait(_RECONCILE_INTERVAL_SECONDS):
+        _reconcile()
 
 
 def setup_profiling(role: str, instance: str) -> None:
-    """
-    Start the per-process profiling reconcile thread. Call once per process, after
-    setup_experimentation(). No-op unless a Pyroscope server is configured.
-    """
-    global _started
+    """Start the per-process profiling reconcile thread. Call once per process, after
+    setup_experimentation(). No-op unless profiling is enabled for this deployment."""
+    global _initialized, _tags
 
-    if not config["PYROSCOPE_SERVER"]:
+    if not config["PYROSCOPE_ENABLED"] or _initialized:
         return
+    _initialized = True
 
-    if _started:
-        logger.warning("setup_profiling() called more than once in a process; ignoring")
-        return
-    _started = True
-
-    tags = {
+    _tags = {
         "role": role,
         "instance": instance,
         "environment": config["COOKIE_DOMAIN"],
         "version": config["VERSION"],
     }
-    thread = threading.Thread(target=_reconcile_loop, args=(tags,), name="profiling-reconcile", daemon=True)
-    thread.start()
-    logger.info("Profiling reconcile thread started (instance=%s)", instance)
+    threading.Thread(target=_reconcile_loop, name="profiling-reconcile", daemon=True).start()

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -244,6 +244,11 @@ def testconfig():
     config["SLACK_DONATIONS_CHANNEL"] = ""
     config["SLACK_MERCH_CHANNEL"] = ""
 
+    # Profiling disabled by default in tests
+    config["PYROSCOPE_ENABLED"] = False
+    config["PYROSCOPE_SERVER"] = "https://localhost"
+    config["PYROSCOPE_AUTH_TOKEN"] = "token"
+
     yield None
 
     config.clear()

--- a/app/backend/src/tests/test_profiling.py
+++ b/app/backend/src/tests/test_profiling.py
@@ -1,0 +1,115 @@
+from typing import Any
+
+import pyroscope
+import pytest
+
+from couchers import profiling
+from couchers.config import config
+
+TAGS = {"role": "api", "instance": "api-1761"}
+
+
+class AgentCalls:
+    def __init__(self) -> None:
+        self.configure: list[dict[str, Any]] = []
+        self.shutdown = 0
+
+
+@pytest.fixture
+def fake_agent(monkeypatch):
+    """Replace the native pyroscope agent with recorders so we can assert configure/shutdown calls."""
+    calls = AgentCalls()
+    monkeypatch.setattr(pyroscope, "configure", lambda **kw: calls.configure.append(kw))
+
+    def _shutdown():
+        calls.shutdown += 1
+
+    monkeypatch.setattr(pyroscope, "shutdown", _shutdown)
+    return calls
+
+
+def _fresh_state():
+    return {"running": False, "sample_rate": None, "oncpu": None}
+
+
+def _enable(feature_flags, *, rate=20, mode="wall"):
+    feature_flags.set("profiling_enabled", True)
+    feature_flags.set("profiling_sample_rate", rate)
+    feature_flags.set("profiling_mode", mode)
+
+
+def test_disabled_does_nothing(feature_flags, fake_agent):
+    feature_flags.set("profiling_enabled", False)
+    state = _fresh_state()
+    profiling._reconcile_once(state, TAGS)
+    assert fake_agent.configure == []
+    assert fake_agent.shutdown == 0
+    assert state["running"] is False
+
+
+def test_enables_with_flag_driven_params(feature_flags, fake_agent, monkeypatch):
+    monkeypatch.setitem(config, "PYROSCOPE_SERVER", "https://pyroscope.couchershq.org")
+    monkeypatch.setitem(config, "PYROSCOPE_AUTH_TOKEN", "secret-token")
+    _enable(feature_flags, rate=50, mode="cpu")
+    state = _fresh_state()
+    profiling._reconcile_once(state, TAGS)
+
+    assert len(fake_agent.configure) == 1
+    kw = fake_agent.configure[0]
+    assert kw["sample_rate"] == 50
+    assert kw["oncpu"] is True
+    assert kw["server_address"] == "https://pyroscope.couchershq.org"
+    assert kw["http_headers"] == {"Authorization": "Bearer secret-token"}
+    # enable_logging must never be True on reconfigure (re-init aborts the process), so it's always False
+    assert kw["enable_logging"] is False
+    assert kw["tags"] == TAGS
+    assert state == {"running": True, "sample_rate": 50, "oncpu": True}
+
+
+def test_idempotent_when_unchanged(feature_flags, fake_agent):
+    _enable(feature_flags)
+    state = _fresh_state()
+    profiling._reconcile_once(state, TAGS)
+    profiling._reconcile_once(state, TAGS)
+    assert len(fake_agent.configure) == 1
+    assert fake_agent.shutdown == 0
+
+
+def test_rate_change_cycles_agent(feature_flags, fake_agent):
+    _enable(feature_flags, rate=20)
+    state = _fresh_state()
+    profiling._reconcile_once(state, TAGS)
+    feature_flags.set("profiling_sample_rate", 73)
+    profiling._reconcile_once(state, TAGS)
+    assert len(fake_agent.configure) == 2
+    assert fake_agent.shutdown == 1
+    assert fake_agent.configure[-1]["sample_rate"] == 73
+    assert state["sample_rate"] == 73
+
+
+def test_mode_change_cycles_agent(feature_flags, fake_agent):
+    _enable(feature_flags, mode="wall")
+    state = _fresh_state()
+    profiling._reconcile_once(state, TAGS)
+    feature_flags.set("profiling_mode", "cpu")
+    profiling._reconcile_once(state, TAGS)
+    assert fake_agent.shutdown == 1
+    assert fake_agent.configure[-1]["oncpu"] is True
+    assert state["oncpu"] is True
+
+
+def test_disable_after_running_shuts_down(feature_flags, fake_agent):
+    _enable(feature_flags)
+    state = _fresh_state()
+    profiling._reconcile_once(state, TAGS)
+    feature_flags.set("profiling_enabled", False)
+    profiling._reconcile_once(state, TAGS)
+    assert fake_agent.shutdown == 1
+    assert state["running"] is False
+
+
+def test_sample_rate_is_clamped(feature_flags, fake_agent):
+    _enable(feature_flags, rate=100000)
+    state = _fresh_state()
+    profiling._reconcile_once(state, TAGS)
+    assert fake_agent.configure[0]["sample_rate"] == profiling._MAX_SAMPLE_RATE

--- a/app/backend/src/tests/test_profiling.py
+++ b/app/backend/src/tests/test_profiling.py
@@ -103,4 +103,4 @@ def test_sample_rate_is_clamped(feature_flags, fake_agent):
     configure_calls, _ = fake_agent
     _enable(feature_flags, rate=100000)
     profiling._reconcile()
-    assert configure_calls[0]["sample_rate"] == profiling._MAX_SAMPLE_RATE
+    assert configure_calls[0]["sample_rate"] == 250

--- a/app/backend/src/tests/test_profiling.py
+++ b/app/backend/src/tests/test_profiling.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import pyroscope
 import pytest
 
@@ -9,27 +7,20 @@ from couchers.config import config
 TAGS = {"role": "api", "instance": "api-1761"}
 
 
-class AgentCalls:
-    def __init__(self) -> None:
-        self.configure: list[dict[str, Any]] = []
-        self.shutdown = 0
-
-
 @pytest.fixture
 def fake_agent(monkeypatch):
-    """Replace the native pyroscope agent with recorders so we can assert configure/shutdown calls."""
-    calls = AgentCalls()
-    monkeypatch.setattr(pyroscope, "configure", lambda **kw: calls.configure.append(kw))
-
-    def _shutdown():
-        calls.shutdown += 1
-
-    monkeypatch.setattr(pyroscope, "shutdown", _shutdown)
-    return calls
-
-
-def _fresh_state():
-    return {"running": False, "sample_rate": None, "oncpu": None}
+    """Replace the native pyroscope agent with recorders and reset the per-process agent state."""
+    configure_calls: list[dict[str, object]] = []
+    shutdown_calls: list[None] = []
+    monkeypatch.setattr(pyroscope, "configure", lambda **kw: configure_calls.append(kw))
+    monkeypatch.setattr(pyroscope, "shutdown", lambda: shutdown_calls.append(None))
+    monkeypatch.setattr(profiling, "_tags", TAGS)
+    monkeypatch.setattr(profiling, "_running", False)
+    monkeypatch.setattr(profiling, "_sample_rate", None)
+    monkeypatch.setattr(profiling, "_oncpu", None)
+    monkeypatch.setitem(config, "PYROSCOPE_SERVER", "https://localhost")
+    monkeypatch.setitem(config, "PYROSCOPE_AUTH_TOKEN", "token")
+    return configure_calls, shutdown_calls
 
 
 def _enable(feature_flags, *, rate=20, mode="wall"):
@@ -39,77 +30,77 @@ def _enable(feature_flags, *, rate=20, mode="wall"):
 
 
 def test_disabled_does_nothing(feature_flags, fake_agent):
+    configure_calls, shutdown_calls = fake_agent
     feature_flags.set("profiling_enabled", False)
-    state = _fresh_state()
-    profiling._reconcile_once(state, TAGS)
-    assert fake_agent.configure == []
-    assert fake_agent.shutdown == 0
-    assert state["running"] is False
+    profiling._reconcile()
+    assert configure_calls == []
+    assert shutdown_calls == []
+    assert profiling._running is False
 
 
 def test_enables_with_flag_driven_params(feature_flags, fake_agent, monkeypatch):
     monkeypatch.setitem(config, "PYROSCOPE_SERVER", "https://pyroscope.couchershq.org")
     monkeypatch.setitem(config, "PYROSCOPE_AUTH_TOKEN", "secret-token")
+    configure_calls, _ = fake_agent
     _enable(feature_flags, rate=50, mode="cpu")
-    state = _fresh_state()
-    profiling._reconcile_once(state, TAGS)
+    profiling._reconcile()
 
-    assert len(fake_agent.configure) == 1
-    kw = fake_agent.configure[0]
+    assert len(configure_calls) == 1
+    kw = configure_calls[0]
     assert kw["sample_rate"] == 50
     assert kw["oncpu"] is True
     assert kw["server_address"] == "https://pyroscope.couchershq.org"
     assert kw["http_headers"] == {"Authorization": "Bearer secret-token"}
-    # enable_logging must never be True on reconfigure (re-init aborts the process), so it's always False
-    assert kw["enable_logging"] is False
     assert kw["tags"] == TAGS
-    assert state == {"running": True, "sample_rate": 50, "oncpu": True}
+    # enable_logging must never be True on a reconfigure (re-init aborts the process)
+    assert kw["enable_logging"] is False
+    assert (profiling._running, profiling._sample_rate, profiling._oncpu) == (True, 50, True)
 
 
 def test_idempotent_when_unchanged(feature_flags, fake_agent):
+    configure_calls, shutdown_calls = fake_agent
     _enable(feature_flags)
-    state = _fresh_state()
-    profiling._reconcile_once(state, TAGS)
-    profiling._reconcile_once(state, TAGS)
-    assert len(fake_agent.configure) == 1
-    assert fake_agent.shutdown == 0
+    profiling._reconcile()
+    profiling._reconcile()
+    assert len(configure_calls) == 1
+    assert shutdown_calls == []
 
 
-def test_rate_change_cycles_agent(feature_flags, fake_agent):
+def test_rate_change_restarts_agent(feature_flags, fake_agent):
+    configure_calls, shutdown_calls = fake_agent
     _enable(feature_flags, rate=20)
-    state = _fresh_state()
-    profiling._reconcile_once(state, TAGS)
+    profiling._reconcile()
     feature_flags.set("profiling_sample_rate", 73)
-    profiling._reconcile_once(state, TAGS)
-    assert len(fake_agent.configure) == 2
-    assert fake_agent.shutdown == 1
-    assert fake_agent.configure[-1]["sample_rate"] == 73
-    assert state["sample_rate"] == 73
+    profiling._reconcile()
+    assert len(configure_calls) == 2
+    assert len(shutdown_calls) == 1
+    assert configure_calls[-1]["sample_rate"] == 73
+    assert profiling._sample_rate == 73
 
 
-def test_mode_change_cycles_agent(feature_flags, fake_agent):
+def test_mode_change_restarts_agent(feature_flags, fake_agent):
+    configure_calls, shutdown_calls = fake_agent
     _enable(feature_flags, mode="wall")
-    state = _fresh_state()
-    profiling._reconcile_once(state, TAGS)
+    profiling._reconcile()
     feature_flags.set("profiling_mode", "cpu")
-    profiling._reconcile_once(state, TAGS)
-    assert fake_agent.shutdown == 1
-    assert fake_agent.configure[-1]["oncpu"] is True
-    assert state["oncpu"] is True
+    profiling._reconcile()
+    assert len(shutdown_calls) == 1
+    assert configure_calls[-1]["oncpu"] is True
+    assert profiling._oncpu is True
 
 
 def test_disable_after_running_shuts_down(feature_flags, fake_agent):
+    _, shutdown_calls = fake_agent
     _enable(feature_flags)
-    state = _fresh_state()
-    profiling._reconcile_once(state, TAGS)
+    profiling._reconcile()
     feature_flags.set("profiling_enabled", False)
-    profiling._reconcile_once(state, TAGS)
-    assert fake_agent.shutdown == 1
-    assert state["running"] is False
+    profiling._reconcile()
+    assert len(shutdown_calls) == 1
+    assert profiling._running is False
 
 
 def test_sample_rate_is_clamped(feature_flags, fake_agent):
+    configure_calls, _ = fake_agent
     _enable(feature_flags, rate=100000)
-    state = _fresh_state()
-    profiling._reconcile_once(state, TAGS)
-    assert fake_agent.configure[0]["sample_rate"] == profiling._MAX_SAMPLE_RATE
+    profiling._reconcile()
+    assert configure_calls[0]["sample_rate"] == profiling._MAX_SAMPLE_RATE

--- a/app/backend/uv.lock
+++ b/app/backend/uv.lock
@@ -285,6 +285,7 @@ dependencies = [
     { name = "psycopg", extra = ["binary"] },
     { name = "py-vapid" },
     { name = "pynacl" },
+    { name = "pyroscope-io" },
     { name = "python-dateutil" },
     { name = "pyyaml" },
     { name = "qrcode" },
@@ -346,6 +347,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "py-vapid", specifier = ">=1.9.2" },
     { name = "pynacl", specifier = ">=1.5.0" },
+    { name = "pyroscope-io", specifier = ">=1.0.9" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "qrcode", specifier = ">=8.0" },
@@ -1379,6 +1381,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
     { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
     { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
+]
+
+[[package]]
+name = "pyroscope-io"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/c6/34a0507c6c997cb752cb23b65a5d3cfcbb8bdddabc5c107303b0927341d8/pyroscope_io-1.0.9.tar.gz", hash = "sha256:19822de49e310401c278ef1e0bf31a784c820b3ec4f04f9f710c5f53190a85b9", size = 31074, upload-time = "2026-05-29T02:19:38.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/7b/625812dcb54378fd5b20d960d6c92bd72f3f77285197f97bec10677ea15e/pyroscope_io-1.0.9-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:74f5f0a93a01bedd152e9102bf6e0963506b02ea336c9e0d649528265ab5f2a4", size = 3600847, upload-time = "2026-05-29T02:19:29.547Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b2/8bea2d06aec23f7cf0510f27d59f2227a102879c73bfac3bd46bbab8aed2/pyroscope_io-1.0.9-cp310-abi3-macosx_11_0_x86_64.whl", hash = "sha256:019824ca46dce223f4508ba409bef9ec564c4740a6d93713b2c5891383e3af3e", size = 3818228, upload-time = "2026-05-29T02:19:31.223Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/1e/6f7b53a43ae45e4e75c933867a5ce6ce8270089d205dfbd44ae01e5693df/pyroscope_io-1.0.9-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2e9262b89acfbe2b53fa87c90693116e988e7f7d37e1eca1ff9693fb326a6282", size = 6852652, upload-time = "2026-05-29T02:19:32.718Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/3d/d0982b484eb4e405fe1f0860722534473c547211152e9e5d3b65d035292f/pyroscope_io-1.0.9-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0d0a7441269cae8156c7fa7426ee81573a8207a13508e56af9d8e127df1fe83", size = 6722222, upload-time = "2026-05-29T02:19:34.284Z" },
+    { url = "https://files.pythonhosted.org/packages/55/82/5a33636358d01642d90807b9840077f9fbe361b01d10dffaafa3b29da116/pyroscope_io-1.0.9-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6a02e85d79ec8ac0fbdab8a76652b03f7fcac786b929b1aa9c294829613a03da", size = 6970645, upload-time = "2026-05-29T02:19:35.676Z" },
+    { url = "https://files.pythonhosted.org/packages/80/dc/b4f3c013c8476e56195300347110103ede8f4deb65a36f470cbaaf1d671d/pyroscope_io-1.0.9-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a4b647a91cef820d2dbb2b8c7007e2d35be48d0a70853d5be6f42928d770e4a3", size = 6889493, upload-time = "2026-05-29T02:19:37.473Z" },
 ]
 
 [[package]]

--- a/app/docker-compose.prod.yml
+++ b/app/docker-compose.prod.yml
@@ -26,6 +26,9 @@ services:
     stop_grace_period: 30s
     init: true
     env_file: backend.prod.env
+    # py-spy (used by the Pyroscope profiling agent) reads process memory via ptrace
+    cap_add:
+      - SYS_PTRACE
     volumes:
       # auxiliary resources
       - "./data/aux/:/app/aux/:ro"


### PR DESCRIPTION
Wires the backend into the Pyroscope server stood up in Couchers-org/tools#36, using the `pyroscope-io` in-process agent. Profiling is controlled entirely by GrowthBook flags, so it can be turned on/off and retuned in prod **without a redeploy**:

| flag | type | default | meaning |
|---|---|---|---|
| `profiling_enabled` | bool | `false` | master on/off |
| `profiling_sample_rate` | int | `20` | samples/sec (clamped 1–250) |
| `profiling_mode` | string | `wall` | `wall` or `cpu` |

Each profiled process (the 4 API workers + the background-job workers; the scheduler is skipped) starts its own reconcile thread after `setup_experimentation()`. The thread polls the flags every 30s and (re)configures or shuts the agent down to match desired state. The agent is per-process since it can't be inherited across the forkserver boundary. Set these as **forced/global** values in GrowthBook (there's no user to bucket).

### Two non-obvious constraints (both verified empirically against `pyroscope-io` 1.0.9 on Python 3.14)
- **`CAP_SYS_PTRACE`**: the agent uses py-spy, which reads process memory via ptrace. Without the capability it silently samples nothing. Added `cap_add: SYS_PTRACE` to the `backend` service in `docker-compose.prod.yml`.
- **Never re-init logging**: `enable_logging=True` on a *second* `configure()` panics (the Rust global logger is one-shot) with a non-unwinding abort that kills the process. The reconcile path passes `enable_logging=False` unconditionally.

Also confirmed empirically that `shutdown()` → `configure(new params)` genuinely applies the new sample_rate/mode (decoded the pprof `period` across cycles: 100/37/11 Hz), which is what makes live rate/mode changes possible.

Bearer auth to the nginx ingest gate goes via `http_headers` (the agent has no `auth_token` param). Profiling is a no-op unless `PYROSCOPE_SERVER` is set, so dev and test are unaffected.

## Deploy
Set in `backend.prod.env` on the host:
```
PYROSCOPE_SERVER=https://pyroscope.couchershq.org
PYROSCOPE_AUTH_TOKEN=<the PYROSCOPE_API_KEY from tools#36>
```
Then create the GrowthBook flags (all default-off/safe) and flip `profiling_enabled` on when investigating.

## Testing
- New `tests/test_profiling.py`: 7 unit tests covering the reconcile state machine (enable, idempotence, rate-change cycle, mode-change cycle, disable→shutdown, rate clamping, and the auth-header/`enable_logging=False` wiring) — driven through the real GrowthBook evaluation path via the `feature_flags` fixture.
- `test_experimentation.py` + `test_bg_jobs.py` pass (the latter exercises the changed `start_jobs_worker` signature).
- `make format` clean; `make mypy` clean except a **pre-existing** `ics` import-untyped error on `develop` unrelated to this PR (worth a separate fix — `make mypy` is currently red on `develop`).

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history (n/a — no DB changes)

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

🤖 Generated with [Claude Code](https://claude.com/claude-code)