### PR TITLE
Backend/emails: Consolidate render_email

### DIFF
--- a/app/backend/src/couchers/email/blocks.py
+++ b/app/backend/src/couchers/email/blocks.py
@@ -1,0 +1,248 @@
+"""
+Data model for emails built out of well-known blocks,
+that can be rendered HTML and plaintext for any locale.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Self
+
+from markupsafe import Markup
+
+from couchers import urls
+from couchers.email.locales import get_emails_i18next
+from couchers.i18n import LocalizationContext
+from couchers.i18n.i18next import SubstitutionDict, full_string_key
+from couchers.proto import api_pb2
+from couchers.utils import now
+
+
+@dataclass
+class EmailBase(ABC):
+    """
+    Base class for email data models, which capture all the data required to render
+    an email's subject line and body as HTML or plaintext, in any locale.
+    """
+
+    user_name: str
+
+    @property
+    @abstractmethod
+    def string_key_base(self) -> str: ...
+
+    def get_subject_line(self, loc_context: LocalizationContext) -> str:
+        """Gets the subject line header of the email."""
+        return self._localize(loc_context, ".subject")
+
+    def get_preview_line(self, loc_context: LocalizationContext) -> str | None:
+        """Gets the line that gets shown as a preview next to the title in users' inboxes."""
+        return None
+
+    @abstractmethod
+    def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
+        """Gets the blocks that form the body of the email."""
+        ...
+
+    def _body_builder(
+        self,
+        loc_context: LocalizationContext,
+        *,
+        standard_greeting: bool = True,
+        standard_closing: bool = True,
+        security_warning: bool = False,
+    ) -> EmailBlocksBuilder:
+        builder = EmailBlocksBuilder(locale=loc_context.locale, string_key_base=self.string_key_base)
+        if standard_greeting:
+            builder.para("generic.greeting_line", {"name": self.user_name})
+        if standard_closing:
+            builder.para("generic.closing_line", epilogue=True)
+        if security_warning:
+            builder.para("generic.security_warning_contact_support", epilogue=True)
+        return builder
+
+    @classmethod
+    @abstractmethod
+    def test_instances(cls) -> list[Self]:
+        """
+        Returns dummy instances covering every distinct rendering variant of this email.
+
+        Emails whose subject or body depends on internal state (e.g. a status enum or a
+        boolean) build their localization keys dynamically, so a single dummy instance only
+        exercises one branch. Such emails override this to return one instance per branch,
+        ensuring the rendering tests resolve every localization key the class can produce.
+        """
+        ...
+
+    # Helpers for localizing email-specific strings
+    def _localize(
+        self, loc_context: LocalizationContext, key: str, substitutions: SubstitutionDict | None = None
+    ) -> str:
+        key = full_string_key(key, relative_base=self.string_key_base)
+        return get_emails_i18next().localize(key, loc_context.locale, substitutions)
+
+
+@dataclass
+class EmailBlock:
+    """Base class for building blocks of an email body, HTML/plaintext-agnostic."""
+
+    pass
+
+
+@dataclass(kw_only=True, slots=True)
+class ParaBlock(EmailBlock):
+    """A paragraph of text which may contain span-level HTML."""
+
+    text: str | Markup
+
+
+@dataclass(kw_only=True, slots=True)
+class UserBlock(EmailBlock):
+    """A banner with another user's profile information, for example preceding a quoted message."""
+
+    info: UserInfo
+    comment: str | Markup | None
+
+
+@dataclass(kw_only=True, slots=True)
+class UserInfo:
+    name: str
+    age: int
+    city: str
+    avatar_url: str
+    profile_url: str
+
+    @classmethod
+    def from_protobuf(cls, user: api_pb2.User) -> Self:
+        return cls(
+            name=user.name,
+            age=user.age,
+            city=user.city,
+            avatar_url=user.avatar_thumbnail_url or urls.icon_url(),
+            profile_url=urls.user_link(username=user.username),
+        )
+
+    @staticmethod
+    def dummy_bob() -> UserInfo:
+        return UserInfo(
+            name="Bob",
+            age=30,
+            city="Berlin",
+            avatar_url="https://couchers.org/logo512.png",
+            profile_url="https://couchers.org/user/bob",
+        )
+
+
+@dataclass(kw_only=True, slots=True)
+class QuoteBlock(EmailBlock):
+    """A quoted message, typically from another user. Either plaintext or markdown."""
+
+    text: str
+    markdown: bool
+
+
+@dataclass(kw_only=True, slots=True)
+class ActionBlock(EmailBlock):
+    """An action that can be performed by the user in response to the email."""
+
+    text: str
+    target_url: str
+
+
+class EmailBlocksBuilder:
+    """
+    Builder object for constructing a list of localized EmailBlock's to form the body of an email.
+    """
+
+    _locale: str
+    _string_key_base: str
+    _blocks: list[EmailBlock]
+    _epilogue: list[EmailBlock]
+
+    def __init__(self, locale: str, string_key_base: str):
+        self._locale = locale
+        self._string_key_base = string_key_base
+        self._blocks = []
+        self._epilogue = []
+
+    def build(self) -> list[EmailBlock]:
+        return self._blocks + self._epilogue
+
+    def para(self, key: str, substitutions: SubstitutionDict | None = None, epilogue: bool = False) -> Self:
+        return self.block(ParaBlock(text=self._markup(key, substitutions)), epilogue=epilogue)
+
+    def quote(self, text: str, *, markdown: bool) -> Self:
+        return self.block(QuoteBlock(text=text, markdown=markdown))
+
+    def user(
+        self,
+        info: UserInfo,
+        comment_key: str | None = None,
+        substitutions: SubstitutionDict | None = None,
+    ) -> Self:
+        comment = self._markup(comment_key, substitutions) if comment_key else None
+        return self.block(UserBlock(info=info, comment=comment))
+
+    def action(self, url: str, text_key: str, substitutions: SubstitutionDict | None = None) -> Self:
+        return self.block(ActionBlock(text=self._text(text_key, substitutions), target_url=url))
+
+    def block(self, block: EmailBlock, epilogue: bool = False) -> Self:
+        if epilogue:
+            self._epilogue.append(block)
+        else:
+            self._blocks.append(block)
+        return self
+
+    def _text(self, key: str, substitutions: SubstitutionDict | None = None) -> str:
+        key = full_string_key(key, relative_base=self._string_key_base)
+        return get_emails_i18next().localize(key, self._locale, substitutions)
+
+    def _markup(self, key: str, substitutions: SubstitutionDict | None = None) -> Markup:
+        key = full_string_key(key, relative_base=self._string_key_base)
+        return get_emails_i18next().localize_with_markup(key, self._locale, substitutions)
+
+
+@dataclass(kw_only=True)
+class EmailFooter:
+    timezone_name: str
+    copyright_year: int = now().year
+    unsubscribe_info: UnsubscribeInfo | None
+
+    def to_template_args(self) -> dict[str, Any]:
+        args: dict[str, Any] = {
+            "footer_timezone_name": self.timezone_name,
+            "footer_copyright_year": self.copyright_year,
+            "footer_email_is_critical": self.unsubscribe_info is None,
+        }
+
+        if unsubscribe_info := self.unsubscribe_info:
+            args.update(unsubscribe_info.to_template_args())
+
+        return args
+
+
+@dataclass(kw_only=True)
+class UnsubscribeInfo:
+    manage_notifications_url: str
+    do_not_email_url: str
+    topic_action_link: UnsubscribeLink
+    topic_key_link: UnsubscribeLink | None = None
+
+    def to_template_args(self) -> dict[str, Any]:
+        args: dict[str, Any] = {
+            "footer_manage_notifications_link": self.manage_notifications_url,
+            "footer_do_not_email_link": self.do_not_email_url,
+            "footer_notification_topic_action": self.topic_action_link.text,
+            "footer_notification_topic_action_link": self.topic_action_link.url,
+        }
+
+        if topic_key_link := self.topic_key_link:
+            args["footer_notification_topic_key"] = topic_key_link.text
+            args["footer_notification_topic_key_link"] = topic_key_link.url
+
+        return args
+
+
+@dataclass(kw_only=True)
+class UnsubscribeLink:
+    text: str
+    url: str

