### PR TITLE
Backend: resolve feature flags from a local file in dev

### DIFF
--- a/app/backend.dev.env
+++ b/app/backend.dev.env
@@ -77,10 +77,10 @@ PUSH_NOTIFICATIONS_VAPID_SUBJECT=mailto:local-development-vapid@couchershq.org
 ACTIVENESS_PROBES_ENABLED=1
 
 # Feature flags
-# In dev we read from a checked-in local file rather than hitting GrowthBook.
-FEATURE_FLAGS_ENABLED=1
-FEATURE_FLAGS_USE_LOCAL_FILE=1
-FEATURE_FLAGS_LOCAL_FILE_PATH=feature-flags.dev.json
+# In dev we resolve flags from a checked-in local file instead of contacting GrowthBook: a flag listed
+# in the file gives its value, anything else falls back to its in-code default. Clear
+# FEATURE_FLAGS_FILE_OVERRIDE_PATH to resolve via GrowthBook instead (using the keys below).
+FEATURE_FLAGS_FILE_OVERRIDE_PATH=feature-flags.dev.json
 GROWTHBOOK_API_HOST=https://gbapi.couchershq.org
 GROWTHBOOK_CLIENT_KEY=sdk-cGmljeXu1BCzHffE
 GROWTHBOOK_CACHE_PATH=growthbook-features-cache.json

--- a/app/backend.dev.env
+++ b/app/backend.dev.env
@@ -76,14 +76,14 @@ PUSH_NOTIFICATIONS_VAPID_SUBJECT=mailto:local-development-vapid@couchershq.org
 
 ACTIVENESS_PROBES_ENABLED=1
 
-# Experimentation (feature flags)
-EXPERIMENTATION_ENABLED=0
-EXPERIMENTATION_PASS_ALL_GATES=1
+# Feature flags
+# In dev we read from a checked-in local file rather than hitting GrowthBook.
+FEATURE_FLAGS_ENABLED=1
+FEATURE_FLAGS_USE_LOCAL_FILE=1
+FEATURE_FLAGS_LOCAL_FILE_PATH=feature-flags.dev.json
 GROWTHBOOK_API_HOST=https://gbapi.couchershq.org
 GROWTHBOOK_CLIENT_KEY=sdk-cGmljeXu1BCzHffE
 GROWTHBOOK_CACHE_PATH=growthbook-features-cache.json
-# Optional path to a JSON file mapping flag keys to forced values for local development.
-FEATURE_FLAG_OVERRIDE_PATH=
 
 # Continuous profiling (Pyroscope; gated at runtime by the profiling_enabled flag)
 PYROSCOPE_ENABLED=0

--- a/app/backend.dev.env
+++ b/app/backend.dev.env
@@ -82,6 +82,8 @@ EXPERIMENTATION_PASS_ALL_GATES=1
 GROWTHBOOK_API_HOST=https://gbapi.couchershq.org
 GROWTHBOOK_CLIENT_KEY=sdk-cGmljeXu1BCzHffE
 GROWTHBOOK_CACHE_PATH=growthbook-features-cache.json
+# Optional path to a JSON file mapping flag keys to forced values for local development.
+FEATURE_FLAG_OVERRIDE_PATH=
 
 # Continuous profiling (Pyroscope; gated at runtime by the profiling_enabled flag)
 PYROSCOPE_ENABLED=0

--- a/app/backend/feature-flags.dev.json
+++ b/app/backend/feature-flags.dev.json
@@ -1,13 +1,12 @@
 {
   "test_growthbook_integration": true,
-  "sms_enabled": true,
-  "strong_verification_enabled": true,
+  "sms_enabled": false,
+  "strong_verification_enabled": false,
   "log_native_ota_requests": true,
-  "donations_enabled": true,
-  "recaptcha_enabled": true,
-  "postal_verification_enabled": true,
-  "listmonk_enabled": true,
-  "remove_removed_users_from_mailing_list_enabled": true,
+  "donations_enabled": false,
+  "recaptcha_enabled": false,
+  "postal_verification_enabled": false,
+  "listmonk_enabled": false,
   "notification_translations_enabled": true,
   "email_ics_attachments_enabled": true
 }

--- a/app/backend/feature-flags.dev.json
+++ b/app/backend/feature-flags.dev.json
@@ -1,0 +1,13 @@
+{
+  "test_growthbook_integration": true,
+  "sms_enabled": true,
+  "strong_verification_enabled": true,
+  "log_native_ota_requests": true,
+  "donations_enabled": true,
+  "recaptcha_enabled": true,
+  "postal_verification_enabled": true,
+  "listmonk_enabled": true,
+  "remove_removed_users_from_mailing_list_enabled": true,
+  "notification_translations_enabled": true,
+  "email_ics_attachments_enabled": true
+}

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -114,8 +114,7 @@ class Config:
     RECAPTHCA_SITE_KEY: str
     # Whether we're in test
     IN_TEST: bool = False
-    # Dev-only: when set, flags are read from this JSON file and GrowthBook is not contacted. Empty in
-    # production, where flags come from GrowthBook.
+    # Dev-only override file; when set, flags are read from it instead of GrowthBook.
     FEATURE_FLAGS_FILE_OVERRIDE_PATH: str = ""
     # GrowthBook (feature flags)
     GROWTHBOOK_API_HOST: str = "https://cdn.growthbook.io"

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -124,6 +124,10 @@ class Config:
     # Disk path for the last-known-good feature payload, used as a cold-start fallback when GrowthBook
     # is unreachable. Required when experimentation is enabled so we never start on in-code defaults.
     GROWTHBOOK_CACHE_PATH: str = ""
+    # Local-override JSON file mapping flag keys to values. When set, overrides take precedence over
+    # GrowthBook, EXPERIMENTATION_PASS_ALL_GATES, and EXPERIMENTATION_ENABLED. Intended for local
+    # development; leave empty in production.
+    FEATURE_FLAG_OVERRIDE_PATH: str = ""
     # Continuous profiling (Pyroscope). Profiling is gated at runtime by the `profiling_enabled` feature
     # flag; PYROSCOPE_ENABLED is the per-deployment master switch.
     PYROSCOPE_ENABLED: bool

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -114,20 +114,20 @@ class Config:
     RECAPTHCA_SITE_KEY: str
     # Whether we're in test
     IN_TEST: bool = False
-    # Experimentation (feature flags via GrowthBook)
-    EXPERIMENTATION_ENABLED: bool = False
-    # When enabled, all feature gates return True (useful for development/testing)
-    EXPERIMENTATION_PASS_ALL_GATES: bool = False
-    # GrowthBook SDK configuration
+    # Feature flag evaluation. When FEATURE_FLAGS_ENABLED is off, every flag falls through to its
+    # in-code default. When on, FEATURE_FLAGS_USE_LOCAL_FILE picks the source: True reads values from
+    # a local JSON file (for dev/test), False uses the GrowthBook integration.
+    FEATURE_FLAGS_ENABLED: bool = False
+    FEATURE_FLAGS_USE_LOCAL_FILE: bool = False
+    # Local JSON file mapping flag keys to values. Used when FEATURE_FLAGS_USE_LOCAL_FILE is on.
+    FEATURE_FLAGS_LOCAL_FILE_PATH: str = ""
+    # GrowthBook SDK configuration; used when FEATURE_FLAGS_USE_LOCAL_FILE is off.
     GROWTHBOOK_API_HOST: str = "https://cdn.growthbook.io"
     GROWTHBOOK_CLIENT_KEY: str = ""
     # Disk path for the last-known-good feature payload, used as a cold-start fallback when GrowthBook
-    # is unreachable. Required when experimentation is enabled so we never start on in-code defaults.
+    # is unreachable. Required when feature flags are enabled in GrowthBook mode so we never start
+    # on in-code defaults.
     GROWTHBOOK_CACHE_PATH: str = ""
-    # Local-override JSON file mapping flag keys to values. When set, overrides take precedence over
-    # GrowthBook, EXPERIMENTATION_PASS_ALL_GATES, and EXPERIMENTATION_ENABLED. Intended for local
-    # development; leave empty in production.
-    FEATURE_FLAG_OVERRIDE_PATH: str = ""
     # Continuous profiling (Pyroscope). Profiling is gated at runtime by the `profiling_enabled` feature
     # flag; PYROSCOPE_ENABLED is the per-deployment master switch.
     PYROSCOPE_ENABLED: bool
@@ -217,11 +217,15 @@ class Config:
             if not self.RECAPTHCA_PROJECT_ID or not self.RECAPTHCA_API_KEY or not self.RECAPTHCA_SITE_KEY:
                 raise Exception("reCAPTCHA credentials must be configured in production")
 
-        if self.EXPERIMENTATION_ENABLED:
-            if not self.GROWTHBOOK_CLIENT_KEY:
-                raise Exception("No GrowthBook client key but experimentation enabled")
-            if not self.GROWTHBOOK_CACHE_PATH:
-                raise Exception("No GrowthBook cache path but experimentation enabled")
+        if self.FEATURE_FLAGS_ENABLED:
+            if self.FEATURE_FLAGS_USE_LOCAL_FILE:
+                if not self.FEATURE_FLAGS_LOCAL_FILE_PATH:
+                    raise Exception("Feature flags in local-file mode but no FEATURE_FLAGS_LOCAL_FILE_PATH set")
+            else:
+                if not self.GROWTHBOOK_CLIENT_KEY:
+                    raise Exception("No GrowthBook client key but feature flags enabled")
+                if not self.GROWTHBOOK_CACHE_PATH:
+                    raise Exception("No GrowthBook cache path but feature flags enabled")
 
         if self.PYROSCOPE_ENABLED:
             if not self.PYROSCOPE_SERVER or not self.PYROSCOPE_AUTH_TOKEN:

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -114,19 +114,16 @@ class Config:
     RECAPTHCA_SITE_KEY: str
     # Whether we're in test
     IN_TEST: bool = False
-    # Feature flag evaluation. When FEATURE_FLAGS_ENABLED is off, every flag falls through to its
-    # in-code default. When on, FEATURE_FLAGS_USE_LOCAL_FILE picks the source: True reads values from
-    # a local JSON file (for dev/test), False uses the GrowthBook integration.
-    FEATURE_FLAGS_ENABLED: bool = False
-    FEATURE_FLAGS_USE_LOCAL_FILE: bool = False
-    # Local JSON file mapping flag keys to values. Used when FEATURE_FLAGS_USE_LOCAL_FILE is on.
-    FEATURE_FLAGS_LOCAL_FILE_PATH: str = ""
-    # GrowthBook SDK configuration; used when FEATURE_FLAGS_USE_LOCAL_FILE is off.
+    # Feature flag source. FEATURE_FLAGS_FILE_OVERRIDE_PATH selects the mode: when set (dev only), flags
+    # are resolved entirely from that JSON file - a key present there gives its value, a key absent
+    # falls through to the in-code default, and GrowthBook is never contacted. When empty, flags are
+    # resolved from GrowthBook (the production path).
+    FEATURE_FLAGS_FILE_OVERRIDE_PATH: str = ""
+    # GrowthBook SDK configuration; the flag source when FEATURE_FLAGS_FILE_OVERRIDE_PATH is empty.
     GROWTHBOOK_API_HOST: str = "https://cdn.growthbook.io"
     GROWTHBOOK_CLIENT_KEY: str = ""
     # Disk path for the last-known-good feature payload, used as a cold-start fallback when GrowthBook
