### PR TITLE
CI: serialize EAS mobile jobs and staging deploy

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -949,6 +949,7 @@ build:mobile-native-devtool:
     default: false
   variables:
     APP_VARIANT: devtool
+  resource_group: mobile-eas-devtool
   before_script:
     - apt-get update -qq && apt-get install -y --no-install-recommends awscli curl
   script:
@@ -1059,6 +1060,7 @@ deploy:mobile-ota-staging:
 
 build:mobile-native-prod-ios:
   extends: .mobile-native-build
+  resource_group: mobile-eas-prod-ios
   variables:
     APP_VARIANT: production
   script:
@@ -1072,6 +1074,7 @@ build:mobile-native-prod-ios:
 
 build:mobile-native-prod-android:
   extends: .mobile-native-build
+  resource_group: mobile-eas-prod-android
   variables:
     APP_VARIANT: production
   script:
@@ -1086,6 +1089,7 @@ build:mobile-native-prod-android:
 deploy:mobile-native-prod-ios:
   extends: .mobile-native-submit
   needs: ["build:mobile-native-prod-ios"]
+  resource_group: mobile-eas-prod-ios
   variables:
     APP_VARIANT: production
   script:
@@ -1097,6 +1101,7 @@ deploy:mobile-native-prod-ios:
 deploy:mobile-native-prod-android:
   extends: .mobile-native-submit
   needs: ["build:mobile-native-prod-android"]
+  resource_group: mobile-eas-prod-android
   variables:
     APP_VARIANT: production
   script:
@@ -1107,6 +1112,7 @@ deploy:mobile-native-prod-android:
 
 build:mobile-native-staging-ios:
   extends: .mobile-native-build
+  resource_group: mobile-eas-staging-ios
   variables:
     APP_VARIANT: staging
   script:
@@ -1120,6 +1126,7 @@ build:mobile-native-staging-ios:
 
 build:mobile-native-staging-android:
   extends: .mobile-native-build
+  resource_group: mobile-eas-staging-android
   variables:
     APP_VARIANT: staging
   script:
@@ -1134,6 +1141,7 @@ build:mobile-native-staging-android:
 deploy:mobile-native-staging-ios:
   extends: .mobile-native-submit
   needs: ["build:mobile-native-staging-ios"]
+  resource_group: mobile-eas-staging-ios
   variables:
     APP_VARIANT: staging
   script:
@@ -1145,6 +1153,7 @@ deploy:mobile-native-staging-ios:
 deploy:mobile-native-staging-android:
   extends: .mobile-native-submit
   needs: ["build:mobile-native-staging-android"]
+  resource_group: mobile-eas-staging-android
   variables:
     APP_VARIANT: staging
   script:
@@ -1474,6 +1483,7 @@ deploy:staging:
   inherit:
     # no docker login
     default: false
+  resource_group: staging-deploy
   script:
     - apt-get update && apt install -y git wget openssh-client
     - export rev=$(git rev-parse @ | cut -c-8)


### PR DESCRIPTION
Adds `resource_group` to the EAS-touching mobile jobs and to the staging deploy so they no longer run concurrently with themselves across pipelines.

Groups (each is a serialized queue):
- `mobile-eas-devtool` — devtool build (both platforms in one job)
- `mobile-eas-prod-ios` / `mobile-eas-prod-android` — prod build + submit per platform
- `mobile-eas-staging-ios` / `mobile-eas-staging-android` — staging build + submit per platform
- `staging-deploy` — the staging deploy job

Variants (prod/staging/devtool) and platforms (iOS/Android) still run in parallel. Build and its corresponding submit share a queue so a submit can't jump ahead of a still-building newer pipeline on the same platform.

Follow-up (outside this PR): set `process_mode=oldest_first` on each resource group via the GitLab UI (Settings → CI/CD → Resource Groups) or API for FCFS ordering. The default `unordered` mode still serializes but picks the next job arbitrarily.

## Testing
- Inspected the rendered config to confirm `resource_group` is set on the intended jobs and not on others.
- Behavior will be observable on the next pipeline that triggers two of these jobs concurrently (the second will be queued).

_This PR was created with the Couchers PR skill._