### PR TITLE
Backend/notifs: Remove deprecated notification_data.ChatMessage.message

### DIFF
--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -281,20 +281,11 @@ class ChatMessageReceivedEmail(EmailBase):
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.ChatMessage, *, user_name: str) -> Self:
-        group_chat_title: str | None = data.group_chat_title
-        if not group_chat_title:
-            # Backcompat (2026-05): The group name previously was formatted in the message string
-            # msg = f"{message.author.name} sent a message in {group_chat.title}"
-            if match := re.search(" sent a message in (.+)$", data.message or ""):
-                group_chat_title = match[1]
-            else:
-                group_chat_title = None
-
         return cls(
             user_name,
             author=UserInfo.from_protobuf(data.author),
             text=data.text,
-            group_chat_title=group_chat_title,
+            group_chat_title=data.group_chat_title,
             view_url=urls.chat_link(chat_id=data.group_chat_id),
         )
 
@@ -350,33 +341,16 @@ class ChatMessagesMissedEmail(EmailBase):
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.ChatMissedMessages, *, user_name: str) -> Self:
-        missed_entries = []
-        for message in data.messages:
-            group_chat_title: str | None = message.group_chat_title
-            missed_count: int = message.unseen_count
-
-            # Backcompat (2026-05): The group name and unseen count were previously was formatted in the message string
-            # msg = f"You missed {unseen_count} message(s) in {group_chat.title}"
-            if not group_chat_title or not missed_count:
-                if match := re.search(" message(s) in (.+)$", message.message or ""):
-                    group_chat_title = match[1]
-                else:
-                    group_chat_title = None
-
-                if match := re.search(r"^You missed (\d+) message(s)", message.message or ""):
-                    missed_count = int(match[1])
-                else:
-                    missed_count = 1
-
-            missed_entries.append(
-                cls.Entry(
-                    group_chat_title=group_chat_title,
-                    missed_count=missed_count,
-                    latest_message_author=UserInfo.from_protobuf(message.author),
-                    latest_message_text=message.text,
-                    view_url=urls.chat_link(chat_id=message.group_chat_id),
-                )
+        missed_entries = [
+            cls.Entry(
+                group_chat_title=message.group_chat_title,
+                missed_count=message.unseen_count,
+                latest_message_author=UserInfo.from_protobuf(message.author),
+                latest_message_text=message.text,
+                view_url=urls.chat_link(chat_id=message.group_chat_id),
             )
+            for message in data.messages
+        ]
 
         return cls(user_name, entries=missed_entries)
 

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -452,7 +452,7 @@ def test_chat_missed_messages_list_unsubscribe_header(db, email_collector: Email
                         author=api_pb2.User(name="Test User", user_id=2, username="testuser"),
                         text="Hello!",
                         group_chat_id=99,
-                        unseen_count=1
+                        unseen_count=1,
                     ),
                 ],
             ),

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -450,9 +450,9 @@ def test_chat_missed_messages_list_unsubscribe_header(db, email_collector: Email
                 messages=[
                     notification_data_pb2.ChatMessage(
                         author=api_pb2.User(name="Test User", user_id=2, username="testuser"),
-                        message="You missed 1 message(s) from Test User",
                         text="Hello!",
                         group_chat_id=99,
+                        unseen_count=1
                     ),
                 ],
             ),

--- a/app/proto/notification_data.proto
+++ b/app/proto/notification_data.proto
@@ -150,7 +150,7 @@ message EventDelete {
 
 message ChatMessage {
   org.couchers.api.core.User author = 1;
-  reserved 2; # Formerly "message", non-localized.
+  reserved 2; // Formerly "message", non-localized.
   string text = 3;
   uint64 group_chat_id = 4;
   string group_chat_title = 5;  // Empty for direct messages

--- a/app/proto/notification_data.proto
+++ b/app/proto/notification_data.proto
@@ -150,8 +150,7 @@ message EventDelete {
 
 message ChatMessage {
   org.couchers.api.core.User author = 1;
-  // Obsolete (2026-05): Was not i18n-friendly. Use group_chat_title. Kept for handling fallback.
-  string message = 2 [deprecated = true];
+  reserved 2; # Formerly "message", non-localized.
   string text = 3;
   uint64 group_chat_id = 4;
   string group_chat_title = 5;  // Empty for direct messages


### PR DESCRIPTION
It was kept as a fallback in #8753 (merged 2026-05-26) because we might still have been processing jobs referencing `ChatMessage` instances with a `message` value. I think it's safe to assume those have drained by now.

## Testing
Updated the test that used this field. Otherwise no test covered the deprecated code path.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
