### PR TITLE
Change mobile map search results puller style

### DIFF
--- a/app/web/features/search/MapSearchContent.tsx
+++ b/app/web/features/search/MapSearchContent.tsx
@@ -50,16 +50,12 @@ const SearchResultsContainer = styled("div", {
     height: "100%",
     width: isListOnlyView ? "100%" : `${drawerWidth}px`,
 
-    ...(!isListOnlyView && {
-      [theme.breakpoints.down("md")]: {
-        width: "100%",
-        height: "45%",
-        minHeight: 0,
-        order: 2,
-        boxShadow: "0px -2px 4px rgba(0,0,0,0.1)",
-        overflow: "hidden",
-      },
-    }),
+    [theme.breakpoints.down("md")]: {
+      width: "100%",
+      height: isListOnlyView ? "100%" : "45%",
+      order: 2,
+      transition: "height 0.3s ease",
+    },
   }),
 );
 
@@ -83,12 +79,12 @@ const MapContainer = styled("div", {
 
     [theme.breakpoints.down("md")]: {
       width: "100%",
-      height: "55%",
+      height: isListOnlyView ? "0%" : "55%",
       order: 1,
-      ...(isListOnlyView && {
-        width: 0,
-        height: 0,
-      }),
+      transition: "height 0.3s ease",
+      position: "relative",
+      overflow: "hidden",
+      pointerEvents: "auto",
     },
   }),
 );

