### PR TITLE
Add Prometheus revenue metric from Stripe webhook

### DIFF
--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -725,6 +725,18 @@ emails_counter: Counter = Counter(
 )
 
 
+# Revenue from successful Stripe charges, in cents, split by source (donation vs merch).
+revenue_cents_counter: Counter = Counter(
+    "couchers_revenue_cents_total",
+    "Revenue from successful Stripe charges, in cents",
+    labelnames=["type"],
+)
+
+
+def observe_revenue(revenue_type: str, amount_cents: int) -> None:
+    revenue_cents_counter.labels(revenue_type).inc(amount_cents)
+
+
 antibots_assessed_counter: Counter = Counter(
     "couchers_antibots_assessed_total",
     "Number of times an antibot assessment is created",

--- a/app/backend/src/couchers/servicers/donations.py
+++ b/app/backend/src/couchers/servicers/donations.py
@@ -12,6 +12,7 @@ from couchers.config import config
 from couchers.context import CouchersContext
 from couchers.event_log import log_event
 from couchers.helpers.badges import user_add_badge
+from couchers.metrics import observe_revenue
 from couchers.models import DonationInitiation, DonationType, Invoice, InvoiceType, User
 from couchers.models.notifications import NotificationTopicAction
 from couchers.notifications.notify import notify
@@ -151,6 +152,7 @@ class Stripe(stripe_pb2_grpc.StripeServicer):
             if metadata.get("site_url") == config.MERCH_SHOP_URL:
                 # merch shop. look up this email and give them the swagster badge
                 customer_email = metadata["customer_email"]
+                observe_revenue("merch", int(data_object["amount"]))
                 amount = int(data_object["amount"]) // 100
                 user = session.execute(select(User).where(User.email == customer_email)).scalar_one_or_none()
                 if user:
@@ -170,6 +172,7 @@ class Stripe(stripe_pb2_grpc.StripeServicer):
                 customer_id = data_object["customer"]
                 user = session.execute(select(User).where(User.stripe_customer_id == customer_id)).scalar_one()
                 # amount comes in cents
+                observe_revenue("donation", int(data_object["amount"]))
                 amount = int(data_object["amount"]) // 100
                 receipt_url = data_object["receipt_url"]
                 payment_intent_id = data_object["payment_intent"]

--- a/app/backend/src/tests/test_donations.py
+++ b/app/backend/src/tests/test_donations.py
@@ -440,6 +440,47 @@ def test_slack_notification_on_recurring_donation(db, monkeypatch):
         assert user.name in call_args
 
 
+def test_revenue_metric_on_donation(db, monkeypatch):
+    """A successful donation charge records revenue in cents under the 'donation' type."""
+    user, token = generate_user()
+
+    new_config = config.copy()
+    new_config.STRIPE_API_KEY = "dummy_api_key"
+    new_config.STRIPE_WEBHOOK_SECRET = "dummy_webhook_secret"
+    new_config.STRIPE_RECURRING_PRODUCT_ID = "price_1KIbmbIfR5z29g5kFWPEUnC6"
+    new_config.MERCH_SHOP_URL = "https://shop.couchershq.org"
+
+    monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
+
+    with donations_session(token) as donations:
+        with patch("couchers.servicers.donations.stripe") as mock:
+            mock.Customer.create.return_value = type("__MockCustomer", (), {"id": "cus_Pv4uq0gT0rDZWN"})
+            mock.checkout.Session.create.return_value = type("__MockCheckoutSession", (), one_time_STRIPE_SESSION)
+            donations.InitiateDonation(donations_pb2.InitiateDonationReq(amount=100, recurring=False))
+
+    with patch("couchers.servicers.donations.observe_revenue") as mock_observe_revenue:
+        # Captured Stripe test-mode event: charge.succeeded for one-time $100 donation
+        fire_stripe_event("evt_3P5El3IfR5z29g5k0TLWlfHq")
+        mock_observe_revenue.assert_called_once_with("donation", 10000)
+
+
+def test_revenue_metric_on_merch(db, monkeypatch):
+    """A successful merch charge records revenue in cents under the 'merch' type."""
+    generate_user(email="test@couchers.org.invalid", last_donated=None)
+
+    new_config = config.copy()
+    new_config.STRIPE_API_KEY = "dummy_api_key"
+    new_config.STRIPE_WEBHOOK_SECRET = "dummy_webhook_secret"
+    new_config.MERCH_SHOP_URL = "https://shop.couchershq.org"
+
+    monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
+
+    with patch("couchers.servicers.donations.observe_revenue") as mock_observe_revenue:
+        # Captured Stripe test-mode event: charge.succeeded for a $50 merch purchase
+        fire_stripe_event("evt_merch_charge_succeeded")
+        mock_observe_revenue.assert_called_once_with("merch", 5000)
+
+
 def fire_stripe_event(event_id):
     event = json.loads(STRIPE_WEBHOOK_EVENTS[event_id])
     with real_stripe_session() as api:


### PR DESCRIPTION
Adds a `couchers_revenue_cents_total` Prometheus counter labelled by `type` (donation/merch) that records revenue in cents on each successful `charge.succeeded` Stripe webhook.

Closes #9135

Generated with [Claude Code](https://claude.ai/code)