### PR TITLE
Web: Fix formatting to unbreak CI

### DIFF
--- a/app/web/components/Bar/BarWithHelp.tsx
+++ b/app/web/components/Bar/BarWithHelp.tsx
@@ -1,11 +1,11 @@
 import { IconButton, styled, Tooltip } from "@mui/material";
 import { HelpIcon } from "components/Icons";
 import React from "react";
-import { theme } from "theme";
 import { useTranslation } from "react-i18next";
+import { theme } from "theme";
 
-import ScoreBar from "./ScoreBar";
 import { GLOBAL } from "../../i18n/namespaces";
+import ScoreBar from "./ScoreBar";
 
 interface BarWithHelpProps {
   value: number;

--- a/app/web/components/Dialog.tsx
+++ b/app/web/components/Dialog.tsx
@@ -13,8 +13,9 @@ import {
 } from "@mui/material";
 import IconButton from "components/IconButton";
 import React from "react";
-import { theme } from "theme";
 import { useTranslation } from "react-i18next";
+import { theme } from "theme";
+
 import { GLOBAL } from "../i18n/namespaces";
 
 export interface AccessibleDialogProps extends Omit<DialogProps, "className"> {

--- a/app/web/features/communities/CommunityPage/CommunityPageSubHeader.tsx
+++ b/app/web/features/communities/CommunityPage/CommunityPageSubHeader.tsx
@@ -49,7 +49,6 @@ export default function CommunityPageSubHeader({
         <StyledBreadcrumbs
           aria-label={t("communities:community_breadcrumb_a11y")}
         >
-
           {community.parentsList
             .map((parent) => parent.community)
             .filter(

--- a/app/web/features/communities/GroupPage.tsx
+++ b/app/web/features/communities/GroupPage.tsx
@@ -140,9 +140,7 @@ export default function GroupPage({
         <>
           <HtmlMeta title={`${group.name} Group Page`} />
           <PageTitle>{group.name} Group Page</PageTitle>
-          <Breadcrumbs
-            aria-label={t("communities:community_breadcrumb_a11y")}
-          >
+          <Breadcrumbs aria-label={t("communities:community_breadcrumb_a11y")}>
             {group.parentsList
               .filter((parent) => !!parent.community || !!parent.group)
               .map((parent) => {

--- a/app/web/features/connections/friends/FriendRequestsSent.tsx
+++ b/app/web/features/connections/friends/FriendRequestsSent.tsx
@@ -28,7 +28,7 @@ function CancelFriendRequestAction({
 }: CancelFriendRequestActionProps) {
   const { cancelFriendRequest, isPending, isSuccess, reset } =
     useCancelFriendRequest();
-    const { t } = useTranslation(CONNECTIONS);
+  const { t } = useTranslation(CONNECTIONS);
 
   return state === FriendRequest.FriendRequestStatus.PENDING ? (
     <Box>

--- a/app/web/features/dashboard/ReminderCarousel.tsx
+++ b/app/web/features/dashboard/ReminderCarousel.tsx
@@ -8,16 +8,16 @@ import Alert from "components/Alert";
 import FadingScrollTrack from "components/FadingScrollTrack";
 import IconButton from "components/IconButton";
 import { RpcError } from "grpc-web";
+import { useTranslation } from "next-i18next";
 import { usePersistedState } from "platform/usePersistedState";
 import { GetRemindersRes, Reminder } from "proto/account_pb";
 import { useEffect, useRef, useState } from "react";
 import { service } from "service";
-import { useTranslation } from "next-i18next";
 
+import { DASHBOARD } from "../../i18n/namespaces";
 import { theme } from "../../theme";
 import { remindersKey } from "../queryKeys";
 import ReminderItem from "./ReminderItem";
-import { DASHBOARD } from "../../i18n/namespaces";
 
 const CARD_WIDTH_DESKTOP = 280;
 const CARD_WIDTH_MOBILE = 200;

--- a/app/web/features/markdown/MarkdownPage.tsx
+++ b/app/web/features/markdown/MarkdownPage.tsx
@@ -11,6 +11,7 @@ import { Trans, useTranslation } from "i18n";
 import markdown from "markdown-it";
 import Head from "next/head";
 import { theme } from "theme";
+
 import { COMMUNITIES } from "../../i18n/namespaces";
 
 const mkd = new markdown();

--- a/app/web/features/profile/view/leaveReference/formSteps/PrivateFeedback.tsx
+++ b/app/web/features/profile/view/leaveReference/formSteps/PrivateFeedback.tsx
@@ -154,7 +154,12 @@ export default function PrivateFeedback({
           )}
           <Controller
             render={({ field }) => (
-              <RadioGroup {...field} aria-label={t("profile:leave_reference.safety_rating_selector_a11y")}>
+              <RadioGroup
+                {...field}
+                aria-label={t(
+                  "profile:leave_reference.safety_rating_selector_a11y",
+                )}
+              >
                 <FormControlLabel
                   value="true"
                   control={<Radio />}

--- a/app/web/features/translate/LanguagePickerSelect.tsx
+++ b/app/web/features/translate/LanguagePickerSelect.tsx
@@ -133,9 +133,7 @@ export default function LanguagePickerSelect({
 
     if (flagCode === "CAT") {
       return (
-        <CatalanFlagIcon
-          sx={{ width: 25, height: 18.75, ...commonStyles }}
-        />
+        <CatalanFlagIcon sx={{ width: 25, height: 18.75, ...commonStyles }} />
       );
     }
 

--- a/app/web/features/translate/TranslationProgress.tsx
+++ b/app/web/features/translate/TranslationProgress.tsx
@@ -142,7 +142,6 @@ export default function TranslationProgress() {
   const { data: languages, isLoading, error } = useWeblateStats();
 
   const renderFlag = (flagCode: string, percent: number) => {
-
     if (flagCode === "CAT") {
       return <CatalanFlag percent={percent} />;
     }

--- a/app/web/i18n/resources.ts
+++ b/app/web/i18n/resources.ts
@@ -23,7 +23,7 @@ const resources = {
   notifications,
   profile,
   search,
-  global
+  global,
 } as const;
 
 export default resources;


### PR DESCRIPTION
Runs the web frontend formatter (prettier/eslint) across the codebase to fix CI, which was failing due to formatting violations. All changes are purely cosmetic — import ordering, line-wrapping, trailing commas, and stray blank lines — with no behavioral changes.

## Testing
- Ran `yarn format` in `app/web`; the 11 changed files are the formatter's output.
- Verified the diff contains only formatting changes (no logic changes).
- Backend (`make format`) and mobile (`prettier --write .`) were already clean — no changes needed.

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._