### PR TITLE
Backend: Fix only_active and add is_statuses to HostRequestReq

### DIFF
--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -64,6 +64,8 @@ hostrequeststatus2api = {
     HostRequestStatus.cancelled: conversations_pb2.HOST_REQUEST_STATUS_CANCELLED,
 }
 
+api2hostrequeststatus = {v: k for k, v in hostrequeststatus2api.items()}
+
 hostrequestquality2sql = {
     requests_pb2.HOST_REQUEST_QUALITY_UNSPECIFIED: HostRequestQuality.high_quality,
     requests_pb2.HOST_REQUEST_QUALITY_LOW: HostRequestQuality.okay_quality,
@@ -464,7 +466,12 @@ class Requests(requests_pb2_grpc.RequestsServicer):
                     HostRequest.status == HostRequestStatus.confirmed,
                 )
             )
-            statement = statement.where(HostRequest.end_time <= func.now())
+            statement = statement.where(HostRequest.end_time >= func.now())
+
+        if request.is_statuses:
+            statement = statement.where(
+                HostRequest.status.in_([api2hostrequeststatus[s] for s in request.is_statuses])
+            )
 
         statement = statement.order_by(Message.id.desc()).limit(pagination + 1)
         results = session.execute(statement).all()

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -469,9 +469,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             statement = statement.where(HostRequest.end_time >= func.now())
 
         if request.is_statuses:
-            statement = statement.where(
-                HostRequest.status.in_([api2hostrequeststatus[s] for s in request.is_statuses])
-            )
+            statement = statement.where(HostRequest.status.in_([api2hostrequeststatus[s] for s in request.is_statuses]))
 
         statement = statement.order_by(Message.id.desc()).limit(pagination + 1)
         results = session.execute(statement).all()

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -64,7 +64,13 @@ hostrequeststatus2api = {
     HostRequestStatus.cancelled: conversations_pb2.HOST_REQUEST_STATUS_CANCELLED,
 }
 
-api2hostrequeststatus = {v: k for k, v in hostrequeststatus2api.items()}
+api2hostrequeststatus = {
+    conversations_pb2.HOST_REQUEST_STATUS_PENDING: HostRequestStatus.pending,
+    conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED: HostRequestStatus.accepted,
+    conversations_pb2.HOST_REQUEST_STATUS_REJECTED: HostRequestStatus.rejected,
+    conversations_pb2.HOST_REQUEST_STATUS_CONFIRMED: HostRequestStatus.confirmed,
+    conversations_pb2.HOST_REQUEST_STATUS_CANCELLED: HostRequestStatus.cancelled,
+}
 
 hostrequestquality2sql = {
     requests_pb2.HOST_REQUEST_QUALITY_UNSPECIFIED: HostRequestQuality.high_quality,
@@ -468,8 +474,8 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             )
             statement = statement.where(HostRequest.end_time >= func.now())
 
