### PR TITLE
Add node name to public trips response

### DIFF
--- a/app/backend/src/couchers/servicers/public_trips.py
+++ b/app/backend/src/couchers/servicers/public_trips.py
@@ -67,6 +67,7 @@ def public_trip_to_pb(
         user=user_model_to_pb(public_trip.user, session, context),
         node_id=public_trip.node_id,
         node_slug=public_trip.node.official_cluster.slug,
+        node_name=public_trip.node.official_cluster.name,
         from_date=date_to_api(public_trip.from_date),
         to_date=date_to_api(public_trip.to_date),
         description=public_trip.description,

--- a/app/backend/src/tests/test_public_trips.py
+++ b/app/backend/src/tests/test_public_trips.py
@@ -109,6 +109,7 @@ def test_create_public_trip(db):
         assert res.user.user_id == user.id
         assert res.node_id == node_id
         assert res.node_slug == "test-community"
+        assert res.node_name == "Test community"
         assert res.from_date == from_date.isoformat()
         assert res.to_date == to_date.isoformat()
         assert res.description == VALID_DESCRIPTION
@@ -346,6 +347,7 @@ def test_get_public_trip(db):
         assert res.trip_id == trip_id
         assert res.user.user_id == user.id
         assert res.node_slug == "test-community"
+        assert res.node_name == "Test community"
 
 
 def test_get_public_trip_not_found(db):
@@ -369,6 +371,7 @@ def test_list_public_trips(db):
         returned_ids = {t.trip_id for t in res.public_trips}
         assert returned_ids == {trip1, trip2}
         assert all(t.node_slug == "test-community" for t in res.public_trips)
+        assert all(t.node_name == "Test community" for t in res.public_trips)
 
 
 def test_list_public_trips_filters_closed_and_past(db):

--- a/app/proto/public_trips.proto
+++ b/app/proto/public_trips.proto
@@ -61,6 +61,8 @@ message PublicTrip {
   // Number of non-cancelled host offers linked to this trip.
   // Only populated when the viewer is the trip owner.
   optional int32 offers_count = 11;
+  // Display name of the community this trip belongs to
+  string node_name = 12;
 }
 
 message CreatePublicTripReq {


### PR DESCRIPTION
Adding this to the backend response so I don't have to make an api call for every public trips card.

<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
