### PR TITLE
Ignore eas.json in the runtime fingerprint, add a full review tripwire

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -612,7 +612,8 @@ test:mobile-expo-doctor:
         - app/mobile/package.json
         - app/mobile/package-lock.json
 
-# Fails when app/mobile/fingerprints no longer matches the computed fingerprints.
+# Checks app/mobile/fingerprints (the runtimeVersion) and fingerprints.full (the
+# review tripwire) against the computed fingerprints.
 test:mobile-fingerprints:
   needs: ["protos"]
   stage: test

--- a/app/mobile/.fingerprintignore
+++ b/app/mobile/.fingerprintignore
@@ -14,3 +14,7 @@ google-services.json
 # build and its OTA bundles would get different runtimeVersions and never match.
 # Its values only flow into `extra` (skipped) and the generated plist/manifest.
 build-version.json
+
+# eas.json's EXPO_PUBLIC_* env is inlined into the JS bundle and delivered via OTA,
+# so an env tweak mustn't bump the runtimeVersion. Still tracked by fingerprints.full.
+eas.json

--- a/app/mobile/fingerprints
+++ b/app/mobile/fingerprints
@@ -1,8 +1,8 @@
 # DO NOT EDIT MANUALLY!
 # Regenerate with `cd app/mobile && npm run fingerprints:write`
-devtool/ios=74f9898064913dee26bdfa2fe82340f39cb9b442
-devtool/android=7f8f4c03ddf3d73f71dbfb77c212bc8ada2e4b0c
-staging/ios=3aa67b0a0fb8f1c73184470616c4a249b5ca7daa
-staging/android=3d1d24b7e15db5e208e2a234bd083e14ecf982d2
-production/ios=24c8176d3e8fd4cb2e2e369e50dae87b62356919
-production/android=7e98f0ad53419aade5f0237277ca754527693dde
+devtool/ios=39a79dc343e28bd532ff009fa0a622f7439e50e7
+devtool/android=f707949d2e90773192d2f30d626aae35fae31904
+staging/ios=8c53e7b9d0e486da8fab97139d928a82a234c1b1
+staging/android=3625e9e21c8c7f89c8f8fadd5ccfb78d006a2898
+production/ios=ca952602407aba49797d3a590583106e253d0ee7
+production/android=c3d065694dbdd89ef935845e4e57d96464273d51

--- a/app/mobile/fingerprints.full
+++ b/app/mobile/fingerprints.full
@@ -1,0 +1,8 @@
+# DO NOT EDIT MANUALLY!
+# Regenerate with `cd app/mobile && npm run fingerprints:write`
+devtool/ios=5c3ed99f10dd62c0b87efeee6cd634848f1746eb
+devtool/android=5aa72a22869a3c9d67cfb3024ec7cf5b1814b813
+staging/ios=4efaf2aacac5ce19f0b1437119ccc882f8db86e9
+staging/android=a35567c0c1ac213969198a57d889f8c76261f082
+production/ios=9ddc952bc0336c67572828414d0221fef80101b6
+production/android=de40f23cfd0df3e6750c2e3834eda92fc56dfd01

--- a/app/mobile/package-lock.json
+++ b/app/mobile/package-lock.json
@@ -72,6 +72,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
+        "@expo/fingerprint": "0.15.5",
         "@testing-library/react-native": "^13.3.3",
         "@types/google-protobuf": "^3.15.12",
         "@types/jest": "^29.5.14",

--- a/app/mobile/package.json
+++ b/app/mobile/package.json
@@ -96,6 +96,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
+    "@expo/fingerprint": "0.15.5",
     "@testing-library/react-native": "^13.3.3",
     "@types/google-protobuf": "^3.15.12",
     "@types/jest": "^29.5.14",

--- a/app/mobile/scripts/fingerprints.mjs
+++ b/app/mobile/scripts/fingerprints.mjs
@@ -1,13 +1,20 @@
 #!/usr/bin/env node
 // Usage: node scripts/fingerprints.mjs <check|write>  (run from app/mobile)
+// Writes/checks `fingerprints` (the runtimeVersion) and `fingerprints.full` (a
+// review tripwire over the OTA-safe inputs the runtime fingerprint skips).
 
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { createFingerprintAsync, SourceSkips } from "@expo/fingerprint";
+
 const HERE = dirname(fileURLToPath(import.meta.url));
-const FILE = resolve(HERE, "..", "fingerprints");
+const PROJECT_ROOT = resolve(HERE, "..");
+const RUNTIME_FILE = resolve(PROJECT_ROOT, "fingerprints");
+const FULL_FILE = resolve(PROJECT_ROOT, "fingerprints.full");
+const EAS_JSON = resolve(PROJECT_ROOT, "eas.json");
 const VARIANTS = ["devtool", "staging", "production"];
 const PLATFORMS = ["ios", "android"];
 
