### PR TITLE
Backend/emails: Move image embedding to templating code

### DIFF
--- a/app/backend/proto/internal/jobs.proto
+++ b/app/backend/proto/internal/jobs.proto
@@ -15,13 +15,17 @@ message SendEmailPayload {
   // source data as to where this email came from
   string source_data = 8;
   reserved 9; // Previous "attachments" field, which had mime_type+filename subfields.
-  repeated EmailAttachmentV2 attachments = 10;
+  repeated EmailPart attachments = 10;
+  repeated EmailPart html_related_parts = 11; // MIME parts which are multipart/related to the HTML body.
 }
 
-message EmailAttachmentV2 {
+// A MIME part of an SMPT email, usable for attached files or inline images.
+message EmailPart {
   bytes data = 1;
   string content_disposition = 2; // The Content-Disposition header, including parameters
   string content_type = 3; // The Content-Type header, including parameters
+  string content_id = 4; // The Content-ID header, including parameters
+  string data_file_path = 5; // The server-side path to the file containing the data (mutually exclusive with "data").
 }
 
 message HandleNotificationPayload {

--- a/app/backend/src/couchers/email/calendar_events.py
+++ b/app/backend/src/couchers/email/calendar_events.py
@@ -7,7 +7,7 @@ from couchers import urls
 from couchers.config import config
 from couchers.email.locales import get_emails_i18next
 from couchers.i18n import LocalizationContext
-from couchers.proto.internal.jobs_pb2 import EmailAttachmentV2
+from couchers.proto.internal.jobs_pb2 import EmailPart
 from couchers.proto.requests_pb2 import HostRequest
 
 HOST_REQUEST_ICS_FILENAME = "host_request.ics"
@@ -15,7 +15,7 @@ HOST_REQUEST_ICS_FILENAME = "host_request.ics"
 
 def create_host_request_attachment(
     host_request: HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext
-) -> EmailAttachmentV2:
+) -> EmailPart:
     calendar = create_host_request_calendar(host_request, other_name, hosting, loc_context)
     return calendar_to_attachment(calendar, HOST_REQUEST_ICS_FILENAME)
 
@@ -67,7 +67,7 @@ def create_host_request_event(
 
 def create_host_request_cancellation_attachment(
     host_request: HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext
-) -> EmailAttachmentV2:
+) -> EmailPart:
     calendar = create_host_request_cancellation_calendar(host_request, other_name, hosting, loc_context)
     return calendar_to_attachment(calendar, HOST_REQUEST_ICS_FILENAME)
 
@@ -96,7 +96,7 @@ def event_to_calendar(event: Event, method: str | None, loc_context: Localizatio
     return calendar
 
 
-def calendar_to_attachment(calendar: Calendar, filename: str) -> EmailAttachmentV2:
+def calendar_to_attachment(calendar: Calendar, filename: str) -> EmailPart:
     data = calendar.serialize().encode("utf-8")
     content_disposition = f'attachment; filename="{filename}"'
     content_type = 'text/calendar; charset="utf-8"'
@@ -105,7 +105,7 @@ def calendar_to_attachment(calendar: Calendar, filename: str) -> EmailAttachment
         # AI recommends avoiding quotes on this parameter for backwards compatibility with old email clients.
         content_type += f"; method={calendar.method}"
 
-    return EmailAttachmentV2(data=data, content_disposition=content_disposition, content_type=content_type)
+    return EmailPart(data=data, content_disposition=content_disposition, content_type=content_type)
 
 
 def get_host_request_event_uid(host_request_id: int) -> str:

--- a/app/backend/src/couchers/email/dump_emails.py
+++ b/app/backend/src/couchers/email/dump_emails.py
@@ -128,7 +128,7 @@ def dump_all(outdir: Path, *, filter_glob: str = "*", locales: list[str] | None 
 
 def dump_email(email: EmailBase, footer: EmailFooter, loc_context: LocalizationContext, filepath_no_ext: Path) -> str:
     """Dumps an email's subject and plaintext+html body to a file, returning the subject line."""
-    rendered = render_email(email, footer, loc_context)
+    rendered = render_email(email, footer, loc_context, embed_images=False)
     html = rendered.body_html.replace("attachment_imgs/", "../attachment_imgs/")
 
     filepath_no_ext.parent.mkdir(parents=True, exist_ok=True)

--- a/app/backend/src/couchers/email/queuing.py
+++ b/app/backend/src/couchers/email/queuing.py
@@ -63,6 +63,7 @@ def queue_userless_email(
             subject=config.NOTIFICATION_PREFIX + rendered.subject,
             plain=rendered.body_plaintext,
             html=rendered.body_html,
+            html_related_parts=rendered.html_image_parts,
             source_data=f"{source_data_header}; version={config.VERSION}",
         ),
     )

--- a/app/backend/src/couchers/email/rendering.py
+++ b/app/backend/src/couchers/email/rendering.py
@@ -4,6 +4,7 @@ Renders blocks-based emails to HTML or plaintext emails for a locale.
 
 import re
 from dataclasses import asdict, dataclass
+from email.headerregistry import Address
 from functools import cache
 from html import unescape
 from pathlib import Path
@@ -11,9 +12,12 @@ from pathlib import Path
 from markdown_it import MarkdownIt
 from markupsafe import Markup
 
+from couchers.config import config
 from couchers.email.blocks import ActionBlock, EmailBase, EmailBlock, EmailFooter, ParaBlock, QuoteBlock, UserBlock
 from couchers.email.locales import get_emails_i18next
+from couchers.email.smtp import embed_html_relative_images
 from couchers.i18n import LocalizationContext
+from couchers.proto.internal import jobs_pb2
 from couchers.templating import Jinja2Template
 
 template_folder = Path(__file__).parent.parent.parent.parent / "templates" / "v2"
@@ -28,9 +32,12 @@ class RenderedEmail:
     subject: str
     body_plaintext: str
     body_html: str
+    html_image_parts: list[jobs_pb2.EmailPart]
 
 
-def render_email(email: EmailBase, footer: EmailFooter, loc_context: LocalizationContext) -> RenderedEmail:
+def render_email(
+    email: EmailBase, footer: EmailFooter, loc_context: LocalizationContext, *, embed_images: bool = True
+) -> RenderedEmail:
     """Renders an EmailBase object to subject and body strings."""
     subject = email.get_subject_line(loc_context)
     preview = email.get_preview_line(loc_context)
@@ -41,7 +48,16 @@ def render_email(email: EmailBase, footer: EmailFooter, loc_context: Localizatio
         subject=subject, preview=preview, blocks=body_blocks, footer=footer, loc_context=loc_context
     )
 
-    return RenderedEmail(subject=subject, body_plaintext=body_plaintext, body_html=body_html)
+    related_parts: list[jobs_pb2.EmailPart] = []
+    if embed_images:
+        content_id_domain = Address(addr_spec=config.NOTIFICATION_EMAIL_ADDRESS).domain
+        body_html, related_parts = embed_html_relative_images(
+            body_html, base_dir=template_folder, content_id_domain=content_id_domain
+        )
+
+    return RenderedEmail(
+        subject=subject, body_plaintext=body_plaintext, body_html=body_html, html_image_parts=related_parts
+    )
 
 
 def render_plaintext_body(*, blocks: list[EmailBlock], footer: EmailFooter, loc_context: LocalizationContext) -> str:

--- a/app/backend/src/couchers/email/smtp.py
+++ b/app/backend/src/couchers/email/smtp.py
@@ -1,22 +1,53 @@
+import re
 import smtplib
+from collections.abc import Sequence
 from email.headerregistry import Address
 from email.message import EmailMessage, MIMEPart
 from email.utils import make_msgid
 from pathlib import Path
 from typing import cast
 
+import couchers
 from couchers.config import config
 from couchers.crypto import EMAIL_SOURCE_DATA_KEY_NAME, random_hex, simple_hash_signature
+from couchers.email.rendering import template_folder
 from couchers.models import Email
 from couchers.proto.internal import jobs_pb2
 
-template_base = Path(Path(__file__).parent / ".." / ".." / ".." / "templates" / "v2")
+# Base directory for EmailPart.data_file_path
+email_related_part_data_path_base = Path(couchers.__file__).parents[3]  # /app/backend
 
 
-def make_cid(sender_email: str) -> tuple[str, str]:
-    cid = make_msgid(domain=Address(addr_spec=sender_email).domain)
-    without_tag = cid[1:-1]
-    return cid, without_tag
+def embed_html_relative_images(
+    html: str, *, base_dir: Path, content_id_domain: str
+) -> tuple[str, list[jobs_pb2.EmailPart]]:
+    """Modifies HTML markup's image references such that they can be embedded in multipart/related MIME parts."""
+    related_parts: list[jobs_pb2.EmailPart] = []
+
+    def process_relative_src_match(match: re.Match[str]) -> str:
+        """Replaces a src="" attribute with a content id reference."""
+        image_path = base_dir / str(match.group(1))
+        if not image_path.exists():
+            raise FileExistsError(f"HTML references missing relative image: {image_path}")
+
+        root_relative_path = image_path.relative_to(email_related_part_data_path_base)
+        mime_type = f"image/{image_path.suffix.removeprefix('.')}"
+        filename = image_path.name
+        bracketed_content_id = make_msgid(domain=content_id_domain)
+        content_id = bracketed_content_id[1:-1]
+        related_parts.append(
+            jobs_pb2.EmailPart(
+                data_file_path=str(root_relative_path),
+                content_type=f'{mime_type}; name="{filename}"',
+                content_disposition=f'inline; filename="{filename}"',
+                content_id=bracketed_content_id,
+            )
+        )
+
+        return f'src="cid:{content_id}"'
+
+    html = re.sub(r'src="([^":]+)"', repl=process_relative_src_match, string=html)
+    return html, related_parts
 
 
 def email_proto_to_message(payload: jobs_pb2.SendEmailPayload, couchers_id: str) -> tuple[EmailMessage, str | None]:
@@ -35,38 +66,55 @@ def email_proto_to_message(payload: jobs_pb2.SendEmailPayload, couchers_id: str)
 
     msg.set_content(payload.plain)
 
-    updated_html: str | None = payload.html
-    if updated_html:
-        # for any png files in attachment_imgs/, goes through and replaces instances of the filename with attachment
-        used_attachments = []
-        for attachment_full_path in (template_base / "attachment_imgs").glob("*.png"):
-            attachment_html_path = str(attachment_full_path.relative_to(template_base))
-            if attachment_html_path not in updated_html:
-                continue
-            # it's used in this template, so attach and replace it
-            data = attachment_full_path.read_bytes()
-            cid, wcid = make_cid(payload.sender_email)
-            updated_html = updated_html.replace(attachment_html_path, f"cid:{wcid}")
-            used_attachments.append((cid, "image", "png", data))
+    html_body: str | None = payload.html
+    if html_body:
+        related_parts: Sequence[jobs_pb2.EmailPart] = payload.html_related_parts
+        if not related_parts:
+            # Backcompat (2026-06): Embedding relative images used to be this function's responsibility,
+            # and was moved to the payload builder. Keep this fallback in case we have queued payloads
+            # that didn't do their own embedding.
+            content_id_domain = Address(addr_spec=payload.sender_email).domain
+            html_body, related_parts = embed_html_relative_images(
+                html_body, base_dir=template_folder, content_id_domain=content_id_domain
+            )
 
-        msg.add_alternative(updated_html, subtype="html")
+        msg.add_alternative(html_body, subtype="html")
+        html_part = cast(list[MIMEPart], msg.get_payload())[-1]
 
-        for cid, mime_type, mime_subtype, data in used_attachments:
-            html_part = cast(list[MIMEPart], msg.get_payload())[-1]
-            html_part.add_related(data, mime_type, mime_subtype, cid=cid)
+        for related_part in related_parts:
+            _add_email_part(html_part, related_part, related=True)
 
     if payload.attachments:
         for attachment in payload.attachments:
-            # Create with generic Content-Type/Content-Disposition headers,
-            # then overwrite them with the headers specified by the caller.
-            msg.add_attachment(
-                attachment.data, maintype="application", subtype="octet-stream", disposition="attachment"
-            )
-            attachment_part = cast(list[MIMEPart], msg.get_payload())[-1]
-            _replace_header_verbatim(attachment_part, "Content-Type", attachment.content_type)
-            _replace_header_verbatim(attachment_part, "Content-Disposition", attachment.content_disposition)
+            _add_email_part(msg, attachment, related=False)
 
-    return msg, updated_html
+    return msg, html_body
+
+
+def _add_email_part(msg: MIMEPart, part: jobs_pb2.EmailPart, *, related: bool) -> MIMEPart:
+    # The data is either part of the payload or must be loaded from a file
+    data = part.data
+    if not data and part.data_file_path:
+        data_path = Path(part.data_file_path)
+        if not data_path.is_absolute():
+            data_path = email_related_part_data_path_base / data_path
+        data = data_path.read_bytes()
+
+    # Create with generic Content-Type/Content-Disposition headers,
+    # then overwrite them with the headers specified by the caller.
+    if related:
+        msg.add_related(data, maintype="application", subtype="octet-stream", disposition="inline")
+    else:
+        msg.add_attachment(data, maintype="application", subtype="octet-stream", disposition="attachment")
+
+    mime_part = cast(list[MIMEPart], msg.get_payload())[-1]
+    _replace_header_verbatim(mime_part, "Content-Type", part.content_type)
+    if part.content_disposition:
+        _replace_header_verbatim(mime_part, "Content-Disposition", part.content_disposition)
+    if part.content_id:
+        _replace_header_verbatim(mime_part, "Content-ID", part.content_id)
+
+    return mime_part
 
 
 def send_smtp_email(payload: jobs_pb2.SendEmailPayload) -> Email:

--- a/app/backend/src/couchers/email/smtp.py
+++ b/app/backend/src/couchers/email/smtp.py
@@ -10,11 +10,12 @@ from typing import cast
 import couchers
 from couchers.config import config
 from couchers.crypto import EMAIL_SOURCE_DATA_KEY_NAME, random_hex, simple_hash_signature
-from couchers.email.rendering import template_folder
 from couchers.models import Email
 from couchers.proto.internal import jobs_pb2
 
-# Base directory for EmailPart.data_file_path
+template_base = Path(Path(__file__).parent / ".." / ".." / ".." / "templates" / "v2")
+
+# Base directory for relative EmailPart.data_file_path
 email_related_part_data_path_base = Path(couchers.__file__).parents[3]  # /app/backend
 
 
@@ -75,7 +76,7 @@ def email_proto_to_message(payload: jobs_pb2.SendEmailPayload, couchers_id: str)
             # that didn't do their own embedding.
             content_id_domain = Address(addr_spec=payload.sender_email).domain
             html_body, related_parts = embed_html_relative_images(
-                html_body, base_dir=template_folder, content_id_domain=content_id_domain
+                html_body, base_dir=template_base, content_id_domain=content_id_domain
             )
 
         msg.add_alternative(html_body, subtype="html")

--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -17,7 +17,7 @@ from couchers.notifications.quick_links import (
     generate_unsub_topic_key,
 )
 from couchers.proto import api_pb2
-from couchers.proto.internal.jobs_pb2 import EmailAttachmentV2, SendEmailPayload
+from couchers.proto.internal.jobs_pb2 import EmailPart, SendEmailPayload
 from couchers.utils import now
 
 logger = logging.getLogger(__name__)
@@ -45,6 +45,7 @@ def get_send_email_payload(
         subject=config.NOTIFICATION_PREFIX + rendered_email.subject,
         plain=rendered_email.body_plaintext,
         html=rendered_email.body_html,
+        html_related_parts=rendered_email.html_image_parts,
         source_data=source_data_header,
         list_unsubscribe_header=list_unsubscribe_header,
         attachments=[attachment] if attachment else [],
@@ -168,7 +169,7 @@ def get_source_data_header(notification: Notification) -> str:
     return f"notification; topic-action={notification.topic_action}; version={config.VERSION}"
 
 
-def get_ics_attachment(notification: Notification, loc_context: LocalizationContext) -> EmailAttachmentV2 | None:
+def get_ics_attachment(notification: Notification, loc_context: LocalizationContext) -> EmailPart | None:
     data = notification.topic_action.data_type.FromString(notification.data)  # type: ignore[attr-defined]
     if notification.topic_action == NotificationTopicAction.host_request__accept:
         # Caveat: The surfer technically still hasn't confirmed, but when they do they don't receive an email,

--- a/app/backend/src/tests/test_email_localization.py
+++ b/app/backend/src/tests/test_email_localization.py
@@ -63,3 +63,4 @@ def test_email_renders_in_english(email: EmailBase):
     assert "<" not in rendered.subject, "Subject line shoudn't contain HTML"
     assert rendered.body_plaintext
     assert rendered.body_html
+    assert len(rendered.html_image_parts) > 0, "Images should have been embedded"

--- a/app/backend/src/tests/test_smtp.py
+++ b/app/backend/src/tests/test_smtp.py
@@ -1,5 +1,8 @@
-from couchers.email.smtp import email_proto_to_message
-from couchers.proto.internal.jobs_pb2 import EmailAttachmentV2, SendEmailPayload
+import re
+
+from couchers.email.rendering import template_folder
+from couchers.email.smtp import email_proto_to_message, embed_html_relative_images
+from couchers.proto.internal.jobs_pb2 import EmailPart, SendEmailPayload
 
 
 def test_verbatim_attachment_headers():
@@ -15,7 +18,7 @@ def test_verbatim_attachment_headers():
         subject="greeting",
         plain="hello",
         attachments=[
-            EmailAttachmentV2(
+            EmailPart(
                 data=bytes([0, 255]),  # Force base64 encoding
                 content_type='maintype/subtype; quoted-header="value"; unquoted-header=value',
                 content_disposition="attachment",
@@ -34,3 +37,23 @@ MIME-Version: 1.0
     """.strip()
 
     assert expected_snippet in smtp_str
+
+
+def test_embed_html_relative_images() -> None:
+    html = """
+        <img src="attachment_imgs/logo-grey.png"/>
+        <img src="https://example.com/foo.png"/>
+    """
+
+    html, related_parts = embed_html_relative_images(html, base_dir=template_folder, content_id_domain="example.com")
+
+    content_id_match = re.search(r'src="cid:(.*@example.com)"', html)
+    assert content_id_match is not None, "html was not modified to include content id"
+
+    assert "https://example.com/foo.png" in html, "Absolute image URL was replaced"
+
+    assert len(related_parts) == 1
+    related_part = related_parts[0]
+    assert related_part.content_type == 'image/png; name="logo-grey.png"'
+    assert related_part.content_disposition == 'inline; filename="logo-grey.png"'
+    assert related_part.content_id == f"<{content_id_match.group(1)}>"


### PR DESCRIPTION
Fixes #8863

Moves the responsibility for embedding images in emails from `send_smtp_email` (emailing job) to `render_email` (templating code), by extending `SendEmailPayload` to support specifying `html_related_parts` and extending `EmailPart` to support a `Content-ID` header and referencing data from a path (the image file).

With this change, `send_smtp_email` merely reconstructs the SMTP message and sends it. However for backcompat I kept the a code path that does the embedding in `send_smtp_email` as fallback until we've deployed long enough to drain the emailing job queue from jobs that didn't do the embedding.

Also renames `EmailAttachmentV2` to `EmailPart` since it can naturally represent both attachments and related image parts.

## Testing
Ran backend + frontend locally and verified with an email that images still work:

<img width="1226" height="1222" alt="image" src="https://github.com/user-attachments/assets/68669042-ec97-4980-a322-6adaa406c1eb" />

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
