### PR TITLE
Backend/emails: Make string keys more hierarchical

### DIFF
--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -41,7 +41,7 @@ class AccountDeletionStartedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "account_deletion_started"
+        return "account_deletion.started"
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
@@ -76,7 +76,7 @@ class AccountDeletionCompletedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "account_deletion_completed"
+        return "account_deletion.completed"
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
@@ -111,7 +111,7 @@ class AccountDeletionRecoveredEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "account_deletion_recovered"
+        return "account_deletion.recovered"
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
@@ -200,14 +200,14 @@ class BadgeChangedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "badge_added" if self.added else "badge_removed"
+        return "badges.added" if self.added else "badges.removed"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
-        return self._localize(loc_context, ".subject", {"badge_name": self.badge_name})
+        return self._localize(loc_context, ".subject", {"name": self.badge_name})
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body", {"badge_name": self.badge_name})
+        builder.para(".body", {"name": self.badge_name})
         return builder.build()
 
     @classmethod
@@ -264,7 +264,7 @@ class ChatMessageReceivedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return f"chat_message_received.{'direct' if self.group_chat_title is None else 'group'}"
+        return f"chat_messages.received.{'direct' if self.group_chat_title is None else 'group'}"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(
@@ -322,7 +322,7 @@ class ChatMessagesMissedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "chat_messages_missed"
+        return "chat_messages.missed"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(loc_context, ".subject")
@@ -386,7 +386,7 @@ class DiscussionCreatedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "discussion_created"
+        return "discussions.created"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(loc_context, ".subject", {"author": self.author.name, "title": self.title})
@@ -444,7 +444,7 @@ class DiscussionCommentEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "discussion_comment"
+        return "discussions.comment"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(
@@ -529,14 +529,14 @@ class DonationReceivedEmail(EmailBase):
 
 
 @dataclass(kw_only=True, slots=True)
-class EmailAddressChangedEmail(EmailBase):
+class EmailChangedEmail(EmailBase):
     """Sent to a user to notify them that their email address was changed."""
 
     new_email: str
 
     @property
     def string_key_base(self) -> str:
-        return "email_address_change_initiated"
+        return "email_change.initiated"
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
@@ -553,7 +553,7 @@ class EmailAddressChangedEmail(EmailBase):
 
 
 @dataclass(kw_only=True, slots=True)
-class EmailAddressChangeConfirmationEmail(EmailBase):
+class EmailChangeConfirmationEmail(EmailBase):
     """Sent to a user to confirm their new email address."""
 
     old_email: str
@@ -561,7 +561,7 @@ class EmailAddressChangeConfirmationEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "email_address_change_confirmation"
+        return "email_change.confirmation"
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
@@ -576,12 +576,12 @@ class EmailAddressChangeConfirmationEmail(EmailBase):
 
 
 @dataclass(kw_only=True, slots=True)
-class EmailAddressVerifiedEmail(EmailBase):
+class EmailVerifiedEmail(EmailBase):
     """Sent to a user to notify them that their new email address has been verified."""
 
     @property
     def string_key_base(self) -> str:
-        return "email_address_verified"
+        return "email_change.verified"
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
@@ -621,7 +621,7 @@ class EventInfo:
         html += time_range_display
         if self.online_link:
             html += "<br>"
-            online_link_text = get_emails_i18next().localize("event.generic.online_link", loc_context.locale)
+            online_link_text = get_emails_i18next().localize("events.generic.online_link", loc_context.locale)
             html += f'<i><a href="{escape(self.online_link)}">{escape(online_link_text)}</a></i>'
         elif self.address:
             html += "<br>"
@@ -633,7 +633,7 @@ class EventInfo:
         return QuoteBlock(text=Markup(self.description_markdown), markdown=True)
 
     def get_view_action_block(self, loc_context: LocalizationContext) -> EmailBlock:
-        view_action_text = get_emails_i18next().localize("event.generic.view_action", loc_context.locale)
+        view_action_text = get_emails_i18next().localize("events.generic.view_action", loc_context.locale)
         return ActionBlock(text=view_action_text, target_url=self.view_url)
 
     @classmethod
@@ -673,7 +673,7 @@ class EventCreatedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return f"event.created.{'invitation' if self.is_invite else 'notification'}"
+        return f"events.created.{'invitation' if self.is_invite else 'notification'}"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(
@@ -737,7 +737,7 @@ class EventUpdatedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "event.updated"
+        return "events.updated"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(
@@ -787,7 +787,7 @@ class EventOrganizerInvitedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "event.organizer_invited"
+        return "events.organizer_invited"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(
@@ -829,7 +829,7 @@ class EventCommentEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "event.comment"
+        return "events.comment"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(loc_context, ".subject", {"author": self.author.name, "title": self.event_info.title})
@@ -873,7 +873,7 @@ class EventReminderEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "event.reminder"
+        return "events.reminder"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(loc_context, ".subject", {"title": self.event_info.title})
@@ -907,7 +907,7 @@ class EventCancelledEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "event.cancel"
+        return "events.cancel"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(
@@ -946,7 +946,7 @@ class EventDeletedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "event.deleted"
+        return "events.deleted"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(loc_context, ".subject", {"title": self.event_info.title})
@@ -983,7 +983,7 @@ class FriendReferenceReceivedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "reference.received.friend"
+        return "references.received.friend"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(loc_context, ".subject", {"name": self.from_user.name})
@@ -993,7 +993,7 @@ class FriendReferenceReceivedEmail(EmailBase):
         builder.para(".body", {"name": self.from_user.name})
         builder.user(self.from_user)
         builder.quote(self.text, markdown=False)
-        builder.action(urls.profile_references_link(), "reference.received.view_action")
+        builder.action(urls.profile_references_link(), "references.received.view_action")
         return builder.build()
 
     @classmethod
@@ -1019,7 +1019,7 @@ class FriendRequestReceivedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "friend_request_received"
+        return "friend_requests.received"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(loc_context, ".subject", {"name": self.befriender.name})
@@ -1058,7 +1058,7 @@ class FriendRequestAcceptedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "friend_request_accepted"
+        return "friend_requests.accepted"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(loc_context, ".subject", {"name": self.new_friend.name})
@@ -1130,7 +1130,7 @@ class HostRequestCreatedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "host_request_created"
+        return "host_requests.created"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(loc_context, ".subject", {"surfer_name": self.surfer.name})
@@ -1140,14 +1140,14 @@ class HostRequestCreatedEmail(EmailBase):
         builder.para(".body", {"surfer_name": self.surfer.name})
         builder.user(
             self.surfer,
-            "host_request_generic.date_range",
+            "host_requests.generic.date_range",
             {
                 "from_date": _localize_host_request_date(self.from_date, loc_context),
                 "to_date": _localize_host_request_date(self.to_date, loc_context),
             },
         )
         builder.quote(self.text, markdown=False)
-        builder.action(self.view_link, "host_request_generic.view_action")
+        builder.action(self.view_link, "host_requests.generic.view_action")
         builder.action(self.quick_decline_link, ".quick_decline_action")
         builder.para(".respond_encouragement")
         builder.para(_do_not_reply_request_string_key)
@@ -1191,7 +1191,7 @@ class HostRequestReminderEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "host_request_reminder"
+        return "host_requests.reminder"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(loc_context, ".subject", {"surfer_name": self.surfer.name})
@@ -1201,13 +1201,13 @@ class HostRequestReminderEmail(EmailBase):
         builder.para(".body")
         builder.user(
             self.surfer,
-            "host_request_generic.date_range",
+            "host_requests.generic.date_range",
             {
                 "from_date": _localize_host_request_date(self.from_date, loc_context),
                 "to_date": _localize_host_request_date(self.to_date, loc_context),
             },
         )
-        builder.action(self.view_link, "host_request_generic.view_action")
+        builder.action(self.view_link, "host_requests.generic.view_action")
         builder.para(_do_not_reply_request_string_key)
         return builder.build()
 
@@ -1248,7 +1248,7 @@ class HostRequestMessageEmail(EmailBase):
     @property
     def string_key_base(self) -> str:
         variant = "from_host" if self.from_host else "from_surfer"
-        return f"host_request_message.{variant}"
+        return f"host_requests.message.{variant}"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(loc_context, ".subject", {"other_name": self.other_user.name})
@@ -1258,14 +1258,14 @@ class HostRequestMessageEmail(EmailBase):
         builder.para(".body", {"other_name": self.other_user.name})
         builder.user(
             self.other_user,
-            "host_request_generic.date_range",
+            "host_requests.generic.date_range",
             {
                 "from_date": _localize_host_request_date(self.from_date, loc_context),
                 "to_date": _localize_host_request_date(self.to_date, loc_context),
             },
         )
         builder.quote(self.text, markdown=False)
-        builder.action(self.view_link, "host_request_generic.view_action")
+        builder.action(self.view_link, "host_requests.generic.view_action")
         builder.para(_do_not_reply_request_string_key)
         return builder.build()
 
@@ -1308,7 +1308,7 @@ class HostRequestMissedMessagesEmail(EmailBase):
     @property
     def string_key_base(self) -> str:
         variant = "from_host" if self.from_host else "from_surfer"
-        return f"host_request_missed_messages.{variant}"
+        return f"host_requests.missed_messages.{variant}"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(loc_context, ".subject", {"other_name": self.other_user.name})
@@ -1318,13 +1318,13 @@ class HostRequestMissedMessagesEmail(EmailBase):
         builder.para(".body", {"other_name": self.other_user.name})
         builder.user(
             self.other_user,
-            "host_request_generic.date_range",
+            "host_requests.generic.date_range",
             {
                 "from_date": _localize_host_request_date(self.from_date, loc_context),
                 "to_date": _localize_host_request_date(self.to_date, loc_context),
             },
         )
-        builder.action(self.view_link, "host_request_generic.view_action")
+        builder.action(self.view_link, "host_requests.generic.view_action")
         builder.para(_do_not_reply_request_string_key)
         return builder.build()
 
@@ -1364,7 +1364,7 @@ class HostRequestStatusChangedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        base_key = "host_request_status_changed"
+        base_key = "host_requests.status_changed"
         match self.new_status:
             case conversations_pb2.HOST_REQUEST_STATUS_ACCEPTED:
                 return f"{base_key}.accepted_by_host"
@@ -1385,13 +1385,13 @@ class HostRequestStatusChangedEmail(EmailBase):
         builder.para(".body", {"other_name": self.other_user.name})
         builder.user(
             self.other_user,
-            "host_request_generic.date_range",
+            "host_requests.generic.date_range",
             {
                 "from_date": _localize_host_request_date(self.from_date, loc_context),
                 "to_date": _localize_host_request_date(self.to_date, loc_context),
             },
         )
-        builder.action(self.view_link, "host_request_generic.view_action")
+        builder.action(self.view_link, "host_requests.generic.view_action")
         builder.para(_do_not_reply_request_string_key)
         return builder.build()
 
@@ -1462,7 +1462,7 @@ class HostReferenceReceivedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "reference.received"
+        return "references.received"
 
     @property
     def string_role_subkey(self) -> str:
@@ -1481,7 +1481,7 @@ class HostReferenceReceivedEmail(EmailBase):
             builder.action(urls.profile_references_link(), ".view_action")
         else:
             builder.para(".reciprocate_encouragement", {"name": self.from_user.name})
-            builder.action(self.leave_reference_url, "reference.write_action", {"name": self.from_user.name})
+            builder.action(self.leave_reference_url, "references.write_action", {"name": self.from_user.name})
         return builder.build()
 
     @classmethod
@@ -1528,7 +1528,7 @@ class HostReferenceReminderEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "reference.reminder"
+        return "references.reminder"
 
     @property
     def string_role_subkey(self) -> str:
@@ -1548,7 +1548,7 @@ class HostReferenceReminderEmail(EmailBase):
         builder.user(self.other_user)
         builder.action(
             self.leave_reference_url,
-            "reference.write_action",
+            "references.write_action",
             {"name": self.other_user.name},
         )
         builder.para(".via_messaging_note")
@@ -1705,7 +1705,7 @@ class PasswordResetCompletedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "password_reset_completed"
+        return "password_reset.completed"
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
@@ -1725,7 +1725,7 @@ class PasswordResetStartedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "password_reset_started"
+        return "password_reset.started"
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
@@ -1755,7 +1755,7 @@ class PhoneNumberChangeEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "phone_number_verified" if self.completed else "phone_number_verification_started"
+        return "phone_number_verification.verified" if self.completed else "phone_number_verification.started"
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
@@ -1788,7 +1788,7 @@ class PostalVerificationFailedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "postal_verification_failed"
+        return "postal_verification.failed"
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
@@ -1828,7 +1828,7 @@ class PostalVerificationPostcardSentEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "postal_verification_postcard_sent"
+        return "postal_verification.postcard_sent"
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
@@ -1850,7 +1850,7 @@ class PostalVerificationSucceededEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "postal_verification_succeeded"
+        return "postal_verification.succeeded"
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
@@ -1923,7 +1923,7 @@ class StrongVerificationFailedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "strong_verification_failed"
+        return "strong_verification.failed"
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
@@ -1962,7 +1962,7 @@ class StrongVerificationSucceededEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return "strong_verification_succeeded"
+        return "strong_verification.succeeded"
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -17,26 +17,28 @@
     "action": "{{text}}: {{url}}",
     "user": "{{name}}, {{age}}, {{city}}"
   },
-  "account_deletion_started": {
-    "subject": "Confirm your Couchers.org account deletion",
-    "request_description": "You requested that we delete your account from Couchers.org.",
-    "confirmation_instructions": "To complete this process, please confirm by clicking the following button:",
-    "confirm_action": "Confirm account deletion"
-  },
-  "account_deletion_completed": {
-    "subject": "Your Couchers.org account has been deleted",
-    "confirmation": "You have successfully deleted your account from Couchers.org.",
-    "farewell": "We are sad to see you go, and wish you the best in your future travels. You are always welcome back on the Couchers.org platform :)",
-    "recovery_instructions_days_one": "If you change your mind, <b>you have {{count}} day to recover your account</b> by clicking the following link:",
-    "recovery_instructions_days_other": "If you change your mind, <b>you have {{count}} days to recover your account</b> by clicking the following link:",
-    "recover_action": "Recover account"
-  },
-  "account_deletion_recovered": {
-    "subject": "Your Couchers.org account has been recovered!",
-    "confirmation": "Your account on Couchers.org has been successfully recovered!",
-    "login_instructions": "We are so glad you decided to stay! To log back in, click the following link:",
-    "login_action": "Log back in",
-    "redelete_instructions": "If you change your mind, you can delete your account at any time."
+  "account_deletion": {
+    "started": {
+      "subject": "Confirm your Couchers.org account deletion",
+      "request_description": "You requested that we delete your account from Couchers.org.",
+      "confirmation_instructions": "To complete this process, please confirm by clicking the following button:",
+      "confirm_action": "Confirm account deletion"
+    },
+    "completed": {
+      "subject": "Your Couchers.org account has been deleted",
+      "confirmation": "You have successfully deleted your account from Couchers.org.",
+      "farewell": "We are sad to see you go, and wish you the best in your future travels. You are always welcome back on the Couchers.org platform :)",
+      "recovery_instructions_days_one": "If you change your mind, <b>you have {{count}} day to recover your account</b> by clicking the following link:",
+      "recovery_instructions_days_other": "If you change your mind, <b>you have {{count}} days to recover your account</b> by clicking the following link:",
+      "recover_action": "Recover account"
+    },
+    "recovered": {
+      "subject": "Your Couchers.org account has been recovered!",
+      "confirmation": "Your account on Couchers.org has been successfully recovered!",
+      "login_instructions": "We are so glad you decided to stay! To log back in, click the following link:",
+      "login_action": "Log back in",
+      "redelete_instructions": "If you change your mind, you can delete your account at any time."
+    }
   },
   "activeness_probe": {
     "subject": "Are you still open to hosting on Couchers.org?",
@@ -55,47 +57,53 @@
     "usage_warning": "This API key is unique to your account; do not share it with anyone, it gives complete access to your account, and you are reponsible for any actions taken using this API key.",
     "policy_warning": "Please remember to abide by our Terms of Service, our Community Guidelines, and other policies while using our APIs. All access is logged and analyzed, and we may terminate your access or account if you abuse the service."
   },
-  "badge_added": {
-    "subject": "The {{ badge_name }} badge was added to your profile",
-    "body": "The {{ badge_name }} badge was added to your profile."
-  },
-  "badge_removed": {
-    "subject": "The {{ badge_name }} badge was removed from your profile",
-    "body": "The {{ badge_name }} badge was removed from your profile."
+  "badges": {
+    "added": {
+      "subject": "The {{ name }} badge was added to your profile",
+      "body": "The {{ name }} badge was added to your profile."
+    },
+    "removed": {
+      "subject": "The {{ name }} badge was removed from your profile",
+      "body": "The {{ name }} badge was removed from your profile."
+    }
   },
   "birthdate_changed": {
     "subject": "Your date of birth was changed",
     "body": "Your date of birth was changed to <b>{{ date }}</b> by an admin."
   },
-  "chat_message_received": {
-    "direct": {
-      "subject": "{{ author }} sent you a message",
-      "body": "{{ author }} sent you a message:",
-      "view_action": "View this message"
+  "chat_messages": {
+    "received": {
+      "direct": {
+        "subject": "{{ author }} sent you a message",
+        "body": "{{ author }} sent you a message:",
+        "view_action": "View this message"
+      },
+      "group": {
+        "subject": "{{ author }} sent a message in \"{{ group }}\"",
+        "body": "{{ author }} sent a message in <b>{{ group }}</b>:",
+        "view_action": "View this message"
+      }
     },
-    "group": {
-      "subject": "{{ author }} sent a message in \"{{ group }}\"",
-      "body": "{{ author }} sent a message in <b>{{ group }}</b>:",
+    "missed": {
+      "subject": "You have unseen messages on Couchers.org!",
+      "in_dm_one": "You missed {{count}} message from {{author}}:",
+      "in_dm_other": "You missed {{count}} messages from {{author}}:",
+      "in_group_one": "You missed {{count}} message in <b>{{group}}</b>:",
+      "in_group_other": "You missed {{count}} messages in <b>{{group}}</b>:",
       "view_action": "View this message"
     }
   },
-  "chat_messages_missed": {
-    "subject": "You have unseen messages on Couchers.org!",
-    "in_dm_one": "You missed {{count}} message from {{author}}:",
-    "in_dm_other": "You missed {{count}} messages from {{author}}:",
-    "in_group_one": "You missed {{count}} message in <b>{{group}}</b>:",
-    "in_group_other": "You missed {{count}} messages in <b>{{group}}</b>:",
-    "view_action": "View this message"
-  },
-  "discussion_created": {
-    "subject": "{{author}} started a discussion: {{title}}",
-    "body": "<b>{{author}}</b> created a new discussion called <b>{{title}}</b> in <b>{{parent_context}}</b>:",
-    "view_action": "View discussion"
-  },
-  "discussion_comment": {
-    "subject": "{{author}} commented on {{discussion_title}}",
-    "body": "<b>{{author}}</b> commented on <b>{{discussion_title}}</b> in <b>{{parent_context}}</b>:",
-    "view_action": "View discussion"
+  "discussions": {
+    "created": {
+      "subject": "{{author}} started a discussion: {{title}}",
+      "body": "<b>{{author}}</b> created a new discussion called <b>{{title}}</b> in <b>{{parent_context}}</b>:",
+      "view_action": "View discussion"
+    },
+    "comment": {
+      "subject": "{{author}} commented on {{discussion_title}}",
+      "body": "<b>{{author}}</b> commented on <b>{{discussion_title}}</b> in <b>{{parent_context}}</b>:",
+      "view_action": "View discussion"
+    }
   },
   "donation_received": {
     "subject": "Thank you for your donation to Couchers.org!",
@@ -108,21 +116,23 @@
     "generosity_helps": "Your generosity will help deliver the platform for everyone.",
     "thank_you": "Thank you!"
   },
-  "email_address_change_initiated": {
-    "subject": "An email change was initiated on your account",
-    "body": "An email change to the email <b>{{ email_address }}</b> was initiated on your account."
+  "email_change": {
+    "initiated": {
+      "subject": "An email change was initiated on your account",
+      "body": "An email change to the email <b>{{ email_address }}</b> was initiated on your account."
+    },
+    "confirmation": {
+      "subject": "Confirm your new email for Couchers.org",
+      "context": "You requested that your email be changed to this email address on Couchers.org. Your old email address is <b>{{ old_email }}</b>. This is the final step in the process.",
+      "instructions": "To complete this change, please confirm your email by clicking the following link:",
+      "confirm_action": "Confirm new email"
+    },
+    "verified": {
+      "subject": "Email change completed",
+      "body": "Your new email address has been verified."
+    }
   },
-  "email_address_change_confirmation": {
-    "subject": "Confirm your new email for Couchers.org",
-    "context": "You requested that your email be changed to this email address on Couchers.org. Your old email address is <b>{{ old_email }}</b>. This is the final step in the process.",
-    "instructions": "To complete this change, please confirm your email by clicking the following link:",
-    "confirm_action": "Confirm new email"
-  },
-  "email_address_verified": {
-    "subject": "Email change completed",
-    "body": "Your new email address has been verified."
-  },
-  "event": {
+  "events": {
     "generic": {
       "online_link": "Online",
       "view_action": "View event"
@@ -168,72 +178,76 @@
       "body": "An event you are subscribed to has been deleted by the moderators:"
     }
   },
-  "friend_request_received": {
-    "subject": "{{name}} wants to be your friend on Couchers.org!",
-    "body": "You've received a friend request from {{name}}.",
-    "view_action": "View friend requests",
-    "closing": "We hope you make a new friend!"
-  },
-  "friend_request_accepted": {
-    "subject": "{{name}} accepted your friend request!",
-    "body": "{{name}} has accepted your friend request.",
-    "view_action": "View their profile",
-    "closing": "We hope you continue making new friends!"
+  "friend_requests": {
+    "received": {
+      "subject": "{{name}} wants to be your friend on Couchers.org!",
+      "body": "You've received a friend request from {{name}}.",
+      "view_action": "View friend requests",
+      "closing": "We hope you make a new friend!"
+    },
+    "accepted": {
+      "subject": "{{name}} accepted your friend request!",
+      "body": "{{name}} has accepted your friend request.",
+      "view_action": "View their profile",
+      "closing": "We hope you continue making new friends!"
+    }
   },
   "gender_changed": {
     "subject": "Your gender was changed",
     "body": "Your gender on Couchers.org was changed to <b>{{ gender }}</b> by an admin."
   },
-  "host_request_created": {
-    "subject": "{{surfer_name}} sent you a host request",
-    "body": "<b>{{surfer_name}}</b> sent you a host request:",
-    "quick_decline_action": "Quick decline (no login needed)",
-    "respond_encouragement": "Please respond to this request, even a quick decline is better than no response!"
-  },
-  "host_request_generic": {
-    "date_range": "From <b>{{from_date}}</b> to <b>{{to_date}}</b>.",
-    "view_action": "View host request"
-  },
-  "host_request_reminder": {
-    "subject": "You have a pending host request from {{surfer_name}}!",
-    "body": "Please respond to the request!"
-  },
-  "host_request_message": {
-    "from_host": {
-      "subject": "{{other_name}} sent you a message in your host request",
-      "body": "<b>{{other_name}}</b> sent you a message in your host request:"
+  "host_requests": {
+    "created": {
+      "subject": "{{surfer_name}} sent you a host request",
+      "body": "<b>{{surfer_name}}</b> sent you a host request:",
+      "quick_decline_action": "Quick decline (no login needed)",
+      "respond_encouragement": "Please respond to this request, even a quick decline is better than no response!"
     },
-    "from_surfer": {
-      "subject": "{{other_name}} sent you a message in their host request",
-      "body": "<b>{{other_name}}</b> sent you a message in their host request:"
-    }
-  },
-  "host_request_missed_messages": {
-    "from_host": {
-      "subject": "{{other_name}} sent you message(s) in your host request",
-      "body": "<b>{{other_name}}</b> sent you message(s) in your host request:"
+    "generic": {
+      "date_range": "From <b>{{from_date}}</b> to <b>{{to_date}}</b>.",
+      "view_action": "View host request"
     },
-    "from_surfer": {
-      "subject": "{{other_name}} sent you message(s) in their host request",
-      "body": "<b>{{other_name}}</b> sent you message(s) in their host request:"
-    }
-  },
-  "host_request_status_changed": {
-    "accepted_by_host": {
-      "subject": "{{other_name}} accepted your host request",
-      "body": "<b>{{other_name}}</b> accepted your host request:"
+    "reminder": {
+      "subject": "You have a pending host request from {{surfer_name}}!",
+      "body": "Please respond to the request!"
     },
-    "declined_by_host": {
-      "subject": "{{other_name}} declined your host request",
-      "body": "<b>{{other_name}}</b> declined your host request:"
+    "message": {
+      "from_host": {
+        "subject": "{{other_name}} sent you a message in your host request",
+        "body": "<b>{{other_name}}</b> sent you a message in your host request:"
+      },
+      "from_surfer": {
+        "subject": "{{other_name}} sent you a message in their host request",
+        "body": "<b>{{other_name}}</b> sent you a message in their host request:"
+      }
     },
-    "confirmed_by_surfer": {
-      "subject": "{{other_name}} confirmed their host request",
-      "body": "<b>{{other_name}}</b> confirmed their host request:"
+    "missed_messages": {
+      "from_host": {
+        "subject": "{{other_name}} sent you message(s) in your host request",
+        "body": "<b>{{other_name}}</b> sent you message(s) in your host request:"
+      },
+      "from_surfer": {
+        "subject": "{{other_name}} sent you message(s) in their host request",
+        "body": "<b>{{other_name}}</b> sent you message(s) in their host request:"
+      }
     },
-    "cancelled_by_surfer": {
-      "subject": "{{other_name}} cancelled their host request",
-      "body": "<b>{{other_name}}</b> cancelled their host request:"
+    "status_changed": {
+      "accepted_by_host": {
+        "subject": "{{other_name}} accepted your host request",
+        "body": "<b>{{other_name}}</b> accepted your host request:"
+      },
+      "declined_by_host": {
+        "subject": "{{other_name}} declined your host request",
+        "body": "<b>{{other_name}}</b> declined your host request:"
+      },
+      "confirmed_by_surfer": {
+        "subject": "{{other_name}} confirmed their host request",
+        "body": "<b>{{other_name}}</b> confirmed their host request:"
+      },
+      "cancelled_by_surfer": {
+        "subject": "{{other_name}} cancelled their host request",
+        "body": "<b>{{other_name}}</b> cancelled their host request:"
+      }
     }
   },
   "moderator_note": {
@@ -274,39 +288,45 @@
     "subject": "Your password was changed",
     "body": "Your login password for Couchers.org was changed."
   },
-  "password_reset_completed": {
-    "subject": "Your password was successfully reset",
-    "body": "Your password on Couchers.org was changed. If that was you, then no further action is needed."
+  "password_reset": {
+    "started": {
+      "subject": "Reset your Couchers.org password",
+      "request_description": "You asked for your password to be reset on Couchers.org.",
+      "confirmation_instructions": "To complete this change, click on the following link:",
+      "reset_action": "Reset your password"
+    },
+    "completed": {
+      "subject": "Your password was successfully reset",
+      "body": "Your password on Couchers.org was changed. If that was you, then no further action is needed."
+    }
   },
-  "password_reset_started": {
-    "subject": "Reset your Couchers.org password",
-    "request_description": "You asked for your password to be reset on Couchers.org.",
-    "confirmation_instructions": "To complete this change, click on the following link:",
-    "reset_action": "Reset your password"
+  "phone_number_verification": {
+    "started": {
+      "subject": "Phone verification started",
+      "body": "You started phone number verification with the number <b>{{ phone_number }}</b>."
+    },
+    "verified": {
+      "subject": "Phone successfully verified",
+      "body": "Your phone was successfully verified as <b>{{ phone_number }}</b>."
+    }
   },
-  "phone_number_verification_started": {
-    "subject": "Phone verification started",
-    "body": "You started phone number verification with the number <b>{{ phone_number }}</b>."
+  "postal_verification": {
+    "postcard_sent": {
+      "subject": "Your verification postcard is on its way",
+      "body": "We've sent a postcard with your verification code to {{ city }}, {{ country }}. It should arrive within 1-3 weeks depending on your location. Once it arrives, enter the code on the platform to complete verification."
+    },
+    "succeeded": {
+      "subject": "Postal Verification succeeded",
+      "body": "You have been verified with Postal Verification! Your address has been confirmed."
+    },
+    "failed": {
+      "subject": "Postal Verification failed",
+      "reason_code_expired": "Your verification code has expired. Codes are valid for 90 days after the postcard is sent. You can start a new verification attempt.",
+      "reason_too_many_attempts": "Too many incorrect code attempts. You can start a new verification attempt.",
+      "reason_unknown": "Your postal verification attempt has failed. You can start a new verification attempt."
+    }
   },
-  "phone_number_verified": {
-    "subject": "Phone successfully verified",
-    "body": "Your phone was successfully verified as <b>{{ phone_number }}</b>."
-  },
-  "postal_verification_failed": {
-    "subject": "Postal Verification failed",
-    "reason_code_expired": "Your verification code has expired. Codes are valid for 90 days after the postcard is sent. You can start a new verification attempt.",
-    "reason_too_many_attempts": "Too many incorrect code attempts. You can start a new verification attempt.",
-    "reason_unknown": "Your postal verification attempt has failed. You can start a new verification attempt."
-  },
-  "postal_verification_postcard_sent": {
-    "subject": "Your verification postcard is on its way",
-    "body": "We've sent a postcard with your verification code to {{ city }}, {{ country }}. It should arrive within 1-3 weeks depending on your location. Once it arrives, enter the code on the platform to complete verification."
-  },
-  "postal_verification_succeeded": {
-    "subject": "Postal Verification succeeded",
-    "body": "You have been verified with Postal Verification! Your address has been confirmed."
-  },
-  "reference": {
+  "references": {
     "received": {
       "friend": {
         "subject": "You've received a friend reference from {{name}}!",
@@ -356,19 +376,21 @@
       "ignore_if_unexpected": "If you did not request a signup, someone else did with your email, and you can safely ignore this message."
     }
   },
-  "strong_verification_failed": {
-    "subject": "Strong Verification failed",
-    "reason_wrong_birthdate_or_gender": "The date of birth or gender on your profile does not match the date of birth or sex on your passport. Please contact the support team to update your date of birth or gender, or if your passport sex does not match your gender identity.",
-    "reason_not_a_passport": "You tried to verify with a document that is not a passport. You can only use a passport for Strong Verification.",
-    "reason_duplicate": "You tried to verify with a passport that has already been used for verification. Please use another passport."
-  },
-  "strong_verification_succeeded": {
-    "subject": "Strong Verification succeeded",
-    "success_message": "You have been verified with Strong Verification! You will now see a tick next to your name on the platform.",
-    "thanks_message": "Thanks for verifying—you're helping make Couchers.org safer for everyone.",
-    "cost_explanation": "Verification is free for you, but it does come at a cost to us. As a nonprofit run by volunteers, we rely on donations to cover expenses like keeping our servers running, verification, and tools for volunteers and community builders.",
-    "donation_request": "If you're able, please consider donating to help keep Couchers.org running and growing.",
-    "donate_action": "Donate to support Couchers.org"
+  "strong_verification": {
+    "succeeded": {
+      "subject": "Strong Verification succeeded",
+      "success_message": "You have been verified with Strong Verification! You will now see a tick next to your name on the platform.",
+      "thanks_message": "Thanks for verifying—you're helping make Couchers.org safer for everyone.",
+      "cost_explanation": "Verification is free for you, but it does come at a cost to us. As a nonprofit run by volunteers, we rely on donations to cover expenses like keeping our servers running, verification, and tools for volunteers and community builders.",
+      "donation_request": "If you're able, please consider donating to help keep Couchers.org running and growing.",
+      "donate_action": "Donate to support Couchers.org"
+    },
+    "failed": {
+      "subject": "Strong Verification failed",
+      "reason_wrong_birthdate_or_gender": "The date of birth or gender on your profile does not match the date of birth or sex on your passport. Please contact the support team to update your date of birth or gender, or if your passport sex does not match your gender identity.",
+      "reason_not_a_passport": "You tried to verify with a document that is not a passport. You can only use a passport for Strong Verification.",
+      "reason_duplicate": "You tried to verify with a passport that has already been used for verification. Please use another passport."
+    }
   },
   "thread_reply": {
     "subject": "{{author}} replied in {{parent_context}}",

--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -80,9 +80,9 @@ def get_notification_email(notification: Notification, *, user_name: str) -> Ema
         case NotificationTopicAction.donation__received:
             return emails.DonationReceivedEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.email_address__change:
-            return emails.EmailAddressChangedEmail.from_notification(data, user_name=user_name)
+            return emails.EmailChangedEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.email_address__verify:
-            return emails.EmailAddressVerifiedEmail(user_name=user_name)
+            return emails.EmailVerifiedEmail(user_name=user_name)
         case NotificationTopicAction.event__create_approved:
             return emails.EventCreatedEmail.from_notification(data, user_name=user_name, is_invite=True)
         case NotificationTopicAction.event__create_any:

--- a/app/backend/src/couchers/tasks.py
+++ b/app/backend/src/couchers/tasks.py
@@ -12,7 +12,7 @@ from couchers.context import CouchersContext
 from couchers.crypto import urlsafe_secure_token
 from couchers.db import session_scope
 from couchers.email.blocks import EmailBase
-from couchers.email.emails import EmailAddressChangeConfirmationEmail, SignupContinueEmail, SignupVerifyEmail
+from couchers.email.emails import EmailChangeConfirmationEmail, SignupContinueEmail, SignupVerifyEmail
 from couchers.email.queuing import queue_system_email, queue_userless_email
 from couchers.models import (
     AccountDeletionReason,
@@ -86,7 +86,7 @@ def send_email_changed_confirmation_to_new_email(context: CouchersContext, sessi
     elif not user.new_email:
         raise ValueError(f"No new email for {user.id}")
 
-    email = EmailAddressChangeConfirmationEmail(
+    email = EmailChangeConfirmationEmail(
         user_name=user.name,
         old_email=user.email,
         confirm_url=urls.change_email_link(confirmation_token=user.new_email_token),


### PR DESCRIPTION
Just helps organize the email strings. I started with a flat structure and later used a hierarchical one, so this standardizes.

## Testing
Left to tests.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
