### PR TITLE
Mobile: scope dev URL override to the running bundle

### DIFF
--- a/app/mobile/config/urls.ts
+++ b/app/mobile/config/urls.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import Constants from "expo-constants";
+import * as Updates from "expo-updates";
 
 const STORAGE_KEY = "@couchers/devUrlOverrides";
 
@@ -19,6 +20,14 @@ export type UrlOverrides = {
   apiBaseUrl: string | null;
   webBaseUrl: string | null;
 };
+
+// An override is bound to the bundle it was set on, so loading a different
+// bundle drops it rather than reusing it. "none" buckets all local Metro dev.
+type StoredOverrides = UrlOverrides & { bundleId?: string };
+
+function currentBundleId(): string {
+  return Updates.updateId ?? "none";
+}
 
 export type Preset = {
   label: string;
@@ -109,7 +118,12 @@ export async function hydrateUrlOverrides(): Promise<void> {
   try {
     const raw = await AsyncStorage.getItem(STORAGE_KEY);
     if (raw) {
-      const parsed = JSON.parse(raw) as Partial<UrlOverrides>;
+      const parsed = JSON.parse(raw) as Partial<StoredOverrides>;
+      if (parsed.bundleId !== currentBundleId()) {
+        cache = { apiBaseUrl: null, webBaseUrl: null };
+        await AsyncStorage.removeItem(STORAGE_KEY);
+        return;
+      }
       cache = {
         apiBaseUrl: normalize(parsed.apiBaseUrl),
         webBaseUrl: normalize(parsed.webBaseUrl),
@@ -125,7 +139,8 @@ export async function setUrlOverrides(overrides: UrlOverrides): Promise<void> {
     apiBaseUrl: normalize(overrides.apiBaseUrl),
     webBaseUrl: normalize(overrides.webBaseUrl),
   };
-  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(cache));
+  const stored: StoredOverrides = { ...cache, bundleId: currentBundleId() };
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
   await addToHistory(cache);
 }
 

--- a/app/mobile/tests/config/urls.test.ts
+++ b/app/mobile/tests/config/urls.test.ts
@@ -1,7 +1,14 @@
 const mockExtra: Record<string, unknown> = {};
+let mockUpdateId: string | null = null;
 
 jest.mock("expo-constants", () => ({
   expoConfig: { extra: mockExtra },
+}));
+
+jest.mock("expo-updates", () => ({
+  get updateId() {
+    return mockUpdateId;
+  },
 }));
 
 function loadUrls() {
@@ -18,6 +25,7 @@ describe("web base URL resolution", () => {
     for (const key of Object.keys(mockExtra)) {
       delete mockExtra[key];
     }
+    mockUpdateId = null;
     delete process.env.EXPO_PUBLIC_COUCHERS_ENV;
   });
 
@@ -50,6 +58,34 @@ describe("web base URL resolution", () => {
     expect(urls.getWebBaseUrl()).toBe("https://override.example.com");
     await urls.clearUrlOverrides();
     expect(urls.getWebBaseUrl()).toBe("https://branch.vercel.app");
+  });
+
+  it("drops an override when a different bundle is loaded", async () => {
+    mockUpdateId = "bundle-A";
+    mockExtra.otaWebBaseUrl = "https://branch.vercel.app";
+    const urls = loadUrls();
+    await urls.setUrlOverrides({
+      apiBaseUrl: null,
+      webBaseUrl: "https://override.example.com",
+    });
+    expect(urls.getWebBaseUrl()).toBe("https://override.example.com");
+
+    // A new OTA branch preview is now running; its own web URL should win.
+    mockUpdateId = "bundle-B";
+    await urls.hydrateUrlOverrides();
+    expect(urls.getWebBaseUrl()).toBe("https://branch.vercel.app");
+  });
+
+  it("keeps an override across reloads of the same bundle", async () => {
+    mockUpdateId = "bundle-A";
+    const urls = loadUrls();
+    await urls.setUrlOverrides({
+      apiBaseUrl: null,
+      webBaseUrl: "https://override.example.com",
+    });
+
+    await urls.hydrateUrlOverrides();
+    expect(urls.getWebBaseUrl()).toBe("https://override.example.com");
   });
 
   it("ignores a non-string manifest value", () => {

--- a/app/web/.env.next
+++ b/app/web/.env.next
@@ -7,7 +7,6 @@ NEXT_PUBLIC_CONSOLE_BASE_URL="https://next-console.couchershq.org"
 NEXT_PUBLIC_NOMINATIM_URL="https://nominatim.openstreetmap.org/"
 NEXT_PUBLIC_STRIPE_KEY="pk_test_51KEzByIfR5z29g5khFE5samD8XKOGLcCrM1lhCkfOomGPUFAEYOw8uAqI2Nkv33wYdPM2FgTQNTC07IiNfHY1kLJ00Jqm8Ppai"
 NEXT_PUBLIC_GLOBAL_MESSAGE_URL="https://gm.couchershq.org/next.json"
-NEXT_PUBLIC_RECAPTCHA_SITE_KEY="6Lck93ArAAAAADGMEjw6scBl7WG1zlR6LdAGPDPi"
 # express.json is the static snapshot path segment (SDK clientKey), not a real GrowthBook key
 NEXT_PUBLIC_GROWTHBOOK_API_HOST="https://next-static.couchershq.org"
 NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY="express.json"


### PR DESCRIPTION
Fixes a stale-override footgun in the Dev Tool. The in-app dev URL override was persisted independently of which JS bundle was running, so after loading a new OTA branch preview the webview silently kept pointing at the URL set on a previous bundle (e.g. an old web preview that still served the since-removed reCAPTCHA).

Each override is now bound to the running bundle's update id (`Updates.updateId`, or `"none"` in local Metro dev):
- Loading a **different** bundle drops the stale override on hydrate, so the new bundle's own `otaWebBaseUrl` takes effect.
- **Reloads of the same bundle** keep the override, so the normal "set it in the settings screen and it sticks" flow is unchanged.

Also removes the now-dead `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` from `app/web/.env.next` — it was missed when reCAPTCHA was stripped (no code reads it anymore).

## Testing
- Added two cases to `app/mobile/tests/config/urls.test.ts`: an override is dropped when a different bundle is loaded, and kept across reloads of the same bundle.
- `npx jest tests/config/urls.test.ts` (8 passing), `npx tsc --noEmit`, and `eslint` on the changed files all pass.

To reproduce manually: in the Dev Tool, set a web URL override via the settings screen, then load a different branch preview — the webview should now use the new branch's web URL instead of the overridden one.

**Web frontend checklist**
- [x] Added tests where relevant

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._