### PR TITLE
Mobile: Badge click via profile should open within profile sheet

### DIFF
--- a/app/web/features/badges/Badge.tsx
+++ b/app/web/features/badges/Badge.tsx
@@ -1,4 +1,5 @@
 import { Chip, styled, Tooltip } from "@mui/material";
+import { useProfileSheet } from "features/profile/ProfileSheetContext";
 import Link from "next/link";
 import { Badge as BadgeType } from "proto/resources_pb";
 import { routeToBadge } from "routes";
@@ -16,6 +17,21 @@ const StyledTooltip = styled(Tooltip)(({ theme }) => ({
 }));
 
 export default function Badge({ badge }: BadgeProps) {
+  const { openProfileUserId, openBadge } = useProfileSheet();
+  const isInSheet = openProfileUserId !== null;
+
+  if (isInSheet) {
+    return (
+      <StyledTooltip title={badge.description}>
+        <Chip
+          label={badge.name}
+          onClick={() => openBadge(badge.id)}
+          sx={{ background: badge.color, cursor: "pointer" }}
+        />
+      </StyledTooltip>
+    );
+  }
+
   return (
     <StyledTooltip title={badge.description}>
       <Chip

--- a/app/web/features/badges/BadgeDetail.tsx
+++ b/app/web/features/badges/BadgeDetail.tsx
@@ -1,0 +1,37 @@
+import { Box, Typography } from "@mui/material";
+import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
+import { useFeatureValue } from "experimentation";
+import Badge from "features/badges/Badge";
+import { useBadges } from "features/badges/hooks";
+import { useTranslation } from "i18n";
+import { PROFILE } from "i18n/namespaces";
+
+import BadgeUserList from "./BadgeUserList";
+
+interface BadgeDetailProps {
+  badgeId: string;
+}
+
+export default function BadgeDetail({ badgeId }: BadgeDetailProps) {
+  const { t } = useTranslation([PROFILE]);
+  const { badges, isLoading } = useBadges();
+
+  const showModeratorBadge = useFeatureValue("show_moderator_badge", true);
+  const isHidden = badgeId === "moderator" && !showModeratorBadge;
+
+  if (isLoading) return <CenteredSpinner />;
+  if (!badges || !(badgeId in badges) || isHidden) {
+    return <Typography>{t("profile:badges.not_found")}</Typography>;
+  }
+
+  const badge = badges[badgeId];
+  return (
+    <>
+      <Box sx={{ display: "flex", gap: 1, alignItems: "center", mb: 2 }}>
+        <Badge badge={badge} />
+        <Typography variant="body1">{badge.description}</Typography>
+      </Box>
+      <BadgeUserList badgeId={badgeId} />
+    </>
+  );
+}

--- a/app/web/features/badges/BadgesPage.tsx
+++ b/app/web/features/badges/BadgesPage.tsx
@@ -6,7 +6,6 @@ import {
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
 import HtmlMeta from "components/HtmlMeta";
 import PageTitle from "components/PageTitle";
 import { useFeatureValue } from "experimentation";
@@ -15,7 +14,7 @@ import { useBadges } from "features/badges/hooks";
 import { useTranslation } from "i18n";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
 
-import BadgeUserList from "./BadgeUserList";
+import BadgeDetail from "./BadgeDetail";
 
 const BadgeListItem = styled("div")(({ theme }) => ({
   [theme.breakpoints.down("md")]: {
@@ -27,13 +26,10 @@ const StyledDivider = styled(Divider)<DividerProps>(({ theme }) => ({
   margin: theme.spacing(2),
 }));
 
-const FlexDiv = styled("div")(({ theme }) => ({
+const ParentFlexDiv = styled("div")(({ theme }) => ({
   display: "flex",
   gap: theme.spacing(2),
   alignItems: "start",
-}));
-
-const ParentFlexDiv = styled(FlexDiv)(({ theme }) => ({
   [theme.breakpoints.down("md")]: {
     flexDirection: "column",
     gap: theme.spacing(0),
@@ -46,11 +42,11 @@ const ContentDiv = styled("div")(({ theme }) => ({
   width: "100%",
 }));
 
-const CenteredDiv = styled(ContentDiv)(({ theme }) => ({
+const CenteredDiv = styled(ContentDiv)({
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
-}));
+});
 
 interface BadgesPageProps {
   badgeId?: string;
@@ -58,7 +54,7 @@ interface BadgesPageProps {
 
 export default function BadgesPage({ badgeId = undefined }: BadgesPageProps) {
   const { t } = useTranslation([GLOBAL, PROFILE]);
-  const { badges, isLoading: isBadgesLoading } = useBadges();
+  const { badges } = useBadges();
   const theme = useTheme();
 
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
@@ -94,21 +90,7 @@ export default function BadgesPage({ badgeId = undefined }: BadgesPageProps) {
         />
         {badgeId ? (
           <ContentDiv>
-            {isBadgesLoading ? (
-              <CenteredSpinner />
-            ) : badges && badgeId in badges && !isHiddenBadge(badgeId) ? (
-              <>
-                <FlexDiv>
-                  <Badge badge={badges[badgeId]} />
-                  <Typography variant="body1">
-                    {badges[badgeId].description}
-                  </Typography>
-                </FlexDiv>
-                <BadgeUserList badgeId={badgeId} />
-              </>
-            ) : (
-              <>{t("profile:badges.not_found")}</>
-            )}
+            <BadgeDetail badgeId={badgeId} />
           </ContentDiv>
         ) : (
           <CenteredDiv>

--- a/app/web/features/profile/ProfileSheet.tsx
+++ b/app/web/features/profile/ProfileSheet.tsx
@@ -7,6 +7,7 @@ import {
   SwipeableDrawer,
 } from "@mui/material";
 import Snackbar from "components/Snackbar";
+import BadgeDetail from "features/badges/BadgeDetail";
 import GroupChatView from "features/messages/groupchats/GroupChatView";
 import NewHostRequest from "features/profile/view/NewHostRequest";
 import NewMessage from "features/profile/view/NewMessage";
@@ -99,6 +100,8 @@ export default function ProfileSheet() {
     closeProfileSheet,
     openGroupChatId,
     closeGroupChat,
+    selectedBadgeId,
+    closeBadge,
   } = useProfileSheet();
   const router = useRouter();
   const { data: user, isLoading } = useUser(openProfileUserId ?? undefined);
@@ -172,9 +175,9 @@ export default function ProfileSheet() {
     >
       <SheetHeader>
         <Puller />
-        {openGroupChatId && (
+        {(openGroupChatId || selectedBadgeId) && (
           <IconButton
-            onClick={closeGroupChat}
+            onClick={selectedBadgeId ? closeBadge : closeGroupChat}
             aria-label={t("global:back")}
             size="small"
           >
@@ -184,6 +187,10 @@ export default function ProfileSheet() {
       </SheetHeader>
       {openGroupChatId ? (
         <GroupChatView chatId={openGroupChatId} embedded />
+      ) : selectedBadgeId ? (
+        <ScrollContent sx={{ p: 2 }}>
+          <BadgeDetail badgeId={selectedBadgeId} />
+        </ScrollContent>
       ) : (
         <ScrollContent ref={scrollRef}>
           {isSuccessRequest && (

--- a/app/web/features/profile/ProfileSheetContext.tsx
+++ b/app/web/features/profile/ProfileSheetContext.tsx
@@ -13,6 +13,9 @@ interface ProfileSheetContextType {
   openGroupChatId: number | null;
   openGroupChat: (groupChatId: number) => void;
   closeGroupChat: () => void;
+  selectedBadgeId: string | null;
+  openBadge: (badgeId: string) => void;
+  closeBadge: () => void;
 }
 
 const ProfileSheetContext = createContext<ProfileSheetContextType | null>(null);
@@ -22,15 +25,18 @@ export function ProfileSheetProvider({ children }: { children: ReactNode }) {
     null,
   );
   const [openGroupChatId, setOpenGroupChatId] = useState<number | null>(null);
+  const [selectedBadgeId, setSelectedBadgeId] = useState<string | null>(null);
 
   const openProfileSheet = useCallback((userId: number) => {
     setOpenProfileUserId(userId);
     setOpenGroupChatId(null);
+    setSelectedBadgeId(null);
   }, []);
 
   const closeProfileSheet = useCallback(() => {
     setOpenProfileUserId(null);
     setOpenGroupChatId(null);
+    setSelectedBadgeId(null);
   }, []);
 
   const openGroupChat = useCallback((groupChatId: number) => {
@@ -39,6 +45,14 @@ export function ProfileSheetProvider({ children }: { children: ReactNode }) {
 
   const closeGroupChat = useCallback(() => {
     setOpenGroupChatId(null);
+  }, []);
+
+  const openBadge = useCallback((badgeId: string) => {
+    setSelectedBadgeId(badgeId);
+  }, []);
+
+  const closeBadge = useCallback(() => {
+    setSelectedBadgeId(null);
   }, []);
 
   return (
@@ -50,6 +64,9 @@ export function ProfileSheetProvider({ children }: { children: ReactNode }) {
         openGroupChatId,
         openGroupChat,
         closeGroupChat,
+        selectedBadgeId,
+        openBadge,
+        closeBadge,
       }}
     >
       {children}
@@ -64,6 +81,9 @@ const noopProfileSheet: ProfileSheetContextType = {
   openGroupChatId: null,
   openGroupChat: () => {},
   closeGroupChat: () => {},
+  selectedBadgeId: null,
+  openBadge: () => {},
+  closeBadge: () => {},
 };
 
 export function useProfileSheet() {


### PR DESCRIPTION
Closes #8577 

A bug was reported that clicking a badge within the profileSheet redirects out of the sheet, making the user lose their place in search results.

I forgot to handle this in the ProfileSheet the first go so doing it now here.


## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*
- Search via the map
- Click a user that has a profile badge
- Click the badge
- The badges view should open with the profile sheet
- Go back to search results and place should be saved

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
