### PR TITLE
Web/Bugfix/date-proper-capitalization

### DIFF
--- a/app/web/features/communities/events/EventCard.tsx
+++ b/app/web/features/communities/events/EventCard.tsx
@@ -141,6 +141,7 @@ export default function EventCard({ event, className }: EventCardProps) {
       locale,
       includeDayOfWeek: true,
       abbreviate: true,
+      capitalize: true,
     },
   );
 

--- a/app/web/features/communities/events/EventPage.tsx
+++ b/app/web/features/communities/events/EventPage.tsx
@@ -441,6 +441,7 @@ export default function EventPage({
                       timezone: BROWSER_TIMEZONE,
                       locale,
                       includeDayOfWeek: true,
+                      capitalize: true,
                     },
                   )}
                 </Typography>

--- a/app/web/features/communities/events/LongEventCard.tsx
+++ b/app/web/features/communities/events/LongEventCard.tsx
@@ -145,6 +145,7 @@ const LongEventCard = ({
       locale,
       includeDayOfWeek: true,
       includeTime: true,
+      capitalize: true,
     },
   );
 

--- a/app/web/features/dashboard/EventListRow.tsx
+++ b/app/web/features/dashboard/EventListRow.tsx
@@ -178,6 +178,7 @@ export default function EventListRow({ event }: EventListRowProps) {
   const month = localizeMonthAbbreviation(startDate, {
     locale,
     timezone: BROWSER_TIMEZONE,
+    capitalize: true,
   });
   const day = startDate.getDate();
 

--- a/app/web/features/profile/view/ReferenceListItem.tsx
+++ b/app/web/features/profile/view/ReferenceListItem.tsx
@@ -66,6 +66,7 @@ export default function ReferenceListItem({
               {localizeYearMonth(timestamp2Date(reference.writtenTime), {
                 locale,
                 abbreviate: true,
+                capitalize: true,
               })}
             </Pill>
           )}

--- a/app/web/features/profile/view/userLabels.tsx
+++ b/app/web/features/profile/view/userLabels.tsx
@@ -272,6 +272,7 @@ export const RemainingAboutLabels = ({ user }: Props) => {
             ? localizeYearMonth(timestamp2Date(user.joined), {
                 locale,
                 abbreviate: true,
+                capitalize: true,
               })
             : ""
         }

--- a/app/web/utils/date.test.ts
+++ b/app/web/utils/date.test.ts
@@ -127,6 +127,66 @@ describe("localizeDateTime", () => {
         locale: "de",
       }),
     ).toContain("Januar");
+    expect(
+      localizeDateTime(dayjs("2000-01-01"), {
+        timezone: UTC_TIMEZONE,
+        locale: "pt-BR",
+      }),
+    ).toContain("janeiro");
+    expect(
+      localizeDateTime(dayjs("2000-01-01"), {
+        timezone: UTC_TIMEZONE,
+        locale: "ca",
+      }),
+    ).toContain("gener");
+    expect(
+      localizeDateTime(dayjs("2000-01-01"), {
+        timezone: UTC_TIMEZONE,
+        locale: "zh-Hans",
+      }),
+    ).toContain("1月");
+    expect(
+      localizeDateTime(dayjs("2000-01-01"), {
+        timezone: UTC_TIMEZONE,
+        locale: "zh-Hant",
+      }),
+    ).toContain("1月");
+  });
+
+  it("does not capitalize day/month names by default (assumed mid-sentence)", () => {
+    // Spanish weekday + month stay lowercase when the date may be part of a sentence.
+    const formatted = localizeDateTime(dayjs("2000-01-01"), {
+      timezone: UTC_TIMEZONE,
+      locale: "es",
+      includeDayOfWeek: true,
+      includeTime: false,
+    });
+    expect(formatted).toMatch(/^sábado/);
+    expect(formatted).toContain("enero");
+  });
+
+  it("capitalizes only the first letter when capitalize is set (standalone date)", () => {
+    const formatted = localizeDateTime(dayjs("2000-01-01"), {
+      timezone: UTC_TIMEZONE,
+      locale: "es",
+      includeDayOfWeek: true,
+      includeTime: false,
+      capitalize: true,
+    });
+    expect(formatted).toMatch(/^Sábado/);
+    // day/month names mid-string are still lowercase
+    expect(formatted).toContain("enero");
+  });
+
+  it("leaves a non-letter first grapheme unchanged when capitalize is set", () => {
+    // Spanish dates without a weekday start with the day number.
+    const formatted = localizeDateTime(dayjs("2000-01-01"), {
+      timezone: UTC_TIMEZONE,
+      locale: "es",
+      includeTime: false,
+      capitalize: true,
+    });
+    expect(formatted).toMatch(/^1 de enero/);
   });
 });
 

--- a/app/web/utils/date.ts
+++ b/app/web/utils/date.ts
@@ -4,6 +4,25 @@ import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
 import daysjs, { Dayjs } from "./dayjs";
 import { dayMillis } from "./timeAgo";
 
