### PR TITLE
Backend/emails: Fix empty chat group name

### DIFF
--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -264,7 +264,7 @@ class ChatMessageReceivedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return f"chat_message_received.{'direct' if self.group_chat_title is None else 'group'}"
+        return f"chat_message_received.{'group' if self.group_chat_title else 'direct'}"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -264,7 +264,7 @@ class ChatMessageReceivedEmail(EmailBase):
 
     @property
     def string_key_base(self) -> str:
-        return f"chat_message_received.{'group' if self.group_chat_title else 'direct'}"
+        return f"chat_message_received.{'direct' if self.group_chat_title is None else 'group'}"
 
     def get_subject_line(self, loc_context: LocalizationContext) -> str:
         return self._localize(
@@ -330,10 +330,10 @@ class ChatMessagesMissedEmail(EmailBase):
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
         for entry in self.entries:
-            if entry.group_chat_title:
-                builder.para(".in_group", {"count": entry.missed_count, "group": entry.group_chat_title})
-            else:
+            if entry.group_chat_title is None:
                 builder.para(".in_dm", {"count": entry.missed_count, "author": entry.latest_message_author.name})
+            else:
+                builder.para(".in_group", {"count": entry.missed_count, "group": entry.group_chat_title})
             builder.user(entry.latest_message_author)
             builder.quote(entry.latest_message_text, markdown=False)
             builder.action(entry.view_url, ".view_action")

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -285,7 +285,7 @@ class ChatMessageReceivedEmail(EmailBase):
             user_name,
             author=UserInfo.from_protobuf(data.author),
             text=data.text,
-            group_chat_title=data.group_chat_title,
+            group_chat_title=data.group_chat_title or None,
             view_url=urls.chat_link(chat_id=data.group_chat_id),
         )
 
@@ -343,7 +343,7 @@ class ChatMessagesMissedEmail(EmailBase):
     def from_notification(cls, data: notification_data_pb2.ChatMissedMessages, *, user_name: str) -> Self:
         missed_entries = [
             cls.Entry(
-                group_chat_title=message.group_chat_title,
+                group_chat_title=message.group_chat_title or None,
                 missed_count=message.unseen_count,
                 latest_message_author=UserInfo.from_protobuf(message.author),
                 latest_message_text=message.text,

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -265,7 +265,7 @@ def send_message_notifications(payload: empty_pb2.Empty) -> None:
                             ),
                             text=message.text,
                             group_chat_id=message.conversation_id,
-                            group_chat_title=group_chat.title,
+                            group_chat_title=group_chat.title or None,
                             unseen_count=unseen_count,
                         )
                         for group_chat, message, unseen_count in unseen_messages

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -210,7 +210,7 @@ def generate_message_notifications(payload: jobs_pb2.GenerateMessageNotification
                     ),
                     text=message.text,
                     group_chat_id=message.conversation_id,
-                    group_chat_title=group_chat.title,
+                    group_chat_title=group_chat.title or None,
                     # unseen_count irrelevant for this notification
                 ),
                 moderation_state_id=group_chat.moderation_state_id,

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -20,7 +20,7 @@ from couchers.proto import api_pb2, conversations_pb2, notification_data_pb2, no
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_HOURS
 from couchers.utils import Duration_from_timedelta, now, to_aware_datetime
 from tests.fixtures.db import generate_user, make_friends, make_user_block, make_user_invisible
-from tests.fixtures.misc import EmailCollector, PushCollector, process_jobs
+from tests.fixtures.misc import EmailCollector, Moderator, PushCollector, process_jobs
 from tests.fixtures.sessions import api_session, conversations_session, notifications_session
 
 
@@ -678,21 +678,62 @@ def test_make_remove_group_chat_admin(db, moderator):
         assert e.value.code() == grpc.StatusCode.PERMISSION_DENIED
 
 
-def test_send_message(db):
+def test_send_message(db, moderator: Moderator, push_collector: PushCollector, email_collector: EmailCollector):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
     user3, token3 = generate_user()
     make_friends(user1, user2)
     make_friends(user1, user3)
 
+    # Let user2 receive email notifications for every chat message
+    with notifications_session(token2) as n:
+        n.SetNotificationSettings(
+            notifications_pb2.SetNotificationSettingsReq(
+                preferences=[
+                    notifications_pb2.SingleNotificationPreference(
+                        topic=NotificationTopicAction.chat__message.topic,
+                        action=NotificationTopicAction.chat__message.action,
+                        delivery_method="email",
+                        enabled=True,
+                    )
+                ]
+            )
+        )
+
+    group_chat_title = "My group chat"
+    message1 = "Test message 1"
+
+    # Let user1 create a group chat with user2 and send a message
     with conversations_session(token1) as c:
