### PR TITLE
mobile: regenerate proto stubs on EAS native builds

### DIFF
--- a/app/mobile/ci-build-protos.sh
+++ b/app/mobile/ci-build-protos.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # Generates the gRPC-Web/JS stubs consumed by the Expo app (app/mobile/proto).
-# Self-contained (downloads its own protoc/grpc-web) as a local convenience for mobile
-# devs without the full dev toolchain, via `npm run build:protos`. CI (GitLab) and EAS
-# Build both use the stubs generated once by the shared `protos` job
-# (app/generate_protos.sh) and shipped as an artifact — they do not run this script.
+# Self-contained (downloads its own protoc/grpc-web) so it can run in environments
+# without the full dev toolchain: EAS Build's eas-build-pre-install hook, and as a
+# local fallback via `npm run build:protos`. GitLab CI instead generates these stubs
+# in the shared `protos` job (app/generate_protos.sh) and ships them as an artifact —
+# its OTA/test jobs consume that artifact in place, but EAS cloud native builds upload
+# the project and must regenerate the (git-ignored) stubs themselves via the hook.
 
 set -euo pipefail
 

--- a/app/mobile/package.json
+++ b/app/mobile/package.json
@@ -9,6 +9,7 @@
     "start:devtool": "APP_VARIANT=devtool expo start --scheme couchers-devtool",
     "start:localhost": "expo start --localhost",
     "build:protos": "bash ./ci-build-protos.sh",
+    "eas-build-pre-install": "npm run build:protos",
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",


### PR DESCRIPTION
## Description

Fixes the `develop` mobile native build breakage introduced by `devops/refactor/mobile-protos-shared-gen`:

```
Unable to resolve module @/proto/bugs_pb from .../app/mobile/features/diagnostics/NativeUpdatePrompt.tsx
```

### Root cause

The refactor moved mobile proto-stub generation into the shared `generate_protos.sh` (emitting into the git-ignored `app/mobile/proto/`) and dropped the `eas-build-pre-install` hook, on the assumption that EAS cloud native builds would carry the stubs from the GitLab `protos` artifact.

That assumption holds for the **OTA/test jobs** — they run on the GitLab runner (`needs: ["protos"]`) and consume the artifact in place. It fails for **native builds**: `eas build` uploads the project to EAS's cloud, and `app/mobile/proto/` is git-ignored (`proto/**`), so the generated stubs never make it into the upload. Metro then can't resolve `@/proto/bugs_pb`.

### Fix

Restore the EAS-only `eas-build-pre-install` hook so the cloud native build regenerates its own stubs from the committed `.proto` sources via the self-contained `ci-build-protos.sh` — exactly as it did before the refactor. `npm ci` on the GitLab runners does not trigger this hook, so the OTA/test jobs keep using the artifact unchanged.

## Testing

- `eas-build-pre-install` only runs inside EAS Build, so it doesn't affect the GitLab OTA/test jobs.
- Validated locally that `npm run build:protos` regenerates `app/mobile/proto/bugs_pb.js` (and the rest of the stubs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)