### PR TITLE
Fix notification serialization for non-visible actors

### DIFF
--- a/app/backend/src/couchers/context.py
+++ b/app/backend/src/couchers/context.py
@@ -72,6 +72,7 @@ class CouchersContext:
         token: str | None,
         localization: LocalizationContext,
         sofa: str | None = None,
+        serialize_shadowed: bool,
     ):
         """Don't ever construct directly, always use the `make_*_context_` functions!"""
         self._grpc_context = grpc_context
@@ -80,6 +81,7 @@ class CouchersContext:
         self.__token = token
         self.__localization = localization
         self._sofa = sofa
+        self.__serialize_shadowed = serialize_shadowed
         self.__is_interactive = is_interactive
         self.__logged_in = self._user_id is not None
         self.__cookies: list[str] = []
@@ -192,6 +194,10 @@ class CouchersContext:
     def localization(self) -> LocalizationContext:
         return self.__localization
 
+    @property
+    def serialize_shadowed(self) -> bool:
+        return self.__serialize_shadowed
+
     # Feature-flag evaluation methods mirror the OpenFeature evaluation API, evaluating for this
     # context's user. The gating lives in experimentation; we just pass our cached per-request
     # evaluator. The in-code default is honored even for flags not yet set up in GrowthBook.
@@ -233,6 +239,7 @@ def make_interactive_context(
         token=token,
         localization=localization,
         sofa=sofa,
+        serialize_shadowed=False,
     )
 
 
@@ -244,6 +251,7 @@ def make_one_off_interactive_user_context(couchers_context: CouchersContext, use
         is_api_key=None,
         token=None,
         localization=couchers_context.localization,
+        serialize_shadowed=False,
     )
 
 
@@ -255,6 +263,7 @@ def make_media_context(grpc_context: grpc.ServicerContext) -> CouchersContext:
         grpc_context=grpc_context,
         token=None,
         localization=LocalizationContext.en_utc(),
+        serialize_shadowed=False,
     )
 
 
@@ -266,6 +275,19 @@ def make_background_user_context(user_id: int, localization: LocalizationContext
         grpc_context=None,
         token=None,
         localization=localization or LocalizationContext.en_utc(),
+        serialize_shadowed=False,
+    )
+
+
+def make_notification_user_context(user_id: int, localization: LocalizationContext | None = None) -> CouchersContext:
+    return CouchersContext(
+        is_interactive=False,
+        user_id=user_id,
+        is_api_key=None,
+        grpc_context=None,
+        token=None,
+        localization=localization or LocalizationContext.en_utc(),
+        serialize_shadowed=True,
     )
 
 
@@ -277,4 +299,5 @@ def make_logged_out_context(localization: LocalizationContext) -> CouchersContex
         grpc_context=None,
         token=None,
         localization=localization,
+        serialize_shadowed=False,
     )

--- a/app/backend/src/couchers/helpers/badges.py
+++ b/app/backend/src/couchers/helpers/badges.py
@@ -2,7 +2,7 @@ from sqlalchemy import exists, select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import delete
 
-from couchers.context import make_background_user_context
+from couchers.context import make_notification_user_context
 from couchers.models import UserBadge
 from couchers.models.notifications import NotificationTopicAction
 from couchers.notifications.notify import notify