-    # is unreachable. Required when feature flags are enabled in GrowthBook mode so we never start
-    # on in-code defaults.
+    # is unreachable, so we never start on in-code defaults.
     GROWTHBOOK_CACHE_PATH: str = ""
     # Continuous profiling (Pyroscope). Profiling is gated at runtime by the `profiling_enabled` feature
     # flag; PYROSCOPE_ENABLED is the per-deployment master switch.
@@ -217,15 +214,16 @@ class Config:
             if not self.RECAPTHCA_PROJECT_ID or not self.RECAPTHCA_API_KEY or not self.RECAPTHCA_SITE_KEY:
                 raise Exception("reCAPTCHA credentials must be configured in production")
 
-        if self.FEATURE_FLAGS_ENABLED:
-            if self.FEATURE_FLAGS_USE_LOCAL_FILE:
-                if not self.FEATURE_FLAGS_LOCAL_FILE_PATH:
-                    raise Exception("Feature flags in local-file mode but no FEATURE_FLAGS_LOCAL_FILE_PATH set")
-            else:
-                if not self.GROWTHBOOK_CLIENT_KEY:
-                    raise Exception("No GrowthBook client key but feature flags enabled")
-                if not self.GROWTHBOOK_CACHE_PATH:
-                    raise Exception("No GrowthBook cache path but feature flags enabled")
+            # The local-file flag source is a dev-only convenience; production always resolves via GrowthBook.
+            if self.FEATURE_FLAGS_FILE_OVERRIDE_PATH:
+                raise Exception("FEATURE_FLAGS_FILE_OVERRIDE_PATH is dev-only and must not be set in production")
+
+        # GrowthBook is the flag source unless the dev-only local file is configured.
+        if not self.FEATURE_FLAGS_FILE_OVERRIDE_PATH:
+            if not self.GROWTHBOOK_CLIENT_KEY:
+                raise Exception("No GrowthBook client key configured")
+            if not self.GROWTHBOOK_CACHE_PATH:
+                raise Exception("No GrowthBook cache path configured")
 
         if self.PYROSCOPE_ENABLED:
             if not self.PYROSCOPE_SERVER or not self.PYROSCOPE_AUTH_TOKEN:

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -114,12 +114,10 @@ class Config:
     RECAPTHCA_SITE_KEY: str
     # Whether we're in test
     IN_TEST: bool = False
-    # Feature flag source. FEATURE_FLAGS_FILE_OVERRIDE_PATH selects the mode: when set (dev only), flags
-    # are resolved entirely from that JSON file - a key present there gives its value, a key absent
-    # falls through to the in-code default, and GrowthBook is never contacted. When empty, flags are
-    # resolved from GrowthBook (the production path).
+    # Dev-only: when set, flags are read from this JSON file and GrowthBook is not contacted. Empty in
+    # production, where flags come from GrowthBook.
     FEATURE_FLAGS_FILE_OVERRIDE_PATH: str = ""
-    # GrowthBook SDK configuration; the flag source when FEATURE_FLAGS_FILE_OVERRIDE_PATH is empty.
+    # GrowthBook (feature flags)
     GROWTHBOOK_API_HOST: str = "https://cdn.growthbook.io"
     GROWTHBOOK_CLIENT_KEY: str = ""
     # Disk path for the last-known-good feature payload, used as a cold-start fallback when GrowthBook
@@ -214,11 +212,9 @@ class Config:
             if not self.RECAPTHCA_PROJECT_ID or not self.RECAPTHCA_API_KEY or not self.RECAPTHCA_SITE_KEY:
                 raise Exception("reCAPTCHA credentials must be configured in production")
 
-            # The local-file flag source is a dev-only convenience; production always resolves via GrowthBook.
             if self.FEATURE_FLAGS_FILE_OVERRIDE_PATH:
                 raise Exception("FEATURE_FLAGS_FILE_OVERRIDE_PATH is dev-only and must not be set in production")
 
-        # GrowthBook is the flag source unless the dev-only local file is configured.
         if not self.FEATURE_FLAGS_FILE_OVERRIDE_PATH:
             if not self.GROWTHBOOK_CLIENT_KEY:
                 raise Exception("No GrowthBook client key configured")

--- a/app/backend/src/couchers/context.py
+++ b/app/backend/src/couchers/context.py
@@ -196,7 +196,7 @@ class CouchersContext:
     # context's user. The gating lives in experimentation; we just pass our cached per-request
     # evaluator. The in-code default is honored even for flags not yet set up in GrowthBook.
     def get_boolean_value(self, flag_key: str, default: bool) -> bool:
-        return experimentation._boolean_value(flag_key, default, self._get_growthbook)
+        return experimentation._feature_value(flag_key, default, self._get_growthbook)
 
     def get_string_value(self, flag_key: str, default: str) -> str:
         return experimentation._feature_value(flag_key, default, self._get_growthbook)

--- a/app/backend/src/couchers/experimentation.py
+++ b/app/backend/src/couchers/experimentation.py
@@ -133,8 +133,6 @@ def _refresh_loop() -> None:
 @cache
 def _load_local_flags(path_str: str) -> dict[str, Any]:
     """Read and validate the dev-only override file; cached per path."""
-    if not path_str:
-        raise ValueError("FEATURE_FLAGS_FILE_OVERRIDE_PATH is empty")
     loaded = json.loads(Path(path_str).read_text())
     if not isinstance(loaded, dict):
         raise ValueError(f"Feature flag override file {path_str} must contain a JSON object")

--- a/app/backend/src/couchers/experimentation.py
+++ b/app/backend/src/couchers/experimentation.py
@@ -1,9 +1,8 @@
 """
 Feature flag and experimentation framework.
 
-FEATURE_FLAGS_FILE_OVERRIDE_PATH selects the flag source: when set (dev only) flags come from that
-JSON file and GrowthBook is not contacted; when empty they come from GrowthBook. Unknown flags fall
-through to their in-code default either way.
+FEATURE_FLAGS_FILE_OVERRIDE_PATH (dev only) reads flags from a JSON file instead of GrowthBook;
+unknown flags fall through to their in-code default either way.
 
 Two ways to evaluate a flag:
   - Per-user/request: use the CouchersContext methods (context.get_boolean_value, get_string_value,
@@ -281,12 +280,7 @@ def _global_evaluator() -> GrowthBook:
 # passes its own cached per-request evaluator). get_evaluator stays lazy - skipped in file-override mode.
 def _feature_value[T](flag_key: str, default: T, get_evaluator: Callable[[], GrowthBook]) -> T:
     if config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"]:
-        if flag_key in _local_flags:
-            value = _local_flags[flag_key]
-            metrics.observe_feature_flag_evaluation(flag_key, "local_file", value)
-            return value  # type: ignore[no-any-return]
-        metrics.observe_feature_flag_evaluation(flag_key, "local_file_missing", default)
-        return default
+        return _local_flags.get(flag_key, default)  # type: ignore[no-any-return]
     result = get_evaluator().eval_feature(flag_key)
     value = default if result.value is None else result.value
     metrics.observe_feature_flag_evaluation(flag_key, result.source, value)

--- a/app/backend/src/couchers/experimentation.py
+++ b/app/backend/src/couchers/experimentation.py
@@ -1,12 +1,9 @@
 """
 Feature flag and experimentation framework.
 
