### PR TITLE
Backend: assert x-couchers-real-ip is present in prod

### DIFF
--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -21,6 +21,7 @@ from sqlalchemy import Function, literal_column, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.sql import func
 
+from couchers.config import config
 from couchers.constants import (
     CALL_CANCELLED_ERROR_MESSAGE,
     COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE,
@@ -357,6 +358,9 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                 headers = parse_headers(dict(handler_call_details.invocation_metadata))
             except BadHeaders:
                 return unauthenticated_handler(COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE)
+
+            # if this is not present in prod, it's a Big Bug in config
+            assert config.DEV or headers.ip_address is not None
 
             auth_info = _try_get_and_update_user_details(
                 headers.token,


### PR DESCRIPTION
nginx sets `x-couchers-real-ip` on every external route to the backend (`api.conf`, `web.conf`), so the header is always present in production and cannot be spoofed (it's set to `$remote_addr`, overriding any client-supplied value). This adds an assert in the middleware interceptor, right after header parsing, that the IP is present outside `DEV`.

The motivation is upcoming per-IP rate limiting, which keys on this header: if a proxy change ever dropped it, per-IP limiting would silently become ineffective. The assert makes that misconfig fail loudly instead. It's gated on `config.DEV` so it's a no-op in dev/test (where requests don't go through nginx); `IN_TEST` implies `DEV`.

## Testing
`make format` and `make mypy` both pass. The assert is a no-op under `DEV`, so the existing interceptor tests are unaffected. No behavior change in dev/test; in prod the header is guaranteed by nginx.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._