### PR TITLE
Backend: finer native age buckets and per-call checkin counter

### DIFF
--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -934,25 +934,37 @@ postcards_sent_counter: Counter = Counter(
 )
 
 
-# Native app / OTA update metrics. The histograms are observed once per CheckNativeStatus call from each
-# client; the bucket layout is dense around the OTA window (~28d) and store window (~91d) so the warn/block
-# thresholds are visible on the percentile curves.
+# Native app / OTA update metrics. Bucket layout is minute-resolution at the low end (watch an OTA
+# rolling out), dense around the OTA (~28d) and store (~91d) windows, and sparse past it for stragglers.
 _NATIVE_AGE_BUCKETS: tuple[float, ...] = (
+    60,
+    5 * 60,
+    15 * 60,
+    30 * 60,
     3_600,
+    2 * 3_600,
     6 * 3_600,
+    12 * 3_600,
     86_400,
+    2 * 86_400,
     3 * 86_400,
+    5 * 86_400,
     7 * 86_400,
+    10 * 86_400,
     14 * 86_400,
     21 * 86_400,
     28 * 86_400,
     35 * 86_400,
     45 * 86_400,
     60 * 86_400,
+    75 * 86_400,
     91 * 86_400,
     120 * 86_400,
+    150 * 86_400,
     180 * 86_400,
+    270 * 86_400,
     365 * 86_400,
+    730 * 86_400,
     _INF,
 )
 
@@ -1011,6 +1023,40 @@ native_ota_manifest_requests_counter: Counter = Counter(
 
 def observe_native_ota_manifest_request(platform: str, result: str) -> None:
     native_ota_manifest_requests_counter.labels(platform or "unknown", result).inc()
+
+
+# One increment per CheckNativeStatus, labeled by build/bundle identity, to see the live mix of
+# versions and bundles running in the fleet.
+native_client_checkins_counter: Counter = Counter(
+    "couchers_native_client_checkins_total",
+    "CheckNativeStatus calls, labeled by build/bundle identity",
+    labelnames=[
+        "platform",
+        "is_ota_launch",
+        "embedded_display_version",
+        "embedded_runtime_version",
+        "ota_display_version",
+        "ota_update_id",
+    ],
+)
+
+
+def observe_native_client_checkin(
+    platform: str,
+    is_ota_launch: bool,
+    embedded_display_version: str,
+    embedded_runtime_version: str,
+    ota_display_version: str,
+    ota_update_id: str,
+) -> None:
+    native_client_checkins_counter.labels(
+        platform or "unknown",
+        "true" if is_ota_launch else "false",
+        embedded_display_version or "unknown",
+        embedded_runtime_version or "unknown",
+        ota_display_version or "none",
+        ota_update_id or "none",
+    ).inc()
 
 
 # Recomputed at scrape time via the hacky-gauge mechanism, so it reflects live age. 0 when disabled

--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -23,6 +23,7 @@ from couchers.metrics import (
     observe_native_banned_bundle_hit,
     observe_native_binary_age,
     observe_native_bundle_age,
+    observe_native_client_checkin,
     observe_native_ota_manifest_request,
     observe_native_update_decision,
 )
@@ -126,12 +127,27 @@ def _newest_non_banned_ota_package(session: Session, platform: str, fingerprint:
     ).scalar_one_or_none()
 
 
-def _observe_native_check_metrics(info: NativeClientInfo, decision: Any, now: datetime, *, banned: bool) -> None:
+def _observe_native_check_metrics(
+    request: bugs_pb2.CheckNativeStatusReq,
+    info: NativeClientInfo,
+    decision: Any,
+    now: datetime,
+    *,
+    banned: bool,
+) -> None:
     if info.binary_created_at is not None:
         observe_native_binary_age(info.platform, (now - info.binary_created_at).total_seconds())
     if info.bundle_created_at is not None:
         observe_native_bundle_age(info.platform, info.is_ota_launch, (now - info.bundle_created_at).total_seconds())
     observe_native_update_decision(info.platform, decision.action.name, decision.severity.name)
+    observe_native_client_checkin(
+        platform=info.platform,
+        is_ota_launch=info.is_ota_launch,
+        embedded_display_version=request.embedded_display_version,
+        embedded_runtime_version=info.runtime_version,
+        ota_display_version=request.running_display_version if info.is_ota_launch else "",
+        ota_update_id=info.update_id or "",
+    )
     if banned:
         observe_native_banned_bundle_hit(info.platform)
 
@@ -327,7 +343,7 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
                     f"newest_non_banned_created_at={None if newest is None else newest.manifest_created_at})"
                 )
 
-        _observe_native_check_metrics(info, decision, now, banned=banned)
+        _observe_native_check_metrics(request, info, decision, now, banned=banned)
 
         if context.is_logged_in():
             session.add(NativeClientUser(eas_client_id=info.eas_client_id, user_id=context.user_id))


### PR DESCRIPTION
Improves visibility into what native app versions/bundles are running in the wild at any given time.

Two changes to `couchers/metrics.py` + the bugs servicer wiring:

1. **More resolution in `_NATIVE_AGE_BUCKETS`** (15 → 29 buckets):
   - Minute buckets at the low end (1m / 5m / 15m / 30m / 2h / 12h) so we can watch an OTA roll out in real time.
   - Denser sub-180d buckets (2d / 5d / 10d / 75d / 120d / 150d) around the OTA-warn / OTA-block / store-warn / store-block thresholds.
   - More high-end resolution (270d / 730d) so very-old installs aren't all collapsed into the `+Inf` overflow.

2. **New `couchers_native_client_checkins_total` counter**, one increment per `CheckNativeStatus`, labeled by:
   - `platform`, `is_ota_launch`
   - `embedded_display_version`, `embedded_runtime_version` (the embedded fingerprint)
   - `ota_display_version`, `ota_update_id` (the OTA fingerprint; `"none"` when launching from the embedded build)

   `count by (embedded_display_version, ota_update_id) (rate(couchers_native_client_checkins_total[5m]))` gives the live mix of versions/bundles in the fleet.

## Testing
- `make -C app/backend format` clean
- `uv run pytest src/tests/test_bugs.py` — 29 passed
- New counter / expanded buckets verified by inspection; histograms will start producing data on the next CheckNativeStatus call after deploy.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug — existing `test_bugs.py` exercises the touched path
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto \`develop\` if necessary for linear migration history — n/a, metrics-only

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._