### PR TITLE
Mobile: auto-apply forced OTA updates

### DIFF
--- a/app/mobile/features/diagnostics/NativeUpdatePrompt.tsx
+++ b/app/mobile/features/diagnostics/NativeUpdatePrompt.tsx
@@ -1,5 +1,5 @@
 import * as Updates from "expo-updates";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ActivityIndicator,
@@ -51,25 +51,12 @@ export default function NativeUpdatePrompt({
   const [busy, setBusy] = useState(false);
   const [failed, setFailed] = useState(false);
 
-  if (!prompt) return null;
+  const info = prompt?.info ?? null;
+  const mode = prompt?.mode ?? null;
+  const isOta = info?.action === NativeUpdateAction.NATIVE_UPDATE_ACTION_OTA;
 
-  const { info, mode } = prompt;
-  const dismissible = mode !== "block";
-
-  const colors = {
-    background: isDark
-      ? theme.dark.background.default
-      : theme.palette.background.default,
-    text: isDark ? theme.dark.text.primary : theme.palette.text.primary,
-    textSecondary: isDark
-      ? theme.dark.text.secondary
-      : theme.palette.text.secondary,
-    primary: isDark ? theme.dark.primary.main : theme.palette.primary.main,
-  };
-
-  const isOta = info.action === NativeUpdateAction.NATIVE_UPDATE_ACTION_OTA;
-
-  const handlePrimary = async () => {
+  const handlePrimary = useCallback(async () => {
+    if (!info) return;
     setFailed(false);
     if (isOta) {
       setBusy(true);
@@ -86,6 +73,31 @@ export default function NativeUpdatePrompt({
     if (info.linkUrl) {
       await Linking.openURL(info.linkUrl);
     }
+  }, [info, isOta]);
+
+  // A forced OTA leaves the user no choice, so apply it automatically instead of
+  // making them tap. The button below stays as the retry path if the fetch fails.
+  const autoStarted = useRef(false);
+  useEffect(() => {
+    if (mode === "block" && isOta && !autoStarted.current) {
+      autoStarted.current = true;
+      void handlePrimary();
+    }
+  }, [mode, isOta, handlePrimary]);
+
+  if (!prompt || !info) return null;
+
+  const dismissible = mode !== "block";
+
+  const colors = {
+    background: isDark
+      ? theme.dark.background.default
+      : theme.palette.background.default,
+    text: isDark ? theme.dark.text.primary : theme.palette.text.primary,
+    textSecondary: isDark
+      ? theme.dark.text.secondary
+      : theme.palette.text.secondary,
+    primary: isDark ? theme.dark.primary.main : theme.palette.primary.main,
   };
 
   const title = t("update.required_title");


### PR DESCRIPTION
When a required OTA update has passed its deadline (`block` mode), the user has no choice but to update — the modal is non-dismissible. Making them tap the "Update" button is pure friction. This applies the OTA update automatically on mount instead.

`NativeUpdatePrompt` now auto-triggers `fetchUpdateAsync()` + `reloadAsync()` once on mount when `mode === "block"` and the action is OTA. The button is retained as the retry path if the fetch fails. `warn`/`nag` modes (dismissible) are unchanged, and store/reinstall actions still require a manual tap since they can only deep-link to the store.

## Testing
- `npx eslint` passes clean on the changed file.
- Manual: with a forced (post-deadline) OTA, the block screen now shows the spinner immediately and reloads into the new bundle without a tap. On a simulated fetch failure, the button reappears as a retry. `warn` and store-update prompts behave as before.

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._