### PR TITLE
Add caching to dashboard list communities query

### DIFF
--- a/app/web/features/communities/CommunityPage/JoinCommunityButton.tsx
+++ b/app/web/features/communities/CommunityPage/JoinCommunityButton.tsx
@@ -22,7 +22,9 @@ export default function JoinCommunityButton({
   const queryClient = useQueryClient();
   const invalidateMembershipQueries = () => {
     queryClient.invalidateQueries({ queryKey: [userCommunitiesKey] });
-    queryClient.invalidateQueries({ queryKey: [listMyCommunitiesDiscussionsKey] });
+    queryClient.invalidateQueries({
+      queryKey: [listMyCommunitiesDiscussionsKey],
+    });
     queryClient.invalidateQueries({ queryKey: ["myCommunityEvents"] });
   };
   const join = useMutation<void, RpcError>({

--- a/app/web/features/communities/CommunityPage/JoinCommunityButton.tsx
+++ b/app/web/features/communities/CommunityPage/JoinCommunityButton.tsx
@@ -7,7 +7,11 @@ import { COMMUNITIES } from "i18n/namespaces";
 import { Community } from "proto/communities_pb";
 import { service } from "service";
 
-import { communityKey } from "../../queryKeys";
+import {
+  communityKey,
+  listMyCommunitiesDiscussionsKey,
+  userCommunitiesKey,
+} from "../../queryKeys";
 
 export default function JoinCommunityButton({
   community,
@@ -16,6 +20,11 @@ export default function JoinCommunityButton({
 }) {
   const { t } = useTranslation([COMMUNITIES]);
   const queryClient = useQueryClient();
+  const invalidateMembershipQueries = () => {
+    queryClient.invalidateQueries({ queryKey: [userCommunitiesKey] });
+    queryClient.invalidateQueries({ queryKey: [listMyCommunitiesDiscussionsKey] });
+    queryClient.invalidateQueries({ queryKey: ["myCommunityEvents"] });
+  };
   const join = useMutation<void, RpcError>({
     mutationFn: () => service.communities.joinCommunity(community.communityId),
     onSuccess() {
@@ -32,6 +41,7 @@ export default function JoinCommunityButton({
       queryClient.invalidateQueries({
         queryKey: communityKey(community.communityId),
       });
+      invalidateMembershipQueries();
     },
   });
   const leave = useMutation<void, RpcError>({
@@ -50,6 +60,7 @@ export default function JoinCommunityButton({
       queryClient.invalidateQueries({
         queryKey: communityKey(community.communityId),
       });
+      invalidateMembershipQueries();
     },
   });
   const isLoading = join.isPending || leave.isPending;

--- a/app/web/features/userQueries/useUserCommunities.ts
+++ b/app/web/features/userQueries/useUserCommunities.ts
@@ -20,5 +20,6 @@ export default function useUserCommunities({
     initialPageParam: undefined,
     getNextPageParam: (lastPage) =>
       lastPage.nextPageToken ? lastPage.nextPageToken : undefined,
+    staleTime: 10 * 60 * 1000,
   });
 }


### PR DESCRIPTION
This doesn't change much so adding some caching to the query so it calms down a bit. The query will be invalidated when someone joins or leaves a community.

<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
