### PR TITLE
Backend/emails: Make footers mostly localizable

### DIFF
--- a/app/backend/src/couchers/email/blocks.py
+++ b/app/backend/src/couchers/email/blocks.py
@@ -5,7 +5,7 @@ that can be rendered HTML and plaintext for any locale.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Self
+from typing import Self
 
 from markupsafe import Markup
 
@@ -207,18 +207,6 @@ class EmailFooter:
     copyright_year: int = now().year
     unsubscribe_info: UnsubscribeInfo | None
 
-    def to_template_args(self) -> dict[str, Any]:
-        args: dict[str, Any] = {
-            "footer_timezone_name": self.timezone_name,
-            "footer_copyright_year": self.copyright_year,
-            "footer_email_is_critical": self.unsubscribe_info is None,
-        }
-
-        if unsubscribe_info := self.unsubscribe_info:
-            args.update(unsubscribe_info.to_template_args())
-
-        return args
-
 
 @dataclass(kw_only=True)
 class UnsubscribeInfo:
@@ -226,20 +214,6 @@ class UnsubscribeInfo:
     do_not_email_url: str
     topic_action_link: UnsubscribeLink
     topic_key_link: UnsubscribeLink | None = None
-
-    def to_template_args(self) -> dict[str, Any]:
-        args: dict[str, Any] = {
-            "footer_manage_notifications_link": self.manage_notifications_url,
-            "footer_do_not_email_link": self.do_not_email_url,
-            "footer_notification_topic_action": self.topic_action_link.text,
-            "footer_notification_topic_action_link": self.topic_action_link.url,
-        }
-
-        if topic_key_link := self.topic_key_link:
-            args["footer_notification_topic_key"] = topic_key_link.text
-            args["footer_notification_topic_key_link"] = topic_key_link.url
-
-        return args
 
 
 @dataclass(kw_only=True)

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -12,7 +12,7 @@
       "donate_link": "Donate",
       "volunteer_link": "Volunteer",
       "blog_link": "Blog",
-      "nonprofit_note": "<i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>",
+      "nonprofit_note": "Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.",
       "security_email_note": "This is a security email, you cannot unsubscribe from it.",
       "notification_settings_link": "Manage notification preferences",
       "do_not_email_link": "Do not email me (disables hosting)",

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -4,7 +4,20 @@
     "closing_line": "Best,<br>The Couchers.org Team",
     "founders_signature": "Aapeli and Itsi,<br>Couchers.org Founders",
     "security_warning_contact_support": "If you did not initiate this action, please contact us by emailing <a href=\"mailto:support@couchers.org\">support@couchers.org</a> so we can sort this out as soon as possible!",
