### PR TITLE
Mobile: Sync Sentry tags/contexts to native scope so app hang/crash events carry them

### DIFF
--- a/app/mobile/service/sentry.ts
+++ b/app/mobile/service/sentry.ts
@@ -37,42 +37,6 @@ if (sentryEnabled) {
     // matching the values its source-map upload uses. The store-binary and OTA
     // identities below are surfaced as tags/contexts (which don't affect
     // symbolication) for searching and filtering.
-    initialScope: {
-      tags: {
-        appVariant,
-        // Embedded store-binary identity (fixed across OTAs)
-        embeddedDisplayVersion,
-        embeddedDebugVersion,
-        // Running bundle identity (varies per OTA)
-        runningDisplayVersion,
-        runningDebugVersion,
-        runningDebugVersionOTA,
-        runtimeVersion,
-        launchSource: isEmbeddedLaunch ? "embedded" : "ota",
-        // Backend/web wiring
-        apiBaseUrl,
-        webBaseUrl,
-      },
-      contexts: {
-        config: {
-          apiBaseUrl,
-          webBaseUrl,
-        },
-        store_build: {
-          displayVersion: embeddedDisplayVersion,
-          debugVersion: embeddedDebugVersion,
-        },
-        ota: {
-          displayVersion: runningDisplayVersion,
-          debugVersion: runningDebugVersion,
-          debugVersionOTA: runningDebugVersionOTA,
-          updateId,
-          runtimeVersion,
-          isEmbeddedLaunch,
-          createdAt,
-        },
-      },
-    },
 
     // Adds more context data to events (IP address, cookies, user, etc.)
     // For more information, visit: https://docs.sentry.io/platforms/react-native/data-management/data-collected/
@@ -88,5 +52,41 @@ if (sentryEnabled) {
       Sentry.mobileReplayIntegration(),
       Sentry.feedbackIntegration(),
     ],
+  });
+
+  // Set via the bridged setters rather than initialScope, which never reaches
+  // the native scope (getsentry/sentry-react-native#1661) and so would be
+  // missing from natively-captured events like app hangs and crashes.
+  Sentry.setTags({
+    appVariant,
+    // Embedded store-binary identity (fixed across OTAs)
+    embeddedDisplayVersion,
+    embeddedDebugVersion,
+    // Running bundle identity (varies per OTA)
+    runningDisplayVersion,
+    runningDebugVersion,
+    runningDebugVersionOTA,
+    runtimeVersion,
+    launchSource: isEmbeddedLaunch ? "embedded" : "ota",
+    // Backend/web wiring
+    apiBaseUrl,
+    webBaseUrl,
+  });
+  Sentry.setContext("config", {
+    apiBaseUrl,
+    webBaseUrl,
+  });
+  Sentry.setContext("store_build", {
+    displayVersion: embeddedDisplayVersion,
+    debugVersion: embeddedDebugVersion,
+  });
+  Sentry.setContext("ota", {
+    displayVersion: runningDisplayVersion,
+    debugVersion: runningDebugVersion,
+    debugVersionOTA: runningDebugVersionOTA,
+    updateId,
+    runtimeVersion,
+    isEmbeddedLaunch,
+    createdAt,
   });
 }


### PR DESCRIPTION
A native-captured Sentry event (App Hanging from sentry-cocoa) arrived without any of the build/OTA identity tags and contexts we set in `Sentry.init`. The cause: `initialScope` is applied only to the JS scope and is never synced to the native layer (getsentry/sentry-react-native#1661), so natively-captured events (app hangs, native crashes, watchdog terminations) don't carry it — unlike `Sentry.setUser`, which goes through the native bridge and did show up on the event.

This moves the tags and the `config`/`store_build`/`ota` contexts out of `initialScope` into `Sentry.setTags`/`Sentry.setContext` calls right after `Sentry.init`, which sync to the native scope.

## Testing
`eslint` and `tsc --noEmit` pass. The values and structure are unchanged — only how they're attached to the scope. To verify end-to-end: on a staging build, trigger an app hang (block the main thread >2s) and check the Sentry event carries the `runningDisplayVersion` etc. tags and the `ota` context; the triple-tap debug report should be unchanged.

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._