### PR TITLE
Mobile/CI: Write PR preview comment per-section from each producer

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -969,13 +969,12 @@ preview:pr-comment-stub:
   rules:
     - if: $CI_COMMIT_BRANCH != $RELEASE_BRANCH
 
-preview:pr-comment:
+preview:pr-comment-mobile:
   needs:
     - job: preview:pr-comment-stub
       artifacts: false
     - job: preview:mobile-ota-devtool
       artifacts: false
-      optional: true
   stage: preview
   image: python:3.14-slim
   inherit:
@@ -985,7 +984,28 @@ preview:pr-comment:
     OTA_PLATFORMS: "ios android"
   script:
     - pip install --quiet --no-cache-dir requests
-    - python app/scripts/pr_preview_comment.py
+    - python app/scripts/pr_preview_comment.py --section mobile
+  # mirror preview:mobile-ota-devtool so this runs exactly when the OTA upload does
+  rules:
+    - if: ($BUILD_MOBILE == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
+      changes:
+        - app/proto/**/*
+        - app/mobile/**/*
+        - app/scripts/**/*
+
+# Vercel owns the web deploy, so this resolves the preview URL from its API
+preview:pr-comment-web:
+  needs:
+    - job: preview:pr-comment-stub
+      artifacts: false
+  stage: preview
+  image: python:3.14-slim
+  inherit:
+    default: false
+  resource_group: pr-preview-comment
+  script:
+    - pip install --quiet --no-cache-dir requests
+    - python app/scripts/pr_preview_comment.py --section web
   rules:
     - if: $CI_COMMIT_BRANCH != $RELEASE_BRANCH
 

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -737,6 +737,11 @@ preview:backend:
   inherit:
     # no docker login
     default: false
+  # serialize comment writes within a PR (see preview:pr-comment-stub)
+  resource_group: preview-comment-$CI_COMMIT_REF_SLUG
+  before_script:
+    # aws-base has no python; needed for the schema diff and the PR comment
+    - apt-get update -qq && apt-get install -y --no-install-recommends python3
   script:
     # Create cleaned schema.sql with git hash header (only if schema file exists)
     - |
@@ -751,6 +756,12 @@ preview:backend:
             | grep -v 'ALTER .* OWNER TO postgres;' \
             | cat -s
         } > artifacts/schema_dumps/schema.sql
+      fi
+    # Render a highlighted HTML diff of this branch's schema against develop's
+    - |
+      if [ -f "artifacts/schema_dumps/schema.sql" ]; then
+        curl -fsSL "https://develop--schema.$PREVIEW_DOMAIN/schema.sql" -o develop-schema.sql || true
+        python3 app/scripts/schema_diff_html.py develop-schema.sql artifacts/schema_dumps/schema.sql artifacts/schema_dumps/diff.html
       fi
     # Upload coverage report to S3
     - aws s3 rm s3://$AWS_PREVIEW_BUCKET/bcov/$CI_COMMIT_SHORT_SHA/ --recursive
@@ -771,6 +782,8 @@ preview:backend:
     - aws s3 cp artifacts/test_artifacts s3://$AWS_PREVIEW_BUCKET/test-artifacts/$CI_COMMIT_REF_SLUG/ --recursive 2>/dev/null || true
     - echo "Done, test artifacts available at https://$CI_COMMIT_SHORT_SHA--test-artifacts.$PREVIEW_DOMAIN/ and https://$CI_COMMIT_REF_SLUG--test-artifacts.$PREVIEW_DOMAIN/"
     - echo "Sample emails index at https://$CI_COMMIT_SHORT_SHA--test-artifacts.$PREVIEW_DOMAIN/emails/index.html and https://$CI_COMMIT_REF_SLUG--test-artifacts.$PREVIEW_DOMAIN/emails/index.html"
+    # write the backend items into the sticky PR comment (no-op off a PR)
+    - python3 app/scripts/pr_preview_comment.py --items schema,schema-diff,emails,bcov
   artifacts:
     paths:
       - artifacts/schema_dumps
@@ -830,12 +843,16 @@ preview:wcov:
   inherit:
     # no docker login
     default: false
+  resource_group: preview-comment-$CI_COMMIT_REF_SLUG
+  before_script:
+    - apt-get update -qq && apt-get install -y --no-install-recommends python3
   script:
     - aws s3 rm s3://$AWS_PREVIEW_BUCKET/wcov/$CI_COMMIT_SHORT_SHA/ --recursive
     - aws s3 cp artifacts/lcov-report s3://$AWS_PREVIEW_BUCKET/wcov/$CI_COMMIT_SHORT_SHA/ --recursive
     - aws s3 rm s3://$AWS_PREVIEW_BUCKET/wcov/$CI_COMMIT_REF_SLUG/ --recursive
     - aws s3 cp artifacts/lcov-report s3://$AWS_PREVIEW_BUCKET/wcov/$CI_COMMIT_REF_SLUG/ --recursive
     - echo "Done, coverage report available at https://$CI_COMMIT_SHORT_SHA--wcov.$PREVIEW_DOMAIN/ and https://$CI_COMMIT_REF_SLUG--wcov.$PREVIEW_DOMAIN/"
+    - python3 app/scripts/pr_preview_comment.py --items wcov
   rules:
     - if: ($BUILD_WEB == "true") && ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
     - if: ($BUILD_WEB == "true") && ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
@@ -961,10 +978,9 @@ preview:pr-comment-stub:
   image: python:3.14-slim
   inherit:
     default: false
-  # serialize comment writes across concurrent pipelines
-  resource_group: pr-preview-comment
+  # serialize all writes to one PR's comment; different PRs don't contend
+  resource_group: preview-comment-$CI_COMMIT_REF_SLUG
   script:
-    - pip install --quiet --no-cache-dir requests
     - python app/scripts/pr_preview_comment.py --stub
   rules:
     - if: $CI_COMMIT_BRANCH != $RELEASE_BRANCH
@@ -979,12 +995,11 @@ preview:pr-comment-mobile:
   image: python:3.14-slim
   inherit:
     default: false
-  resource_group: pr-preview-comment
+  resource_group: preview-comment-$CI_COMMIT_REF_SLUG
   variables:
     OTA_PLATFORMS: "ios android"
   script:
