### PR TITLE
Fix unbounded width on messages pages, centralize standard page width in PageContainer

### DIFF
--- a/app/web/components/AppRoute.tsx
+++ b/app/web/components/AppRoute.tsx
@@ -5,6 +5,7 @@ import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
 import CookieBanner from "components/CookieBanner";
 import ErrorBoundary from "components/ErrorBoundary";
 import Footer from "components/Footer";
+import { STANDARD_PAGE_MAX_WIDTH } from "components/PageContainer";
 import { useAuthContext } from "features/auth/AuthProvider";
 import { PushNotificationBanner } from "features/notifications/PushNotificationBanner";
 import { useRouter } from "next/router";
@@ -174,7 +175,7 @@ function AppRoute({
                 variant === "full-width" ||
                 variant === "no-overflow"
                   ? false
-                  : "lg"
+                  : STANDARD_PAGE_MAX_WIDTH
               }
             >
               {children}

--- a/app/web/components/AppRoute.tsx
+++ b/app/web/components/AppRoute.tsx
@@ -19,7 +19,7 @@ import Navigation from "./Navigation";
 interface AppRouteProps {
   isPrivate: boolean;
   noFooter?: boolean;
-  variant?: "standard" | "full-screen" | "full-width" | "no-overflow";
+  variant?: "standard" | "full-width" | "no-overflow";
   bottomMargin?: string;
   children: ReactNode;
 }
@@ -171,9 +171,7 @@ function AppRoute({
               disableGutters
               variant={variant}
               maxWidth={
-                variant === "full-screen" ||
-                variant === "full-width" ||
-                variant === "no-overflow"
+                variant === "full-width" || variant === "no-overflow"
                   ? false
                   : STANDARD_PAGE_MAX_WIDTH
               }

--- a/app/web/components/PageContainer.tsx
+++ b/app/web/components/PageContainer.tsx
@@ -1,0 +1,14 @@
+import { Container, ContainerProps } from "@mui/material";
+
+// The platform-standard content width, used by the "standard" layout variant
+// in AppRoute and by PageContainer below.
+export const STANDARD_PAGE_MAX_WIDTH = "lg" as const;
+
+/**
+ * Container capped at the platform-standard page width. Pages that opt out of
+ * the standard layout variant (e.g. "full-width" for a full-bleed hero) should
+ * wrap their non-full-bleed content in this instead of hardcoding a width.
+ */
+export default function PageContainer(props: Omit<ContainerProps, "maxWidth">) {
+  return <Container maxWidth={STANDARD_PAGE_MAX_WIDTH} {...props} />;
+}

--- a/app/web/components/TOS.tsx
+++ b/app/web/components/TOS.tsx
@@ -29,10 +29,10 @@ export default function TOS() {
   return isLoading ? (
     <CenteredSpinner />
   ) : data ? (
-    <main>
+    <>
       <HtmlMeta title={t("terms_of_service")} />
       <PageTitle>{t("terms_of_service")}</PageTitle>
       <Markdown source={data?.termsOfService} />
-    </main>
+    </>
   ) : null;
 }

--- a/app/web/components/TOS.tsx
+++ b/app/web/components/TOS.tsx
@@ -1,4 +1,3 @@
-import { styled } from "@mui/material";
 import { useQuery } from "@tanstack/react-query";
 import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
 import HtmlMeta from "components/HtmlMeta";
@@ -10,12 +9,6 @@ import { useTranslation } from "i18n";
 import { GLOBAL } from "i18n/namespaces";
 import { GetTermsOfServiceRes } from "proto/resources_pb";
 import { service } from "service";
-
-const StyledWrapper = styled("div")(({ theme }) => ({
-  maxWidth: theme.breakpoints.values.lg,
-  margin: "0 auto",
-  padding: theme.spacing(2),
-}));
 
 export default function TOS() {
   const { t } = useTranslation(GLOBAL);
@@ -36,10 +29,10 @@ export default function TOS() {
   return isLoading ? (
     <CenteredSpinner />
   ) : data ? (
-    <StyledWrapper>
+    <main>
       <HtmlMeta title={t("terms_of_service")} />
       <PageTitle>{t("terms_of_service")}</PageTitle>
       <Markdown source={data?.termsOfService} />
-    </StyledWrapper>
+    </main>
   ) : null;
 }

--- a/app/web/features/auth/password/CompleteResetPassword.tsx
+++ b/app/web/features/auth/password/CompleteResetPassword.tsx
@@ -19,7 +19,7 @@ import { theme } from "theme";
 import { useIsNativeEmbed } from "utils/nativeLink";
 import stringOrFirstString from "utils/stringOrFirstString";
 
-const StyledContainer = styled("main")(() => ({
+const StyledContainer = styled("div")(() => ({
   marginTop: theme.spacing(2),
 }));
 

--- a/app/web/features/auth/password/CompleteResetPassword.tsx
+++ b/app/web/features/auth/password/CompleteResetPassword.tsx
@@ -1,11 +1,5 @@
 import { Visibility, VisibilityOff } from "@mui/icons-material";
-import {
-  Container,
-  IconButton,
-  InputAdornment,
-  styled,
-  Typography,
-} from "@mui/material";
+import { IconButton, InputAdornment, styled, Typography } from "@mui/material";
 import { useMutation } from "@tanstack/react-query";
 import Alert from "components/Alert";
 import Button from "components/Button";
@@ -25,12 +19,8 @@ import { theme } from "theme";
 import { useIsNativeEmbed } from "utils/nativeLink";
 import stringOrFirstString from "utils/stringOrFirstString";
 
-const StyledContainer = styled(Container)(() => ({
+const StyledContainer = styled("main")(() => ({
   marginTop: theme.spacing(2),
-  paddingLeft: theme.spacing(2),
-  paddingRight: theme.spacing(2),
-  paddingBottom: theme.spacing(2),
-  flex: 1,
 }));
 
 const StyledForm = styled("form")(() => ({

--- a/app/web/features/auth/password/ResetPassword.tsx
+++ b/app/web/features/auth/password/ResetPassword.tsx
@@ -14,10 +14,6 @@ import { service } from "service";
 import { theme } from "theme";
 import { lowercaseAndTrimField } from "utils/validation";
 
-const StyledMain = styled("main")(() => ({
-  padding: theme.spacing(0, 3),
-}));
-
 const StyledForm = styled("form")(() => ({
   "& > * + *": {
     marginBlockStart: theme.spacing(1),
@@ -49,7 +45,7 @@ export default function ResetPassword() {
   });
 
   return (
-    <StyledMain>
+    <main>
       <HtmlMeta title={t("auth:reset_password")} />
       <PageTitle>{t("auth:reset_password")}</PageTitle>
       {error && <Alert severity="error">{error.message}</Alert>}
@@ -71,6 +67,6 @@ export default function ResetPassword() {
           </Typography>
         )}
       </StyledForm>
-    </StyledMain>
+    </main>
   );
 }

--- a/app/web/features/auth/password/ResetPassword.tsx
+++ b/app/web/features/auth/password/ResetPassword.tsx
@@ -45,7 +45,7 @@ export default function ResetPassword() {
   });
 
   return (
-    <main>
+    <>
       <HtmlMeta title={t("auth:reset_password")} />
       <PageTitle>{t("auth:reset_password")}</PageTitle>
       {error && <Alert severity="error">{error.message}</Alert>}
@@ -67,6 +67,6 @@ export default function ResetPassword() {
           </Typography>
         )}
       </StyledForm>
-    </main>
+    </>
   );
 }

--- a/app/web/features/auth/signup/Signup.tsx
+++ b/app/web/features/auth/signup/Signup.tsx
@@ -1,16 +1,10 @@
-import {
-  alpha,
-  Box,
-  Container,
-  Skeleton,
-  styled,
-  Typography,
-} from "@mui/material";
+import { alpha, Box, Skeleton, styled, Typography } from "@mui/material";
 import { useQuery } from "@tanstack/react-query";
 import Alert from "components/Alert";
 import Avatar from "components/Avatar";
 import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
 import HtmlMeta from "components/HtmlMeta";
+import PageContainer from "components/PageContainer";
 import Redirect from "components/Redirect";
 import StyledLink from "components/StyledLink";
 import { RpcError } from "grpc-web";
@@ -118,9 +112,8 @@ export default function Signup() {
     <>
       {authenticated && <Redirect to={dashboardRoute} />}
       <HtmlMeta title={t("global:sign_up")} />
-      <Container
+      <PageContainer
         component="section"
-        maxWidth="lg"
         sx={{
           display: "flex",
           flexDirection: "column",
@@ -193,7 +186,7 @@ export default function Signup() {
             </Trans>
           </Typography>
         </StyledFormWrapper>
-      </Container>
+      </PageContainer>
     </>
   );
 }

--- a/app/web/features/dashboard/Dashboard.tsx
+++ b/app/web/features/dashboard/Dashboard.tsx
@@ -1,6 +1,7 @@
-import { Alert, Box, Container, Grid, Typography } from "@mui/material";
+import { Alert, Box, Grid, Typography } from "@mui/material";
 import Divider from "components/Divider";
 import HtmlMeta from "components/HtmlMeta";
+import PageContainer from "components/PageContainer";
 import PageTitle from "components/PageTitle";
 import StyledLink from "components/StyledLink";
 import { useTranslation } from "i18n";
@@ -25,7 +26,7 @@ export default function Dashboard() {
       <Hero />
       {/* this view uses a container, instead of it coming from the route layout,
         because the hero section is full viewport width */}
-      <Container maxWidth="lg">
+      <PageContainer>
         <Grid container direction="row">
           <Grid size={{ sm: 4, xs: 12 }} sx={{ marginTop: theme.spacing(3) }}>
             <DashboardUserProfileSummary />
@@ -106,7 +107,7 @@ export default function Dashboard() {
             <CommunitiesSection />
           </Grid>
         </Grid>
-      </Container>
+      </PageContainer>
     </>
   );
 }

--- a/app/web/features/landing/HistoryTimeline.tsx
+++ b/app/web/features/landing/HistoryTimeline.tsx
@@ -1,5 +1,6 @@
 import { ChevronRightRounded } from "@mui/icons-material";
-import { Box, Container, Stack, Typography } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
+import PageContainer from "components/PageContainer";
 import { useTranslation } from "i18n";
 import { GLOBAL } from "i18n/namespaces";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -180,7 +181,7 @@ export default function HistoryTimeline() {
         minHeight: 450,
       }}
     >
-      <Container maxWidth="lg">
+      <PageContainer>
         <Typography
           variant="h2"
           sx={{
@@ -320,7 +321,7 @@ export default function HistoryTimeline() {
             {items[activeIndex].text}
           </Typography>
         </Box>
-      </Container>
+      </PageContainer>
     </Box>
   );
 }

--- a/app/web/features/landing/LandingPage.tsx
+++ b/app/web/features/landing/LandingPage.tsx
@@ -2,6 +2,7 @@ import { Box, Container, styled, useMediaQuery } from "@mui/material";
 import { useQueryClient } from "@tanstack/react-query";
 import Button from "components/Button";
 import HtmlMeta from "components/HtmlMeta";
+import PageContainer from "components/PageContainer";
 import { useAuthContext } from "features/auth/AuthProvider";
 import { useTranslation } from "i18n";
 import { GLOBAL } from "i18n/namespaces";
@@ -38,9 +39,9 @@ export default function LandingPage() {
   return (
     <>
       <HtmlMeta />
-      <Container component="section" maxWidth="lg">
+      <PageContainer component="section">
         <HeroSection />
-      </Container>
+      </PageContainer>
       <StyledSpacer />
       <Container
         component="section"
@@ -55,17 +56,17 @@ export default function LandingPage() {
         <SocialProof />
       </Container>
       <StyledSpacer />
-      <Container component="section" maxWidth="lg">
+      <PageContainer component="section">
         <WhyCouchersSection />
-      </Container>
+      </PageContainer>
       <StyledSpacer />
-      <Container component="section" maxWidth="lg">
+      <PageContainer component="section">
         <MapSection />
-      </Container>
+      </PageContainer>
       <StyledSpacer />
-      <Container component="section" maxWidth="lg">
+      <PageContainer component="section">
         <CouchersMission />
-      </Container>
+      </PageContainer>
       {isMobile && !authState.authenticated && (
         <Box
           sx={{

--- a/app/web/features/landing/WhatIsCouchSurfingPage.tsx
+++ b/app/web/features/landing/WhatIsCouchSurfingPage.tsx
@@ -10,7 +10,6 @@ import {
 } from "@mui/icons-material";
 import {
   Box,
-  Container,
   Grid,
   List,
   ListItem,
@@ -20,6 +19,7 @@ import {
 } from "@mui/material";
 import Button from "components/Button";
 import HtmlMeta from "components/HtmlMeta";
+import PageContainer from "components/PageContainer";
 import { Trans, useTranslation } from "i18n";
 import { GLOBAL } from "i18n/namespaces";
 import { useRouter } from "next/router";
@@ -37,13 +37,9 @@ export default function WhatIsCouchSurfingPage() {
   return (
     <>
       <HtmlMeta title={t("what_is_cs.title")} />
-      <Container
-        component="article"
-        maxWidth="lg"
-        sx={{ py: { xs: 0, md: 8 } }}
-      >
+      <PageContainer component="article" sx={{ py: { xs: 0, md: 8 } }}>
         <Box component="section" sx={{ py: 6 }}>
-          <Container maxWidth="lg" sx={{ px: { xs: 0, md: 3 } }}>
+          <PageContainer sx={{ px: { xs: 0, md: 3 } }}>
             <Grid
               container
               spacing={{ xs: 1, md: 4 }}
@@ -107,7 +103,7 @@ export default function WhatIsCouchSurfingPage() {
                 </Box>
               </Grid>
             </Grid>
-          </Container>
+          </PageContainer>
         </Box>
         <HistoryTimeline />
         <Box component="section" sx={{ py: 6 }}>
@@ -306,7 +302,7 @@ export default function WhatIsCouchSurfingPage() {
             width: "100vw",
           }}
         >
-          <Container maxWidth="lg">
+          <PageContainer>
             <Grid container spacing={4} alignItems="center">
               <Grid size={{ xs: 12, md: 6 }}>
                 <Typography
@@ -405,7 +401,7 @@ export default function WhatIsCouchSurfingPage() {
                 </Box>
               </Grid>
             </Grid>
-          </Container>
+          </PageContainer>
         </Box>
 
         <Box component="section" sx={{ py: 6 }}>
@@ -421,7 +417,7 @@ export default function WhatIsCouchSurfingPage() {
           </Typography>
           <CompareTable />
         </Box>
-      </Container>
+      </PageContainer>
       <Box
         component="section"
         sx={{
@@ -435,7 +431,7 @@ export default function WhatIsCouchSurfingPage() {
           width: "100vw",
         }}
       >
-        <Container maxWidth="lg">
+        <PageContainer>
           <Stack spacing={2} alignItems="center" textAlign="center">
             <Typography
               variant="h2"
@@ -460,7 +456,7 @@ export default function WhatIsCouchSurfingPage() {
               {t("what_is_cs.join_couchers")}
             </Button>
           </Stack>
-        </Container>
+        </PageContainer>
       </Box>
     </>
   );

--- a/app/web/features/team/Team.tsx
+++ b/app/web/features/team/Team.tsx
@@ -1,6 +1,7 @@
-import { Container, Typography } from "@mui/material";
+import { Typography } from "@mui/material";
 import Button from "components/Button";
 import HtmlMeta from "components/HtmlMeta";
+import PageContainer from "components/PageContainer";
 import PageTitle from "components/PageTitle";
 import { useListVolunteers } from "features/communities/hooks";
 import { useTranslation } from "i18n";
@@ -18,7 +19,7 @@ export default function Team() {
   return (
     <>
       <HtmlMeta title="The Team" />
-      <Container maxWidth="lg">
+      <PageContainer>
         <PageTitle>{t("team.title")}</PageTitle>
         <Typography
           sx={{
@@ -44,13 +45,13 @@ export default function Team() {
             {t("team.join_the_team")}
           </Button>
         </Typography>
-      </Container>
+      </PageContainer>
       <TeamSection
         volunteers={volunteers.data?.currentVolunteersList}
         variant={"current"}
       />
 
-      <Container maxWidth="lg">
+      <PageContainer>
         <Typography
           variant="h2"
           sx={{
@@ -60,12 +61,12 @@ export default function Team() {
         >
           {t("team.past_members")}
         </Typography>
-      </Container>
+      </PageContainer>
       <TeamSection
         volunteers={volunteers.data?.pastVolunteersList}
         variant={"past"}
       />
-      <Container maxWidth="lg">
+      <PageContainer>
         <Typography variant="h2" component="h2">
           {t("team.have_skills_contribute")}
         </Typography>
@@ -93,7 +94,7 @@ export default function Team() {
             {t("team.join_our_team")}
           </Button>
         </Typography>
-      </Container>
+      </PageContainer>
     </>
   );
 }

--- a/app/web/pages/complete-password-reset.tsx
+++ b/app/web/pages/complete-password-reset.tsx
@@ -20,5 +20,4 @@ export default function CompletePasswordResetPage() {
 
 CompletePasswordResetPage.getLayout = appGetLayout({
   isPrivate: false,
-  variant: "full-screen",
 });

--- a/app/web/pages/invite.tsx
+++ b/app/web/pages/invite.tsx
@@ -22,5 +22,5 @@ export default function InvitePage() {
 InvitePage.getLayout = appGetLayout({
   isPrivate: false,
   noFooter: true,
-  variant: "full-screen",
+  variant: "full-width",
 });

--- a/app/web/pages/landing.tsx
+++ b/app/web/pages/landing.tsx
@@ -28,6 +28,6 @@ export default function HomePage() {
 
 HomePage.getLayout = appGetLayout({
   isPrivate: false,
-  variant: "full-screen",
+  variant: "full-width",
   bottomMargin: "80px",
 });

--- a/app/web/pages/login.tsx
+++ b/app/web/pages/login.tsx
@@ -17,5 +17,5 @@ export default function LoginPage() {
 LoginPage.getLayout = appGetLayout({
   isPrivate: false,
   noFooter: true,
-  variant: "full-screen",
+  variant: "full-width",
 });

--- a/app/web/pages/messages/[[...slug]].tsx
+++ b/app/web/pages/messages/[[...slug]].tsx
@@ -1,4 +1,5 @@
 import { appGetLayout } from "components/AppRoute";
+import PageContainer from "components/PageContainer";
 import AllMessagesTab from "features/messages/AllMessagesTab";
 import GroupChatView from "features/messages/groupchats/GroupChatView";
 import MessagesHeader from "features/messages/MessagesHeader";
@@ -21,7 +22,7 @@ export const getStaticProps: GetStaticProps = translationStaticProps([
   NOTIFICATIONS,
   PROFILE,
 ]);
-export default function LeaveReferencePage() {
+function MessagesPageContent() {
   const router = useRouter();
   const slugs =
     typeof router.query.slug === "undefined"
@@ -64,7 +65,15 @@ export default function LeaveReferencePage() {
   return <NotFoundPage />;
 }
 
-LeaveReferencePage.getLayout = appGetLayout({
+export default function MessagesPage() {
+  return (
+    <PageContainer disableGutters>
+      <MessagesPageContent />
+    </PageContainer>
+  );
+}
+
+MessagesPage.getLayout = appGetLayout({
   variant: "full-width",
   noFooter: true,
 });

--- a/app/web/pages/password-reset.tsx
+++ b/app/web/pages/password-reset.tsx
@@ -14,5 +14,4 @@ export default function PasswordResetPage() {
 
 PasswordResetPage.getLayout = appGetLayout({
   isPrivate: false,
-  variant: "full-screen",
 });

--- a/app/web/pages/signup.tsx
+++ b/app/web/pages/signup.tsx
@@ -21,5 +21,5 @@ export default function SignupPage() {
 SignupPage.getLayout = appGetLayout({
   isPrivate: false,
   noFooter: true,
-  variant: "full-screen",
+  variant: "full-width",
 });

--- a/app/web/pages/terms.tsx
+++ b/app/web/pages/terms.tsx
@@ -19,5 +19,4 @@ export default function TOSPage() {
 
 TOSPage.getLayout = appGetLayout({
   isPrivate: false,
-  variant: "full-screen",
 });


### PR DESCRIPTION
Tested all the mentioned pages. All others look the same as before except messaging pages (fixed) and password reset (fixed).

---
The messages routes (`/messages`, `/messages/chats/<id>`, `/messages/request/<id>`) use the `full-width` layout variant but never re-constrained their content, so on wide desktop screens they stretched across the whole viewport with no max-width, making them hard to use.

This PR fixes that and makes the underlying pattern principled:

- Adds `components/PageContainer.tsx` — a thin wrapper around MUI `Container` that bakes in the platform-standard page width (`lg`), exported alongside a `STANDARD_PAGE_MAX_WIDTH` constant which `AppRoute`'s `standard` variant now also uses. The standard width is defined in exactly one place.
- Wraps the messages page content in `PageContainer` (with `disableGutters`, since the views carry their own edge padding — mobile/tablet appearance is unchanged). The page keeps the `full-width` variant because the `standard` variant's bottom padding would break the chat view's `100dvh`-based height math.
- Migrates all other hardcoded `<Container maxWidth="lg">` usages to `PageContainer`: Dashboard, Team, Signup, LandingPage, HistoryTimeline, WhatIsCouchSurfingPage. Raw `Container` now signals a deliberately non-standard width (e.g. the landing page's full-bleed band).
- Switches `terms`, `password-reset`, and `complete-password-reset` from the `full-screen` variant to the standard layout — they have no full-bleed content, so the variant did nothing useful. Their now-redundant hand-rolled width/padding wrappers (`TOS`, `ResetPassword`, `CompleteResetPassword`) are removed in favor of the layout's container.

Per review, the `full-screen` variant is now merged into `full-width` — the two have been behaviorally identical since nav-height handling moved into the flex layout chain, so the alias was vestigial. Its remaining users (landing, login, signup, invite) now pass `full-width`.

## Testing

- `npx tsc --noEmit`, `eslint`, and `prettier` pass on all changed files
- Ran test suites for `features/auth/password`, `components/AppRoute`, `features/dashboard`, `features/team` — 56 tests pass
- Still to do before marking ready: visual check on desktop/tablet/mobile of `/messages/chats/<id>`, `/messages/request/<id>`, the messages list tabs, `/terms`, `/password-reset`, and `/complete-password-reset` (the last three had minor padding geometry changes)

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant (no new behavior; existing suites cover the touched components)
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._
