### PR TITLE
mobile: force-build flags and refreshed native fingerprints

### DIFF
--- a/app/mobile/fingerprints.full
+++ b/app/mobile/fingerprints.full
@@ -1,8 +1,8 @@
 # DO NOT EDIT MANUALLY!
 # Regenerate with `cd app/mobile && npm run fingerprints:write`
-devtool/ios=6ddd0451d045a6d2fa7624b4f26a4ab4260fcf20
-devtool/android=ecdf132341aae4873c29ae235f01d28bfcf5f7a1
-staging/ios=29a1f57f466a4e9d0b31f8b3ca311b0fce30db07
-staging/android=d294429eec37beb8f2c759bb5cbd04a60af92d40
-production/ios=b789d1aaff21e9c022ee73911ea10ea8a500190c
-production/android=3d926785d83e26a30e49e7f9fff53ba47af085c3
+devtool/ios=b38ce271ddc6de057a9942546be867fc05be3633
+devtool/android=fe955f89b0a51dda96408db06c3364d2bc7a5382
+staging/ios=bf8bf0583a926b7c08c7366cfbde9f03229cb631
+staging/android=8c10ac8a17da48e42bff469fca424be39d306d24
+production/ios=0e0d7911c4d990059a3872bd60c322ae1f15a36a
+production/android=94dd0c377af826ddd00ef0bf199286300f33729c

--- a/app/mobile/scripts/devtool-build.sh
+++ b/app/mobile/scripts/devtool-build.sh
@@ -45,16 +45,17 @@ if [ -n "${CI_COMMIT_BEFORE_SHA:-}" ] && [ "${CI_COMMIT_BEFORE_SHA}" != "0000000
 fi
 echo "previous $PLATFORM fingerprint: ${PREVIOUS:-<none>}"
 
-if [ "$PREV_FILE_PRESENT" = "false" ]; then
-  echo "fingerprints file wasn't present at the previous develop commit — treating as unchanged (migration)."
+if [ "${FORCE_NATIVE_BUILD_AND_SUBMIT:-}" = "true" ] || [ "${FORCE_NATIVE_DEVTOOL_BUILD_AND_SUBMIT:-}" = "true" ]; then
+  echo "Force flag set — building a new Dev Tool $PLATFORM client regardless of fingerprint."
+elif [ "$PREV_FILE_PRESENT" = "false" ]; then
+  echo "fingerprints file wasn't present at the previous develop commit — treating as unchanged (migration). Set FORCE_NATIVE_BUILD_AND_SUBMIT or FORCE_NATIVE_DEVTOOL_BUILD_AND_SUBMIT to override."
   exit 0
-fi
-if [ "$PREVIOUS" = "$CURRENT" ]; then
+elif [ "$PREVIOUS" = "$CURRENT" ]; then
   echo "Fingerprint unchanged for $PLATFORM — installed Dev Tool client still current, skipping build."
   exit 0
+else
+  echo "Fingerprint changed for $PLATFORM — building a new Dev Tool client."
 fi
-
-echo "Fingerprint changed for $PLATFORM — building a new Dev Tool client."
 
 if [ "$PLATFORM" = "ios" ]; then
   eas build --platform ios --profile devtool --auto-submit --non-interactive

--- a/app/mobile/scripts/fingerprints.mjs
+++ b/app/mobile/scripts/fingerprints.mjs
@@ -141,18 +141,10 @@ function check(label, file, actual, advice) {
 }
 
 const RUNTIME_ADVICE =
-  "A native-affecting change moved the runtimeVersion. If intended, run\n" +
-  "  (cd app/mobile && npm run fingerprints:write)\n" +
-  "and commit the updated fingerprints. Merging it to develop will trigger a new\n" +
-  "store build. If you didn't intend to change native behavior, revisit your\n" +
-  "change — something in it moved the runtimeVersion.";
+  "DO NOT MERGE without full confirmation from the mobile dev leads. A native-affecting change moved the runtimeVersion. IF YOU MERGE THIS WE WILL LOSE OTA FORWARDS COMPATIBILITY.";
 
 const FULL_ADVICE =
-  "An OTA-safe but native-adjacent input changed (eas.json, the app version, a\n" +
-  "build script, or .gitignore). This needs no new store build, but should be\n" +
-  "reviewed. If the change is intended, run\n" +
-  "  (cd app/mobile && npm run fingerprints:write)\n" +
-  "and commit the updated fingerprints.full to acknowledge it.";
+  "The full fingerprints changed. Please consult the mobile dev leads to confirm this is a safe change to land.";
 
 async function main() {
   const mode = process.argv[2];

--- a/app/mobile/scripts/native-build.sh
+++ b/app/mobile/scripts/native-build.sh
@@ -57,12 +57,14 @@ echo "previous $VARIANT/$PLATFORM fingerprint: ${PREVIOUS:-<none>}"
 
 echo "EAS_FINGERPRINT=$CURRENT" > "$DOTENV"
 
-# FORCE_NATIVE_BUILD_AND_SUBMIT cuts a fresh build even when nothing native
-# changed, so the store binary doesn't go stale behind OTA.
-if [ "${FORCE_NATIVE_BUILD_AND_SUBMIT:-}" = "true" ]; then
-  echo "FORCE_NATIVE_BUILD_AND_SUBMIT set — building a new $PLATFORM $VARIANT app regardless of fingerprint."
+case "$VARIANT" in
+  production) VARIANT_FORCE="${FORCE_NATIVE_PROD_BUILD_AND_SUBMIT:-}" ;;
+  staging) VARIANT_FORCE="${FORCE_NATIVE_STAGING_BUILD_AND_SUBMIT:-}" ;;
+esac
+if [ "${FORCE_NATIVE_BUILD_AND_SUBMIT:-}" = "true" ] || [ "$VARIANT_FORCE" = "true" ]; then
+  echo "Force flag set — building a new $PLATFORM $VARIANT app regardless of fingerprint."
 elif [ "$PREV_FILE_PRESENT" = "false" ]; then
