### PR TITLE
Backend: fix mypy unused-ignore failing CI on develop

### DIFF
--- a/app/backend/src/couchers/email/calendar_events.py
+++ b/app/backend/src/couchers/email/calendar_events.py
@@ -1,6 +1,6 @@
 from email.headerregistry import Address
 
-from ics import Calendar, Event  # type: ignore[import-untyped]
+from ics import Calendar, Event
 from ics.grammar.parse import ContentLine  # type: ignore[import-untyped]
 
 from couchers import urls


### PR DESCRIPTION
Fixes the `test:backend-mypy` failure on `develop`.

Commit 894647566 added `ics` to mypy's `ignore_missing_imports` override, which made the `# type: ignore[import-untyped]` on the top-level `from ics import Calendar, Event` redundant. mypy's `unused-ignore` check then failed CI. This removes the now-unused comment. The submodule import (`ics.grammar.parse`) keeps its ignore since the override only covers the `ics` module itself.

## Testing
`uv run mypy src/couchers` (CI scope) and `uv run mypy src` (full, what `make mypy` runs) both pass with a fresh cache.

**Backend checklist**
- [x] Run the backend locally and it works

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

🤖 Generated with [Claude Code](https://claude.com/claude-code)