### PR TITLE
mobile: declare native client platform to the backend

### DIFF
--- a/app/mobile/service/client.ts
+++ b/app/mobile/service/client.ts
@@ -5,6 +5,7 @@ import { AuthPromiseClient } from "@/proto/auth_grpc_web_pb";
 import { BugsPromiseClient } from "@/proto/bugs_grpc_web_pb";
 import { NotificationsPromiseClient } from "@/proto/notifications_grpc_web_pb";
 import isGrpcError from "@/service/utils/isGrpcError";
+import { getClientPlatform } from "@/utils/clientPlatform";
 import { applicationNameForUserAgent } from "@/utils/userAgent";
 
 const IS_PROD =
@@ -67,15 +68,30 @@ export class UserAgentInterceptor {
   }
 }
 
+export class PlatformInterceptor {
+  async intercept(
+    request: Request<unknown, unknown>,
+    invoker: (request: unknown) => unknown,
+  ) {
+    const platform = getClientPlatform();
+    if (platform) {
+      request.getMetadata()["x-couchers-client-platform"] = platform;
+    }
+    return invoker(request);
+  }
+}
+
 const authInterceptor = new AuthInterceptor();
 const timeoutInterceptor = new TimeoutInterceptor();
 const userAgentInterceptor = new UserAgentInterceptor();
+const platformInterceptor = new PlatformInterceptor();
 
 const opts = {
   unaryInterceptors: [
     authInterceptor,
     timeoutInterceptor,
     userAgentInterceptor,
+    platformInterceptor,
   ],
   // this modifies the behaviour on the API so that it will send cookies on the requests
   withCredentials: true,

--- a/app/mobile/tests/service/client.test.ts
+++ b/app/mobile/tests/service/client.test.ts
@@ -2,9 +2,11 @@ import { Request, StatusCode } from "grpc-web";
 
 import {
   AuthInterceptor,
+  PlatformInterceptor,
   setUnauthenticatedErrorHandler,
   UserAgentInterceptor,
 } from "@/service/client";
+import { getClientPlatform } from "@/utils/clientPlatform";
 
 describe("AuthInterceptor", () => {
   it("returns a successful response", async () => {
@@ -52,5 +54,24 @@ describe("UserAgentInterceptor", () => {
 
     expect(response).toMatchObject({ test: "test" });
     expect(metadata["User-Agent"]).toContain("CouchersNative/");
+  });
+});
+
+describe("PlatformInterceptor", () => {
+  it("declares the native client platform on the request metadata", async () => {
+    const metadata: Record<string, string> = {};
+    const request = {
+      getMetadata: () => metadata,
+    } as unknown as Request<unknown, unknown>;
+    const invokerMock = jest.fn(() => ({ test: "test" }));
+    const interceptor = new PlatformInterceptor();
+
+    const response = await interceptor.intercept(request, invokerMock);
+
+    expect(response).toMatchObject({ test: "test" });
+    expect(metadata["x-couchers-client-platform"]).toBe(getClientPlatform());
+    expect(["app_ios", "app_android"]).toContain(
+      metadata["x-couchers-client-platform"],
+    );
   });
 });

--- a/app/mobile/utils/clientPlatform.ts
+++ b/app/mobile/utils/clientPlatform.ts
@@ -1,0 +1,14 @@
+import { Platform } from "react-native";
+
+export type ClientPlatform = "app_ios" | "app_android";
+
+export function getClientPlatform(): ClientPlatform | null {
+  switch (Platform.OS) {
+    case "ios":
+      return "app_ios";
+    case "android":
+      return "app_android";
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
Adds a `PlatformInterceptor` to the mobile gRPC client that sends the `x-couchers-client-platform` metadata header (`app_ios` / `app_android`) on every request, mirroring the web client's interceptor.

The backend recently started recording the client platform (`logging.api_calls`, `user_activity`, and the active-users-by-platform metric) by reading this client-declared header. The web frontend already sends `web_desktop` / `web_mobile`, but the native app sent nothing, so its traffic showed up as `unknown`. With this change native API calls are attributed to iOS/Android correctly.

A new `utils/clientPlatform.ts` maps `Platform.OS` to the backend enum values (returning `null` for anything other than ios/android, so the web build never sends a bogus value).

## Testing
- `npm run lint` — clean.
- `npm test tests/service/client.test.ts` — 5/5 passing, including a new `PlatformInterceptor` test asserting the metadata header is set to the native platform value.

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._