-        if request.is_statuses:
-            statement = statement.where(HostRequest.status.in_([api2hostrequeststatus[s] for s in request.is_statuses]))
+        if request.status_in:
+            statement = statement.where(HostRequest.status.in_([api2hostrequeststatus[s] for s in request.status_in]))
 
         statement = statement.order_by(Message.id.desc()).limit(pagination + 1)
         results = session.execute(statement).all()

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -17,6 +17,7 @@ from couchers.models import (
     Cluster,
     ClusterRole,
     ClusterSubscription,
+    HostRequest,
     Message,
     MessageType,
     Node,
@@ -599,6 +600,145 @@ def test_ListHostRequests_active_filter(db, moderator):
         assert len(res.host_requests) == 1
         res = api.ListHostRequests(requests_pb2.ListHostRequestsReq(only_active=True))
         assert len(res.host_requests) == 0
+
+
+def test_ListHostRequests_active_filter_excludes_past(db, moderator):
+    """only_active must exclude requests whose end date has passed (regression test for <= bug)."""
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
+
+    with requests_session(token1) as api:
+        request_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=user2.id,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
+                text=valid_request_text("Past stay regression"),
+            )
+        ).host_request_id
+
+    moderator.approve_host_request(request_id)
+
+    with requests_session(token2) as api:
+        api.RespondHostRequest(
+            requests_pb2.RespondHostRequestReq(
+                host_request_id=request_id,
+                status=conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED,
+            )
+        )
+
+    # Future request is visible with only_active
+    with requests_session(token2) as api:
+        res = api.ListHostRequests(requests_pb2.ListHostRequestsReq(only_active=True))
+        assert len(res.host_requests) == 1
+
+    # Move dates into the past
+    with session_scope() as session:
+        hr = session.execute(select(HostRequest).where(HostRequest.conversation_id == request_id)).scalar_one()
+        hr.from_date = today() - timedelta(days=3)
+        hr.to_date = today() - timedelta(days=2)
+
+    # Past request must be excluded by only_active
+    with requests_session(token2) as api:
+        res = api.ListHostRequests(requests_pb2.ListHostRequestsReq(only_active=True))
+        assert len(res.host_requests) == 0
+
+    # Still visible without the filter
+    with requests_session(token2) as api:
+        res = api.ListHostRequests(requests_pb2.ListHostRequestsReq(only_received=True))
+        assert len(res.host_requests) == 1
+
+
+def test_ListHostRequests_is_statuses_filter(db, moderator):
+    """is_statuses must return only requests with the specified statuses."""
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    today_plus_2 = today() + timedelta(days=2)
+    today_plus_3 = today() + timedelta(days=3)
+    today_plus_4 = today() + timedelta(days=4)
+    today_plus_5 = today() + timedelta(days=5)
+
+    # Create a pending request
+    with requests_session(token1) as api:
+        pending_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=user2.id,
+                from_date=today_plus_2.isoformat(),
+                to_date=today_plus_3.isoformat(),
+                text=valid_request_text("Pending"),
+            )
+        ).host_request_id
+
+    moderator.approve_host_request(pending_id)
+
+    # Create an accepted request
+    with requests_session(token1) as api:
+        accepted_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=user2.id,
+                from_date=today_plus_4.isoformat(),
+                to_date=today_plus_5.isoformat(),
+                text=valid_request_text("Accepted"),
+            )
+        ).host_request_id
+
+    moderator.approve_host_request(accepted_id)
+
+    with requests_session(token2) as api:
+        api.RespondHostRequest(
+            requests_pb2.RespondHostRequestReq(
+                host_request_id=accepted_id,
+                status=conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED,
+            )
+        )
+
+    # Filter to accepted only
+    with requests_session(token2) as api:
+        res = api.ListHostRequests(
+            requests_pb2.ListHostRequestsReq(
+                is_statuses=[conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED],
+            )
+        )
+        assert len(res.host_requests) == 1
+        assert res.host_requests[0].status == conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED
+
+    # Filter to pending only
+    with requests_session(token2) as api:
+        res = api.ListHostRequests(
+            requests_pb2.ListHostRequestsReq(
+                is_statuses=[conversations_pb2.HOST_REQUEST_STATUS_PENDING],
+            )
+        )
+        assert len(res.host_requests) == 1
+        assert res.host_requests[0].status == conversations_pb2.HOST_REQUEST_STATUS_PENDING
+
+    # Filter to accepted + pending — both appear
+    with requests_session(token2) as api:
+        res = api.ListHostRequests(
+            requests_pb2.ListHostRequestsReq(
+                is_statuses=[
+                    conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED,
+                    conversations_pb2.HOST_REQUEST_STATUS_PENDING,
+                ],
+            )
+        )
+        assert len(res.host_requests) == 2
+
+    # Filter to confirmed — none appear
+    with requests_session(token2) as api:
+        res = api.ListHostRequests(
+            requests_pb2.ListHostRequestsReq(
+                is_statuses=[conversations_pb2.HOST_REQUEST_STATUS_CONFIRMED],
+            )
+        )
+        assert len(res.host_requests) == 0
+
+    # Empty is_statuses — all requests returned (no filter applied)
+    with requests_session(token2) as api:
+        res = api.ListHostRequests(requests_pb2.ListHostRequestsReq(only_received=True))
+        assert len(res.host_requests) == 2
 
 
 def test_RespondHostRequests(db, moderator):

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -651,8 +651,8 @@ def test_ListHostRequests_active_filter_excludes_past(db, moderator):
         assert len(res.host_requests) == 1
 
 
