### PR TITLE
fix(web): cookie banner no longer blocks Save on hosting prefs (#8909)

### DIFF
--- a/app/web/features/profile/edit/EditHostingPreferenceForm.tsx
+++ b/app/web/features/profile/edit/EditHostingPreferenceForm.tsx
@@ -122,7 +122,7 @@ const StickySaveBar = styled(Box, {
 
   return {
     position: "fixed",
-    bottom: 0,
+    bottom: "var(--cookie-banner-height, 0px)",
     left: 0,
     right: 0,
     backgroundColor: "var(--mui-palette-background-paper)",
@@ -136,7 +136,7 @@ const StickySaveBar = styled(Box, {
     gap: theme.spacing(2),
 
     [theme.breakpoints.down("md")]: {
-      bottom: bottomNavHeight,
+      bottom: `calc(${bottomNavHeight}px + var(--cookie-banner-height, 0px))`,
       padding: theme.spacing(1),
       paddingBottom: safePadding,
     },


### PR DESCRIPTION
Closes #8909.

On the **Edit profile → My Home** (hosting preferences) tab, the fixed cookie banner overlapped the sticky "Save changes" button. If the banner wasn't dismissed it sat on top of the button and intercepted clicks — likely why some users reported they couldn't save their profile.

The Home tab's `StickySaveBar` was pinned to the viewport/bottom-nav bottom with no allowance for the banner. The **About** tab's save bar already handles this by offsetting its `bottom` with the `--cookie-banner-height` CSS variable (published by `CookieBanner` via a ResizeObserver). This change applies the same offset to the Home tab — a 2-line diff, no new code or variable:

- desktop: `bottom: 0` → `bottom: var(--cookie-banner-height, 0px)`
- mobile: `bottom: bottomNavHeight` → `bottom: calc(${bottomNavHeight}px + var(--cookie-banner-height, 0px))`

Native embed is unaffected (`CookieBanner` returns null there, so the variable falls back to `0px`).

## Testing
Reproduce: log in, go to **Edit profile → My Home**, ensure the cookie banner is **not** dismissed (clear `localStorage.hasSeenCookieBanner`), change a field so the save bar appears.
- **Before:** banner overlaps "Save changes" and intercepts clicks.
- **After:** save bar sits flush above the banner; dismissing the banner drops it back.

Verified before/after:
- **Desktop (Playwright):** with banner present, buggy save bar overlapped by 61px and `elementFromPoint` over the button returned the banner; after the fix the bar lifts by exactly the banner height (e.g. 68px) and the button is the topmost element at its center.
- **Android (adb, Pixel 9 emulator, Chrome):** save bar renders above the bottom nav and cookie banner, fully visible/tappable.

Before 
<img width="802" height="76" alt="image" src="https://github.com/user-attachments/assets/4b8ee1a7-c513-4e94-ab00-1d3ab83bb884" />


After
<img width="1910" height="194" alt="image" src="https://github.com/user-attachments/assets/cafd4aa6-c337-424c-9e55-fee7470f56be" />



**Web frontend checklist**
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant <!-- CSS-only positioning; covered by existing EditHostingPreference suite which still passes -->
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me