--- a/app/web/features/search/MapSearchResultsList.tsx
+++ b/app/web/features/search/MapSearchResultsList.tsx
@@ -140,8 +140,7 @@ const MapSearchResultsList = ({
             touchStartY.current = e.touches[0].clientY;
           }}
           onTouchEnd={(e) => {
-            const deltaY =
-              touchStartY.current - e.changedTouches[0].clientY;
+            const deltaY = touchStartY.current - e.changedTouches[0].clientY;
             if (deltaY > 50 && !isExpanded) {
               onSetMapView(MapViews.LIST_ONLY);
             } else if (deltaY < -50 && isExpanded) {

--- a/app/web/features/search/MapSearchResultsList.tsx
+++ b/app/web/features/search/MapSearchResultsList.tsx
@@ -3,6 +3,7 @@ import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
 import ResizeableDrawer from "components/ResizeableDrawer";
 import { RpcError } from "grpc-web";
 import { SearchUser } from "proto/search_pb";
+import { useRef } from "react";
 import { theme } from "theme";
 
 import PreviousNextPagination from "./PreviousNextPagination";
@@ -27,17 +28,54 @@ interface MapSearchResultsListProps {
   users: SearchUser.AsObject[] | undefined;
 }
 
-const DrawerContainer = styled("div")(({ theme }) => ({
+const DrawerContainer = styled("div")({
   height: "100%",
   width: "100%",
   display: "flex",
   flexDirection: "column",
   minHeight: 0,
-}));
+});
 
 const SpinnerWrapper = styled("div")(({ theme }) => ({
   paddingTop: theme.spacing(8),
 }));
+
+const MobileSheet = styled("div")({
+  height: "100%",
+  width: "100%",
+  display: "flex",
+  flexDirection: "column",
+  backgroundColor: "var(--mui-palette-background-paper)",
+  borderTopLeftRadius: 16,
+  borderTopRightRadius: 16,
+  boxShadow: "0px -2px 8px rgba(0,0,0,0.15)",
+  overflow: "hidden",
+});
+
+const MobileSheetHeader = styled("div")({
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  padding: "10px 16px 4px",
+  cursor: "pointer",
+  flexShrink: 0,
+  width: "100%",
+  boxSizing: "border-box" as const,
+  userSelect: "none" as const,
+});
+
+const PullerPill = styled("div")({
+  width: 30,
+  height: 6,
+  backgroundColor: "var(--mui-palette-grey-300)",
+  borderRadius: 3,
+});
+
+const MobileScrollable = styled("div")({
+  overflowY: "auto",
+  flexGrow: 1,
+  WebkitOverflowScrolling: "touch",
+});
 
 const MapSearchResultsList = ({
   error,
@@ -69,11 +107,71 @@ const MapSearchResultsList = ({
     query !== undefined ||
     shouldSearchByUserId;
 
+  const touchStartY = useRef<number>(0);
+
+  const listContent = isLoading ? (
+    <SpinnerWrapper>
+      <CenteredSpinner />
+    </SpinnerWrapper>
+  ) : (
+    <SearchResultListContent
+      error={error}
+      currentRange={currentRange}
+      onUserCardClick={onUserCardClick}
+      showAlert={!isLoading && !meetsSearchCriteria}
+      showTopSpace={
+        !isMobile &&
+        (mapView === MapViews.LIST_ONLY ||
+          (mapView === MapViews.MAP_AND_LIST &&
+            drawerWidth > window.innerWidth / 2))
+      }
+      totalItems={totalItems}
+      users={users}
+    />
+  );
+
+  if (isMobile) {
+    const isExpanded = mapView === MapViews.LIST_ONLY;
+
+    return (
+      <MobileSheet>
+        <MobileSheetHeader
+          onTouchStart={(e) => {
+            touchStartY.current = e.touches[0].clientY;
+          }}
+          onTouchEnd={(e) => {
+            const deltaY =
+              touchStartY.current - e.changedTouches[0].clientY;
+            if (deltaY > 50 && !isExpanded) {
+              onSetMapView(MapViews.LIST_ONLY);
+            } else if (deltaY < -50 && isExpanded) {
+              onSetMapView(MapViews.MAP_AND_LIST);
+            }
+          }}
+          onClick={() =>
+            onSetMapView(
+              isExpanded ? MapViews.MAP_AND_LIST : MapViews.LIST_ONLY,
+            )
+          }
+        >
+          <PullerPill />
+        </MobileSheetHeader>
+        <MobileScrollable>{listContent}</MobileScrollable>
+        <PreviousNextPagination
+          hasPreviousPage={hasPreviousPage}
+          hasNextPage={hasNextPage}
+          onPreviousClick={onLoadPreviousPage}
+          onNextClick={onLoadNextPage}
+        />
+      </MobileSheet>
+    );
+  }
+
   return (
     <DrawerContainer>
       <ResizeableDrawer
         onDrawerWidthChange={onDrawerWidthChange}
-        showDragger={!isMobile && mapView !== MapViews.LIST_ONLY}
+        showDragger={mapView !== MapViews.LIST_ONLY}
         nonScrollableChildren={
           <PreviousNextPagination
             hasPreviousPage={hasPreviousPage}
@@ -83,28 +181,7 @@ const MapSearchResultsList = ({
           />
         }
       >
-        {isLoading ? (
-          <SpinnerWrapper>
-            <CenteredSpinner />
-          </SpinnerWrapper>
-        ) : (
-          <SearchResultListContent
-            error={error}
-            mapView={mapView}
-            currentRange={currentRange}
-            onSetMapView={onSetMapView}
-            onUserCardClick={onUserCardClick}
-            showAlert={!isLoading && !meetsSearchCriteria}
-            showTopSpace={
-              !isMobile &&
-              (mapView === MapViews.LIST_ONLY ||
-                (mapView === MapViews.MAP_AND_LIST &&
-                  drawerWidth > window.innerWidth / 2))
-            }
-            totalItems={totalItems}
-            users={users}
-          />
-        )}
+        {listContent}
       </ResizeableDrawer>
     </DrawerContainer>
   );

--- a/app/web/features/search/SearchResultListContent.tsx
+++ b/app/web/features/search/SearchResultListContent.tsx
@@ -1,13 +1,4 @@
-import { KeyboardArrowDown, KeyboardArrowUp } from "@mui/icons-material";
-import {
-  Alert,
-  Box,
-  Button,
-  IconButton,
-  styled,
-  Typography,
-  useMediaQuery,
-} from "@mui/material";
+import { Alert, Box, Button, styled, Typography } from "@mui/material";
 import BetaFlag from "components/BetaFlag";
 import { DEFAULT_DRAWER_WIDTH } from "components/ResizeableDrawer";
 import { RpcError } from "grpc-web";
@@ -19,13 +10,10 @@ import { theme } from "theme";
 import SearchResultUserCard from "./SeachResultUserCard";
 import { useMapSearchState } from "./state/mapSearchContext";
 import { useMapSearchActions } from "./state/useMapSearchActions";
-import { MapViews } from "./utils/constants";
 
 interface SearchResultListContentProps {
   error: RpcError | null;
-  mapView: MapViews;
   currentRange: string;
-  onSetMapView: (view: MapViews) => void;
   onUserCardClick: (userId: number) => void;
   showAlert: boolean;
   showTopSpace?: boolean;
@@ -72,13 +60,15 @@ const CenteredRow = styled("div")(({ theme }) => ({
   alignItems: "center",
   width: "100%",
   padding: theme.spacing(1, 0),
+
+  [theme.breakpoints.down("md")]: {
+    paddingTop: theme.spacing(0.5),
+  },
 }));
 
 const SearchResultListContent = ({
   error,
-  mapView,
   currentRange,
-  onSetMapView,
   onUserCardClick,
   showAlert,
   showTopSpace = false,
@@ -86,7 +76,6 @@ const SearchResultListContent = ({
   users,
 }: SearchResultListContentProps) => {
   const { t } = useTranslation([SEARCH]);
-  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
   const { filters, selectedUserId } = useMapSearchState();
 
@@ -145,42 +134,6 @@ const SearchResultListContent = ({
               count: totalItems, // "count" name enables plurals
             })}
           </Typography>
-        )}
-
-        {isMobile && (
-          <IconButton
-            onClick={() => {
-              if (mapView === MapViews.LIST_ONLY) {
-                onSetMapView(MapViews.MAP_AND_LIST);
-              } else {
-                onSetMapView(MapViews.LIST_ONLY);
-              }
-            }}
-            aria-label={t(
-              `global:${mapView === MapViews.LIST_ONLY ? "retract" : "expand"}`,
-            )}
-            sx={{
-              fontSize: "24px",
-              backgroundColor: "var(--mui-palette-background-paper)",
-              border: `1px solid var(--mui-palette-divider)`,
-              height: "25px",
-              width: "25px",
-              position: "absolute",
-              top: theme.spacing(1),
-              right: theme.spacing(2),
-              zIndex: 10,
-
-              "&:hover": {
-                backgroundColor: "var(--mui-palette-background-paper)",
-              },
-            }}
-          >
-            {mapView === MapViews.LIST_ONLY ? (
-              <KeyboardArrowDown />
-            ) : (
-              <KeyboardArrowUp />
-            )}
-          </IconButton>
         )}
       </CenteredRow>
       {shouldShowSuggestion && (


### PR DESCRIPTION
There were some comments that people didn't see the arrow to realize you could increase the list height on mobile for the map search results. That weird design was never meant to be permanent anyway so how about this?

<img width="380" height="463" alt="Screenshot 2026-05-31 at 23 46 45" src="https://github.com/user-attachments/assets/827cfb21-3378-4b73-8af2-3df255f1842f" />


<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*
- Use map search to search something
- Go in mobile responsive view
- Use puller to make it go up and down
- Chewck desktop view is still okay

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
