### PR TITLE
Mobile: Add request for review prompt after positive reference left

### DIFF
--- a/app/mobile/components/WebEmbed.tsx
+++ b/app/mobile/components/WebEmbed.tsx
@@ -1,4 +1,5 @@
 import { useFocusEffect } from "expo-router";
+import { hasAction, requestReview } from "expo-store-review";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -369,6 +370,10 @@ export default function WebEmbed({
       } else if (payload?.type === "REQUEST_IMAGE_PICK") {
         // WebView file input crashes on mobile; use native picker instead.
         pickImage(sendImagePickResult);
+      } else if (payload?.type === "REQUEST_REVIEW") {
+        hasAction().then((canReview) => {
+          if (canReview) requestReview();
+        });
       }
     } catch (error) {
       // Ignore non-JSON messages from browser/WebView internals.

--- a/app/web/features/profile/view/leaveReference/formSteps/submit/SubmitReference.tsx
+++ b/app/web/features/profile/view/leaveReference/formSteps/submit/SubmitReference.tsx
@@ -136,15 +136,17 @@ export default function SubmitReference({
   };
 
   const redirectToThankYouPage = () => {
+    const rating = referenceData.rating ?? 0;
+    const ratingParam = `?rating=${rating}`;
     if (
       referenceType === referenceTypeRoute[ReferenceType.REFERENCE_TYPE_FRIEND]
     ) {
       router.push(
-        `${leaveReferenceBaseRoute}/${referenceType}/${userId}/${referenceStepStrings[4]}`,
+        `${leaveReferenceBaseRoute}/${referenceType}/${userId}/${referenceStepStrings[4]}${ratingParam}`,
       );
     } else {
       router.push(
-        `${leaveReferenceBaseRoute}/${referenceType}/${userId}/${hostRequestId}/${referenceStepStrings[4]}`,
+        `${leaveReferenceBaseRoute}/${referenceType}/${userId}/${hostRequestId}/${referenceStepStrings[4]}${ratingParam}`,
       );
     }
   };

--- a/app/web/features/profile/view/leaveReference/formSteps/submit/ThankYouReference.tsx
+++ b/app/web/features/profile/view/leaveReference/formSteps/submit/ThankYouReference.tsx
@@ -4,12 +4,24 @@ import StyledLink from "components/StyledLink";
 import { Trans, useTranslation } from "i18n";
 import { PROFILE } from "i18n/namespaces";
 import { useRouter } from "next/router";
+import { useEffect } from "react";
 import { dashboardRoute, donationsRoute } from "routes";
 import { theme } from "theme";
+import { sendNativeRequestReview, useIsNativeEmbed } from "utils/nativeLink";
 
 const ThankYouReference = () => {
   const { t } = useTranslation([PROFILE]);
   const router = useRouter();
+
+  const isNativeEmbed = useIsNativeEmbed();
+
+  useEffect(() => {
+    if (!isNativeEmbed) return;
+    const rating = Number(router.query.rating);
+    if (!isNaN(rating) && rating > 0.5) {
+      sendNativeRequestReview();
+    }
+  }, [isNativeEmbed, router.query.rating]);
 
   return (
     <>

--- a/app/web/utils/nativeLink.ts
+++ b/app/web/utils/nativeLink.ts
@@ -41,7 +41,8 @@ type MessageType =
   | "clearState"
   | "REQUEST_IMAGE_PICK"
   | "NATIVE_BACK"
-  | "LANGUAGE_CHANGE";
+  | "LANGUAGE_CHANGE"
+  | "REQUEST_REVIEW";
 
 function sendToNative(type: MessageType, data: unknown) {
   if (!isNativeEmbed()) return;
@@ -64,6 +65,10 @@ export function clearState(key: string) {
 
 export function sendLanguageChange(locale: string) {
   sendToNative("LANGUAGE_CHANGE", { locale });
+}
+
+export function sendNativeRequestReview() {
+  sendToNative("REQUEST_REVIEW", {});
 }
 
 // Image picker bridge for native mobile app


### PR DESCRIPTION
Sneaking this in as it didn't seem that hard to implement.

When landing on the thank you final page of the reference flow, if the rating was positive, it will prompt the user to review the app.

Apple/Google Play controls how often this shows, so just be careful when testing as it might be a one shot deal.

<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*
- Send a host request and let the time pass
- Leave a review with a positive rating with mobile app and finish the flow
- It should prompt to leave a review if you have not already

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
