### PR TITLE
Docs: forbid renumbering / repurposing proto fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,20 @@ make mypy
 - Run `make protos` from backend after changes
 - Internal job payloads in `/app/backend/proto/internal/jobs.proto`
 
+**⚠️ FIELD NUMBERS ARE PERMANENT — NEVER RENUMBER OR REPURPOSE A FIELD ⚠️**
+
+Field numbers are the wire format. Once a field has shipped, its number is bound to that semantic FOREVER:
+- **NEVER** change the number of an existing field.
+- **NEVER** change the type of an existing field (e.g. `string` → `bytes`, `int32` → `int64`).
+- **NEVER** rename a field to mean something different — the wire doesn't see the name, it sees the number, so the old client's bytes will be silently decoded as the new field of the same tag (e.g. an old `string debug_json = 1` decoded as a new `string install_id = 1` looks valid but is garbage data).
+- **NEVER** reuse a removed field's number OR name for something new.
+
+When removing a field that has shipped: delete the field and add `reserved <number>;` AND `reserved "field_name";` lines so neither the tag nor the name can ever be reused. Reserving the name matters too — it stops a future field from accidentally reviving an old meaning by reusing the name, and protects JSON/text-format consumers that key on names. When the field has never shipped, delete it outright.
+
+When adding a field: pick the next unused number. You may place the line wherever it reads best in the file — proto3 doesn't care about source order, only the number matters. The number must always be a previously-unused tag.
+
+If you ever feel tempted to renumber, STOP and ask the user. There is essentially never a valid reason.
+
 ### Localization
 - Never hardcode English text - always use the `t()` function or `<Trans>` component for user-facing text
 - Store all English strings in the appropriate locale files (`features/*/locales/en.json`)


### PR DESCRIPTION
Adds a guardrail to CLAUDE.md against renumbering or repurposing proto fields. The "Proto Files" section now spells out that field numbers are the wire format, lays out the four "NEVERs" (don't change a field's number, type, meaning, or reuse a removed number/name), and documents the correct removal path (delete + reserve number AND name; or delete outright if the field never shipped). Adding a field is allowed wherever it reads best — only the tag matters.

Lesson from #8943: that PR silently renumbered every field on \`CheckNativeStatusReq\` because the typed-fields rewrite hadn't shipped to production yet. Safe in that case, but the codebase deserves explicit guidance so future contributors don't try the same move when fields HAVE shipped.

## Testing
Docs-only — no code changes.

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._