### PR TITLE
Mobile: silently auto-apply OTA on cold start during warn period

### DIFF
--- a/app/mobile/app/_layout.tsx
+++ b/app/mobile/app/_layout.tsx
@@ -72,16 +72,31 @@ SplashScreen.preventAutoHideAsync();
 function RootNavigator({ fontsLoaded }: { fontsLoaded: boolean }) {
   const { authenticated, checkedAuthStatus } = useAuthContext();
   const featuresReady = useGrowthBook().ready;
+  const { prompt, dismiss, autoApplyingOta, startupGate } =
+    useNativeDiagnostics();
+
+  const basicsReady = fontsLoaded && checkedAuthStatus && featuresReady;
+  // Hide splash once basics are ready and we've either committed to auto-applying
+  // (the JS overlay takes over from the splash) or know there's no auto-apply
+  // pending (gate is open). While the gate is still closed with no auto-apply
+  // in flight, we keep the splash up rather than flashing the app for a moment.
+  const splashCanHide = basicsReady && (autoApplyingOta || !startupGate);
 
   useEffect(() => {
-    if (fontsLoaded && checkedAuthStatus && featuresReady) {
+    if (splashCanHide) {
       SplashScreen.hideAsync();
     }
-  }, [fontsLoaded, checkedAuthStatus, featuresReady]);
+  }, [splashCanHide]);
 
