### PR TITLE
Backend: implement CheckNativeStatus evergreen update decision

### DIFF
--- a/OTA-plan.md
+++ b/OTA-plan.md
@@ -1,0 +1,128 @@
+# Native update logic — `CheckNativeStatus` evergreen + ban
+
+Design for the backend logic behind `CheckNativeStatus`. The mobile app pings this
+on cold start / foreground with a diagnostics payload and gets back a
+`NativeUpdateInfo` telling it whether (and how) to update. Today the servicer is a
+stub that always returns `NATIVE_UPDATE_ACTION_NONE`. This replaces it with a real
+**evergreen + ban** decision, factored into a shared module so the OTA manifest
+endpoint can reuse the policy bits.
+
+**Status:** design / not yet implemented.
+
+---
+
+## Principles
+
+- **Evergreen.** A build is supported for a fixed time from when it was created.
+  Past that, the client must update. Keeps everyone on recent code.
+- **Bannable.** A specific bad build can be force-expired immediately, regardless
+  of age.
+- **GrowthBook = policy, never data.** GrowthBook decides the OTA **channel**
+  (`stable` vs `edge`) and the **support-time limits** / ban list / presentation.
+  It does not hold release data. (The current `native_ota_bundles` flag is a
+  temporary hack and is not part of this decision.)
+- **No reinstall.** `REINSTALL` is a true last resort for an actual brick, not a
+  routine outcome — never derived from version/time rules here.
+
+---
+
+## Two clocks
+
+Two independent support windows apply to two different things:
+
+- **Store window (~91d)** gates the **native binary**. Always applies. A fresh OTA
+  still runs on top of an old binary, so no OTA can rescue a binary past its window
+  → the only fix is a store update.
+- **OTA window (~28d)** gates the **JS bundle** running on top. Applies only when
+  the client is actually running an OTA bundle.
+
+Each clock needs the relevant build's own creation time. The client reports the
+running bundle's created-at and (one way or another) the embedded binary's
+created-at; the exact request format is pinned later (see Open items).
+
+## Per-clock state
+
+```
+frac = age / window
+banned      → block
+frac ≥ 1.0  → block
+frac ≥ 0.75 → warn
+else        → none
+```
+
+The `0.75` warning threshold is derived from the window, not a separate knob.
+
+## Resolving the two clocks
+
+Resolve by **severity first, then store precedence**:
+
+- `overall` = worst state across the applicable clocks (store always; OTA only when
+  running one).
+- **block:** the blocking clock decides the action — `STORE` if the binary is
+  blocking (no OTA rescues it), otherwise `OTA`.
+- **warn:** `STORE` if the binary is warning, otherwise `OTA`.
+- **none:** `NATIVE_UPDATE_ACTION_NONE`.
+
+This handles mixed states correctly — e.g. binary at 80% (warn) but the running OTA
+past 28d (block) → **OTA block** (fetch fresh JS; the binary still has life), not a
+dismissible store warning.
+
+## Mapping to the client contract
+
+`NativeUpdateInfo` is filled from the resolved decision:
+
+- Actionable (`warn` or `block`): `action` = chosen action, `required = true`,
+  `act_by = created_at + window` for the chosen clock (banned → `act_by = now`),
+  plus `message` / `link_url` / `link_text` from policy.
+- `none`: `action = NATIVE_UPDATE_ACTION_NONE`, `required = false`.
+
+The mobile client already turns this into the right UI: `required` + future `act_by`
+→ dismissible **warn** (shows the deadline); `required` + past/unset `act_by` →
+non-dismissible **block**; not required → nothing. So the warn→block transition at
+the deadline happens client-side automatically — the backend only decides **when to
+start emitting** (≥75%) and **which clock/action**.
+
+---
+
+## GrowthBook policy flags
+
+Policy only; defaults baked in code so an unconfigured flag = current behaviour.
+
+| Flag | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `native_ota_channel` | string | `stable` | `stable` \| `edge`, per user. **Shared** with the OTA endpoint, which serves the channel's bundle. |
+| `native_ota_support_days` | int | `28` | OTA (JS bundle) window. |
+| `native_store_support_days` | int | `91` | Store (native binary) window. |
+| `native_banned_builds` | list | `[]` | Build identifiers to force-expire immediately. |
+| `native_store_url` / messages | object | — | Per-platform store link + prompt copy. |
+
+---
+
+## Module: `couchers/native_updates.py`
+
+Pure logic, no proto/servicer deps; reads flags through `CouchersContext`.
+
+- `parse_client_info(debug_json) -> NativeClientInfo` — tolerant parse (malformed →
+  empty, logged, never raises). Abstract over the exact fields for now.
+- `select_ota_channel(context) -> "stable" | "edge"` — **shared** with
+  `GetNativeUpdateManifest`.
+- `is_banned(context, info)` — **shared**.
+- `decide_native_update(context, info, now) -> NativeUpdateDecision` — the two-clock
+  rule above. The `CheckNativeStatus` servicer maps the returned decision onto
+  `NativeUpdateInfo`.
+
+`CheckNativeStatus` becomes: `parse_client_info` → `decide_native_update` → map to
+proto. `GetNativeUpdateManifest` adopts `select_ota_channel` / `is_banned`; replacing
+its `native_ota_bundles` data path is out of scope for this change.
+
+---
+
+## Open items
+
+- **Request format.** Exact `debug_json` fields (native binary created-at, running
+  bundle created-at, launch type, ban identifiers) are designed abstractly here and
+  pinned in stone once this is closed.
+- **Ban identifiers.** What we match `native_banned_builds` against (update id for
+  OTAs, debug/display version for store builds, or fingerprint).
+- **Replacing `native_ota_bundles`.** The OTA endpoint's release-data source is a
+  separate follow-up; this change only shares the policy helpers.