-def test_ListHostRequests_is_statuses_filter(db, moderator):
-    """is_statuses must return only requests with the specified statuses."""
+def test_ListHostRequests_status_in_filter(db, moderator):
+    """status_in must return only requests with the specified statuses."""
     user1, token1 = generate_user()
     user2, token2 = generate_user()
     today_plus_2 = today() + timedelta(days=2)
@@ -698,7 +698,7 @@ def test_ListHostRequests_is_statuses_filter(db, moderator):
     with requests_session(token2) as api:
         res = api.ListHostRequests(
             requests_pb2.ListHostRequestsReq(
-                is_statuses=[conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED],
+                status_in=[conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED],
             )
         )
         assert len(res.host_requests) == 1
@@ -708,7 +708,7 @@ def test_ListHostRequests_is_statuses_filter(db, moderator):
     with requests_session(token2) as api:
         res = api.ListHostRequests(
             requests_pb2.ListHostRequestsReq(
-                is_statuses=[conversations_pb2.HOST_REQUEST_STATUS_PENDING],
+                status_in=[conversations_pb2.HOST_REQUEST_STATUS_PENDING],
             )
         )
         assert len(res.host_requests) == 1
@@ -718,7 +718,7 @@ def test_ListHostRequests_is_statuses_filter(db, moderator):
     with requests_session(token2) as api:
         res = api.ListHostRequests(
             requests_pb2.ListHostRequestsReq(
-                is_statuses=[
+                status_in=[
                     conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED,
                     conversations_pb2.HOST_REQUEST_STATUS_PENDING,
                 ],
@@ -730,12 +730,12 @@ def test_ListHostRequests_is_statuses_filter(db, moderator):
     with requests_session(token2) as api:
         res = api.ListHostRequests(
             requests_pb2.ListHostRequestsReq(
-                is_statuses=[conversations_pb2.HOST_REQUEST_STATUS_CONFIRMED],
+                status_in=[conversations_pb2.HOST_REQUEST_STATUS_CONFIRMED],
             )
         )
         assert len(res.host_requests) == 0
 
-    # Empty is_statuses — all requests returned (no filter applied)
+    # Empty status_in — all requests returned (no filter applied)
     with requests_session(token2) as api:
         res = api.ListHostRequests(requests_pb2.ListHostRequestsReq(only_received=True))
         assert len(res.host_requests) == 2

--- a/app/proto/requests.proto
+++ b/app/proto/requests.proto
@@ -119,6 +119,9 @@ message ListHostRequestsReq {
   bool only_sent = 4;
   bool only_received = 5;
   optional bool only_archived = 6;
+
+  // If non-empty, only return requests with one of these statuses.
+  repeated org.couchers.api.conversations.HostRequestStatus is_statuses = 7;
 }
 
 message ListHostRequestsRes {

--- a/app/proto/requests.proto
+++ b/app/proto/requests.proto
@@ -121,7 +121,7 @@ message ListHostRequestsReq {
   optional bool only_archived = 6;
 
   // If non-empty, only return requests with one of these statuses.
-  repeated org.couchers.api.conversations.HostRequestStatus is_statuses = 7;
+  repeated org.couchers.api.conversations.HostRequestStatus status_in = 7;
 }
 
 message ListHostRequestsRes {


### PR DESCRIPTION
I realized the `only_active` in `HostRequestReq` was `<=` when it should be `>=` while working on the dashboard 2.0. I'm also adding `is_statuses` to allow the frontend to send which statuses it wants returned as I need that too.


<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
