### PR TITLE
mobile: drop @expo/app-integrity (no SDK 54 version exists)

### DIFF
--- a/app/mobile/package-lock.json
+++ b/app/mobile/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.1.20",
       "dependencies": {
         "@expo-google-fonts/ubuntu": "^0.4.1",
-        "@expo/app-integrity": "^56.0.3",
         "@expo/cli": "^55.0.0-canary-20260105-6b962e6",
         "@expo/vector-icons": "^15.0.3",
         "@expo/xcpretty": "^4.3.2",
@@ -1816,16 +1815,6 @@
       "resolved": "https://registry.npmjs.org/@expo-google-fonts/ubuntu/-/ubuntu-0.4.1.tgz",
       "integrity": "sha512-dwfRVuLkdFJH/D9iVMYZXDBwbCEKGLfH53AqBMyKhATYBs21iDxkf3NjyjI0MYEHm24mOM7i236idCfyF23Z6Q==",
       "license": "MIT AND UFL-1.0"
-    },
-    "node_modules/@expo/app-integrity": {
-      "version": "56.0.3",
-      "resolved": "https://registry.npmjs.org/@expo/app-integrity/-/app-integrity-56.0.3.tgz",
-      "integrity": "sha512-GwiKp93dmGR/bs6ONfJKap1swkWz04yd3us7UdNQV5za76OLDrAAjh5bo+qSprbQV5p94Gwv2cNWEPpEc/zjDQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
-      }
     },
     "node_modules/@expo/cli": {
       "version": "55.0.16",

--- a/app/mobile/package.json
+++ b/app/mobile/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@expo-google-fonts/ubuntu": "^0.4.1",
-    "@expo/app-integrity": "^56.0.3",
     "@expo/cli": "^55.0.0-canary-20260105-6b962e6",
     "@expo/vector-icons": "^15.0.3",
     "@expo/xcpretty": "^4.3.2",


### PR DESCRIPTION
Removes `@expo/app-integrity` from the mobile app. The package ships a pre-built AAR compiled against a newer `expo-modules-core` that references `expo.modules.kotlin.types.AnyTypeCache` — a class that doesn't exist in `expo-modules-core@3.0.30` (Expo SDK 54, our current version). As a result, the devtool APK crashed at native init with `NoClassDefFoundError: expo.modules.kotlin.types.AnyTypeCache` before any JS could load.

The first version published on npm is `55.0.0`, so there is no SDK 54-compatible release. Nothing in our code imported it yet (it was only added recently in 7f332e7f0), so the removal is just `package.json` + `package-lock.json`. We can re-add it once we upgrade Expo to SDK 55+.

## Testing
- Verified no source file imports `@expo/app-integrity`.
- Verified `node_modules/@expo/app-integrity` is gone after `npm install`.
- Devtool APK rebuild needed: removing this package changes both the Android (AAR) and iOS (podspec) dep graphs, so fingerprint will change on both platforms and the next `eas build` will be a fresh native build.

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._