### PR TITLE
Backend: per-user rate limit overrides via feature flag

### DIFF
--- a/app/backend/src/couchers/rate_limits/check.py
+++ b/app/backend/src/couchers/rate_limits/check.py
@@ -1,15 +1,19 @@
 import logging
 from collections.abc import Sequence
+from typing import Any
 
 from sqlalchemy import RowMapping, exists, select
 from sqlalchemy.orm import Session
 
+from couchers.context import CouchersContext
 from couchers.models import RateLimitAction, RateLimitViolation
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_INTERVAL
 from couchers.tasks import send_rate_limit_violation_report_email
 from couchers.utils import now
 
 logger = logging.getLogger(__name__)
+
+RATE_LIMIT_OVERRIDES_FLAG = "rate_limit_overrides"
 
 
 def _get_user_events_in_past_time_interval(
@@ -52,17 +56,40 @@ def _user_has_violated_rate_limit_in_past_time_interval(
     ).scalar_one()
 
 
-def process_rate_limits_and_check_abort(session: Session, user_id: int, action: RateLimitAction) -> bool:
+def _coerce_int_limit(value: Any, fallback: int) -> int:
+    # Reject bools explicitly: bool is a subclass of int, so `True` would otherwise pass through as 1
+    # and silently set a hard limit of 1.
+    if isinstance(value, bool) or not isinstance(value, int):
+        return fallback
+    return int(value)
+
+
+def _resolve_limits(context: CouchersContext, action: RateLimitAction) -> tuple[int, int]:
+    """Resolve (warning_limit, hard_limit) for this user, applying any per-user override from the
+    `rate_limit_overrides` object flag. Schema: `{<action.name>: {warning_limit?: int, hard_limit?: int}}`."""
+    definition = RATE_LIMIT_DEFINITIONS[action]
+    overrides: dict[str, Any] = context.get_object_value(RATE_LIMIT_OVERRIDES_FLAG, {})
+    action_override = overrides.get(action.name) if isinstance(overrides, dict) else None
+    if not isinstance(action_override, dict):
+        return definition.warning_limit, definition.hard_limit
+    return (
+        _coerce_int_limit(action_override.get("warning_limit"), definition.warning_limit),
+        _coerce_int_limit(action_override.get("hard_limit"), definition.hard_limit),
+    )
+
+
+def process_rate_limits_and_check_abort(context: CouchersContext, session: Session, action: RateLimitAction) -> bool:
     """
     Check if the user has reached a rate limit. Notify the moderation team in a separate background job if so.
 
     Returns True if the user has reached a hard rate limit.
     """
-    rate_limit_definition = RATE_LIMIT_DEFINITIONS[action]
-    count_last_interval = rate_limit_definition.count_actions_query(session, user_id)
+    user_id = context.user_id
+    warning_limit, hard_limit = _resolve_limits(context, action)
+    count_last_interval = RATE_LIMIT_DEFINITIONS[action].count_actions_query(session, user_id)
     for limit, is_hard_limit in [
-        (rate_limit_definition.hard_limit, True),
-        (rate_limit_definition.warning_limit, False),
+        (hard_limit, True),
+        (warning_limit, False),
     ]:
         if count_last_interval >= limit:
             if not _user_has_violated_rate_limit_in_past_time_interval(

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -760,9 +760,7 @@ class API(api_pb2_grpc.APIServicer):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "friends_already_or_pending")
 
         # Check if user has been sending friend requests excessively
-        if process_rate_limits_and_check_abort(
-            session=session, user_id=context.user_id, action=RateLimitAction.friend_request
-        ):
+        if process_rate_limits_and_check_abort(context=context, session=session, action=RateLimitAction.friend_request):
             context.abort_with_error_code(
                 grpc.StatusCode.RESOURCE_EXHAUSTED,
                 "friend_request_rate_limit2",

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -756,7 +756,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
 
         # Check if user has been initiating chats excessively
         if process_rate_limits_and_check_abort(
-            session=session, user_id=context.user_id, action=RateLimitAction.chat_initiation
+            context=context, session=session, action=RateLimitAction.chat_initiation
         ):
             context.abort_with_error_code(
                 grpc.StatusCode.RESOURCE_EXHAUSTED,

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -241,9 +241,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             )
 
         # Check if user has been sending host requests excessively
-        if process_rate_limits_and_check_abort(
-            session=session, user_id=context.user_id, action=RateLimitAction.host_request
-        ):
+        if process_rate_limits_and_check_abort(context=context, session=session, action=RateLimitAction.host_request):
             context.abort_with_error_code(
                 grpc.StatusCode.RESOURCE_EXHAUSTED,
                 "host_request_rate_limit2",

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -356,6 +356,40 @@ def test_excessive_requests_are_reported(db, email_collector: EmailCollector):
         assert "The user has been blocked from sending further host requests for now." in email.plain
 
 
+def test_rate_limit_feature_flag_override_lowers_hard_limit(db, feature_flags, email_collector: EmailCollector):
+    """A per-user override via the `rate_limit_overrides` flag should be applied instead of the static definition."""
+    feature_flags.set(
+        "rate_limit_overrides",
+        {"host_request": {"warning_limit": 1, "hard_limit": 2}},
+    )
+    user, token = generate_user()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
+    with requests_session(token) as api:
+        for _ in range(2):
+            host_user, _ = generate_user()
+            api.CreateHostRequest(
+                requests_pb2.CreateHostRequestReq(
+                    host_user_id=host_user.id,
+                    from_date=today_plus_2.isoformat(),
+                    to_date=today_plus_3.isoformat(),
+                    text=valid_request_text(),
+                )
+            )
+
+        host_user, _ = generate_user()
+        with pytest.raises(grpc.RpcError) as exc_info:
+            api.CreateHostRequest(
+                requests_pb2.CreateHostRequestReq(
+                    host_user_id=host_user.id,
+                    from_date=today_plus_2.isoformat(),
+                    to_date=today_plus_3.isoformat(),
+                    text=valid_request_text("Excessive"),
+                )
+            )
+        assert exc_info.value.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
+
+
 def add_message(db, text, author_id, conversation_id):
     with session_scope() as session:
         message = Message(


### PR DESCRIPTION
Adds support for overriding rate limit warning/hard thresholds on a per-user basis through GrowthBook.

`process_rate_limits_and_check_abort` now takes the `CouchersContext` and reads the `rate_limit_overrides` object flag. The flag is keyed by `RateLimitAction.name`; each entry may set `warning_limit` and/or `hard_limit` (both optional). Missing keys fall through to the static `RATE_LIMIT_DEFINITIONS`. Non-int / bool values in the payload are rejected to avoid a misconfigured flag silently disabling a limit.

Flag schema:

```json
{
  "host_request":    {"warning_limit": 20, "hard_limit": 80},
  "friend_request":  {"warning_limit": 10, "hard_limit": 40},
  "chat_initiation": {"warning_limit": 15, "hard_limit": 150}
}
```

Per-user targeting comes for free from GrowthBook (rollouts, individual user overrides, etc.). Refresh propagation is ~60s — not for real-time incident response, but fine for trust/abuse tuning.

## Testing
- Existing rate-limit tests (`test_excessive_requests_are_reported`, `test_excessive_friend_requests_are_reported`, `test_excessive_chat_initiations_are_reported`) still pass — they exercise the default (no-override) path.
- New test `test_rate_limit_feature_flag_override_lowers_hard_limit` sets the flag to `warning_limit=1, hard_limit=2` for host requests and verifies the user gets `RESOURCE_EXHAUSTED` at the overridden threshold.
- `make format` and `make mypy` clean (one pre-existing unrelated mypy error in `test_calendar_events.py`).

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto \`develop\` if necessary for linear migration history (n/a — no schema changes)

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._