### PR TITLE
Backend: add per-step signup funnel counters

### DIFF
--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -622,6 +622,25 @@ signup_completions_counter: Counter = Counter(
     "Number of completed signups",
     labelnames=["gender"],
 )
+# Per-step signup funnel counters. Each fires once, the first time a signup flow satisfies the given gate, so
+# that step_total/initiations_total gives the fraction of signups that reached that step. Unlabeled to match
+# signup_initiations_counter for clean ratios.
+signup_account_filled_counter: Counter = Counter(
+    "couchers_signup_account_filled_total",
+    "Number of signup flows that filled in their account details",
+)
+signup_email_verified_counter: Counter = Counter(
+    "couchers_signup_email_verified_total",
+    "Number of signup flows that verified their email address",
+)
+signup_guidelines_accepted_counter: Counter = Counter(
+    "couchers_signup_guidelines_accepted_total",
+    "Number of signup flows that accepted the community guidelines",
+)
+signup_motivations_filled_counter: Counter = Counter(
+    "couchers_signup_motivations_filled_total",
+    "Number of signup flows that filled in their motivations",
+)
 signup_time_histogram: Histogram = Histogram(
     "couchers_signup_time_seconds",
     "Time taken for a user to sign up",

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -20,8 +20,12 @@ from couchers.metrics import (
     logins_counter,
     password_reset_completions_counter,
     password_reset_initiations_counter,
+    signup_account_filled_counter,
     signup_completions_counter,
+    signup_email_verified_counter,
+    signup_guidelines_accepted_counter,
     signup_initiations_counter,
+    signup_motivations_filled_counter,
     signup_time_histogram,
 )
 from couchers.models import (
@@ -187,6 +191,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 flow.email_token_expiry = None
 
                 session.flush()
+                signup_email_verified_counter.inc()
             else:
                 # just try to find the flow by flow token, no verification is done
                 flow = session.execute(
@@ -296,6 +301,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 flow.accepted_tos = TOS_VERSION
                 flow.opt_out_of_newsletter = request.account.opt_out_of_newsletter
                 session.flush()
+                signup_account_filled_counter.inc()
 
             if request.HasField("feedback"):
                 if flow.filled_feedback:
@@ -319,10 +325,13 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 flow.heard_about_couchers = request.motivations.heard_about_couchers or None
                 flow.signup_motivations = list(request.motivations.motivations)
                 session.flush()
+                signup_motivations_filled_counter.inc()
 
             if request.HasField("accept_community_guidelines"):
                 if not request.accept_community_guidelines.value:
                     context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "must_accept_community_guidelines")
+                if flow.accepted_community_guidelines < GUIDELINES_VERSION:
+                    signup_guidelines_accepted_counter.inc()
                 flow.accepted_community_guidelines = GUIDELINES_VERSION
                 session.flush()
 

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -1,5 +1,6 @@
 import http.cookies
 from typing import cast
+from unittest.mock import DEFAULT, patch
 
 import grpc
 import pytest
@@ -224,6 +225,85 @@ def test_signup_incremental(db):
         assert form.contribute == ContributeOption.yes
         assert form.contribute_ways == ["serving", "backend"]
         assert form.expertise == "I'd love to be your server: I can compute very fast, but only simple opcodes"
+
+
+def test_signup_funnel_counters(db):
+    """Each per-step signup funnel counter should fire exactly once across an incremental signup."""
+    with patch.multiple(
+        "couchers.servicers.auth",
+        signup_initiations_counter=DEFAULT,
+        signup_account_filled_counter=DEFAULT,
+        signup_email_verified_counter=DEFAULT,
+        signup_guidelines_accepted_counter=DEFAULT,
+        signup_motivations_filled_counter=DEFAULT,
+        signup_completions_counter=DEFAULT,
+    ) as counters:
+        with auth_api_session() as (auth_api, metadata_interceptor):
+            res = auth_api.SignupFlow(
+                auth_pb2.SignupFlowReq(
+                    basic=auth_pb2.SignupBasic(name="testing", email="email@couchers.org.invalid"),
+                )
+            )
+        flow_token = res.flow_token
+        counters["signup_initiations_counter"].inc.assert_called_once()
+
+        with session_scope() as session:
+            email_token = (
+                session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one().email_token
+            )
+
+        with auth_api_session() as (auth_api, metadata_interceptor):
+            auth_api.SignupFlow(
+                auth_pb2.SignupFlowReq(
+                    flow_token=flow_token,
+                    account=auth_pb2.SignupAccount(
+                        username="frodo",
+                        password="a very insecure password",
+                        birthdate="1970-01-01",
+                        gender="Bot",
+                        hosting_status=api_pb2.HOSTING_STATUS_MAYBE,
+                        city="New York City",
+                        lat=40.7331,
+                        lng=-73.9778,
+                        radius=500,
+                        accept_tos=True,
+                    ),
+                )
+            )
+        counters["signup_account_filled_counter"].inc.assert_called_once()
+
+        # accept the guidelines twice; the counter must still only fire once
+        with auth_api_session() as (auth_api, metadata_interceptor):
+            auth_api.SignupFlow(
+                auth_pb2.SignupFlowReq(
+                    flow_token=flow_token,
+                    accept_community_guidelines=wrappers_pb2.BoolValue(value=True),
+                )
+            )
+        with auth_api_session() as (auth_api, metadata_interceptor):
+            auth_api.SignupFlow(
+                auth_pb2.SignupFlowReq(
+                    flow_token=flow_token,
+                    accept_community_guidelines=wrappers_pb2.BoolValue(value=True),
+                )
+            )
+        counters["signup_guidelines_accepted_counter"].inc.assert_called_once()
+
+        with auth_api_session() as (auth_api, metadata_interceptor):
+            auth_api.SignupFlow(
+                auth_pb2.SignupFlowReq(
+                    flow_token=flow_token,
+                    motivations=auth_pb2.SignupMotivations(motivations=["surfing"]),
+                )
+            )
+        counters["signup_motivations_filled_counter"].inc.assert_called_once()
+
+        with auth_api_session() as (auth_api, metadata_interceptor):
+            res = auth_api.SignupFlow(auth_pb2.SignupFlowReq(flow_token=flow_token, email_token=email_token))
+        counters["signup_email_verified_counter"].inc.assert_called_once()
+
+        assert res.HasField("auth_res")
+        counters["signup_completions_counter"].labels.assert_called_once_with("Bot")
 
 
 def _quick_signup() -> int:


### PR DESCRIPTION
Adds Prometheus counters for each step of the signup flow, so the funnel between signup initiation and completion is observable for realtime-ish monitoring (current volume is ~100-300 signups/day).

We already expose `couchers_signup_initiations_total` and `couchers_signup_completions_total`, from which the headline completion rate is computable downstream as `sum(rate(completions[24h])) / rate(initiations[24h])` (the <20min completion time makes cohort lag negligible at a 24h window). The new counters fill in the intermediate steps so a broken deploy points at *which* step died rather than just nudging the blended rate:

- `couchers_signup_account_filled_total`
- `couchers_signup_email_verified_total`
- `couchers_signup_guidelines_accepted_total`
- `couchers_signup_motivations_filled_total`

They are unlabeled (matching `signup_initiations_total`) for clean ratios, and each fires exactly once the first time a flow passes its gate. The account/email/motivations steps are already guarded against re-entry; guidelines acceptance is not, so its increment is gated on the `accepted_community_guidelines < GUIDELINES_VERSION` transition.

## Testing
- Added `test_signup_funnel_counters`, which runs an incremental signup and asserts each counter fires exactly once — including that re-accepting the community guidelines does not double-count.
- `make format` and `make mypy` clean for the touched files (pre-existing mypy errors in unrelated test files remain).
- All 41 tests in `test_auth.py` pass.

No database changes / migrations.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._