### PR TITLE
Profiles/i18n: Fix unsupported user names

### DIFF
--- a/app/backend/src/couchers/constants.py
+++ b/app/backend/src/couchers/constants.py
@@ -15,6 +15,8 @@ EMAIL_REGEX = r"^[0-9a-z]([0-9a-z\-\_\+]|(\.[0-9a-z\-\_\+]))*@([0-9a-z\-]+\.)*[0
 # Must match the frontend values in app/web/utils/validation.ts
 VALID_NAME_MIN_LENGTH = 2
 VALID_NAME_MAX_LENGTH = 100
+
+# Letters, diacritics, internal spaces, quotes, dashes, commas, dots, and's for two names. See tests!
 VALID_NAME_REGEX = r"""^(?!\p{Zs})[\p{L}\p{M}\p{Zs}\p{Pi}\p{Pf}\p{Pd},.'"·・&/|]+(?<!\p{Zs})$"""
 
 BANNED_USERNAME_PHRASES = [

--- a/app/backend/src/couchers/constants.py
+++ b/app/backend/src/couchers/constants.py
@@ -15,7 +15,7 @@ EMAIL_REGEX = r"^[0-9a-z]([0-9a-z\-\_\+]|(\.[0-9a-z\-\_\+]))*@([0-9a-z\-]+\.)*[0
 # Must match the frontend values in app/web/utils/validation.ts
 VALID_NAME_MIN_LENGTH = 2
 VALID_NAME_MAX_LENGTH = 100
-VALID_NAME_REGEX = r"^[\p{L}'-]+(\s+[\p{L}'-]+)*$"
+VALID_NAME_REGEX = r"""^(?!\p{Zs})[\p{L}\p{M}\p{Zs}\p{Pi}\p{Pf}\p{Pd},.'"·・&/|]+(?<!\p{Zs})$"""
 
 BANNED_USERNAME_PHRASES = [
     "admin",

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -35,7 +35,7 @@ from couchers.crypto import (
 )
 from couchers.proto.internal import internal_pb2
 
-_VALID_NAME_PATTERN = regex.compile(VALID_NAME_REGEX)
+_VALID_NAME_PATTERN = regex.compile(VALID_NAME_REGEX, regex.UNICODE)
 
 if TYPE_CHECKING:
     from couchers.models import Geom

--- a/app/backend/src/tests/test_db.py
+++ b/app/backend/src/tests/test_db.py
@@ -81,7 +81,7 @@ def test_is_valid_name() -> None:
 
     # Apostrophes and Quotes
     assert is_valid_name("O'Connor")
-    assert is_valid_name('William “Bill” Clinton')
+    assert is_valid_name("William “Bill” Clinton")
     assert is_valid_name("Sha’Nia Jenkins")
 
     # Other scripts

--- a/app/backend/src/tests/test_db.py
+++ b/app/backend/src/tests/test_db.py
@@ -72,6 +72,12 @@ def test_is_valid_name() -> None:
     assert is_valid_name("O'Connor")
     assert is_valid_name("Jean-Luc")
     assert is_valid_name("老子")
+    assert is_valid_name("Combining Diặcritics")
+    assert is_valid_name("काव्य")  # Hindi combining diacritics
+    assert is_valid_name("Meritxell Col·lell")  # Catalan middle dot
+    assert is_valid_name("レオナルド・ディカプリオ")  # Japanese middle dot
+    assert is_valid_name("Homer J. Simpson")  # Abbreviating dot
+    assert is_valid_name("Lanaʻi")  # Hawaiian ʻokina glottal stop
 
     # invalid: too short
     assert not is_valid_name("a")

--- a/app/backend/src/tests/test_db.py
+++ b/app/backend/src/tests/test_db.py
@@ -11,6 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.sql import func
 
 from couchers.config import config
+from couchers.constants import VALID_NAME_MAX_LENGTH
 from couchers.db import _get_base_engine, apply_migrations, get_parent_node_at_location, session_scope
 from couchers.jobs.handlers import DatabaseInconsistencyError, check_database_consistency
 from couchers.models import User
@@ -66,34 +67,51 @@ def test_is_valid_username() -> None:
 
 
 def test_is_valid_name() -> None:
-    # valid names
+    # Basics
     assert is_valid_name("ab")
     assert is_valid_name("a b")
-    assert is_valid_name("O'Connor")
     assert is_valid_name("Jean-Luc")
-    assert is_valid_name("老子")
+
+    # OK punctuation
+    assert is_valid_name("King K. Rool")
+    assert is_valid_name("Doe, John")
+    assert is_valid_name("Alice & Bob")
+    assert is_valid_name("Alice / Bob")
+    assert is_valid_name("Alice | Bob")
+
+    # Apostrophes and Quotes
+    assert is_valid_name("O'Connor")
+    assert is_valid_name('William “Bill” Clinton')
+    assert is_valid_name("Sha’Nia Jenkins")
+
+    # Other scripts
+    assert is_valid_name("孙悟空")
     assert is_valid_name("Combining Diặcritics")
     assert is_valid_name("काव्य")  # Hindi combining diacritics
     assert is_valid_name("Meritxell Col·lell")  # Catalan middle dot
     assert is_valid_name("レオナルド・ディカプリオ")  # Japanese middle dot
-    assert is_valid_name("Homer J. Simpson")  # Abbreviating dot
     assert is_valid_name("Lanaʻi")  # Hawaiian ʻokina glottal stop
 
-    # invalid: too short
+    # invalid: too short / too long
     assert not is_valid_name("a")
+    assert not is_valid_name("a" * (VALID_NAME_MAX_LENGTH + 1))
     # invalid: only whitespace
     assert not is_valid_name("	")
     assert not is_valid_name("")
     assert not is_valid_name(" ")
     assert not is_valid_name("  ")
     # invalid: leading/trailing whitespace
-    assert not is_valid_name(" ab")
-    assert not is_valid_name("ab ")
-    assert not is_valid_name(" ab ")
-    # invalid: contains characters outside of letters/whitespace/'/-
-    assert not is_valid_name("1")
-    # invalid: too long
-    assert not is_valid_name("a" * 101)
+    assert not is_valid_name(" leading whitespace")
+    assert not is_valid_name("trailing whitespace ")
+    assert not is_valid_name(" surrounding whitespace ")
+    # invalid: disallowed characters
+    assert not is_valid_name("digits123")
+    assert not is_valid_name("email@domain.com")
+    assert not is_valid_name("Frosty the ☃️")
+    assert not is_valid_name("exclamative!")
+    assert not is_valid_name("interrogative?")
+    assert not is_valid_name("under_score")
+    assert not is_valid_name("(╯‵□′)╯︵┻━┻")
 
 
 def test_parse_date() -> None:

--- a/app/web/utils/validation.ts
+++ b/app/web/utils/validation.ts
@@ -1,5 +1,6 @@
 // taken from backend
-export const nameValidationPattern = /^[\p{L}'-]+(\s+[\p{L}'-]+)*$/u;
+export const nameValidationPattern =
+  /^(?!\p{Zs})[\p{L}\p{M}\p{Zs}\p{Pi}\p{Pf}\p{Pd},.'"·・&/|]+(?<!\p{Zs})$/u;
 export const nameMinLength = 2;
 export const nameMaxLength = 100;
 export const usernameValidationPattern = /^[a-z][0-9a-z_]*[a-z0-9]$/i;


### PR DESCRIPTION
Some legit names were getting blocked by our validation regex. The regex is getting quite unwieldly so if it doesn't cover everything we should consider giving up validation (often a best practice for i18n).

Fixes #9183

## Testing
Added backend tests. Ran frontend and tried values from the backend test.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
