### PR TITLE
Skip package.json scripts and .gitignore in mobile fingerprint

### DIFF
--- a/app/mobile/fingerprint.config.js
+++ b/app/mobile/fingerprint.config.js
@@ -1,15 +1,12 @@
-// @expo/fingerprint hashes the resolved Expo config, including `extra`. Our
-// app.config.js injects the git commit hash into `extra.gitHash`, so without
-// this skip every commit produced a unique runtimeVersion and an OTA update
-// could never match an already-installed build. Nothing under `extra` (router,
-// eas, gitHash) affects the native binary, so excluding it keeps the fingerprint
-// stable across commits while still rebuilding when real native inputs change.
-// The default package.json script skip is preserved. ExpoConfigVersions excludes
-// the marketing version/build number so a release bump keeps OTA continuity.
 module.exports = {
   sourceSkips: [
-    "PackageJsonAndroidAndIosScriptsIfNotContainRun",
+    // no native-affecting build scripts, so an npm script shouldn't rebuild
+    "PackageJsonScriptsAll",
+    // app.config.js injects a per-commit gitHash into `extra`; nothing native
     "ExpoConfigExtraSection",
+    // a version/build-number bump shouldn't break OTA continuity
     "ExpoConfigVersions",
+    // .gitignore contents never affect the native binary
+    "GitIgnore",
   ],
 };

--- a/app/mobile/fingerprints
+++ b/app/mobile/fingerprints
@@ -4,9 +4,9 @@
 # mismatch with what `npx expo-updates fingerprint:generate` produces means
 # a native change has moved the fingerprint and a fresh store build will be
 # needed when merged to develop.
-devtool/ios=6b238b87ad144ebdcbc7d49a7359c5f2b9cd5e6f
-devtool/android=6e72ee772e49c553678d854867c22a5d12c23ee1
-staging/ios=db697158b6248b8e15719b562190cc430bb3bc30
-staging/android=17a3f8e266093c3b8a0c2f21d3c6ca3e99232ed3
-production/ios=6c963a899641a27c31a2ed4317e6a055a705e6c6
-production/android=31863b221f7e2610021c7511c5f4959404b9e27a
+devtool/ios=cf92fd351582c641c0768a39bcb6f162f679073a
+devtool/android=0f357250be201c1592af9ed86eeaea8a543ea9a9
+staging/ios=cf92fd351582c641c0768a39bcb6f162f679073a
+staging/android=0f357250be201c1592af9ed86eeaea8a543ea9a9
+production/ios=cf92fd351582c641c0768a39bcb6f162f679073a
+production/android=0f357250be201c1592af9ed86eeaea8a543ea9a9


### PR DESCRIPTION
Excludes the package.json `scripts` section and `.gitignore` contents from the mobile Expo fingerprint, since neither affects the native binary and so neither should move the `runtimeVersion` (or trigger a store rebuild).

- Swaps the narrow `PackageJsonAndroidAndIosScriptsIfNotContainRun` skip for `PackageJsonScriptsAll` — the former only stripped the `android`/`ios` script keys, so adding any other npm script (e.g. the recent `fingerprints:check`/`fingerprints:write`) silently moved the fingerprint. The latter is a superset, so the narrow skip is dropped.
- Adds `GitIgnore` to stop hashing `.gitignore` file contents.
- Regenerates the pinned `app/mobile/fingerprints` to match.

Note: on the current tree all three variants now hash identically per platform. This is **not** caused by these skips — the previously-committed per-variant values were stale, and the old config produces the same collapse when run against the current tree. `app.config.js` (which sets per-variant scheme/bundleId/name/icons) is unchanged, so the per-variant ExpoConfig differences aren't reaching the fingerprinter on this tree. Cross-variant isolation is enforced by per-variant OTA URL + code-signing cert rather than the runtimeVersion, so this is not a safety regression, but flagging it for awareness.

## Testing
- `npm run fingerprints:write` from `app/mobile` regenerates the committed values; `npm run fingerprints:check` then passes.
- Verified the skip change is the only cause of the hash move by computing the old committed config against the current tree.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._