### PR TITLE
Fix CBs shouldn't see delete and edit discussions

### DIFF
--- a/app/web/features/communities/discussions/DiscussionPage.tsx
+++ b/app/web/features/communities/discussions/DiscussionPage.tsx
@@ -172,7 +172,7 @@ export default function DiscussionPage({
           },
         ] as EllipsisMenuItem[])
       : []),
-    ...((discussion?.canEdit || discussion?.canModerate) && !discussion?.deleted
+    ...(discussion?.canEdit && !discussion?.deleted
       ? ([
           {
             icon: DeleteOutlined,


### PR DESCRIPTION
Removing this as it looks like we changed the backend then I forgot to update it on the frontend. This is the bug we saw when screensharing at the last meeting.
<!--
Reference issues with "closes #1234", or simply "#1234" if not closing.
-->

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
