### PR TITLE
Backend/logging: Memoize sensitive-field detection in API call logging

### DIFF
--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -3,6 +3,7 @@ from collections.abc import Callable, Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
+from functools import cache
 from os import getpid
 from threading import get_ident
 from time import perf_counter_ns
@@ -12,7 +13,7 @@ from zoneinfo import ZoneInfo
 
 import grpc
 import sentry_sdk
-from google.protobuf.descriptor import ServiceDescriptor
+from google.protobuf.descriptor import Descriptor, ServiceDescriptor
 from google.protobuf.descriptor_pool import DescriptorPool
 from google.protobuf.message import Message
 from opentelemetry import trace
@@ -190,35 +191,71 @@ def unauthenticated_handler[T, R](
     return abort_handler(message, status_code)
 
 
+@cache
+def _descriptor_has_sensitive(descriptor: Descriptor) -> bool:
+    """Whether this message type transitively contains any field marked sensitive."""
+    seen: set[Descriptor] = set()
+    stack = [descriptor]
+    while stack:
+        d = stack.pop()
+        if d in seen:
+            continue
+        seen.add(d)
+        for f in d.fields:
+            if f.GetOptions().Extensions[annotations_pb2.sensitive]:
+                return True
+            if f.message_type is not None:
+                stack.append(f.message_type)
+    return False
+
+
+@cache
+def _sanitize_plan(descriptor: Descriptor) -> tuple[tuple[str, ...], tuple[tuple[str, bool], ...]]:
+    """For a message type, the fields to clear and the (name, is_repeated) subfields worth recursing into."""
+    clear = []
+    recurse = []
+    for f in descriptor.fields:
+        if f.GetOptions().Extensions[annotations_pb2.sensitive]:
+            clear.append(f.name)
+        elif f.message_type is not None and _descriptor_has_sensitive(f.message_type):
+            recurse.append((f.name, f.is_repeated))
+    return tuple(clear), tuple(recurse)
+
+
+def _sanitize_message(message: Message) -> None:
+    clear, recurse = _sanitize_plan(message.DESCRIPTOR)
+    for name in clear:
+        message.ClearField(name)
+    for name, is_repeated in recurse:
+        submessage = getattr(message, name)
+        if not submessage:
+            continue
+        if is_repeated:
+            for msg in submessage:
+                _sanitize_message(msg)
+        else:
+            _sanitize_message(submessage)
+
+
 @overload
 def _sanitized_bytes(proto: Message) -> bytes: ...
 @overload
 def _sanitized_bytes(proto: None) -> None: ...
 def _sanitized_bytes(proto: Message | None) -> bytes | None:
     """
-    Remove fields marked sensitive and return serialized bytes
+    Remove fields marked sensitive and return serialized bytes.
+
+    Sensitivity is static per message type, so the descriptor analysis is cached: messages whose type has no
+    sensitive field anywhere serialize directly without a copy or walk.
     """
     if not proto:
         return None
 
+    if not _descriptor_has_sensitive(proto.DESCRIPTOR):
+        return proto.SerializeToString()
+
     new_proto = deepcopy(proto)
-
-    def _sanitize_message(message: Message) -> None:
-        for name, descriptor in message.DESCRIPTOR.fields_by_name.items():
-            if descriptor.GetOptions().Extensions[annotations_pb2.sensitive]:
-                message.ClearField(name)
-            if descriptor.message_type:
-                submessage = getattr(message, name)
-                if not submessage:
-                    continue
-                if descriptor.is_repeated:
-                    for msg in submessage:
-                        _sanitize_message(msg)
-                else:
-                    _sanitize_message(submessage)
-
     _sanitize_message(new_proto)
-
     return new_proto.SerializeToString()
 
 

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -209,9 +209,15 @@ def _descriptor_has_sensitive(descriptor: Descriptor) -> bool:
     return False
 
 
+@dataclass(frozen=True, slots=True)
+class _SanitizePlan:
+    fields_to_clear: tuple[str, ...]
+    fields_to_recurse: tuple[tuple[str, bool], ...]  # (field name, is_repeated)
+
+
 @cache
-def _sanitize_plan(descriptor: Descriptor) -> tuple[tuple[str, ...], tuple[tuple[str, bool], ...]]:
-    """For a message type, the fields to clear and the (name, is_repeated) subfields worth recursing into."""
+def _sanitize_plan(descriptor: Descriptor) -> _SanitizePlan:
+    """For a message type, the fields to clear and the subfields worth recursing into."""
     clear = []
     recurse = []
     for f in descriptor.fields:
@@ -219,14 +225,14 @@ def _sanitize_plan(descriptor: Descriptor) -> tuple[tuple[str, ...], tuple[tuple
             clear.append(f.name)
         elif f.message_type is not None and _descriptor_has_sensitive(f.message_type):
             recurse.append((f.name, f.is_repeated))
-    return tuple(clear), tuple(recurse)
+    return _SanitizePlan(fields_to_clear=tuple(clear), fields_to_recurse=tuple(recurse))
 
 
 def _sanitize_message(message: Message) -> None:
-    clear, recurse = _sanitize_plan(message.DESCRIPTOR)
-    for name in clear:
+    plan = _sanitize_plan(message.DESCRIPTOR)
+    for name in plan.fields_to_clear:
         message.ClearField(name)
-    for name, is_repeated in recurse:
+    for name, is_repeated in plan.fields_to_recurse:
         submessage = getattr(message, name)
         if not submessage:
             continue

--- a/app/backend/src/tests/test_sanitized_bytes.py
+++ b/app/backend/src/tests/test_sanitized_bytes.py
@@ -36,7 +36,10 @@ class TestSanitizedBytes:
         """Test that sensitive fields are cleared from messages."""
         # AuthReq has a sensitive password field
         proto = auth_pb2.AuthReq(user="testuser", password="supersecret123", remember_device=True)
+        # the plaintext is present in the wire bytes unsanitized, but must not survive sanitization
+        assert b"supersecret123" in proto.SerializeToString()
         result = _sanitized_bytes(proto)
+        assert b"supersecret123" not in result
 
         deserialized = auth_pb2.AuthReq.FromString(result)
 
@@ -54,7 +57,9 @@ class TestSanitizedBytes:
             flow_token="token123",
             account=auth_pb2.SignupAccount(username="nesteduser", password="nestedsecret", city="Boston"),
         )
+        assert b"nestedsecret" in proto.SerializeToString()
         result = _sanitized_bytes(proto)
+        assert b"nestedsecret" not in result
 
         deserialized = auth_pb2.SignupFlowReq.FromString(result)
 
@@ -169,7 +174,9 @@ class TestSanitizedBytes:
             basic=auth_pb2.SignupBasic(name="Test User", email="test@example.com"),
             account=auth_pb2.SignupAccount(username="testuser", password="shouldberemoved"),
         )
+        assert b"shouldberemoved" in proto.SerializeToString()
         result = _sanitized_bytes(proto)
+        assert b"shouldberemoved" not in result
 
         deserialized = auth_pb2.SignupFlowReq.FromString(result)
 
@@ -189,8 +196,10 @@ class TestSanitizedBytes:
         original_user = original.user
         original_password = original.password
 
+        assert b"original_password" in original.SerializeToString()
         # Call _sanitized_bytes
         result = _sanitized_bytes(original)
+        assert b"original_password" not in result
 
         # Original should not be modified
         assert original.user == original_user
@@ -232,7 +241,9 @@ class TestSanitizedBytes:
             email_token="email_verification_token",
         )
 