-  if (!fontsLoaded || !checkedAuthStatus || !featuresReady) {
-    return null;
+  if (!basicsReady) return null;
+
+  if (autoApplyingOta) {
+    return (
+      <NativeUpdatePrompt prompt={null} onDismiss={() => {}} autoApplying />
+    );
   }
+
+  if (startupGate) return null;
 
   // Using Stack.Protected with guard prop is the recommended Expo Router pattern
   // for auth flows. When the guard condition changes, Expo Router automatically:
@@ -89,19 +104,22 @@ function RootNavigator({ fontsLoaded }: { fontsLoaded: boolean }) {
   // - Resets the navigation state appropriately
   // - Prevents back navigation to screens that shouldn't be accessible
   return (
-    <Stack screenOptions={{ headerShown: false }}>
-      <Stack.Protected guard={authenticated}>
-        <Stack.Screen name="(tabs)" />
-      </Stack.Protected>
-      <Stack.Protected guard={!authenticated}>
-        <Stack.Screen name="login" />
-        <Stack.Screen name="signup" />
-        <Stack.Screen name="complete-password-reset" />
-      </Stack.Protected>
-      {/* Accessible regardless of auth state */}
-      <Stack.Screen name="confirm-email" />
-      <Stack.Screen name="dev-settings" options={{ presentation: "modal" }} />
-    </Stack>
+    <>
+      <Stack screenOptions={{ headerShown: false }}>
+        <Stack.Protected guard={authenticated}>
+          <Stack.Screen name="(tabs)" />
+        </Stack.Protected>
+        <Stack.Protected guard={!authenticated}>
+          <Stack.Screen name="login" />
+          <Stack.Screen name="signup" />
+          <Stack.Screen name="complete-password-reset" />
+        </Stack.Protected>
+        {/* Accessible regardless of auth state */}
+        <Stack.Screen name="confirm-email" />
+        <Stack.Screen name="dev-settings" options={{ presentation: "modal" }} />
+      </Stack>
+      <NativeUpdatePrompt prompt={prompt} onDismiss={dismiss} />
+    </>
   );
 }
 
@@ -226,6 +244,5 @@ function useNotificationObserver() {
 function PushNotificationsRegistrar() {
   useRegisterPushNotifications();
   useNotificationObserver();
-  const { prompt, dismiss } = useNativeDiagnostics();
-  return <NativeUpdatePrompt prompt={prompt} onDismiss={dismiss} />;
+  return null;
 }

--- a/app/mobile/app/_layout.tsx
+++ b/app/mobile/app/_layout.tsx
@@ -76,10 +76,9 @@ function RootNavigator({ fontsLoaded }: { fontsLoaded: boolean }) {
     useNativeDiagnostics();
 
   const basicsReady = fontsLoaded && checkedAuthStatus && featuresReady;
-  // Hide splash once basics are ready and we've either committed to auto-applying
-  // (the JS overlay takes over from the splash) or know there's no auto-apply
-  // pending (gate is open). While the gate is still closed with no auto-apply
-  // in flight, we keep the splash up rather than flashing the app for a moment.
+  // Keep the splash up until either the cold-start decision is in (gate open)
+  // or the JS spinner overlay takes over (auto-applying); avoids flashing the
+  // app for a frame before the overlay appears.
   const splashCanHide = basicsReady && (autoApplyingOta || !startupGate);
 
   useEffect(() => {

--- a/app/mobile/features/diagnostics/NativeUpdatePrompt.tsx
+++ b/app/mobile/features/diagnostics/NativeUpdatePrompt.tsx
@@ -35,8 +35,7 @@ function defaultLinkText(
 // Renders the update prompt:
 //   - non-dismissible block screen (mode = "block")
 //   - dismissible warn screen (mode = "warn")
-//   - non-dismissible "applying" overlay (autoApplying = true): logo + spinner shown
-//     while a cold-start OTA download is in progress, in place of any prompt.
+//   - silent logo + spinner overlay (autoApplying = true) for cold-start OTAs
 //
 // The body and preamble are hardcoded on the client so they read naturally and translators
 // don't have to keep variants in sync. If the backend supplies info.message (reserved for
@@ -68,8 +67,6 @@ export default function NativeUpdatePrompt({
     primary: isDark ? theme.dark.primary.main : theme.palette.primary.main,
   };
 
-  // Cold-start auto-apply: render only the logo + spinner — no prompt, no text.
-  // The user hasn't been told there's an update; we're just continuing the splash.
   if (autoApplying) {
     return (
       <Modal

--- a/app/mobile/features/diagnostics/NativeUpdatePrompt.tsx
+++ b/app/mobile/features/diagnostics/NativeUpdatePrompt.tsx
@@ -35,6 +35,8 @@ function defaultLinkText(
 // Renders the update prompt:
 //   - non-dismissible block screen (mode = "block")
 //   - dismissible warn screen (mode = "warn")
+//   - non-dismissible "applying" overlay (autoApplying = true): logo + spinner shown
+//     while a cold-start OTA download is in progress, in place of any prompt.
 //
 // The body and preamble are hardcoded on the client so they read naturally and translators
 // don't have to keep variants in sync. If the backend supplies info.message (reserved for
@@ -42,19 +44,18 @@ function defaultLinkText(
 export default function NativeUpdatePrompt({
   prompt,
   onDismiss,
+  autoApplying = false,
 }: {
   prompt: UpdatePrompt | null;
   onDismiss: () => void;
+  autoApplying?: boolean;
 }) {
   const { t } = useTranslation();
   const isDark = useColorScheme() === "dark";
   const [busy, setBusy] = useState(false);
   const [failed, setFailed] = useState(false);
 
-  if (!prompt) return null;
-
-  const { info, mode } = prompt;
-  const dismissible = mode !== "block";
+  if (!prompt && !autoApplying) return null;
 
   const colors = {
     background: isDark
@@ -66,6 +67,31 @@ export default function NativeUpdatePrompt({
       : theme.palette.text.secondary,
     primary: isDark ? theme.dark.primary.main : theme.palette.primary.main,
   };
+
+  // Cold-start auto-apply: render only the logo + spinner — no prompt, no text.
+  // The user hasn't been told there's an update; we're just continuing the splash.
+  if (autoApplying) {
+    return (
+      <Modal
+        visible
+        transparent={false}
+        animationType="fade"
+        onRequestClose={() => {}}
+      >
+        <View
+          style={[styles.container, { backgroundColor: colors.background }]}
+        >
+          <View style={styles.content}>
+            <Image source={logo} style={styles.logo} resizeMode="contain" />
+            <ActivityIndicator size="large" color={colors.primary} />
+          </View>
+        </View>
+      </Modal>
+    );
+  }
+
+  const { info, mode } = prompt!;
+  const dismissible = mode !== "block";
 
   const isOta = info.action === NativeUpdateAction.NATIVE_UPDATE_ACTION_OTA;
 

--- a/app/mobile/features/diagnostics/useNativeDiagnostics.ts
+++ b/app/mobile/features/diagnostics/useNativeDiagnostics.ts
@@ -3,6 +3,7 @@ import * as Application from "expo-application";
 import Constants from "expo-constants";
 import * as Device from "expo-device";
 import * as Notifications from "expo-notifications";
+import * as Updates from "expo-updates";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AppState, AppStateStatus, Platform } from "react-native";
@@ -18,7 +19,7 @@ import {
   updateMode,
   UpdatePrompt,
 } from "@/features/diagnostics/updateDecision";
-import { NativeUpdateInfo } from "@/proto/bugs_pb";
+import { NativeUpdateAction, NativeUpdateInfo } from "@/proto/bugs_pb";
 import {
   appVariant,
   createdAt,
@@ -36,6 +37,9 @@ import { checkNativeStatus } from "@/service/checkNativeStatus";
 const LAST_OPEN_KEY = "diagnostics.lastOpenAt";
 const LAST_NAG_KEY = "diagnostics.lastNagDismissedAt";
 const PING_THROTTLE_MS = 5 * 60 * 1000;
+// Safety fallback: if the cold-start diagnostics ping is slow or hangs, open the
+// startup gate after this so the app loads instead of sitting on the splash.
+const STARTUP_GATE_TIMEOUT_MS = 5_000;
 
 // Cleared on process restart, so dismissing a session-scoped prompt suppresses it
 // until the next cold start.
@@ -88,6 +92,12 @@ export interface NativeDiagnostics {
   prompt: UpdatePrompt | null;
   // Dismisses the current prompt (no-op for non-dismissible "block" prompts).
   dismiss: () => void;
+  // True while a cold-start OTA download is in progress. The caller should
+  // render the applying overlay (logo + spinner) instead of the app shell.
+  autoApplyingOta: boolean;
+  // True until the cold-start diagnostics decision has been made (or the safety
+  // timeout has elapsed). Callers should keep the splash up while this is true.
+  startupGate: boolean;
 }
 
 // Reports a diagnostics snapshot to CheckNativeStatus on cold start and each foreground
@@ -100,6 +110,21 @@ export function useNativeDiagnostics(): NativeDiagnostics {
   const [prompt, setPrompt] = useState<UpdatePrompt | null>(null);
   const promptRef = useRef<UpdatePrompt | null>(null);
   promptRef.current = prompt;
+
+  const [autoApplyingOta, setAutoApplyingOta] = useState(false);
+
+  const [startupGate, setStartupGate] = useState(true);
+  const startupGateOpenedRef = useRef(false);
+
+  // Cold-start = the very first ping after this hook mounts. AppState 'active'
+  // pings after that are NOT cold starts and never auto-apply.
+  const coldStartRef = useRef(true);
+
+  const openStartupGate = useCallback(() => {
+    if (startupGateOpenedRef.current) return;
+    startupGateOpenedRef.current = true;
+    setStartupGate(false);
+  }, []);
 
   // Refs so the AppState listener sees current values without re-subscribing.
   const authenticatedRef = useRef(authenticated);
@@ -115,22 +140,54 @@ export function useNativeDiagnostics(): NativeDiagnostics {
   }, []);
 
   useEffect(() => {
+    // Safety net: if the first ping is slow, hangs, or never starts, drop the
+    // gate so the user isn't stuck staring at the splash forever.
+    const timer = setTimeout(openStartupGate, STARTUP_GATE_TIMEOUT_MS);
+
     async function surface(
       info: NativeUpdateInfo.AsObject | undefined,
       now: number,
+      isColdStart: boolean,
     ) {
       if (!info || !isActionable(info)) {
         setPrompt(null);
         return;
       }
-      const candidate: UpdatePrompt = {
-        info,
-        mode: updateMode(info, new Date(now)),
-      };
+      const mode = updateMode(info, new Date(now));
+
+      // Cold-start auto-apply: if the user is in the warn period and the
+      // configured action is an OTA, silently download + reload instead of
+      // showing the prompt. If anything goes wrong we fall through to the
+      // normal warn screen, which is still actionable.
+      if (
+        isColdStart &&
+        mode === "warn" &&
+        info.action === NativeUpdateAction.NATIVE_UPDATE_ACTION_OTA
+      ) {
+        setAutoApplyingOta(true);
+        try {
+          const result = await Updates.fetchUpdateAsync();
+          if (result.isNew) {
+            await Updates.reloadAsync();
+            return; // reloadAsync restarts the JS context; nothing past this runs
+          }
+          // No new bundle was actually downloaded (already current, or expo-updates
+          // disabled in dev). Treat as a no-op and don't surface a prompt.
+          setAutoApplyingOta(false);
+          return;
+        } catch (error) {
+          console.warn("Auto OTA failed, falling back to prompt:", error);
+          setAutoApplyingOta(false);
+        }
+      }
+
+      const candidate: UpdatePrompt = { info, mode };
       setPrompt((await isSuppressed(candidate, now)) ? null : candidate);
     }
 
     async function maybeReport() {
+      const isColdStart = coldStartRef.current;
+      coldStartRef.current = false;
       try {
         const now = Date.now();
         const lastOpenRaw = await AsyncStorage.getItem(LAST_OPEN_KEY);
@@ -204,9 +261,15 @@ export function useNativeDiagnostics(): NativeDiagnostics {
         });
 
         await AsyncStorage.setItem(LAST_OPEN_KEY, String(now));
-        await surface(result.updateInfo, now);
+        await surface(result.updateInfo, now, isColdStart);
       } catch (error) {
         console.warn("Failed to check native status:", error);
+      } finally {
+        // The cold-start decision has now been made (success, throttle, fail,
+        // or auto-apply finished without reloading). Drop the gate so the app
+        // can render — by this point autoApplyingOta reflects whether the
+        // caller should render the overlay or the app shell.
+        if (isColdStart) openStartupGate();
       }
     }
 
@@ -222,9 +285,10 @@ export function useNativeDiagnostics(): NativeDiagnostics {
     );
 
     return () => {
+      clearTimeout(timer);
       subscription.remove();
     };
-  }, []);
+  }, [openStartupGate]);
 
-  return { prompt, dismiss };
+  return { prompt, dismiss, autoApplyingOta, startupGate };
 }

--- a/app/mobile/features/diagnostics/useNativeDiagnostics.ts
+++ b/app/mobile/features/diagnostics/useNativeDiagnostics.ts
@@ -37,8 +37,7 @@ import { checkNativeStatus } from "@/service/checkNativeStatus";
 const LAST_OPEN_KEY = "diagnostics.lastOpenAt";
 const LAST_NAG_KEY = "diagnostics.lastNagDismissedAt";
 const PING_THROTTLE_MS = 5 * 60 * 1000;
-// Safety fallback: if the cold-start diagnostics ping is slow or hangs, open the
-// startup gate after this so the app loads instead of sitting on the splash.
+// Safety net so a slow/hung diagnostics ping can't keep the splash up forever.
 const STARTUP_GATE_TIMEOUT_MS = 5_000;
 
 // Cleared on process restart, so dismissing a session-scoped prompt suppresses it
@@ -88,15 +87,12 @@ async function recordDismissal(
 }
 
 export interface NativeDiagnostics {
-  // The update prompt to render right now, or null when nothing should be shown.
   prompt: UpdatePrompt | null;
-  // Dismisses the current prompt (no-op for non-dismissible "block" prompts).
   dismiss: () => void;
-  // True while a cold-start OTA download is in progress. The caller should
-  // render the applying overlay (logo + spinner) instead of the app shell.
+  // True while a cold-start OTA download is in progress; render the spinner
+  // overlay instead of the app shell.
   autoApplyingOta: boolean;
-  // True until the cold-start diagnostics decision has been made (or the safety
-  // timeout has elapsed). Callers should keep the splash up while this is true.
+  // True while the cold-start decision is still pending; keep the splash up.
   startupGate: boolean;
 }
 
@@ -116,8 +112,8 @@ export function useNativeDiagnostics(): NativeDiagnostics {
   const [startupGate, setStartupGate] = useState(true);
   const startupGateOpenedRef = useRef(false);
 
-  // Cold-start = the very first ping after this hook mounts. AppState 'active'
-  // pings after that are NOT cold starts and never auto-apply.
+  // Only the very first ping is a "cold start"; later AppState 'active' pings
+  // never auto-apply, since the user is already using the app.
   const coldStartRef = useRef(true);
 
   const openStartupGate = useCallback(() => {
@@ -140,8 +136,6 @@ export function useNativeDiagnostics(): NativeDiagnostics {
   }, []);
 
   useEffect(() => {
-    // Safety net: if the first ping is slow, hangs, or never starts, drop the
-    // gate so the user isn't stuck staring at the splash forever.
     const timer = setTimeout(openStartupGate, STARTUP_GATE_TIMEOUT_MS);
 
     async function surface(
@@ -155,10 +149,8 @@ export function useNativeDiagnostics(): NativeDiagnostics {
       }
       const mode = updateMode(info, new Date(now));
 
-      // Cold-start auto-apply: if the user is in the warn period and the
-      // configured action is an OTA, silently download + reload instead of
-      // showing the prompt. If anything goes wrong we fall through to the
-      // normal warn screen, which is still actionable.
+      // Cold-start warn + OTA: silently download + reload instead of prompting.
+      // Falls through to the regular warn screen on any failure.
       if (
         isColdStart &&
         mode === "warn" &&
@@ -169,10 +161,8 @@ export function useNativeDiagnostics(): NativeDiagnostics {
           const result = await Updates.fetchUpdateAsync();
           if (result.isNew) {
             await Updates.reloadAsync();
-            return; // reloadAsync restarts the JS context; nothing past this runs
+            return;
           }
-          // No new bundle was actually downloaded (already current, or expo-updates
-          // disabled in dev). Treat as a no-op and don't surface a prompt.
           setAutoApplyingOta(false);
           return;
         } catch (error) {
@@ -265,10 +255,6 @@ export function useNativeDiagnostics(): NativeDiagnostics {
       } catch (error) {
         console.warn("Failed to check native status:", error);
       } finally {
-        // The cold-start decision has now been made (success, throttle, fail,
-        // or auto-apply finished without reloading). Drop the gate so the app
-        // can render — by this point autoApplyingOta reflects whether the
-        // caller should render the overlay or the app shell.
         if (isColdStart) openStartupGate();
       }
     }

--- a/app/mobile/tests/features/diagnostics/NativeUpdatePrompt.test.tsx
+++ b/app/mobile/tests/features/diagnostics/NativeUpdatePrompt.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import * as Updates from "expo-updates";
-import { Linking } from "react-native";
+import { ActivityIndicator, Linking } from "react-native";
 
 import NativeUpdatePrompt from "@/features/diagnostics/NativeUpdatePrompt";
 import { UpdatePrompt } from "@/features/diagnostics/updateDecision";
@@ -46,6 +46,17 @@ describe("NativeUpdatePrompt", () => {
       <NativeUpdatePrompt prompt={null} onDismiss={jest.fn()} />,
     );
     expect(toJSON()).toBeNull();
+  });
+
+  it("renders a silent overlay (no buttons, no copy) when autoApplying", () => {
+    render(
+      <NativeUpdatePrompt prompt={null} onDismiss={jest.fn()} autoApplying />,
+    );
+    // No prompt copy and no buttons — the user shouldn't know there's an update.
+    expect(screen.queryByText("update.required_title")).toBeNull();
+    expect(screen.queryByText("update.later")).toBeNull();
+    expect(screen.queryByText("Update now")).toBeNull();
+    expect(screen.UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
   });
 
   it("shows the backend message and link text", () => {


### PR DESCRIPTION
When the diagnostics backend reports we're in the warn period and the configured action is an OTA, the mobile app now silently fetches and reloads the new bundle on cold start instead of showing the warning screen. From the user's perspective, the splash just lingers for a few extra seconds while the bundle downloads, then the app launches on the new version with no prompt or copy informing them an update happened.

Block, nag, and non-OTA flows are unchanged. If the fetch fails (e.g. no network) or there's no newer bundle than expected, the app falls through to the existing warn prompt so the user can still act on it manually. A 5s safety timeout opens the splash gate in case the diagnostics ping hangs. Foreground `AppState` transitions never trigger an auto-apply — only the very first ping after the JS process starts.

## Testing
- All mobile tests pass (149/149, including the new applying-overlay test).
- TypeScript clean (`tsc --noEmit`).
- Lint + Prettier clean (`yarn format`).
- Manual: should be exercised against staging with the diagnostics backend configured to issue an OTA warn decision — verify the splash stays up, no warn screen is shown, and the app cold-starts on the new bundle. If you toggle airplane mode mid-download, the warn prompt should appear as fallback.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._