### PR TITLE
Media: Set CORS header on error responses too

### DIFF
--- a/app/media/src/media/server.py
+++ b/app/media/src/media/server.py
@@ -8,7 +8,7 @@ import backoff
 import grpc
 import pyvips
 import sentry_sdk
-from flask import Flask, Response, abort, make_response, request, send_file
+from flask import Flask, Response, abort, request, send_file
 from sentry_sdk.integrations import argv, atexit, dedupe, modules, stdlib, threading
 from sentry_sdk.integrations import logging as sentry_logging
 from werkzeug.utils import secure_filename
@@ -56,6 +56,14 @@ def create_app(
     (media_upload_location / "thumbnail").mkdir(exist_ok=True, parents=True)
 
     app = Flask(__name__)
+
+    @app.after_request
+    def add_cors_header(response: Response) -> Response:
+        # this must be set on error responses too: a cross-origin response without
+        # ACAO is treated as a network error by browsers, so the client would never
+        # see the status code
+        response.access_control_allow_origin = media_cors_origin
+        return response
 
     def get_path(filename: str, size: str = "full") -> str:
         return str(media_upload_location / size / filename)
@@ -143,17 +151,13 @@ def create_app(
         # let the main server know the upload succeeded, or delete the file
         try:
             send_confirmation_to_main_server(req.key, filename)
-            res = make_response(
-                {
-                    "ok": True,
-                    "key": req.key,
-                    "filename": filename,
-                    "full_url": f"{media_server_base_url}/img/full/{filename}",
-                    "thumbnail_url": f"{media_server_base_url}/img/thumbnail/{filename}",
-                }
-            )
-            res.access_control_allow_origin = media_cors_origin
-            return res
+            return {
+                "ok": True,
+                "key": req.key,
+                "filename": filename,
+                "full_url": f"{media_server_base_url}/img/full/{filename}",
+                "thumbnail_url": f"{media_server_base_url}/img/thumbnail/{filename}",
+            }
         except Exception as e:
             os.remove(path)
             raise e

--- a/app/media/src/tests/test_server.py
+++ b/app/media/src/tests/test_server.py
@@ -16,8 +16,8 @@ from nacl.utils import random as random_bytes
 from PIL import Image
 from PIL.JpegImagePlugin import JpegImageFile
 
-from media.server import create_app
 from media.proto import media_pb2, media_pb2_grpc
+from media.server import create_app
 
 DATADIR = Path(__file__).parent / "data"
 
@@ -510,6 +510,46 @@ def test_fails_expired(client_with_secrets):
             rv = client.post(upload_path, data={"file": (f, "pixel.jpg")})
 
         assert rv.status_code == 400
+
+
+def test_cors_header_set_on_all_responses(client_with_secrets):
+    # a cross-origin response without ACAO is treated as a network error by
+    # browsers, so the header must be present on error responses too
+    client, secret_key, bearer_token = client_with_secrets
+
+    # success
+    key, request = create_upload_request()
+    upload_path = generate_upload_path(request, secret_key)
+
+    with mock_main_server(bearer_token, lambda x: True):
+        with open(DATADIR / "1x1.jpg", "rb") as f:
+            rv = client.post(upload_path, data={"file": (f, "1x1.jpg")})
+
+    assert rv.status_code == 200
+    assert rv.headers["Access-Control-Allow-Origin"] == "*"
+
+    # broken signature
+    rv = client.post("upload?data=krz&sig=foo", data={"file": (io.BytesIO(b"bar"), "1x1.jpg")})
+    assert rv.status_code == 400
+    assert rv.headers["Access-Control-Allow-Origin"] == "*"
+
+    # invalid image
+    key, request = create_upload_request()
+    upload_path = generate_upload_path(request, secret_key)
+
+    with open(DATADIR / "badfile.txt", "rb") as f:
+        rv = client.post(upload_path, data={"file": (f, "badfile.txt")})
+
+    assert rv.status_code == 400
+    assert rv.headers["Access-Control-Allow-Origin"] == "*"
+
+    # missing file
+    key, request = create_upload_request()
+    upload_path = generate_upload_path(request, secret_key)
+
+    rv = client.post(upload_path)
+    assert rv.status_code == 400
+    assert rv.headers["Access-Control-Allow-Origin"] == "*"
 
 
 def one_pixel_bytes():


### PR DESCRIPTION
The media server only set `Access-Control-Allow-Origin` on the success path of `/upload`. Every `abort()` (invalid signature, expired request, invalid image, missing file, etc.) and any unhandled 500 returned without the header. Since the upload is a cross-origin fetch from the web app, browsers treat a response missing ACAO as a network error — the fetch rejects instead of returning a response object, so the client's status-code handling in `service/api.ts` (e.g. the 413 → "image too large" branch) was unreachable in production and all upload errors surfaced as a generic fetch failure.

This moves the header into an `@app.after_request` hook so it is set on every response, including error responses from `abort()` and unhandled exceptions.

Note: a 413 generated by nginx (`client_max_body_size 50M` in `media.conf`) never reaches Flask and still lacks the header; that needs a separate fix in the nginx config.

## Testing
Added `test_cors_header_set_on_all_responses` covering a successful upload plus three error paths (broken signature, invalid image, missing file). All media server tests pass with `uv run pytest` from `app/media`.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._