+        assert b"complexsecret" in proto.SerializeToString()
         result = _sanitized_bytes(proto)
+        assert b"complexsecret" not in result
 
         deserialized = auth_pb2.SignupFlowReq.FromString(result)
 


### PR DESCRIPTION
`_sanitized_bytes` strips fields marked `(sensitive)` before logging every request and response to the `APICall` table. It did this by `deepcopy`-ing the message and recursively walking every field, calling `descriptor.GetOptions().Extensions[...]` per field — on **every** RPC. Profiling (pyroscope) showed this at ~2% of total backend CPU self-time, almost all of it wasted: there are only 6 sensitive fields in the entire API (all password strings in `auth.proto`/`account.proto`), so the vast majority of messages contain nothing to strip.

Sensitivity is a static property of a message type, so this caches the descriptor analysis:

- `_descriptor_has_sensitive(descriptor)` — `@cache`d, cycle-safe reachability walk; whether a type transitively contains any sensitive field.
- `_sanitize_plan(descriptor)` — `@cache`d per-type plan (fields to clear + which subfields are worth recursing into).
- `_sanitized_bytes` — for the ~99% of types with no sensitive field anywhere, now just `SerializeToString()` with **no deepcopy and no walk**. Only password-bearing messages take the copy-and-clear path.

Behavior is unchanged — the same fields are cleared.

## Testing
- `make format` and `make mypy` clean (no errors in `interceptors.py`)
- `test_sanitized_bytes.py` — all 13 existing tests pass
- Strengthened the sensitive-field tests with a byte-level roundtrip assertion: the plaintext secret is present in the unsanitized `SerializeToString()` but absent from the sanitized output (`assert b"<secret>" not in result`), directly verifying the secret never reaches the serialized payload rather than only that the field reads back as its default.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history (no schema changes)

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._