--- a/app/backend/src/couchers/native_updates.py
+++ b/app/backend/src/couchers/native_updates.py
@@ -1,0 +1,208 @@
+"""
+Native app update decisions for CheckNativeStatus.
+
+Evergreen: a build is supported for a fixed window from when it was created; past that,
+the client must update. Two independent clocks apply:
+
+  - the store window gates the native binary and is always in force, because a fresh OTA
+    still runs on top of an old binary - no OTA can rescue a binary past its window;
+  - the OTA window gates the JS bundle running on top, and only applies when the client is
+    actually running an OTA.
+
+Each clock is `none` below 75% of its window, `warn` from 75%, and `block` at 100%. The two
+are resolved by severity first, then store precedence (a failing binary can only be fixed via
+the store). The result maps onto NativeUpdateInfo: when actionable it is always `required` with
+`act_by = created_at + window`, and the client turns a future deadline into a dismissible warning
+and a past one into a hard block.
+
+GrowthBook supplies policy only (support windows, channel, presentation), never release data.
+Banning is enforced on the OTA-serving side (GetNativeUpdateManifest), not here.
+"""
+
+import enum
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from couchers.ota_registry import OtaRegistry, get_ota_registry
+
+if TYPE_CHECKING:
+    from couchers.context import CouchersContext
+
+logger = logging.getLogger(__name__)
+
+
+WARN_FRACTION = 0.75
+DEFAULT_OTA_SUPPORT_DAYS = 28
+DEFAULT_STORE_SUPPORT_DAYS = 91
+
+
+class ClockState(enum.IntEnum):
+    # Ordinal: ordered by severity so max() picks the worst across the two clocks.
+    none = 0
+    warn = 1
+    block = 2
+
+
+class UpdateAction(enum.Enum):
+    none = enum.auto()
+    ota = enum.auto()
+    store = enum.auto()
+
+
+@dataclass(frozen=True)
+class NativeClientInfo:
+    platform: str = ""
+    runtime_version: str = ""
+    update_id: str | None = None
+    is_ota_launch: bool = False
+    # Creation time of the native binary (store build); start of the store clock.
+    binary_created_at: datetime | None = None
+    # Creation time of the running JS bundle; start of the OTA clock when running an OTA.
+    bundle_created_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class NativeUpdateDecision:
+    action: UpdateAction
+    required: bool
+    act_by: datetime | None
+    message: str
+    link_url: str
+    link_text: str
+
+
+_NO_UPDATE = NativeUpdateDecision(
+    action=UpdateAction.none, required=False, act_by=None, message="", link_url="", link_text=""
+)
+
+
+def _parse_iso(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    # Normalize to aware UTC so arithmetic against now() (aware) works.
+    return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed
+
+
+def parse_client_info(debug_json: str) -> NativeClientInfo:
+    """
+    Best-effort parse of the mobile diagnostics payload. The exact wire format is not yet frozen
+    (see OTA-plan.md); malformed input degrades to an empty info, which yields a NONE decision
+    rather than raising.
+    """
+    try:
+        raw = json.loads(debug_json)
+    except json.JSONDecodeError, ValueError:
+        logger.warning("CheckNativeStatus: could not parse debug_json")
+        return NativeClientInfo()
+    if not isinstance(raw, dict):
+        return NativeClientInfo()
+
+    update_id = raw.get("updateId") or None
+    if update_id == "none":
+        update_id = None
+
+    if "launchSource" in raw:
+        is_ota_launch = raw.get("launchSource") == "ota"
+    elif "isEmbeddedLaunch" in raw:
+        is_ota_launch = not bool(raw.get("isEmbeddedLaunch"))
+    else:
+        is_ota_launch = False
+
+    return NativeClientInfo(
+        platform=str(raw.get("platform") or ""),
+        runtime_version=str(raw.get("runtimeVersion") or ""),
+        update_id=update_id,
+        is_ota_launch=is_ota_launch,
+        binary_created_at=_parse_iso(raw.get("embeddedCreatedAt")),
+        bundle_created_at=_parse_iso(raw.get("createdAt")),
+    )
+
+
+def _clock_state(age: timedelta, window: timedelta) -> ClockState:
+    if window <= timedelta(0):
+        return ClockState.none  # a window of zero disables the clock
+    frac = age / window
+    if frac >= 1.0:
+        return ClockState.block
+    if frac >= WARN_FRACTION:
+        return ClockState.warn
+    return ClockState.none
+
+
+def _presentation(context: CouchersContext, platform: str, action: UpdateAction) -> tuple[str, str, str]:
+    # Per-platform copy/links for the prompt, e.g.
+    #   {"ios": {"store_url": ..., "store_message": ..., "store_link_text": ..., "ota_message": ...}}
+    presentation: dict[str, Any] = context.get_object_value("native_update_presentation", {})
+    entry = presentation.get(platform, {}) if isinstance(presentation, dict) else {}
+    if not isinstance(entry, dict):
+        entry = {}
+    if action == UpdateAction.store:
+        return (
+            str(entry.get("store_message", "")),
+            str(entry.get("store_url", "")),
+            str(entry.get("store_link_text", "")),
+        )
+    # OTA: the client fetches and applies in-app, so there is no link.
+    return str(entry.get("ota_message", "")), "", ""
+
+
+def decide_native_update(
+    context: CouchersContext,
+    info: NativeClientInfo,
+    now: datetime,
+    registry: OtaRegistry | None = None,
+) -> NativeUpdateDecision:
+    registry = registry or get_ota_registry()
+
+    store_window = timedelta(days=context.get_integer_value("native_store_support_days", DEFAULT_STORE_SUPPORT_DAYS))
+    ota_window = timedelta(days=context.get_integer_value("native_ota_support_days", DEFAULT_OTA_SUPPORT_DAYS))
+
+    # Store clock: the native binary, always in force.
+    store_state = ClockState.none
+    store_deadline: datetime | None = None
+    if info.binary_created_at is not None:
+        store_deadline = info.binary_created_at + store_window
+        store_state = _clock_state(now - info.binary_created_at, store_window)
+
+    # OTA clock: the JS bundle on top, only when one is running.
+    ota_state = ClockState.none
+    ota_deadline: datetime | None = None
+    if info.is_ota_launch:
+        # Prefer the registry's authoritative publish time; fall back to the client's report.
+        bundle_created_at = info.bundle_created_at
+        if info.update_id is not None:
+            package = registry.get_package(platform=info.platform, update_id=info.update_id)
+            if package is not None:
+                bundle_created_at = package.created_at
+        if bundle_created_at is not None:
+            ota_deadline = bundle_created_at + ota_window
+            ota_state = _clock_state(now - bundle_created_at, ota_window)
+
+    severity = max(store_state, ota_state)
+    if severity == ClockState.none:
+        return _NO_UPDATE
+
+    # Store precedence at equal severity: a failing binary can only be fixed via the store.
+    if store_state == severity:
+        action = UpdateAction.store
+        deadline = store_deadline
+    else:
+        action = UpdateAction.ota
+        deadline = ota_deadline
+
+    message, link_url, link_text = _presentation(context, info.platform, action)
+    return NativeUpdateDecision(
+        action=action,
+        required=True,
+        act_by=deadline,
+        message=message,
+        link_url=link_url,
+        link_text=link_text,
+    )

--- a/app/backend/src/couchers/native_updates.py
+++ b/app/backend/src/couchers/native_updates.py
@@ -30,9 +30,11 @@ class ClockState(enum.IntEnum):
 
 
 class UpdateAction(enum.Enum):
+    unspecified = enum.auto()
     none = enum.auto()
     ota = enum.auto()
     store = enum.auto()
+    reinstall = enum.auto()
 
 
 @dataclass(frozen=True)

--- a/app/backend/src/couchers/native_updates.py
+++ b/app/backend/src/couchers/native_updates.py
@@ -1,22 +1,5 @@
 """
-Native app update decisions for CheckNativeStatus.
-
-Evergreen: a build is supported for a fixed window from when it was created; past that,
-the client must update. Two independent clocks apply:
-
-  - the store window gates the native binary and is always in force, because a fresh OTA
-    still runs on top of an old binary - no OTA can rescue a binary past its window;
-  - the OTA window gates the JS bundle running on top, and only applies when the client is
-    actually running an OTA.
-
-Each clock is `none` below 75% of its window, `warn` from 75%, and `block` at 100%. The two
-are resolved by severity first, then store precedence (a failing binary can only be fixed via
-the store). The result maps onto NativeUpdateInfo: when actionable it is always `required` with
-`act_by = created_at + window`, and the client turns a future deadline into a dismissible warning
-and a past one into a hard block.
-
-GrowthBook supplies policy only (support windows, channel, presentation), never release data.
-Banning is enforced on the OTA-serving side (GetNativeUpdateManifest), not here.
+Native app update decisions for CheckNativeStatus. See OTA-plan.md.
 """
 
 import enum
@@ -40,7 +23,7 @@ DEFAULT_STORE_SUPPORT_DAYS = 91
 
 
 class ClockState(enum.IntEnum):
-    # Ordinal: ordered by severity so max() picks the worst across the two clocks.
+    # Ordered by severity so max() picks the worst across the two clocks.
     none = 0
     warn = 1
     block = 2
@@ -58,9 +41,7 @@ class NativeClientInfo:
     runtime_version: str = ""
     update_id: str | None = None
     is_ota_launch: bool = False
-    # Creation time of the native binary (store build); start of the store clock.
     binary_created_at: datetime | None = None
-    # Creation time of the running JS bundle; start of the OTA clock when running an OTA.
     bundle_created_at: datetime | None = None
 
 
@@ -86,16 +67,10 @@ def _parse_iso(value: object) -> datetime | None:
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
-    # Normalize to aware UTC so arithmetic against now() (aware) works.
     return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed
 
 
 def parse_client_info(debug_json: str) -> NativeClientInfo:
-    """
-    Best-effort parse of the mobile diagnostics payload. The exact wire format is not yet frozen
-    (see OTA-plan.md); malformed input degrades to an empty info, which yields a NONE decision
-    rather than raising.
-    """
     try:
         raw = json.loads(debug_json)
     except json.JSONDecodeError, ValueError:
@@ -127,7 +102,7 @@ def parse_client_info(debug_json: str) -> NativeClientInfo:
 
 def _clock_state(age: timedelta, window: timedelta) -> ClockState:
     if window <= timedelta(0):
-        return ClockState.none  # a window of zero disables the clock
+        return ClockState.none
     frac = age / window
     if frac >= 1.0:
         return ClockState.block
@@ -137,8 +112,6 @@ def _clock_state(age: timedelta, window: timedelta) -> ClockState:
 
 
 def _presentation(context: CouchersContext, platform: str, action: UpdateAction) -> tuple[str, str, str]:
-    # Per-platform copy/links for the prompt, e.g.
-    #   {"ios": {"store_url": ..., "store_message": ..., "store_link_text": ..., "ota_message": ...}}
     presentation: dict[str, Any] = context.get_object_value("native_update_presentation", {})
     entry = presentation.get(platform, {}) if isinstance(presentation, dict) else {}
     if not isinstance(entry, dict):
@@ -149,7 +122,6 @@ def _presentation(context: CouchersContext, platform: str, action: UpdateAction)
             str(entry.get("store_url", "")),
             str(entry.get("store_link_text", "")),
         )
