### PR TITLE
Backend/auth: Cut redundant DB round-trips in auth interceptor

### DIFF
--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -105,7 +105,9 @@ def _try_get_and_update_user_details(
 
     with session_scope() as session:
         result = session.execute(
-            select(User, UserSession)
+            # compute is_jailed as a column so the two jail checks ride along in this query as EXISTS subqueries,
+            # rather than firing a separate count + relationship lazy-load when we read user.is_jailed below
+            select(User, UserSession, User.is_jailed)
             .select_from(UserSession)
             .join(User, User.id == UserSession.user_id)
             .where(User.is_visible)
@@ -117,7 +119,7 @@ def _try_get_and_update_user_details(
         if not result:
             return None
 
-        user, user_session = result._tuple()
+        user, user_session, is_jailed = result._tuple()
 
         # update user last active time if it's been a while
         if now() - user.last_active > timedelta(minutes=5):
@@ -155,11 +157,11 @@ def _try_get_and_update_user_details(
             )
         )
 
-        session.commit()
-
-        return UserAuthInfo(
+        # build the result before committing: the default expire_on_commit=True would otherwise expire
+        # every attribute, forcing a fresh SELECT to reload user + user_session when we read them here
+        auth_info = UserAuthInfo(
             user_id=user.id,
-            is_jailed=user.is_jailed,
+            is_jailed=is_jailed,
             is_editor=user.is_editor,
             is_superuser=user.is_superuser,
             token_expiry=user_session.expiry,
@@ -168,6 +170,10 @@ def _try_get_and_update_user_details(
             token=token,
             is_api_key=is_api_key,
         )
+
+        session.commit()
+
+        return auth_info
 
 
 def abort_handler[T, R](

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -105,8 +105,6 @@ def _try_get_and_update_user_details(
 
     with session_scope() as session:
         result = session.execute(
-            # compute is_jailed as a column so the two jail checks ride along in this query as EXISTS subqueries,
-            # rather than firing a separate count + relationship lazy-load when we read user.is_jailed below
             select(User, UserSession, User.is_jailed)
             .select_from(UserSession)
             .join(User, User.id == UserSession.user_id)
@@ -157,8 +155,7 @@ def _try_get_and_update_user_details(
             )
         )
 
-        # build the result before committing: the default expire_on_commit=True would otherwise expire
-        # every attribute, forcing a fresh SELECT to reload user + user_session when we read them here
+        # build before committing to avoid expire_on_commit reloading these attributes
         auth_info = UserAuthInfo(
             user_id=user.id,
             is_jailed=is_jailed,

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -485,10 +485,20 @@ class User(Base, kw_only=True):
         # mod_notes come from a backref in ModNote
         return self.mod_notes.where(ModNote.is_pending).count() > 0
 
+    @jailed_pending_mod_notes.inplace.expression
+    @classmethod
+    def _jailed_pending_mod_notes_expression(cls) -> ColumnElement[bool]:
+        return select(ModNote.id).where(ModNote.user_id == cls.id, ModNote.is_pending).exists()
+
     @hybrid_property
     def jailed_pending_activeness_probe(self) -> Any:
         # search for User.pending_activeness_probe
         return self.pending_activeness_probe != None
+
+    @jailed_pending_activeness_probe.inplace.expression
+    @classmethod
+    def _jailed_pending_activeness_probe_expression(cls) -> ColumnElement[bool]:
+        return select(ActivenessProbe.id).where(ActivenessProbe.user_id == cls.id, ActivenessProbe.is_pending).exists()
 
     @hybrid_property
     def is_jailed(self) -> Any:
@@ -498,6 +508,17 @@ class User(Base, kw_only=True):
             | self.is_missing_location
             | self.jailed_pending_mod_notes
             | self.jailed_pending_activeness_probe
+        )
+
+    @is_jailed.inplace.expression
+    @classmethod
+    def _is_jailed_expression(cls) -> ColumnElement[bool]:
+        return (
+            cls.jailed_missing_tos
+            | cls.jailed_missing_community_guidelines
+            | cls.is_missing_location
+            | cls.jailed_pending_mod_notes
+            | cls.jailed_pending_activeness_probe
         )
 
     @hybrid_property


### PR DESCRIPTION

<img width="1477" height="1176" alt="Screenshot 2026-06-05 at 20 00 14" src="https://github.com/user-attachments/assets/2c25527b-05b7-4f28-a065-43eb2e15adf9" />



Reduces the cost of `_try_get_and_update_user_details`, which pyroscope showed at ~28% of backend CPU. Two changes:

1. Build `UserAuthInfo` before `session.commit()` so the default `expire_on_commit` doesn't force a redundant re-SELECT of the user + session rows when constructing the result.
2. Compute `is_jailed` as a column (two correlated `EXISTS` subqueries hitting existing partial indexes) in the main auth query, instead of firing a separate `mod_notes` `COUNT` and an activeness-probe relationship lazy-load on every authenticated request.

The canonical jail definition stays in the model (added `.expression` forms for `jailed_pending_mod_notes`, `jailed_pending_activeness_probe`, and `is_jailed`), so the interceptor and `jail.py` servicer can't drift. Net: ~3 fewer DB round-trips per authenticated request.

## Testing
- `make format` and `make mypy` clean (no new errors in changed files)
- `test_interceptors.py`, `test_jail.py`, `test_auth.py` all pass
- Verified generated SQL uses `ix_mod_notes_unacknowledged` and `ix_activeness_probe_unique_pending_response`

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug (covered by existing interceptor/jail/auth tests)
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history (no schema changes)

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._