### PR TITLE
mobile: force-build escape hatch + version-stable fingerprint for OTA continuity

### DIFF
--- a/app/mobile/fingerprint.config.js
+++ b/app/mobile/fingerprint.config.js
@@ -4,10 +4,12 @@
 // could never match an already-installed build. Nothing under `extra` (router,
 // eas, gitHash) affects the native binary, so excluding it keeps the fingerprint
 // stable across commits while still rebuilding when real native inputs change.
-// The default package.json script skip is preserved.
+// The default package.json script skip is preserved. ExpoConfigVersions excludes
+// the marketing version/build number so a release bump keeps OTA continuity.
 module.exports = {
   sourceSkips: [
     "PackageJsonAndroidAndIosScriptsIfNotContainRun",
     "ExpoConfigExtraSection",
+    "ExpoConfigVersions",
   ],
 };

--- a/app/mobile/scripts/production-build.sh
+++ b/app/mobile/scripts/production-build.sh
@@ -44,13 +44,19 @@ echo "EAS_FINGERPRINT=$CURRENT" > "$DOTENV"
 PREVIOUS="$(aws s3 cp "$MARKER" - 2>/dev/null || true)"
 echo "last-submitted $PLATFORM fingerprint: ${PREVIOUS:-<none>}"
 
-if [ -n "$PREVIOUS" ] && [ "$PREVIOUS" = "$CURRENT" ]; then
+# A scheduled pipeline sets FORCE_NATIVE_BUILD_AND_SUBMIT to cut a fresh store build
+# even when nothing native changed, so the store/TestFlight binary doesn't go stale
+# behind OTA. The new build keeps the same runtimeVersion, so the live OTA bundle
+# still applies; autoIncrement bumps the build number so nothing collides.
+if [ "${FORCE_NATIVE_BUILD_AND_SUBMIT:-}" = "true" ]; then
+  echo "FORCE_NATIVE_BUILD_AND_SUBMIT set — building a new $PLATFORM production app regardless of fingerprint."
+elif [ -n "$PREVIOUS" ] && [ "$PREVIOUS" = "$CURRENT" ]; then
   echo "Fingerprint unchanged for $PLATFORM — the live production build still matches, skipping build."
   echo "EAS_BUILD_ID=" >> "$DOTENV"
   exit 0
+else
+  echo "Fingerprint changed for $PLATFORM — building a new production app on EAS."
 fi
-
-echo "Fingerprint changed for $PLATFORM — building a new production app on EAS."
 
 # EAS evaluates app.config.js and the native-build plugin on its own servers,
 # which don't see this job's shell env, so the embedded version would fall back to

--- a/app/mobile/scripts/production-build.sh
+++ b/app/mobile/scripts/production-build.sh
@@ -44,10 +44,10 @@ echo "EAS_FINGERPRINT=$CURRENT" > "$DOTENV"
 PREVIOUS="$(aws s3 cp "$MARKER" - 2>/dev/null || true)"
 echo "last-submitted $PLATFORM fingerprint: ${PREVIOUS:-<none>}"
 
-# A scheduled pipeline sets FORCE_NATIVE_BUILD_AND_SUBMIT to cut a fresh store build
-# even when nothing native changed, so the store/TestFlight binary doesn't go stale
-# behind OTA. The new build keeps the same runtimeVersion, so the live OTA bundle
-# still applies; autoIncrement bumps the build number so nothing collides.
+# Set FORCE_NATIVE_BUILD_AND_SUBMIT to cut a fresh store build even when nothing
+# native changed, so the store/TestFlight binary doesn't go stale behind OTA. The
+# new build keeps the same runtimeVersion, so the live OTA bundle still applies;
+# autoIncrement bumps the build number so nothing collides.
 if [ "${FORCE_NATIVE_BUILD_AND_SUBMIT:-}" = "true" ]; then
   echo "FORCE_NATIVE_BUILD_AND_SUBMIT set — building a new $PLATFORM production app regardless of fingerprint."
 elif [ -n "$PREVIOUS" ] && [ "$PREVIOUS" = "$CURRENT" ]; then


### PR DESCRIPTION
Two related mobile build/OTA changes.

**1. `FORCE_NATIVE_BUILD_AND_SUBMIT` escape hatch** (`production-build.sh`). A production store build is normally only cut when the Expo fingerprint changes vs. the last-submitted marker in S3 — pure JS/TS changes ship via OTA instead. That's the right default, but it means the store/TestFlight binary can go stale behind OTA over a long run of JS-only changes. Setting `FORCE_NATIVE_BUILD_AND_SUBMIT=true` on a pipeline skips the fingerprint short-circuit and always builds, so the existing `deploy:production-native-*` jobs submit it (iOS → TestFlight/ASC, Android → Play internal track; public promotion stays manual). The forced build keeps the same `runtimeVersion`, so the live signed OTA bundle still applies to it, and `autoIncrement` bumps the build number so nothing collides. Default behavior (variable unset) is unchanged.

**2. Exclude the store version from the fingerprint** (`fingerprint.config.js`). Adds `ExpoConfigVersions` to the fingerprint `sourceSkips`, so bumping the marketing `version` (and the EAS-assigned build number) no longer moves the `runtimeVersion`. Without this, every release bump cuts a new `runtimeVersion` and strands installed builds; with it, OTA continuity holds across version bumps. (Consequence: a `version` bump alone no longer triggers a store build via the fingerprint comparison — cut the new-version binary with a forced build.)

## Testing
- `bash -n scripts/production-build.sh` passes.
- The force flag is a guarded branch: var unset leaves the fingerprint-skip path untouched; var set always builds and populates `EAS_BUILD_ID` so the submit job runs.
- The `ExpoConfigVersions` skip is verified against the installed `@expo/fingerprint` source: with that flag set, `normalizeExpoConfig` deletes `version`/`versionCode`/`buildNumber` before hashing.

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._