### PR TITLE
Lower envoy DNS refresh rate to reduce deploy downtime

### DIFF
--- a/app/proxy/envoy.yaml
+++ b/app/proxy/envoy.yaml
@@ -153,6 +153,8 @@ static_resources:
   - name: couchers_service
     connect_timeout: 0.25s
     type: strict_dns
+    # faster than the 5s default so envoy picks up the backend's new IP quickly when it's recreated on deploy
+    dns_refresh_rate: 1s
     # round-robins across the backend's API worker processes; keep these endpoints in sync with API_WORKER_COUNT
     lb_policy: round_robin
     load_assignment:


### PR DESCRIPTION
Lowers the `dns_refresh_rate` on the `couchers_service` cluster in `envoy.yaml` to `1s` (down from the Envoy 5s default).

When the backend container is recreated during a deploy, its IP can change. With strict DNS and the 5s default refresh rate, Envoy can keep routing to the stale IP for up to ~5s, causing avoidable downtime. Refreshing once per second lets Envoy pick up the new backend IP much faster, reducing downtime during deploys.

## Testing
Config-only change. Verified the YAML is well-formed and the directive is placed on the `couchers_service` cluster. Behavior can be confirmed during the next deploy by observing reduced request errors / downtime as the backend is recreated.

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._