### PR TITLE
Add Bugs.LogExperimentExposure for client-side exposure logging

### DIFF
--- a/app/backend/src/couchers/experimentation.py
+++ b/app/backend/src/couchers/experimentation.py
@@ -33,7 +33,7 @@ from sqlalchemy.dialects.postgresql import insert
 from couchers import metrics
 from couchers.config import config
 from couchers.db import session_scope
-from couchers.models.logging import ExperimentExposure, FeatureUsage
+from couchers.models.logging import ExperimentExposure, ExposureSource, FeatureUsage
 
 logger = logging.getLogger(__name__)
 
@@ -203,6 +203,7 @@ def _record_exposure(user_id: int, experiment: Experiment, result: Result, **_: 
             user_id=user_id,
             experiment_key=experiment.key,
             variation_id=result.variationId,
+            source=ExposureSource.backend,
             data=data,
         )
         .on_conflict_do_nothing(constraint="uq_experiment_exposures_user_exp_var")

--- a/app/backend/src/couchers/migrations/versions/0161_add_source_to_experiment_exposures.py
+++ b/app/backend/src/couchers/migrations/versions/0161_add_source_to_experiment_exposures.py
@@ -1,0 +1,35 @@
+"""Add source to experiment_exposures
+
+Revision ID: 0161
+Revises: 0160
+Create Date: 2026-05-31 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0161"
+down_revision = "0160"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    exposuresource_enum = sa.Enum("backend", "client", name="exposuresource", schema="public")
+    exposuresource_enum.create(op.get_bind(), checkfirst=True)
+
+    # add nullable, backfill existing (all server-side) rows, then make NOT NULL
+    op.add_column(
+        "experiment_exposures",
+        sa.Column("source", exposuresource_enum, nullable=True),
+        schema="logging",
+    )
+    op.execute("UPDATE logging.experiment_exposures SET source = 'backend' WHERE source IS NULL")
+    op.alter_column("experiment_exposures", "source", nullable=False, schema="logging")
+
+
+def downgrade() -> None:
+    op.drop_column("experiment_exposures", "source", schema="logging")
+    sa.Enum(name="exposuresource", schema="public").drop(op.get_bind(), checkfirst=True)

--- a/app/backend/src/couchers/models/logging.py
+++ b/app/backend/src/couchers/models/logging.py
@@ -18,6 +18,11 @@ class EventSource(enum.Enum):
     frontend = enum.auto()
 
 
+class ExposureSource(enum.Enum):
+    backend = enum.auto()
+    client = enum.auto()
+
+
 class APICall(Base, kw_only=True):
     """
     API call logs
@@ -155,6 +160,8 @@ class ExperimentExposure(Base, kw_only=True):
 
     # the variation the user was bucketed into
     variation_id: Mapped[int] = mapped_column(BigInteger)
+
+    source: Mapped[ExposureSource] = mapped_column(Enum(ExposureSource))
 
     # remaining GrowthBook fields (variation_key, hash_attribute, hash_value,
     # bucket, in_experiment, feature_id, sticky_bucket_used, etc.)

--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -9,6 +9,7 @@ import grpc
 import requests
 from google.protobuf import empty_pb2, struct_pb2
 from sqlalchemy import insert, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
 
@@ -18,7 +19,7 @@ from couchers.constants import STABLE_THRESHOLD_SECONDS
 from couchers.context import CouchersContext
 from couchers.descriptor_pool import get_descriptors_pb
 from couchers.models import User
-from couchers.models.logging import EventLog, EventSource
+from couchers.models.logging import EventLog, EventSource, ExperimentExposure, ExposureSource
 from couchers.proto import bugs_pb2, bugs_pb2_grpc
 from couchers.proto.google.api import httpbody_pb2
 
@@ -241,3 +242,33 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
             holder["value"] = value
             res.value.CopyFrom(holder.fields["value"])
         return res
