### PR TITLE
Backend/emails: Remove HTML from subject line

### DIFF
--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -74,7 +74,7 @@
       "view_action": "View this message"
     },
     "group": {
-      "subject": "{{ author }} sent a message in {{ group }}",
+      "subject": "{{ author }} sent a message in \"{{ group }}\"",
       "body": "{{ author }} sent a message in <b>{{ group }}</b>:",
       "view_action": "View this message"
     }

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -74,7 +74,7 @@
       "view_action": "View this message"
     },
     "group": {
-      "subject": "{{ author }} sent a message in <b>{{ group }}</b>",
+      "subject": "{{ author }} sent a message in {{ group }}",
       "body": "{{ author }} sent a message in <b>{{ group }}</b>:",
       "view_action": "View this message"
     }

--- a/app/backend/src/tests/test_email_localization.py
+++ b/app/backend/src/tests/test_email_localization.py
@@ -60,5 +60,6 @@ def test_email_renders_in_english(email: EmailBase):
     # Render all email strings, since each resolve their own keys.
     rendered = render_email(email, _FOOTER, loc_context)
     assert rendered.subject
+    assert "<" not in rendered.subject, "Subject line shoudn't contain HTML"
     assert rendered.body_plaintext
     assert rendered.body_html


### PR DESCRIPTION
One email had `<b>` tags. This was a mistake; subject lines don't support HTML. Added test validation too.

## Testing
Added test validation

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
