### PR TITLE
web: Add native app install upsell for Android and iOS

### DIFF
--- a/app/web/Dockerfile.prod
+++ b/app/web/Dockerfile.prod
@@ -17,6 +17,7 @@ RUN cp .env.$environment env && \
     mv env .env.local && \
     if [ "$environment" = "production" ]; then \
         cp public/robots-prod.txt public/robots.txt && \
+        cp public/manifest-prod.json public/manifest.json && \
         cp public/.well-known/apple-app-site-association-prod public/.well-known/apple-app-site-association && \
         cp public/.well-known/assetlinks-prod.json public/.well-known/assetlinks.json; \
     fi

--- a/app/web/pages/_document.tsx
+++ b/app/web/pages/_document.tsx
@@ -24,6 +24,10 @@ export default function MyDocument(
 
         <link rel="preconnect" href="https://cdn.couchers.org" />
         <meta name="theme-color" content={theme.palette.primary.main} />
+        {/* iOS Smart App Banner; only the prod app is listed on the App Store */}
+        {process.env.NEXT_PUBLIC_COUCHERS_ENV === "prod" && (
+          <meta name="apple-itunes-app" content="app-id=6623776751" />
+        )}
         <link rel="manifest" href="/manifest.json" />
         <link rel="apple-touch-icon" href="/logo512.png" />
         <link

--- a/app/web/public/manifest-prod.json
+++ b/app/web/public/manifest-prod.json
@@ -26,8 +26,8 @@
   "related_applications": [
     {
       "platform": "play",
-      "id": "org.couchers.staging.android",
-      "url": "https://play.google.com/store/apps/details?id=org.couchers.staging.android"
+      "id": "org.couchers.android",
+      "url": "https://play.google.com/store/apps/details?id=org.couchers.android"
     }
   ]
 }


### PR DESCRIPTION
Adds native-app install upsell signals on both platforms so the site nudges visitors toward the native apps, complementing the existing deep-link associations (`apple-app-site-association` / `assetlinks.json`).

**Android** — adds `related_applications` and `prefer_related_applications: true` to the web app manifest so Chrome prefers the native Android app over the installable PWA. Following the existing staging→prod swap convention (used for `robots`, `assetlinks`, `apple-app-site-association`):
- `public/manifest.json` (default) uses the staging package `org.couchers.staging.android`.
- `public/manifest-prod.json` (new) uses the prod package `org.couchers.android` plus an `itunes` entry, copied over `manifest.json` in `Dockerfile.prod`.

**iOS** — adds the `apple-itunes-app` meta tag in `_document.tsx` so Safari shows the App Store Smart App Banner. Gated to `NEXT_PUBLIC_COUCHERS_ENV === "prod"` since only the prod app (app-id `6623776751`) is listed on the App Store.

Behavioural notes:
- `prefer_related_applications: true` suppresses Chrome's PWA install prompt in favour of the native app. Chrome also no longer shows automatic native-app install banners, so the Android side is a signal rather than a visible banner.
- The iOS `apple-itunes-app` tag *does* produce a prominent banner at the top of Safari on every page — so it's the more visible of the two changes.

## Testing
- Validated both manifest JSON files parse correctly; linted `_document.tsx`.
- Verified the `Dockerfile.prod` swap line mirrors the existing prod overrides.
- Reviewer can confirm: `/manifest.json` shows the staging package on staging and the prod package on a prod build; the Smart App Banner appears in Safari only on the prod environment.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._