### PR TITLE
Improve missing friend request error handling

### DIFF
--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -476,7 +476,7 @@ def _render_friend_request__create(
         loc_context,
         substitutions={"from_user": data.other_user.name},
         icon_user=data.other_user,
-        action_url=urls.friend_requests_link(),
+        action_url=urls.friend_requests_link(from_user_id=data.other_user.user_id),
     )
 
 

--- a/app/backend/src/couchers/urls.py
+++ b/app/backend/src/couchers/urls.py
@@ -91,8 +91,11 @@ def profile_references_link() -> str:
     return f"{config['BASE_URL']}/profile/references"
 
 
-def friend_requests_link() -> str:
-    return f"{config['BASE_URL']}/connections/friends/"
+def friend_requests_link(*, from_user_id: int | None = None) -> str:
+    url = f"{config['BASE_URL']}/connections/friends/"
+    if from_user_id is not None:
+        url += f"?from={from_user_id}"
+    return url
 
 
 def media_upload_url(*, path: str) -> str:

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -867,6 +867,7 @@ def test_friend_request_flow(db, email_collector: EmailCollector, push_collector
     push = push_collector.pop_for_user(user2.id, last=True)
     assert push.content.title == f"Friend request from {user1.name}"
     assert push.content.body == f"{user1.name} wants to be your friend."
+    assert push.content.action_url == f"http://localhost:3000/connections/friends/?from={user1.id}"
 
     email = email_collector.pop_for_recipient(user2.email, last=True)
     assert email.recipient == user2.email

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -361,7 +361,7 @@ def test_list_notifications(db, push_collector: PushCollector, moderator):
     assert n.title == f"Friend request from {user2.name}"
     assert n.body == f"{user2.name} wants to be your friend."
     assert n.icon.startswith("http://localhost:5001/img/thumbnail/")
-    assert n.url == "http://localhost:3000/connections/friends/"
+    assert n.url == f"http://localhost:3000/connections/friends/?from={user2.id}"
 
     with conversations_session(token2) as c:
         res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user1.id]))