-    "do_not_reply_request": "<b>Do not reply to this email.</b> Use one of the buttons above to reply to this request."
+    "do_not_reply_request": "<b>Do not reply to this email.</b> Use one of the buttons above to reply to this request.",
+    "footer": {
+      "received_because": "You're receiving this email because you signed up for Couchers.org.",
+      "contact_support": "You can reach our support team at <a href=\"mailto:support@couchers.org\">support@couchers.org</a>.",
+      "timezone_note": "All times are in {{ timezone }}, based on your profile location.",
+      "donate_link": "Donate",
+      "volunteer_link": "Volunteer",
+      "blog_link": "Blog",
+      "nonprofit_note": "<i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>",
+      "security_email_note": "This is a security email, you cannot unsubscribe from it.",
+      "notification_settings_link": "Manage notification preferences",
+      "do_not_email_link": "Do not email me (disables hosting)",
+      "happy_couch_icon_caption": "The happy Couchers couch hopes you have a great rest of the day."
+    }
   },
   "calendar_events": {
     "title_cancelled": "Cancelled: {{ title }}",

--- a/app/backend/src/couchers/email/rendering.py
+++ b/app/backend/src/couchers/email/rendering.py
@@ -156,6 +156,7 @@ def _get_footer_template_args(footer: EmailFooter, loc_context: LocalizationCont
     }
 
     if unsubscribe_info := footer.unsubscribe_info:
+        # TODO(#7420): Localize "Turn off emails for: " text, avoiding string concatenations.
         args.update(
             {
                 "notification_settings_link": localize(".notification_settings_link"),

--- a/app/backend/src/couchers/email/rendering.py
+++ b/app/backend/src/couchers/email/rendering.py
@@ -8,6 +8,7 @@ from email.headerregistry import Address
 from functools import cache
 from html import unescape
 from pathlib import Path
+from typing import Any
 
 from markdown_it import MarkdownIt
 from markupsafe import Markup
@@ -17,6 +18,7 @@ from couchers.email.blocks import ActionBlock, EmailBase, EmailBlock, EmailFoote
 from couchers.email.locales import get_emails_i18next
 from couchers.email.smtp import embed_html_relative_images
 from couchers.i18n import LocalizationContext
+from couchers.i18n.i18next import SubstitutionDict, full_string_key
 from couchers.proto.internal import jobs_pb2
 from couchers.templating import Jinja2Template
 
@@ -103,8 +105,10 @@ def render_plaintext_body(*, blocks: list[EmailBlock], footer: EmailFooter, loc_
     footer_template = Jinja2Template(
         source=(template_folder / "_footer.txt").read_text(encoding="utf8").strip(), html=False
     )
-    footer_template_args = footer.to_template_args()
-    return "".join(concat) + footer_template.render(footer_template_args)
+    footer_template_args = _get_footer_template_args(footer, loc_context)
+    concat.append(footer_template.render(footer_template_args))
+
+    return "".join(concat)
 
 
 def _to_plaintext(text: str | Markup) -> str:
@@ -130,6 +134,46 @@ def _to_plaintext(text: str | Markup) -> str:
 
     # We've handled tags but still have escapes like "&gt;", convert those to plaintext.
     return unescape(text)
+
+
+def _get_footer_template_args(footer: EmailFooter, loc_context: LocalizationContext) -> dict[str, Any]:
+    i18n = get_emails_i18next()
+
+    def localize(key: str, substitutions: SubstitutionDict | None = None) -> Markup:
+        key = full_string_key(key, relative_base="generic.footer")
+        return i18n.localize_with_markup(key, loc_context.locale, substitutions)
+
+    args: dict[str, Any] = {
+        "received_because": localize(".received_because"),
+        "contact_support": localize(".contact_support"),
+        "timezone_note": localize(".timezone_note", {"timezone": footer.timezone_name}),
+        "copyright_year": footer.copyright_year,
+        "donate_link": localize(".donate_link"),
+        "volunteer_link": localize(".volunteer_link"),
+        "blog_link": localize(".blog_link"),
+        "nonprofit_note": localize(".nonprofit_note"),
+        "is_critical": footer.unsubscribe_info is None,
+    }
+
+    if unsubscribe_info := footer.unsubscribe_info:
+        args.update(
+            {
+                "notification_settings_link": localize(".notification_settings_link"),
+                "manage_notifications_url": unsubscribe_info.manage_notifications_url,
+                "do_not_email_link": localize(".do_not_email_link"),
+                "do_not_email_url": unsubscribe_info.do_not_email_url,
+                "topic_action_description": unsubscribe_info.topic_action_link.text,
+                "unsubscribe_topic_action_url": unsubscribe_info.topic_action_link.url,
+            }
+        )
+
+        if topic_key_link := unsubscribe_info.topic_key_link:
+            args["topic_key_description"] = topic_key_link.text
+            args["unsubscribe_topic_key_url"] = topic_key_link.url
+    else:
+        args["security_email_note"] = localize(".security_email_note")
+
+    return args
 
 
 def render_html_body(
@@ -228,7 +272,7 @@ class HTMLRenderer:
                     raise TypeError(f"Unexpected email block type: {block.__class__}")
 
         # Render the footer
-        footer_template_args = footer.to_template_args()
+        footer_template_args = _get_footer_template_args(footer, loc_context)
         concats.append(self.footer_template.render(footer_template_args))
 
         return "\n".join(concats)

--- a/app/backend/templates/v2/_footer.txt
+++ b/app/backend/templates/v2/_footer.txt
@@ -2,16 +2,16 @@
 
 ---
 
-{% if footer_email_is_critical %}
-This is a security email, you cannot unsubscribe from it.
+{% if is_critical %}
+{{ security_email_note }}
 {% else %}
-Edit your notification settings at <{{footer_manage_notifications_link}}>
-{% if footer_notification_topic_action %}
-Turn off emails for {{footer_notification_topic_action}}: <{{footer_notification_topic_action_link}}>
+{{ notification_settings_link }}: <{{ manage_notifications_url }}>
+{% if topic_action_description %}
+Turn off emails for {{ topic_action_description }}: <{{ unsubscribe_topic_action_url }}>
 {% endif %}
-{% if footer_notification_topic_key %}
-Turn off emails for {{footer_notification_topic_key}}: <{{footer_notification_topic_key_link}}>
+{% if topic_key_description %}
+Turn off emails for {{ topic_key_description }}: <{{ unsubscribe_topic_key_url }}>
 {% endif %}
 
-Do not email me (disables hosting): <{{footer_do_not_email_link}}>
+{{ do_not_email_link }}: <{{ do_not_email_url }}>
 {% endif %}

--- a/app/backend/templates/v2/blocks.mjml
+++ b/app/backend/templates/v2/blocks.mjml
@@ -83,12 +83,21 @@
       <mj-section padding="0px">
         <mj-column>
           <mj-divider border-color="#00a398" border-width="1px"></mj-divider>
-          <mj-text align="center" font-size="10px" line-height="12px"> You're receiving this email because you signed up for Couchers.org.<br /> You can reach our support team at <a href="mailto:support@couchers.org">support@couchers.org</a>.<br /> All times are in {{ footer_timezone_name }}, based on your profile location. </mj-text>
-          <mj-text align="center" font-size="10px"><a href="https://couchers.org/donate">Donate</a> | <a href="https://github.com/Couchers-org/couchers">GitHub</a> | <a href="https://couchers.org/volunteer">Volunteer</a> | <a href="https://couchers.org/blog">Blog</a></mj-text>
+          <mj-text align="center" font-size="10px" line-height="12px">
+            {{ received_because }}<br />
+            {{ contact_support }}<br />
+            {{ timezone_note }}
+          </mj-text>
+          <mj-text align="center" font-size="10px">
+            <a href="https://couchers.org/donate">{{ footer_donate_link }}</a>
+            | <a href="https://github.com/Couchers-org/couchers">GitHub</a>
+            | <a href="https://couchers.org/volunteer">{{ footer_volunteer_link }}</a>
+            | <a href="https://couchers.org/blog">{{ footer_blog_link }}</a>
+          </mj-text>
           <mj-text align="center" font-size="8px" line-height="10px">
-            &copy; {{ footer_copyright_year }} Couchers, Inc.<br />
+            &copy; {{ copyright_year }} Couchers, Inc.<br />
             1908 Thomes Ave, Suite 79585, Cheyenne, WY 82001, USA.<br />
-            <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
+            {{ nonprofit_note }}
           </mj-text>
         </mj-column>
       </mj-section>
@@ -96,27 +105,27 @@
     <mj-section>
       <mj-column>
         <mj-text css-class="unsub" align="center" font-size="10px" line-height="16px" color="#777" padding="0px">
-          {% if footer_email_is_critical %}
-            This is a security email, you cannot unsubscribe from it.
+          {% if is_critical %}
+            {{ security_email_note }}
           {% else %}
-            <a href="{{footer_manage_notifications_link}}">Manage notification preferences</a>.
-            {% if footer_notification_topic_action or footer_notification_topic_key %}
+            <a href="{{ manage_notifications_url }}">{{ notification_settings_link }}</a>.
+            {% if topic_action_description or topic_key_description %}
               <br />
               Turn off emails for:
-              {% if footer_notification_topic_action %}
-                <a href="{{footer_notification_topic_action_link}}">{{footer_notification_topic_action}}</a>
+              {% if topic_action_description %}
+                <a href="{{ unsubscribe_topic_action_url }}">{{ topic_action_description }}</a>
               {% endif %}
-              {% if footer_notification_topic_key %}
-                {% if footer_notification_topic_action %} / {% endif %}
-                <a href="{{footer_notification_topic_key_link}}">{{footer_notification_topic_key}}</a>
+              {% if topic_key_description %}
+                {% if topic_action_description %} / {% endif %}
+                <a href="{{ unsubscribe_topic_key_url }}">{{ topic_key_description }}</a>
               {% endif %}
             {% endif %}
             <br />
-            <a href="{{footer_do_not_email_link}}">Do not email me (disables hosting)</a>.
+            <a href="{{ do_not_email_url }}">{{ do_not_email_link }}</a>.
           {% endif %}
         </mj-text>
         <mj-image src="attachment_imgs/logo-grey.png" width="50px" padding="0px"></mj-image>
-        <mj-text css-class="unsub" align="center" font-size="8px" line-height="16px" color="#777" padding="0px">The happy Couchers couch hopes you have a great rest of the day.</mj-text>
+        <mj-text css-class="unsub" align="center" font-size="8px" line-height="16px" color="#777" padding="0px">{{ happy_couch_icon_caption }}</mj-text>
       </mj-column>
     </mj-section>
   </mj-body>

--- a/app/backend/templates/v2/blocks.mjml
+++ b/app/backend/templates/v2/blocks.mjml
@@ -97,7 +97,7 @@
           <mj-text align="center" font-size="8px" line-height="10px">
             &copy; {{ copyright_year }} Couchers, Inc.<br />
             1908 Thomes Ave, Suite 79585, Cheyenne, WY 82001, USA.<br />
-            {{ nonprofit_note }}
+            <i>{{ nonprofit_note }}</i>
           </mj-text>
         </mj-column>
       </mj-section>

--- a/app/backend/templates/v2/blocks.mjml
+++ b/app/backend/templates/v2/blocks.mjml
@@ -89,10 +89,10 @@
             {{ timezone_note }}
           </mj-text>
           <mj-text align="center" font-size="10px">
-            <a href="https://couchers.org/donate">{{ footer_donate_link }}</a>
+            <a href="https://couchers.org/donate">{{ donate_link }}</a>
             | <a href="https://github.com/Couchers-org/couchers">GitHub</a>
-            | <a href="https://couchers.org/volunteer">{{ footer_volunteer_link }}</a>
-            | <a href="https://couchers.org/blog">{{ footer_blog_link }}</a>
+            | <a href="https://couchers.org/volunteer">{{ volunteer_link }}</a>
+            | <a href="https://couchers.org/blog">{{ blog_link }}</a>
           </mj-text>
           <mj-text align="center" font-size="8px" line-height="10px">
             &copy; {{ copyright_year }} Couchers, Inc.<br />

--- a/app/backend/templates/v2/generated_html/blocks.html
+++ b/app/backend/templates/v2/generated_html/blocks.html
@@ -392,7 +392,7 @@
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                   <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ copyright_year }} Couchers, Inc.<br> 1908 Thomes Ave, Suite 79585, Cheyenne, WY 82001, USA.<br>
-                                    {{ nonprofit_note }}
+                                    <i>{{ nonprofit_note }}</i>
                                   </div>
                                 </td>
                               </tr>

--- a/app/backend/templates/v2/generated_html/blocks.html
+++ b/app/backend/templates/v2/generated_html/blocks.html
@@ -386,7 +386,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:1;text-align:center;color:#333333;"><a href="https://couchers.org/donate" style="color: #00a398;">{{ footer_donate_link }}</a> | <a href="https://github.com/Couchers-org/couchers" style="color: #00a398;">GitHub</a> | <a href="https://couchers.org/volunteer" style="color: #00a398;">{{ footer_volunteer_link }}</a> | <a href="https://couchers.org/blog" style="color: #00a398;">{{ footer_blog_link }}</a></div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:1;text-align:center;color:#333333;"><a href="https://couchers.org/donate" style="color: #00a398;">{{ donate_link }}</a> | <a href="https://github.com/Couchers-org/couchers" style="color: #00a398;">GitHub</a> | <a href="https://couchers.org/volunteer" style="color: #00a398;">{{ volunteer_link }}</a> | <a href="https://couchers.org/blog" style="color: #00a398;">{{ blog_link }}</a></div>
                                 </td>
                               </tr>
                               <tr>

--- a/app/backend/templates/v2/generated_html/blocks.html
+++ b/app/backend/templates/v2/generated_html/blocks.html
@@ -378,18 +378,21 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">You're receiving this email because you signed up for Couchers.org.<br> You can reach our support team at <a href="mailto:support@couchers.org" style="color: #00a398;">support@couchers.org</a>.<br> All times are in {{ footer_timezone_name }}, based on your profile location.</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:12px;text-align:center;color:#333333;">{{ received_because }}<br>
+                                    {{ contact_support }}<br>
+                                    {{ timezone_note }}
+                                  </div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:1;text-align:center;color:#333333;"><a href="https://couchers.org/donate" style="color: #00a398;">Donate</a> | <a href="https://github.com/Couchers-org/couchers" style="color: #00a398;">GitHub</a> | <a href="https://couchers.org/volunteer" style="color: #00a398;">Volunteer</a> | <a href="https://couchers.org/blog" style="color: #00a398;">Blog</a></div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:1;text-align:center;color:#333333;"><a href="https://couchers.org/donate" style="color: #00a398;">{{ footer_donate_link }}</a> | <a href="https://github.com/Couchers-org/couchers" style="color: #00a398;">GitHub</a> | <a href="https://couchers.org/volunteer" style="color: #00a398;">{{ footer_volunteer_link }}</a> | <a href="https://couchers.org/blog" style="color: #00a398;">{{ footer_blog_link }}</a></div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ footer_copyright_year }} Couchers, Inc.<br> 1908 Thomes Ave, Suite 79585, Cheyenne, WY 82001, USA.<br>
-                                    <i>Couchers.org is a project of Couchers, Inc. a U.S. 501(c)(3) non-profit, tax-exempt organization.</i>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:10px;text-align:center;color:#333333;">&copy; {{ copyright_year }} Couchers, Inc.<br> 1908 Thomes Ave, Suite 79585, Cheyenne, WY 82001, USA.<br>
+                                    {{ nonprofit_note }}
                                   </div>
                                 </td>
                               </tr>
@@ -420,8 +423,8 @@
                   <tbody>
                     <tr>
                       <td align="center" class="unsub" style="font-size:0px;padding:0px;word-break:break-word;">
-                        <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:16px;text-align:center;color:#777777;">{% if footer_email_is_critical %} This is a security email, you cannot unsubscribe from it. {% else %} <a href="{{footer_manage_notifications_link}}" style="color: #777; text-decoration: underline; text-decoration-color: #ccc;">Manage notification preferences</a>. {% if footer_notification_topic_action or footer_notification_topic_key %} <br> Turn off emails for: {% if footer_notification_topic_action %} <a href="{{footer_notification_topic_action_link}}" style="color: #777; text-decoration: underline; text-decoration-color: #ccc;">{{footer_notification_topic_action}}</a> {% endif %} {% if footer_notification_topic_key %} {% if footer_notification_topic_action %} / {% endif %} <a href="{{footer_notification_topic_key_link}}" style="color: #777; text-decoration: underline; text-decoration-color: #ccc;">{{footer_notification_topic_key}}</a> {% endif %} {% endif %} <br>
-                          <a href="{{footer_do_not_email_link}}" style="color: #777; text-decoration: underline; text-decoration-color: #ccc;">Do not email me (disables hosting)</a>. {% endif %}
+                        <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:16px;text-align:center;color:#777777;">{% if is_critical %} {{ security_email_note }} {% else %} <a href="{{ manage_notifications_url }}" style="color: #777; text-decoration: underline; text-decoration-color: #ccc;">{{ notification_settings_link }}</a>. {% if topic_action_description or topic_key_description %} <br> Turn off emails for: {% if topic_action_description %} <a href="{{ unsubscribe_topic_action_url }}" style="color: #777; text-decoration: underline; text-decoration-color: #ccc;">{{ topic_action_description }}</a> {% endif %} {% if topic_key_description %} {% if topic_action_description %} / {% endif %} <a href="{{ unsubscribe_topic_key_url }}" style="color: #777; text-decoration: underline; text-decoration-color: #ccc;">{{ topic_key_description }}</a> {% endif %} {% endif %} <br>
+                          <a href="{{ do_not_email_url }}" style="color: #777; text-decoration: underline; text-decoration-color: #ccc;">{{ do_not_email_link }}</a>. {% endif %}
                         </div>
                       </td>
                     </tr>
@@ -440,7 +443,7 @@
                     </tr>
                     <tr>
                       <td align="center" class="unsub" style="font-size:0px;padding:0px;word-break:break-word;">
-                        <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:16px;text-align:center;color:#777777;">The happy Couchers couch hopes you have a great rest of the day.</div>
+                        <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:8px;line-height:16px;text-align:center;color:#777777;">{{ happy_couch_icon_caption }}</div>
                       </td>
                     </tr>
                   </tbody>


### PR DESCRIPTION
... except for the `Turn off emails for: <topic-action>` part which is inherently tricky to localize because of string concatenation and might need a new design. I'll address it separately.

Related to #7420

## Testing
Ran `uv run dump-emails`:

<img width="1051" height="793" alt="image" src="https://github.com/user-attachments/assets/5427344d-a11e-4b5b-86aa-1da5977ae252" />

```

---

Manage notification preferences: <https://example.com/manage-notifications>
Turn off emails for topic-action: <https://example.com/unsubscribe>

Do not email me (disables hosting): <https://example.com/do-not-email>
```

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me