### PR TITLE
Guard against unsatisfiable OTA blocks in CheckNativeStatus

### DIFF
--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -114,9 +114,6 @@ def _is_update_id_banned(session: Session, info: NativeClientInfo) -> bool:
 
 
 def _newest_non_banned_ota_package(session: Session, platform: str, fingerprint: str) -> OTAPackage | None:
-    # The bundle GetNativeUpdateManifest would serve a build on this (platform, fingerprint): the
-    # newest non-banned one by manifest createdAt. The device only applies it if it's strictly newer
-    # than what it's running.
     if platform not in OTAPlatform.__members__ or not fingerprint:
         return None
     return session.execute(
@@ -313,11 +310,9 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
         banned = _is_update_id_banned(session, info)
         decision = decide_native_update(context, info, now, banned=banned)
 
-        # A forced OTA update we can't actually serve — the manifest endpoint has nothing newer than
-        # the bundle the client is running — would loop it on the block screen forever. That's a
-        # publish/ban misconfiguration, never a state to serve a user: raise so it pages (Sentry), and
-        # the client, which ignores CheckNativeStatus errors, is simply left unblocked. Store blocks
-        # aren't checkable here — the backend keeps no record of the latest store build.
+        # An OTA block with no newer bundle to serve would loop the client on the block screen
+        # forever, so refuse to serve it: raise (pages via Sentry) and the client, which ignores
+        # these errors, stays unblocked. Store blocks aren't checkable — no record of the latest build.
         if decision.action == UpdateAction.ota and decision.severity == Severity.block:
             newest = _newest_non_banned_ota_package(session, info.platform, info.runtime_version)
             newer_available = newest is not None and (

--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -113,6 +113,22 @@ def _is_update_id_banned(session: Session, info: NativeClientInfo) -> bool:
     )
 
 
+def _newest_non_banned_ota_package(session: Session, platform: str, fingerprint: str) -> OTAPackage | None:
+    # The bundle GetNativeUpdateManifest would serve a build on this (platform, fingerprint): the
+    # newest non-banned one by manifest createdAt. The device only applies it if it's strictly newer
+    # than what it's running.
+    if platform not in OTAPlatform.__members__ or not fingerprint:
+        return None
+    return session.execute(
+        select(OTAPackage)
+        .where(OTAPackage.platform == OTAPlatform[platform])
+        .where(OTAPackage.fingerprint == fingerprint)
+        .where(OTAPackage.banned_at.is_(None))
+        .order_by(OTAPackage.manifest_created_at.desc(), OTAPackage.id.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+
+
 def _observe_native_check_metrics(info: NativeClientInfo, decision: Any, now: datetime, *, banned: bool) -> None:
     if info.binary_created_at is not None:
         observe_native_binary_age(info.platform, (now - info.binary_created_at).total_seconds())
@@ -228,16 +244,7 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
         # Newest non-banned bundle for the build's fingerprint, by manifest createdAt. The device's
         # selection policy only applies it if it's newer than what it's running, so a stale store build
         # self-heals while a newer one keeps its embedded bundle.
-        package = None
-        if platform in OTAPlatform.__members__ and fingerprint:
-            package = session.execute(
-                select(OTAPackage)
-                .where(OTAPackage.platform == OTAPlatform[platform])
-                .where(OTAPackage.fingerprint == fingerprint)
-                .where(OTAPackage.banned_at.is_(None))
-                .order_by(OTAPackage.manifest_created_at.desc(), OTAPackage.id.desc())
-                .limit(1)
-            ).scalar_one_or_none()
+        package = _newest_non_banned_ota_package(session, platform, fingerprint)
 
         if package is None:
             observe_native_ota_manifest_request(platform, "no_match" if not fingerprint else "no_update")
@@ -305,6 +312,25 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
         now = datetime.now(UTC)
         banned = _is_update_id_banned(session, info)
         decision = decide_native_update(context, info, now, banned=banned)
+
+        # A forced OTA update we can't actually serve — the manifest endpoint has nothing newer than
+        # the bundle the client is running — would loop it on the block screen forever. That's a
+        # publish/ban misconfiguration, never a state to serve a user: raise so it pages (Sentry), and
+        # the client, which ignores CheckNativeStatus errors, is simply left unblocked. Store blocks
+        # aren't checkable here — the backend keeps no record of the latest store build.
+        if decision.action == UpdateAction.ota and decision.severity == Severity.block:
+            newest = _newest_non_banned_ota_package(session, info.platform, info.runtime_version)
+            newer_available = newest is not None and (
+                info.bundle_created_at is None or newest.manifest_created_at > info.bundle_created_at
+            )
+            if not newer_available:
+                raise Exception(
+                    "CheckNativeStatus would force an OTA update with no newer bundle to move to "
+                    f"(platform={info.platform!r} fingerprint={info.runtime_version!r} "
+                    f"cause={decision.cause.name} update_id={info.update_id!r} "
+                    f"running_bundle_created_at={info.bundle_created_at} "
+                    f"newest_non_banned_created_at={None if newest is None else newest.manifest_created_at})"
+                )
 
         _observe_native_check_metrics(info, decision, now, banned=banned)
 

--- a/app/backend/src/tests/test_bugs.py
+++ b/app/backend/src/tests/test_bugs.py
@@ -734,6 +734,92 @@ def test_native_update_manifest_no_package_returns_directive(db):
     assert _multipart_part_json(res.data.decode(), "directive") == {"type": "noUpdateAvailable"}
 
 
+def _ota_check_req(*, created_at, update_id=""):
+    # An OTA-launched client running a bundle published `created_at`, past the default 28-day block.
+    ts = timestamp_pb2.Timestamp()
+    ts.FromDatetime(created_at)
+    return bugs_pb2.CheckNativeStatusReq(
+        eas_client_id=str(EAS_CLIENT_ID),
+        platform="ios",
+        runtime_version="ios-fingerprint",
+        launch_source="ota",
+        update_id=update_id,
+        created_at=ts,
+    )
+
+
+def test_check_native_status_ota_block_with_newer_bundle(db):
+    # OTA bundle past its window, and a newer non-banned bundle exists to move to -> OTA block served.
+    _add_ota_package(
+        platform=OTAPlatform.ios,
+        fingerprint="ios-fingerprint",
+        version="v1.3.2.newer",
+        created_at=datetime.now(UTC) - timedelta(days=1),
+    )
+    with bugs_session() as bugs:
+        res = bugs.CheckNativeStatus(_ota_check_req(created_at=datetime.now(UTC) - timedelta(days=40)))
+
+    assert res.update_info.action == bugs_pb2.NATIVE_UPDATE_ACTION_OTA
+    assert res.update_info.required is True
+    assert res.update_info.cause == bugs_pb2.NATIVE_UPDATE_CAUSE_AGE
+
+
+def test_check_native_status_ota_block_without_target_raises(db):
+    # OTA bundle past its window but nothing to move to -> the client would loop, so we raise loudly.
+    with bugs_session() as bugs, pytest.raises(Exception, match="no newer bundle to move to"):
+        bugs.CheckNativeStatus(_ota_check_req(created_at=datetime.now(UTC) - timedelta(days=40)))
+
+
+def test_check_native_status_ota_block_only_older_target_raises(db):
+    # The only available bundle is older than what the client runs; the device won't move backwards.
+    _add_ota_package(
+        platform=OTAPlatform.ios,
+        fingerprint="ios-fingerprint",
+        version="v1.3.1.older",
+        created_at=datetime.now(UTC) - timedelta(days=50),
+    )
+    with bugs_session() as bugs, pytest.raises(Exception, match="no newer bundle to move to"):
+        bugs.CheckNativeStatus(_ota_check_req(created_at=datetime.now(UTC) - timedelta(days=40)))
+
+
+def test_check_native_status_banned_ota_block_with_successor(db):
+    # Running a banned bundle with a newer non-banned successor -> banned OTA block served.
+    _add_ota_package(
+        platform=OTAPlatform.ios,
+        fingerprint="ios-fingerprint",
+        version="v1.bad",
+        created_at=datetime.now(UTC) - timedelta(days=5),
+        banned=True,
+    )
+    _add_ota_package(
+        platform=OTAPlatform.ios,
+        fingerprint="ios-fingerprint",
+        version="v1.good",
+        created_at=datetime.now(UTC) - timedelta(days=1),
+    )
+    with bugs_session() as bugs:
+        res = bugs.CheckNativeStatus(
+            _ota_check_req(created_at=datetime.now(UTC) - timedelta(days=5), update_id="id-v1.bad")
+        )
+
+    assert res.update_info.action == bugs_pb2.NATIVE_UPDATE_ACTION_OTA
+    assert res.update_info.required is True
+    assert res.update_info.cause == bugs_pb2.NATIVE_UPDATE_CAUSE_BANNED
+
+
+def test_check_native_status_banned_ota_block_no_successor_raises(db):
+    # Banning the only bundle on this fingerprint leaves its devices nowhere to go -> raise loudly.
+    _add_ota_package(
+        platform=OTAPlatform.ios,
+        fingerprint="ios-fingerprint",
+        version="v1.bad",
+        created_at=datetime.now(UTC) - timedelta(days=5),
+        banned=True,
+    )
+    with bugs_session() as bugs, pytest.raises(Exception, match="no newer bundle to move to"):
+        bugs.CheckNativeStatus(_ota_check_req(created_at=datetime.now(UTC) - timedelta(days=5), update_id="id-v1.bad"))
+
+
 def test_log_experiment_exposure(db):
     user, token = generate_user()
 

--- a/app/backend/src/tests/test_bugs.py
+++ b/app/backend/src/tests/test_bugs.py
@@ -735,7 +735,6 @@ def test_native_update_manifest_no_package_returns_directive(db):
 
 
 def _ota_check_req(*, created_at, update_id=""):
-    # An OTA-launched client running a bundle published `created_at`, past the default 28-day block.
     ts = timestamp_pb2.Timestamp()
     ts.FromDatetime(created_at)
     return bugs_pb2.CheckNativeStatusReq(
@@ -749,7 +748,6 @@ def _ota_check_req(*, created_at, update_id=""):
 
 
 def test_check_native_status_ota_block_with_newer_bundle(db):
-    # OTA bundle past its window, and a newer non-banned bundle exists to move to -> OTA block served.
     _add_ota_package(
         platform=OTAPlatform.ios,
         fingerprint="ios-fingerprint",
@@ -765,13 +763,11 @@ def test_check_native_status_ota_block_with_newer_bundle(db):
 
 
 def test_check_native_status_ota_block_without_target_raises(db):
-    # OTA bundle past its window but nothing to move to -> the client would loop, so we raise loudly.
     with bugs_session() as bugs, pytest.raises(Exception, match="no newer bundle to move to"):
         bugs.CheckNativeStatus(_ota_check_req(created_at=datetime.now(UTC) - timedelta(days=40)))
 
 
 def test_check_native_status_ota_block_only_older_target_raises(db):
-    # The only available bundle is older than what the client runs; the device won't move backwards.
     _add_ota_package(
         platform=OTAPlatform.ios,
         fingerprint="ios-fingerprint",
@@ -783,7 +779,6 @@ def test_check_native_status_ota_block_only_older_target_raises(db):
 
 
 def test_check_native_status_banned_ota_block_with_successor(db):
-    # Running a banned bundle with a newer non-banned successor -> banned OTA block served.
     _add_ota_package(
         platform=OTAPlatform.ios,
         fingerprint="ios-fingerprint",
@@ -808,7 +803,6 @@ def test_check_native_status_banned_ota_block_with_successor(db):
 
 
 def test_check_native_status_banned_ota_block_no_successor_raises(db):
-    # Banning the only bundle on this fingerprint leaves its devices nowhere to go -> raise loudly.
     _add_ota_package(
         platform=OTAPlatform.ios,
         fingerprint="ios-fingerprint",


### PR DESCRIPTION
`CheckNativeStatus`'s update decision is purely age-based and never checked whether an upgrade target actually exists. If the OTA block clock fires (or a bundle is banned) but there's no newer non-banned bundle for the client's `(platform, fingerprint)` to move to, the forced-update screen would loop the client forever — it fetches, finds nothing newer, reloads, and is blocked again.

This adds a server-side guard: when `CheckNativeStatus` would emit an OTA block, it verifies (reusing the same query `GetNativeUpdateManifest` uses, so the two can't drift) that a strictly-newer non-banned bundle exists. If not, it raises — a publish/ban misconfiguration that should never be served to a user. The raise is reported to Sentry, and the client ignores `CheckNativeStatus` errors, so the affected device is simply left unblocked rather than bricked.

Store blocks aren't checkable here (the backend keeps no record of the latest store build) and a store block opens a store link rather than looping, so this is scoped to OTA blocks.

## Testing
`make format` and `make mypy` are clean for the changed files. Added 5 tests to `test_bugs.py` and the full `test_bugs.py` + `test_native_updates.py` suites pass (55 tests):

- satisfiable age block → OTA block served
- age block with no target → raises
- age block with only an older target → raises
- banned block with a non-banned successor → OTA block served
- banned-the-only-bundle → raises

```
uv run pytest src/tests/test_bugs.py src/tests/test_native_updates.py
```

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history (n/a — no schema changes)

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._