### PR TITLE
Serialize friend and host request notifications from the recipient's perspective

### DIFF
--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -13,7 +13,7 @@ from sqlalchemy.sql import and_, delete, exists, func, intersect, or_, union
 from couchers import urls
 from couchers.config import config
 from couchers.constants import GHOST_USERNAME
-from couchers.context import CouchersContext
+from couchers.context import CouchersContext, make_background_user_context
 from couchers.crypto import b64encode, generate_hash_signature, random_hex
 from couchers.event_log import log_event
 from couchers.helpers.completed_profile import has_completed_profile
@@ -792,13 +792,18 @@ class API(api_pb2_grpc.APIServicer):
 
         assert friend_relationship is not None  # set by create_friend_relationship callback
 
+        # the notification is rendered for the recipient, so serialize the sender from their perspective
         notify(
             session,
             user_id=friend_relationship.to_user_id,
             topic_action=NotificationTopicAction.friend_request__create,
             key=str(friend_relationship.from_user_id),
             data=notification_data_pb2.FriendRequestCreate(
-                other_user=user_model_to_pb(friend_relationship.from_user, session, context),
+                other_user=user_model_to_pb(
+                    friend_relationship.from_user,
+                    session,
+                    make_background_user_context(user_id=friend_relationship.to_user_id),
+                ),
             ),
             moderation_state_id=moderation_state.id,
         )
@@ -876,6 +881,7 @@ class API(api_pb2_grpc.APIServicer):
 
         session.flush()
 
+        # the notification is rendered for the original requester, so serialize the responder from their perspective
         if friend_request.status == FriendStatus.accepted:
             notify(
                 session,
@@ -883,7 +889,11 @@ class API(api_pb2_grpc.APIServicer):
                 topic_action=NotificationTopicAction.friend_request__accept,
                 key=str(friend_request.to_user_id),
                 data=notification_data_pb2.FriendRequestAccept(
-                    other_user=user_model_to_pb(friend_request.to_user, session, context),
+                    other_user=user_model_to_pb(
+                        friend_request.to_user,
+                        session,
+                        make_background_user_context(user_id=friend_request.from_user_id),
+                    ),
                 ),
             )
 

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -792,7 +792,6 @@ class API(api_pb2_grpc.APIServicer):
 
         assert friend_relationship is not None  # set by create_friend_relationship callback
 
