### PR TITLE
web: contain long unbroken words in search result cards

### DIFF
--- a/app/web/features/search/SeachResultUserCard.tsx
+++ b/app/web/features/search/SeachResultUserCard.tsx
@@ -184,10 +184,6 @@ const generateAboutText = (
       <LinesEllipsis
         maxLine={isMobile ? 3 : 7}
         text={stripMarkdown(aboutText(user, t))}
-        // basedOn="letters" so long, space-less words (e.g. "asdfasdf…", a pasted
-        // URL) are truncated per character. The default auto-detects "words" for
-        // ASCII text, which can't split a space-less string and so fails to
-        // truncate at maxLine, letting the text overflow the card.
         basedOn="letters"
         style={{ wordBreak: "break-all", overflow: "hidden" }}
       />

--- a/app/web/features/search/SeachResultUserCard.tsx
+++ b/app/web/features/search/SeachResultUserCard.tsx
@@ -184,6 +184,11 @@ const generateAboutText = (
       <LinesEllipsis
         maxLine={isMobile ? 3 : 7}
         text={stripMarkdown(aboutText(user, t))}
+        // basedOn="letters" so long, space-less words (e.g. "asdfasdf…", a pasted
+        // URL) are truncated per character. The default auto-detects "words" for
+        // ASCII text, which can't split a space-less string and so fails to
+        // truncate at maxLine, letting the text overflow the card.
+        basedOn="letters"
         style={{ wordBreak: "break-all", overflow: "hidden" }}
       />
     );

--- a/app/web/features/search/SeachResultUserCard.tsx
+++ b/app/web/features/search/SeachResultUserCard.tsx
@@ -184,6 +184,7 @@ const generateAboutText = (
       <LinesEllipsis
         maxLine={isMobile ? 3 : 7}
         text={stripMarkdown(aboutText(user, t))}
+        style={{ wordBreak: "break-all", overflow: "hidden" }}
       />
     );
   }


### PR DESCRIPTION
Long, space-less words (e.g. a pasted URL or a string of repeated characters like `asdfasdf…`) in a user's "About me" could break the search result card layout, overflowing the card and spilling into the card below it.

**Root cause:** the About snippet uses `react-lines-ellipsis`, which auto-selects `basedOn="words"` for ASCII text. A space-less string can't be split into words, so it is never truncated at `maxLine` and renders in full. Adding `word-break: break-all` made the text *wrap*, but it still wasn't *truncated*, so the card grew vertically and overlapped the next card.

**Fix:** set `basedOn="letters"` on the About `LinesEllipsis` in `app/web/features/search/SeachResultUserCard.tsx` so the snippet truncates per character at `maxLine` (with the existing `word-break: break-all` + `overflow: hidden` keeping each line within the card width).

closes #8278

## Testing
Verified live against the dev/staging backend with Playwright (logged-in account):
- Searched the Berlin area and located the reported **"Andy Test1"** card whose About is a long `asdfasdf…` string.
- Before: the About rendered ~13 lines and overflowed into the next card. After: it truncates to the `maxLine` limit (7 desktop / 3 mobile) ending in `…`, and the card's `scrollHeight === clientHeight` (no vertical overflow); the following card starts cleanly below.
- `yarn prettier` + `yarn eslint` on the changed file — clean.

Reviewer steps: log in, search a location with a user whose "About me" is a very long word with no spaces (e.g. "Andy Test1" in Berlin), confirm the card stays within bounds.

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

![Uploading image.png…]()




_This PR was created with the Couchers PR skill._