-FEATURE_FLAGS_FILE_OVERRIDE_PATH selects the flag source:
-  - Set (dev only): flags are resolved entirely from that JSON file, loaded once at startup. A key
-    present in the file gives its value; a key absent falls through to the in-code default. GrowthBook
-    is never contacted. Setting it in production is rejected at config check.
-  - Empty: flags come from GrowthBook, with a background-refreshed in-memory snapshot and a disk cache
-    fallback at startup. A flag with no GrowthBook value falls through to the in-code default.
+FEATURE_FLAGS_FILE_OVERRIDE_PATH selects the flag source: when set (dev only) flags come from that
+JSON file and GrowthBook is not contacted; when empty they come from GrowthBook. Unknown flags fall
+through to their in-code default either way.
 
 Two ways to evaluate a flag:
   - Per-user/request: use the CouchersContext methods (context.get_boolean_value, get_string_value,
@@ -54,8 +51,7 @@ _refresh_thread: threading.Thread | None = None
 # load from the API or seed from the disk cache; drives the staleness metric.
 _last_fetch_time: float | None = None
 
-# Flag values loaded from FEATURE_FLAGS_FILE_OVERRIDE_PATH in local-file mode (dev only). In that mode this
-# dict is the entire source of flag values; keys absent here fall through to the in-code default.
+# Flag values loaded from FEATURE_FLAGS_FILE_OVERRIDE_PATH; the entire flag source in file-override mode.
 _local_flags: dict[str, Any] = {}
 
 
@@ -282,11 +278,8 @@ def _global_evaluator() -> GrowthBook:
 
 
 # Single home of the gating logic, shared by the global functions below and by CouchersContext (which
-# passes its own cached per-request evaluator). get_evaluator is only invoked on the GrowthBook path,
-# so it stays lazy in local-file mode.
+# passes its own cached per-request evaluator). get_evaluator stays lazy - skipped in file-override mode.
 def _feature_value[T](flag_key: str, default: T, get_evaluator: Callable[[], GrowthBook]) -> T:
-    # Local-file mode (dev only): the file is the entire source - a listed flag gives its value, an
-    # unlisted flag falls through to the in-code default. GrowthBook is never contacted.
     if config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"]:
         if flag_key in _local_flags:
             value = _local_flags[flag_key]

--- a/app/backend/src/couchers/experimentation.py
+++ b/app/backend/src/couchers/experimentation.py
@@ -156,9 +156,8 @@ def setup_experimentation() -> None:
     if _initialized:
         return
 
-    override_path = config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"]
-    if override_path:
-        _load_local_flags(override_path)
+    if config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"]:
+        _load_local_flags(config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"])
         _initialized = True
         return
 
@@ -277,9 +276,8 @@ def _global_evaluator() -> GrowthBook:
 # Single home of the gating logic, shared by the global functions below and by CouchersContext (which
 # passes its own cached per-request evaluator). get_evaluator stays lazy - skipped in file-override mode.
 def _feature_value[T](flag_key: str, default: T, get_evaluator: Callable[[], GrowthBook]) -> T:
-    override_path = config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"]
-    if override_path:
-        return _load_local_flags(override_path).get(flag_key, default)  # type: ignore[no-any-return]
+    if config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"]:
+        return _load_local_flags(config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"]).get(flag_key, default)  # type: ignore[no-any-return]
     result = get_evaluator().eval_feature(flag_key)
     value = default if result.value is None else result.value
     metrics.observe_feature_flag_evaluation(flag_key, result.source, value)

--- a/app/backend/src/couchers/experimentation.py
+++ b/app/backend/src/couchers/experimentation.py
@@ -133,10 +133,12 @@ def _refresh_loop() -> None:
 @cache
 def _load_local_flags(path_str: str) -> dict[str, Any]:
     """Read and validate the dev-only override file; cached per path."""
-    loaded = json.loads(Path(path_str).read_text())
+    # resolve relative to the backend root, independent of cwd (absolute paths are left untouched)
+    path = Path(__file__).parent / ".." / ".." / path_str
+    loaded = json.loads(path.read_text())
     if not isinstance(loaded, dict):
-        raise ValueError(f"Feature flag override file {path_str} must contain a JSON object")
-    logger.info("Loaded %d feature flag override(s) from %s", len(loaded), path_str)
+        raise ValueError(f"Feature flag override file {path} must contain a JSON object")
+    logger.info("Loaded %d feature flag override(s) from %s", len(loaded), path)
     return loaded
 
 

--- a/app/backend/src/couchers/experimentation.py
+++ b/app/backend/src/couchers/experimentation.py
@@ -1,7 +1,13 @@
 """
-Experimentation framework for feature flags and experiments.
+Feature flag and experimentation framework.
 
-Uses GrowthBook under the hood, but abstracts the implementation details.
+The flag source is picked by config:
+  - FEATURE_FLAGS_ENABLED=False: all evaluations return the in-code default.
+  - FEATURE_FLAGS_ENABLED=True, FEATURE_FLAGS_USE_LOCAL_FILE=True: values are read from a JSON file
+    at FEATURE_FLAGS_LOCAL_FILE_PATH, loaded once at startup. Keys missing from the file fall
+    through to the in-code default. No GrowthBook contact - intended for local dev and tests.
+  - FEATURE_FLAGS_ENABLED=True, FEATURE_FLAGS_USE_LOCAL_FILE=False: values come from GrowthBook, with
+    a background-refreshed in-memory snapshot and a disk cache fallback at startup.
 
 Two ways to evaluate a flag:
   - Per-user/request: use the CouchersContext methods (context.get_boolean_value, get_string_value,
@@ -12,8 +18,7 @@ Two ways to evaluate a flag:
     to vary per user. Whenever a user is (or could reasonably be) available, use the context: only the
     per-user path can do percentage rollouts, experiments, and feature-usage tracking.
 
-Both paths share the enabled / pass-all-gates gating helpers here. setup_experimentation() is called
-once at process startup.
+setup_experimentation() is called once at process startup.
 """
 
 import json
@@ -50,11 +55,10 @@ _refresh_thread: threading.Thread | None = None
 # load from the API or seed from the disk cache; drives the staleness metric.
 _last_fetch_time: float | None = None
 
-# Local development override: maps flag keys to forced values, loaded from the file at
-# FEATURE_FLAG_OVERRIDE_PATH if set. Takes precedence over GrowthBook, PASS_ALL_GATES, and the
-# EXPERIMENTATION_ENABLED gate.
-_overrides: dict[str, Any] = {}
-_NO_OVERRIDE = object()
+# Flag values loaded from FEATURE_FLAGS_LOCAL_FILE_PATH when FEATURE_FLAGS_USE_LOCAL_FILE is on.
+# Missing keys fall through to the in-code default; this dict is the entire source of flag values
+# in local-file mode.
+_local_flags: dict[str, Any] = {}
 
 
 class ExperimentationNotInitializedError(Exception):
@@ -135,38 +139,40 @@ def _refresh_loop() -> None:
         # On a failed fetch, keep last-known-good state and retry next tick; the staleness metric climbs.
 
 
-def _load_overrides() -> None:
-    """Load local feature-flag overrides from FEATURE_FLAG_OVERRIDE_PATH, if set."""
-    global _overrides
-    path_str = config["FEATURE_FLAG_OVERRIDE_PATH"]
+def _load_local_flags() -> None:
+    """Load flag values from FEATURE_FLAGS_LOCAL_FILE_PATH into the in-memory snapshot."""
+    global _local_flags
+    path_str = config["FEATURE_FLAGS_LOCAL_FILE_PATH"]
     if not path_str:
-        _overrides = {}
-        return
-    _overrides = json.loads(Path(path_str).read_text())
-    if not isinstance(_overrides, dict):
-        raise ValueError(f"Feature flag override file {path_str} must contain a JSON object")
-    logger.warning("Loaded %d local feature-flag override(s) from %s", len(_overrides), path_str)
+        raise ValueError("FEATURE_FLAGS_USE_LOCAL_FILE is on but FEATURE_FLAGS_LOCAL_FILE_PATH is empty")
+    loaded = json.loads(Path(path_str).read_text())
+    if not isinstance(loaded, dict):
+        raise ValueError(f"Feature flag local file {path_str} must contain a JSON object")
+    _local_flags = loaded
+    logger.info("Loaded %d feature flag(s) from local file %s", len(_local_flags), path_str)
 
 
 def setup_experimentation() -> None:
     """
-    Initialize the experimentation framework.
+    Initialize the feature flag framework.
 
-    Safe to call multiple times - subsequent calls are no-ops. Fetches the
-    feature payload once synchronously, then starts a background thread that
-    refreshes every minute. Request threads only ever read the in-memory
-    snapshot - they never block on the GrowthBook CDN.
+    Safe to call multiple times - subsequent calls are no-ops. In GrowthBook mode this fetches the
+    feature payload once synchronously, then starts a background thread that refreshes every minute;
+    request threads only ever read the in-memory snapshot. In local-file mode it loads the JSON file
+    once. When feature flags are disabled, evaluations short-circuit to in-code defaults.
     """
     global _initialized, _refresh_thread
 
     if _initialized:
         return
 
-    # Local overrides apply even when experimentation is disabled, so load before that gate.
-    _load_overrides()
+    if not config["FEATURE_FLAGS_ENABLED"]:
+        logger.info("Feature flags disabled, all evaluations return in-code defaults")
+        _initialized = True
+        return
 
-    if not config["EXPERIMENTATION_ENABLED"]:
-        logger.info("Experimentation is disabled, skipping initialization")
+    if config["FEATURE_FLAGS_USE_LOCAL_FILE"]:
+        _load_local_flags()
         _initialized = True
         return
 
@@ -282,30 +288,23 @@ def _global_evaluator() -> GrowthBook:
     return _create_evaluator(None)
 
 
-# These two helpers are the single home of the gating logic, shared by the global functions below
-# and by CouchersContext (which passes its own cached per-request evaluator). get_evaluator is only
-# invoked once gating passes, so it stays lazy.
+# Single home of the gating logic, shared by the global functions below and by CouchersContext (which
+# passes its own cached per-request evaluator). get_evaluator is only invoked on the GrowthBook path,
+# so it stays lazy in the disabled and local-file paths.
 def _feature_value[T](flag_key: str, default: T, get_evaluator: Callable[[], GrowthBook]) -> T:
-    override = _overrides.get(flag_key, _NO_OVERRIDE)
-    if override is not _NO_OVERRIDE:
-        metrics.observe_feature_flag_evaluation(flag_key, "override", override)
-        return override  # type: ignore[no-any-return]
-    if not config["EXPERIMENTATION_ENABLED"]:
+    if not config["FEATURE_FLAGS_ENABLED"]:
+        return default
+    if config["FEATURE_FLAGS_USE_LOCAL_FILE"]:
+        if flag_key in _local_flags:
+            value = _local_flags[flag_key]
+            metrics.observe_feature_flag_evaluation(flag_key, "local_file", value)
+            return value  # type: ignore[no-any-return]
+        metrics.observe_feature_flag_evaluation(flag_key, "local_file_missing", default)
         return default
     result = get_evaluator().eval_feature(flag_key)
     value = default if result.value is None else result.value
     metrics.observe_feature_flag_evaluation(flag_key, result.source, value)
     return value
-
-
-def _boolean_value(flag_key: str, default: bool, get_evaluator: Callable[[], GrowthBook]) -> bool:
-    override = _overrides.get(flag_key, _NO_OVERRIDE)
-    if override is not _NO_OVERRIDE:
-        metrics.observe_feature_flag_evaluation(flag_key, "override", override)
-        return bool(override)
-    if config["EXPERIMENTATION_PASS_ALL_GATES"]:
-        return True
-    return _feature_value(flag_key, default, get_evaluator)
 
 
 # Global (no-user) flag evaluation. Use these ONLY when there is genuinely no user to evaluate for and
@@ -315,7 +314,7 @@ def _boolean_value(flag_key: str, default: bool, get_evaluator: Callable[[], Gro
 # feature-usage tracking. With no user to bucket, rollouts and experiments are skipped and flags fall
 # through to their in-code defaults unless a rule forces a value globally.
 def get_global_boolean_value(flag_key: str, default: bool) -> bool:
-    return _boolean_value(flag_key, default, _global_evaluator)
+    return _feature_value(flag_key, default, _global_evaluator)
 
 
 def get_global_string_value(flag_key: str, default: str) -> str:

--- a/app/backend/src/couchers/experimentation.py
+++ b/app/backend/src/couchers/experimentation.py
@@ -1,13 +1,12 @@
 """
 Feature flag and experimentation framework.
 
-The flag source is picked by config:
-  - FEATURE_FLAGS_ENABLED=False: all evaluations return the in-code default.
-  - FEATURE_FLAGS_ENABLED=True, FEATURE_FLAGS_USE_LOCAL_FILE=True: values are read from a JSON file
-    at FEATURE_FLAGS_LOCAL_FILE_PATH, loaded once at startup. Keys missing from the file fall
-    through to the in-code default. No GrowthBook contact - intended for local dev and tests.
-  - FEATURE_FLAGS_ENABLED=True, FEATURE_FLAGS_USE_LOCAL_FILE=False: values come from GrowthBook, with
-    a background-refreshed in-memory snapshot and a disk cache fallback at startup.
+FEATURE_FLAGS_FILE_OVERRIDE_PATH selects the flag source:
+  - Set (dev only): flags are resolved entirely from that JSON file, loaded once at startup. A key
+    present in the file gives its value; a key absent falls through to the in-code default. GrowthBook
+    is never contacted. Setting it in production is rejected at config check.
+  - Empty: flags come from GrowthBook, with a background-refreshed in-memory snapshot and a disk cache
+    fallback at startup. A flag with no GrowthBook value falls through to the in-code default.
 
 Two ways to evaluate a flag:
   - Per-user/request: use the CouchersContext methods (context.get_boolean_value, get_string_value,
@@ -55,9 +54,8 @@ _refresh_thread: threading.Thread | None = None
 # load from the API or seed from the disk cache; drives the staleness metric.
 _last_fetch_time: float | None = None
 
-# Flag values loaded from FEATURE_FLAGS_LOCAL_FILE_PATH when FEATURE_FLAGS_USE_LOCAL_FILE is on.
-# Missing keys fall through to the in-code default; this dict is the entire source of flag values
-# in local-file mode.
+# Flag values loaded from FEATURE_FLAGS_FILE_OVERRIDE_PATH in local-file mode (dev only). In that mode this
+# dict is the entire source of flag values; keys absent here fall through to the in-code default.
 _local_flags: dict[str, Any] = {}
 
 
@@ -140,16 +138,16 @@ def _refresh_loop() -> None:
 
 
 def _load_local_flags() -> None:
-    """Load flag values from FEATURE_FLAGS_LOCAL_FILE_PATH into the in-memory snapshot."""
+    """Load the dev-only override flags from FEATURE_FLAGS_FILE_OVERRIDE_PATH into the in-memory layer."""
     global _local_flags
-    path_str = config["FEATURE_FLAGS_LOCAL_FILE_PATH"]
+    path_str = config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"]
     if not path_str:
-        raise ValueError("FEATURE_FLAGS_USE_LOCAL_FILE is on but FEATURE_FLAGS_LOCAL_FILE_PATH is empty")
+        raise ValueError("FEATURE_FLAGS_FILE_OVERRIDE_PATH is empty")
     loaded = json.loads(Path(path_str).read_text())
     if not isinstance(loaded, dict):
         raise ValueError(f"Feature flag local file {path_str} must contain a JSON object")
     _local_flags = loaded
-    logger.info("Loaded %d feature flag(s) from local file %s", len(_local_flags), path_str)
+    logger.info("Loaded %d feature flag override(s) from local file %s", len(_local_flags), path_str)
 
 
 def setup_experimentation() -> None:
@@ -158,20 +156,15 @@ def setup_experimentation() -> None:
 
     Safe to call multiple times - subsequent calls are no-ops. In GrowthBook mode this fetches the
     feature payload once synchronously, then starts a background thread that refreshes every minute;
-    request threads only ever read the in-memory snapshot. In local-file mode it loads the JSON file
-    once. When feature flags are disabled, evaluations short-circuit to in-code defaults.
+    request threads only ever read the in-memory snapshot. In local-file mode (dev only) it loads the
+    JSON file once and never contacts GrowthBook.
     """
     global _initialized, _refresh_thread
 
     if _initialized:
         return
 
-    if not config["FEATURE_FLAGS_ENABLED"]:
-        logger.info("Feature flags disabled, all evaluations return in-code defaults")
-        _initialized = True
-        return
-
-    if config["FEATURE_FLAGS_USE_LOCAL_FILE"]:
+    if config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"]:
         _load_local_flags()
         _initialized = True
         return
@@ -290,11 +283,11 @@ def _global_evaluator() -> GrowthBook:
 
 # Single home of the gating logic, shared by the global functions below and by CouchersContext (which
 # passes its own cached per-request evaluator). get_evaluator is only invoked on the GrowthBook path,
-# so it stays lazy in the disabled and local-file paths.
+# so it stays lazy in local-file mode.
 def _feature_value[T](flag_key: str, default: T, get_evaluator: Callable[[], GrowthBook]) -> T:
-    if not config["FEATURE_FLAGS_ENABLED"]:
-        return default
-    if config["FEATURE_FLAGS_USE_LOCAL_FILE"]:
+    # Local-file mode (dev only): the file is the entire source - a listed flag gives its value, an
+    # unlisted flag falls through to the in-code default. GrowthBook is never contacted.
+    if config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"]:
         if flag_key in _local_flags:
             value = _local_flags[flag_key]
             metrics.observe_feature_flag_evaluation(flag_key, "local_file", value)

--- a/app/backend/src/couchers/experimentation.py
+++ b/app/backend/src/couchers/experimentation.py
@@ -50,6 +50,12 @@ _refresh_thread: threading.Thread | None = None
 # load from the API or seed from the disk cache; drives the staleness metric.
 _last_fetch_time: float | None = None
 
+# Local development override: maps flag keys to forced values, loaded from the file at
+# FEATURE_FLAG_OVERRIDE_PATH if set. Takes precedence over GrowthBook, PASS_ALL_GATES, and the
+# EXPERIMENTATION_ENABLED gate.
+_overrides: dict[str, Any] = {}
+_NO_OVERRIDE = object()
+
 
 class ExperimentationNotInitializedError(Exception):
     """Raised when experimentation functions are called before initialization."""
@@ -129,6 +135,19 @@ def _refresh_loop() -> None:
         # On a failed fetch, keep last-known-good state and retry next tick; the staleness metric climbs.
 
 
+def _load_overrides() -> None:
+    """Load local feature-flag overrides from FEATURE_FLAG_OVERRIDE_PATH, if set."""
+    global _overrides
+    path_str = config["FEATURE_FLAG_OVERRIDE_PATH"]
+    if not path_str:
+        _overrides = {}
+        return
+    _overrides = json.loads(Path(path_str).read_text())
+    if not isinstance(_overrides, dict):
+        raise ValueError(f"Feature flag override file {path_str} must contain a JSON object")
+    logger.warning("Loaded %d local feature-flag override(s) from %s", len(_overrides), path_str)
+
+
 def setup_experimentation() -> None:
     """
     Initialize the experimentation framework.
@@ -142,6 +161,9 @@ def setup_experimentation() -> None:
 
     if _initialized:
         return
+
+    # Local overrides apply even when experimentation is disabled, so load before that gate.
+    _load_overrides()
 
     if not config["EXPERIMENTATION_ENABLED"]:
         logger.info("Experimentation is disabled, skipping initialization")
@@ -264,6 +286,10 @@ def _global_evaluator() -> GrowthBook:
 # and by CouchersContext (which passes its own cached per-request evaluator). get_evaluator is only
 # invoked once gating passes, so it stays lazy.
 def _feature_value[T](flag_key: str, default: T, get_evaluator: Callable[[], GrowthBook]) -> T:
+    override = _overrides.get(flag_key, _NO_OVERRIDE)
+    if override is not _NO_OVERRIDE:
+        metrics.observe_feature_flag_evaluation(flag_key, "override", override)
+        return override  # type: ignore[no-any-return]
     if not config["EXPERIMENTATION_ENABLED"]:
         return default
     result = get_evaluator().eval_feature(flag_key)
@@ -273,6 +299,10 @@ def _feature_value[T](flag_key: str, default: T, get_evaluator: Callable[[], Gro
 
 
 def _boolean_value(flag_key: str, default: bool, get_evaluator: Callable[[], GrowthBook]) -> bool:
+    override = _overrides.get(flag_key, _NO_OVERRIDE)
+    if override is not _NO_OVERRIDE:
+        metrics.observe_feature_flag_evaluation(flag_key, "override", override)
+        return bool(override)
     if config["EXPERIMENTATION_PASS_ALL_GATES"]:
         return True
     return _feature_value(flag_key, default, get_evaluator)

--- a/app/backend/src/couchers/experimentation.py
+++ b/app/backend/src/couchers/experimentation.py
@@ -21,6 +21,7 @@ import logging
 import threading
 import time
 from collections.abc import Callable
+from functools import cache
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any
@@ -49,9 +50,6 @@ _refresh_thread: threading.Thread | None = None
 # Unix time of the last successful pull from GrowthBook (None until the first success). Set when we
 # load from the API or seed from the disk cache; drives the staleness metric.
 _last_fetch_time: float | None = None
-
-# Flag values loaded from FEATURE_FLAGS_FILE_OVERRIDE_PATH; the entire flag source in file-override mode.
-_local_flags: dict[str, Any] = {}
 
 
 class ExperimentationNotInitializedError(Exception):
@@ -132,17 +130,16 @@ def _refresh_loop() -> None:
         # On a failed fetch, keep last-known-good state and retry next tick; the staleness metric climbs.
 
 
-def _load_local_flags() -> None:
-    """Load the dev-only override flags from FEATURE_FLAGS_FILE_OVERRIDE_PATH into the in-memory layer."""
-    global _local_flags
-    path_str = config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"]
+@cache
+def _load_local_flags(path_str: str) -> dict[str, Any]:
+    """Read and validate the dev-only override file; cached per path."""
     if not path_str:
         raise ValueError("FEATURE_FLAGS_FILE_OVERRIDE_PATH is empty")
     loaded = json.loads(Path(path_str).read_text())
     if not isinstance(loaded, dict):
-        raise ValueError(f"Feature flag local file {path_str} must contain a JSON object")
-    _local_flags = loaded
-    logger.info("Loaded %d feature flag override(s) from local file %s", len(_local_flags), path_str)
+        raise ValueError(f"Feature flag override file {path_str} must contain a JSON object")
+    logger.info("Loaded %d feature flag override(s) from %s", len(loaded), path_str)
+    return loaded
 
 
 def setup_experimentation() -> None:
@@ -159,8 +156,9 @@ def setup_experimentation() -> None:
     if _initialized:
         return
 
-    if config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"]:
-        _load_local_flags()
+    override_path = config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"]
+    if override_path:
+        _load_local_flags(override_path)
         _initialized = True
         return
 
@@ -279,8 +277,9 @@ def _global_evaluator() -> GrowthBook:
 # Single home of the gating logic, shared by the global functions below and by CouchersContext (which
 # passes its own cached per-request evaluator). get_evaluator stays lazy - skipped in file-override mode.
 def _feature_value[T](flag_key: str, default: T, get_evaluator: Callable[[], GrowthBook]) -> T:
-    if config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"]:
-        return _local_flags.get(flag_key, default)  # type: ignore[no-any-return]
+    override_path = config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"]
+    if override_path:
+        return _load_local_flags(override_path).get(flag_key, default)  # type: ignore[no-any-return]
     result = get_evaluator().eval_feature(flag_key)
     value = default if result.value is None else result.value
     metrics.observe_feature_flag_evaluation(flag_key, result.source, value)

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -151,6 +151,8 @@ def db_class(setup_testdb: None, testdb_conn: Connection) -> None:
 @pytest.fixture(scope="class")
 def testconfig():
     prevconfig = config.copy()
+    prev_initialized = experimentation._initialized
+    prev_local_flags = experimentation._local_flags
 
     config["IN_TEST"] = True
 
@@ -222,12 +224,29 @@ def testconfig():
     config["RECAPTHCA_API_KEY"] = "..."
     config["RECAPTHCA_SITE_KEY"] = "..."
 
-    config["EXPERIMENTATION_ENABLED"] = False
-    config["EXPERIMENTATION_PASS_ALL_GATES"] = True
+    # Default tests to local-file mode with every production boolean gate forced True. This preserves
+    # the prior "everything's enabled in tests" convenience that the old EXPERIMENTATION_PASS_ALL_GATES
+    # provided. Tests that need a specific GrowthBook setup use the `feature_flags` fixture instead.
+    config["FEATURE_FLAGS_ENABLED"] = True
+    config["FEATURE_FLAGS_USE_LOCAL_FILE"] = True
+    config["FEATURE_FLAGS_LOCAL_FILE_PATH"] = ""
     config["GROWTHBOOK_API_HOST"] = "https://cdn.growthbook.io"
     config["GROWTHBOOK_CLIENT_KEY"] = ""
     config["GROWTHBOOK_CACHE_PATH"] = ""
-    config["FEATURE_FLAG_OVERRIDE_PATH"] = ""
+    experimentation._initialized = True
+    experimentation._local_flags = {
+        "test_growthbook_integration": True,
+        "sms_enabled": True,
+        "strong_verification_enabled": True,
+        "log_native_ota_requests": True,
+        "donations_enabled": True,
+        "recaptcha_enabled": True,
+        "postal_verification_enabled": True,
+        "listmonk_enabled": True,
+        "remove_removed_users_from_mailing_list_enabled": True,
+        "notification_translations_enabled": True,
+        "email_ics_attachments_enabled": True,
+    }
 
     # Moderation auto-approval deadline - 0 disables, set in tests that need it
     config["MODERATION_AUTO_APPROVE_DEADLINE_SECONDS"] = 0
@@ -251,6 +270,8 @@ def testconfig():
     yield None
 
     config.copy_from(prevconfig)
+    experimentation._initialized = prev_initialized
+    experimentation._local_flags = prev_local_flags
 
 
 class FeatureFlags:
@@ -271,7 +292,7 @@ class FeatureFlags:
 @pytest.fixture
 def feature_flags(monkeypatch) -> FeatureFlags:
     """
-    Enable experimentation with an in-memory snapshot and let tests set flag values by key.
+    Enable GrowthBook-mode flag evaluation against an in-memory snapshot; tests set values by key.
 
     Usage:
         def test_x(db, feature_flags):
@@ -281,8 +302,8 @@ def feature_flags(monkeypatch) -> FeatureFlags:
     features: dict[str, Any] = {}
     monkeypatch.setattr(experimentation, "_initialized", True)
     monkeypatch.setattr(experimentation, "_state", {"features": features, "savedGroups": {}})
-    monkeypatch.setitem(config, "EXPERIMENTATION_ENABLED", True)
-    monkeypatch.setitem(config, "EXPERIMENTATION_PASS_ALL_GATES", False)
+    monkeypatch.setitem(config, "FEATURE_FLAGS_ENABLED", True)
+    monkeypatch.setitem(config, "FEATURE_FLAGS_USE_LOCAL_FILE", False)
     return FeatureFlags(features)
 
 

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -148,6 +148,23 @@ def db_class(setup_testdb: None, testdb_conn: Connection) -> None:
     _truncate_non_static_tables(testdb_conn)
 
 
+# Production gates forced True so tests run as "everything enabled". Used by testconfig and the `flags`
+# fixture; tests flip individual values via `flags`.
+_TEST_FLAG_DEFAULTS: dict[str, Any] = {
+    "test_growthbook_integration": True,
+    "sms_enabled": True,
+    "strong_verification_enabled": True,
+    "log_native_ota_requests": True,
+    "donations_enabled": True,
+    "recaptcha_enabled": True,
+    "postal_verification_enabled": True,
+    "listmonk_enabled": True,
+    "remove_removed_users_from_mailing_list_enabled": True,
+    "notification_translations_enabled": True,
+    "email_ics_attachments_enabled": True,
+}
+
+
 @pytest.fixture(scope="class")
 def testconfig():
     prevconfig = config.copy()
@@ -230,19 +247,7 @@ def testconfig():
     config["GROWTHBOOK_CLIENT_KEY"] = ""
     config["GROWTHBOOK_CACHE_PATH"] = ""
     experimentation._initialized = True
-    experimentation._load_local_flags = lambda _path: {  # type: ignore[assignment]
-        "test_growthbook_integration": True,
-        "sms_enabled": True,
-        "strong_verification_enabled": True,
-        "log_native_ota_requests": True,
-        "donations_enabled": True,
-        "recaptcha_enabled": True,
-        "postal_verification_enabled": True,
-        "listmonk_enabled": True,
-        "remove_removed_users_from_mailing_list_enabled": True,
-        "notification_translations_enabled": True,
-        "email_ics_attachments_enabled": True,
-    }
+    experimentation._load_local_flags = lambda _path: _TEST_FLAG_DEFAULTS  # type: ignore[assignment]
 
     # Moderation auto-approval deadline - 0 disables, set in tests that need it
     config["MODERATION_AUTO_APPROVE_DEADLINE_SECONDS"] = 0
@@ -268,6 +273,44 @@ def testconfig():
     config.copy_from(prevconfig)
     experimentation._initialized = prev_initialized
     experimentation._load_local_flags = prev_load_local_flags
+
+
+class Flags:
+    """Test handle for setting feature flag values in file-override mode; see the `flags` fixture."""
+
+    def __init__(self, values: dict[str, Any]) -> None:
+        self._values = values
+
+    def set_boolean(self, key: str, value: bool) -> None:
+        self._values[key] = value
+
+    def set_string(self, key: str, value: str) -> None:
+        self._values[key] = value
+
+    def set_integer(self, key: str, value: int) -> None:
+        self._values[key] = value
+
+    def set_float(self, key: str, value: float) -> None:
+        self._values[key] = value
+
+    def set_object(self, key: str, value: Any) -> None:
+        self._values[key] = value
+
+
+@pytest.fixture
+def flags(monkeypatch) -> Flags:
+    """
+    Override feature flag values for a test (file-override mode).
+
+    Starts from the test defaults (production gates on), so a test flips individual flags:
+
+        def test_x(flags):
+            flags.set_boolean("test_growthbook_integration", False)
+    """
+    values = dict(_TEST_FLAG_DEFAULTS)
+    monkeypatch.setattr(experimentation, "_load_local_flags", lambda _path: values)
+    monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", "feature-flags.dev.json")
+    return Flags(values)
 
 
 class FeatureFlags:

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -224,10 +224,9 @@ def testconfig():
     config["RECAPTHCA_API_KEY"] = "..."
     config["RECAPTHCA_SITE_KEY"] = "..."
 
-    # Default tests to local-file mode with every production boolean gate forced True. The path is just
-    # a sentinel that selects the mode - the in-memory _local_flags below is the actual source (the file
-    # is never read because _initialized is set directly). Missing keys fall through to their in-code
-    # default and GrowthBook is never contacted. Tests needing a GrowthBook setup use `feature_flags`.
+    # Run tests in file-override mode with every production gate forced True via _local_flags below. The
+    # path is just a mode-selecting sentinel (the file is never read). Tests needing GrowthBook use
+    # the `feature_flags` fixture.
     config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"] = "feature-flags.dev.json"
     config["GROWTHBOOK_API_HOST"] = "https://cdn.growthbook.io"
     config["GROWTHBOOK_CLIENT_KEY"] = ""

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -152,7 +152,7 @@ def db_class(setup_testdb: None, testdb_conn: Connection) -> None:
 def testconfig():
     prevconfig = config.copy()
     prev_initialized = experimentation._initialized
-    prev_local_flags = experimentation._local_flags
+    prev_load_local_flags = experimentation._load_local_flags
 
     config["IN_TEST"] = True
 
@@ -224,13 +224,13 @@ def testconfig():
     config["RECAPTHCA_API_KEY"] = "..."
     config["RECAPTHCA_SITE_KEY"] = "..."
 
-    # File-override mode; gates forced True via _local_flags below. Tests needing GrowthBook use `feature_flags`.
+    # File-override mode; gates forced True via the stubbed loader below. Tests needing GrowthBook use `feature_flags`.
     config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"] = "feature-flags.dev.json"
     config["GROWTHBOOK_API_HOST"] = "https://cdn.growthbook.io"
     config["GROWTHBOOK_CLIENT_KEY"] = ""
     config["GROWTHBOOK_CACHE_PATH"] = ""
     experimentation._initialized = True
-    experimentation._local_flags = {
+    experimentation._load_local_flags = lambda _path: {  # type: ignore[assignment]
         "test_growthbook_integration": True,
         "sms_enabled": True,
         "strong_verification_enabled": True,
@@ -267,7 +267,7 @@ def testconfig():
 
     config.copy_from(prevconfig)
     experimentation._initialized = prev_initialized
-    experimentation._local_flags = prev_local_flags
+    experimentation._load_local_flags = prev_load_local_flags
 
 
 class FeatureFlags:
@@ -298,8 +298,7 @@ def feature_flags(monkeypatch) -> FeatureFlags:
     features: dict[str, Any] = {}
     monkeypatch.setattr(experimentation, "_initialized", True)
     monkeypatch.setattr(experimentation, "_state", {"features": features, "savedGroups": {}})
-    # Switch to GrowthBook mode (empty local-file path) and clear any local-file values.
-    monkeypatch.setattr(experimentation, "_local_flags", {})
+    # Switch to GrowthBook mode (empty override path).
     monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", "")
     return FeatureFlags(features)
 

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -227,6 +227,7 @@ def testconfig():
     config["GROWTHBOOK_API_HOST"] = "https://cdn.growthbook.io"
     config["GROWTHBOOK_CLIENT_KEY"] = ""
     config["GROWTHBOOK_CACHE_PATH"] = ""
+    config["FEATURE_FLAG_OVERRIDE_PATH"] = ""
 
     # Moderation auto-approval deadline - 0 disables, set in tests that need it
     config["MODERATION_AUTO_APPROVE_DEADLINE_SECONDS"] = 0

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -224,9 +224,7 @@ def testconfig():
     config["RECAPTHCA_API_KEY"] = "..."
     config["RECAPTHCA_SITE_KEY"] = "..."
 
-    # Run tests in file-override mode with every production gate forced True via _local_flags below. The
-    # path is just a mode-selecting sentinel (the file is never read). Tests needing GrowthBook use
-    # the `feature_flags` fixture.
+    # File-override mode; gates forced True via _local_flags below. Tests needing GrowthBook use `feature_flags`.
     config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"] = "feature-flags.dev.json"
     config["GROWTHBOOK_API_HOST"] = "https://cdn.growthbook.io"
     config["GROWTHBOOK_CLIENT_KEY"] = ""

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -224,12 +224,11 @@ def testconfig():
     config["RECAPTHCA_API_KEY"] = "..."
     config["RECAPTHCA_SITE_KEY"] = "..."
 
-    # Default tests to local-file mode with every production boolean gate forced True. This preserves
-    # the prior "everything's enabled in tests" convenience that the old EXPERIMENTATION_PASS_ALL_GATES
-    # provided. Tests that need a specific GrowthBook setup use the `feature_flags` fixture instead.
-    config["FEATURE_FLAGS_ENABLED"] = True
-    config["FEATURE_FLAGS_USE_LOCAL_FILE"] = True
-    config["FEATURE_FLAGS_LOCAL_FILE_PATH"] = ""
+    # Default tests to local-file mode with every production boolean gate forced True. The path is just
+    # a sentinel that selects the mode - the in-memory _local_flags below is the actual source (the file
+    # is never read because _initialized is set directly). Missing keys fall through to their in-code
+    # default and GrowthBook is never contacted. Tests needing a GrowthBook setup use `feature_flags`.
+    config["FEATURE_FLAGS_FILE_OVERRIDE_PATH"] = "feature-flags.dev.json"
     config["GROWTHBOOK_API_HOST"] = "https://cdn.growthbook.io"
     config["GROWTHBOOK_CLIENT_KEY"] = ""
     config["GROWTHBOOK_CACHE_PATH"] = ""
@@ -302,8 +301,9 @@ def feature_flags(monkeypatch) -> FeatureFlags:
     features: dict[str, Any] = {}
     monkeypatch.setattr(experimentation, "_initialized", True)
     monkeypatch.setattr(experimentation, "_state", {"features": features, "savedGroups": {}})
-    monkeypatch.setitem(config, "FEATURE_FLAGS_ENABLED", True)
-    monkeypatch.setitem(config, "FEATURE_FLAGS_USE_LOCAL_FILE", False)
+    # Switch to GrowthBook mode (empty local-file path) and clear any local-file values.
+    monkeypatch.setattr(experimentation, "_local_flags", {})
+    monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", "")
     return FeatureFlags(features)
 
 

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -1369,8 +1369,8 @@ def test_update_badges_skips_moderator_when_flag_off(db, monkeypatch):
         "_state",
         {"features": {"show_moderator_badge": {"defaultValue": True, "rules": [{"force": False}]}}, "savedGroups": {}},
     )
-    monkeypatch.setitem(config, "EXPERIMENTATION_ENABLED", True)
-    monkeypatch.setitem(config, "EXPERIMENTATION_PASS_ALL_GATES", False)
+    monkeypatch.setitem(config, "FEATURE_FLAGS_ENABLED", True)
+    monkeypatch.setitem(config, "FEATURE_FLAGS_USE_LOCAL_FILE", False)
 
     superuser, _ = generate_user(is_superuser=True, last_donated=None)
 

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -1369,7 +1369,6 @@ def test_update_badges_skips_moderator_when_flag_off(db, monkeypatch):
         "_state",
         {"features": {"show_moderator_badge": {"defaultValue": True, "rules": [{"force": False}]}}, "savedGroups": {}},
     )
-    monkeypatch.setattr(experimentation, "_local_flags", {})
     monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", "")
 
     superuser, _ = generate_user(is_superuser=True, last_donated=None)

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -1369,8 +1369,8 @@ def test_update_badges_skips_moderator_when_flag_off(db, monkeypatch):
         "_state",
         {"features": {"show_moderator_badge": {"defaultValue": True, "rules": [{"force": False}]}}, "savedGroups": {}},
     )
-    monkeypatch.setitem(config, "FEATURE_FLAGS_ENABLED", True)
-    monkeypatch.setitem(config, "FEATURE_FLAGS_USE_LOCAL_FILE", False)
+    monkeypatch.setattr(experimentation, "_local_flags", {})
+    monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", "")
 
     superuser, _ = generate_user(is_superuser=True, last_donated=None)
 

--- a/app/backend/src/tests/test_config.py
+++ b/app/backend/src/tests/test_config.py
@@ -30,6 +30,8 @@ def _complete_config(dev: bool) -> Config:
         cfg.BASE_URL = "https://example.com"
         cfg.ENABLE_EMAIL = True
         cfg.IN_TEST = False
+        # the local-file override layer is dev-only and must be empty in production
+        cfg.FEATURE_FLAGS_FILE_OVERRIDE_PATH = ""
     return cfg
 
 

--- a/app/backend/src/tests/test_config.py
+++ b/app/backend/src/tests/test_config.py
@@ -30,7 +30,6 @@ def _complete_config(dev: bool) -> Config:
         cfg.BASE_URL = "https://example.com"
         cfg.ENABLE_EMAIL = True
         cfg.IN_TEST = False
-        # the local-file override layer is dev-only and must be empty in production
         cfg.FEATURE_FLAGS_FILE_OVERRIDE_PATH = ""
     return cfg
 

--- a/app/backend/src/tests/test_experimentation.py
+++ b/app/backend/src/tests/test_experimentation.py
@@ -241,3 +241,71 @@ def test_setup_raises_on_corrupt_cache(setup_isolation, monkeypatch):
 
 def test_seconds_since_last_fetch_none_when_never_fetched(setup_isolation):
     assert experimentation.seconds_since_last_fetch() is None
+
+
+@pytest.fixture
+def overrides(monkeypatch):
+    """Set the in-memory override dict directly, without touching disk."""
+    overrides: dict[str, object] = {}
+    monkeypatch.setattr(experimentation, "_overrides", overrides)
+    return overrides
+
+
+def test_override_takes_precedence_over_growthbook(feature_flags, overrides):
+    feature_flags.set("my_flag", "from_growthbook")
+    overrides["my_flag"] = "from_override"
+    context = make_logged_out_context(LocalizationContext.en_utc())
+    assert context.get_string_value("my_flag", "fallback") == "from_override"
+
+
+def test_override_works_when_experimentation_disabled(monkeypatch, overrides):
+    monkeypatch.setitem(config, "EXPERIMENTATION_ENABLED", False)
+    overrides["my_flag"] = "forced"
+    context = make_logged_out_context(LocalizationContext.en_utc())
+    assert context.get_string_value("my_flag", "fallback") == "forced"
+
+
+def test_override_takes_precedence_over_pass_all_gates(monkeypatch, overrides):
+    monkeypatch.setitem(config, "EXPERIMENTATION_PASS_ALL_GATES", True)
+    overrides["my_flag"] = False
+    context = make_logged_out_context(LocalizationContext.en_utc())
+    assert context.get_boolean_value("my_flag", default=True) is False
+
+
+def test_override_records_metric_with_override_source(overrides):
+    overrides["override_metric_flag"] = "x"
+    before = _flag_eval_count("override_metric_flag", "override", "x")
+    assert experimentation.get_global_string_value("override_metric_flag", "y") == "x"
+    assert _flag_eval_count("override_metric_flag", "override", "x") == before + 1
+
+
+def test_unset_flag_falls_through_when_overrides_present(feature_flags, overrides):
+    feature_flags.set("real_flag", "real_value")
+    overrides["other_flag"] = "other_value"
+    context = make_logged_out_context(LocalizationContext.en_utc())
+    assert context.get_string_value("real_flag", "fallback") == "real_value"
+
+
+def test_load_overrides_from_file(monkeypatch, tmp_path):
+    path = tmp_path / "overrides.json"
+    path.write_text(json.dumps({"flag_a": True, "flag_b": "hello", "flag_c": 42}))
+    monkeypatch.setitem(config, "FEATURE_FLAG_OVERRIDE_PATH", str(path))
+    monkeypatch.setattr(experimentation, "_overrides", {})
+    experimentation._load_overrides()
+    assert experimentation._overrides == {"flag_a": True, "flag_b": "hello", "flag_c": 42}
+
+
+def test_load_overrides_empty_when_path_unset(monkeypatch):
+    monkeypatch.setitem(config, "FEATURE_FLAG_OVERRIDE_PATH", "")
+    monkeypatch.setattr(experimentation, "_overrides", {"stale": "value"})
+    experimentation._load_overrides()
+    assert experimentation._overrides == {}
+
+
+def test_load_overrides_rejects_non_object(monkeypatch, tmp_path):
+    path = tmp_path / "overrides.json"
+    path.write_text(json.dumps(["not", "an", "object"]))
+    monkeypatch.setitem(config, "FEATURE_FLAG_OVERRIDE_PATH", str(path))
+    monkeypatch.setattr(experimentation, "_overrides", {})
+    with pytest.raises(ValueError, match="must contain a JSON object"):
+        experimentation._load_overrides()

--- a/app/backend/src/tests/test_experimentation.py
+++ b/app/backend/src/tests/test_experimentation.py
@@ -259,11 +259,6 @@ def test_load_local_flags_from_file(tmp_path):
     assert experimentation._load_local_flags(str(path)) == {"flag_a": True, "flag_b": "hello", "flag_c": 42}
 
 
-def test_load_local_flags_requires_path():
-    with pytest.raises(ValueError, match="FEATURE_FLAGS_FILE_OVERRIDE_PATH is empty"):
-        experimentation._load_local_flags("")
-
-
 def test_load_local_flags_rejects_non_object(tmp_path):
     path = tmp_path / "flags.json"
     path.write_text(json.dumps(["not", "an", "object"]))

--- a/app/backend/src/tests/test_experimentation.py
+++ b/app/backend/src/tests/test_experimentation.py
@@ -266,19 +266,6 @@ def test_local_file_boolean_value(local_file_flags):
     assert context.get_boolean_value("bool_flag", default=True) is False
 
 
-def test_local_file_records_metric_with_local_file_source(local_file_flags):
-    local_file_flags["metric_local_flag"] = "x"
-    before = _flag_eval_count("metric_local_flag", "local_file", "x")
-    assert experimentation.get_global_string_value("metric_local_flag", "y") == "x"
-    assert _flag_eval_count("metric_local_flag", "local_file", "x") == before + 1
-
-
-def test_local_file_missing_key_records_metric_with_missing_source(local_file_flags):
-    before = _flag_eval_count("absent_local_flag", "local_file_missing", "fallback")
-    assert experimentation.get_global_string_value("absent_local_flag", "fallback") == "fallback"
-    assert _flag_eval_count("absent_local_flag", "local_file_missing", "fallback") == before + 1
-
-
 def test_load_local_flags_from_file(monkeypatch, tmp_path):
     path = tmp_path / "flags.json"
     path.write_text(json.dumps({"flag_a": True, "flag_b": "hello", "flag_c": 42}))

--- a/app/backend/src/tests/test_experimentation.py
+++ b/app/backend/src/tests/test_experimentation.py
@@ -179,7 +179,6 @@ def setup_isolation(monkeypatch, tmp_path):
     monkeypatch.setattr(experimentation, "_initialized", False)
     monkeypatch.setattr(experimentation, "_last_fetch_time", None)
     monkeypatch.setattr(experimentation, "_state", {"features": {}, "savedGroups": {}})
-    monkeypatch.setattr(experimentation, "_local_flags", {})
     monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", "")
     monkeypatch.setitem(config, "GROWTHBOOK_CACHE_PATH", str(tmp_path / "cache.json"))
     yield tmp_path / "cache.json"
@@ -242,8 +241,7 @@ def test_seconds_since_last_fetch_none_when_never_fetched(setup_isolation):
 def local_file_flags(monkeypatch):
     """File-override mode: tests set flag values directly; unlisted flags fall through to the default."""
     flags: dict[str, Any] = {}
-    monkeypatch.setattr(experimentation, "_initialized", True)
-    monkeypatch.setattr(experimentation, "_local_flags", flags)
+    monkeypatch.setattr(experimentation, "_load_local_flags", lambda _path: flags)
     monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", "feature-flags.dev.json")
     return flags
 
@@ -266,41 +264,33 @@ def test_local_file_boolean_value(local_file_flags):
     assert context.get_boolean_value("bool_flag", default=True) is False
 
 
-def test_load_local_flags_from_file(monkeypatch, tmp_path):
+def test_load_local_flags_from_file(tmp_path):
     path = tmp_path / "flags.json"
     path.write_text(json.dumps({"flag_a": True, "flag_b": "hello", "flag_c": 42}))
-    monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", str(path))
-    monkeypatch.setattr(experimentation, "_local_flags", {})
-    experimentation._load_local_flags()
-    assert experimentation._local_flags == {"flag_a": True, "flag_b": "hello", "flag_c": 42}
+    assert experimentation._load_local_flags(str(path)) == {"flag_a": True, "flag_b": "hello", "flag_c": 42}
 
 
-def test_load_local_flags_requires_path(monkeypatch):
-    monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", "")
-    monkeypatch.setattr(experimentation, "_local_flags", {})
+def test_load_local_flags_requires_path():
     with pytest.raises(ValueError, match="FEATURE_FLAGS_FILE_OVERRIDE_PATH is empty"):
-        experimentation._load_local_flags()
+        experimentation._load_local_flags("")
 
 
-def test_load_local_flags_rejects_non_object(monkeypatch, tmp_path):
+def test_load_local_flags_rejects_non_object(tmp_path):
     path = tmp_path / "flags.json"
     path.write_text(json.dumps(["not", "an", "object"]))
-    monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", str(path))
-    monkeypatch.setattr(experimentation, "_local_flags", {})
     with pytest.raises(ValueError, match="must contain a JSON object"):
-        experimentation._load_local_flags()
+        experimentation._load_local_flags(str(path))
 
 
 def test_setup_in_local_file_mode_loads_file_and_skips_growthbook(monkeypatch, tmp_path):
     path = tmp_path / "flags.json"
     path.write_text(json.dumps({"flag_x": "from_file"}))
     monkeypatch.setattr(experimentation, "_initialized", False)
-    monkeypatch.setattr(experimentation, "_local_flags", {})
     monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", str(path))
     # If GrowthBook were touched, this would blow up.
     monkeypatch.setattr(experimentation, "_fetch_features", lambda: pytest.fail("GrowthBook should not be touched"))
 
     setup_experimentation()
 
-    assert experimentation._local_flags == {"flag_x": "from_file"}
+    assert experimentation._load_local_flags(str(path)) == {"flag_x": "from_file"}
     assert experimentation._refresh_thread is None

--- a/app/backend/src/tests/test_experimentation.py
+++ b/app/backend/src/tests/test_experimentation.py
@@ -67,13 +67,6 @@ def test_unknown_feature_returns_in_code_default(feature_flags):
     assert context.get_string_value("does_not_exist", "my_default") == "my_default"
 
 
-def test_value_method_returns_in_code_default_when_disabled(monkeypatch, feature_flags):
-    feature_flags.set("global_flag", True)
-    monkeypatch.setitem(config, "FEATURE_FLAGS_ENABLED", False)
-    context = make_background_user_context(123)
-    assert context.get_string_value("global_flag", "off") == "off"
-
-
 def test_evaluating_an_experiment_flag_records_exactly_one_exposure(db, feature_flags):
     # Evaluating an experiment-backed flag for a bucketed user records exactly one exposure - this is
     # the whole point of per-flag evaluation: exposure is logged only for flags the user actually hits.
@@ -186,8 +179,8 @@ def setup_isolation(monkeypatch, tmp_path):
     monkeypatch.setattr(experimentation, "_initialized", False)
     monkeypatch.setattr(experimentation, "_last_fetch_time", None)
     monkeypatch.setattr(experimentation, "_state", {"features": {}, "savedGroups": {}})
-    monkeypatch.setitem(config, "FEATURE_FLAGS_ENABLED", True)
-    monkeypatch.setitem(config, "FEATURE_FLAGS_USE_LOCAL_FILE", False)
+    monkeypatch.setattr(experimentation, "_local_flags", {})
+    monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", "")
     monkeypatch.setitem(config, "GROWTHBOOK_CACHE_PATH", str(tmp_path / "cache.json"))
     yield tmp_path / "cache.json"
     experimentation._refresh_stop.set()
@@ -247,12 +240,15 @@ def test_seconds_since_last_fetch_none_when_never_fetched(setup_isolation):
 
 @pytest.fixture
 def local_file_flags(monkeypatch):
-    """Switch into local-file mode and let tests set values in the in-memory snapshot directly."""
+    """Switch into local-file mode (dev only) and let tests set values in the in-memory snapshot directly.
+
+    A listed flag resolves from the file; an unlisted flag falls through to the in-code default and
+    GrowthBook is never contacted.
+    """
     flags: dict[str, Any] = {}
     monkeypatch.setattr(experimentation, "_initialized", True)
     monkeypatch.setattr(experimentation, "_local_flags", flags)
-    monkeypatch.setitem(config, "FEATURE_FLAGS_ENABLED", True)
-    monkeypatch.setitem(config, "FEATURE_FLAGS_USE_LOCAL_FILE", True)
+    monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", "feature-flags.dev.json")
     return flags
 
 
@@ -290,23 +286,23 @@ def test_local_file_missing_key_records_metric_with_missing_source(local_file_fl
 def test_load_local_flags_from_file(monkeypatch, tmp_path):
     path = tmp_path / "flags.json"
     path.write_text(json.dumps({"flag_a": True, "flag_b": "hello", "flag_c": 42}))
-    monkeypatch.setitem(config, "FEATURE_FLAGS_LOCAL_FILE_PATH", str(path))
+    monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", str(path))
     monkeypatch.setattr(experimentation, "_local_flags", {})
     experimentation._load_local_flags()
     assert experimentation._local_flags == {"flag_a": True, "flag_b": "hello", "flag_c": 42}
 
 
 def test_load_local_flags_requires_path(monkeypatch):
-    monkeypatch.setitem(config, "FEATURE_FLAGS_LOCAL_FILE_PATH", "")
+    monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", "")
     monkeypatch.setattr(experimentation, "_local_flags", {})
-    with pytest.raises(ValueError, match="FEATURE_FLAGS_LOCAL_FILE_PATH is empty"):
+    with pytest.raises(ValueError, match="FEATURE_FLAGS_FILE_OVERRIDE_PATH is empty"):
         experimentation._load_local_flags()
 
 
 def test_load_local_flags_rejects_non_object(monkeypatch, tmp_path):
     path = tmp_path / "flags.json"
     path.write_text(json.dumps(["not", "an", "object"]))
-    monkeypatch.setitem(config, "FEATURE_FLAGS_LOCAL_FILE_PATH", str(path))
+    monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", str(path))
     monkeypatch.setattr(experimentation, "_local_flags", {})
     with pytest.raises(ValueError, match="must contain a JSON object"):
         experimentation._load_local_flags()
@@ -317,9 +313,7 @@ def test_setup_in_local_file_mode_loads_file_and_skips_growthbook(monkeypatch, t
     path.write_text(json.dumps({"flag_x": "from_file"}))
     monkeypatch.setattr(experimentation, "_initialized", False)
     monkeypatch.setattr(experimentation, "_local_flags", {})
-    monkeypatch.setitem(config, "FEATURE_FLAGS_ENABLED", True)
-    monkeypatch.setitem(config, "FEATURE_FLAGS_USE_LOCAL_FILE", True)
-    monkeypatch.setitem(config, "FEATURE_FLAGS_LOCAL_FILE_PATH", str(path))
+    monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", str(path))
     # If GrowthBook were touched, this would blow up.
     monkeypatch.setattr(experimentation, "_fetch_features", lambda: pytest.fail("GrowthBook should not be touched"))
 

--- a/app/backend/src/tests/test_experimentation.py
+++ b/app/backend/src/tests/test_experimentation.py
@@ -240,11 +240,7 @@ def test_seconds_since_last_fetch_none_when_never_fetched(setup_isolation):
 
 @pytest.fixture
 def local_file_flags(monkeypatch):
-    """Switch into local-file mode (dev only) and let tests set values in the in-memory snapshot directly.
-
-    A listed flag resolves from the file; an unlisted flag falls through to the in-code default and
-    GrowthBook is never contacted.
-    """
+    """File-override mode: tests set flag values directly; unlisted flags fall through to the default."""
     flags: dict[str, Any] = {}
     monkeypatch.setattr(experimentation, "_initialized", True)
     monkeypatch.setattr(experimentation, "_local_flags", flags)

--- a/app/backend/src/tests/test_experimentation.py
+++ b/app/backend/src/tests/test_experimentation.py
@@ -1,5 +1,4 @@
 import json
-from typing import Any
 
 import pytest
 from growthbook.common_types import FeatureResult
@@ -237,29 +236,19 @@ def test_seconds_since_last_fetch_none_when_never_fetched(setup_isolation):
     assert experimentation.seconds_since_last_fetch() is None
 
 
-@pytest.fixture
-def local_file_flags(monkeypatch):
-    """File-override mode: tests set flag values directly; unlisted flags fall through to the default."""
-    flags: dict[str, Any] = {}
-    monkeypatch.setattr(experimentation, "_load_local_flags", lambda _path: flags)
-    monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", "feature-flags.dev.json")
-    return flags
-
-
-def test_local_file_value_returned(local_file_flags):
-    local_file_flags["my_flag"] = "from_file"
+def test_flags_value_returned(flags):
+    flags.set_string("my_flag", "from_file")
     context = make_logged_out_context(LocalizationContext.en_utc())
     assert context.get_string_value("my_flag", "fallback") == "from_file"
 
 
-def test_local_file_missing_key_returns_in_code_default(local_file_flags):
-    local_file_flags["other_flag"] = "x"
+def test_flags_missing_key_returns_in_code_default(flags):
     context = make_logged_out_context(LocalizationContext.en_utc())
     assert context.get_string_value("missing_flag", "fallback") == "fallback"
 
 
-def test_local_file_boolean_value(local_file_flags):
-    local_file_flags["bool_flag"] = False
+def test_flags_boolean_value(flags):
+    flags.set_boolean("bool_flag", False)
     context = make_logged_out_context(LocalizationContext.en_utc())
     assert context.get_boolean_value("bool_flag", default=True) is False
 

--- a/app/backend/src/tests/test_experimentation.py
+++ b/app/backend/src/tests/test_experimentation.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 import pytest
 from growthbook.common_types import FeatureResult
@@ -68,7 +69,7 @@ def test_unknown_feature_returns_in_code_default(feature_flags):
 
 def test_value_method_returns_in_code_default_when_disabled(monkeypatch, feature_flags):
     feature_flags.set("global_flag", True)
-    monkeypatch.setitem(config, "EXPERIMENTATION_ENABLED", False)
+    monkeypatch.setitem(config, "FEATURE_FLAGS_ENABLED", False)
     context = make_background_user_context(123)
     assert context.get_string_value("global_flag", "off") == "off"
 
@@ -185,7 +186,8 @@ def setup_isolation(monkeypatch, tmp_path):
     monkeypatch.setattr(experimentation, "_initialized", False)
     monkeypatch.setattr(experimentation, "_last_fetch_time", None)
     monkeypatch.setattr(experimentation, "_state", {"features": {}, "savedGroups": {}})
-    monkeypatch.setitem(config, "EXPERIMENTATION_ENABLED", True)
+    monkeypatch.setitem(config, "FEATURE_FLAGS_ENABLED", True)
+    monkeypatch.setitem(config, "FEATURE_FLAGS_USE_LOCAL_FILE", False)
     monkeypatch.setitem(config, "GROWTHBOOK_CACHE_PATH", str(tmp_path / "cache.json"))
     yield tmp_path / "cache.json"
     experimentation._refresh_stop.set()
@@ -244,68 +246,84 @@ def test_seconds_since_last_fetch_none_when_never_fetched(setup_isolation):
 
 
 @pytest.fixture
-def overrides(monkeypatch):
-    """Set the in-memory override dict directly, without touching disk."""
-    overrides: dict[str, object] = {}
-    monkeypatch.setattr(experimentation, "_overrides", overrides)
-    return overrides
+def local_file_flags(monkeypatch):
+    """Switch into local-file mode and let tests set values in the in-memory snapshot directly."""
+    flags: dict[str, Any] = {}
+    monkeypatch.setattr(experimentation, "_initialized", True)
+    monkeypatch.setattr(experimentation, "_local_flags", flags)
+    monkeypatch.setitem(config, "FEATURE_FLAGS_ENABLED", True)
+    monkeypatch.setitem(config, "FEATURE_FLAGS_USE_LOCAL_FILE", True)
+    return flags
 
 
-def test_override_takes_precedence_over_growthbook(feature_flags, overrides):
-    feature_flags.set("my_flag", "from_growthbook")
-    overrides["my_flag"] = "from_override"
+def test_local_file_value_returned(local_file_flags):
+    local_file_flags["my_flag"] = "from_file"
     context = make_logged_out_context(LocalizationContext.en_utc())
-    assert context.get_string_value("my_flag", "fallback") == "from_override"
+    assert context.get_string_value("my_flag", "fallback") == "from_file"
 
 
-def test_override_works_when_experimentation_disabled(monkeypatch, overrides):
-    monkeypatch.setitem(config, "EXPERIMENTATION_ENABLED", False)
-    overrides["my_flag"] = "forced"
+def test_local_file_missing_key_returns_in_code_default(local_file_flags):
+    local_file_flags["other_flag"] = "x"
     context = make_logged_out_context(LocalizationContext.en_utc())
-    assert context.get_string_value("my_flag", "fallback") == "forced"
+    assert context.get_string_value("missing_flag", "fallback") == "fallback"
 
 
-def test_override_takes_precedence_over_pass_all_gates(monkeypatch, overrides):
-    monkeypatch.setitem(config, "EXPERIMENTATION_PASS_ALL_GATES", True)
-    overrides["my_flag"] = False
+def test_local_file_boolean_value(local_file_flags):
+    local_file_flags["bool_flag"] = False
     context = make_logged_out_context(LocalizationContext.en_utc())
-    assert context.get_boolean_value("my_flag", default=True) is False
+    assert context.get_boolean_value("bool_flag", default=True) is False
 
 
-def test_override_records_metric_with_override_source(overrides):
-    overrides["override_metric_flag"] = "x"
-    before = _flag_eval_count("override_metric_flag", "override", "x")
-    assert experimentation.get_global_string_value("override_metric_flag", "y") == "x"
-    assert _flag_eval_count("override_metric_flag", "override", "x") == before + 1
+def test_local_file_records_metric_with_local_file_source(local_file_flags):
+    local_file_flags["metric_local_flag"] = "x"
+    before = _flag_eval_count("metric_local_flag", "local_file", "x")
+    assert experimentation.get_global_string_value("metric_local_flag", "y") == "x"
+    assert _flag_eval_count("metric_local_flag", "local_file", "x") == before + 1
 
 
-def test_unset_flag_falls_through_when_overrides_present(feature_flags, overrides):
-    feature_flags.set("real_flag", "real_value")
-    overrides["other_flag"] = "other_value"
-    context = make_logged_out_context(LocalizationContext.en_utc())
-    assert context.get_string_value("real_flag", "fallback") == "real_value"
+def test_local_file_missing_key_records_metric_with_missing_source(local_file_flags):
+    before = _flag_eval_count("absent_local_flag", "local_file_missing", "fallback")
+    assert experimentation.get_global_string_value("absent_local_flag", "fallback") == "fallback"
+    assert _flag_eval_count("absent_local_flag", "local_file_missing", "fallback") == before + 1
 
 
-def test_load_overrides_from_file(monkeypatch, tmp_path):
-    path = tmp_path / "overrides.json"
+def test_load_local_flags_from_file(monkeypatch, tmp_path):
+    path = tmp_path / "flags.json"
     path.write_text(json.dumps({"flag_a": True, "flag_b": "hello", "flag_c": 42}))
-    monkeypatch.setitem(config, "FEATURE_FLAG_OVERRIDE_PATH", str(path))
-    monkeypatch.setattr(experimentation, "_overrides", {})
-    experimentation._load_overrides()
-    assert experimentation._overrides == {"flag_a": True, "flag_b": "hello", "flag_c": 42}
+    monkeypatch.setitem(config, "FEATURE_FLAGS_LOCAL_FILE_PATH", str(path))
+    monkeypatch.setattr(experimentation, "_local_flags", {})
+    experimentation._load_local_flags()
+    assert experimentation._local_flags == {"flag_a": True, "flag_b": "hello", "flag_c": 42}
 
 
-def test_load_overrides_empty_when_path_unset(monkeypatch):
-    monkeypatch.setitem(config, "FEATURE_FLAG_OVERRIDE_PATH", "")
-    monkeypatch.setattr(experimentation, "_overrides", {"stale": "value"})
-    experimentation._load_overrides()
-    assert experimentation._overrides == {}
+def test_load_local_flags_requires_path(monkeypatch):
+    monkeypatch.setitem(config, "FEATURE_FLAGS_LOCAL_FILE_PATH", "")
+    monkeypatch.setattr(experimentation, "_local_flags", {})
+    with pytest.raises(ValueError, match="FEATURE_FLAGS_LOCAL_FILE_PATH is empty"):
+        experimentation._load_local_flags()
 
 
-def test_load_overrides_rejects_non_object(monkeypatch, tmp_path):
-    path = tmp_path / "overrides.json"
+def test_load_local_flags_rejects_non_object(monkeypatch, tmp_path):
+    path = tmp_path / "flags.json"
     path.write_text(json.dumps(["not", "an", "object"]))
-    monkeypatch.setitem(config, "FEATURE_FLAG_OVERRIDE_PATH", str(path))
-    monkeypatch.setattr(experimentation, "_overrides", {})
+    monkeypatch.setitem(config, "FEATURE_FLAGS_LOCAL_FILE_PATH", str(path))
+    monkeypatch.setattr(experimentation, "_local_flags", {})
     with pytest.raises(ValueError, match="must contain a JSON object"):
-        experimentation._load_overrides()
+        experimentation._load_local_flags()
+
+
+def test_setup_in_local_file_mode_loads_file_and_skips_growthbook(monkeypatch, tmp_path):
+    path = tmp_path / "flags.json"
+    path.write_text(json.dumps({"flag_x": "from_file"}))
+    monkeypatch.setattr(experimentation, "_initialized", False)
+    monkeypatch.setattr(experimentation, "_local_flags", {})
+    monkeypatch.setitem(config, "FEATURE_FLAGS_ENABLED", True)
+    monkeypatch.setitem(config, "FEATURE_FLAGS_USE_LOCAL_FILE", True)
+    monkeypatch.setitem(config, "FEATURE_FLAGS_LOCAL_FILE_PATH", str(path))
+    # If GrowthBook were touched, this would blow up.
+    monkeypatch.setattr(experimentation, "_fetch_features", lambda: pytest.fail("GrowthBook should not be touched"))
+
+    setup_experimentation()
+
+    assert experimentation._local_flags == {"flag_x": "from_file"}
+    assert experimentation._refresh_thread is None


### PR DESCRIPTION
Replaces the `EXPERIMENTATION_ENABLED` / `EXPERIMENTATION_PASS_ALL_GATES` config pair with a single dev-only knob: `FEATURE_FLAGS_FILE_OVERRIDE_PATH`.

It selects where flags come from:
- **Set** (dev only): flags are resolved entirely from that JSON file — a listed key gives its value, an unlisted key falls through to its in-code default, and GrowthBook is never contacted.
- **Empty**: flags are resolved from GrowthBook (the production path), as before.

Setting the path while `DEV=0` is rejected at config check, so it can never shadow GrowthBook in production. GrowthBook's client key / cache path are required whenever the path is empty.

This lets devs pin flag values locally (and run fully offline) without spinning up or reconfiguring GrowthBook.

### Details
- `FEATURE_FLAGS_FILE_OVERRIDE_PATH` maps flag keys to forced values; the file is read once and cached per path. Restart the backend to pick up changes.
- The dev env (`backend.dev.env`) now points at a checked-in `feature-flags.dev.json`. Flags gating features that need real external credentials (Stripe, Iris ID, MyPostcard, SMS, Listmonk, reCAPTCHA) are off there, since dev only has placeholder keys.
- Removed the `EXPERIMENTATION_*` toggles entirely; `get_global_boolean_value` and the per-request context methods go through one evaluation path.
- File-override evaluations don't emit the feature-flag metric (it's just noise for local dev); GrowthBook evaluations still record source + value.

### Testing
- New `flags` pytest fixture for file-override mode: `flags.set_boolean("test_growthbook_integration", False)` (also `set_string` / `set_integer` / `set_float` / `set_object`). Seeds from shared test defaults so flipping one flag leaves the rest on. The existing `feature_flags` fixture still covers GrowthBook rollouts/experiments.
- Tests in `test_experimentation.py` cover file-override resolution, fall-through to in-code defaults, file loading + non-object rejection, and that setup skips GrowthBook in file-override mode. `test_config.py` asserts the dev-only prod guard.
- `uv run pytest src/tests/test_experimentation.py src/tests/test_config.py` — 29 passed.
- `make format` and `make mypy` — clean (pre-existing unrelated mypy errors from stale proto stubs aside).

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me