+
+    def LogExperimentExposure(
+        self, request: bugs_pb2.LogExperimentExposureReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
+        # need a logged-in user to attribute the exposure to
+        if context.is_logged_in():
+            data = {
+                "experiment_name": request.experiment_name,
+                "variation_key": request.variation_key,
+                "variation_name": request.variation_name,
+                "hash_attribute": request.hash_attribute,
+                "hash_value": request.hash_value,
+                "bucket": request.bucket if request.HasField("bucket") else None,
+                "in_experiment": request.in_experiment,
+                "hash_used": request.hash_used if request.HasField("hash_used") else None,
+                "sticky_bucket_used": (request.sticky_bucket_used if request.HasField("sticky_bucket_used") else None),
+                "feature_id": request.feature_id,
+            }
+            session.execute(
+                pg_insert(ExperimentExposure)
+                .values(
+                    user_id=context.user_id,
+                    experiment_key=request.experiment_key,
+                    variation_id=request.variation_id,
+                    source=ExposureSource.client,
+                    data=data,
+                )
+                .on_conflict_do_nothing(constraint="uq_experiment_exposures_user_exp_var")
+            )
+        return empty_pb2.Empty()

--- a/app/backend/src/tests/test_bugs.py
+++ b/app/backend/src/tests/test_bugs.py
@@ -5,12 +5,12 @@ from unittest.mock import MagicMock, patch
 import grpc
 import pytest
 from google.protobuf import empty_pb2, timestamp_pb2
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from couchers.config import config
 from couchers.crypto import random_hex
 from couchers.db import session_scope
-from couchers.models.logging import EventLog, EventSource
+from couchers.models.logging import EventLog, EventSource, ExperimentExposure, ExposureSource
 from couchers.proto import bugs_pb2
 from couchers.proto.google.api import httpbody_pb2
 from couchers.servicers.bugs import _fetch_signed_manifest
@@ -523,3 +523,84 @@ def test_native_update_manifest_unconfigured_platform_returns_directive(db, feat
         )
 
     assert _multipart_part_json(res.data.decode(), "directive") == {"type": "noUpdateAvailable"}
+
+
+def test_log_experiment_exposure(db):
+    user, token = generate_user()
+
+    with bugs_session(token) as bugs:
+        bugs.LogExperimentExposure(
+            bugs_pb2.LogExperimentExposureReq(
+                experiment_key="my_experiment",
+                experiment_name="My Experiment",
+                variation_id=1,
+                variation_key="treatment",
+                variation_name="Treatment",
+                hash_attribute="id",
+                hash_value=str(user.id),
+                feature_id="my_feature",
+                in_experiment=True,
+                bucket=0.5,
+                hash_used=True,
+                sticky_bucket_used=False,
+            )
+        )
+
+    with session_scope() as session:
+        exposure = session.execute(select(ExperimentExposure)).scalar_one()
+        assert exposure.user_id == user.id
+        assert exposure.experiment_key == "my_experiment"
+        assert exposure.variation_id == 1
+        assert exposure.source == ExposureSource.client
+        assert exposure.data == {
+            "experiment_name": "My Experiment",
+            "variation_key": "treatment",
+            "variation_name": "Treatment",
+            "hash_attribute": "id",
+            "hash_value": str(user.id),
+            "bucket": 0.5,
+            "in_experiment": True,
+            "hash_used": True,
+            "sticky_bucket_used": False,
+            "feature_id": "my_feature",
+        }
+
+
+def test_log_experiment_exposure_deduped(db):
+    user, token = generate_user()
+
+    with bugs_session(token) as bugs:
+        for _ in range(3):
+            bugs.LogExperimentExposure(
+                bugs_pb2.LogExperimentExposureReq(
+                    experiment_key="my_experiment",
+                    variation_id=1,
+                    variation_key="treatment",
+                    hash_attribute="id",
+                    hash_value=str(user.id),
+                )
+            )
+
+    with session_scope() as session:
+        exposure = session.execute(select(ExperimentExposure)).scalar_one()
+        # unset optional fields are stored as null, not a misleading 0/false
+        assert exposure.data["bucket"] is None
+        assert exposure.data["hash_used"] is None
+        assert exposure.data["sticky_bucket_used"] is None
+
+
+def test_log_experiment_exposure_anonymous_ignored(db):
+    with bugs_session() as bugs:
+        bugs.LogExperimentExposure(
+            bugs_pb2.LogExperimentExposureReq(
+                experiment_key="my_experiment",
+                variation_id=1,
+                variation_key="treatment",
+                hash_attribute="id",
+                hash_value="123",
+            )
+        )
+
+    with session_scope() as session:
+        count = session.execute(select(func.count()).select_from(ExperimentExposure)).scalar_one()
+        assert count == 0

--- a/app/backend/src/tests/test_experimentation.py
+++ b/app/backend/src/tests/test_experimentation.py
@@ -11,7 +11,7 @@ from couchers.db import session_scope
 from couchers.experimentation import GrowthBookUnavailableError, _record_feature_usage, setup_experimentation
 from couchers.i18n import LocalizationContext
 from couchers.metrics import feature_flag_evaluations_counter
-from couchers.models.logging import ExperimentExposure, FeatureUsage
+from couchers.models.logging import ExperimentExposure, ExposureSource, FeatureUsage
 from couchers.proto import bugs_pb2
 from tests.fixtures.sessions import bugs_session
 
@@ -84,6 +84,7 @@ def test_evaluating_an_experiment_flag_records_exactly_one_exposure(db, feature_
         rows = session.execute(select(ExperimentExposure).where(ExperimentExposure.user_id == 123)).scalars().all()
         assert len(rows) == 1
         assert rows[0].experiment_key == "my_experiment"
+        assert rows[0].source == ExposureSource.backend
 
 
 def test_evaluate_feature_flag_servicer_returns_value(feature_flags, db):

--- a/app/proto/bugs.proto
+++ b/app/proto/bugs.proto
@@ -61,6 +61,10 @@ service Bugs {
     // logged out) and return the resolved value. Evaluated one flag at a time, on demand, so the
     // server only evaluates flags the client actually uses - which keeps exposure logging accurate.
   }
+
+  rpc LogExperimentExposure(LogExperimentExposureReq) returns (google.protobuf.Empty) {
+    // Record a client-side experiment exposure, reported by the SDK as the user is bucketed.
+  }
 }
 
 message VersionInfo {
@@ -169,4 +173,19 @@ message EvaluateFeatureFlagRes {
   // The flag's resolved value (bool, string, number, or JSON object/array). Unset when the flag
   // isn't configured server-side, so the frontend's in-code default applies.
   google.protobuf.Value value = 1;
+}
+
+message LogExperimentExposureReq {
+  string experiment_key = 1;
+  string experiment_name = 2;
+  int32 variation_id = 3;
+  string variation_key = 4;
+  string variation_name = 5;
+  string hash_attribute = 6;
+  string hash_value = 7;
+  string feature_id = 8;
+  bool in_experiment = 9;
+  optional double bucket = 10;
+  optional bool hash_used = 11;
+  optional bool sticky_bucket_used = 12;
 }


### PR DESCRIPTION
Feature flags are moving to client-side evaluation (see the companion web/mobile PR #8901), so the backend can no longer log experiment exposures as a side effect of evaluating a flag. This adds an endpoint the client SDK calls to report exposures.

- **`Bugs.LogExperimentExposure`** — records a client-reported exposure into `logging.experiment_exposures`, attributed to the session user, deduped per `(user, experiment, variation)` via the existing unique constraint (`ON CONFLICT DO NOTHING`), and ignored when logged out. The payload mirrors the data captured by server-side exposure logging (`experiment_name`, `variation_name`, `bucket`, `in_experiment`, `hash_used`, `sticky_bucket_used`, `feature_id`, …).
- **`source` column** — elevated from a key inside the `data` JSONB to a non-null `experiment_exposures.source` column (`backend`/`client`); migration `0161` backfills existing rows to `backend`.

The shared `bugs.proto` change lives here (the contract the endpoint implements); it also appears in #8901 so that PR's web/mobile build is green, and the identical hunk merges cleanly.

## Testing
- New servicer tests: happy path (asserts the full stored row), dedupe, and anonymous-ignored.
- `test_experimentation` asserts server-side exposures get `source = backend`.
- `make format` clean; `make mypy` clean (pre-existing unrelated `ics` stub error only); `uv run pytest src/tests/test_bugs.py src/tests/test_experimentation.py` passes.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._