+// Creating Intl.Segmenter every time is slow, so cache one per locale.
+const segmenterCache = new Map<string, Intl.Segmenter>();
+
+/// Uppercases the first grapheme cluster of a string, leaving the rest untouched.
+/// Non-capitalizable first clusters (digits, CJK, etc.) are returned unchanged.
+/// Only for dates that stand alone (their own "sentence") — never for dates
+/// interpolated into a larger translated string.
+function capitalizeFirstLetter(value: string, locale: string): string {
+  let segmenter = segmenterCache.get(locale);
+  if (!segmenter) {
+    segmenter = new Intl.Segmenter(locale, { granularity: "grapheme" });
+    segmenterCache.set(locale, segmenter);
+  }
+  const first = segmenter.segment(value)[Symbol.iterator]().next()
+    .value?.segment;
+  if (!first) return value;
+  return first.toLocaleUpperCase(locale) + value.slice(first.length);
+}
+
 const numNights = (date1: string, date2: string) => {
   const diffTime = Date.parse(date1) - Date.parse(date2);
   const diffDays = Math.ceil(diffTime / dayMillis);
@@ -31,6 +50,10 @@ interface LocalizeDateTimeParams {
   includeSeconds?: boolean;
   /// Whether to abbreviate days of the week and month names (defaults to false).
   abbreviate?: boolean;
+  /// Whether to uppercase the first letter (defaults to false). Set this only when
+  /// the date stands alone (not interpolated into a larger sentence) so it reads
+  /// like the start of a sentence. Day/month names are never otherwise capitalized.
+  capitalize?: boolean;
 }
 
 /// Localizes a date and time, optionally with the day of the week.
@@ -42,7 +65,10 @@ export function localizeDateTime(
     date = date.toDate();
   }
   const format = getIntlDateTimeFormat(args);
-  return format.format(date);
+  const formatted = format.format(date);
+  return args.capitalize
+    ? capitalizeFirstLetter(formatted, args.locale)
+    : formatted;
 }
 
 /// Localizes only the year and month of a date.
@@ -52,12 +78,14 @@ export function localizeYearMonth(
     timezone?: string | typeof BROWSER_TIMEZONE;
     locale: string;
     abbreviate?: boolean;
+    capitalize?: boolean;
   },
 ): string {
   return localizeDateTime(date, {
     timezone: args.timezone,
     locale: args.locale,
     abbreviate: args.abbreviate,
+    capitalize: args.capitalize,
     includeDay: false,
     includeTime: false,
   });
@@ -76,7 +104,10 @@ export function localizeDateTimeRange(
     end = end.toDate();
   }
   const format = getIntlDateTimeFormat(args);
-  return format.formatRange(start, end);
+  const formatted = format.formatRange(start, end);
+  return args.capitalize
+    ? capitalizeFirstLetter(formatted, args.locale)
+    : formatted;
 }
 
 // Creating Intl.DateTimeFormat every time is 40x slower.
@@ -130,7 +161,11 @@ function createIntlDateTimeFormat(
 /// Localizes just the abbreviated month name of a date (e.g. "Jan", "Mai" in German).
 export function localizeMonthAbbreviation(
   date: Date | Dayjs,
-  args: { locale: string; timezone?: string | typeof BROWSER_TIMEZONE },
+  args: {
+    locale: string;
+    timezone?: string | typeof BROWSER_TIMEZONE;
+    capitalize?: boolean;
+  },
 ): string {
   if (daysjs.isDayjs(date)) {
     date = date.toDate();
@@ -147,7 +182,10 @@ export function localizeMonthAbbreviation(
     format = Intl.DateTimeFormat(args.locale, options);
     intlDateTimeFormatCache.set(cacheKey, format);
   }
-  return format.format(date);
+  const formatted = format.format(date);
+  return args.capitalize
+    ? capitalizeFirstLetter(formatted, args.locale)
+    : formatted;
 }
 
 const isoMuiDateFormat = "YYYY-MM-DD";


### PR DESCRIPTION
Standalone dates (event cards, the event page, profile "joined" / local time, the reference pill, the month chip) now have their first letter capitalized so they read like the start of a sentence, while dates interpolated into a larger sentence keep their natural casing.

Adds an opt-in `capitalize` flag to the date helpers in `app/web/utils/date.ts`. When set, only the first Unicode **grapheme cluster** is uppercased (via `Intl.Segmenter` + `toLocaleUpperCase`); non-capitalizable first clusters (digits, CJK, …) are left unchanged. Day and month names are **never** capitalized mid-string, and there are **no per-language special cases**. Call sites that render a standalone date opt in via `capitalize: true`; dates interpolated into translated sentences keep `Intl`'s default (sentence-style) casing.

This replaces the earlier per-word `capitalizeDateString` regex, which wrongly capitalized month/day names and relied on a hardcoded Spanish/Portuguese word list.

Closes #8164

## Testing
Updated `app/web/utils/date.test.ts`: by default day/month names stay lowercase (e.g. Spanish "enero"); with `capitalize: true` only the first letter is uppercased — verified that a leading weekday capitalizes ("Sábado…") while the month stays lowercase mid-string ("…enero…"), and that a digit-first date is unchanged. Also verified manually in English, Spanish and Portuguese-Brazil that standalone dates capitalize the first letter and in-sentence dates do not.

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<img width="1152" height="865" alt="image" src="https://github.com/user-attachments/assets/5687a5c4-85c3-42e4-97f2-5f7809847576" />

<img width="1152" height="2510" alt="image" src="https://github.com/user-attachments/assets/3ed54ee3-63ef-4299-a892-9684be426322" />

