### PR TITLE
Backend/i18n: Support localizing userless emails

### DIFF
--- a/app/backend/src/couchers/email/queuing.py
+++ b/app/backend/src/couchers/email/queuing.py
@@ -5,6 +5,7 @@ import yaml
 from sqlalchemy.orm.session import Session
 
 from couchers.config import config
+from couchers.context import CouchersContext
 from couchers.email.emails import EmailBase
 from couchers.email.rendering import EmailFooter, render_html_body, render_plaintext_body
 from couchers.i18n import LocalizationContext
@@ -37,15 +38,18 @@ def queue_email(session: Session, payload: jobs_pb2.SendEmailPayload) -> None:
     _queue_email(session, payload)
 
 
-def queue_userless_email(session: Session, recipient: str, email: EmailBase, source_data_header: str) -> None:
+def queue_userless_email(
+    context: CouchersContext, session: Session, recipient: str, email: EmailBase, source_data_header: str
+) -> None:
     """
     This is a simplified version of couchers.notifications.background._send_email_notification
 
     It's for the few security emails where we don't have a user to email but send directly to an email address.
     """
 
-    # Not yet localizable
-    loc_context = LocalizationContext.en_utc()
+    loc_context = context.localization
+    if not context.get_boolean_value("notification_translations_enabled", default=False):
+        loc_context = LocalizationContext(locale="en", timezone=loc_context.timezone)
 
     subject = email.get_subject_line(loc_context)
     preview = email.get_preview_line(loc_context)

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -259,7 +259,7 @@ class Account(account_pb2_grpc.AccountServicer):
         user.new_email_token_created = now()
         user.new_email_token_expiry = now() + timedelta(hours=2)
 
-        send_email_changed_confirmation_to_new_email(session, user)
+        send_email_changed_confirmation_to_new_email(context, session, user)
 
         # will still go into old email
         notify(

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -215,7 +215,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                     select(SignupFlow).where(SignupFlow.email == request.basic.email)
                 ).scalar_one_or_none()
                 if existing_flow:
-                    send_signup_email(session, existing_flow)
+                    send_signup_email(context, session, existing_flow)
                     session.commit()
                     context.abort_with_error_code(
                         grpc.StatusCode.FAILED_PRECONDITION, "signup_flow_email_started_signup"
@@ -330,7 +330,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
             # send verification email if needed
             if not flow.email_sent or request.resend_verification_email:
-                send_signup_email(session, flow)
+                send_signup_email(context, session, flow)
 
             session.flush()
 
@@ -472,7 +472,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 select(SignupFlow).where(username_or_email(request.user, table=SignupFlow))
             ).scalar_one_or_none()
             if signup_flow:
-                send_signup_email(session, signup_flow)
+                send_signup_email(context, session, signup_flow)
                 session.commit()
                 context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "signup_flow_email_started_signup")
             logger.debug("Didn't find user")

--- a/app/backend/src/couchers/tasks.py
+++ b/app/backend/src/couchers/tasks.py
@@ -9,6 +9,7 @@ import couchers.email.emails as emails
 from couchers import urls
 from couchers.config import config
 from couchers.constants import SIGNUP_EMAIL_TOKEN_VALIDITY
+from couchers.context import CouchersContext
 from couchers.crypto import urlsafe_secure_token
 from couchers.db import session_scope
 from couchers.email.queuing import queue_system_email, queue_userless_email
@@ -34,7 +35,7 @@ from couchers.utils import now
 logger = logging.getLogger(__name__)
 
 
-def send_signup_email(session: Session, flow: SignupFlow) -> None:
+def send_signup_email(context: CouchersContext, session: Session, flow: SignupFlow) -> None:
     logger.info(f"Sending signup email to {flow.email=}:")
 
     # whether we've sent an email at all yet
@@ -61,10 +62,16 @@ def send_signup_email(session: Session, flow: SignupFlow) -> None:
     else:
         email = emails.SignupVerifyEmail(user_name=flow.name, verify_url=signup_link)
 
-    queue_userless_email(session, flow.email, email, source_data_header=f"signup; initial={not email_sent_before}")
+    queue_userless_email(
+        context,
+        session,
+        flow.email,
+        email,
+        source_data_header=f"signup; initial={not email_sent_before}",
+    )
 
 
-def send_email_changed_confirmation_to_new_email(session: Session, user: User) -> None:
+def send_email_changed_confirmation_to_new_email(context: CouchersContext, session: Session, user: User) -> None:
     """
     Send an email to the user's new email address requesting confirmation of email change
     """
@@ -84,7 +91,7 @@ def send_email_changed_confirmation_to_new_email(session: Session, user: User) -
         confirm_url=urls.change_email_link(confirmation_token=user.new_email_token),
     )
 
-    queue_userless_email(session, user.new_email, email, source_data_header="email_changed_confirmation")
+    queue_userless_email(context, session, user.new_email, email, source_data_header="email_changed_confirmation")
 
 
 def send_content_report_email(session: Session, content_report: ContentReport) -> None:

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -5,11 +5,12 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from sqlalchemy import func, select, update
 
-import couchers.email
 import couchers.jobs.handlers
 from couchers.config import config
+from couchers.context import make_background_user_context, make_logged_out_context
 from couchers.crypto import b64decode, random_hex, urlsafe_secure_token
 from couchers.db import session_scope
+from couchers.i18n import LocalizationContext
 from couchers.models import (
     ContentReport,
     Email,
@@ -55,7 +56,8 @@ def test_signup_verification_email(db, email_collector: EmailCollector):
     flow = SignupFlow(name="Frodo", email=request_email, flow_token="")
 
     with session_scope() as session:
-        send_signup_email(session, flow)
+        context = make_logged_out_context(LocalizationContext.en_utc())
+        send_signup_email(context, session, flow)
 
     email = email_collector.pop_for_recipient(request_email, last=True)
     assert email.recipient == request_email
@@ -224,8 +226,10 @@ def test_email_changed_confirmation_sent_to_new_email(db, email_collector: Email
     user, user_token = generate_user()
     user.new_email = f"{random_hex(12)}@couchers.org.invalid"
     user.new_email_token = confirmation_token
+
     with session_scope() as session:
-        send_email_changed_confirmation_to_new_email(session, user)
+        user_context = make_background_user_context(user.id)
+        send_email_changed_confirmation_to_new_email(user_context, session, user)
 
     email = email_collector.pop_for_recipient(user.new_email, last=True)
     assert "new email" in email.subject


### PR DESCRIPTION
So-called "userless emails" are when we're not sending to the info stored in a `User` object. They too can be localized since we do have the localization context via the couchers context (which also provides feature flags).

Fixes #7734

## Testing
Left to CI

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
