### PR TITLE
Frontend/profile: Validate names like during signup

### DIFF
--- a/app/backend/src/couchers/constants.py
+++ b/app/backend/src/couchers/constants.py
@@ -8,7 +8,9 @@ GUIDELINES_VERSION = 1
 
 EMAIL_REGEX = r"^[0-9a-z]([0-9a-z\-\_\+]|(\.[0-9a-z\-\_\+]))*@([0-9a-z\-]+\.)*[0-9a-z\-]+\.[a-z]{2,}$"
 
-# Must match the frontend pattern in app/web/utils/validation.ts
+# Must match the frontend values in app/web/utils/validation.ts
+VALID_NAME_MIN_LENGTH = 2
+VALID_NAME_MAX_LENGTH = 100
 VALID_NAME_REGEX = r"^[\p{L}'-]+(\s+[\p{L}'-]+)*$"
 
 BANNED_USERNAME_PHRASES = [

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -19,7 +19,13 @@ from sqlalchemy.sql import func
 from sqlalchemy.types import DateTime
 
 from couchers.config import config
-from couchers.constants import EMAIL_REGEX, PREFERRED_LANGUAGE_COOKIE_EXPIRY, VALID_NAME_REGEX
+from couchers.constants import (
+    EMAIL_REGEX,
+    PREFERRED_LANGUAGE_COOKIE_EXPIRY,
+    VALID_NAME_MAX_LENGTH,
+    VALID_NAME_MIN_LENGTH,
+    VALID_NAME_REGEX,
+)
 from couchers.crypto import (
     create_sofa_id,
     decode_sofa,
@@ -66,7 +72,7 @@ def is_valid_name(field: str) -> bool:
     * no leading or trailing whitespace
     * 2-100 characters
     """
-    if len(field) > 100 or len(field) < 2:
+    if len(field) > VALID_NAME_MAX_LENGTH or len(field) < VALID_NAME_MIN_LENGTH:
         return False
 
     return _VALID_NAME_PATTERN.fullmatch(field) is not None

--- a/app/web/features/auth/signup/BasicForm.tsx
+++ b/app/web/features/auth/signup/BasicForm.tsx
@@ -16,6 +16,8 @@ import { service } from "service";
 import {
   emailValidationPattern,
   lowercaseAndTrimField,
+  nameMinLength,
+  nameMaxLength,
   nameValidationPattern,
 } from "utils/validation";
 
@@ -89,11 +91,11 @@ export default function BasicForm({
           {...register("name", {
             required: t("auth:basic_form.name.required_error"),
             minLength: {
-              value: 2,
+              value: nameMinLength,
               message: t("auth:basic_form.name.min_length_error"),
             },
             maxLength: {
-              value: 100,
+              value: nameMaxLength,
               message: t("auth:basic_form.name.max_length_error"),
             },
             pattern: {

--- a/app/web/features/auth/signup/BasicForm.tsx
+++ b/app/web/features/auth/signup/BasicForm.tsx
@@ -16,8 +16,8 @@ import { service } from "service";
 import {
   emailValidationPattern,
   lowercaseAndTrimField,
-  nameMinLength,
   nameMaxLength,
+  nameMinLength,
   nameValidationPattern,
 } from "utils/validation";
 

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -323,7 +323,7 @@ export default function EditProfileForm() {
     getValues,
   } = useForm<EditProfileFormValues>({
     shouldFocusError: true,
-    mode: "onTouched",
+    mode: "onBlur",
     values: initialFormValues,
     resetOptions: { keepDirty: true },
   });

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -45,6 +45,11 @@ import {
   useUnsavedChangesWarning,
 } from "utils/hooks";
 import { useIsNativeEmbed } from "utils/nativeLink";
+import {
+  nameMaxLength,
+  nameMinLength,
+  nameValidationPattern,
+} from "utils/validation";
 
 import {
   ABOUT_ME_MIN_LENGTH,
@@ -568,13 +573,27 @@ export default function EditProfileForm() {
               <FieldGroup>
                 <StyledProfileTextInput
                   id="name"
-                  {...register("name", { required: true })}
+                  {...register("name", {
+                    required: t("auth:basic_form.name.required_error"),
+                    minLength: {
+                      value: nameMinLength,
+                      message: t("auth:basic_form.name.min_length_error"),
+                    },
+                    maxLength: {
+                      value: nameMaxLength,
+                      message: t("auth:basic_form.name.max_length_error"),
+                    },
+                    pattern: {
+                      message: t(
+                        "auth:basic_form.name.invalid_characters_error",
+                      ),
+                      value: nameValidationPattern,
+                    },
+                  })}
                   label={t("profile:edit_profile_headings.name")}
                   defaultValue={user.name}
-                  error={!!errors.name}
-                  helperText={
-                    errors.name ? t("profile:edit_profile_name_required") : ""
-                  }
+                  error={!!errors?.name?.message}
+                  helperText={errors?.name?.message ?? " "}
                 />
               </FieldGroup>
 

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -278,6 +278,7 @@ export default function EditProfileForm() {
     useState(false);
   const [showSuccessToast, setShowSuccessToast] = useState(false);
   const galleryEditorRef = useRef<HTMLDivElement>(null);
+  const hasInitialized = useRef(false);
 
   const {
     control,
@@ -297,8 +298,11 @@ export default function EditProfileForm() {
 
   // Reset form with user data when user and data are loaded
   // This allows only showing save bar once something changes
+  // hasInitialized prevents background refetches from overwriting in-progress edits
   useEffect(() => {
     if (user && languages && regions) {
+      if (hasInitialized.current) return;
+      hasInitialized.current = true;
       reset(
         {
           name: user.name,
@@ -584,10 +588,10 @@ export default function EditProfileForm() {
                       message: t("auth:basic_form.name.max_length_error"),
                     },
                     pattern: {
+                      value: nameValidationPattern,
                       message: t(
                         "auth:basic_form.name.invalid_characters_error",
                       ),
-                      value: nameValidationPattern,
                     },
                   })}
                   label={t("profile:edit_profile_headings.name")}

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -278,33 +278,12 @@ export default function EditProfileForm() {
     useState(false);
   const [showSuccessToast, setShowSuccessToast] = useState(false);
   const galleryEditorRef = useRef<HTMLDivElement>(null);
-  const hasInitialized = useRef(false);
-
-  const {
-    control,
-    register,
-    handleSubmit,
-    setValue,
-    reset,
-    formState: { errors, isDirty, isSubmitted },
-    watch,
-    getValues,
-  } = useForm<EditProfileFormValues>({
-    shouldFocusError: true,
-  });
-
   const { regions, regionsLookup } = useRegions();
   const { languages, languagesLookup } = useLanguages();
 
-  // Reset form with user data when user and data are loaded
-  // This allows only showing save bar once something changes
-  // hasInitialized prevents background refetches from overwriting in-progress edits
-  useEffect(() => {
-    if (user && languages && regions) {
-      if (hasInitialized.current) return;
-      hasInitialized.current = true;
-      reset(
-        {
+  const initialFormValues =
+    user && languages && regions
+      ? {
           name: user.name,
           pronouns: user.pronouns,
           hometown: user.hometown,
@@ -330,37 +309,24 @@ export default function EditProfileForm() {
             lng: user.lng,
             radius: user.radius,
           },
-        },
-        { keepDirty: false, keepErrors: false },
-      );
-    } else {
-      // Initialize with empty arrays to prevent undefined errors
-      reset(
-        {
-          name: "",
-          pronouns: "",
-          hometown: "",
-          occupation: "",
-          education: "",
-          hostingStatus: user?.hostingStatus,
-          meetupStatus: user?.meetupStatus,
-          fluentLanguages: [],
-          regionsVisited: [],
-          regionsLived: [],
-          aboutMe: "",
-          thingsILike: DEFAULT_HOBBIES_HEADINGS,
-          additionalInformation: "",
-          location: {
-            city: user?.city || "",
-            lat: user?.lat || 0,
-            lng: user?.lng || 0,
-            radius: user?.radius || 0,
-          },
-        },
-        { keepDirty: false, keepErrors: false },
-      );
-    }
-  }, [user, reset, languages, regions]);
+        }
+      : undefined;
+
+  const {
+    control,
+    register,
+    handleSubmit,
+    setValue,
+    reset,
+    formState: { errors, isDirty, isSubmitted },
+    watch,
+    getValues,
+  } = useForm<EditProfileFormValues>({
+    shouldFocusError: true,
+    mode: "onTouched",
+    values: initialFormValues,
+    resetOptions: { keepDirty: true },
+  });
 
   // Scroll to gallery editor if hash is #gallery (from ProfilePage avatar click)
   useEffect(() => {

--- a/app/web/features/profile/edit/EditProfilePage.test.tsx
+++ b/app/web/features/profile/edit/EditProfilePage.test.tsx
@@ -6,6 +6,7 @@ import i18n from "test/i18n";
 import { getLanguages, getRegions, getUser } from "test/serviceMockDefaults";
 import { addDefaultUser } from "test/utils";
 
+import { ABOUT_ME_MIN_LENGTH } from "./constants";
 import EditProfilePage from "./EditProfilePage";
 
 const { t } = i18n;
@@ -217,7 +218,10 @@ describe("Edit profile", () => {
   }, 10000);
 
   it("should reject names with invalid characters like !@#$", async () => {
-    getUserMock.mockImplementation(getUser);
+    getUserMock.mockImplementation(async (user) => ({
+      ...(await getUser(user)),
+      aboutMe: "a".repeat(ABOUT_ME_MIN_LENGTH),
+    }));
 
     await renderPage();
 
@@ -229,17 +233,16 @@ describe("Edit profile", () => {
 
     await user.clear(nameInput);
     await user.type(nameInput, "John!@#$");
-    await user.tab();
+
+    await user.click(
+      await screen.findByRole("button", { name: t("global:save_changes") }),
+    );
 
     await waitFor(() => {
       expect(
         screen.getByText(t("auth:basic_form.name.invalid_characters_error")),
       ).toBeInTheDocument();
     });
-
-    await user.click(
-      await screen.findByRole("button", { name: t("global:save_changes") }),
-    );
 
     await waitFor(() => {
       expect(updateProfileMock).not.toHaveBeenCalled();

--- a/app/web/features/profile/edit/EditProfilePage.test.tsx
+++ b/app/web/features/profile/edit/EditProfilePage.test.tsx
@@ -216,6 +216,36 @@ describe("Edit profile", () => {
     });
   }, 10000);
 
+  it("should reject names with invalid characters like !@#$", async () => {
+    getUserMock.mockImplementation(getUser);
+
+    await renderPage();
+
+    const user = userEvent.setup();
+
+    const nameInput = await screen.findByLabelText(
+      t("profile:edit_profile_headings.name"),
+    );
+
+    await user.clear(nameInput);
+    await user.type(nameInput, "John!@#$");
+    await user.tab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(t("auth:basic_form.name.invalid_characters_error")),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: t("global:save_changes") }),
+    );
+
+    await waitFor(() => {
+      expect(updateProfileMock).not.toHaveBeenCalled();
+    });
+  });
+
   it("should only show save bar when form is dirty", async () => {
     jest.spyOn(window, "confirm").mockImplementation(() => true);
 

--- a/app/web/pages/profile/edit/[tab].tsx
+++ b/app/web/pages/profile/edit/[tab].tsx
@@ -2,7 +2,7 @@ import { appGetLayout } from "components/AppRoute";
 import NotFoundPage from "features/NotFoundPage";
 import EditProfilePageComponent from "features/profile/edit/EditProfilePage";
 import { appServerSideTranslations } from "i18n/appServerSideTranslations";
-import { GLOBAL, NOTIFICATIONS, PROFILE } from "i18n/namespaces";
+import { AUTH, GLOBAL, NOTIFICATIONS, PROFILE } from "i18n/namespaces";
 import { GetStaticPaths, GetStaticProps } from "next";
 import { useRouter } from "next/router";
 import { editUserTabs } from "routes";
@@ -15,6 +15,7 @@ export const getStaticPaths: GetStaticPaths = () => ({
 export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await appServerSideTranslations(locale ?? "en", [
+      AUTH,
       GLOBAL,
       NOTIFICATIONS,
       PROFILE,

--- a/app/web/utils/validation.ts
+++ b/app/web/utils/validation.ts
@@ -1,5 +1,7 @@
 // taken from backend
 export const nameValidationPattern = /^[\p{L}'-]+(\s+[\p{L}'-]+)*$/u;
+export const nameMinLength = 2;
+export const nameMaxLength = 100;
 export const usernameValidationPattern = /^[a-z][0-9a-z_]*[a-z0-9]$/i;
 export const validatePassword = (password: string) => {
   return password.length >= 8 && password.length < 256;


### PR DESCRIPTION
During signup we validate the name field on the frontend, but we didn't when later editing the profile, however the backend still would do the validation.

There's at least one user (#8933) who somehow had a bad character in their name (trailing space), which stopped them from editing their profile because that would fail validation on the backend. With this change they'll see a local error and can figure out to fix it locally.

Fixes #8933

## Testing
Added a test

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me