-        # the notification is rendered for the recipient, so serialize the sender from their perspective
         notify(
             session,
             user_id=friend_relationship.to_user_id,
@@ -881,7 +880,6 @@ class API(api_pb2_grpc.APIServicer):
 
         session.flush()
 
-        # the notification is rendered for the original requester, so serialize the responder from their perspective
         if friend_request.status == FriendStatus.accepted:
             notify(
                 session,

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session, aliased
 from sqlalchemy.sql import and_, func, or_
 
 from couchers.constants import HOST_REQUEST_MIN_LENGTH_UTF16
-from couchers.context import CouchersContext
+from couchers.context import CouchersContext, make_background_user_context
 from couchers.db import can_moderate_node
 from couchers.event_log import log_event
 from couchers.helpers.completed_profile import has_completed_profile
@@ -339,14 +339,15 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         session.add(host_request)
         session.flush()
 
+        recipient_context = make_background_user_context(user_id=host_request.recipient_user_id)
         notify(
             session,
             user_id=host_request.recipient_user_id,
             topic_action=NotificationTopicAction.host_request__create,
             key=str(host_request.conversation_id),
             data=notification_data_pb2.HostRequestCreate(
-                host_request=host_request_to_pb(host_request, session, context),
-                surfer=user_model_to_pb(host_request.initiator, session, context),
+                host_request=host_request_to_pb(host_request, session, recipient_context),
+                surfer=user_model_to_pb(host_request.initiator, session, recipient_context),
                 text=request.text,
             ),
             moderation_state_id=moderation_state.id,
@@ -572,14 +573,15 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             host_request.status = HostRequestStatus.accepted
             session.flush()
 
+            recipient_context = make_background_user_context(user_id=host_request.initiator_user_id)
             notify(
                 session,
                 user_id=host_request.initiator_user_id,
                 topic_action=NotificationTopicAction.host_request__accept,
                 key=str(host_request.conversation_id),
                 data=notification_data_pb2.HostRequestAccept(
-                    host_request=host_request_to_pb(host_request, session, context),
-                    host=user_model_to_pb(host_request.recipient, session, context),
+                    host_request=host_request_to_pb(host_request, session, recipient_context),
+                    host=user_model_to_pb(host_request.recipient, session, recipient_context),
                 ),
                 moderation_state_id=host_request.moderation_state_id,
             )
@@ -613,14 +615,15 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             host_request.status = HostRequestStatus.rejected
             session.flush()
 
+            recipient_context = make_background_user_context(user_id=host_request.initiator_user_id)
             notify(
                 session,
                 user_id=host_request.initiator_user_id,
                 topic_action=NotificationTopicAction.host_request__reject,
                 key=str(host_request.conversation_id),
                 data=notification_data_pb2.HostRequestReject(
-                    host_request=host_request_to_pb(host_request, session, context),
-                    host=user_model_to_pb(host_request.recipient, session, context),
+                    host_request=host_request_to_pb(host_request, session, recipient_context),
+                    host=user_model_to_pb(host_request.recipient, session, recipient_context),
                 ),
                 moderation_state_id=host_request.moderation_state_id,
             )
@@ -654,14 +657,15 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             host_request.status = HostRequestStatus.confirmed
             session.flush()
 
+            recipient_context = make_background_user_context(user_id=host_request.recipient_user_id)
             notify(
                 session,
                 user_id=host_request.recipient_user_id,
                 topic_action=NotificationTopicAction.host_request__confirm,
                 key=str(host_request.conversation_id),
                 data=notification_data_pb2.HostRequestConfirm(
-                    host_request=host_request_to_pb(host_request, session, context),
-                    surfer=user_model_to_pb(host_request.initiator, session, context),
+                    host_request=host_request_to_pb(host_request, session, recipient_context),
+                    surfer=user_model_to_pb(host_request.initiator, session, recipient_context),
                 ),
                 moderation_state_id=host_request.moderation_state_id,
             )
@@ -694,14 +698,15 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             host_request.status = HostRequestStatus.cancelled
             session.flush()
 
+            recipient_context = make_background_user_context(user_id=host_request.recipient_user_id)
             notify(
                 session,
                 user_id=host_request.recipient_user_id,
                 topic_action=NotificationTopicAction.host_request__cancel,
                 key=str(host_request.conversation_id),
                 data=notification_data_pb2.HostRequestCancel(
-                    host_request=host_request_to_pb(host_request, session, context),
-                    surfer=user_model_to_pb(host_request.initiator, session, context),
+                    host_request=host_request_to_pb(host_request, session, recipient_context),
+                    surfer=user_model_to_pb(host_request.initiator, session, recipient_context),
                 ),
                 moderation_state_id=host_request.moderation_state_id,
             )
@@ -820,14 +825,15 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         if host_request.initiator_user_id == context.user_id:
             host_request.initiator_last_seen_message_id = message.id
 
+            recipient_context = make_background_user_context(user_id=host_request.recipient_user_id)
             notify(
                 session,
                 user_id=host_request.recipient_user_id,
                 topic_action=NotificationTopicAction.host_request__message,
                 key=str(host_request.conversation_id),
                 data=notification_data_pb2.HostRequestMessage(
-                    host_request=host_request_to_pb(host_request, session, context),
-                    user=user_model_to_pb(host_request.initiator, session, context),
+                    host_request=host_request_to_pb(host_request, session, recipient_context),
+                    user=user_model_to_pb(host_request.initiator, session, recipient_context),
                     text=request.text,
                     am_host=True,
                 ),
@@ -837,14 +843,15 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         else:
             host_request.recipient_last_seen_message_id = message.id
 
+            recipient_context = make_background_user_context(user_id=host_request.initiator_user_id)
             notify(
                 session,
                 user_id=host_request.initiator_user_id,
                 topic_action=NotificationTopicAction.host_request__message,
                 key=str(host_request.conversation_id),
                 data=notification_data_pb2.HostRequestMessage(
-                    host_request=host_request_to_pb(host_request, session, context),
-                    user=user_model_to_pb(host_request.recipient, session, context),
+                    host_request=host_request_to_pb(host_request, session, recipient_context),
+                    user=user_model_to_pb(host_request.recipient, session, recipient_context),
                     text=request.text,
                     am_host=False,
                 ),


### PR DESCRIPTION
Friend request and host request notifications serialized the other user (and, for host requests, perspective-dependent fields like last-seen/archived/feedback) from the acting user's own context rather than the recipient's. Since these payloads are rendered for and delivered to the recipient, they must be built from the recipient's context. This aligns these sites with the host request reminder/background-job and reference paths.

## Testing
Existing API, notification, and email tests pass (`test_api.py`, `test_requests.py`, `test_notifications.py`, `test_email.py`).

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._