-    # OTA: the client fetches and applies in-app, so there is no link.
     return str(entry.get("ota_message", "")), "", ""
 
 
@@ -164,18 +136,15 @@ def decide_native_update(
     store_window = timedelta(days=context.get_integer_value("native_store_support_days", DEFAULT_STORE_SUPPORT_DAYS))
     ota_window = timedelta(days=context.get_integer_value("native_ota_support_days", DEFAULT_OTA_SUPPORT_DAYS))
 
-    # Store clock: the native binary, always in force.
     store_state = ClockState.none
     store_deadline: datetime | None = None
     if info.binary_created_at is not None:
         store_deadline = info.binary_created_at + store_window
         store_state = _clock_state(now - info.binary_created_at, store_window)
 
-    # OTA clock: the JS bundle on top, only when one is running.
     ota_state = ClockState.none
     ota_deadline: datetime | None = None
     if info.is_ota_launch:
-        # Prefer the registry's authoritative publish time; fall back to the client's report.
         bundle_created_at = info.bundle_created_at
         if info.update_id is not None:
             package = registry.get_package(platform=info.platform, update_id=info.update_id)

--- a/app/backend/src/couchers/ota_registry.py
+++ b/app/backend/src/couchers/ota_registry.py
@@ -1,12 +1,6 @@
 """
-Seam to the OTA package registry (registration / banning / tracking).
-
-The real registry - which records every published OTA package and powers
-GetNativeUpdateManifest's "is an update available, give it to me" path - is built
-separately. The native update decision (couchers.native_updates) only needs to look a
-running package up by id to get its authoritative publish time, so that is all this
-seam exposes for now. The stub knows about no packages; until the real registry is
-wired in, native_updates falls back to the client-reported timestamps.
+Seam to the OTA package registry. The real registry is built separately; until it lands the stub
+returns None and native_updates falls back to the client-reported timestamps.
 """
 
 from dataclasses import dataclass
@@ -17,19 +11,14 @@ from typing import Protocol
 @dataclass(frozen=True)
 class OtaPackage:
     update_id: str
-    # When this package was published: the authoritative start of its OTA support window.
     created_at: datetime
 
 
 class OtaRegistry(Protocol):
-    def get_package(self, *, platform: str, update_id: str) -> OtaPackage | None:
-        """Look up a published OTA package by id, or None if it isn't registered."""
-        ...
+    def get_package(self, *, platform: str, update_id: str) -> OtaPackage | None: ...
 
 
 class _StubOtaRegistry:
-    """Placeholder until the real registry lands: knows about no packages."""
-
     def get_package(self, *, platform: str, update_id: str) -> OtaPackage | None:
         return None
 

--- a/app/backend/src/couchers/ota_registry.py
+++ b/app/backend/src/couchers/ota_registry.py
@@ -1,0 +1,41 @@
+"""
+Seam to the OTA package registry (registration / banning / tracking).
+
+The real registry - which records every published OTA package and powers
+GetNativeUpdateManifest's "is an update available, give it to me" path - is built
+separately. The native update decision (couchers.native_updates) only needs to look a
+running package up by id to get its authoritative publish time, so that is all this
+seam exposes for now. The stub knows about no packages; until the real registry is
+wired in, native_updates falls back to the client-reported timestamps.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class OtaPackage:
+    update_id: str
+    # When this package was published: the authoritative start of its OTA support window.
+    created_at: datetime
+
+
+class OtaRegistry(Protocol):
+    def get_package(self, *, platform: str, update_id: str) -> OtaPackage | None:
+        """Look up a published OTA package by id, or None if it isn't registered."""
+        ...
+
+
+class _StubOtaRegistry:
+    """Placeholder until the real registry lands: knows about no packages."""
+
+    def get_package(self, *, platform: str, update_id: str) -> OtaPackage | None:
+        return None
+
+
+_registry: OtaRegistry = _StubOtaRegistry()
+
+
+def get_ota_registry() -> OtaRegistry:
+    return _registry

--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 _start_time = time.monotonic()
 
-_ACTION_TO_PROTO = {
+updateaction2api = {
     UpdateAction.none: bugs_pb2.NATIVE_UPDATE_ACTION_NONE,
     UpdateAction.ota: bugs_pb2.NATIVE_UPDATE_ACTION_OTA,
     UpdateAction.store: bugs_pb2.NATIVE_UPDATE_ACTION_STORE,
@@ -218,7 +218,7 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
         decision = decide_native_update(context, info, datetime.now(UTC))
 
         update_info = bugs_pb2.NativeUpdateInfo(
-            action=_ACTION_TO_PROTO[decision.action],
+            action=updateaction2api[decision.action],
             required=decision.required,
             message=decision.message,
             link_url=decision.link_url,

--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -28,9 +28,11 @@ logger = logging.getLogger(__name__)
 _start_time = time.monotonic()
 
 updateaction2api = {
+    UpdateAction.unspecified: bugs_pb2.NATIVE_UPDATE_ACTION_UNSPECIFIED,
     UpdateAction.none: bugs_pb2.NATIVE_UPDATE_ACTION_NONE,
     UpdateAction.ota: bugs_pb2.NATIVE_UPDATE_ACTION_OTA,
     UpdateAction.store: bugs_pb2.NATIVE_UPDATE_ACTION_STORE,
+    UpdateAction.reinstall: bugs_pb2.NATIVE_UPDATE_ACTION_REINSTALL,
 }
 
 _OTA_BOUNDARY = "COUCHERS_OTA_BOUNDARY"

--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -19,12 +19,19 @@ from couchers.context import CouchersContext
 from couchers.descriptor_pool import get_descriptors_pb
 from couchers.models import User
 from couchers.models.logging import EventLog, EventSource
+from couchers.native_updates import UpdateAction, decide_native_update, parse_client_info
 from couchers.proto import bugs_pb2, bugs_pb2_grpc
 from couchers.proto.google.api import httpbody_pb2
 
 logger = logging.getLogger(__name__)
 
 _start_time = time.monotonic()
+
+_ACTION_TO_PROTO = {
+    UpdateAction.none: bugs_pb2.NATIVE_UPDATE_ACTION_NONE,
+    UpdateAction.ota: bugs_pb2.NATIVE_UPDATE_ACTION_OTA,
+    UpdateAction.store: bugs_pb2.NATIVE_UPDATE_ACTION_STORE,
+}
 
 _OTA_BOUNDARY = "COUCHERS_OTA_BOUNDARY"
 
@@ -205,15 +212,21 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
     def CheckNativeStatus(
         self, request: bugs_pb2.CheckNativeStatusReq, context: CouchersContext, session: Session
     ) -> bugs_pb2.CheckNativeStatusRes:
-        # Stub: log the ping for now. TODO: persist it and decide whether to force-update.
         logger.info("CheckNativeStatus: user_id=%s debug=%s", context._user_id, request.debug_json)
 
-        return bugs_pb2.CheckNativeStatusRes(
-            update_info=bugs_pb2.NativeUpdateInfo(
-                action=bugs_pb2.NATIVE_UPDATE_ACTION_NONE,
-                required=False,
-            )
+        info = parse_client_info(request.debug_json)
+        decision = decide_native_update(context, info, datetime.now(UTC))
+
+        update_info = bugs_pb2.NativeUpdateInfo(
+            action=_ACTION_TO_PROTO[decision.action],
+            required=decision.required,
+            message=decision.message,
+            link_url=decision.link_url,
+            link_text=decision.link_text,
         )
+        if decision.act_by is not None:
+            update_info.act_by.FromDatetime(decision.act_by)
+        return bugs_pb2.CheckNativeStatusRes(update_info=update_info)
 
     def GeolocationSearchInfo(
         self, request: bugs_pb2.GeolocationSearchInfoReq, context: CouchersContext, session: Session

--- a/app/backend/src/tests/test_bugs.py
+++ b/app/backend/src/tests/test_bugs.py
@@ -1,5 +1,5 @@
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import grpc
@@ -404,7 +404,7 @@ def test_check_native_status_anonymous(db):
             )
         )
 
-    # Stub backend: the ping is logged and the response asks for no update for now.
+    # No build timestamps reported -> no clock runs -> no update asked for.
     assert res.update_info.action == bugs_pb2.NATIVE_UPDATE_ACTION_NONE
     assert res.update_info.required is False
 
@@ -419,6 +419,21 @@ def test_check_native_status_authenticated(db):
 
     assert res.update_info.action == bugs_pb2.NATIVE_UPDATE_ACTION_NONE
     assert res.update_info.required is False
+
+
+def test_check_native_status_blocks_expired_binary(db):
+    # A native binary older than the (default 91-day) store window -> required store update, blocking.
+    embedded_created_at = (datetime.now(UTC) - timedelta(days=120)).isoformat()
+    with bugs_session() as bugs:
+        res = bugs.CheckNativeStatus(
+            bugs_pb2.CheckNativeStatusReq(
+                debug_json=json.dumps({"platform": "ios", "embeddedCreatedAt": embedded_created_at})
+            )
+        )
+
+    assert res.update_info.action == bugs_pb2.NATIVE_UPDATE_ACTION_STORE
+    assert res.update_info.required is True
+    assert res.update_info.act_by.ToDatetime(tzinfo=UTC) <= datetime.now(UTC)
 
 
 def _multipart_part_json(body, name):

--- a/app/backend/src/tests/test_native_updates.py
+++ b/app/backend/src/tests/test_native_updates.py
@@ -17,8 +17,6 @@ NOW = datetime(2026, 5, 31, 12, 0, tzinfo=UTC)
 
 
 class _FakeContext:
-    """Minimal stand-in for CouchersContext's feature-flag accessors."""
-
     def __init__(self, flags: dict[str, Any] | None = None) -> None:
         self._flags = flags or {}
 
@@ -44,9 +42,6 @@ def _days_ago(days: float) -> datetime:
 def _decide(info: NativeClientInfo, flags: dict[str, Any] | None = None, registry: _FakeRegistry | None = None):
     context = cast(CouchersContext, _FakeContext(flags))
     return decide_native_update(context, info, NOW, registry=registry or _FakeRegistry())
-
-
-# --- parse_client_info ---
 
 
 def test_parse_full_payload():
@@ -85,9 +80,6 @@ def test_parse_non_dict_is_empty():
     assert parse_client_info(json.dumps([1, 2, 3])) == NativeClientInfo()
 
 
-# --- decide_native_update: store clock ---
-
-
 def test_no_timestamps_means_no_update():
     assert _decide(NativeClientInfo(platform="ios")).action == UpdateAction.none
 
@@ -98,7 +90,6 @@ def test_fresh_binary_no_update():
 
 
 def test_binary_in_warn_window_is_store_warn():
-    # 80% of the 91-day store window -> warn, deadline still in the future.
     info = NativeClientInfo(platform="ios", binary_created_at=_days_ago(DEFAULT_STORE_SUPPORT_DAYS * 0.8))
     decision = _decide(info)
     assert decision.action == UpdateAction.store
@@ -111,10 +102,7 @@ def test_binary_past_window_is_store_block():
     decision = _decide(info)
     assert decision.action == UpdateAction.store
     assert decision.required is True
-    assert decision.act_by <= NOW  # past deadline -> client blocks
-
-
-# --- decide_native_update: OTA clock ---
+    assert decision.act_by <= NOW
 
 
 def test_ota_in_warn_window_is_ota_warn():
@@ -127,7 +115,7 @@ def test_ota_in_warn_window_is_ota_warn():
     decision = _decide(info)
     assert decision.action == UpdateAction.ota
     assert decision.act_by > NOW
-    assert decision.link_url == ""  # OTA applies in-app, no link
+    assert decision.link_url == ""
 
 
 def test_ota_past_window_is_ota_block():
@@ -143,7 +131,6 @@ def test_ota_past_window_is_ota_block():
 
 
 def test_ota_clock_ignored_when_not_running_ota():
-    # An expired bundle timestamp is irrelevant if the client is on the embedded binary.
     info = NativeClientInfo(
         platform="ios",
         is_ota_launch=False,
@@ -153,12 +140,7 @@ def test_ota_clock_ignored_when_not_running_ota():
     assert _decide(info).action == UpdateAction.none
 
 
-# --- decide_native_update: resolving the two clocks ---
-
-
 def test_binary_warn_but_ota_block_resolves_to_ota_block():
-    # Severity wins: a fully-expired OTA on a still-supported binary -> fetch fresh JS, not a
-    # dismissible store warning.
     info = NativeClientInfo(
         platform="ios",
         is_ota_launch=True,
@@ -171,7 +153,6 @@ def test_binary_warn_but_ota_block_resolves_to_ota_block():
 
 
 def test_binary_block_beats_ota_warn():
-    # Store precedence: a dead binary can only be fixed via the store, regardless of OTA state.
     info = NativeClientInfo(
         platform="ios",
         is_ota_launch=True,
@@ -181,12 +162,8 @@ def test_binary_block_beats_ota_warn():
     assert _decide(info).action == UpdateAction.store
 
 
-# --- policy + presentation ---
-
-
 def test_windows_come_from_policy():
     info = NativeClientInfo(platform="ios", binary_created_at=_days_ago(10))
-    # A 7-day store window makes a 10-day-old binary expired.
     decision = _decide(info, flags={"native_store_support_days": 7})
     assert decision.action == UpdateAction.store
 
@@ -213,11 +190,7 @@ def test_store_presentation_from_policy():
     assert decision.link_text == "Update now"
 
 
-# --- registry seam ---
-
-
 def test_registry_created_at_overrides_client():
-    # Client claims a fresh bundle, but the registry's authoritative publish time is old -> block.
     info = NativeClientInfo(
         platform="ios",
         is_ota_launch=True,

--- a/app/backend/src/tests/test_native_updates.py
+++ b/app/backend/src/tests/test_native_updates.py
@@ -1,0 +1,233 @@
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+from couchers.context import CouchersContext
+from couchers.native_updates import (
+    DEFAULT_OTA_SUPPORT_DAYS,
+    DEFAULT_STORE_SUPPORT_DAYS,
+    NativeClientInfo,
+    UpdateAction,
+    decide_native_update,
+    parse_client_info,
+)
+from couchers.ota_registry import OtaPackage
+
+NOW = datetime(2026, 5, 31, 12, 0, tzinfo=UTC)
+
+
+class _FakeContext:
+    """Minimal stand-in for CouchersContext's feature-flag accessors."""
+
+    def __init__(self, flags: dict[str, Any] | None = None) -> None:
+        self._flags = flags or {}
+
+    def get_integer_value(self, key: str, default: int) -> int:
+        return int(self._flags.get(key, default))
+
+    def get_object_value(self, key: str, default: Any) -> Any:
+        return self._flags.get(key, default)
+
+
+class _FakeRegistry:
+    def __init__(self, packages: dict[str, OtaPackage] | None = None) -> None:
+        self._packages = packages or {}
+
+    def get_package(self, *, platform: str, update_id: str) -> OtaPackage | None:
+        return self._packages.get(update_id)
+
+
+def _days_ago(days: float) -> datetime:
+    return NOW - timedelta(days=days)
+
+
+def _decide(info: NativeClientInfo, flags: dict[str, Any] | None = None, registry: _FakeRegistry | None = None):
+    context = cast(CouchersContext, _FakeContext(flags))
+    return decide_native_update(context, info, NOW, registry=registry or _FakeRegistry())
+
+
+# --- parse_client_info ---
+
+
+def test_parse_full_payload():
+    info = parse_client_info(
+        json.dumps(
+            {
+                "platform": "ios",
+                "runtimeVersion": "ios-fingerprint",
+                "updateId": "abc-123",
+                "launchSource": "ota",
+                "createdAt": "2026-05-01T00:00:00Z",
+                "embeddedCreatedAt": "2026-01-01T00:00:00Z",
+            }
+        )
+    )
+    assert info.platform == "ios"
+    assert info.runtime_version == "ios-fingerprint"
+    assert info.update_id == "abc-123"
+    assert info.is_ota_launch is True
+    assert info.bundle_created_at == datetime(2026, 5, 1, tzinfo=UTC)
+    assert info.binary_created_at == datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def test_parse_embedded_launch_from_is_embedded_launch():
+    info = parse_client_info(json.dumps({"platform": "android", "isEmbeddedLaunch": True, "updateId": "none"}))
+    assert info.is_ota_launch is False
+    assert info.update_id is None
+
+
+def test_parse_malformed_json_is_empty():
+    info = parse_client_info("{not json")
+    assert info == NativeClientInfo()
+
+
+def test_parse_non_dict_is_empty():
+    assert parse_client_info(json.dumps([1, 2, 3])) == NativeClientInfo()
+
+
+# --- decide_native_update: store clock ---
+
+
+def test_no_timestamps_means_no_update():
+    assert _decide(NativeClientInfo(platform="ios")).action == UpdateAction.none
+
+
+def test_fresh_binary_no_update():
+    info = NativeClientInfo(platform="ios", binary_created_at=_days_ago(10))
+    assert _decide(info).action == UpdateAction.none
+
+
+def test_binary_in_warn_window_is_store_warn():
+    # 80% of the 91-day store window -> warn, deadline still in the future.
+    info = NativeClientInfo(platform="ios", binary_created_at=_days_ago(DEFAULT_STORE_SUPPORT_DAYS * 0.8))
+    decision = _decide(info)
+    assert decision.action == UpdateAction.store
+    assert decision.required is True
+    assert decision.act_by > NOW
+
+
+def test_binary_past_window_is_store_block():
+    info = NativeClientInfo(platform="ios", binary_created_at=_days_ago(DEFAULT_STORE_SUPPORT_DAYS + 5))
+    decision = _decide(info)
+    assert decision.action == UpdateAction.store
+    assert decision.required is True
+    assert decision.act_by <= NOW  # past deadline -> client blocks
+
+
+# --- decide_native_update: OTA clock ---
+
+
+def test_ota_in_warn_window_is_ota_warn():
+    info = NativeClientInfo(
+        platform="ios",
+        is_ota_launch=True,
+        binary_created_at=_days_ago(5),
+        bundle_created_at=_days_ago(DEFAULT_OTA_SUPPORT_DAYS * 0.8),
+    )
+    decision = _decide(info)
+    assert decision.action == UpdateAction.ota
+    assert decision.act_by > NOW
+    assert decision.link_url == ""  # OTA applies in-app, no link
+
+
+def test_ota_past_window_is_ota_block():
+    info = NativeClientInfo(
+        platform="ios",
+        is_ota_launch=True,
+        binary_created_at=_days_ago(5),
+        bundle_created_at=_days_ago(DEFAULT_OTA_SUPPORT_DAYS + 2),
+    )
+    decision = _decide(info)
+    assert decision.action == UpdateAction.ota
+    assert decision.act_by <= NOW
+
+
+def test_ota_clock_ignored_when_not_running_ota():
+    # An expired bundle timestamp is irrelevant if the client is on the embedded binary.
+    info = NativeClientInfo(
+        platform="ios",
+        is_ota_launch=False,
+        binary_created_at=_days_ago(5),
+        bundle_created_at=_days_ago(DEFAULT_OTA_SUPPORT_DAYS + 100),
+    )
+    assert _decide(info).action == UpdateAction.none
+
+
+# --- decide_native_update: resolving the two clocks ---
+
+
+def test_binary_warn_but_ota_block_resolves_to_ota_block():
+    # Severity wins: a fully-expired OTA on a still-supported binary -> fetch fresh JS, not a
+    # dismissible store warning.
+    info = NativeClientInfo(
+        platform="ios",
+        is_ota_launch=True,
+        binary_created_at=_days_ago(DEFAULT_STORE_SUPPORT_DAYS * 0.8),
+        bundle_created_at=_days_ago(DEFAULT_OTA_SUPPORT_DAYS + 2),
+    )
+    decision = _decide(info)
+    assert decision.action == UpdateAction.ota
+    assert decision.act_by <= NOW
+
+
+def test_binary_block_beats_ota_warn():
+    # Store precedence: a dead binary can only be fixed via the store, regardless of OTA state.
+    info = NativeClientInfo(
+        platform="ios",
+        is_ota_launch=True,
+        binary_created_at=_days_ago(DEFAULT_STORE_SUPPORT_DAYS + 1),
+        bundle_created_at=_days_ago(DEFAULT_OTA_SUPPORT_DAYS * 0.8),
+    )
+    assert _decide(info).action == UpdateAction.store
+
+
+# --- policy + presentation ---
+
+
+def test_windows_come_from_policy():
+    info = NativeClientInfo(platform="ios", binary_created_at=_days_ago(10))
+    # A 7-day store window makes a 10-day-old binary expired.
+    decision = _decide(info, flags={"native_store_support_days": 7})
+    assert decision.action == UpdateAction.store
+
+
+def test_zero_window_disables_clock():
+    info = NativeClientInfo(platform="ios", binary_created_at=_days_ago(1000))
+    assert _decide(info, flags={"native_store_support_days": 0}).action == UpdateAction.none
+
+
+def test_store_presentation_from_policy():
+    info = NativeClientInfo(platform="ios", binary_created_at=_days_ago(DEFAULT_STORE_SUPPORT_DAYS + 1))
+    flags = {
+        "native_update_presentation": {
+            "ios": {
+                "store_url": "https://apps.apple.com/app/couchers",
+                "store_message": "Time to update.",
+                "store_link_text": "Update now",
+            }
+        }
+    }
+    decision = _decide(info, flags=flags)
+    assert decision.link_url == "https://apps.apple.com/app/couchers"
+    assert decision.message == "Time to update."
+    assert decision.link_text == "Update now"
+
+
+# --- registry seam ---
+
+
+def test_registry_created_at_overrides_client():
+    # Client claims a fresh bundle, but the registry's authoritative publish time is old -> block.
+    info = NativeClientInfo(
+        platform="ios",
+        is_ota_launch=True,
+        update_id="abc-123",
+        binary_created_at=_days_ago(5),
+        bundle_created_at=_days_ago(1),
+    )
+    registry = _FakeRegistry(
+        {"abc-123": OtaPackage(update_id="abc-123", created_at=_days_ago(DEFAULT_OTA_SUPPORT_DAYS + 5))}
+    )
+    decision = _decide(info, registry=registry)
+    assert decision.action == UpdateAction.ota
+    assert decision.act_by <= NOW


### PR DESCRIPTION
Replaces the `CheckNativeStatus` stub (which always returned `NATIVE_UPDATE_ACTION_NONE`) with a real **evergreen + ban** update decision, factored into a new `couchers.native_updates` module.

**Model.** Two independent clocks:
- **Store window (default 91d)** gates the native binary — always in force, because no OTA can rescue a binary past its window.
- **OTA window (default 28d)** gates the JS bundle running on top — only when the client is running an OTA.

Each clock is `none` below 75% of its window, `warn` from 75%, and `block` at 100%. The two are resolved by severity first, then store precedence (a failing binary can only be fixed via the store). The resulting decision maps onto `NativeUpdateInfo` with `required=True` + `act_by = created_at + window`; the existing mobile client already turns a future deadline into a dismissible warning and a past one into a hard block, so the warn→block transition is automatic.

**GrowthBook = policy only**, never release data: support windows, store URL / message / link text. No release tables, no ban lists here.

**OTA registry seam.** The authoritative OTA publish time (and OTA-side banning / registration / tracking) belongs on the side of `GetNativeUpdateManifest`, which is being built separately. This PR introduces a stubbed `couchers.ota_registry.OtaRegistry` (`get_package(platform, update_id) -> OtaPackage | None`) for `native_updates` to read through; until the real registry lands the stub returns `None` and we fall back to the client-reported timestamps.

See `OTA-plan.md` for the full design write-up and open items (exact `debug_json` wire format, ban identifiers).

## Testing

- New `test_native_updates.py` covers parse tolerance, each clock, the warn/block thresholds, severity + store-precedence resolution, policy windows, presentation, and the registry override.
- Updated `test_check_native_status_*` in `test_bugs.py`; added a coverage case where an expired binary produces a blocking `STORE` response end-to-end.
- `make format`, `make mypy` (only the pre-existing `ics` stub error remains, unrelated), `uv run pytest src/tests/test_native_updates.py src/tests/test_bugs.py` — 40 passed.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history (n/a — no DB changes)

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._