### PR TITLE
CI: always run devtool native build on develop

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -14,7 +14,6 @@ variables:
   BUILD_WEB: "true"
   BUILD_MOBILE: "true"
   PREVIEW_DOMAIN: preview.couchershq.org
-  DEVTOOL_BUILD_BRANCH: develop
   GIT_DEPTH: 1  # Speed up the checkout.
   DOCKER_HOST: tcp://docker:2376
   DOCKER_TLS_CERTDIR: "/certs"
@@ -959,10 +958,7 @@ build:mobile-native-devtool:
     - bash scripts/devtool-build.sh ios
     - bash scripts/devtool-build.sh android
   rules:
-    - if: ($BUILD_MOBILE == "true") && ($CI_COMMIT_BRANCH == $DEVTOOL_BUILD_BRANCH)
-      changes:
-        - app/proto/**/*
-        - app/mobile/**/*
+    - if: ($BUILD_MOBILE == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
 
 build:mobile-ota-staging:
   needs: ["protos"]


### PR DESCRIPTION
The `build:mobile-native-devtool` job's only rule was

```yaml
- if: ($BUILD_MOBILE == "true") && ($CI_COMMIT_BRANCH == $DEVTOOL_BUILD_BRANCH)
  changes:
    - app/proto/**/*
    - app/mobile/**/*
```

When `if:` and `changes:` are in the same rule entry, both must match — so the job was silently skipped on develop pipelines whose diff didn't touch `app/proto` or `app/mobile`. That's why its resource group (`mobile-eas-devtool`, added in #8905) never came into existence.

This PR makes it match the pattern used by every other mobile native build / staging deploy job: always run on develop, never on feature branches. Also drops `DEVTOOL_BUILD_BRANCH` from `variables:` since it just duplicated `RELEASE_BRANCH` and was referenced only here.

I audited the rest of the file for the same anti-pattern (`changes:` attached to a develop-matching rule) — this was the only instance.

## Testing
- Eyeballed the diff; rule now matches `.mobile-native` exactly.
- Next develop pipeline will instantiate `build:mobile-native-devtool` and create the `mobile-eas-devtool` resource group, at which point its `process_mode` can be set to `oldest_first` via the GitLab API/UI for FCFS (the other five groups were already set after #8905 merged).

_This PR was created with the Couchers PR skill._