### PR TITLE
Fix messages queries after backend changes

### DIFF
--- a/app/web/features/messages/AllMessagesTab.tsx
+++ b/app/web/features/messages/AllMessagesTab.tsx
@@ -18,11 +18,7 @@ import { MESSAGES } from "i18n/namespaces";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { GroupChat, ListGroupChatsRes } from "proto/conversations_pb";
-import {
-  HostRequest,
-  HostRequestSortBy,
-  ListHostRequestsRes,
-} from "proto/requests_pb";
+import { HostRequest, ListHostRequestsRes } from "proto/requests_pb";
 import React, { useMemo } from "react";
 import { routeToGroupChat, routeToHostRequest } from "routes";
 import { service } from "service";
@@ -142,6 +138,9 @@ export default function AllMessagesTab() {
     router.push(`/messages/${newFilter}`);
   };
 
+  const shouldFetchChats = filter !== "hosting" && filter !== "surfing";
+  const shouldFetchRequests = filter !== "chats";
+
   // Fetch group chats
   const {
     data: chatsData,
@@ -163,6 +162,7 @@ export default function AllMessagesTab() {
         ? undefined
         : lastPage.lastMessageId,
     initialPageParam: undefined,
+    enabled: shouldFetchChats,
   });
 
   // Fetch host requests
@@ -183,13 +183,13 @@ export default function AllMessagesTab() {
         pageToken: pageToken as string | undefined,
         onlyArchived: showArchived,
         type: requestType,
-        sortBy: HostRequestSortBy.HOST_REQUEST_SORT_BY_LAST_ACTIVE,
       }),
     getNextPageParam: (lastPage) =>
       lastPage.noMore || !lastPage.nextPageToken
         ? undefined
         : lastPage.nextPageToken,
     initialPageParam: undefined,
+    enabled: shouldFetchRequests,
   });
 
   const isLoading = chatsLoading || requestsLoading;
@@ -261,9 +261,6 @@ export default function AllMessagesTab() {
     }
     return allMessages;
   }, [allMessages, filter, currentUser?.userId]);
-
-  const shouldFetchChats = filter !== "hosting" && filter !== "surfing";
-  const shouldFetchRequests = filter !== "chats";
 
   const hasMoreMessages =
     (shouldFetchChats && chatsHasNextPage) ||

--- a/app/web/features/messages/AllMessagesTab.tsx
+++ b/app/web/features/messages/AllMessagesTab.tsx
@@ -18,7 +18,11 @@ import { MESSAGES } from "i18n/namespaces";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { GroupChat, ListGroupChatsRes } from "proto/conversations_pb";
-import { HostRequest, ListHostRequestsRes } from "proto/requests_pb";
+import {
+  HostRequest,
+  HostRequestSortBy,
+  ListHostRequestsRes,
+} from "proto/requests_pb";
 import React, { useMemo } from "react";
 import { routeToGroupChat, routeToHostRequest } from "routes";
 import { service } from "service";
@@ -155,7 +159,9 @@ export default function AllMessagesTab() {
         showArchived,
       ),
     getNextPageParam: (lastPage) =>
-      lastPage.noMore ? undefined : lastPage.lastMessageId,
+      lastPage.noMore || !lastPage.lastMessageId
+        ? undefined
+        : lastPage.lastMessageId,
     initialPageParam: undefined,
   });
 
@@ -177,9 +183,12 @@ export default function AllMessagesTab() {
         pageToken: pageToken as string | undefined,
         onlyArchived: showArchived,
         type: requestType,
+        sortBy: HostRequestSortBy.HOST_REQUEST_SORT_BY_LAST_ACTIVE,
       }),
     getNextPageParam: (lastPage) =>
-      lastPage.noMore ? undefined : lastPage.nextPageToken,
+      lastPage.noMore || !lastPage.nextPageToken
+        ? undefined
+        : lastPage.nextPageToken,
     initialPageParam: undefined,
   });
 
@@ -253,13 +262,22 @@ export default function AllMessagesTab() {
     return allMessages;
   }, [allMessages, filter, currentUser?.userId]);
 
-  const hasMoreMessages = chatsHasNextPage || requestsHasNextPage;
-  const isFetchingMore = chatsIsFetchingNextPage || requestsIsFetchingNextPage;
+  const shouldFetchChats = filter !== "hosting" && filter !== "surfing";
+  const shouldFetchRequests = filter !== "chats";
+
+  const hasMoreMessages =
+    (shouldFetchChats && chatsHasNextPage) ||
+    (shouldFetchRequests && requestsHasNextPage);
+  const isFetchingMore =
+    (shouldFetchChats && chatsIsFetchingNextPage) ||
+    (shouldFetchRequests && requestsIsFetchingNextPage);
 
   const loadMoreMessages = async () => {
     const promises = [];
-    if (chatsHasNextPage) promises.push(chatsFetchNextPage());
-    if (requestsHasNextPage) promises.push(requestsFetchNextPage());
+    if (shouldFetchChats && chatsHasNextPage)
+      promises.push(chatsFetchNextPage());
+    if (shouldFetchRequests && requestsHasNextPage)
+      promises.push(requestsFetchNextPage());
     await Promise.all(promises);
   };
 


### PR DESCRIPTION
I noticed the messages load more was not acting as expected after merging those backend changes. Adjusting the frontend here to fix it up.

<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*
- Go to messages different views and load more messages at the bottom
<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
