### PR TITLE
mobile: fix root .easignore directory pruning for EAS uploads

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -2,21 +2,22 @@
 # present, so this defines the whole upload. It exists to ship app/mobile/proto
 # (git-ignored, built by the `protos` job) to EAS without regenerating it there.
 
-# Upload only the mobile app.
+# Upload only the mobile app. (No trailing slash on the re-includes: eas-cli's
+# directory walker tests bare names like "app", and "!/app/" wouldn't match those.)
 /*
-!/app/
+!/app
 /app/*
-!/app/mobile/
+!/app/mobile
 
 # app/mobile ignores, minus proto/. Anchored /ios|/android so modules/*/ios stays.
-.expo/
-dist/
-web-build/
+.expo
+dist
+web-build
 expo-env.d.ts
-/app/mobile/ios/
-/app/mobile/android/
-.kotlin/
-/app/mobile/ota-out/
+/app/mobile/ios
+/app/mobile/android
+.kotlin
+/app/mobile/ota-out
 /app/mobile/ota-expo-config.json
 .metro-health-check*
 npm-debug.*
@@ -35,6 +36,6 @@ GoogleService-Info.plist
 .env*.local
 *.orig.*
 *.tsbuildinfo
-coverage/
-submit/
+coverage
+submit
 .DS_Store


### PR DESCRIPTION
Follow-up to #8887, which merged but broke the EAS native build:

```
package.json does not exist in /Users/expo/workingdir/build/app/mobile
```

### Root cause

eas-cli walks the project tree and **prunes ignored directories**, querying bare directory names (`app`, `app/mobile`) — no trailing slash. The whitelist re-includes from #8887 were written with trailing slashes (`!/app/`, `!/app/mobile/`), which the `ignore` npm package only matches against `app/`, not the bare `app`. So `/*` kept `app` ignored, eas-cli pruned the entire `app/` subtree before descending, and `app/mobile` (hence `package.json`) never made it into the build.

I'd originally verified with `git check-ignore`, which uses directory-by-directory traversal and re-includes `app/` correctly — masking the bug. eas-cli uses the `ignore` package with a prune-walk, which behaves differently. This time I verified against the actual `ignore` package.

### Fix

- Drop the trailing slashes on the re-includes (`!/app`, `!/app/mobile`) so the bare directory names match and the walker descends into `app/mobile`.
- Drop them on the ignore-dir patterns too (`/app/mobile/ios`, `.expo`, `coverage`, …) so those prune outright instead of being descended into and emptied file-by-file. Anchoring still protects `modules/*/ios`.

## Testing

Verified every rule — both bare-directory and file forms — against the `ignore` npm package that eas-cli actually uses (40/40 assertions): `app/mobile` plus the proto stubs and the public OTA code-signing certs upload; `app/mobile/ios|android`, caches, secrets, and the entire non-mobile monorepo are excluded. The real confirmation is the EAS build on this branch.

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._