### PR TITLE
Mobile: send EAS client ID in CheckNativeStatus

### DIFF
--- a/app/mobile/features/diagnostics/useNativeDiagnostics.ts
+++ b/app/mobile/features/diagnostics/useNativeDiagnostics.ts
@@ -2,6 +2,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Application from "expo-application";
 import Constants from "expo-constants";
 import * as Device from "expo-device";
+import { clientID as easClientID } from "expo-eas-client";
 import * as Notifications from "expo-notifications";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -172,6 +173,7 @@ export function useNativeDiagnostics(): NativeDiagnostics {
         }
 
         const result = await checkNativeStatus({
+          easClientId: easClientID,
           installId,
           stickyId,
           idfv: deviceIds.idfv,

--- a/app/mobile/package-lock.json
+++ b/app/mobile/package-lock.json
@@ -31,6 +31,7 @@
         "expo-crypto": "~15.0.9",
         "expo-dev-client": "~6.0.21",
         "expo-device": "~8.0.10",
+        "expo-eas-client": "~1.0.0",
         "expo-file-system": "~19.0.23",
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",

--- a/app/mobile/package.json
+++ b/app/mobile/package.json
@@ -55,6 +55,7 @@
     "expo-crypto": "~15.0.9",
     "expo-dev-client": "~6.0.21",
     "expo-device": "~8.0.10",
+    "expo-eas-client": "~1.0.0",
     "expo-file-system": "~19.0.23",
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",

--- a/app/mobile/service/checkNativeStatus.ts
+++ b/app/mobile/service/checkNativeStatus.ts
@@ -6,6 +6,7 @@ import client from "@/service/client";
 
 export interface NativeStatusPayload {
   // Identity
+  easClientId: string;
   installId: string;
   stickyId?: string;
   idfv?: string;
@@ -66,6 +67,7 @@ function secondsToDuration(seconds: number | undefined): Duration | null {
 export async function checkNativeStatus(payload: NativeStatusPayload) {
   const req = new CheckNativeStatusReq();
 
+  req.setEasClientId(payload.easClientId);
   req.setInstallId(payload.installId);
   if (payload.stickyId) req.setStickyId(payload.stickyId);
   if (payload.idfv) req.setIdfv(payload.idfv);

--- a/app/mobile/tests/service/checkNativeStatus.test.ts
+++ b/app/mobile/tests/service/checkNativeStatus.test.ts
@@ -19,6 +19,7 @@ function mockResponse(asObject: unknown) {
 
 function basePayload(): NativeStatusPayload {
   return {
+    easClientId: "00000000-0000-0000-0000-000000000001",
     installId: "install-1",
     platform: "ios",
     osVersion: "17.4",
@@ -54,6 +55,7 @@ describe("checkNativeStatus", () => {
 
     expect(mockCheckNativeStatus).toHaveBeenCalledTimes(1);
     const req = mockCheckNativeStatus.mock.calls[0][0];
+    expect(req.getEasClientId()).toBe("00000000-0000-0000-0000-000000000001");
     expect(req.getInstallId()).toBe("install-1");
     expect(req.getPlatform()).toBe("ios");
     expect(req.getAppVersion()).toBe("1.1.20");


### PR DESCRIPTION
Wires the EAS client UUID into the `CheckNativeStatus` request from the mobile client. The proto field `eas_client_id` and the backend's strict `uuid.UUID(request.eas_client_id)` parse were added in 72d5bfed9, but the client side was never connected — so every `CheckNativeStatus` call has been failing the UUID parse server-side.

This adds `expo-eas-client` and threads `Client.clientID` through `NativeStatusPayload` → `checkNativeStatus` → the diagnostics ping. Same canonical UUID Expo's SDK already sends as the `eas-client-id` header on the manifest path.

Note: `expo-eas-client` is autolinked with native modules, so this **bumps the native fingerprint** — it ships via a new store build, not OTA.

## Testing
- Updated `checkNativeStatus.test.ts`: `basePayload()` now includes `easClientId`, and the typed-field test asserts `req.getEasClientId()` is set.
- Reviewer steps: `cd app/mobile && npm install && npx jest tests/service/checkNativeStatus.test.ts`. Then a native build is needed to exercise the live `Client.clientID` source on device.

**Web frontend checklist**
- [x] Added tests where relevant (`checkNativeStatus.test.ts`)

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._