### PR TITLE
Backend: add user email campaign engine + host my home nudge

### DIFF
--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -987,6 +987,28 @@ class HostRequestStatusChangedEmail(EmailBase):
 
 
 @dataclass(kw_only=True, slots=True)
+class HostMyHomeNudgeEmail(EmailBase):
+    """Sent to a host-status user who hasn't filled in their "My Home" section."""
+
+    @property
+    def string_key_base(self) -> str:
+        return "host_my_home_nudge"
+
+    def get_preview_line(self, loc_context: LocalizationContext) -> str:
+        return self._localize(loc_context, ".preview")
+
+    def build_body(self, builder: EmailBlocksBuilder, loc_context: LocalizationContext) -> None:
+        builder.para(".intro")
+        builder.para(".details")
+        builder.action(urls.edit_home_link(), ".cta_action")
+        builder.para(".closing")
+
+    @classmethod
+    def test_instances(cls) -> list[Self]:
+        return [cls(user_name="Alice")]
+
+
+@dataclass(kw_only=True, slots=True)
 class ModeratorNoteEmail(EmailBase):
     """Sent to a user to notify them they have received a moderator note."""
 

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -162,6 +162,14 @@
       "body": "<b>{{other_name}}</b> cancelled their host request:"
     }
   },
+  "host_my_home_nudge": {
+    "subject": "Get ready to host a couch surfer",
+    "preview": "Travellers are looking for a host in your area &mdash; finish your My Home section to start showing up.",
+    "intro": "You signed up as someone who's open to hosting on Couchers.org, and there are travellers passing through who would love to stay with you.",
+    "details": "The last step before surfers can find you and send you a request is your \"My Home\" section: a bit about your place, how many guests you can take, and your sleeping arrangement.",
+    "cta_action": "Complete your My Home section",
+    "closing": "It only takes a couple of minutes, and once it's done you'll start showing up to people searching to stay in your area."
+  },
   "moderator_note": {
     "subject": "You have received a mod note",
     "body": "You have received an important note from the moderators. You must read and acknowledge it before continuing to use the platform."

--- a/app/backend/src/couchers/jobs/definitions.py
+++ b/app/backend/src/couchers/jobs/definitions.py
@@ -26,6 +26,7 @@ from couchers.jobs.handlers import (
     update_randomized_locations,
     update_recommendation_scores,
 )
+from couchers.jobs.user_email_campaigns import run_user_email_campaigns
 from couchers.materialized_views import refresh_materialized_views, refresh_materialized_views_rapid
 from couchers.notifications.background import handle_email_digests, handle_notification
 from couchers.notifications.send_raw_push_notification import send_raw_push_notification_v2
@@ -87,6 +88,7 @@ _JOBS_LIST = [
     Job(send_message_notifications, schedule=timedelta(minutes=3)),
     Job(send_request_notifications, schedule=timedelta(minutes=3)),
     Job(send_onboarding_emails, schedule=timedelta(hours=1)),
+    Job(run_user_email_campaigns, schedule=timedelta(hours=1)),
     Job(send_reference_reminders, schedule=timedelta(hours=1)),
     Job(send_host_request_reminders, schedule=timedelta(minutes=15)),
     Job(add_users_to_email_list, schedule=timedelta(hours=1)),

--- a/app/backend/src/couchers/jobs/user_email_campaigns.py
+++ b/app/backend/src/couchers/jobs/user_email_campaigns.py
@@ -1,0 +1,100 @@
+"""
+A small engine for sending User-targeted email campaigns based on per-user predicates.
+
+Each campaign declares:
+  - a SQL predicate over User (the candidate set);
+  - optionally, a per-user filter run in Python (used for things that need a per-user
+    CouchersContext, e.g. feature-flag evaluation that picks a per-user window).
+
+The engine dedups via the `user_email_campaign_sends` table: a campaign is sent to a user at
+most once for a given campaign_key. Multi-stage campaigns (e.g. onboarding 1 -> 2) are
+expressed as separate campaigns whose predicate references the previous stage via an EXISTS
+against this table.
+"""
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import timedelta
+
+from google.protobuf import empty_pb2
+from sqlalchemy import Select, select
+
+from couchers.context import CouchersContext, make_background_user_context
+from couchers.db import session_scope
+from couchers.models import (
+    HostingStatus,
+    NotificationTopicAction,
+    User,
+    UserEmailCampaignSend,
+)
+from couchers.notifications.notify import notify
+from couchers.utils import now
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class UserEmailCampaign:
+    key: str
+    topic_action: NotificationTopicAction
+    predicate: Callable[[], Select[tuple[User]]]
+    per_user_filter: Callable[[CouchersContext, User], bool] | None = None
+
+
+def _host_my_home_nudge_predicate() -> Select[tuple[User]]:
+    # Candidate set: visible hosts (or maybe-hosts) who finished the onboarding nudge track
+    # but still haven't filled out "My Home". Final signup-window check is per-user (depends on
+    # a GrowthBook integer flag) and lives in the per_user_filter below.
+    return (
+        select(User)
+        .where(User.is_visible)
+        .where(User.hosting_status.in_([HostingStatus.can_host, HostingStatus.maybe]))
+        .where(User.onboarding_emails_sent >= 2)
+        .where(~User.has_completed_my_home)
+    )
+
+
+def _host_my_home_nudge_per_user(context: CouchersContext, user: User) -> bool:
+    # Flag value is the days-since-signup at which we start nudging this user. -1 disables.
+    days = context.get_integer_value("host_my_home_nudge_days_after_signup", -1)
+    if days < 0:
+        return False
+    age = now() - user.joined
+    return timedelta(days=days) <= age <= timedelta(days=days + 60)
+
+
+CAMPAIGNS: list[UserEmailCampaign] = [
+    UserEmailCampaign(
+        key="host_my_home_nudge",
+        topic_action=NotificationTopicAction.host_my_home__nudge,
+        predicate=_host_my_home_nudge_predicate,
+        per_user_filter=_host_my_home_nudge_per_user,
+    ),
+]
+
+
+def run_user_email_campaigns(payload: empty_pb2.Empty) -> None:
+    """Hourly: walk each campaign, send to newly-eligible users, record the send."""
+    for campaign in CAMPAIGNS:
+        logger.info("Running user email campaign %s", campaign.key)
+        with session_scope() as session:
+            already_sent = (
+                select(UserEmailCampaignSend.user_id)
+                .where(UserEmailCampaignSend.campaign_key == campaign.key)
+                .scalar_subquery()
+            )
+            candidates = session.execute(campaign.predicate().where(~User.id.in_(already_sent))).scalars().all()
+            for user in candidates:
+                if campaign.per_user_filter is not None:
+                    context = make_background_user_context(user_id=user.id)
+                    if not campaign.per_user_filter(context, user):
+                        continue
+                notify(
+                    session,
+                    user_id=user.id,
+                    topic_action=campaign.topic_action,
+                    key=campaign.key,
+                )
+                session.add(UserEmailCampaignSend(user_id=user.id, campaign_key=campaign.key))
+                session.commit()

--- a/app/backend/src/couchers/migrations/versions/0163_add_user_email_campaign_sends.py
+++ b/app/backend/src/couchers/migrations/versions/0163_add_user_email_campaign_sends.py
@@ -1,0 +1,34 @@
+"""Add user_email_campaign_sends table
+
+Revision ID: 0163
+Revises: 0162
+Create Date: 2026-06-01 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0163"
+down_revision = "0162"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_email_campaign_sends",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("campaign_key", sa.String(), nullable=False),
+        sa.Column("sent_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name=op.f("fk_user_email_campaign_sends_user_id_users")),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_user_email_campaign_sends")),
+        sa.UniqueConstraint("user_id", "campaign_key", name="uq_user_email_campaign_sends_user_id_campaign_key"),
+    )
+    op.create_index("ix_user_email_campaign_sends_campaign_key", "user_email_campaign_sends", ["campaign_key"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_email_campaign_sends_campaign_key", table_name="user_email_campaign_sends")
+    op.drop_table("user_email_campaign_sends")

--- a/app/backend/src/couchers/models/__init__.py
+++ b/app/backend/src/couchers/models/__init__.py
@@ -19,5 +19,6 @@ from .public_trips import *  # noqa: F401,F403
 from .rest import *  # noqa: F401,F403
 from .static import *  # noqa: F401,F403
 from .uploads import *  # noqa: F401,F403
+from .user_email_campaigns import *  # noqa: F401,F403
 from .users import *  # noqa: F401,F403
 from .verification import *  # noqa: F401,F403

--- a/app/backend/src/couchers/models/notifications.py
+++ b/app/backend/src/couchers/models/notifications.py
@@ -155,6 +155,7 @@ class NotificationTopicAction(enum.Enum):
     donation__received = ("donation:received", dt_sec, True, nd.DonationReceived)
 
     onboarding__reminder = ("onboarding:reminder", dt_sec, False, empty_pb2.Empty)
+    host_my_home__nudge = ("host_my_home:nudge", [dt.email], False, empty_pb2.Empty)
 
     modnote__create = ("modnote:create", dt_sec, True, empty_pb2.Empty)
 

--- a/app/backend/src/couchers/models/user_email_campaigns.py
+++ b/app/backend/src/couchers/models/user_email_campaigns.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Index, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from couchers.models.base import Base
+
+if TYPE_CHECKING:
+    from couchers.models.users import User
+
+
+class UserEmailCampaignSend(Base, kw_only=True):
+    __tablename__ = "user_email_campaign_sends"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    campaign_key: Mapped[str] = mapped_column(String)
+    sent_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
+
+    user: Mapped[User] = relationship(init=False)
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "campaign_key", name="uq_user_email_campaign_sends_user_id_campaign_key"),
+        Index("ix_user_email_campaign_sends_campaign_key", "campaign_key"),
+    )

--- a/app/backend/src/couchers/notifications/locales/en.json
+++ b/app/backend/src/couchers/notifications/locales/en.json
@@ -352,6 +352,11 @@
       }
     }
   },
+  "host_my_home": {
+    "nudge": {
+      "event_description": "Reminder to fill in your My Home section so you can host"
+    }
+  },
   "password": {
     "change": {
       "event_description": "Your password is changed",

--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -131,6 +131,8 @@ def _get_generic_templated_email(user_name: str, notification: Notification) -> 
             return emails.EmailAddressChangedEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.email_address__verify:
             return emails.EmailAddressVerifiedEmail(user_name=user_name)
+        case NotificationTopicAction.host_my_home__nudge:
+            return emails.HostMyHomeNudgeEmail(user_name=user_name)
         case NotificationTopicAction.host_request__create:
             return emails.HostRequestCreatedEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.host_request__reminder:
@@ -555,6 +557,8 @@ def get_topic_action_unsubscribe_text(topic_action: NotificationTopicAction) -> 
             return "accepted friend requests"
         case NotificationTopicAction.onboarding__reminder:
             return "onboarding emails"
+        case NotificationTopicAction.host_my_home__nudge:
+            return "hosting nudges"
         case NotificationTopicAction.postal_verification__postcard_sent:
             return "postal verification postcards"
         case NotificationTopicAction.general__new_blog_post:

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -104,6 +104,9 @@ def render_push_notification(notification: Notification, loc_context: Localizati
             return _render_modnote__create(loc_context)
         case NotificationTopicAction.onboarding__reminder:
             return _render_onboarding__reminder(notification.key, loc_context)
+        case NotificationTopicAction.host_my_home__nudge:
+            # Delivery defaults to email only; this case exists to satisfy exhaustiveness.
+            raise NotImplementedError("host_my_home__nudge is email-only")
         case NotificationTopicAction.password__change:
             return _render_password__change(loc_context)
         case NotificationTopicAction.password_reset__start:

--- a/app/backend/src/couchers/notifications/settings.py
+++ b/app/backend/src/couchers/notifications/settings.py
@@ -205,6 +205,13 @@ settings_layout = [
                 ],
             ),
             (
+                "host_my_home",
+                "Hosting Nudges",
+                [
+                    NotificationTopicAction.host_my_home__nudge,
+                ],
+            ),
+            (
                 "badge",
                 "Updates to Badges on your profile",
                 [

--- a/app/backend/src/couchers/urls.py
+++ b/app/backend/src/couchers/urls.py
@@ -27,6 +27,10 @@ def edit_profile_link() -> str:
     return f"{config['BASE_URL']}/profile/edit"
 
 
+def edit_home_link() -> str:
+    return f"{config['BASE_URL']}/profile/edit/home"
+
+
 def signup_link(*, token: str) -> str:
     return f"{config['BASE_URL']}/signup?token={token}"
 

--- a/app/backend/src/tests/test_user_email_campaigns.py
+++ b/app/backend/src/tests/test_user_email_campaigns.py
@@ -1,0 +1,155 @@
+from datetime import timedelta
+from typing import Any
+
+import pytest
+from google.protobuf import empty_pb2
+from sqlalchemy import select
+from sqlalchemy.sql import func
+
+from couchers.db import session_scope
+from couchers.jobs.user_email_campaigns import run_user_email_campaigns
+from couchers.models import (
+    BackgroundJob,
+    HostingStatus,
+    SleepingArrangement,
+    UserEmailCampaignSend,
+)
+from couchers.utils import now
+from tests.fixtures.db import generate_user
+from tests.fixtures.misc import process_jobs
+
+CAMPAIGN_KEY = "host_my_home_nudge"
+FLAG_KEY = "host_my_home_nudge_days_after_signup"
+
+
+@pytest.fixture(autouse=True)
+def _(testconfig):
+    pass
+
+
+def _make_eligible_user(**overrides: Any):
+    """A user matching all SQL-side criteria for the host_my_home_nudge campaign."""
+    kwargs: dict[str, Any] = dict(
+        hosting_status=HostingStatus.can_host,
+        onboarding_emails_sent=2,
+        joined=now() - timedelta(days=30),
+        # has_completed_my_home == False because max_guests + sleeping_arrangement are unset
+        max_guests=None,
+        sleeping_arrangement=None,
+    )
+    kwargs.update(overrides)
+    return generate_user(complete_profile=True, **kwargs)
+
+
+def _send_email_jobs() -> int:
+    with session_scope() as session:
+        return session.execute(
+            select(func.count()).select_from(BackgroundJob).where(BackgroundJob.job_type == "send_email")
+        ).scalar_one()
+
+
+def _campaign_sends(campaign_key: str = CAMPAIGN_KEY) -> int:
+    with session_scope() as session:
+        return session.execute(
+            select(func.count())
+            .select_from(UserEmailCampaignSend)
+            .where(UserEmailCampaignSend.campaign_key == campaign_key)
+        ).scalar_one()
+
+
+def test_host_my_home_nudge_happy_path(db, feature_flags):
+    feature_flags.set(FLAG_KEY, 14)
+    user, _ = _make_eligible_user()
+
+    run_user_email_campaigns(empty_pb2.Empty())
+    process_jobs()
+
+    assert _send_email_jobs() == 1
+    assert _campaign_sends() == 1
+
+
+def test_host_my_home_nudge_dedups_on_rerun(db, feature_flags):
+    feature_flags.set(FLAG_KEY, 14)
+    _make_eligible_user()
+
+    run_user_email_campaigns(empty_pb2.Empty())
+    run_user_email_campaigns(empty_pb2.Empty())
+    process_jobs()
+
+    assert _send_email_jobs() == 1
+    assert _campaign_sends() == 1
+
+
+def test_host_my_home_nudge_flag_disabled(db, feature_flags):
+    # default of -1 means the flag isn't set up in GrowthBook yet; should send nothing.
+    _make_eligible_user()
+
+    run_user_email_campaigns(empty_pb2.Empty())
+    process_jobs()
+
+    assert _send_email_jobs() == 0
+    assert _campaign_sends() == 0
+
+
+def test_host_my_home_nudge_signup_before_window(db, feature_flags):
+    feature_flags.set(FLAG_KEY, 14)
+    # Joined too recently (< 14 days ago) — not yet in the window.
+    _make_eligible_user(joined=now() - timedelta(days=5))
+
+    run_user_email_campaigns(empty_pb2.Empty())
+    process_jobs()
+
+    assert _send_email_jobs() == 0
+
+
+def test_host_my_home_nudge_signup_after_window(db, feature_flags):
+    feature_flags.set(FLAG_KEY, 14)
+    # Joined too long ago (> 14 + 60 days ago) — past the window.
+    _make_eligible_user(joined=now() - timedelta(days=200))
+
+    run_user_email_campaigns(empty_pb2.Empty())
+    process_jobs()
+
+    assert _send_email_jobs() == 0
+
+
+def test_host_my_home_nudge_skips_non_hosts(db, feature_flags):
+    feature_flags.set(FLAG_KEY, 14)
+    _make_eligible_user(hosting_status=HostingStatus.cant_host)
+
+    run_user_email_campaigns(empty_pb2.Empty())
+    process_jobs()
+
+    assert _send_email_jobs() == 0
+
+
+def test_host_my_home_nudge_includes_maybe_hosts(db, feature_flags):
+    feature_flags.set(FLAG_KEY, 14)
+    _make_eligible_user(hosting_status=HostingStatus.maybe)
+
+    run_user_email_campaigns(empty_pb2.Empty())
+    process_jobs()
+
+    assert _send_email_jobs() == 1
+
+
+def test_host_my_home_nudge_skips_before_onboarding_completed(db, feature_flags):
+    feature_flags.set(FLAG_KEY, 14)
+    # Still mid-onboarding-nudge track — wait until those have run their course.
+    _make_eligible_user(onboarding_emails_sent=1)
+
+    run_user_email_campaigns(empty_pb2.Empty())
+    process_jobs()
+
+    assert _send_email_jobs() == 0
+
+
+def test_host_my_home_nudge_skips_when_my_home_complete(db, feature_flags):
+    feature_flags.set(FLAG_KEY, 14)
+    # Filling in max_guests + sleeping_arrangement (about_place is set by default) satisfies has_completed_my_home.
+    _make_eligible_user(max_guests=2, sleeping_arrangement=SleepingArrangement.private)
+
+    run_user_email_campaigns(empty_pb2.Empty())
+    process_jobs()
+
+    assert _send_email_jobs() == 0


### PR DESCRIPTION
Adds a small registry-driven engine for User-targeted email campaigns, and ships the first campaign on it: a nudge to hosts who completed the onboarding email track but still have an empty "My Home" section.

The engine is designed so future onboarding/lifecycle emails are a thin addition: a predicate function over `User`, an optional per-user filter (for things like GrowthBook windows that vary per user), and a `NotificationTopicAction`. Dedup lives in a new `user_email_campaign_sends` table (one row per `(user_id, campaign_key)`), so we stop accreting `*_emails_sent` columns on `User` for every campaign.

The host my home nudge itself is gated by an integer GrowthBook flag `host_my_home_nudge_days_after_signup` (default `-1` = off). When enabled, the flag's value is the days-since-signup at which the user becomes eligible; the window is 2 months wide. Email-only delivery, uses the new generic templating system.

`send_onboarding_emails` and friends are intentionally left alone for now — easy to port later.

## Testing
- Added `tests/test_user_email_campaigns.py` with 9 cases covering the engine and the host nudge campaign: happy path, dedup across reruns, flag-disabled, signup before/after window, hosting status variants, onboarding-not-completed gate, my-home-already-complete gate.
- `test_email_localization` auto-picks up the new `HostMyHomeNudgeEmail` class and verifies every key resolves in English.
- `make format` and `make mypy` clean (existing mypy errors on `develop` unrelated).

To exercise manually: set `host_my_home_nudge_days_after_signup` in GrowthBook to a small int, create a `can_host` user with `onboarding_emails_sent=2`, joined that many days ago, with `max_guests`/`sleeping_arrangement` blank; the next hourly tick should send.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._