### PR TITLE
Web: Add empty alt to language flag img to fix lint warning

### DIFF
--- a/app/web/features/translate/LanguagePickerSelect.tsx
+++ b/app/web/features/translate/LanguagePickerSelect.tsx
@@ -140,6 +140,7 @@ export default function LanguagePickerSelect({
     return (
       <img
         src={`https://cdn.couchers.org/img/language-icons/${flagCode}.svg`}
+        alt=""
         style={{ width: 25, ...commonStyles }}
       />
     );


### PR DESCRIPTION
Adds an empty `alt=""` to the decorative language flag `<img>` in `LanguagePickerSelect`, fixing a `jsx-a11y/alt-text` lint warning. The flag is purely decorative (it sits beside the language name), so an empty alt is the correct accessible treatment.

## Testing
Ran `yarn lint` — passes with no warnings or errors.

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._