--- a/app/web/features/connections/friends/FriendRequestsReceived.test.tsx
+++ b/app/web/features/connections/friends/FriendRequestsReceived.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import mockRouter from "next-router-mock";
+import { FriendRequest } from "proto/api_pb";
+import { service } from "service";
+import wrapper from "test/hookWrapper";
+import i18n from "test/i18n";
+import { getLiteUsers } from "test/serviceMockDefaults";
+
+import FriendRequestsReceived from "./FriendRequestsReceived";
+
+const { t } = i18n;
+
+const getLiteUsersMock = service.user.getLiteUsers as jest.Mock;
+const listFriendRequestsMock = service.api.listFriendRequests as jest.Mock<
+  ReturnType<typeof service.api.listFriendRequests>
+>;
+
+const pendingRequestFromUser3: FriendRequest.AsObject = {
+  friendRequestId: 10,
+  state: FriendRequest.FriendRequestStatus.PENDING,
+  userId: 3,
+  sent: false,
+};
+
+beforeEach(() => {
+  mockRouter.setCurrentUrl("/connections/friends/");
+  getLiteUsersMock.mockImplementation(getLiteUsers);
+  listFriendRequestsMock.mockResolvedValue({
+    receivedList: [],
+    sentList: [],
+  });
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe("FriendRequestsReceived with no ?from query param", () => {
+  it("shows the empty state message when there are no pending requests", async () => {
+    render(<FriendRequestsReceived />, { wrapper });
+
+    expect(
+      await screen.findByText(t("connections:no_friend_requests")),
+    ).toBeVisible();
+    expect(
+      screen.queryByText(t("connections:friend_request_no_longer_available")),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows pending requests without an alert", async () => {
+    listFriendRequestsMock.mockResolvedValue({
+      receivedList: [pendingRequestFromUser3],
+      sentList: [],
+    });
+
+    render(<FriendRequestsReceived />, { wrapper });
+
+    expect(
+      await screen.findByRole("heading", { name: /Funny Kid/ }),
+    ).toBeVisible();
+    expect(
+      screen.queryByText(t("connections:friend_request_no_longer_available")),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("FriendRequestsReceived with ?from=<userId> query param", () => {
+  it("does not show an alert when the expected request is present", async () => {
+    mockRouter.setCurrentUrl("/connections/friends/?from=3");
+    listFriendRequestsMock.mockResolvedValue({
+      receivedList: [pendingRequestFromUser3],
+      sentList: [],
+    });
+
+    render(<FriendRequestsReceived />, { wrapper });
+
+    await screen.findByRole("heading", { name: /Funny Kid/ });
+    expect(
+      screen.queryByText(t("connections:friend_request_no_longer_available")),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows an info alert when the expected request is not in the list", async () => {
+    mockRouter.setCurrentUrl("/connections/friends/?from=3");
+
+    render(<FriendRequestsReceived />, { wrapper });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(t("connections:friend_request_no_longer_available")),
+      ).toBeVisible(),
+    );
+  });
+
+  it("shows an alert when requests exist but none are from the expected user", async () => {
+    mockRouter.setCurrentUrl("/connections/friends/?from=3");
+    listFriendRequestsMock.mockResolvedValue({
+      receivedList: [
+        {
+          friendRequestId: 11,
+          state: FriendRequest.FriendRequestStatus.PENDING,
+          userId: 2,
+          sent: false,
+        },
+      ],
+      sentList: [],
+    });
+
+    render(<FriendRequestsReceived />, { wrapper });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(t("connections:friend_request_no_longer_available")),
+      ).toBeVisible(),
+    );
+    // The other (unrelated) request still renders
+    expect(
+      await screen.findByRole("heading", { name: /Funny Dog/ }),
+    ).toBeVisible();
+  });
+});

--- a/app/web/features/connections/friends/FriendRequestsReceived.tsx
+++ b/app/web/features/connections/friends/FriendRequestsReceived.tsx
@@ -1,6 +1,8 @@
 import { Stack } from "@mui/material";
+import Alert from "components/Alert";
 import Button from "components/Button";
 import { CONNECTIONS } from "i18n/namespaces";
+import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { FriendRequest } from "proto/api_pb";
 import { useIsMounted, useSafeState } from "utils/hooks";
@@ -70,30 +72,45 @@ function FriendRequestsReceived() {
   const [mutationError, setMutationError] = useSafeState(isMounted, "");
   const { data, isLoading, isError, errors } = useFriendRequests("received");
   const { t } = useTranslation([CONNECTIONS]);
+  const router = useRouter();
+
+  const fromUserId = router.query.from ? Number(router.query.from) : null;
+  const requestNotFound =
+    fromUserId !== null &&
+    !isLoading &&
+    data !== undefined &&
+    !data.some((req) => req.userId === fromUserId);
 
   return (
-    <FriendTile
-      title={t("connections:friend_requests")}
-      errorMessage={
-        isError ? errors.join("\n") : mutationError ? mutationError : null
-      }
-      isLoading={isLoading}
-      hasData={!!data?.length}
-      noDataMessage={t("connections:no_friend_requests")}
-    >
-      {data &&
-        data.map((friendRequest) => (
-          <FriendSummaryView
-            key={friendRequest.friendRequestId}
-            friend={friendRequest.friend}
-          >
-            <RespondToFriendRequestAction
-              friendRequest={friendRequest}
-              setMutationError={setMutationError}
-            />
-          </FriendSummaryView>
-        ))}
-    </FriendTile>
+    <>
+      {requestNotFound && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          {t("connections:friend_request_no_longer_available")}
+        </Alert>
+      )}
+      <FriendTile
+        title={t("connections:friend_requests")}
+        errorMessage={
+          isError ? errors.join("\n") : mutationError ? mutationError : null
+        }
+        isLoading={isLoading}
+        hasData={!!data?.length}
+        noDataMessage={t("connections:no_friend_requests")}
+      >
+        {data &&
+          data.map((friendRequest) => (
+            <FriendSummaryView
+              key={friendRequest.friendRequestId}
+              friend={friendRequest.friend}
+            >
+              <RespondToFriendRequestAction
+                friendRequest={friendRequest}
+                setMutationError={setMutationError}
+              />
+            </FriendSummaryView>
+          ))}
+      </FriendTile>
+    </>
   );
 }
 

--- a/app/web/features/connections/locales/en.json
+++ b/app/web/features/connections/locales/en.json
@@ -22,6 +22,7 @@
   "no_blocked_users": "No blocked users",
   "no_friends": "No friends available",
   "no_friend_requests": "No pending friend requests",
+  "friend_request_no_longer_available": "This friend request is no longer available.",
   "no_friend_requests_sent": "No pending friend requests",
   "pending": "Pending",
   "remove_friend": "Remove friend",


### PR DESCRIPTION
My attempt to improve the missing friend request error handling after a bug report.

Closes #8814 
<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*
- You need two accounts, make a new dummy one and friend request our other account
- Delete that user
- Log into other account and tap notification for friend request
- It should have the proper error

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