@@ -20,7 +20,7 @@ def user_add_badge(session: Session, user_id: int, badge_id: str, do_notify: boo
     session.add(UserBadge(user_id=user_id, badge_id=badge_id))
     session.flush()
     if do_notify:
-        context = make_background_user_context(user_id=user_id)
+        context = make_notification_user_context(user_id=user_id)
         notify(
             session,
             user_id=user_id,
@@ -39,7 +39,7 @@ def user_remove_badge(session: Session, user_id: int, badge_id: str) -> None:
     badge = get_badge_dict()[badge_id]
     session.execute(delete(UserBadge).where(UserBadge.user_id == user_id, UserBadge.badge_id == badge.id))
     session.flush()
-    context = make_background_user_context(user_id=user_id)
+    context = make_notification_user_context(user_id=user_id)
     notify(
         session,
         user_id=user_id,

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -39,7 +39,7 @@ from couchers.constants import (
     HOST_REQUEST_MAX_REMINDERS,
     HOST_REQUEST_REMINDER_INTERVAL,
 )
-from couchers.context import make_background_user_context
+from couchers.context import make_background_user_context, make_notification_user_context
 from couchers.crypto import (
     USER_LOCATION_RANDOMIZATION_NAME,
     asym_encrypt,
@@ -202,7 +202,7 @@ def send_message_notifications(payload: empty_pb2.Empty) -> None:
         )
 
         for user in users:
-            context = make_background_user_context(user_id=user.id)
+            context = make_notification_user_context(user_id=user.id)
             # now actually grab all the group chats, not just less than 5 min old
             subquery = (
                 where_users_column_visible(
@@ -307,7 +307,7 @@ def send_request_notifications(payload: empty_pb2.Empty) -> None:
         candidate_user_ids = session.execute(union_all(surfer_ids, host_ids)).scalars().unique().all()
 
         for user_id in candidate_user_ids:
-            context = make_background_user_context(user_id=user_id)
+            context = make_notification_user_context(user_id=user_id)
 
             # requests where this user is surfing
             surfing_reqs = session.execute(
@@ -537,7 +537,7 @@ def send_reference_reminders(payload: empty_pb2.Empty) -> None:
             for surfed, host_request, user, other_user in reference_reminders:
                 # visibility and blocking already checked in sql
                 assert user.is_visible
-                context = make_background_user_context(user_id=user.id)
+                context = make_notification_user_context(user_id=user.id)
                 topic_action = (
                     NotificationTopicAction.reference__reminder_surfed
                     if surfed
@@ -592,7 +592,7 @@ def send_host_request_reminders(payload: empty_pb2.Empty) -> None:
             host_request.recipient_sent_request_reminders += 1
             host_request.last_sent_request_reminder_time = now()
 
-            context = make_background_user_context(user_id=host_request.recipient_user_id)
+            context = make_notification_user_context(user_id=host_request.recipient_user_id)
             notify(
                 session,
                 user_id=host_request.recipient_user_id,
@@ -1076,7 +1076,7 @@ def send_activeness_probes(payload: empty_pb2.Empty) -> None:
 
             for probe in probes:
                 probe.notifications_sent = probe_number_minus_1 + 1
-                context = make_background_user_context(user_id=probe.user.id)
+                context = make_notification_user_context(user_id=probe.user.id)
                 notify(
                     session,
                     user_id=probe.user.id,
@@ -1174,7 +1174,7 @@ def send_event_reminders(payload: empty_pb2.Empty) -> None:
             ).all()
 
             for user, attendee in results:
-                context = make_background_user_context(user_id=user.id)
+                context = make_notification_user_context(user_id=user.id)
 
                 notify(
                     session,

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -13,7 +13,7 @@ from sqlalchemy.sql import and_, delete, exists, func, intersect, or_, union
 from couchers import urls
 from couchers.config import config
 from couchers.constants import GHOST_USERNAME
-from couchers.context import CouchersContext, make_background_user_context
+from couchers.context import CouchersContext, make_notification_user_context
 from couchers.crypto import b64encode, generate_hash_signature, random_hex
 from couchers.event_log import log_event
 from couchers.helpers.completed_profile import has_completed_profile
@@ -801,7 +801,7 @@ class API(api_pb2_grpc.APIServicer):
                 other_user=user_model_to_pb(
                     friend_relationship.from_user,
                     session,
-                    make_background_user_context(user_id=friend_relationship.to_user_id),
+                    make_notification_user_context(user_id=friend_relationship.to_user_id),
                 ),
             ),
             moderation_state_id=moderation_state.id,
@@ -890,7 +890,7 @@ class API(api_pb2_grpc.APIServicer):
                     other_user=user_model_to_pb(
                         friend_request.to_user,
                         session,
-                        make_background_user_context(user_id=friend_request.from_user_id),
+                        make_notification_user_context(user_id=friend_request.from_user_id),
                     ),
                 ),
             )
@@ -1044,7 +1044,9 @@ def user_model_to_pb(
     # note that this function is sometimes called by a logged out user, in which case context comes from make_logged_out_context
 
     viewer_user_id = context.user_id if context.is_logged_in() else None
-    if not is_admin_see_ghosts and is_not_visible(session, viewer_user_id, db_user.id):
+    if not is_admin_see_ghosts and is_not_visible(
+        session, viewer_user_id, db_user.id, ignore_shadow=context.serialize_shadowed
+    ):
         # User is not visible (deleted, banned, or blocked)
         if is_get_user_return_ghosts:
             # Return an anonymized "ghost" user profile
@@ -1245,7 +1247,9 @@ def lite_user_to_pb(
     is_admin_see_ghosts: bool = False,
     is_get_user_return_ghosts: bool = False,
 ) -> api_pb2.LiteUser:
-    if not is_admin_see_ghosts and is_not_visible(session, context.user_id, lite_user.id):
+    if not is_admin_see_ghosts and is_not_visible(
+        session, context.user_id, lite_user.id, ignore_shadow=context.serialize_shadowed
+    ):
         # User is not visible (deleted, banned, or blocked)
         if is_get_user_return_ghosts:
             # Return an anonymized "ghost" user profile

--- a/app/backend/src/couchers/servicers/blocking.py
+++ b/app/backend/src/couchers/servicers/blocking.py
@@ -1,6 +1,6 @@
 import grpc
 from google.protobuf import empty_pb2
-from sqlalchemy import exists, select
+from sqlalchemy import exists, false, select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import not_, or_, union
 
@@ -11,14 +11,18 @@ from couchers.models.uploads import get_avatar_photo_subquery
 from couchers.proto import blocking_pb2, blocking_pb2_grpc
 
 
-def is_not_visible(session: Session, user1_id: int | None, user2_id: int | None) -> bool:
+def is_not_visible(
+    session: Session, user1_id: int | None, user2_id: int | None, *, ignore_shadow: bool = False
+) -> bool:
     """
     Check if users are not visible to each other (due to block or because either account is deleted/banned/shadowed).
     """
     hidden_users = select(User.id).where(or_(User.id == user1_id, User.id == user2_id)).where(not_(User.is_visible))
-    shadowed_target = select(User.id).where(User.id == user2_id).where(User.shadowed_at.is_not(None))
-    if user1_id is not None:
-        shadowed_target = shadowed_target.where(User.id != user1_id)
+    shadowed_target = select(User.id).where(false())
+    if not ignore_shadow:
+        shadowed_target = select(User.id).where(User.id == user2_id).where(User.shadowed_at.is_not(None))
+        if user1_id is not None:
+            shadowed_target = shadowed_target.where(User.id != user1_id)
     # if either user_id is empty, just check if either user is hidden (as they can't block each other)
     if not user1_id or not user2_id:
         return (

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session, contains_eager
 from sqlalchemy.sql import func, not_, or_
 
 from couchers.constants import DATETIME_INFINITY, DATETIME_MINUS_INFINITY
-from couchers.context import CouchersContext, make_background_user_context
+from couchers.context import CouchersContext, make_background_user_context, make_notification_user_context
 from couchers.db import session_scope
 from couchers.event_log import log_event
 from couchers.helpers.completed_profile import has_completed_profile
@@ -206,7 +206,7 @@ def generate_message_notifications(payload: jobs_pb2.GenerateMessageNotification
                     author=user_model_to_pb(
                         message.author,
                         session,
-                        make_background_user_context(user_id=user_id),
+                        make_notification_user_context(user_id=user_id),
                     ),
                     text=message.text,
                     group_chat_id=message.conversation_id,

--- a/app/backend/src/couchers/servicers/discussions.py
+++ b/app/backend/src/couchers/servicers/discussions.py
@@ -4,7 +4,7 @@ import grpc
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from couchers.context import CouchersContext, make_background_user_context
+from couchers.context import CouchersContext, make_notification_user_context
 from couchers.db import can_moderate_node, session_scope
 from couchers.event_log import log_event
 from couchers.jobs.enqueue import queue_job
@@ -62,7 +62,7 @@ def generate_create_discussion_notifications(payload: jobs_pb2.GenerateCreateDis
         for user in list(cluster.members.where(User.is_visible)):
             if is_not_visible(session, user.id, discussion.creator_user_id):
                 continue
-            context = make_background_user_context(user_id=user.id)
+            context = make_notification_user_context(user_id=user.id)
             notify(
                 session,
                 user_id=user.id,

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -9,7 +9,7 @@ from sqlalchemy import Select, select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import and_, func, or_, update
 
-from couchers.context import CouchersContext, make_background_user_context
+from couchers.context import CouchersContext, make_notification_user_context
 from couchers.db import can_moderate_node, get_parent_node_at_location, session_scope
 from couchers.event_log import log_event
 from couchers.helpers.completed_profile import has_completed_profile
@@ -294,7 +294,7 @@ def generate_event_create_notifications(payload: jobs_pb2.GenerateEventCreateNot
         for user in users:
             if is_not_visible(session, user.id, creator.id):
                 continue
-            context = make_background_user_context(user_id=user.id)
+            context = make_notification_user_context(user_id=user.id)
             topic_action = (
                 NotificationTopicAction.event__create_approved
                 if payload.approved
@@ -327,7 +327,7 @@ def generate_event_update_notifications(payload: jobs_pb2.GenerateEventUpdateNot
         for user_id in set(subscribed_user_ids + attending_user_ids):
             if is_not_visible(session, user_id, updating_user.id):
                 continue
-            context = make_background_user_context(user_id=user_id)
+            context = make_notification_user_context(user_id=user_id)
             notify(
                 session,
                 user_id=user_id,
@@ -354,7 +354,7 @@ def generate_event_cancel_notifications(payload: jobs_pb2.GenerateEventCancelNot
         for user_id in set(subscribed_user_ids + attending_user_ids):
             if is_not_visible(session, user_id, cancelling_user.id):
                 continue
-            context = make_background_user_context(user_id=user_id)
+            context = make_notification_user_context(user_id=user_id)
             notify(
                 session,
                 user_id=user_id,
@@ -378,7 +378,7 @@ def generate_event_delete_notifications(payload: jobs_pb2.GenerateEventDeleteNot
         attending_user_ids = [user.user_id for user in occurrence.attendances]
 
         for user_id in set(subscribed_user_ids + attending_user_ids):
-            context = make_background_user_context(user_id=user_id)
+            context = make_notification_user_context(user_id=user_id)
             notify(
                 session,
                 user_id=user_id,
@@ -1289,7 +1289,7 @@ class Events(events_pb2_grpc.EventsServicer):
         )
         session.flush()
 
-        other_user_context = make_background_user_context(user_id=request.user_id)
+        other_user_context = make_notification_user_context(user_id=request.user_id)
 
         notify(
             session,

--- a/app/backend/src/couchers/servicers/references.py
+++ b/app/backend/src/couchers/servicers/references.py
@@ -13,7 +13,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session, aliased
 from sqlalchemy.sql import and_, func, literal, or_, union_all
 
-from couchers.context import CouchersContext, make_background_user_context
+from couchers.context import CouchersContext, make_notification_user_context
 from couchers.db import are_friends
 from couchers.event_log import log_event
 from couchers.materialized_views import LiteUser
@@ -306,7 +306,7 @@ class References(references_pb2_grpc.ReferencesServicer):
             topic_action=NotificationTopicAction.reference__receive_friend,
             key=str(reference.id),
             data=notification_data_pb2.ReferenceReceiveFriend(
-                from_user=user_model_to_pb(user, session, make_background_user_context(user_id=request.to_user_id)),
+                from_user=user_model_to_pb(user, session, make_notification_user_context(user_id=request.to_user_id)),
                 text=reference_text,
             ),
             moderation_state_id=reference.moderation_state_id,
@@ -397,7 +397,7 @@ class References(references_pb2_grpc.ReferencesServicer):
             key=str(host_request.conversation_id),
             data=notification_data_pb2.ReferenceReceiveHostRequest(
                 host_request_id=host_request.conversation_id,
-                from_user=user_model_to_pb(user, session, make_background_user_context(user_id=reference.to_user_id)),
+                from_user=user_model_to_pb(user, session, make_notification_user_context(user_id=reference.to_user_id)),
                 text=reference_text if other_reference is not None else None,
             ),
             moderation_state_id=reference.moderation_state_id,

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session, aliased
 from sqlalchemy.sql import and_, func, or_
 
 from couchers.constants import HOST_REQUEST_MIN_LENGTH_UTF16
-from couchers.context import CouchersContext, make_background_user_context
+from couchers.context import CouchersContext, make_notification_user_context
 from couchers.db import can_moderate_node
 from couchers.event_log import log_event
 from couchers.helpers.completed_profile import has_completed_profile
@@ -339,7 +339,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         session.add(host_request)
         session.flush()
 
-        recipient_context = make_background_user_context(user_id=host_request.recipient_user_id)
+        recipient_context = make_notification_user_context(user_id=host_request.recipient_user_id)
         notify(
             session,
             user_id=host_request.recipient_user_id,
@@ -603,7 +603,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             host_request.status = HostRequestStatus.accepted
             session.flush()
 
-            recipient_context = make_background_user_context(user_id=host_request.initiator_user_id)
+            recipient_context = make_notification_user_context(user_id=host_request.initiator_user_id)
             notify(
                 session,
                 user_id=host_request.initiator_user_id,
@@ -645,7 +645,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             host_request.status = HostRequestStatus.rejected
             session.flush()
 
-            recipient_context = make_background_user_context(user_id=host_request.initiator_user_id)
+            recipient_context = make_notification_user_context(user_id=host_request.initiator_user_id)
             notify(
                 session,
                 user_id=host_request.initiator_user_id,
@@ -687,7 +687,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             host_request.status = HostRequestStatus.confirmed
             session.flush()
 
-            recipient_context = make_background_user_context(user_id=host_request.recipient_user_id)
+            recipient_context = make_notification_user_context(user_id=host_request.recipient_user_id)
             notify(
                 session,
                 user_id=host_request.recipient_user_id,
@@ -728,7 +728,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             host_request.status = HostRequestStatus.cancelled
             session.flush()
 
-            recipient_context = make_background_user_context(user_id=host_request.recipient_user_id)
+            recipient_context = make_notification_user_context(user_id=host_request.recipient_user_id)
             notify(
                 session,
                 user_id=host_request.recipient_user_id,
@@ -855,7 +855,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         if host_request.initiator_user_id == context.user_id:
             host_request.initiator_last_seen_message_id = message.id
 
-            recipient_context = make_background_user_context(user_id=host_request.recipient_user_id)
+            recipient_context = make_notification_user_context(user_id=host_request.recipient_user_id)
             notify(
                 session,
                 user_id=host_request.recipient_user_id,
@@ -873,7 +873,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         else:
             host_request.recipient_last_seen_message_id = message.id
 
-            recipient_context = make_background_user_context(user_id=host_request.initiator_user_id)
+            recipient_context = make_notification_user_context(user_id=host_request.initiator_user_id)
             notify(
                 session,
                 user_id=host_request.initiator_user_id,

--- a/app/backend/src/couchers/servicers/threads.py
+++ b/app/backend/src/couchers/servicers/threads.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
 
-from couchers.context import CouchersContext, make_background_user_context
+from couchers.context import CouchersContext, make_background_user_context, make_notification_user_context
 from couchers.db import session_scope
 from couchers.jobs.enqueue import queue_job
 from couchers.models import (
@@ -116,7 +116,7 @@ def generate_reply_notifications(payload: jobs_pb2.GenerateReplyNotificationsPay
                         continue
                     if user_id == comment.author_user_id:
                         continue
-                    context = make_background_user_context(user_id=user_id)
+                    context = make_notification_user_context(user_id=user_id)
                     notify(
                         session,
                         user_id=user_id,
@@ -142,7 +142,7 @@ def generate_reply_notifications(payload: jobs_pb2.GenerateReplyNotificationsPay
                     if user_id == comment.author_user_id:
                         continue
 
-                    context = make_background_user_context(user_id=user_id)
+                    context = make_notification_user_context(user_id=user_id)
                     notify(
                         session,
                         user_id=user_id,
@@ -200,7 +200,7 @@ def generate_reply_notifications(payload: jobs_pb2.GenerateReplyNotificationsPay
                 # thread is an event thread
                 occurrence = event.occurrences.order_by(EventOccurrence.id.desc()).limit(1).one()
                 for user_id in user_ids_to_notify:
-                    context = make_background_user_context(user_id=user_id)
+                    context = make_notification_user_context(user_id=user_id)
                     notify(
                         session,
                         user_id=user_id,
@@ -216,7 +216,7 @@ def generate_reply_notifications(payload: jobs_pb2.GenerateReplyNotificationsPay
             elif discussion:
                 # community discussion thread
                 for user_id in user_ids_to_notify:
-                    context = make_background_user_context(user_id=user_id)
+                    context = make_notification_user_context(user_id=user_id)
                     notify(
                         session,
                         user_id=user_id,

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -1812,6 +1812,29 @@ def test_handle_notification_delivered_when_content_visible(db, moderator):
         assert len(deliveries) > 0
 
 
+def test_notification_serializes_shadowed_actor(db, moderator):
+    recipient, _ = generate_user(complete_profile=True)
+    sender, sender_token = generate_user(complete_profile=True)
+
+    with session_scope() as session:
+        session.execute(update(User).where(User.id == sender.id).values(shadowed_at=now()))
+
+    with api_session(sender_token) as api:
+        api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=recipient.id))
+
+    process_job()
+
+    with session_scope() as session:
+        notification = session.execute(
+            select(Notification)
+            .where(Notification.user_id == recipient.id)
+            .where(Notification.topic_action == NotificationTopicAction.friend_request__create)
+        ).scalar_one()
+        data = notification_data_pb2.FriendRequestCreate.FromString(notification.data)
+        assert data.other_user.user_id == sender.id
+        assert not data.other_user.is_ghost
+
+
 def test_handle_notification_multiple_delivery_types(
     db, email_collector: EmailCollector, push_collector: PushCollector
 ):


### PR DESCRIPTION
Fixes serialization of notification actors so notifications no longer fail when the actor isn't visible to the recipient.

## Testing
- Added a regression test in `test_notifications.py`
- `make format`, `make mypy` (clean aside from a pre-existing unrelated error), and the backend notification/requests/references/threads/blocking/visibility suites pass locally

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._