-  echo "fingerprints file wasn't present at the previous develop commit — treating as unchanged (migration). Use FORCE_NATIVE_BUILD_AND_SUBMIT to override."
+  echo "fingerprints file wasn't present at the previous develop commit — treating as unchanged (migration). Set FORCE_NATIVE_BUILD_AND_SUBMIT or the per-variant force flag to override."
   echo "EAS_BUILD_ID=" >> "$DOTENV"
   exit 0
 elif [ "$PREVIOUS" = "$CURRENT" ]; then


### PR DESCRIPTION
Adds escape-hatch force flags to the mobile native build scripts so a fresh EAS build can be cut regardless of the fingerprint diff:

- **`FORCE_NATIVE_BUILD_AND_SUBMIT`** — forces all three variants (prod, staging, devtool).
- **`FORCE_NATIVE_PROD_BUILD_AND_SUBMIT`** / **`FORCE_NATIVE_STAGING_BUILD_AND_SUBMIT`** (`native-build.sh`) and **`FORCE_NATIVE_DEVTOOL_BUILD_AND_SUBMIT`** (`devtool-build.sh`) — force a single variant.

Each flag bypasses both the "fingerprint unchanged" skip and the "fingerprints file absent at the previous commit (migration)" skip. The migration skip is the path that silently drops a build when GitLab hands the pipeline no usable `CI_COMMIT_BEFORE_SHA` (common on mirror pushes) — these flags are the manual recovery for that. `native-submit.sh` needs no change: it submits whenever `native-build.sh` emits an `EAS_BUILD_ID`, so a forced build flows straight into submission.

Also regenerates `fingerprints.full` to the CI-computed values (the review tripwire was failing on `develop`) and tightens the `fingerprints.mjs` advice messages.

## Testing
- `bash -n` on both build scripts.
- Verified the force-flag matrix in isolation: the global flag forces any variant, and each per-variant flag forces only its own variant.

The flags are read from the environment, so they work as GitLab "Run pipeline" variables without any `.gitlab-ci.yml` change.

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._