### PR TITLE
Mobile: fix typecheck by adding cause to NativeUpdateInfo test fixtures

### DIFF
--- a/app/mobile/tests/features/diagnostics/NativeUpdatePrompt.test.tsx
+++ b/app/mobile/tests/features/diagnostics/NativeUpdatePrompt.test.tsx
@@ -4,7 +4,11 @@ import { Linking } from "react-native";
 
 import NativeUpdatePrompt from "@/features/diagnostics/NativeUpdatePrompt";
 import { UpdatePrompt } from "@/features/diagnostics/updateDecision";
-import { NativeUpdateAction, NativeUpdateInfo } from "@/proto/bugs_pb";
+import {
+  NativeUpdateAction,
+  NativeUpdateCause,
+  NativeUpdateInfo,
+} from "@/proto/bugs_pb";
 
 jest.mock("expo-updates", () => ({
   fetchUpdateAsync: jest.fn(),
@@ -20,6 +24,7 @@ function info(
     message: "A new version is available.",
     linkUrl: "https://apps.apple.com/app/id123",
     linkText: "Update now",
+    cause: NativeUpdateCause.NATIVE_UPDATE_CAUSE_AGE,
     ...overrides,
   };
 }

--- a/app/mobile/tests/features/diagnostics/updateDecision.test.ts
+++ b/app/mobile/tests/features/diagnostics/updateDecision.test.ts
@@ -2,7 +2,11 @@ import {
   isActionable,
   updateMode,
 } from "@/features/diagnostics/updateDecision";
-import { NativeUpdateAction, NativeUpdateInfo } from "@/proto/bugs_pb";
+import {
+  NativeUpdateAction,
+  NativeUpdateCause,
+  NativeUpdateInfo,
+} from "@/proto/bugs_pb";
 
 function info(
   overrides: Partial<NativeUpdateInfo.AsObject> = {},
@@ -13,6 +17,7 @@ function info(
     message: "",
     linkUrl: "",
     linkText: "",
+    cause: NativeUpdateCause.NATIVE_UPDATE_CAUSE_AGE,
     ...overrides,
   };
 }


### PR DESCRIPTION
Mobile typecheck was failing because `cause` is a required field on `NativeUpdateInfo.AsObject` (added when OTA-prompt copy was split by cause), but the test fixture factories in `NativeUpdatePrompt.test.tsx` and `updateDecision.test.ts` didn't set it.

Sets `cause: NativeUpdateCause.NATIVE_UPDATE_CAUSE_AGE` as the default in each `info()` factory (still overridable via `overrides`).

## Testing
- `./node_modules/.bin/tsc --noEmit` (the two reported errors are gone).

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._