--- a/app/backend/src/couchers/email/calendar_events.py
+++ b/app/backend/src/couchers/email/calendar_events.py
@@ -5,7 +5,7 @@ from ics.grammar.parse import ContentLine  # type: ignore[import-untyped]
 
 from couchers import urls
 from couchers.config import config
-from couchers.email.rendering import get_emails_i18next
+from couchers.email.locales import get_emails_i18next
 from couchers.i18n import LocalizationContext
 from couchers.proto.internal.jobs_pb2 import EmailAttachmentV2
 from couchers.proto.requests_pb2 import HostRequest

--- a/app/backend/src/couchers/email/dump_emails.py
+++ b/app/backend/src/couchers/email/dump_emails.py
@@ -16,15 +16,13 @@ from pathlib import Path
 from markupsafe import Markup
 
 import couchers.email.emails
-from couchers.email.emails import EmailBase
-from couchers.email.rendering import (
+from couchers.email.blocks import (
+    EmailBase,
     EmailFooter,
     UnsubscribeInfo,
     UnsubscribeLink,
-    render_html_body,
-    render_plaintext_body,
-    template_folder,
 )
+from couchers.email.rendering import render_email, template_folder
 from couchers.i18n import LocalizationContext
 from couchers.i18n.locales import DEFAULT_LOCALE, get_supported_locales
 from couchers.templating import Jinja2Template
@@ -130,22 +128,14 @@ def dump_all(outdir: Path, *, filter_glob: str = "*", locales: list[str] | None 
 
 def dump_email(email: EmailBase, footer: EmailFooter, loc_context: LocalizationContext, filepath_no_ext: Path) -> str:
     """Dumps an email's subject and plaintext+html body to a file, returning the subject line."""
-    subject_line = email.get_subject_line(loc_context)
-    preview_line = email.get_preview_line(loc_context)
-    blocks = email.get_body_blocks(loc_context)
+    rendered = render_email(email, footer, loc_context)
+    html = rendered.body_html.replace("attachment_imgs/", "../attachment_imgs/")
 
     filepath_no_ext.parent.mkdir(parents=True, exist_ok=True)
-
-    html = render_html_body(
-        subject=subject_line, preview=preview_line, blocks=blocks, footer=footer, loc_context=loc_context
-    )
-    html = html.replace("attachment_imgs/", "../attachment_imgs/")
     filepath_no_ext.with_suffix(".html").write_text(html)
+    filepath_no_ext.with_suffix(".txt").write_text(rendered.body_plaintext)
 
-    plaintext = render_plaintext_body(blocks=blocks, footer=footer, loc_context=loc_context)
-    filepath_no_ext.with_suffix(".txt").write_text(plaintext)
-
-    return subject_line
+    return rendered.subject
 
 
 def write_index(index_path: Path, rendered: list[RenderedVariation], locales: list[str]) -> None:

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -3,7 +3,6 @@ Defines data models for each email we sent out to users.
 """
 
 import re
-from abc import ABC, abstractmethod
 from dataclasses import dataclass, replace
 from datetime import UTC, date, datetime
 from typing import Self, assert_never
@@ -13,86 +12,20 @@ from markupsafe import Markup, escape
 from couchers import urls
 from couchers.config import config
 from couchers.constants import LATEST_RELEASE_BLOG_URL
-from couchers.email.rendering import (
+from couchers.email.blocks import (
     ActionBlock,
+    EmailBase,
     EmailBlock,
-    EmailBlocksBuilder,
     ParaBlock,
     QuoteBlock,
     UserInfo,
-    get_emails_i18next,
 )
+from couchers.email.locales import get_emails_i18next
 from couchers.i18n import LocalizationContext
-from couchers.i18n.i18next import SubstitutionDict, full_string_key
 from couchers.i18n.localize import format_phone_number
 from couchers.notifications.quick_links import generate_quick_decline_link
 from couchers.proto import conversations_pb2, events_pb2, notification_data_pb2
 from couchers.utils import now, to_aware_datetime
-
-
-@dataclass
-class EmailBase(ABC):
-    """
-    Base class for email data models, which capture all the data required to render
-    an email's subject line and body as HTML or plaintext, in any locale.
-    """
-
-    user_name: str
-
-    @property
-    @abstractmethod
-    def string_key_base(self) -> str: ...
-
-    def get_subject_line(self, loc_context: LocalizationContext) -> str:
-        """Gets the subject line header of the email."""
-        return self._localize(loc_context, ".subject")
-
-    def get_preview_line(self, loc_context: LocalizationContext) -> str | None:
-        """Gets the line that gets shown as a preview next to the title in users' inboxes."""
-        return None
-
-    @abstractmethod
-    def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
-        """Gets the blocks that form the body of the email."""
-        ...
-
-    def _body_builder(
-        self,
-        loc_context: LocalizationContext,
-        *,
-        standard_greeting: bool = True,
-        standard_closing: bool = True,
-        security_warning: bool = False,
-    ) -> EmailBlocksBuilder:
-        builder = EmailBlocksBuilder(locale=loc_context.locale, string_key_base=self.string_key_base)
-        if standard_greeting:
-            builder.para("generic.greeting_line", {"name": self.user_name})
-        if standard_closing:
-            builder.para("generic.closing_line", epilogue=True)
-        if security_warning:
-            builder.para("generic.security_warning_contact_support", epilogue=True)
-        return builder
-
-    @classmethod
-    @abstractmethod
-    def test_instances(cls) -> list[Self]:
-        """
-        Returns dummy instances covering every distinct rendering variant of this email.
-
-        Emails whose subject or body depends on internal state (e.g. a status enum or a
-        boolean) build their localization keys dynamically, so a single dummy instance only
-        exercises one branch. Such emails override this to return one instance per branch,
-        ensuring the rendering tests resolve every localization key the class can produce.
-        """
-        ...
-
-    # Helpers for localizing email-specific strings
-    def _localize(
-        self, loc_context: LocalizationContext, key: str, substitutions: SubstitutionDict | None = None
-    ) -> str:
-        key = full_string_key(key, relative_base=self.string_key_base)
-        return get_emails_i18next().localize(key, loc_context.locale, substitutions)
-
 
 # Common string keys
 _do_not_reply_request_string_key = "generic.do_not_reply_request"

--- a/app/backend/src/couchers/email/locales.py
+++ b/app/backend/src/couchers/email/locales.py
@@ -1,0 +1,10 @@
+from functools import cache
+from pathlib import Path
+
+from couchers.i18n.i18next import I18Next
+from couchers.i18n.locales import load_locales
+
+
+@cache
+def get_emails_i18next() -> I18Next:
+    return load_locales(Path(__file__).parent / "locales")

--- a/app/backend/src/couchers/email/queuing.py
+++ b/app/backend/src/couchers/email/queuing.py
@@ -6,8 +6,8 @@ from sqlalchemy.orm.session import Session
 
 from couchers.config import config
 from couchers.context import CouchersContext
-from couchers.email.emails import EmailBase
-from couchers.email.rendering import EmailFooter, render_html_body, render_plaintext_body
+from couchers.email.blocks import EmailBase, EmailFooter
+from couchers.email.rendering import render_email
 from couchers.i18n import LocalizationContext
 from couchers.jobs.enqueue import queue_job
 from couchers.metrics import emails_counter
@@ -51,16 +51,8 @@ def queue_userless_email(
     if not context.get_boolean_value("notification_translations_enabled", default=False):
         loc_context = LocalizationContext(locale="en", timezone=loc_context.timezone)
 
-    subject = email.get_subject_line(loc_context)
-    preview = email.get_preview_line(loc_context)
-    body_blocks = email.get_body_blocks(loc_context)
-
     footer = EmailFooter(timezone_name=loc_context.localized_timezone, copyright_year=now().year, unsubscribe_info=None)
-
-    body_plaintext = render_plaintext_body(blocks=body_blocks, footer=footer, loc_context=loc_context)
-    body_html = render_html_body(
-        subject=subject, preview=preview, blocks=body_blocks, footer=footer, loc_context=loc_context
-    )
+    rendered = render_email(email, footer, loc_context)
 
     queue_email(
         session,
@@ -68,9 +60,9 @@ def queue_userless_email(
             sender_name=config.NOTIFICATION_EMAIL_SENDER,
             sender_email=config.NOTIFICATION_EMAIL_ADDRESS,
             recipient=recipient,
-            subject=config.NOTIFICATION_PREFIX + subject,
-            plain=body_plaintext,
-            html=body_html,
+            subject=config.NOTIFICATION_PREFIX + rendered.subject,
+            plain=rendered.body_plaintext,
+            html=rendered.body_html,
             source_data=f"{source_data_header}; version={config.VERSION}",
         ),
     )

--- a/app/backend/src/couchers/email/rendering.py
+++ b/app/backend/src/couchers/email/rendering.py
@@ -1,207 +1,20 @@
 """
-Renders HTML and plaintext emails out of well-known blocks.
+Renders blocks-based emails to HTML or plaintext emails for a locale.
 """
 
 import re
 from dataclasses import asdict, dataclass
-from functools import lru_cache
+from functools import cache
 from html import unescape
 from pathlib import Path
-from typing import Any, Self
 
 from markdown_it import MarkdownIt
 from markupsafe import Markup
 
-from couchers import urls
+from couchers.email.blocks import ActionBlock, EmailBase, EmailBlock, EmailFooter, ParaBlock, QuoteBlock, UserBlock
+from couchers.email.locales import get_emails_i18next
 from couchers.i18n import LocalizationContext
-from couchers.i18n.i18next import I18Next, SubstitutionDict, full_string_key
-from couchers.i18n.locales import load_locales
-from couchers.proto import api_pb2
 from couchers.templating import Jinja2Template
-from couchers.utils import now
-
-
-@dataclass
-class EmailBlock:
-    """Base class for building blocks of an email body, HTML/plaintext-agnostic."""
-
-    pass
-
-
-@dataclass(kw_only=True, slots=True)
-class ParaBlock(EmailBlock):
-    """A paragraph of text which may contain span-level HTML."""
-
-    text: str | Markup
-
-
-@dataclass(kw_only=True, slots=True)
-class UserBlock(EmailBlock):
-    """A banner with another user's profile information, for example preceding a quoted message."""
-
-    info: UserInfo
-    comment: str | Markup | None
-
-
-@dataclass(kw_only=True, slots=True)
-class UserInfo:
-    name: str
-    age: int
-    city: str
-    avatar_url: str
-    profile_url: str
-
-    @classmethod
-    def from_protobuf(cls, user: api_pb2.User) -> Self:
-        return cls(
-            name=user.name,
-            age=user.age,
-            city=user.city,
-            avatar_url=user.avatar_thumbnail_url or urls.icon_url(),
-            profile_url=urls.user_link(username=user.username),
-        )
-
-    @staticmethod
-    def dummy_bob() -> UserInfo:
-        return UserInfo(
-            name="Bob",
-            age=30,
-            city="Berlin",
-            avatar_url="https://couchers.org/logo512.png",
-            profile_url="https://couchers.org/user/bob",
-        )
-
-
-@dataclass(kw_only=True, slots=True)
-class QuoteBlock(EmailBlock):
-    """A quoted message, typically from another user. Either plaintext or markdown."""
-
-    text: str
-    markdown: bool
-
-
-@dataclass(kw_only=True, slots=True)
-class ActionBlock(EmailBlock):
-    """An action that can be performed by the user in response to the email."""
-
-    text: str
-    target_url: str
-
-
-@dataclass(kw_only=True, slots=True)
-class TwoButtonHTMLBlock(EmailBlock):
-    """An HTML-only block for rendering as side-by-side buttons."""
-
-    text_1: str
-    target_url_1: str
-    text_2: str
-    target_url_2: str
-
-
-class EmailBlocksBuilder:
-    """
-    Builder object for constructing a list of localized EmailBlock's to form the body of an email.
-    """
-
-    _locale: str
-    _string_key_base: str
-    _blocks: list[EmailBlock]
-    _epilogue: list[EmailBlock]
-
-    def __init__(self, locale: str, string_key_base: str):
-        self._locale = locale
-        self._string_key_base = string_key_base
-        self._blocks = []
-        self._epilogue = []
-
-    def build(self) -> list[EmailBlock]:
-        return self._blocks + self._epilogue
-
-    def para(self, key: str, substitutions: SubstitutionDict | None = None, epilogue: bool = False) -> Self:
-        return self.block(ParaBlock(text=self._markup(key, substitutions)), epilogue=epilogue)
-
-    def quote(self, text: str, *, markdown: bool) -> Self:
-        return self.block(QuoteBlock(text=text, markdown=markdown))
-
-    def user(
-        self,
-        info: UserInfo,
-        comment_key: str | None = None,
-        substitutions: SubstitutionDict | None = None,
-    ) -> Self:
-        comment = self._markup(comment_key, substitutions) if comment_key else None
-        return self.block(UserBlock(info=info, comment=comment))
-
-    def action(self, url: str, text_key: str, substitutions: SubstitutionDict | None = None) -> Self:
-        return self.block(ActionBlock(text=self._text(text_key, substitutions), target_url=url))
-
-    def block(self, block: EmailBlock, epilogue: bool = False) -> Self:
-        if epilogue:
-            self._epilogue.append(block)
-        else:
-            self._blocks.append(block)
-        return self
-
-    def _text(self, key: str, substitutions: SubstitutionDict | None = None) -> str:
-        key = full_string_key(key, relative_base=self._string_key_base)
-        return get_emails_i18next().localize(key, self._locale, substitutions)
-
-    def _markup(self, key: str, substitutions: SubstitutionDict | None = None) -> Markup:
-        key = full_string_key(key, relative_base=self._string_key_base)
-        return get_emails_i18next().localize_with_markup(key, self._locale, substitutions)
-
-
-@dataclass(kw_only=True)
-class EmailFooter:
-    timezone_name: str
-    copyright_year: int = now().year
-    unsubscribe_info: UnsubscribeInfo | None
-
-    def to_template_args(self) -> dict[str, Any]:
-        args: dict[str, Any] = {
-            "footer_timezone_name": self.timezone_name,
-            "footer_copyright_year": self.copyright_year,
-            "footer_email_is_critical": self.unsubscribe_info is None,
-        }
-
-        if unsubscribe_info := self.unsubscribe_info:
-            args.update(unsubscribe_info.to_template_args())
-
-        return args
-
-
-@dataclass(kw_only=True)
-class UnsubscribeInfo:
-    manage_notifications_url: str
-    do_not_email_url: str
-    topic_action_link: UnsubscribeLink
-    topic_key_link: UnsubscribeLink | None = None
-
-    def to_template_args(self) -> dict[str, Any]:
-        args: dict[str, Any] = {
-            "footer_manage_notifications_link": self.manage_notifications_url,
-            "footer_do_not_email_link": self.do_not_email_url,
-            "footer_notification_topic_action": self.topic_action_link.text,
-            "footer_notification_topic_action_link": self.topic_action_link.url,
-        }
-
-        if topic_key_link := self.topic_key_link:
-            args["footer_notification_topic_key"] = topic_key_link.text
-            args["footer_notification_topic_key_link"] = topic_key_link.url
-
-        return args
-
-
-@dataclass(kw_only=True)
-class UnsubscribeLink:
-    text: str
-    url: str
-
-
-@lru_cache(maxsize=1)
-def get_emails_i18next() -> I18Next:
-    return load_locales(Path(__file__).parent / "locales")
-
 
 template_folder = Path(__file__).parent.parent.parent.parent / "templates" / "v2"
 
@@ -210,18 +23,25 @@ _markdown = MarkdownIt("zero", {"typographer": True}).enable(
 )
 
 
-def render_html_body(
-    *,
-    subject: str,
-    preview: str | None,
-    blocks: list[EmailBlock],
-    footer: EmailFooter,
-    loc_context: LocalizationContext,
-) -> str:
-    """Renders the body of an email as HTML."""
-    return HTMLRenderer.default().render(
-        subject=subject, preview=preview, blocks=blocks, footer=footer, loc_context=loc_context
+@dataclass(kw_only=True, slots=True)
+class RenderedEmail:
+    subject: str
+    body_plaintext: str
+    body_html: str
+
+
+def render_email(email: EmailBase, footer: EmailFooter, loc_context: LocalizationContext) -> RenderedEmail:
+    """Renders an EmailBase object to subject and body strings."""
+    subject = email.get_subject_line(loc_context)
+    preview = email.get_preview_line(loc_context)
+    body_blocks = email.get_body_blocks(loc_context)
+
+    body_plaintext = render_plaintext_body(blocks=body_blocks, footer=footer, loc_context=loc_context)
+    body_html = render_html_body(
+        subject=subject, preview=preview, blocks=body_blocks, footer=footer, loc_context=loc_context
     )
+
+    return RenderedEmail(subject=subject, body_plaintext=body_plaintext, body_html=body_html)
 
 
 def render_plaintext_body(*, blocks: list[EmailBlock], footer: EmailFooter, loc_context: LocalizationContext) -> str:
@@ -294,6 +114,41 @@ def _to_plaintext(text: str | Markup) -> str:
 
     # We've handled tags but still have escapes like "&gt;", convert those to plaintext.
     return unescape(text)
+
+
+def render_html_body(
+    *,
+    subject: str,
+    preview: str | None,
+    blocks: list[EmailBlock],
+    footer: EmailFooter,
+    loc_context: LocalizationContext,
+) -> str:
+    """Renders the body of an email as HTML."""
+    return HTMLRenderer.default().render(
+        subject=subject, preview=preview, blocks=blocks, footer=footer, loc_context=loc_context
+    )
+
+
+@dataclass(kw_only=True, slots=True)
+class TwoButtonHTMLBlock(EmailBlock):
+    """An HTML-only block used internally for rendering as side-by-side buttons."""
+
+    text_1: str
+    target_url_1: str
+    text_2: str
+    target_url_2: str
+
+
+# Matches a begin-block / end-block pair of comments in the html file containing template
+_block_regex = re.compile(
+    r"""
+<!-- begin-block:(?P<name>[\w-]+) -->\s*
+(?P<snippet>[\s\S]*?)
+\s*<!-- end-block:(?P=name) -->
+""".strip(),
+    re.MULTILINE,
+)
 
 
 @dataclass
@@ -384,10 +239,10 @@ class HTMLRenderer:
 
         return blocks
 
-    @lru_cache(maxsize=1)
+    @cache
     @staticmethod
     def default() -> HTMLRenderer:
-        template = (template_folder / "generated_html" / "blocks.html").read_text(encoding="utf8")
+        template = (template_folder / "generated_html" / "html").read_text(encoding="utf8")
         return HTMLRenderer.from_template(template)
 
     @staticmethod
@@ -407,14 +262,3 @@ class HTMLRenderer:
             action_block_template=Jinja2Template(source=block_templates["action"], html=True),
             two_buttons_block_template=Jinja2Template(source=block_templates["two-buttons"], html=True),
         )
-
-
-# Matches a begin-block / end-block pair of comments in the html file containing template blocks.
-_block_regex = re.compile(
-    r"""
-<!-- begin-block:(?P<name>[\w-]+) -->\s*
-(?P<snippet>[\s\S]*?)
-\s*<!-- end-block:(?P=name) -->
-""".strip(),
-    re.MULTILINE,
-)

--- a/app/backend/src/couchers/email/rendering.py
+++ b/app/backend/src/couchers/email/rendering.py
@@ -242,7 +242,7 @@ class HTMLRenderer:
     @cache
     @staticmethod
     def default() -> HTMLRenderer:
-        template = (template_folder / "generated_html" / "html").read_text(encoding="utf8")
+        template = (template_folder / "generated_html" / "blocks.html").read_text(encoding="utf8")
         return HTMLRenderer.from_template(template)
 
     @staticmethod

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -5,7 +5,6 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import exists, func
 
-from couchers.config import config
 from couchers.context import make_background_user_context
 from couchers.db import session_scope
 from couchers.email.queuing import queue_email
@@ -17,7 +16,7 @@ from couchers.models import (
     User,
 )
 from couchers.notifications.push import push_to_user
-from couchers.notifications.render_email import render_email_notification
+from couchers.notifications.render_email import get_send_email_payload
 from couchers.notifications.render_push import render_push_notification
 from couchers.notifications.settings import get_preference
 from couchers.notifications.utils import can_notify_deleted_user
@@ -46,27 +45,14 @@ def _send_email_notification(session: Session, user: User, notification: Notific
     if not context.get_boolean_value("notification_translations_enabled", default=False):
         loc_context = LocalizationContext(locale="en", timezone=loc_context.timezone)
 
-    rendered = render_email_notification(
+    payload = get_send_email_payload(
         user,
         notification,
         loc_context,
         include_ics_attachments=context.get_boolean_value("email_ics_attachments_enabled", default=False),
     )
 
-    queue_email(
-        session,
-        jobs_pb2.SendEmailPayload(
-            sender_name=config.NOTIFICATION_EMAIL_SENDER,
-            sender_email=config.NOTIFICATION_EMAIL_ADDRESS,
-            recipient=user.email,
-            subject=config.NOTIFICATION_PREFIX + rendered.subject,
-            plain=rendered.body_plaintext,
-            html=rendered.body_html,
-            source_data=rendered.source_data,
-            list_unsubscribe_header=rendered.list_unsubscribe_header,
-            attachments=rendered.attachments,
-        ),
-    )
+    queue_email(session, payload)
 
 
 def _send_push_notification(session: Session, user: User, notification: Notification) -> None:

--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -1,18 +1,13 @@
 import logging
-from dataclasses import dataclass, field
-from typing import Any, assert_never
+from dataclasses import dataclass
+from typing import assert_never
 
 import couchers.email.emails as emails
 from couchers import urls
 from couchers.config import config
+from couchers.email.blocks import EmailBase, EmailFooter, UnsubscribeInfo, UnsubscribeLink
 from couchers.email.calendar_events import create_host_request_attachment, create_host_request_cancellation_attachment
-from couchers.email.rendering import (
-    EmailFooter,
-    UnsubscribeInfo,
-    UnsubscribeLink,
-    render_html_body,
-    render_plaintext_body,
-)
+from couchers.email.rendering import render_email
 from couchers.i18n import LocalizationContext
 from couchers.models import Notification, NotificationTopicAction, User
 from couchers.notifications.quick_links import (
@@ -22,53 +17,41 @@ from couchers.notifications.quick_links import (
     generate_unsub_topic_key,
 )
 from couchers.proto import api_pb2
-from couchers.proto.internal.jobs_pb2 import EmailAttachmentV2
+from couchers.proto.internal.jobs_pb2 import EmailAttachmentV2, SendEmailPayload
 from couchers.utils import now
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass(kw_only=True, slots=True)
-class RenderedEmailNotification:
-    subject: str
-    body_plaintext: str
-    body_html: str | None
-    source_data: str | None
-    list_unsubscribe_header: str | None
-    attachments: list[EmailAttachmentV2] = field(default_factory=list)
-
-
-def render_email_notification(
+def get_send_email_payload(
     user: User, notification: Notification, loc_context: LocalizationContext, *, include_ics_attachments: bool
-) -> RenderedEmailNotification:
-    email = _notification_to_email(notification, user_name=user.name)
-    subject = email.get_subject_line(loc_context)
-    preview = email.get_preview_line(loc_context)
-    body_blocks = email.get_body_blocks(loc_context)
-    footer = get_email_footer(user, notification, loc_context)
-    body_plaintext = render_plaintext_body(blocks=body_blocks, footer=footer, loc_context=loc_context)
-    body_html = render_html_body(
-        subject=subject, preview=preview, blocks=body_blocks, footer=footer, loc_context=loc_context
-    )
-    source_data = f"notification; topic-action={notification.topic_action}; version={config.VERSION}"
+) -> SendEmailPayload:
+    email = get_notification_email(notification, user_name=user.name)
+    email_footer = get_email_footer(user, notification, loc_context)
+    rendered_email = render_email(email, email_footer, loc_context)
 
+    source_data_header = get_source_data_header(notification)
     list_unsubscribe_header = get_list_unsubscribe_header(notification)
+
     if include_ics_attachments:
         attachment = get_ics_attachment(notification, loc_context)
     else:
         attachment = None
 
-    return RenderedEmailNotification(
-        subject=subject,
-        body_plaintext=body_plaintext,
-        body_html=body_html,
-        source_data=source_data,
+    return SendEmailPayload(
+        sender_name=config.NOTIFICATION_EMAIL_SENDER,
+        sender_email=config.NOTIFICATION_EMAIL_ADDRESS,
+        recipient=user.email,
+        subject=config.NOTIFICATION_PREFIX + rendered_email.subject,
+        plain=rendered_email.body_plaintext,
+        html=rendered_email.body_html,
+        source_data=source_data_header,
         list_unsubscribe_header=list_unsubscribe_header,
         attachments=[attachment] if attachment else [],
     )
 
 
-def _notification_to_email(notification: Notification, *, user_name: str) -> emails.EmailBase:
+def get_notification_email(notification: Notification, *, user_name: str) -> EmailBase:
     data = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
     match notification.topic_action:
         case NotificationTopicAction.account_deletion__start:
@@ -181,16 +164,8 @@ def _notification_to_email(notification: Notification, *, user_name: str) -> ema
             assert_never(notification.topic_action)
 
 
-@dataclass(kw_only=True)
-class CustomTemplatedEmail:
-    # email subject
-    subject: str
-    # shows up when listing emails in many clients
-    preview: str
-    # corresponds to .mjml + .txt file in templates/v2
-    template_name: str
-    # other template args
-    template_args: dict[str, Any]
+def get_source_data_header(notification: Notification) -> str:
+    return f"notification; topic-action={notification.topic_action}; version={config.VERSION}"
 
 
 def get_ics_attachment(notification: Notification, loc_context: LocalizationContext) -> EmailAttachmentV2 | None:

--- a/app/backend/src/couchers/tasks.py
+++ b/app/backend/src/couchers/tasks.py
@@ -5,13 +5,14 @@ from sqlalchemy import RowMapping, insert, select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
 
-import couchers.email.emails as emails
 from couchers import urls
 from couchers.config import config
 from couchers.constants import SIGNUP_EMAIL_TOKEN_VALIDITY
 from couchers.context import CouchersContext
 from couchers.crypto import urlsafe_secure_token
 from couchers.db import session_scope
+from couchers.email.blocks import EmailBase
+from couchers.email.emails import EmailAddressChangeConfirmationEmail, SignupContinueEmail, SignupVerifyEmail
 from couchers.email.queuing import queue_system_email, queue_userless_email
 from couchers.models import (
     AccountDeletionReason,
@@ -56,11 +57,11 @@ def send_signup_email(context: CouchersContext, session: Session, flow: SignupFl
 
     flow.email_sent = True
 
-    email: emails.EmailBase
+    email: EmailBase
     if email_sent_before:
-        email = emails.SignupContinueEmail(user_name=flow.name, continue_url=signup_link)
+        email = SignupContinueEmail(user_name=flow.name, continue_url=signup_link)
     else:
-        email = emails.SignupVerifyEmail(user_name=flow.name, verify_url=signup_link)
+        email = SignupVerifyEmail(user_name=flow.name, verify_url=signup_link)
 
     queue_userless_email(
         context,
@@ -85,7 +86,7 @@ def send_email_changed_confirmation_to_new_email(context: CouchersContext, sessi
     elif not user.new_email:
         raise ValueError(f"No new email for {user.id}")
 
-    email = emails.EmailAddressChangeConfirmationEmail(
+    email = EmailAddressChangeConfirmationEmail(
         user_name=user.name,
         old_email=user.email,
         confirm_url=urls.change_email_link(confirmation_token=user.new_email_token),

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -349,7 +349,7 @@ def test_email_prefix_config(db, email_collector: EmailCollector, monkeypatch):
     new_config.NOTIFICATION_EMAIL_ADDRESS = "testco@testing.co.invalid"
     new_config.NOTIFICATION_PREFIX = ""
 
-    monkeypatch.setattr(couchers.notifications.background, "config", new_config)
+    monkeypatch.setattr(couchers.notifications.render_email, "config", new_config)
 
     with session_scope() as session:
         notify(

--- a/app/backend/src/tests/test_email_localization.py
+++ b/app/backend/src/tests/test_email_localization.py
@@ -14,14 +14,13 @@ from datetime import UTC
 import pytest
 
 import couchers.email.emails
-from couchers.email.emails import EmailBase
-from couchers.email.rendering import (
+from couchers.email.blocks import (
+    EmailBase,
     EmailFooter,
     UnsubscribeInfo,
     UnsubscribeLink,
-    render_html_body,
-    render_plaintext_body,
 )
+from couchers.email.rendering import render_email
 from couchers.i18n import LocalizationContext
 
 
@@ -58,12 +57,8 @@ def _(testconfig):
 def test_email_renders_in_english(email: EmailBase):
     loc_context = LocalizationContext(locale="en", timezone=UTC)
 
-    subject = email.get_subject_line(loc_context)
-    assert subject
-
-    preview = email.get_preview_line(loc_context)
-    blocks = email.get_body_blocks(loc_context)
-
-    # Render both the html and plaintext bodies end-to-end, since each resolves its own keys.
-    render_html_body(subject=subject, preview=preview, blocks=blocks, footer=_FOOTER, loc_context=loc_context)
-    render_plaintext_body(blocks=blocks, footer=_FOOTER, loc_context=loc_context)
+    # Render all email strings, since each resolve their own keys.
+    rendered = render_email(email, _FOOTER, loc_context)
+    assert rendered.subject
+    assert rendered.body_plaintext
+    assert rendered.body_html


### PR DESCRIPTION
We had 3 different pieces of code doing the same sequence of calls to render an `EmailBase` into subject+body strings. This PR extracts it into `render_email`.

Also adjusts how the email system is split between files:

- `blocks.py`: Data model for blocks-based emails, including `EmailBase` base class.
- `emails.py`: All concrete email definitions implementing `EmailBase`.
- `rendering.py`: Rendering logic for block-based emails.

Fixes #7419

## Testing
Left to existing CI coverage.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me