-    - pip install --quiet --no-cache-dir requests
-    - python app/scripts/pr_preview_comment.py --section mobile
+    - python app/scripts/pr_preview_comment.py --items mobile
   # mirror preview:mobile-ota-devtool so this runs exactly when the OTA upload does
   rules:
     - if: ($BUILD_MOBILE == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
@@ -1002,10 +1017,9 @@ preview:pr-comment-web:
   image: python:3.14-slim
   inherit:
     default: false
-  resource_group: pr-preview-comment
+  resource_group: preview-comment-$CI_COMMIT_REF_SLUG
   script:
-    - pip install --quiet --no-cache-dir requests
-    - python app/scripts/pr_preview_comment.py --section web
+    - python app/scripts/pr_preview_comment.py --items web
   rules:
     - if: $CI_COMMIT_BRANCH != $RELEASE_BRANCH
 
@@ -1324,6 +1338,9 @@ preview:protos:
   inherit:
     # no docker login
     default: false
+  resource_group: preview-comment-$CI_COMMIT_REF_SLUG
+  before_script:
+    - apt-get update -qq && apt-get install -y --no-install-recommends python3
   script:
     - python_sum=$(sha256sum app/proto/gen/python.tar.gz | head -c 64)
     - ts_sum=$(sha256sum app/proto/gen/ts.tar.gz | head -c 64)
@@ -1353,6 +1370,7 @@ preview:protos:
     - aws s3 cp app/proto/gen/index.html s3://$AWS_PREVIEW_BUCKET/protos/$CI_COMMIT_SHORT_SHA/
     - aws s3 cp app/proto/gen/index.html s3://$AWS_PREVIEW_BUCKET/protos/$CI_COMMIT_REF_SLUG/
     - echo "Done, protos available at https://$CI_COMMIT_SHORT_SHA--protos.$PREVIEW_DOMAIN/ and https://$CI_COMMIT_REF_SLUG--protos.$PREVIEW_DOMAIN/"
+    - python3 app/scripts/pr_preview_comment.py --items protos
 
 # Having this here frees us from having to list out all the needs in each release below.
 # List out all that need to be waited for until releasing a new version

--- a/app/scripts/pr_preview_comment.py
+++ b/app/scripts/pr_preview_comment.py
@@ -1,13 +1,21 @@
 #!/usr/bin/env python3
 """Post (or update) a sticky preview comment on the GitHub PR for this pipeline.
 
-Runs twice per pipeline: with --stub at the very start (posts a placeholder
-within seconds of the push, only if no comment exists yet) and after the
-upload jobs (replaces the comment with the real sections, each included only
-when its preview actually exists). Requires GITHUB_PREVIEW_TOKEN; no-ops
+One invocation per preview, each owning a marker-delimited section of the comment:
+
+  --stub           a "building" placeholder, posted within seconds of the push
+                   (only if no comment exists yet)
+  --section mobile the mobile OTA section, run right after the OTA upload job —
+                   so the manifest is known-live, no probing
+  --section web    the Vercel web preview section
+
+A section write merges over whatever sections are already posted, so each
+preview updates only its own and a web-only commit keeps the mobile section an
+earlier commit posted (and vice versa). Requires GITHUB_PREVIEW_TOKEN; no-ops
 (exit 0) when there is no open PR for the commit.
 """
 
+import argparse
 import os
 import sys
 import time
@@ -16,6 +24,7 @@ import urllib.parse
 import requests
 
 MARKER = "<!-- couchers-preview-bot -->"
+SECTION_ORDER = ("mobile", "web")
 GITHUB_API = "https://api.github.com"
 VERCEL_API = "https://api.vercel.com"
 
@@ -87,13 +96,6 @@ def no_previews_section():
     return "_No previews are available for this commit._"
 
 
-def ota_is_live(short_sha, domain, platform):
-    try:
-        return requests.head(f"https://{short_sha}--ota.{domain}/{platform}/manifest", timeout=10).ok
-    except requests.RequestException:
-        return False
-
-
 def web_preview_section(url):
     return f"## Web preview\n\nView the [Vercel web preview]({url}) for this branch."
 
@@ -131,14 +133,23 @@ def resolve_web_preview_url(branch, sha, attempts=6, delay_seconds=10):
         if attempt > 1:
             time.sleep(delay_seconds)
 
-        ready = (vercel_get("/v6/deployments", {**base, "state": "READY", "meta-githubCommitRef": branch}, token).get("deployments") or [None])[0]
+        ready = (
+            vercel_get("/v6/deployments", {**base, "state": "READY", "meta-githubCommitRef": branch}, token).get(
+                "deployments"
+            )
+            or [None]
+        )[0]
         if ready:
             aliases = vercel_get(f"/v2/deployments/{ready['uid']}/aliases", {"teamId": team_id}, token)
-            branch_alias = next((a["alias"] for a in aliases.get("aliases", []) if "-git-" in (a.get("alias") or "")), None)
+            branch_alias = next(
+                (a["alias"] for a in aliases.get("aliases", []) if "-git-" in (a.get("alias") or "")), None
+            )
             if branch_alias:
                 return f"https://{branch_alias}"
 
-        by_sha = (vercel_get("/v6/deployments", {**base, "meta-githubCommitSha": sha}, token).get("deployments") or [None])[0]
+        by_sha = (
+            vercel_get("/v6/deployments", {**base, "meta-githubCommitSha": sha}, token).get("deployments") or [None]
+        )[0]
         if by_sha and by_sha.get("state") not in VERCEL_FAILED_STATES:
             return f"https://{by_sha['url']}"
         if ready:
@@ -147,13 +158,41 @@ def resolve_web_preview_url(branch, sha, attempts=6, delay_seconds=10):
     return None
 
 
-def build_body(sections, sha, pipeline_url):
+def section_markers(key):
+    return f"<!-- couchers-preview:{key}:start -->", f"<!-- couchers-preview:{key}:end -->"
+
+
+def section_footer(sha, pipeline_url):
     footer = f"commit `{sha[:8]}`"
     if pipeline_url:
         footer += f" · [pipeline]({pipeline_url})"
-    # blank-line separators: a heading right after </details> renders literally
-    parts = [MARKER, *[section for section in sections if section], "---", f"<sub>{footer}</sub>"]
-    return "\n\n".join(parts)
+    return f"<sub>{footer}</sub>"
+
+
+def wrap_section(key, content):
+    start, end = section_markers(key)
+    # blank lines around the markers so a heading after them doesn't render literally
+    return f"{start}\n\n{content}\n\n{end}"
+
+
+def parse_sections(body):
+    sections = {}
+    for key in SECTION_ORDER:
+        start, end = section_markers(key)
+        i = body.find(start)
+        j = body.find(end, i + len(start)) if i != -1 else -1
+        if i != -1 and j != -1:
+            sections[key] = body[i + len(start) : j].strip()
+    return sections
+
+
+def build_body(existing_body, updates):
+    sections = parse_sections(existing_body)
+    sections.update(updates)
+    rendered = [wrap_section(key, sections[key]) for key in SECTION_ORDER if sections.get(key)]
+    if not rendered:
+        rendered = [no_previews_section()]
+    return "\n\n".join([MARKER, *rendered])
 
 
 def find_open_pr(repo, sha, token):
@@ -180,8 +219,7 @@ def find_marker_comments(repo, pr, token):
     return [c for c in resp.json() if MARKER in (c.get("body") or "")]
 
 
-def upsert_comment(repo, pr, body, token):
-    marked = find_marker_comments(repo, pr, token)
+def upsert_comment(repo, pr, body, marked, token):
     if marked:
         existing, *duplicates = marked
         # concurrent pipelines can race the check above and double-post
@@ -208,47 +246,59 @@ def upsert_comment(repo, pr, body, token):
     return resp.json().get("html_url")
 
 
-def build_sections(sha, short_sha, domain, platforms):
-    live_platforms = [p for p in platforms if ota_is_live(short_sha, domain, p)]
+def mobile_update(sha, pipeline_url):
+    short_sha = env("CI_COMMIT_SHORT_SHA", required=True)
+    domain = env("PREVIEW_DOMAIN", required=True)
+    platforms = env("OTA_PLATFORMS", "ios").split()
+    return f"{mobile_ota_section(short_sha, domain, platforms)}\n\n{section_footer(sha, pipeline_url)}"
+
+
+def web_update(sha, pipeline_url):
     try:
         web_url = resolve_web_preview_url(env("CI_COMMIT_BRANCH"), sha)
     except requests.RequestException as e:
-        # a Vercel API outage must not take the mobile section down with it
-        print(f"Vercel API error - skipping the web preview section: {e}")
-        web_url = None
-
-    sections = []
-    if live_platforms:
-        sections.append(mobile_ota_section(short_sha, domain, live_platforms))
-    if web_url:
-        sections.append(web_preview_section(web_url))
-    # always replace the stub rather than leave "building…" up forever
-    return sections or [no_previews_section()]
+        print(f"Vercel API error - leaving the web section unchanged: {e}")
+        return None
+    if not web_url:
+        return None
+    return f"{web_preview_section(web_url)}\n\n{section_footer(sha, pipeline_url)}"
 
 
 def main():
-    stub = "--stub" in sys.argv[1:]
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--stub", action="store_true", help="post the building placeholder if no comment exists yet")
+    mode.add_argument("--section", choices=SECTION_ORDER, help="build and upsert just this preview section")
+    args = parser.parse_args()
+
     token = env("GITHUB_PREVIEW_TOKEN", required=True)
     repo = env("GITHUB_REPO", "Couchers-org/couchers")
     sha = env("CI_COMMIT_SHA", required=True)
-    short_sha = env("CI_COMMIT_SHORT_SHA", required=True)
-    domain = env("PREVIEW_DOMAIN", required=True)
     pipeline_url = env("CI_PIPELINE_URL", "")
-    platforms = env("OTA_PLATFORMS", "ios").split()
 
     pr = find_open_pr(repo, sha, token)
     if not pr:
         print(f"No open PR for {sha} - skipping preview comment.")
         return
 
-    # never downgrade an existing comment to a placeholder
-    if stub and find_marker_comments(repo, pr, token):
-        print(f"Preview comment already exists on PR #{pr} - leaving it for the full update.")
-        return
+    # the resource_group serializes comment writes, so this read is race-free
+    marked = find_marker_comments(repo, pr, token)
 
-    sections = [stub_section()] if stub else build_sections(sha, short_sha, domain, platforms)
-    url = upsert_comment(repo, pr, build_body(sections, sha, pipeline_url), token)
-    print(f"Posted {'stub ' if stub else ''}preview comment to PR #{pr}: {url}")
+    if args.stub:
+        if marked:
+            print(f"Preview comment already exists on PR #{pr} - leaving it for the section updates.")
+            return
+        body = f"{MARKER}\n\n{stub_section()}"
+    else:
+        builder = {"mobile": mobile_update, "web": web_update}[args.section]
+        content = builder(sha, pipeline_url)
+        existing_body = marked[0]["body"] if marked else ""
+        # empty update => keep existing sections, so a failed web resolve can't wipe mobile
+        body = build_body(existing_body, {args.section: content} if content else {})
+
+    url = upsert_comment(repo, pr, body, marked, token)
+    label = "stub" if args.stub else f"{args.section} section"
+    print(f"Posted {label} to PR #{pr}: {url}")
 
 
 if __name__ == "__main__":

--- a/app/scripts/pr_preview_comment.py
+++ b/app/scripts/pr_preview_comment.py
@@ -230,11 +230,6 @@ def item_markers(key):
     return f"<!-- cp:item:{key}:start -->", f"<!-- cp:item:{key}:end -->"
 
 
-def wrap_item(key, payload):
-    start, end = item_markers(key)
-    return f"{start}{payload}{end}"
-
-
 def parse_items(body):
     items = {}
     for key in ITEM_KEYS:
@@ -242,8 +237,21 @@ def parse_items(body):
         i = body.find(start)
         j = body.find(end, i + len(start)) if i != -1 else -1
         if i != -1 and j != -1:
-            items[key] = body[i + len(start) : j]
+            items[key] = body[i + len(start) : j].strip()
     return items
+
+
+def wrap_block(key, payload):
+    # markers on their own lines: a marker glued to the payload makes GitHub treat
+    # the whole line as an HTML block and skip the markdown (links) on it
+    start, end = item_markers(key)
+    return f"{start}\n\n{payload}\n\n{end}"
+
+
+def wrap_cell(key, payload):
+    # inside a table row the cell is inline context, so an inline comment is fine
+    start, end = item_markers(key)
+    return f"{start}{payload}{end}"
 
 
 def render(items):
@@ -253,9 +261,9 @@ def render(items):
         if not present:
             continue
         if style == "rich":
-            body = "\n\n".join(wrap_item(key, payload) for key, payload in present)
+            body = "\n\n".join(wrap_block(key, payload) for key, payload in present)
         else:
-            cells = " | ".join(wrap_item(key, payload) for key, payload in present)
+            cells = " | ".join(wrap_cell(key, payload) for key, payload in present)
             separators = " | ".join("---" for _ in present)
             body = f"| {cells} |\n| {separators} |"
         blocks.append(f"## {heading}\n\n{body}")

--- a/app/scripts/pr_preview_comment.py
+++ b/app/scripts/pr_preview_comment.py
@@ -1,32 +1,44 @@
 #!/usr/bin/env python3
 """Post (or update) a sticky preview comment on the GitHub PR for this pipeline.
 
-One invocation per preview, each owning a marker-delimited section of the comment:
+The comment is assembled from independently-written items, each wrapped in its
+own marker. A fixed layout (see LAYOUT) groups items into Mobile / Web / Backend
+/ Other; the last two render as compact one-row link tables. Each writer
+rewrites only the items it owns and leaves the rest untouched, so a commit that
+rebuilt only some artifacts keeps the others' items from an earlier commit.
 
-  --stub           a "building" placeholder, posted within seconds of the push
-                   (only if no comment exists yet)
-  --section mobile the mobile OTA section, run right after the OTA upload job —
-                   so the manifest is known-live, no probing
-  --section web    the Vercel web preview section
+Modes:
+  --stub          post a "building" placeholder if no comment exists yet
+  --items a,b,c   (re)build these items and upsert them (keys: see ITEM_BUILDERS)
 
-A section write merges over whatever sections are already posted, so each
-preview updates only its own and a web-only commit keeps the mobile section an
-earlier commit posted (and vice versa). Requires GITHUB_PREVIEW_TOKEN; no-ops
-(exit 0) when there is no open PR for the commit.
+Pure stdlib so it runs on any python3 without pip. Requires GITHUB_PREVIEW_TOKEN;
+no-ops (exit 0) when there is no open PR for the commit.
 """
 
 import argparse
+import json
 import os
 import sys
 import time
+import urllib.error
 import urllib.parse
-
-import requests
+import urllib.request
 
 MARKER = "<!-- couchers-preview-bot -->"
-SECTION_ORDER = ("mobile", "web")
 GITHUB_API = "https://api.github.com"
 VERCEL_API = "https://api.vercel.com"
+USER_AGENT = "couchers-preview-bot"
+
+# (heading, style, item keys) - items render in this order; a group with no
+# present items is dropped. "rich" renders the item bodies under the heading;
+# "table" renders the items as a compact one-row markdown link table.
+LAYOUT = [
+    ("Mobile", "rich", ["mobile"]),
+    ("Web (Vercel)", "rich", ["web"]),
+    ("Backend", "table", ["schema", "schema-diff", "emails"]),
+    ("Other", "table", ["protos", "bcov", "wcov"]),
+]
+ITEM_KEYS = [key for _, _, keys in LAYOUT for key in keys]
 
 
 def env(name, default=None, *, required=False):
@@ -36,23 +48,110 @@ def env(name, default=None, *, required=False):
     return value
 
 
-def gh_headers(token):
-    return {
+def http_json(method, url, headers, *, params=None, body=None):
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method, headers={**headers, "User-Agent": USER_AGENT})
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        raw = resp.read()
+    return json.loads(raw) if raw else None
+
+
+def gh(method, path, token, **kwargs):
+    headers = {
         "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
     }
+    return http_json(method, f"{GITHUB_API}{path}", headers, **kwargs)
+
+
+def find_open_pr(repo, sha, token):
+    for pr in gh("GET", f"/repos/{repo}/commits/{sha}/pulls", token) or []:
+        if pr.get("state") == "open":
+            return pr["number"]
+    return None
+
+
+def find_marker_comments(repo, pr, token):
+    comments = gh("GET", f"/repos/{repo}/issues/{pr}/comments", token, params={"per_page": 100}) or []
+    return [c for c in comments if MARKER in (c.get("body") or "")]
+
+
+def upsert_comment(repo, pr, body, marked, token):
+    if marked:
+        existing, *duplicates = marked
+        # concurrent pipelines can race the check above and double-post
+        for duplicate in duplicates:
+            gh("DELETE", f"/repos/{repo}/issues/comments/{duplicate['id']}", token)
+        result = gh("PATCH", f"/repos/{repo}/issues/comments/{existing['id']}", token, body={"body": body})
+    else:
+        result = gh("POST", f"/repos/{repo}/issues/{pr}/comments", token, body={"body": body})
+    return (result or {}).get("html_url")
+
+
+def vercel_get(path, params, token):
+    return http_json("GET", f"{VERCEL_API}{path}", {"Authorization": f"Bearer {token}"}, params=params)
+
+
+VERCEL_FAILED_STATES = ("ERROR", "CANCELED", "DELETED")
+
+
+def resolve_web_preview_url(branch, sha, attempts=6, delay_seconds=10):
+    """Resolve the Vercel preview URL for this commit.
+
+    Mirrors app/mobile/scripts/vercel-preview-url.mjs: the stable branch alias
+    once the branch has built successfully, else the in-flight deployment's own
+    URL. Returns None when unconfigured or nothing is found.
+    """
+    token = env("VERCEL_TOKEN")
+    project_id = env("VERCEL_PROJECT_ID")
+    team_id = env("VERCEL_TEAM_ID")
+    if not (token and project_id and team_id and branch):
+        print("Vercel API not configured - skipping the web preview.")
+        return None
+
+    base = {"projectId": project_id, "teamId": team_id, "limit": "1"}
+    for attempt in range(1, attempts + 1):
+        if attempt > 1:
+            time.sleep(delay_seconds)
+
+        ready = (
+            (
+                vercel_get("/v6/deployments", {**base, "state": "READY", "meta-githubCommitRef": branch}, token) or {}
+            ).get("deployments")
+            or [None]
+        )[0]
+        if ready:
+            aliases = vercel_get(f"/v2/deployments/{ready['uid']}/aliases", {"teamId": team_id}, token) or {}
+            branch_alias = next(
+                (a["alias"] for a in aliases.get("aliases", []) if "-git-" in (a.get("alias") or "")), None
+            )
+            if branch_alias:
+                return f"https://{branch_alias}"
+
+        by_sha = (
+            (vercel_get("/v6/deployments", {**base, "meta-githubCommitSha": sha}, token) or {}).get("deployments")
+            or [None]
+        )[0]
+        if by_sha and by_sha.get("state") not in VERCEL_FAILED_STATES:
+            return f"https://{by_sha['url']}"
+        if ready:
+            return f"https://{ready['url']}"
+        print(f"No Vercel deployment for {branch} ({sha}) yet (attempt {attempt}/{attempts}).")
+    return None
 
 
 def deep_link(manifest_url):
     return "couchers-devtool://expo-development-client/?url=" + urllib.parse.quote(manifest_url, safe="")
 
 
-def mobile_ota_section(short_sha, domain, platforms):
+def mobile_block(short_sha, domain, platforms):
     apk_url = f"https://android--devtool-builds.{domain}/index.html"
     lines = [
-        "## Mobile Dev Tool preview",
-        "",
         f"Download the Dev Tool for iOS from TestFlight, for Android, you can get the latest .apk [here]({apk_url}).",
         "",
         "Scan the QR with your phone camera, or tap **Open in Dev Tool** on the device, "
@@ -88,193 +187,98 @@ def mobile_ota_section(short_sha, domain, platforms):
     return "\n".join(lines)
 
 
-def stub_section():
-    return "## Previews\n\n⏳ Previews for this commit are building — QR codes and links will appear here once ready."
+def preview_url(host, path=""):
+    short_sha = env("CI_COMMIT_SHORT_SHA", required=True)
+    domain = env("PREVIEW_DOMAIN", required=True)
+    return f"https://{short_sha}--{host}.{domain}/{path}"
 
 
-def no_previews_section():
-    return "_No previews are available for this commit._"
+def link(label, url):
+    return f"[{label}]({url})"
 
 
-def web_preview_section(url):
-    return f"## Web preview\n\nView the [Vercel web preview]({url}) for this branch."
-
-
-def vercel_get(path, params, token):
-    resp = requests.get(
-        f"{VERCEL_API}{path}",
-        params=params,
-        headers={"Authorization": f"Bearer {token}"},
-        timeout=30,
-    )
-    resp.raise_for_status()
-    return resp.json()
-
-
-VERCEL_FAILED_STATES = ("ERROR", "CANCELED", "DELETED")
-
-
-def resolve_web_preview_url(branch, sha, attempts=6, delay_seconds=10):
-    """Resolve the Vercel preview URL for this commit.
-
-    Mirrors app/mobile/scripts/vercel-preview-url.mjs: the stable branch alias
-    once the branch has built successfully, else the in-flight deployment's own
-    URL. Returns None when unconfigured or nothing is found.
-    """
-    token = env("VERCEL_TOKEN")
-    project_id = env("VERCEL_PROJECT_ID")
-    team_id = env("VERCEL_TEAM_ID")
-    if not (token and project_id and team_id and branch):
-        print("Vercel API not configured - skipping the web preview section.")
-        return None
-
-    base = {"projectId": project_id, "teamId": team_id, "limit": "1"}
-    for attempt in range(1, attempts + 1):
-        if attempt > 1:
-            time.sleep(delay_seconds)
-
-        ready = (
-            vercel_get("/v6/deployments", {**base, "state": "READY", "meta-githubCommitRef": branch}, token).get(
-                "deployments"
-            )
-            or [None]
-        )[0]
-        if ready:
-            aliases = vercel_get(f"/v2/deployments/{ready['uid']}/aliases", {"teamId": team_id}, token)
-            branch_alias = next(
-                (a["alias"] for a in aliases.get("aliases", []) if "-git-" in (a.get("alias") or "")), None
-            )
-            if branch_alias:
-                return f"https://{branch_alias}"
-
-        by_sha = (
-            vercel_get("/v6/deployments", {**base, "meta-githubCommitSha": sha}, token).get("deployments") or [None]
-        )[0]
-        if by_sha and by_sha.get("state") not in VERCEL_FAILED_STATES:
-            return f"https://{by_sha['url']}"
-        if ready:
-            return f"https://{ready['url']}"
-        print(f"No Vercel deployment for {branch} ({sha}) yet (attempt {attempt}/{attempts}).")
-    return None
-
-
-def section_markers(key):
-    return f"<!-- couchers-preview:{key}:start -->", f"<!-- couchers-preview:{key}:end -->"
-
-
-def section_footer(sha, pipeline_url):
-    footer = f"commit `{sha[:8]}`"
-    if pipeline_url:
-        footer += f" · [pipeline]({pipeline_url})"
-    return f"<sub>{footer}</sub>"
-
-
-def wrap_section(key, content):
-    start, end = section_markers(key)
-    # blank lines around the markers so a heading after them doesn't render literally
-    return f"{start}\n\n{content}\n\n{end}"
-
-
-def parse_sections(body):
-    sections = {}
-    for key in SECTION_ORDER:
-        start, end = section_markers(key)
-        i = body.find(start)
-        j = body.find(end, i + len(start)) if i != -1 else -1
-        if i != -1 and j != -1:
-            sections[key] = body[i + len(start) : j].strip()
-    return sections
-
-
-def build_body(existing_body, updates):
-    sections = parse_sections(existing_body)
-    sections.update(updates)
-    rendered = [wrap_section(key, sections[key]) for key in SECTION_ORDER if sections.get(key)]
-    if not rendered:
-        rendered = [no_previews_section()]
-    return "\n\n".join([MARKER, *rendered])
-
-
-def find_open_pr(repo, sha, token):
-    resp = requests.get(
-        f"{GITHUB_API}/repos/{repo}/commits/{sha}/pulls",
-        headers=gh_headers(token),
-        timeout=30,
-    )
-    resp.raise_for_status()
-    for pr in resp.json():
-        if pr.get("state") == "open":
-            return pr["number"]
-    return None
-
-
-def find_marker_comments(repo, pr, token):
-    resp = requests.get(
-        f"{GITHUB_API}/repos/{repo}/issues/{pr}/comments",
-        headers=gh_headers(token),
-        params={"per_page": 100},
-        timeout=30,
-    )
-    resp.raise_for_status()
-    return [c for c in resp.json() if MARKER in (c.get("body") or "")]
-
-
-def upsert_comment(repo, pr, body, marked, token):
-    if marked:
-        existing, *duplicates = marked
-        # concurrent pipelines can race the check above and double-post
-        for duplicate in duplicates:
-            requests.delete(
-                f"{GITHUB_API}/repos/{repo}/issues/comments/{duplicate['id']}",
-                headers=gh_headers(token),
-                timeout=30,
-            ).raise_for_status()
-        resp = requests.patch(
-            f"{GITHUB_API}/repos/{repo}/issues/comments/{existing['id']}",
-            headers=gh_headers(token),
-            json={"body": body},
-            timeout=30,
-        )
-    else:
-        resp = requests.post(
-            f"{GITHUB_API}/repos/{repo}/issues/{pr}/comments",
-            headers=gh_headers(token),
-            json={"body": body},
-            timeout=30,
-        )
-    resp.raise_for_status()
-    return resp.json().get("html_url")
-
-
-def mobile_update(sha, pipeline_url):
+def item_mobile(_sha):
     short_sha = env("CI_COMMIT_SHORT_SHA", required=True)
     domain = env("PREVIEW_DOMAIN", required=True)
     platforms = env("OTA_PLATFORMS", "ios").split()
-    return f"{mobile_ota_section(short_sha, domain, platforms)}\n\n{section_footer(sha, pipeline_url)}"
+    return mobile_block(short_sha, domain, platforms)
 
 
-def web_update(sha, pipeline_url):
+def item_web(sha):
     try:
-        web_url = resolve_web_preview_url(env("CI_COMMIT_BRANCH"), sha)
-    except requests.RequestException as e:
-        print(f"Vercel API error - leaving the web section unchanged: {e}")
+        url = resolve_web_preview_url(env("CI_COMMIT_BRANCH"), sha)
+    except urllib.error.URLError as e:
+        print(f"Vercel API error - leaving the web preview unchanged: {e}")
         return None
-    if not web_url:
-        return None
-    return f"{web_preview_section(web_url)}\n\n{section_footer(sha, pipeline_url)}"
+    return f"View the [Vercel web preview]({url}) for this branch." if url else None
+
+
+# table items are deterministic links to the per-commit preview hosts
+ITEM_BUILDERS = {
+    "mobile": item_mobile,
+    "web": item_web,
+    "schema": lambda _sha: link("Schema", preview_url("schema", "schema.sql")),
+    "schema-diff": lambda _sha: link("Schema diff", preview_url("schema", "diff.html")),
+    "emails": lambda _sha: link("Sample emails", preview_url("test-artifacts", "emails/index.html")),
+    "protos": lambda _sha: link("Protos", preview_url("protos")),
+    "bcov": lambda _sha: link("Backend coverage", preview_url("bcov")),
+    "wcov": lambda _sha: link("Web coverage", preview_url("wcov")),
+}
+
+
+def item_markers(key):
+    return f"<!-- cp:item:{key}:start -->", f"<!-- cp:item:{key}:end -->"
+
+
+def wrap_item(key, payload):
+    start, end = item_markers(key)
+    return f"{start}{payload}{end}"
+
+
+def parse_items(body):
+    items = {}
+    for key in ITEM_KEYS:
+        start, end = item_markers(key)
+        i = body.find(start)
+        j = body.find(end, i + len(start)) if i != -1 else -1
+        if i != -1 and j != -1:
+            items[key] = body[i + len(start) : j]
+    return items
+
+
+def render(items):
+    blocks = []
+    for heading, style, keys in LAYOUT:
+        present = [(key, items[key]) for key in keys if items.get(key)]
+        if not present:
+            continue
+        if style == "rich":
+            body = "\n\n".join(wrap_item(key, payload) for key, payload in present)
+        else:
+            cells = " | ".join(wrap_item(key, payload) for key, payload in present)
+            separators = " | ".join("---" for _ in present)
+            body = f"| {cells} |\n| {separators} |"
+        blocks.append(f"## {heading}\n\n{body}")
+    return blocks
+
+
+def build_body(existing_body, updates):
+    items = parse_items(existing_body)
+    items.update(updates)
+    blocks = render(items) or ["_No previews are available for this commit._"]
+    return "\n\n".join([MARKER, *blocks])
 
 
 def main():
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description="Upsert the sticky PR preview comment.")
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--stub", action="store_true", help="post the building placeholder if no comment exists yet")
-    mode.add_argument("--section", choices=SECTION_ORDER, help="build and upsert just this preview section")
+    mode.add_argument("--items", help="comma-separated item keys to (re)build")
     args = parser.parse_args()
 
     token = env("GITHUB_PREVIEW_TOKEN", required=True)
     repo = env("GITHUB_REPO", "Couchers-org/couchers")
     sha = env("CI_COMMIT_SHA", required=True)
-    pipeline_url = env("CI_PIPELINE_URL", "")
 
     pr = find_open_pr(repo, sha, token)
     if not pr:
@@ -286,19 +290,22 @@ def main():
 
     if args.stub:
         if marked:
-            print(f"Preview comment already exists on PR #{pr} - leaving it for the section updates.")
+            print(f"Preview comment already exists on PR #{pr} - leaving it for the item updates.")
             return
-        body = f"{MARKER}\n\n{stub_section()}"
+        body = (
+            f"{MARKER}\n\n## Previews\n\n⏳ Previews for this commit are building — links will appear here once ready."
+        )
     else:
-        builder = {"mobile": mobile_update, "web": web_update}[args.section]
-        content = builder(sha, pipeline_url)
+        keys = [key.strip() for key in args.items.split(",") if key.strip()]
+        unknown = [key for key in keys if key not in ITEM_BUILDERS]
+        if unknown:
+            sys.exit(f"unknown item(s): {', '.join(unknown)}")
+        updates = {key: payload for key in keys if (payload := ITEM_BUILDERS[key](sha))}
         existing_body = marked[0]["body"] if marked else ""
-        # empty update => keep existing sections, so a failed web resolve can't wipe mobile
-        body = build_body(existing_body, {args.section: content} if content else {})
+        body = build_body(existing_body, updates)
 
     url = upsert_comment(repo, pr, body, marked, token)
-    label = "stub" if args.stub else f"{args.section} section"
-    print(f"Posted {label} to PR #{pr}: {url}")
+    print(f"Posted {'stub' if args.stub else args.items} to PR #{pr}: {url}")
 
 
 if __name__ == "__main__":

--- a/app/scripts/schema_diff_html.py
+++ b/app/scripts/schema_diff_html.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Render an HTML page diffing two SQL schema dumps (develop vs this branch).
+
+Usage: schema_diff_html.py <old.sql> <new.sql> <out.html>
+
+A missing old file (e.g. develop's schema not published yet) diffs against
+empty, so the page shows the whole schema as added rather than failing.
+"""
+
+import difflib
+import sys
+
+
+def read_lines(path):
+    try:
+        with open(path) as f:
+            return f.read().splitlines()
+    except FileNotFoundError:
+        return []
+
+
+def main():
+    old_path, new_path, out_path = sys.argv[1:4]
+    html = difflib.HtmlDiff(wrapcolumn=100).make_file(
+        read_lines(old_path),
+        read_lines(new_path),
+        fromdesc="develop",
+        todesc="this branch",
+        context=True,
+        numlines=3,
+    )
+    with open(out_path, "w") as f:
+        f.write(html)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/mobile-dev-tool-ota.md
+++ b/docs/mobile-dev-tool-ota.md
@@ -293,14 +293,22 @@ multipart content-type), `bundle.hbc`, `assets/`, `qr.png`, and `open.html` to
 very start of every non-`develop` branch pipeline and posts the sticky comment
 as a "previews are building" placeholder within seconds of the push.
 
-**`preview:pr-comment`** (`python:3.14-slim`) — `needs:` the stub job plus the
-upload job (the latter `optional:`, since the job runs for every branch
-pipeline, not just mobile ones), then runs `app/scripts/pr_preview_comment.py`
-to replace the placeholder with the real sections (§9). Sections are included
-only when their preview exists (the web link is the commit's per-deployment
-URL and may still be building when posted); when nothing exists, the comment
-says so. No-ops if `GITHUB_PREVIEW_TOKEN` is unset or there's no open PR, so
-it never reds the pipeline.
+**`preview:pr-comment-mobile`** (`python:3.14-slim`) — `needs:` the stub job and
+the OTA upload job (non-optional, and it mirrors the upload job's `changes:`
+rules), so it runs exactly when a commit rebuilds mobile. Because it's gated on
+the upload, the manifest it links to is already live — it just renders the
+mobile section (§9), no probing. `pr_preview_comment.py --section mobile`.
+
+**`preview:pr-comment-web`** (`python:3.14-slim`) — `needs:` only the stub, runs
+on every branch pipeline (Vercel deploys on every push), and resolves the
+preview URL from the Vercel API. `pr_preview_comment.py --section web`.
+
+Each writer owns its own marker-delimited section and merges over whatever's
+already posted, so a web-only commit updates just the web section and keeps the
+mobile section an earlier commit posted (and vice versa). All three comment jobs
+share `resource_group: pr-preview-comment` so the read-modify-write never races.
+They no-op if `GITHUB_PREVIEW_TOKEN` is unset or there's no open PR, so they
+never red the pipeline.
 
 ---
 
@@ -343,11 +351,12 @@ static pipeline (`build:mobile-ota-staging` / `build:mobile-ota-prod` in
 
 ## 9. PR comment + QR
 
-`preview:pr-comment` posts one **sticky** comment per PR (marked with the HTML
-comment `<!-- couchers-preview-bot -->`; `app/scripts/pr_preview_comment.py`
+The `preview:pr-comment-*` jobs post one **sticky** comment per PR (marked with the
+HTML comment `<!-- couchers-preview-bot -->`; `app/scripts/pr_preview_comment.py`
 resolves the PR from the commit SHA via the GitHub API, then upserts the comment).
-It's assembled from **sections**, so more previews (web, coverage, …) can be
-appended as the pipeline grows.
+It's assembled from marker-delimited **sections** (`<!-- couchers-preview:<name>:start -->`
+… `:end -->`), each written independently by its own job, so more previews
+(coverage, …) can be added as the pipeline grows.
 
 **Implemented today — the RN-shell OTA section**, one block per platform with:
 
@@ -378,10 +387,11 @@ repointing via `couchers-devtool://dev-settings?api=<url>&web=<url>`
 wins over the manifest.
 
 The PR comment gains a **Web preview** section with the same link, resolved
-Python-side in `pr_preview_comment.py` (mirror of the `.mjs` resolver). Each
-section is included only when its preview is actually live (HEAD on the OTA
-manifest / Vercel API lookup), and the job runs for every branch pipeline —
-backend-only PRs get an honest "no previews" comment. Vercel's own PR comments
+Python-side in `pr_preview_comment.py` (mirror of the `.mjs` resolver) by the
+`preview:pr-comment-web` job, which runs for every branch pipeline. The mobile
+section is gated on the OTA upload and so is only written when it's live; a
+backend-only PR (neither writer contributes) gets an honest "no previews"
+comment from the web job's empty update. Vercel's own PR comments
 are silenced in the Vercel dashboard (project → Settings → Git → Connected
 Git Repository toggles); the `github.silent` vercel.json property is
 deprecated and doesn't work, so the repo carries no vercel.json.
@@ -478,7 +488,7 @@ loadable.
 - App config / channels: `app/mobile/app.config.js`, `app/mobile/eas.json`
 - In-app web/API override: `app/mobile/config/urls.ts`, `app/mobile/app/dev-settings.tsx`
 - QR pattern precedent: `app/mobile/dev-url-qr.html`
-- CI publish jobs: `app/.gitlab-ci.yml` (`build:mobile-ota-devtool`, `preview:mobile-ota-devtool`, `preview:pr-comment`)
+- CI publish jobs: `app/.gitlab-ci.yml` (`build:mobile-ota-devtool`, `preview:mobile-ota-devtool`, `preview:pr-comment-stub`/`-mobile`/`-web`)
 - Manifest/bundle layout: `app/mobile/scripts/ota-bundle.mjs`; `open.html`
   redirect: `app/mobile/scripts/ota-open-page.mjs` (QR is rendered in CI)
 - PR comment generator: `app/scripts/pr_preview_comment.py`

--- a/docs/mobile-dev-tool-ota.md
+++ b/docs/mobile-dev-tool-ota.md
@@ -293,22 +293,14 @@ multipart content-type), `bundle.hbc`, `assets/`, `qr.png`, and `open.html` to
 very start of every non-`develop` branch pipeline and posts the sticky comment
 as a "previews are building" placeholder within seconds of the push.
 
-**`preview:pr-comment-mobile`** (`python:3.14-slim`) — `needs:` the stub job and
-the OTA upload job (non-optional, and it mirrors the upload job's `changes:`
-rules), so it runs exactly when a commit rebuilds mobile. Because it's gated on
-the upload, the manifest it links to is already live — it just renders the
-mobile section (§9), no probing. `pr_preview_comment.py --section mobile`.
-
-**`preview:pr-comment-web`** (`python:3.14-slim`) — `needs:` only the stub, runs
-on every branch pipeline (Vercel deploys on every push), and resolves the
-preview URL from the Vercel API. `pr_preview_comment.py --section web`.
-
-Each writer owns its own marker-delimited section and merges over whatever's
-already posted, so a web-only commit updates just the web section and keeps the
-mobile section an earlier commit posted (and vice versa). All three comment jobs
-share `resource_group: pr-preview-comment` so the read-modify-write never races.
-They no-op if `GITHUB_PREVIEW_TOKEN` is unset or there's no open PR, so they
-never red the pipeline.
+**`preview:pr-comment`** (`python:3.14-slim`) — `needs:` the stub job plus the
+upload job (the latter `optional:`, since the job runs for every branch
+pipeline, not just mobile ones), then runs `app/scripts/pr_preview_comment.py`
+to replace the placeholder with the real sections (§9). Sections are included
+only when their preview exists (the web link is the commit's per-deployment
+URL and may still be building when posted); when nothing exists, the comment
+says so. No-ops if `GITHUB_PREVIEW_TOKEN` is unset or there's no open PR, so
+it never reds the pipeline.
 
 ---
 
@@ -351,12 +343,11 @@ static pipeline (`build:mobile-ota-staging` / `build:mobile-ota-prod` in
 
 ## 9. PR comment + QR
 
-The `preview:pr-comment-*` jobs post one **sticky** comment per PR (marked with the
-HTML comment `<!-- couchers-preview-bot -->`; `app/scripts/pr_preview_comment.py`
+`preview:pr-comment` posts one **sticky** comment per PR (marked with the HTML
+comment `<!-- couchers-preview-bot -->`; `app/scripts/pr_preview_comment.py`
 resolves the PR from the commit SHA via the GitHub API, then upserts the comment).
-It's assembled from marker-delimited **sections** (`<!-- couchers-preview:<name>:start -->`
-… `:end -->`), each written independently by its own job, so more previews
-(coverage, …) can be added as the pipeline grows.
+It's assembled from **sections**, so more previews (web, coverage, …) can be
+appended as the pipeline grows.
 
 **Implemented today — the RN-shell OTA section**, one block per platform with:
 
@@ -387,11 +378,10 @@ repointing via `couchers-devtool://dev-settings?api=<url>&web=<url>`
 wins over the manifest.
 
 The PR comment gains a **Web preview** section with the same link, resolved
-Python-side in `pr_preview_comment.py` (mirror of the `.mjs` resolver) by the
-`preview:pr-comment-web` job, which runs for every branch pipeline. The mobile
-section is gated on the OTA upload and so is only written when it's live; a
-backend-only PR (neither writer contributes) gets an honest "no previews"
-comment from the web job's empty update. Vercel's own PR comments
+Python-side in `pr_preview_comment.py` (mirror of the `.mjs` resolver). Each
+section is included only when its preview is actually live (HEAD on the OTA
+manifest / Vercel API lookup), and the job runs for every branch pipeline —
+backend-only PRs get an honest "no previews" comment. Vercel's own PR comments
 are silenced in the Vercel dashboard (project → Settings → Git → Connected
 Git Repository toggles); the `github.silent` vercel.json property is
 deprecated and doesn't work, so the repo carries no vercel.json.
@@ -488,7 +478,7 @@ loadable.
 - App config / channels: `app/mobile/app.config.js`, `app/mobile/eas.json`
 - In-app web/API override: `app/mobile/config/urls.ts`, `app/mobile/app/dev-settings.tsx`
 - QR pattern precedent: `app/mobile/dev-url-qr.html`
-- CI publish jobs: `app/.gitlab-ci.yml` (`build:mobile-ota-devtool`, `preview:mobile-ota-devtool`, `preview:pr-comment-stub`/`-mobile`/`-web`)
+- CI publish jobs: `app/.gitlab-ci.yml` (`build:mobile-ota-devtool`, `preview:mobile-ota-devtool`, `preview:pr-comment`)
 - Manifest/bundle layout: `app/mobile/scripts/ota-bundle.mjs`; `open.html`
   redirect: `app/mobile/scripts/ota-open-page.mjs` (QR is rendered in CI)
 - PR comment generator: `app/scripts/pr_preview_comment.py`


### PR DESCRIPTION
Fixes a regression from #9056: a web-only commit was wiping the mobile preview section.

The preview comment was rebuilt wholesale on every pipeline by a single `preview:pr-comment` job, which decided whether to include a mobile section by HEAD-probing `…/<short_sha>/…/manifest` for the **current** commit (`ota_is_live`). On a web-only commit no OTA exists for that short SHA, so the job produced only a web section and the `PATCH` overwrote the entire comment — deleting the mobile section an earlier commit had posted.

This drops the probe and gives each preview its own writer that owns a marker-delimited section and merges only that section over whatever is already posted:

- `pr_preview_comment.py` gains `--section mobile` / `--section web` (replacing the single full-rebuild run); `ota_is_live` and the combined `build_sections` are gone.
- **`preview:pr-comment-mobile`** is gated on `preview:mobile-ota-devtool` (and mirrors its `changes:` rules), so it runs exactly when a commit rebuilds mobile and the manifest it links to is already live — no probing.
- **`preview:pr-comment-web`** runs on every branch pipeline and resolves the Vercel URL (Vercel owns the web deploy, so it's the one thing that must still be asked). A failed/empty resolve preserves the existing mobile section and only falls back to "no previews" when a lone stub is all that's there.
- All three comment jobs keep `resource_group: pr-preview-comment`, so the shared comment's read-modify-write stays race-free.

Net: each preview updates only its own section; a web-only commit keeps the mobile section (and its original commit footer) an earlier commit posted, and vice versa.

## Testing

This is CI-only plumbing (no app runtime change), validated locally:

- `ruff check` / `ruff format --check` clean on the script.
- Parsed `app/.gitlab-ci.yml` and confirmed all three comment jobs carry the right `needs`/`rules`.
- Ran a merge/integration simulation of the section logic: stub → mobile-write → web-write → a later **web-only** commit, asserting the mobile section (and its original `commit` footer) survives while web updates, ordering stays mobile-then-web, a lone stub falls back to "no previews", and argparse rejects missing/conflicting modes.
- End-to-end behaviour will be confirmed by this PR's own pipeline producing a correct sticky comment.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._