### PR TITLE
Frontend/friend reqs: "decline" -> "dismiss"

### DIFF
--- a/app/web/features/connections/friends/FriendRequestsReceived.tsx
+++ b/app/web/features/connections/friends/FriendRequestsReceived.tsx
@@ -35,7 +35,7 @@ function RespondToFriendRequestAction({
   return (
     <Stack direction="row" spacing={1}>
       <Button
-        aria-label={t("connections:decline")}
+        aria-label={t("connections:friend_requests_dismiss_button")}
         onClick={() => {
           reset();
           respondToFriendRequest({
@@ -47,7 +47,7 @@ function RespondToFriendRequestAction({
         variant="outlined"
         loading={isLoading}
       >
-        {t("connections:decline")}
+        {t("connections:friend_requests_dismiss_button")}
       </Button>
       <Button
         aria-label={t("connections:accept")}

--- a/app/web/features/connections/locales/en.json
+++ b/app/web/features/connections/locales/en.json
@@ -6,7 +6,7 @@
     "confirm": "Yes, I know them. Send request!"
   },
   "accept": "Accept",
-  "decline": "Decline",
+  "friend_requests_dismiss_button": "Dismiss",
   "blocked_list_title": "Blocked users",
   "block_user": "Block user",
   "block_user_confirmation_dialog": {

--- a/app/web/features/profile/actions/PendingFriendReqButton.tsx
+++ b/app/web/features/profile/actions/PendingFriendReqButton.tsx
@@ -80,7 +80,7 @@ function PendingFriendReqButton({
             </MenuItem>
             <MenuItem onClick={handleClick("declined")}>
               <CloseIcon />
-              {t("profile:actions.decline_friend_label")}
+              {t("profile:actions.dismiss_friend_request_menuitem")}
             </MenuItem>
           </Menu>
         </>

--- a/app/web/features/profile/locales/en.json
+++ b/app/web/features/profile/locales/en.json
@@ -6,7 +6,7 @@
     "back_to_dashboard": "Back to dashboard",
     "message_label": "Message",
     "accept_friend_label": "Accept",
-    "decline_friend_label": "Decline",
+    "dismiss_friend_request_menuitem": "Dismiss",
     "request": "Request"
   },
   "heading": {
@@ -256,8 +256,6 @@
     "hosted": "Hosted",
     "surfed": "Guest"
   },
-  "accept_friend_label": "Accept friend request",
-  "decline_friend_label": "Decline friend request",
   "no_references": "No references of this kind yet!",
   "references_filter_a11y_label": "Show references: ",
   "see_more_references": "See more references",


### PR DESCRIPTION
Following a conversation about whether the befriender would be notified of a "decline" response, it seems like "dismiss" is less ambiguous.

My new string keys are inconsistent, but context is more important than consistency for translators, and at some point I'll lock weblate and do a big rename of our string keys to improve them.

## Testing
<img width="1222" height="543" alt="image" src="https://github.com/user-attachments/assets/a0e98f8c-4d58-49f0-9a3f-7f10a863d144" />

<img width="597" height="768" alt="image" src="https://github.com/user-attachments/assets/5e660e00-6afc-4234-82c2-9097be933df5" />

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
