### PR TITLE
Try to fix mobile tests not running on CI

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -560,8 +560,10 @@ test:mobile:
     - if: ($BUILD_MOBILE == "true") && ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
     - if: ($BUILD_MOBILE == "true") && ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
       changes:
-        - app/proto/**/*
-        - app/mobile/**/*
+        paths:
+          - app/proto/**/*
+          - app/mobile/**/*
+        compare_to: refs/heads/develop
 
 test:mobile-linting:
   needs: ["protos"]
@@ -577,7 +579,9 @@ test:mobile-linting:
     - if: ($BUILD_MOBILE == "true") && ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
     - if: ($BUILD_MOBILE == "true") && ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
       changes:
-        - app/mobile/**/*
+        paths:
+          - app/mobile/**/*
+        compare_to: refs/heads/develop
 
 test:mobile-typecheck:
   needs: ["protos"]
@@ -593,7 +597,9 @@ test:mobile-typecheck:
     - if: ($BUILD_MOBILE == "true") && ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
     - if: ($BUILD_MOBILE == "true") && ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
       changes:
-        - app/mobile/**/*
+        paths:
+          - app/mobile/**/*
+        compare_to: refs/heads/develop
 
 test:mobile-expo-doctor:
   needs: ["protos"]
@@ -610,8 +616,10 @@ test:mobile-expo-doctor:
     - if: ($BUILD_MOBILE == "true") && ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
     - if: ($BUILD_MOBILE == "true") && ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
       changes:
-        - app/mobile/package.json
-        - app/mobile/package-lock.json
+        paths:
+          - app/mobile/package.json
+          - app/mobile/package-lock.json
+        compare_to: refs/heads/develop
 
 test:proxy:
   needs: ["build:proxy"]


### PR DESCRIPTION
We merged some failing mobile tests in a branch which made me realize the mobile tests are not running as part of the CI when they should. 

This is an attempt to fix that, i.e. if there is mobile code changes in the `/mobile/` folder it should run the mobile tests as part of the gitlab CI so we can see when tests are failing before we merge anything.

<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
