### PR TITLE
backend: rewrite where_users_column_visible as EXISTS to kill alias hotspot

### DIFF
--- a/app/backend/src/couchers/sql.py
+++ b/app/backend/src/couchers/sql.py
@@ -91,13 +91,17 @@ def where_users_column_visible[T: tuple[Any, ...]](
     """
     Filters the given column, not yet joined/selected from
     """
-    hidden_users = _relevant_user_blocks(context.user_id)
-    aliased_user = aliased(User)
-    return (
-        query.join(aliased_user, aliased_user.id == column)
-        .where(aliased_user.is_visible)
-        .where(_shadow_clause(context, aliased_user))
-        .where(~aliased_user.id.in_(hidden_users))
+    # EXISTS on the bare User table rather than aliased(User): aliasing the wide User entity per call
+    # is a major CPU hotspot (rebuilds the ORM proxy index). correlate_except keeps this User local to
+    # the subquery so it doesn't bind to a bare User already in the outer query (e.g. jobs/handlers.py).
+    return query.where(
+        exists(
+            select(1)
+            .select_from(User)
+            .where(User.id == column)
+            .where(users_visible(context, User))
+            .correlate_except(User)
+        )
     )
 
 


### PR DESCRIPTION
Rewrites `where_users_column_visible` (`src/couchers/sql.py`) from a per-call `aliased(User)` join to a correlated `EXISTS` on the bare `User` table.

A `py-spy --gil` capture of the live API process identified this helper as the single biggest GIL hotspot (~20% of GIL-held time), entirely in SQLAlchemy's column-correspondence / proxy-set machinery. The cost was `aliased(User)` on every call: aliasing the very wide `User` ORM entity rebuilds the column-correspondence proxy index (O(columns-of-User)), never cached. It runs on nearly every list/count query and several times per `Ping`, so it's a permanent fleet-wide CPU tax.

The rewrite uses the bare mapped `User` (no alias → no proxy-index rebuild) inside an `EXISTS`, reusing the existing `users_visible()` helper for the visibility conditions. `correlate_except(User)` is load-bearing: it keeps the subquery's `User` local so it doesn't auto-correlate to a bare `User` already present in the outer query (the message-notification queries in `jobs/handlers.py` select from `User` as the initiator while filtering the recipient).

Row-equivalence holds because the old join was on `User.id` (PK), so it never multiplied rows — it was purely a filter, which `EXISTS` reproduces exactly. Generated SQL was inspected for both the simple case and the outer-`User` case to confirm correct correlation.

## Testing
- Verified generated SQL by compiling statements for both a plain `FriendRelationship` count and the `jobs/handlers.py`-style query (outer `User` = initiator, filter on recipient); correlation resolves as intended.
- `uv run pytest` on the affected suites, all green:
  - `test_visible_users` (5) — covers blocked-either-direction, deleted/banned, shadowed-hidden-from-others, and the shadowed-self exception
  - references / requests / conversations / public_trips (122)
  - threads / events / groups / api (107)
  - search (23), bg_jobs incl. message notifications (30)
- `make format` clean; `make mypy` clean for this change (one pre-existing unrelated error in `test_calendar_events.py` re: missing `ics` stubs).

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug (existing `test_visible_users.py` covers the equivalence; no behavior change)
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history (no database changes)

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._