### PR TITLE
Backend: Support strongly-typed config vars access

### DIFF
--- a/app/backend/src/app.py
+++ b/app/backend/src/app.py
@@ -20,7 +20,7 @@ import sentry_sdk
 from sentry_sdk.integrations import excepthook
 from sqlalchemy.sql import text
 
-from couchers.config import check_config, config
+from couchers.config import config
 from couchers.constants import API_BASE_PORT, API_WORKER_COUNT, GRACEFUL_SHUTDOWN_TIMEOUT, MEDIA_PORT
 from couchers.db import apply_migrations, db_post_fork, session_scope
 from couchers.experimentation import setup_experimentation
@@ -33,7 +33,7 @@ from couchers.supervisor import supervise
 from couchers.tracing import setup_tracing
 from dummy_data import add_dummy_data
 
-check_config(config)
+config.check()
 
 logging.basicConfig(
     format="[%(process)5d:%(thread)20d] %(asctime)s: %(name)s:%(lineno)d: %(message)s", level=logging.INFO

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -150,46 +150,6 @@ class Config:
                 continue
             self.__setattr__(attr_name, default_value)
 
-    def __getitem__(self, key: str) -> Any:
-        """Weakly-typed indexer access using env var names for backcompat."""
-        attr_name = key.lower()
-        if Config.__annotations__.get(attr_name) is None:
-            raise KeyError(f"No such config key: {key}.")
-
-        try:
-            return self.__getattribute__(attr_name)
-        except AttributeError:
-            raise KeyError(f"Config key undefined and has no default: {key}.") from None
-
-    def __setitem__(self, key: str, value: Any) -> None:
-        """Weakly-typed indexer access using env var names for backcompat."""
-        attr_name = key.lower()
-        attr_type = Config.__annotations__.get(attr_name)
-        if attr_type is None:
-            raise KeyError(f"No such config key: {key}.")
-
-        if typing.get_origin(attr_type) is Literal:  # type: ignore[comparison-overlap]
-            options = typing.get_args(attr_type)
-            if value not in options:
-                raise ValueError(f"Invalid value for {key}, need one of {', '.join(options)}")
-        elif not isinstance(value, attr_type):
-            raise TypeError(f"Invalid type for {key}: expected {attr_type}, got {type(value)}")
-
-        self.__setattr__(attr_name, value)
-
-    def get(self, key: str, default: Any = None) -> Any:
-        """Weakly-typed indexer access using env var names for backcompat."""
-        attr_name = key.lower()
-        try:
-            return self.__getitem__(attr_name)
-        except KeyError:
-            return default
-
-    def copy(self) -> Config:
-        copy = Config()
-        copy.copy_from(self)
-        return copy
-
     def copy_from(self, other: Config) -> None:
         for attr_name in Config.__annotations__.keys():
             try:
@@ -201,6 +161,11 @@ class Config:
                     pass
                 continue
             self.__setattr__(attr_name, attr_value)
+
+    def copy(self) -> Config:
+        copy = Config()
+        copy.copy_from(self)
+        return copy
 
     def check(self) -> None:
         """Checks that the config is valid, i.e., all required values are set to valid values."""
@@ -292,6 +257,47 @@ class Config:
                 raise ValueError(f"Unsupported config type {attr_type} for {env_name}")
 
             self.__setattr__(attr_name, attr_value)
+
+    # Weakly typed dict-like interface using env var names for backcompat.
+
+    def __getitem__(self, key: str) -> Any:
+        """Weakly-typed indexer access using env var names for backcompat."""
+        attr_name = key.lower()
+        if Config.__annotations__.get(attr_name) is None:
+            raise KeyError(f"No such config key: {key}.")
+
+        try:
+            return self.__getattribute__(attr_name)
+        except AttributeError:
+            raise KeyError(f"Config key undefined and has no default: {key}.") from None
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        """Weakly-typed indexer access using env var names for backcompat."""
+        attr_name = key.lower()
+        attr_type = Config.__annotations__.get(attr_name)
+        if attr_type is None:
+            raise KeyError(f"No such config key: {key}.")
+
+        if typing.get_origin(attr_type) is Literal:  # type: ignore[comparison-overlap]
+            options = typing.get_args(attr_type)
+            if value not in options:
+                raise ValueError(f"Invalid value for {key}, need one of {', '.join(options)}")
+        elif not isinstance(value, attr_type):
+            raise TypeError(f"Invalid type for {key}: expected {attr_type}, got {type(value)}")
+
+        self.__setattr__(attr_name, value)
+
+    def __delitem__(self, key: str) -> None:
+        """Weakly-typed indexer access using env var names for backcompat."""
+        self.__delattr__(key.lower())
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Weakly-typed indexer access using env var names for backcompat."""
+        attr_name = key.lower()
+        try:
+            return self.__getitem__(attr_name)
+        except KeyError:
+            return default
 
 
 config = Config()

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -17,150 +17,150 @@ class Config:
     """
 
     # Whether we're in dev mode
-    dev: bool
+    DEV: bool
     # Whether we're `api` mode (answering API queries) or `scheduler` (scheduling background jobs), or `worker`
     # (servicing background jobs). Can also be set to `all` to do all three simultaneously
-    role: Literal["api", "scheduler", "worker", "all"] = "all"
+    ROLE: Literal["api", "scheduler", "worker", "all"] = "all"
     # number of bg worker processes, requires worker or all above
-    background_worker_count: int = 2
+    BACKGROUND_WORKER_COUNT: int = 2
     # Version string
-    version: str = "unknown"
+    VERSION: str = "unknown"
     # ISO 8601 timestamp of the deployed commit (CI_COMMIT_TIMESTAMP), empty outside CI builds
-    commit_timestamp: str = ""
+    COMMIT_TIMESTAMP: str = ""
     # Base URL of frontend, e.g. https://couchers.org
-    base_url: str
+    BASE_URL: str
     # URL of the backend, e.g. https://api.couchers.org
-    backend_base_url: str
+    BACKEND_BASE_URL: str
     # URL of the console, e.g. https://console.couchers.org
-    console_base_url: str
+    CONSOLE_BASE_URL: str
     # URL of the merch shop, e.g. https://shop.couchershq.org
-    merch_shop_url: str
+    MERCH_SHOP_URL: str
     # Used to generate a variety of secrets
-    secret: bytes
+    SECRET: bytes
     # Domain that cookies should set as their domain value
-    cookie_domain: str
+    COOKIE_DOMAIN: str
     # SQLAlchemy database connection string
-    database_connection_string: str
+    DATABASE_CONNECTION_STRING: str
     # OpenTelemetry endpoint to send traces to
-    opentelemetry_endpoint: str = ""
+    OPENTELEMETRY_ENDPOINT: str = ""
     # Path to a GeoLite2-City.mmdb file for geocoding IPs in user session info
-    geolite2_city_mmdb_file_location: str = ""
-    geolite2_asn_mmdb_file_location: str = ""
+    GEOLITE2_CITY_MMDB_FILE_LOCATION: str = ""
+    GEOLITE2_ASN_MMDB_FILE_LOCATION: str = ""
     # Whether to try adding dummy data
-    add_dummy_data: bool
+    ADD_DUMMY_DATA: bool
     # Donations (gated at runtime by the `donations_enabled` feature flag)
-    stripe_api_key: str
-    stripe_webhook_secret: str
-    stripe_recurring_product_id: str
+    STRIPE_API_KEY: str
+    STRIPE_WEBHOOK_SECRET: str
+    STRIPE_RECURRING_PRODUCT_ID: str
     # Strong verification through Iris ID (gated at runtime by the `strong_verification_enabled` feature flag)
-    iris_id_pubkey: str
-    iris_id_secret: str
-    verification_data_public_key: bytes
+    IRIS_ID_PUBKEY: str
+    IRIS_ID_SECRET: str
+    VERIFICATION_DATA_PUBLIC_KEY: bytes
     # Postal verification (MyPostcard API; gated at runtime by the `postal_verification_enabled` feature flag)
-    mypostcard_api_key: str
-    mypostcard_username: str
-    mypostcard_password: str
-    mypostcard_product_code: str
-    mypostcard_campaign_id: str
+    MYPOSTCARD_API_KEY: str
+    MYPOSTCARD_USERNAME: str
+    MYPOSTCARD_PASSWORD: str
+    MYPOSTCARD_PRODUCT_CODE: str
+    MYPOSTCARD_CAMPAIGN_ID: str
     # SMS (gated at runtime by the `sms_enabled` feature flag)
-    sms_sender_id: str
+    SMS_SENDER_ID: str
     # Email
-    enable_email: bool
+    ENABLE_EMAIL: bool
     # Sender name for outgoing notification emails e.g. "Couchers.org"
-    notification_email_sender: str
+    NOTIFICATION_EMAIL_SENDER: str
     # Sender email, e.g. "notify@couchers.org"
-    notification_email_address: str
+    NOTIFICATION_EMAIL_ADDRESS: str
     # An optional prefix for email subject, e.g. [STAGING]
-    notification_prefix: str = ""
+    NOTIFICATION_PREFIX: str = ""
     # Address to send emails about reported users
-    reports_email_recipient: str
+    REPORTS_EMAIL_RECIPIENT: str
     # Address to send contributor forms when users sign up/fill the form
-    contributor_form_email_recipient: str
+    CONTRIBUTOR_FORM_EMAIL_RECIPIENT: str
     # Address to moderation notifications
-    mods_email_recipient: str
+    MODS_EMAIL_RECIPIENT: str
     # SMTP settings
-    smtp_host: str
-    smtp_port: int
-    smtp_username: str
-    smtp_password: str
+    SMTP_HOST: str
+    SMTP_PORT: int
+    SMTP_USERNAME: str
+    SMTP_PASSWORD: str
     # Media server
-    enable_media: bool
-    media_server_secret_key: bytes
-    media_server_bearer_token: str
-    media_server_base_url: str
-    media_server_upload_base_url: str
+    ENABLE_MEDIA: bool
+    MEDIA_SERVER_SECRET_KEY: bytes
+    MEDIA_SERVER_BEARER_TOKEN: str
+    MEDIA_SERVER_BASE_URL: str
+    MEDIA_SERVER_UPLOAD_BASE_URL: str
     # Bug reporting tool
-    bug_tool_enabled: bool
-    bug_tool_github_repo: str
-    bug_tool_github_username: str
-    bug_tool_github_token: str
+    BUG_TOOL_ENABLED: bool
+    BUG_TOOL_GITHUB_REPO: str
+    BUG_TOOL_GITHUB_USERNAME: str
+    BUG_TOOL_GITHUB_TOKEN: str
     # Sentry
-    sentry_enabled: bool
-    sentry_url: str
+    SENTRY_ENABLED: bool
+    SENTRY_URL: str
     # Push notifications
-    push_notifications_enabled: bool
-    push_notifications_vapid_private_key: str
-    push_notifications_vapid_subject: str
+    PUSH_NOTIFICATIONS_ENABLED: bool
+    PUSH_NOTIFICATIONS_VAPID_PRIVATE_KEY: str
+    PUSH_NOTIFICATIONS_VAPID_SUBJECT: str
     # Whether to initiate new activeness probes
-    activeness_probes_enabled: bool
+    ACTIVENESS_PROBES_ENABLED: bool
     # Listmonk (mailing list, gated at runtime by the `listmonk_enabled` feature flag)
-    listmonk_base_url: str
-    listmonk_api_username: str
-    listmonk_api_key: str
-    listmonk_list_id: int
+    LISTMONK_BASE_URL: str
+    LISTMONK_API_USERNAME: str
+    LISTMONK_API_KEY: str
+    LISTMONK_LIST_ID: int
     # Google recaptcha antibot (gated at runtime by the `recaptcha_enabled` feature flag)
-    recapthca_project_id: str
-    recapthca_api_key: str
-    recapthca_site_key: str
+    RECAPTHCA_PROJECT_ID: str
+    RECAPTHCA_API_KEY: str
+    RECAPTHCA_SITE_KEY: str
     # Whether we're in test
-    in_test: bool = False
+    IN_TEST: bool = False
     # Experimentation (feature flags via GrowthBook)
-    experimentation_enabled: bool = False
+    EXPERIMENTATION_ENABLED: bool = False
     # When enabled, all feature gates return True (useful for development/testing)
-    experimentation_pass_all_gates: bool = False
+    EXPERIMENTATION_PASS_ALL_GATES: bool = False
     # GrowthBook SDK configuration
-    growthbook_api_host: str = "https://cdn.growthbook.io"
-    growthbook_client_key: str = ""
+    GROWTHBOOK_API_HOST: str = "https://cdn.growthbook.io"
+    GROWTHBOOK_CLIENT_KEY: str = ""
     # Disk path for the last-known-good feature payload, used as a cold-start fallback when GrowthBook
     # is unreachable. Required when experimentation is enabled so we never start on in-code defaults.
-    growthbook_cache_path: str = ""
+    GROWTHBOOK_CACHE_PATH: str = ""
     # Continuous profiling (Pyroscope). Profiling is gated at runtime by the `profiling_enabled` feature
     # flag; PYROSCOPE_ENABLED is the per-deployment master switch.
-    pyroscope_enabled: bool
-    pyroscope_server: str
-    pyroscope_auth_token: str
+    PYROSCOPE_ENABLED: bool
+    PYROSCOPE_SERVER: str
+    PYROSCOPE_AUTH_TOKEN: str
     # Moderation auto-approval deadline in seconds (0 to disable auto-approval)
-    moderation_auto_approve_deadline_seconds: int
+    MODERATION_AUTO_APPROVE_DEADLINE_SECONDS: int
     # User ID of the bot user for automated moderation actions
-    moderation_bot_user_id: int
+    MODERATION_BOT_USER_ID: int
     # Enable development APIs (e.g., SendDevPushNotification)
-    enable_dev_apis: bool
+    ENABLE_DEV_APIS: bool
     # Slack notifications
-    slack_enabled: bool
-    slack_bot_token: str
-    slack_donations_channel: str
-    slack_merch_channel: str
+    SLACK_ENABLED: bool
+    SLACK_BOT_TOKEN: str
+    SLACK_DONATIONS_CHANNEL: str
+    SLACK_MERCH_CHANNEL: str
 
     def __init__(self) -> None:
         # Initialize instance attributes with default values from class attributes.
-        for attr_name in Config.__annotations__.keys():
+        for var_name in Config.__annotations__.keys():
             try:
-                default_value = getattr(Config, attr_name)
+                default_value = getattr(Config, var_name)
             except AttributeError:
                 continue
-            self.__setattr__(attr_name, default_value)
+            self.__setattr__(var_name, default_value)
 
     def copy_from(self, other: Config) -> None:
-        for attr_name in Config.__annotations__.keys():
+        for var_name in Config.__annotations__.keys():
             try:
-                attr_value = other.__getattribute__(attr_name)
+                attr_value = other.__getattribute__(var_name)
             except AttributeError:
                 try:
-                    self.__delattr__(attr_name)
+                    self.__delattr__(var_name)
                 except AttributeError:
                     pass
                 continue
-            self.__setattr__(attr_name, attr_value)
+            self.__setattr__(var_name, attr_value)
 
     def copy(self) -> Config:
         copy = Config()
@@ -173,129 +173,125 @@ class Config:
             if not hasattr(self, attr_name):
                 raise ValueError(f"Config value {attr_name} not set")
 
-        if not self.dev:
+        if not self.DEV:
             # checks for prod
-            if "https" not in self.base_url:
+            if "https" not in self.BASE_URL:
                 raise Exception("Production site must be over HTTPS")
-            if not self.enable_email:
+            if not self.ENABLE_EMAIL:
                 raise Exception("Production site must have email enabled")
-            if self.in_test:
+            if self.IN_TEST:
                 raise Exception("IN_TEST while not DEV")
 
             # Donations are gated at runtime by the `donations_enabled` feature flag, which can be flipped on
             # remotely at any time, so prod must always have Stripe credentials present so the feature can run.
-            if not self.stripe_api_key or not self.stripe_webhook_secret or not self.stripe_recurring_product_id:
+            if not self.STRIPE_API_KEY or not self.STRIPE_WEBHOOK_SECRET or not self.STRIPE_RECURRING_PRODUCT_ID:
                 raise Exception("Stripe credentials must be configured in production")
 
             # Listmonk is gated at runtime by the `listmonk_enabled` feature flag, which can be flipped on
             # remotely at any time, so prod must always have the Listmonk credentials present.
             if (
-                not self.listmonk_base_url
-                or not self.listmonk_api_username
-                or not self.listmonk_api_key
-                or not self.listmonk_list_id
+                not self.LISTMONK_BASE_URL
+                or not self.LISTMONK_API_USERNAME
+                or not self.LISTMONK_API_KEY
+                or not self.LISTMONK_LIST_ID
             ):
                 raise Exception("Listmonk credentials must be configured in production")
 
             # The following features are gated at runtime by feature flags (`strong_verification_enabled`,
             # `postal_verification_enabled`, `recaptcha_enabled`), which can be flipped on remotely at any
             # time, so prod must always have their credentials present.
-            if not self.iris_id_pubkey or not self.iris_id_secret or not self.verification_data_public_key:
+            if not self.IRIS_ID_PUBKEY or not self.IRIS_ID_SECRET or not self.VERIFICATION_DATA_PUBLIC_KEY:
                 raise Exception("Iris ID credentials must be configured in production")
             if (
-                not self.mypostcard_api_key
-                or not self.mypostcard_username
-                or not self.mypostcard_password
-                or not self.mypostcard_product_code
-                or not self.mypostcard_campaign_id
+                not self.MYPOSTCARD_API_KEY
+                or not self.MYPOSTCARD_USERNAME
+                or not self.MYPOSTCARD_PASSWORD
+                or not self.MYPOSTCARD_PRODUCT_CODE
+                or not self.MYPOSTCARD_CAMPAIGN_ID
             ):
                 raise Exception("MyPostcard API credentials must be configured in production")
-            if not self.recapthca_project_id or not self.recapthca_api_key or not self.recapthca_site_key:
+            if not self.RECAPTHCA_PROJECT_ID or not self.RECAPTHCA_API_KEY or not self.RECAPTHCA_SITE_KEY:
                 raise Exception("reCAPTCHA credentials must be configured in production")
 
-        if self.experimentation_enabled:
-            if not self.growthbook_client_key:
+        if self.EXPERIMENTATION_ENABLED:
+            if not self.GROWTHBOOK_CLIENT_KEY:
                 raise Exception("No GrowthBook client key but experimentation enabled")
-            if not self.growthbook_cache_path:
+            if not self.GROWTHBOOK_CACHE_PATH:
                 raise Exception("No GrowthBook cache path but experimentation enabled")
 
-        if self.pyroscope_enabled:
-            if not self.pyroscope_server or not self.pyroscope_auth_token:
+        if self.PYROSCOPE_ENABLED:
+            if not self.PYROSCOPE_SERVER or not self.PYROSCOPE_AUTH_TOKEN:
                 raise Exception("No Pyroscope server or auth token but profiling enabled")
 
     def load_from_env(self, env: Mapping[str, str]) -> None:
         """Populates this config object from environment variables."""
-        for attr_name, attr_type in Config.__annotations__.items():
-            env_name = attr_name.upper()
-            env_value = env.get(env_name)
+        for var_name, var_type in Config.__annotations__.items():
+            env_value = env.get(var_name)
             if env_value is None:
                 continue
 
             attr_value: Any
-            if attr_type is str:
+            if var_type is str:
                 attr_value = env_value
-            elif attr_type is int:
+            elif var_type is int:
                 if not env_value.isdigit():
-                    raise ValueError(f"Invalid int for {env_name}")
+                    raise ValueError(f"Invalid int for {var_name}")
                 attr_value = int(env_value)
-            elif attr_type is bool:
+            elif var_type is bool:
                 # 1 is true, 0 is false, everything else is illegal
                 if env_value not in ("0", "1"):
-                    raise ValueError(f'Invalid bool for {env_name}, need "0" or "1"')
+                    raise ValueError(f'Invalid bool for {var_name}, need "0" or "1"')
                 attr_value = env_value == "1"
-            elif attr_type is bytes:
+            elif var_type is bytes:
                 # decode from hex
                 attr_value = bytes.fromhex(env_value)
             # mypy erroneously reports an error below (https://github.com/python/mypy/issues/15630)
-            elif typing.get_origin(attr_type) is Literal:  # type: ignore[comparison-overlap]
+            elif typing.get_origin(var_type) is Literal:  # type: ignore[comparison-overlap]
                 # list of allowed string values
-                options = typing.get_args(attr_type)
+                options = typing.get_args(var_type)
                 if env_value not in options:
-                    raise ValueError(f"Invalid value for {env_name}, need one of {', '.join(options)}")
+                    raise ValueError(f"Invalid value for {var_name}, need one of {', '.join(options)}")
                 attr_value = env_value
             else:
-                raise ValueError(f"Unsupported config type {attr_type} for {env_name}")
+                raise ValueError(f"Unsupported config type {var_type} for {var_name}")
 
-            self.__setattr__(attr_name, attr_value)
+            self.__setattr__(var_name, attr_value)
 
     # Weakly typed dict-like interface using env var names for backcompat.
 
     def __getitem__(self, key: str) -> Any:
         """Weakly-typed indexer access using env var names for backcompat."""
-        attr_name = key.lower()
-        if Config.__annotations__.get(attr_name) is None:
+        if Config.__annotations__.get(key) is None:
             raise KeyError(f"No such config key: {key}.")
 
         try:
-            return self.__getattribute__(attr_name)
+            return self.__getattribute__(key)
         except AttributeError:
             raise KeyError(f"Config key undefined and has no default: {key}.") from None
 
     def __setitem__(self, key: str, value: Any) -> None:
         """Weakly-typed indexer access using env var names for backcompat."""
-        attr_name = key.lower()
-        attr_type = Config.__annotations__.get(attr_name)
-        if attr_type is None:
+        var_type = Config.__annotations__.get(key)
+        if var_type is None:
             raise KeyError(f"No such config key: {key}.")
 
-        if typing.get_origin(attr_type) is Literal:  # type: ignore[comparison-overlap]
-            options = typing.get_args(attr_type)
+        if typing.get_origin(var_type) is Literal:  # type: ignore[comparison-overlap]
+            options = typing.get_args(var_type)
             if value not in options:
                 raise ValueError(f"Invalid value for {key}, need one of {', '.join(options)}")
-        elif not isinstance(value, attr_type):
-            raise TypeError(f"Invalid type for {key}: expected {attr_type}, got {type(value)}")
+        elif not isinstance(value, var_type):
+            raise TypeError(f"Invalid type for {key}: expected {var_type}, got {type(value)}")
 
-        self.__setattr__(attr_name, value)
+        self.__setattr__(key, value)
 
     def __delitem__(self, key: str) -> None:
         """Weakly-typed indexer access using env var names for backcompat."""
-        self.__delattr__(key.lower())
+        self.__delattr__(key)
 
     def get(self, key: str, default: Any = None) -> Any:
         """Weakly-typed indexer access using env var names for backcompat."""
-        attr_name = key.lower()
         try:
-            return self.__getitem__(attr_name)
+            return self.__getitem__(key)
         except KeyError:
             return default
 

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -155,6 +155,31 @@ class Config:
         except AttributeError:
             raise KeyError(f"Config key undefined and has no default: {key}.") from None
 
+    def get(self, key: str, default: Any = None) -> Any:
+        """Weakly-typed indexer access using env var names for backcompat."""
+        attr_name = key.lower()
+        try:
+            return self.__getitem__(attr_name)
+        except KeyError:
+            return default
+
+    def copy(self) -> Config:
+        copy = Config()
+        copy.copy_from(self)
+        return copy
+
+    def copy_from(self, other: Config) -> None:
+        for attr_name in Config.__annotations__.keys():
+            try:
+                attr_value = other.__getattribute__(attr_name)
+            except AttributeError:
+                try:
+                    self.__delattr__(attr_name)
+                except AttributeError:
+                    pass
+                continue
+            self.__setattr__(attr_name, attr_value)
+
     def check(self) -> None:
         """Checks that the config is valid, i.e., all required values are set to valid values."""
         for attr_name in Config.__annotations__.keys():

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -3,239 +3,249 @@ A simple config system
 """
 
 import os
-from typing import Any
+import typing
+from collections.abc import Mapping
+from typing import Any, Literal
 
-CONFIG_T = list[tuple[str, type | list[str]] | tuple[str, type | list[str], str | int]]
 
-# Allowed config options, as tuples (name, type, default).
-# All fields are required
-CONFIG_OPTIONS: CONFIG_T = [
+# Not a dataclass. Not all attributes must be initialized.
+class Config:
     # Whether we're in dev mode
-    ("DEV", bool),
+    dev: bool
     # Whether we're `api` mode (answering API queries) or `scheduler` (scheduling background jobs), or `worker`
     # (servicing background jobs). Can also be set to `all` to do all three simultaneously
-    ("ROLE", ["api", "scheduler", "worker", "all"], "all"),
+    role: Literal["api", "scheduler", "worker", "all"] = "all"
     # number of bg worker processes, requires worker or all above
-    ("BACKGROUND_WORKER_COUNT", int, 2),
+    background_worker_count: int = 2
     # Version string
-    ("VERSION", str, "unknown"),
+    version: str = "unknown"
     # ISO 8601 timestamp of the deployed commit (CI_COMMIT_TIMESTAMP), empty outside CI builds
-    ("COMMIT_TIMESTAMP", str, ""),
+    commit_timestamp: str = ""
     # Base URL of frontend, e.g. https://couchers.org
-    ("BASE_URL", str),
+    base_url: str
     # URL of the backend, e.g. https://api.couchers.org
-    ("BACKEND_BASE_URL", str),
+    backend_base_url: str
     # URL of the console, e.g. https://console.couchers.org
-    ("CONSOLE_BASE_URL", str),
+    console_base_url: str
     # URL of the merch shop, e.g. https://shop.couchershq.org
-    ("MERCH_SHOP_URL", str),
+    merch_shop_url: str
     # Used to generate a variety of secrets
-    ("SECRET", bytes),
+    secret: bytes
     # Domain that cookies should set as their domain value
-    ("COOKIE_DOMAIN", str),
+    cookie_domain: str
     # SQLAlchemy database connection string
-    ("DATABASE_CONNECTION_STRING", str),
+    database_connection_string: str
     # OpenTelemetry endpoint to send traces to
-    ("OPENTELEMETRY_ENDPOINT", str, ""),
+    opentelemetry_endpoint: str = ""
     # Path to a GeoLite2-City.mmdb file for geocoding IPs in user session info
-    ("GEOLITE2_CITY_MMDB_FILE_LOCATION", str, ""),
-    ("GEOLITE2_ASN_MMDB_FILE_LOCATION", str, ""),
+    geolite2_city_mmdb_file_location: str = ""
+    geolite2_asn_mmdb_file_location: str = ""
     # Whether to try adding dummy data
-    ("ADD_DUMMY_DATA", bool),
+    add_dummy_data: bool
     # Donations (gated at runtime by the `donations_enabled` feature flag)
-    ("STRIPE_API_KEY", str),
-    ("STRIPE_WEBHOOK_SECRET", str),
-    ("STRIPE_RECURRING_PRODUCT_ID", str),
+    stripe_api_key: str
+    stripe_webhook_secret: str
+    stripe_recurring_product_id: str
     # Strong verification through Iris ID (gated at runtime by the `strong_verification_enabled` feature flag)
-    ("IRIS_ID_PUBKEY", str),
-    ("IRIS_ID_SECRET", str),
-    ("VERIFICATION_DATA_PUBLIC_KEY", bytes),
+    iris_id_pubkey: str
+    iris_id_secret: str
+    verification_data_public_key: bytes
     # Postal verification (MyPostcard API; gated at runtime by the `postal_verification_enabled` feature flag)
-    ("MYPOSTCARD_API_KEY", str),
-    ("MYPOSTCARD_USERNAME", str),
-    ("MYPOSTCARD_PASSWORD", str),
-    ("MYPOSTCARD_PRODUCT_CODE", str),
-    ("MYPOSTCARD_CAMPAIGN_ID", str),
+    mypostcard_api_key: str
+    mypostcard_username: str
+    mypostcard_password: str
+    mypostcard_product_code: str
+    mypostcard_campaign_id: str
     # SMS (gated at runtime by the `sms_enabled` feature flag)
-    ("SMS_SENDER_ID", str),
+    sms_sender_id: str
     # Email
-    ("ENABLE_EMAIL", bool),
+    enable_email: bool
     # Sender name for outgoing notification emails e.g. "Couchers.org"
-    ("NOTIFICATION_EMAIL_SENDER", str),
+    notification_email_sender: str
     # Sender email, e.g. "notify@couchers.org"
-    ("NOTIFICATION_EMAIL_ADDRESS", str),
+    notification_email_address: str
     # An optional prefix for email subject, e.g. [STAGING]
-    ("NOTIFICATION_PREFIX", str, ""),
+    notification_prefix: str = ""
     # Address to send emails about reported users
-    ("REPORTS_EMAIL_RECIPIENT", str),
+    reports_email_recipient: str
     # Address to send contributor forms when users sign up/fill the form
-    ("CONTRIBUTOR_FORM_EMAIL_RECIPIENT", str),
+    contributor_form_email_recipient: str
     # Address to moderation notifications
-    ("MODS_EMAIL_RECIPIENT", str),
+    mods_email_recipient: str
     # SMTP settings
-    ("SMTP_HOST", str),
-    ("SMTP_PORT", int),
-    ("SMTP_USERNAME", str),
-    ("SMTP_PASSWORD", str),
+    smtp_host: str
+    smtp_port: int
+    smtp_username: str
+    smtp_password: str
     # Media server
-    ("ENABLE_MEDIA", bool),
-    ("MEDIA_SERVER_SECRET_KEY", bytes),
-    ("MEDIA_SERVER_BEARER_TOKEN", str),
-    ("MEDIA_SERVER_BASE_URL", str),
-    ("MEDIA_SERVER_UPLOAD_BASE_URL", str),
+    enable_media: bool
+    media_server_secret_key: bytes
+    media_server_bearer_token: str
+    media_server_base_url: str
+    media_server_upload_base_url: str
     # Bug reporting tool
-    ("BUG_TOOL_ENABLED", bool),
-    ("BUG_TOOL_GITHUB_REPO", str),
-    ("BUG_TOOL_GITHUB_USERNAME", str),
-    ("BUG_TOOL_GITHUB_TOKEN", str),
+    bug_tool_enabled: bool
+    bug_tool_github_repo: str
+    bug_tool_github_username: str
+    bug_tool_github_token: str
     # Sentry
-    ("SENTRY_ENABLED", bool),
-    ("SENTRY_URL", str),
+    sentry_enabled: bool
+    sentry_url: str
     # Push notifications
-    ("PUSH_NOTIFICATIONS_ENABLED", bool),
-    ("PUSH_NOTIFICATIONS_VAPID_PRIVATE_KEY", str),
-    ("PUSH_NOTIFICATIONS_VAPID_SUBJECT", str),
+    push_notifications_enabled: bool
+    push_notifications_vapid_private_key: str
+    push_notifications_vapid_subject: str
     # Whether to initiate new activeness probes
-    ("ACTIVENESS_PROBES_ENABLED", bool),
+    activeness_probes_enabled: bool
     # Listmonk (mailing list, gated at runtime by the `listmonk_enabled` feature flag)
-    ("LISTMONK_BASE_URL", str),
-    ("LISTMONK_API_USERNAME", str),
-    ("LISTMONK_API_KEY", str),
-    ("LISTMONK_LIST_ID", int),
+    listmonk_base_url: str
+    listmonk_api_username: str
+    listmonk_api_key: str
+    listmonk_list_id: int
     # Google recaptcha antibot (gated at runtime by the `recaptcha_enabled` feature flag)
-    ("RECAPTHCA_PROJECT_ID", str),
-    ("RECAPTHCA_API_KEY", str),
-    ("RECAPTHCA_SITE_KEY", str),
+    recapthca_project_id: str
+    recapthca_api_key: str
+    recapthca_site_key: str
     # Whether we're in test
-    ("IN_TEST", bool, "0"),
+    in_test: bool = False
     # Experimentation (feature flags via GrowthBook)
-    ("EXPERIMENTATION_ENABLED", bool, "0"),
+    experimentation_enabled: bool = False
     # When enabled, all feature gates return True (useful for development/testing)
-    ("EXPERIMENTATION_PASS_ALL_GATES", bool, "0"),
+    experimentation_pass_all_gates: bool = False
     # GrowthBook SDK configuration
-    ("GROWTHBOOK_API_HOST", str, "https://cdn.growthbook.io"),
-    ("GROWTHBOOK_CLIENT_KEY", str, ""),
+    growthbook_api_host: str = "https://cdn.growthbook.io"
+    growthbook_client_key: str = ""
     # Disk path for the last-known-good feature payload, used as a cold-start fallback when GrowthBook
     # is unreachable. Required when experimentation is enabled so we never start on in-code defaults.
-    ("GROWTHBOOK_CACHE_PATH", str, ""),
+    growthbook_cache_path: str = ""
     # Continuous profiling (Pyroscope). Profiling is gated at runtime by the `profiling_enabled` feature
     # flag; PYROSCOPE_ENABLED is the per-deployment master switch.
-    ("PYROSCOPE_ENABLED", bool),
-    ("PYROSCOPE_SERVER", str),
-    ("PYROSCOPE_AUTH_TOKEN", str),
+    pyroscope_enabled: bool
+    pyroscope_server: str
+    pyroscope_auth_token: str
     # Moderation auto-approval deadline in seconds (0 to disable auto-approval)
-    ("MODERATION_AUTO_APPROVE_DEADLINE_SECONDS", int),
+    moderation_auto_approve_deadline_seconds: int
     # User ID of the bot user for automated moderation actions
-    ("MODERATION_BOT_USER_ID", int),
+    moderation_bot_user_id: int
     # Enable development APIs (e.g., SendDevPushNotification)
-    ("ENABLE_DEV_APIS", bool),
+    enable_dev_apis: bool
     # Slack notifications
-    ("SLACK_ENABLED", bool),
-    ("SLACK_BOT_TOKEN", str),
-    ("SLACK_DONATIONS_CHANNEL", str),
-    ("SLACK_MERCH_CHANNEL", str),
-]
+    slack_enabled: bool
+    slack_bot_token: str
+    slack_donations_channel: str
+    slack_merch_channel: str
 
-
-def check_config(cfg: dict[str, Any]) -> None:
-    for name, *_ in CONFIG_OPTIONS:
-        if name not in cfg:
-            raise ValueError(f"Required config value {name} not set")
-
-    if not cfg["DEV"]:
-        # checks for prod
-        if "https" not in cfg["BASE_URL"]:
-            raise Exception("Production site must be over HTTPS")
-        if not cfg["ENABLE_EMAIL"]:
-            raise Exception("Production site must have email enabled")
-        if cfg["IN_TEST"]:
-            raise Exception("IN_TEST while not DEV")
-
-        # Donations are gated at runtime by the `donations_enabled` feature flag, which can be flipped on
-        # remotely at any time, so prod must always have Stripe credentials present so the feature can run.
-        if not cfg["STRIPE_API_KEY"] or not cfg["STRIPE_WEBHOOK_SECRET"] or not cfg["STRIPE_RECURRING_PRODUCT_ID"]:
-            raise Exception("Stripe credentials must be configured in production")
-
-        # Listmonk is gated at runtime by the `listmonk_enabled` feature flag, which can be flipped on
-        # remotely at any time, so prod must always have the Listmonk credentials present.
-        if (
-            not cfg["LISTMONK_BASE_URL"]
-            or not cfg["LISTMONK_API_USERNAME"]
-            or not cfg["LISTMONK_API_KEY"]
-            or not cfg["LISTMONK_LIST_ID"]
-        ):
-            raise Exception("Listmonk credentials must be configured in production")
-
-        # The following features are gated at runtime by feature flags (`strong_verification_enabled`,
-        # `postal_verification_enabled`, `recaptcha_enabled`), which can be flipped on remotely at any
-        # time, so prod must always have their credentials present.
-        if not cfg["IRIS_ID_PUBKEY"] or not cfg["IRIS_ID_SECRET"] or not cfg["VERIFICATION_DATA_PUBLIC_KEY"]:
-            raise Exception("Iris ID credentials must be configured in production")
-        if (
-            not cfg["MYPOSTCARD_API_KEY"]
-            or not cfg["MYPOSTCARD_USERNAME"]
-            or not cfg["MYPOSTCARD_PASSWORD"]
-            or not cfg["MYPOSTCARD_PRODUCT_CODE"]
-            or not cfg["MYPOSTCARD_CAMPAIGN_ID"]
-        ):
-            raise Exception("MyPostcard API credentials must be configured in production")
-        if not cfg["RECAPTHCA_PROJECT_ID"] or not cfg["RECAPTHCA_API_KEY"] or not cfg["RECAPTHCA_SITE_KEY"]:
-            raise Exception("reCAPTCHA credentials must be configured in production")
-
-    if cfg["EXPERIMENTATION_ENABLED"]:
-        if not cfg["GROWTHBOOK_CLIENT_KEY"]:
-            raise Exception("No GrowthBook client key but experimentation enabled")
-        if not cfg["GROWTHBOOK_CACHE_PATH"]:
-            raise Exception("No GrowthBook cache path but experimentation enabled")
-
-    if cfg["PYROSCOPE_ENABLED"]:
-        if not cfg["PYROSCOPE_SERVER"] or not cfg["PYROSCOPE_AUTH_TOKEN"]:
-            raise Exception("No Pyroscope server or auth token but profiling enabled")
-
-
-def make_config() -> dict[str, Any]:
-    cfg = {}
-
-    for config_option in CONFIG_OPTIONS:
-        if len(config_option) == 2:
-            name, type_ = config_option
-            optional = False
-        elif len(config_option) == 3:
-            name, type_, default_value = config_option
-            optional = True
-        else:
-            raise ValueError("Invalid CONFIG_OPTIONS")
-
-        value: str | int | bytes | None = os.getenv(name)
-
-        if not value:
-            if not optional:
-                # config value not set - will cause a KeyError when trying
-                # to access it.
+    def __init__(self) -> None:
+        # Initialize instance attributes with default values from class attributes.
+        for attr_name in Config.__annotations__.keys():
+            try:
+                default_value = getattr(Config, attr_name)
+            except AttributeError:
                 continue
+            self.__setattr__(attr_name, default_value)
+
+    def __getitem__(self, key: str) -> Any:
+        """Weakly-typed indexer access using env var names for backcompat."""
+        attr_name = key.lower()
+        if Config.__annotations__.get(attr_name) is None:
+            raise KeyError(f"No such config key: {key}.")
+
+        try:
+            return self.__getattribute__(attr_name)
+        except AttributeError:
+            raise KeyError(f"Config key undefined and has no default: {key}.") from None
+
+    def check(self) -> None:
+        """Checks that the config is valid, i.e., all required values are set to valid values."""
+        for attr_name in Config.__annotations__.keys():
+            if not hasattr(self, attr_name):
+                raise ValueError(f"Config value {attr_name} not set")
+
+        if not self.dev:
+            # checks for prod
+            if "https" not in self.base_url:
+                raise Exception("Production site must be over HTTPS")
+            if not self.enable_email:
+                raise Exception("Production site must have email enabled")
+            if self.in_test:
+                raise Exception("IN_TEST while not DEV")
+
+            # Donations are gated at runtime by the `donations_enabled` feature flag, which can be flipped on
+            # remotely at any time, so prod must always have Stripe credentials present so the feature can run.
+            if not self.stripe_api_key or not self.stripe_webhook_secret or not self.stripe_recurring_product_id:
+                raise Exception("Stripe credentials must be configured in production")
+
+            # Listmonk is gated at runtime by the `listmonk_enabled` feature flag, which can be flipped on
+            # remotely at any time, so prod must always have the Listmonk credentials present.
+            if (
+                not self.listmonk_base_url
+                or not self.listmonk_api_username
+                or not self.listmonk_api_key
+                or not self.listmonk_list_id
+            ):
+                raise Exception("Listmonk credentials must be configured in production")
+
+            # The following features are gated at runtime by feature flags (`strong_verification_enabled`,
+            # `postal_verification_enabled`, `recaptcha_enabled`), which can be flipped on remotely at any
+            # time, so prod must always have their credentials present.
+            if not self.iris_id_pubkey or not self.iris_id_secret or not self.verification_data_public_key:
+                raise Exception("Iris ID credentials must be configured in production")
+            if (
+                not self.mypostcard_api_key
+                or not self.mypostcard_username
+                or not self.mypostcard_password
+                or not self.mypostcard_product_code
+                or not self.mypostcard_campaign_id
+            ):
+                raise Exception("MyPostcard API credentials must be configured in production")
+            if not self.recapthca_project_id or not self.recapthca_api_key or not self.recapthca_site_key:
+                raise Exception("reCAPTCHA credentials must be configured in production")
+
+        if self.experimentation_enabled:
+            if not self.growthbook_client_key:
+                raise Exception("No GrowthBook client key but experimentation enabled")
+            if not self.growthbook_cache_path:
+                raise Exception("No GrowthBook cache path but experimentation enabled")
+
+        if self.pyroscope_enabled:
+            if not self.pyroscope_server or not self.pyroscope_auth_token:
+                raise Exception("No Pyroscope server or auth token but profiling enabled")
+
+    def load_from_env(self, env: Mapping[str, str]) -> None:
+        """Populates this config object from environment variables."""
+        for attr_name, attr_type in Config.__annotations__.items():
+            env_name = attr_name.upper()
+            env_value = env.get(env_name)
+            if env_value is None:
+                continue
+
+            attr_value: Any
+            if attr_type is str:
+                attr_value = env_value
+            elif attr_type is int:
+                if not env_value.isdigit():
+                    raise ValueError(f"Invalid int for {env_name}")
+                attr_value = int(env_value)
+            elif attr_type is bool:
+                # 1 is true, 0 is false, everything else is illegal
+                if env_value not in ("0", "1"):
+                    raise ValueError(f'Invalid bool for {env_name}, need "0" or "1"')
+                attr_value = env_value == "1"
+            elif attr_type is bytes:
+                # decode from hex
+                attr_value = bytes.fromhex(env_value)
+            # mypy erroneously reports an error below (https://github.com/python/mypy/issues/15630)
+            elif typing.get_origin(attr_type) is Literal:  # type: ignore[comparison-overlap]
+                # list of allowed string values
+                options = typing.get_args(attr_type)
+                if env_value not in options:
+                    raise ValueError(f"Invalid value for {env_name}, need one of {', '.join(options)}")
+                attr_value = env_value
             else:
-                value = default_value
+                raise ValueError(f"Unsupported config type {attr_type} for {env_name}")
 
-        if type_ is bool:
-            # 1 is true, 0 is false, everything else is illegal
-            if value not in ["0", "1"]:
-                raise ValueError(f'Invalid bool for {name}, need "0" or "1"')
-            value = value == "1"
-        elif type_ is bytes:
-            # decode from hex
-            if not isinstance(value, str):
-                raise RuntimeError(type(value))
-            value = bytes.fromhex(value)
-        elif isinstance(type_, list):
-            # list of allowed string values
-            if value not in type_:
-                raise ValueError(f"Invalid value for {name}, need one of {', '.join(type_)}")
-        else:
-            value = type_(value)
-
-        cfg[name] = value
-
-    return cfg
+            self.__setattr__(attr_name, attr_value)
 
 
-config = make_config()
+config = Config()
+config.load_from_env(os.environ)

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -155,6 +155,22 @@ class Config:
         except AttributeError:
             raise KeyError(f"Config key undefined and has no default: {key}.") from None
 
+    def __setitem__(self, key: str, value: Any) -> None:
+        """Weakly-typed indexer access using env var names for backcompat."""
+        attr_name = key.lower()
+        attr_type = Config.__annotations__.get(attr_name)
+        if attr_type is None:
+            raise KeyError(f"No such config key: {key}.")
+
+        if typing.get_origin(attr_type) is Literal:  # type: ignore[comparison-overlap]
+            options = typing.get_args(attr_type)
+            if value not in options:
+                raise ValueError(f"Invalid value for {key}, need one of {', '.join(options)}")
+        elif not isinstance(value, attr_type):
+            raise TypeError(f"Invalid type for {key}: expected {attr_type}, got {type(value)}")
+
+        self.__setattr__(attr_name, value)
+
     def get(self, key: str, default: Any = None) -> Any:
         """Weakly-typed indexer access using env var names for backcompat."""
         attr_name = key.lower()

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -10,6 +10,12 @@ from typing import Any, Literal
 
 # Not a dataclass. Not all attributes must be initialized.
 class Config:
+    """
+    Defines strongly-typed application config values,
+    initializable from matching environment variables,
+    also supporting weakly-typed dict-like access for backcompat with existing code.
+    """
+
     # Whether we're in dev mode
     dev: bool
     # Whether we're `api` mode (answering API queries) or `scheduler` (scheduling background jobs), or `worker`

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -151,8 +151,6 @@ def db_class(setup_testdb: None, testdb_conn: Connection) -> None:
 @pytest.fixture(scope="class")
 def testconfig():
     prevconfig = config.copy()
-    config.clear()
-    config.update(prevconfig)
 
     config["IN_TEST"] = True
 
@@ -251,8 +249,7 @@ def testconfig():
 
     yield None
 
-    config.clear()
-    config.update(prevconfig)
+    config.copy_from(prevconfig)
 
 
 class FeatureFlags:

--- a/app/backend/src/tests/test_config.py
+++ b/app/backend/src/tests/test_config.py
@@ -12,62 +12,62 @@ def _complete_config(dev: bool) -> Config:
     so Config.check() should succeed against it.
     """
     cfg = Config()
-    for attr_name, attr_type in Config.__annotations__.items():
-        if attr_type is bool:
-            setattr(cfg, attr_name, True)
-        elif attr_type is int:
-            setattr(cfg, attr_name, 1)
-        elif attr_type is bytes:
-            setattr(cfg, attr_name, b"x")
-        elif typing.get_origin(attr_type) is typing.Literal:
-            setattr(cfg, attr_name, typing.get_args(attr_type)[0])
+    for var_name, var_type in Config.__annotations__.items():
+        if var_type is bool:
+            setattr(cfg, var_name, True)
+        elif var_type is int:
+            setattr(cfg, var_name, 1)
+        elif var_type is bytes:
+            setattr(cfg, var_name, b"x")
+        elif typing.get_origin(var_type) is typing.Literal:
+            setattr(cfg, var_name, typing.get_args(var_type)[0])
         else:
-            setattr(cfg, attr_name, "x")
+            setattr(cfg, var_name, "x")
 
-    cfg.dev = dev
+    cfg.DEV = dev
     if not dev:
         # production invariants that aren't satisfiable by a generic truthy value
-        cfg.base_url = "https://example.com"
-        cfg.enable_email = True
-        cfg.in_test = False
+        cfg.BASE_URL = "https://example.com"
+        cfg.ENABLE_EMAIL = True
+        cfg.IN_TEST = False
     return cfg
 
 
 def test_load_from_env() -> None:
     cfg = Config()
-    assert not hasattr(cfg, "base_url")
+    assert not hasattr(cfg, "BASE_URL")
     cfg.load_from_env({"BASE_URL": "https://example.com"})
-    assert cfg.base_url == "https://example.com"
+    assert cfg.BASE_URL == "https://example.com"
 
 
 def test_load_from_env_types() -> None:
     cfg = Config()
 
     cfg.load_from_env({"IN_TEST": "1"})
-    assert cfg.in_test is True
+    assert cfg.IN_TEST is True
     with pytest.raises(ValueError):
         cfg.load_from_env({"IN_TEST": "not a bool"})
 
     cfg.load_from_env({"BACKGROUND_WORKER_COUNT": "42"})
-    assert cfg.background_worker_count == 42
+    assert cfg.BACKGROUND_WORKER_COUNT == 42
     with pytest.raises(ValueError):
         cfg.load_from_env({"BACKGROUND_WORKER_COUNT": "not an int"})
 
     cfg.load_from_env({"SECRET": bytes.hex(b"abc")})
-    assert cfg.secret == b"abc"
+    assert cfg.SECRET == b"abc"
     with pytest.raises(ValueError):
         cfg.load_from_env({"SECRET": "not hex"})
 
     cfg.load_from_env({"ROLE": "worker"})
-    assert cfg.role == "worker"
+    assert cfg.ROLE == "worker"
     with pytest.raises(ValueError):
         cfg.load_from_env({"ROLE": "not a valid role"})
 
 
 def test_getitem() -> None:
     cfg = Config()
-    cfg.base_url = "https://example.com"
-    assert cfg.base_url == "https://example.com"
+    cfg.BASE_URL = "https://example.com"
+    assert cfg.BASE_URL == "https://example.com"
     assert cfg["BASE_URL"] == "https://example.com"
 
 
@@ -75,7 +75,7 @@ def test_setitem() -> None:
     cfg = Config()
 
     cfg["BASE_URL"] = "https://example.com"
-    assert cfg.base_url == "https://example.com"
+    assert cfg.BASE_URL == "https://example.com"
     assert cfg["BASE_URL"] == "https://example.com"
 
     with pytest.raises(KeyError):
@@ -86,32 +86,31 @@ def test_setitem() -> None:
 
 
 def test_instances_state_are_independent() -> None:
-    """"""
     # Default values are declared at the class level, but should be copied to each instance.
-    assert Config.in_test is False
+    assert Config.IN_TEST is False
 
     cfg1 = Config()
     cfg2 = Config()
 
-    assert cfg1.in_test is False
-    assert cfg2.in_test is False
+    assert cfg1.IN_TEST is False
+    assert cfg2.IN_TEST is False
 
-    cfg1.in_test = True
+    cfg1.IN_TEST = True
 
-    assert cfg1.in_test is True
-    assert cfg2.in_test is False
+    assert cfg1.IN_TEST is True
+    assert cfg2.IN_TEST is False
 
 
 def test_copy() -> None:
     cfg = Config()
 
-    cfg.background_worker_count = 1
+    cfg.BACKGROUND_WORKER_COUNT = 1
     copy1 = cfg.copy()
-    cfg.background_worker_count = 2
+    cfg.BACKGROUND_WORKER_COUNT = 2
     copy2 = cfg.copy()
 
-    assert copy1.background_worker_count == 1
-    assert copy2.background_worker_count == 2
+    assert copy1.BACKGROUND_WORKER_COUNT == 1
+    assert copy2.BACKGROUND_WORKER_COUNT == 2
 
 
 @pytest.mark.parametrize("dev", [True, False])

--- a/app/backend/src/tests/test_config.py
+++ b/app/backend/src/tests/test_config.py
@@ -1,44 +1,99 @@
-from typing import Any
+import typing
 
 import pytest
 
-from couchers.config import CONFIG_OPTIONS, check_config
+from couchers.config import Config
 
 
-def _complete_config(dev: bool) -> dict[str, Any]:
-    """Build a config dict with every CONFIG_OPTIONS key populated with a valid, truthy value.
+def _complete_config(dev: bool) -> Config:
+    """Build a config object attribute populated with a valid, truthy value.
 
-    This mirrors what make_config() produces when every env var is set, so check_config() must be
-    able to run against it without touching any key outside CONFIG_OPTIONS.
+    This mirrors what Config.load_from_env() produces when every env var is set,
+    so Config.check() should succeed against it.
     """
-    cfg: dict[str, Any] = {}
-    for name, type_, *_ in CONFIG_OPTIONS:
-        if type_ is bool:
-            cfg[name] = True
-        elif type_ is int:
-            cfg[name] = 1
-        elif type_ is bytes:
-            cfg[name] = b"x"
-        elif isinstance(type_, list):
-            cfg[name] = type_[0]
+    cfg = Config()
+    for attr_name, attr_type in Config.__annotations__.items():
+        if attr_type is bool:
+            setattr(cfg, attr_name, True)
+        elif attr_type is int:
+            setattr(cfg, attr_name, 1)
+        elif attr_type is bytes:
+            setattr(cfg, attr_name, b"x")
+        elif typing.get_origin(attr_type) is typing.Literal:
+            setattr(cfg, attr_name, typing.get_args(attr_type)[0])
         else:
-            cfg[name] = "x"
+            setattr(cfg, attr_name, "x")
 
-    cfg["DEV"] = dev
+    cfg.dev = dev
     if not dev:
         # production invariants that aren't satisfiable by a generic truthy value
-        cfg["BASE_URL"] = "https://example.com"
-        cfg["ENABLE_EMAIL"] = True
-        cfg["IN_TEST"] = False
+        cfg.base_url = "https://example.com"
+        cfg.enable_email = True
+        cfg.in_test = False
     return cfg
+
+
+def test_load_from_env() -> None:
+    cfg = Config()
+    assert not hasattr(cfg, "base_url")
+    cfg.load_from_env({"BASE_URL": "https://example.com"})
+    assert cfg.base_url == "https://example.com"
+
+
+def test_load_from_env_types() -> None:
+    cfg = Config()
+
+    cfg.load_from_env({"IN_TEST": "1"})
+    assert cfg.in_test is True
+    with pytest.raises(ValueError):
+        cfg.load_from_env({"IN_TEST": "not a bool"})
+
+    cfg.load_from_env({"BACKGROUND_WORKER_COUNT": "42"})
+    assert cfg.background_worker_count == 42
+    with pytest.raises(ValueError):
+        cfg.load_from_env({"BACKGROUND_WORKER_COUNT": "not an int"})
+
+    cfg.load_from_env({"SECRET": bytes.hex(b"abc")})
+    assert cfg.secret == b"abc"
+    with pytest.raises(ValueError):
+        cfg.load_from_env({"SECRET": "not hex"})
+
+    cfg.load_from_env({"ROLE": "worker"})
+    assert cfg.role == "worker"
+    with pytest.raises(ValueError):
+        cfg.load_from_env({"ROLE": "not a valid role"})
+
+
+def test_indexer_access() -> None:
+    cfg = Config()
+    cfg.base_url = "https://example.com"
+    assert cfg.base_url == "https://example.com"
+    assert cfg["BASE_URL"] == "https://example.com"
+
+
+def test_instances_state_are_independent() -> None:
+    """"""
+    # Default values are declared at the class level, but should be copied to each instance.
+    assert Config.in_test == "0"
+
+    cfg1 = Config()
+    cfg2 = Config()
+
+    assert cfg1.in_test == "0"
+    assert cfg2.in_test == "0"
+
+    cfg1.in_test = "1"
+
+    assert cfg1.in_test == "1"
+    assert cfg2.in_test == "0"
 
 
 @pytest.mark.parametrize("dev", [True, False])
 def test_check_config_only_references_known_keys(dev):
-    """check_config() must only access config keys that are declared in CONFIG_OPTIONS.
+    """Config.check() must only access config keys that are declared as attributes.
 
-    A reference to a key that was removed from CONFIG_OPTIONS (e.g. a toggle migrated to a feature
+    A reference to a key that was removed from attributes (e.g. a toggle migrated to a feature
     flag) would raise KeyError at app boot but is invisible to the rest of the test suite, since
-    check_config() only runs in app.py's startup path. Exercising it here catches that.
+    Config.check() only runs in app.py's startup path. Exercising it here catches that.
     """
-    check_config(_complete_config(dev=dev))
+    _complete_config(dev=dev).check()

--- a/app/backend/src/tests/test_config.py
+++ b/app/backend/src/tests/test_config.py
@@ -64,11 +64,25 @@ def test_load_from_env_types() -> None:
         cfg.load_from_env({"ROLE": "not a valid role"})
 
 
-def test_indexer_access() -> None:
+def test_getitem() -> None:
     cfg = Config()
     cfg.base_url = "https://example.com"
     assert cfg.base_url == "https://example.com"
     assert cfg["BASE_URL"] == "https://example.com"
+
+
+def test_setitem() -> None:
+    cfg = Config()
+
+    cfg["BASE_URL"] = "https://example.com"
+    assert cfg.base_url == "https://example.com"
+    assert cfg["BASE_URL"] == "https://example.com"
+
+    with pytest.raises(KeyError):
+        cfg["NOT_A_KEY"] = "value"
+
+    with pytest.raises(TypeError):
+        cfg["BASE_URL"] = 123
 
 
 def test_instances_state_are_independent() -> None:

--- a/app/backend/src/tests/test_config.py
+++ b/app/backend/src/tests/test_config.py
@@ -74,18 +74,30 @@ def test_indexer_access() -> None:
 def test_instances_state_are_independent() -> None:
     """"""
     # Default values are declared at the class level, but should be copied to each instance.
-    assert Config.in_test == "0"
+    assert Config.in_test is False
 
     cfg1 = Config()
     cfg2 = Config()
 
-    assert cfg1.in_test == "0"
-    assert cfg2.in_test == "0"
+    assert cfg1.in_test is False
+    assert cfg2.in_test is False
 
-    cfg1.in_test = "1"
+    cfg1.in_test = True
 
-    assert cfg1.in_test == "1"
-    assert cfg2.in_test == "0"
+    assert cfg1.in_test is True
+    assert cfg2.in_test is False
+
+
+def test_copy() -> None:
+    cfg = Config()
+
+    cfg.background_worker_count = 1
+    copy1 = cfg.copy()
+    cfg.background_worker_count = 2
+    copy2 = cfg.copy()
+
+    assert copy1.background_worker_count == 1
+    assert copy2.background_worker_count == 2
 
 
 @pytest.mark.parametrize("dev", [True, False])


### PR DESCRIPTION
Refactors `config` to store values as statically-typed, mypy-verifiable attributes. E.g. `config.background_worker_count` with static type `int` instead of untyped `config["BACKGROUND_WORKER_COUNT"]`.

To maintain backcompat and ease migration, the new `Config` style also mimics a dictionary, so indexed access using all caps environment variable names still works. I'd remove that after migrating to only accessing through attributes. Undefined config attributes are also still possible and will raise `AttributeError` on access, or `KeyError` if using indexed dictionary-like access.

We can't use a regular @dataclass because our code relies on working with partial environment variables [see here](https://github.com/Couchers-org/couchers/blob/045c86ca65a3e0172d23360690a2f4c69f4c3a21/app/backend/src/tests/conftest.py#L14), which I'd like to see if I can address subsequently.

If we're cool with the design, I'll migrate all accesses to use the attributes directly in a follow-up PR.

## Testing
Added tests.

Ran the server locally. I'm hitting these but they seem unrelated:

`[116010:     264350263812128] 2026-06-01 07:35:53,449: couchers.jobs.worker:96: 401 Client Error: Unauthorized for url: https://www.mypostcard.com/api/v1/request_orders`

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
