### PR TITLE
fix: Make report flag button on message teal by default

### DIFF
--- a/app/web/features/messages/messagelist/MessageView.tsx
+++ b/app/web/features/messages/messagelist/MessageView.tsx
@@ -118,12 +118,12 @@ const StyledFooter = styled("div")(({ theme }) => ({
 
 const StyledFlagButton = styled(FlagButton)(({ theme }) => ({
   padding: theme.spacing(0.25),
-  color: "var(--mui-palette-text-secondary)",
+  color: "var(--mui-palette-primary-main)",
   "& svg": {
     fontSize: "1rem",
   },
   "&:hover, &:focus-visible": {
-    color: "var(--mui-palette-primary-main)",
+    color: "var(--mui-palette-primary-dark)",
   },
 }));
 


### PR DESCRIPTION
*Describe briefly what this PR is doing and why.*

<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

I don't think there is a formal ticket for this, other than addressing the feedback I got on this from a meeting 2-3 weeks ago.

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

- Open a DM or a group chat
- Check the report message flag is now shown as teal by default, darker teal on hover
  - Check this also looks fine on dark mode 

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->


https://github.com/user-attachments/assets/05927bdb-5d66-4774-9705-3b3acf08e18f



**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
