### PR TITLE
Backend: enforce chat initiation rate limit on SendDirectMessage

### DIFF
--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -888,6 +888,14 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         ).scalar_one_or_none()
 
         if not chat:
+            if process_rate_limits_and_check_abort(
+                session=session, user_id=user_id, action=RateLimitAction.chat_initiation
+            ):
+                context.abort_with_error_code(
+                    grpc.StatusCode.RESOURCE_EXHAUSTED,
+                    "chat_initiation_rate_limit2",
+                    substitutions={"count": RATE_LIMIT_HOURS},
+                )
             chat = _create_chat(session, user_id, [recipient_id])
 
         # Retrieve the sender's active subscription to the chat

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -796,6 +796,57 @@ def test_excessive_chat_initiations_are_reported(db, email_collector: EmailColle
         assert "The user has been blocked from sending further chat initiations for now." in email.plain
 
 
+def test_send_direct_message_rate_limit(db, moderator, email_collector: EmailCollector):
+    """SendDirectMessage should enforce the chat_initiation rate limit when creating a new DM, but not when sending into an existing one."""
+    user, token = generate_user(complete_profile=True)
+    rate_limit_definition = RATE_LIMIT_DEFINITIONS[RateLimitAction.chat_initiation]
+
+    with conversations_session(token) as c:
+        for _ in range(rate_limit_definition.warning_limit):
+            recipient, _ = generate_user()
+            c.SendDirectMessage(conversations_pb2.SendDirectMessageReq(recipient_user_id=recipient.id, text="hi"))
+
+        assert email_collector.count_for_reports() == 0
+
+        recipient, _ = generate_user()
+        existing_dm_recipient_id = recipient.id
+        c.SendDirectMessage(
+            conversations_pb2.SendDirectMessageReq(recipient_user_id=existing_dm_recipient_id, text="hi")
+        )
+
+        email = email_collector.pop_for_reports(last=True)
+        assert email.plain.startswith(
+            f"User {user.username} has sent {rate_limit_definition.warning_limit} chat initiations in the past {RATE_LIMIT_HOURS} hours."
+        )
+
+        for _ in range(rate_limit_definition.hard_limit - rate_limit_definition.warning_limit - 1):
+            recipient, _ = generate_user()
+            c.SendDirectMessage(conversations_pb2.SendDirectMessageReq(recipient_user_id=recipient.id, text="hi"))
+
+        assert email_collector.count_for_reports() == 0
+
+        # follow-up into an existing DM must not count as a new initiation
+        c.SendDirectMessage(
+            conversations_pb2.SendDirectMessageReq(recipient_user_id=existing_dm_recipient_id, text="follow-up")
+        )
+        assert email_collector.count_for_reports() == 0
+
+        recipient, _ = generate_user()
+        with pytest.raises(grpc.RpcError) as exc_info:
+            c.SendDirectMessage(conversations_pb2.SendDirectMessageReq(recipient_user_id=recipient.id, text="hi"))
+        assert exc_info.value.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
+        assert (
+            exc_info.value.details()
+            == "You have messaged a lot of users in the past 24 hours. To avoid spam, you can't contact any more users for now."
+        )
+
+        email = email_collector.pop_for_reports(last=True)
+        assert email.plain.startswith(
+            f"User {user.username} has sent {rate_limit_definition.hard_limit} chat initiations in the past {RATE_LIMIT_HOURS} hours."
+        )
+        assert "The user has been blocked from sending further chat initiations for now." in email.plain
+
+
 def test_leave_invite_to_group_chat(db, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()


### PR DESCRIPTION
The streamlined DM path (`SendDirectMessage`) creates a new `GroupChat` whenever no DM already exists between the sender and recipient, but it never called `process_rate_limits_and_check_abort`. That left DM initiation effectively unbounded ever since the streamlined system was wired up — the legacy `CreateGroupChat` RPC still applied the `chat_initiation` limit, but the new web "New message" entry point (`features/profile/view/NewMessage.tsx`) goes through `SendDirectMessage`.

This adds the same rate-limit check, but only inside the `if not chat:` branch — so follow-up messages into an existing DM don't count as initiations.

## Testing
- Added `test_send_direct_message_rate_limit` in `test_conversations.py` that asserts:
  - warning email fires at the warning threshold
  - hard limit aborts with `RESOURCE_EXHAUSTED` and the localized error string
  - re-sending into an already-existing DM does NOT increment the bucket
- `uv run pytest src/tests/test_conversations.py::test_send_direct_message_rate_limit src/tests/test_conversations.py::test_excessive_chat_initiations_are_reported src/tests/test_conversations.py::test_send_direct_message` — all 3 pass.
- `make format` clean.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._