### PR TITLE
Enable zstd WAL compression in PostGIS config

### DIFF
--- a/app/postgis/postgresql.conf
+++ b/app/postgis/postgresql.conf
@@ -18,6 +18,7 @@ dynamic_shared_memory_type = posix
 wal_buffers = 64MB
 max_wal_size = 2GB
 min_wal_size = 80MB
+wal_compression = zstd
 
 # Planner (SSD)
 random_page_cost = 1.1


### PR DESCRIPTION
Enables `wal_compression = zstd` in the PostGIS `postgresql.conf`. This compresses full-page images written to the WAL using zstd, reducing WAL volume and therefore disk I/O as well as archive/replication traffic.

## Testing
Config-only change. Verified the directive is valid for our PostgreSQL/PostGIS version (`wal_compression = zstd` is supported on PostgreSQL 15+). The setting takes effect on server reload; no migration or code change is required.

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._