### PR TITLE
web/mobile: tighten feature flag refresh to 1min / 5min

### DIFF
--- a/app/mobile/features/experimentation/growthbook.ts
+++ b/app/mobile/features/experimentation/growthbook.ts
@@ -10,7 +10,6 @@ const FLAGS_URL =
 const CACHE_KEY = "featureFlagsPayload";
 // At startup we reuse the cache without a network fetch unless it's older than this.
 const CACHE_MAX_AGE_MS = 5 * 60 * 1000;
-// Matches the payload's CDN Cache-Control max-age=60, so each poll lands as the HTTP cache lapses.
 const REFRESH_INTERVAL_MS = 60 * 1000;
 
 export const growthbook = new GrowthBook({ trackingCallback: recordExposure });

--- a/app/mobile/features/experimentation/growthbook.ts
+++ b/app/mobile/features/experimentation/growthbook.ts
@@ -9,8 +9,9 @@ const FLAGS_URL =
   "https://cdn.couchers.org/express/current.json";
 const CACHE_KEY = "featureFlagsPayload";
 // At startup we reuse the cache without a network fetch unless it's older than this.
-const CACHE_MAX_AGE_MS = 15 * 60 * 1000;
-const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+const CACHE_MAX_AGE_MS = 5 * 60 * 1000;
+// Matches the payload's CDN Cache-Control max-age=60, so each poll lands as the HTTP cache lapses.
+const REFRESH_INTERVAL_MS = 60 * 1000;
 
 export const growthbook = new GrowthBook({ trackingCallback: recordExposure });
 

--- a/app/web/features/experimentation/growthbook.ts
+++ b/app/web/features/experimentation/growthbook.ts
@@ -7,8 +7,9 @@ const FLAGS_URL =
   "https://cdn.couchers.org/express/current.json";
 const CACHE_KEY = "featureFlagsPayload";
 // At startup we reuse the cache without a network fetch unless it's older than this.
-const CACHE_MAX_AGE_MS = 15 * 60 * 1000;
-const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+const CACHE_MAX_AGE_MS = 5 * 60 * 1000;
+// Matches the payload's CDN Cache-Control max-age=60, so each poll lands as the HTTP cache lapses.
+const REFRESH_INTERVAL_MS = 60 * 1000;
 
 export const growthbook = new GrowthBook({ trackingCallback: recordExposure });
 

--- a/app/web/features/experimentation/growthbook.ts
+++ b/app/web/features/experimentation/growthbook.ts
@@ -8,7 +8,6 @@ const FLAGS_URL =
 const CACHE_KEY = "featureFlagsPayload";
 // At startup we reuse the cache without a network fetch unless it's older than this.
 const CACHE_MAX_AGE_MS = 5 * 60 * 1000;
-// Matches the payload's CDN Cache-Control max-age=60, so each poll lands as the HTTP cache lapses.
 const REFRESH_INTERVAL_MS = 60 * 1000;
 
 export const growthbook = new GrowthBook({ trackingCallback: recordExposure });


### PR DESCRIPTION
Tightens the GrowthBook flag refresh cadence on both web and mobile:

- **Background refresh**: `5min → 60s`. The payload is served with `Cache-Control: public, max-age=60` (confirmed on both `cdn.couchers.org` and `next-static.couchershq.org`), so 60s is the freshness the infra was set up to deliver, and it's the natural poll interval — each tick lands as the browser's HTTP cache lapses. Polling faster would just hit the HTTP cache; polling slower (the old 5min) left freshness on the table.
- **Startup cache staleness**: `15min → 5min`. On load we reuse the cached payload without a network fetch only if it's younger than this; with the 60s background poll a session converges to fresh within ~1min regardless.

Net effect: flag (and global-message) changes propagate to clients within ~1 minute instead of up to 5. Real origin load is unchanged — the CDN's 60s edge TTL caps it no matter the client poll rate, and CloudFront absorbs the conditional requests.

## Testing
- `yarn lint` and `yarn format` clean locally (web). Change is two numeric constants mirrored across web and mobile.
- Not separately exercised at runtime; behaviour is identical to the existing refresh loop, only the intervals differ.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._