-        res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id]))
+        res = c.CreateGroupChat(
+            conversations_pb2.CreateGroupChatReq(
+                title=wrappers_pb2.StringValue(value=group_chat_title), recipient_user_ids=[user2.id]
+            )
+        )
         group_chat_id = res.group_chat_id
-        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message 1"))
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text=message1))
+
+        # Sender can already see group chat
         res = c.GetGroupChatMessages(conversations_pb2.GetGroupChatMessagesReq(group_chat_id=group_chat_id))
-        assert res.messages[0].text.text == "Test message 1"
+        assert res.messages[0].text.text == message1
         assert to_aware_datetime(res.messages[0].time) <= now()
         assert res.messages[0].author_user_id == user1.id
+
+    # user2 sees nothing until the group chat is approved
+    assert push_collector.count_for_user(user2.id) == 0
+    assert email_collector.count_for_recipient(user2.email) == 0
+
+    moderator.approve_group_chat(group_chat_id)
+
+    # user2 gets email and push notifications
+    push = push_collector.pop_for_user(user2.id, last=True)
+    assert push.topic_action == NotificationTopicAction.chat__message.display
+    assert message1 in push.content.body
+
+    email = email_collector.pop_for_recipient(user2.email, last=True)
+    assert group_chat_title in email.subject
+    assert message1 in email.plain
+    assert message1 in email.html
 
     # can't send message if not in chat
     with conversations_session(token3) as c:
@@ -707,12 +748,28 @@ def test_send_message(db):
         assert e.value.details() == "You can't send a message in this chat."
 
 
-def test_send_direct_message(db, moderator, push_collector: PushCollector):
+def test_send_direct_message(db, moderator: Moderator, push_collector: PushCollector, email_collector: EmailCollector):
     user1, token1 = generate_user(complete_profile=True)
     user2, token2 = generate_user(complete_profile=True)
 
     make_friends(user1, user2)
 
+    # Let user2 receive email notifications for every chat message
+    with notifications_session(token2) as n:
+        n.SetNotificationSettings(
+            notifications_pb2.SetNotificationSettingsReq(
+                preferences=[
+                    notifications_pb2.SingleNotificationPreference(
+                        topic=NotificationTopicAction.chat__message.topic,
+                        action=NotificationTopicAction.chat__message.action,
+                        delivery_method="email",
+                        enabled=True,
+                    )
+                ]
+            )
+        )
+
+    # Let user1 send two DM's to user2
     message1 = "Hello, user2!"
     message2 = "One more message."
 
@@ -723,17 +780,26 @@ def test_send_direct_message(db, moderator, push_collector: PushCollector):
 
         c1.SendDirectMessage(conversations_pb2.SendDirectMessageReq(recipient_user_id=user2.id, text=message2))
 
-    process_jobs()
-
+    # user2 should have received push and email notifications for both messages
     push = push_collector.pop_for_user(user2.id, last=False)
     assert push.topic_action == NotificationTopicAction.chat__message.display
     assert push.content.title == user1.name
     assert push.content.body == message1
 
+    email = email_collector.pop_for_recipient(user2.email, last=False)
+    assert user1.name in email.subject
+    assert message1 in email.plain
+    assert message1 in email.html
+
     push = push_collector.pop_for_user(user2.id, last=True)
     assert push.topic_action == NotificationTopicAction.chat__message.display
     assert push.content.title == user1.name
     assert push.content.body == message2
+
+    email = email_collector.pop_for_recipient(user2.email, last=True)
+    assert user1.name in email.subject
+    assert message2 in email.plain
+    assert message2 in email.html
 
     with conversations_session(token2) as c2:
         # Fetch the chat by ID returned from SendDirectMessage


### PR DESCRIPTION
The notification data had the group name as an empty string to indicate the absence of a value, whereas later code expected `None`. Ideally our code is clear about using `None` for the absence of a value when the type is `str | None`, so updated as follows:

- Don't produce notifications with group name = "" (long-term fix)
- Coerce "" into None when creating the email object (catches already queued notifications)

Fixes https://github.com/Couchers-org/bugs/issues/11

## Testing
Added notifications asserts in chat message tests. See:

```py
assert group_chat_title in email.subject # For group chats
assert user1.name in email.subject # For DM's
```

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