@@ -16,7 +23,8 @@ const HEADER = [
   "# Regenerate with `cd app/mobile && npm run fingerprints:write`",
 ].join("\n");
 
-function compute(variant, platform) {
+// Via the CLI so it stays byte-identical to the runtimeVersion EAS computes.
+function computeRuntime(variant, platform) {
   const r = spawnSync(
     "npx",
     ["expo-updates", "fingerprint:generate", "--platform", platform],
@@ -38,21 +46,44 @@ function compute(variant, platform) {
   return json.hash;
 }
 
-function computeAll() {
-  const out = {};
-  for (const v of VARIANTS) {
-    for (const p of PLATFORMS) {
-      process.stderr.write(`computing fingerprint for ${v}/${p}…\n`);
-      out[`${v}/${p}`] = compute(v, p);
-    }
-  }
-  return out;
+// .fingerprintignore drops eas.json from the runtime fingerprint; re-add it as an
+// explicit source so the full tripwire still catches eas.json changes.
+const EAS_JSON_SOURCE = {
+  type: "contents",
+  id: "eas.json",
+  contents: readFileSync(EAS_JSON),
+  reasons: ["full-fingerprint"],
+};
+
+async function computeFull(variant, platform) {
+  process.env.APP_VARIANT = variant;
+  const fp = await createFingerprintAsync(PROJECT_ROOT, {
+    platforms: [platform],
+    // Skip the extra section only: it carries a per-commit gitHash/version.
+    sourceSkips: SourceSkips.ExpoConfigExtraSection,
+    extraSources: [EAS_JSON_SOURCE],
+    silent: true,
+  });
+  return fp.hash;
 }
 
-function readCommitted() {
-  if (!existsSync(FILE)) return null;
+async function computeAll() {
+  const runtime = {};
+  const full = {};
+  for (const v of VARIANTS) {
+    for (const p of PLATFORMS) {
+      process.stderr.write(`computing fingerprints for ${v}/${p}…\n`);
+      runtime[`${v}/${p}`] = computeRuntime(v, p);
+      full[`${v}/${p}`] = await computeFull(v, p);
+    }
+  }
+  return { runtime, full };
+}
+
+function readCommitted(file) {
+  if (!existsSync(file)) return null;
   const out = {};
-  for (const raw of readFileSync(FILE, "utf-8").split("\n")) {
+  for (const raw of readFileSync(file, "utf-8").split("\n")) {
     const line = raw.trim();
     if (!line || line.startsWith("#")) continue;
     const eq = line.indexOf("=");
@@ -62,8 +93,8 @@ function readCommitted() {
   return out;
 }
 
-function serialize(actual) {
-  const lines = [HEADER];
+function serialize(actual, header) {
+  const lines = [header];
   for (const v of VARIANTS) {
     for (const p of PLATFORMS) {
       lines.push(`${v}/${p}=${actual[`${v}/${p}`]}`);
@@ -77,53 +108,75 @@ function diff(actual, committed) {
   for (const v of VARIANTS) {
     for (const p of PLATFORMS) {
       const key = `${v}/${p}`;
-      const c = committed?.[key];
-      const a = actual[key];
-      if (c !== a) out.push({ key, expected: c, actual: a });
+      if (committed?.[key] !== actual[key]) {
+        out.push({ key, expected: committed?.[key], actual: actual[key] });
+      }
     }
   }
   return out;
 }
 
-const mode = process.argv[2];
-
-if (mode === "check") {
-  const committed = readCommitted();
+function check(label, file, actual, advice) {
+  const committed = readCommitted(file);
   if (!committed) {
     process.stderr.write(
-      `No fingerprints file found at ${FILE}.\n` +
+      `No ${label} file found at ${file}.\n` +
         `Run \`npm run fingerprints:write\` (in app/mobile) to create it.\n`,
     );
-    process.exit(1);
+    return true;
   }
-  const actual = computeAll();
   const mismatches = diff(actual, committed);
   if (mismatches.length === 0) {
-    process.stdout.write("Fingerprints match.\n");
-    process.exit(0);
+    process.stdout.write(`${label}: match.\n`);
+    return false;
   }
-  process.stderr.write(
-    "Fingerprint mismatch — native-affecting change(s) detected:\n\n",
-  );
+  process.stderr.write(`${label}: mismatch.\n`);
   for (const m of mismatches) {
     process.stderr.write(`  ${m.key}:\n`);
     process.stderr.write(`    committed: ${m.expected ?? "(missing)"}\n`);
     process.stderr.write(`    computed:  ${m.actual}\n`);
   }
-  process.stderr.write(
-    "\nIf you intentionally made a native-affecting change, run:\n" +
-      "  (cd app/mobile && npm run fingerprints:write)\n" +
-      "and commit the updated fingerprints file. Merging it to develop will\n" +
-      "trigger a new store build.\n\n" +
-      "If you didn't intend to change native behavior, revisit your change —\n" +
-      "something in it moved the runtimeVersion.\n",
-  );
-  process.exit(1);
-} else if (mode === "write") {
-  const actual = computeAll();
-  writeFileSync(FILE, serialize(actual));
-  process.stdout.write(`Wrote ${FILE}\n`);
-} else {
-  process.stderr.write("Usage: node scripts/fingerprints.mjs <check|write>\n");
-  process.exit(2);
+  process.stderr.write("\n" + advice + "\n");
+  return true;
 }
+
+const RUNTIME_ADVICE =
+  "A native-affecting change moved the runtimeVersion. If intended, run\n" +
+  "  (cd app/mobile && npm run fingerprints:write)\n" +
+  "and commit the updated fingerprints. Merging it to develop will trigger a new\n" +
+  "store build. If you didn't intend to change native behavior, revisit your\n" +
+  "change — something in it moved the runtimeVersion.";
+
+const FULL_ADVICE =
+  "An OTA-safe but native-adjacent input changed (eas.json, the app version, a\n" +
+  "build script, or .gitignore). This needs no new store build, but should be\n" +
+  "reviewed. If the change is intended, run\n" +
+  "  (cd app/mobile && npm run fingerprints:write)\n" +
+  "and commit the updated fingerprints.full to acknowledge it.";
+
+async function main() {
+  const mode = process.argv[2];
+  if (mode === "check") {
+    const { runtime, full } = await computeAll();
+    let failed = false;
+    failed =
+      check("fingerprints (runtime)", RUNTIME_FILE, runtime, RUNTIME_ADVICE) ||
+      failed;
+    failed =
+      check("fingerprints.full (review)", FULL_FILE, full, FULL_ADVICE) ||
+      failed;
+    process.exit(failed ? 1 : 0);
+  } else if (mode === "write") {
+    const { runtime, full } = await computeAll();
+    writeFileSync(RUNTIME_FILE, serialize(runtime, HEADER));
+    writeFileSync(FULL_FILE, serialize(full, HEADER));
+    process.stdout.write(`Wrote ${RUNTIME_FILE}\nWrote ${FULL_FILE}\n`);
+  } else {
+    process.stderr.write(
+      "Usage: node scripts/fingerprints.mjs <check|write>\n",
+    );
+    process.exit(2);
+  }
+}
+
+await main();


### PR DESCRIPTION
Fixes the mobile fingerprint check that's been failing on `develop`, and adds a second fingerprint as a review tripwire.

**What broke.** The runtime fingerprint *is* the Expo `runtimeVersion`, so it should move only when a new native build is genuinely required. But `eas.json` was hashed whole-file, so the feature-flag-URL change to its `EXPO_PUBLIC_*` env (#8990) drifted all six variant fingerprints and broke `test:mobile-fingerprints` on `develop` — even though that env is inlined into the JS bundle and delivered via OTA, needing no rebuild.

**The fix (minimal guard).** Add `eas.json` to `.fingerprintignore` so OTA-safe env/orchestration changes no longer bump the `runtimeVersion` or trigger store builds, and regenerate `fingerprints`. The variants stay distinct because their genuine native differences (bundle id / scheme / name) come from `app.config.js` keyed on `APP_VARIANT`, not from `eas.json`.

**The fix (review tripwire).** To keep visibility of changes the runtime fingerprint now waves through, add a second file, `fingerprints.full`. It hashes the native-adjacent inputs runtime deliberately ignores — `eas.json`, the app `version`, build scripts, `.gitignore` — skipping only the per-commit `extra` section (which bakes a gitHash/version and would otherwise churn every commit). 

- **`fingerprints` mismatch** → the `runtimeVersion` moved; a new store build is due (hard gate, unchanged behavior; `native-build.sh` still reads this file, format unchanged).
- **`fingerprints.full`-only mismatch** → an OTA-safe but native-adjacent input changed; review it and run `npm run fingerprints:write` to acknowledge. No store build needed.

The runtime fingerprint stays byte-identical to what EAS computes (still generated via the `expo-updates` CLI). The full one is computed via `@expo/fingerprint`'s JS API with `eas.json` folded back in (the fingerprinter nulls it because `.fingerprintignore` excludes it). `@expo/fingerprint` is now a direct devDependency (pinned, deduped against the copy `expo` already pulls in).

## Testing
- `cd app/mobile && npm run fingerprints:check` → both `fingerprints (runtime)` and `fingerprints.full (review)` report match.
- Verified the tripwire: editing an `EXPO_PUBLIC_FEATURE_FLAGS_URL` in `eas.json` leaves **runtime matching** (no needless store build) but trips **full** across all variants; reverting clears both.
- Confirmed each variant produces a distinct runtime *and* full hash (variant distinction comes from `app.config.js`, not `eas.json`), and that the full hash is stable across repeated runs at the same commit (the per-commit `extra` section is skipped).
- All fingerprints regenerated and verified locally against the CLI output (no values copied from CI).
- `prettier --write` + `eslint` clean on the changed script.

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._