### PR TITLE
Backend/emails: Review copy before localizing

### DIFF
--- a/app/backend/src/couchers/email/blocks.py
+++ b/app/backend/src/couchers/email/blocks.py
@@ -51,7 +51,7 @@ class EmailBase(ABC):
         default_closing: bool = True,
         security_warning: bool = False,
     ) -> EmailBlocksBuilder:
-        builder = EmailBlocksBuilder(locale=loc_context.locale_list, string_key_base=self.string_key_base)
+        builder = EmailBlocksBuilder(locales=loc_context.locale_list, string_key_base=self.string_key_base)
         if default_greeting:
             builder.para("generic.greeting_line", {"name": self.user_name})
         if security_warning:

--- a/app/backend/src/couchers/email/blocks.py
+++ b/app/backend/src/couchers/email/blocks.py
@@ -47,17 +47,17 @@ class EmailBase(ABC):
         self,
         loc_context: LocalizationContext,
         *,
-        standard_greeting: bool = True,
-        standard_closing: bool = True,
+        default_greeting: bool = True,
+        default_closing: bool = True,
         security_warning: bool = False,
     ) -> EmailBlocksBuilder:
-        builder = EmailBlocksBuilder(locales=loc_context.locale_list, string_key_base=self.string_key_base)
-        if standard_greeting:
+        builder = EmailBlocksBuilder(locale=loc_context.locale_list, string_key_base=self.string_key_base)
+        if default_greeting:
             builder.para("generic.greeting_line", {"name": self.user_name})
-        if standard_closing:
-            builder.para("generic.closing_line", epilogue=True)
         if security_warning:
             builder.para("generic.security_warning_contact_support", epilogue=True)
+        if default_closing:
+            builder.para("generic.closing_lines.default", epilogue=True)
         return builder
 
     @classmethod
@@ -126,7 +126,7 @@ class UserInfo:
         return UserInfo(
             name="Bob",
             age=30,
-            city="Berlin",
+            city="Berlin, Germany",
             avatar_url="https://couchers.org/logo512.png",
             profile_url="https://couchers.org/user/bob",
         )

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -1,5 +1,29 @@
 """
 Defines data models for each email we sent out to users.
+
+Email writing style guidelines
+
+Subject line:
+  Single sentence of the form "who did what" (avoid passive voice when possible)
+  No punctuation*.
+  Do not quote people, community, group or event names.
+  No need to refer to "Couchers.org", the sender name already does.
+
+Preview line:
+  Quoted user content (e.g. comment/reference text), otherwise none.
+  Don't repeat or paraphrase the subject.
+
+Purpose line of the body (first paragraph after the greeting):
+  Usually a single sentence stating the purpose of the email.
+  Similar or identical to the subject but may include additional info (e.g. dates).
+  Key pieces of info (names, locations, dates) should be <strong></strong>.
+  Should be punctuated with a period*, or end with a colon ':' if we then quote user content.
+
+Rest of body:
+  Omit further prose for day-to-day notifications (the purpose line is enough).
+  Provide a link or instructions if the user has follow-up actions.
+
+* Some key emails like new accounts might use an exclamation mark (limit to 1) and more personal prose.
 """
 
 import re
@@ -46,8 +70,7 @@ class AccountDeletionStartedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
-        builder.para(".request_description")
-        builder.para(".confirmation_instructions")
+        builder.para(".purpose")
         builder.action(self.deletion_link, ".confirm_action")
         return builder.build()
 
@@ -81,7 +104,7 @@ class AccountDeletionCompletedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
-        builder.para(".confirmation")
+        builder.para(".purpose")
         builder.para(".farewell")
         builder.para(".recovery_instructions_days", {"count": self.days})
         builder.action(self.undelete_link, ".recover_action")
@@ -139,7 +162,7 @@ class ActivenessProbeEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body")
+        builder.para(".purpose")
         builder.para(".instructions_days", {"count": self.days_left})
         builder.action(urls.app_link(), ".login_action")
         builder.para(".encouragement")
@@ -149,8 +172,7 @@ class ActivenessProbeEmail(EmailBase):
         if version_match := re.search(r"^v?(\d+\.\d+)\b", version):
             version = version_match[1]
 
-        builder.para(".latest_release", {"version": version})
-        builder.action(LATEST_RELEASE_BLOG_URL, ".read_blog_action")
+        builder.para(".latest_release", {"version": version, "blog_url": LATEST_RELEASE_BLOG_URL})
         return builder.build()
 
     @classmethod
@@ -208,7 +230,7 @@ class BadgeChangedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body", {"name": self.badge_name})
+        builder.para(".purpose", {"name": self.badge_name})
         return builder.build()
 
     @classmethod
@@ -237,7 +259,7 @@ class BirthdateChangedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
-        builder.para(".body", {"date": loc_context.localize_date(self.new_birthdate)})
+        builder.para(".purpose", {"date": loc_context.localize_date(self.new_birthdate)})
         return builder.build()
 
     @classmethod
@@ -277,7 +299,7 @@ class ChatMessageReceivedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body", {"author": self.author.name, "group": self.group_chat_title or ""})
+        builder.para(".purpose", {"author": self.author.name, "group": self.group_chat_title or ""})
         builder.user(self.author)
         builder.quote(self.text, markdown=False)
         builder.action(self.view_url, ".view_action")
@@ -338,11 +360,12 @@ class ChatMessagesMissedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
+        builder.para(".purpose")
         for entry in self.entries:
             if entry.group_chat_title is None:
-                builder.para(".in_dm", {"count": entry.missed_count, "author": entry.latest_message_author.name})
+                builder.para(".count_in_dm", {"count": entry.missed_count, "author": entry.latest_message_author.name})
             else:
-                builder.para(".in_group", {"count": entry.missed_count, "group": entry.group_chat_title})
+                builder.para(".count_in_group", {"count": entry.missed_count, "group": entry.group_chat_title})
             builder.user(entry.latest_message_author)
             builder.quote(entry.latest_message_text, markdown=False)
             builder.action(entry.view_url, ".view_action")
@@ -406,14 +429,14 @@ class DiscussionCreatedEmail(EmailBase):
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
         builder.para(
-            ".body",
+            ".purpose",
             {
                 "author": self.author.name,
-                "title": self.title,
                 "parent_context": self.parent_context,
             },
         )
         builder.user(self.author)
+        builder.block(ParaBlock(text=Markup(f"<b>{escape(self.title)}</b>")))
         builder.quote(self.markdown_text, markdown=True)
         builder.action(self.view_link, ".view_action")
         return builder.build()
@@ -469,7 +492,7 @@ class DiscussionCommentEmail(EmailBase):
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
         builder.para(
-            ".body",
+            ".purpose",
             {
                 "author": self.author.name,
                 "discussion_title": self.discussion_title,
@@ -519,16 +542,15 @@ class DonationReceivedEmail(EmailBase):
         return "donation_received"
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
-        builder = self._body_builder(loc_context, standard_closing=False)
-        builder.para(".thanks_amount", {"amount": self.amount})
-        builder.para(".purpose")
+        builder = self._body_builder(loc_context, default_closing=False)
+        builder.para(".purpose", {"amount_with_currency": f"${self.amount}"})
+        builder.para(".contribution_impact")
         builder.para(".invoice_receipt_info")
         builder.action(self.receipt_url, ".download_invoice")
         builder.para(".tax_acknowledgment")
         builder.para(".questions_contact")
-        builder.para(".generosity_helps")
-        builder.para(".thank_you")
-        builder.para("generic.founders_signature")
+        builder.para("generic.thanks")
+        builder.para("generic.closing_lines.founders")
         return builder.build()
 
     @classmethod
@@ -552,7 +574,7 @@ class EmailChangedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
-        builder.para(".body", {"email_address": self.new_email})
+        builder.para(".purpose", {"email_address": self.new_email})
         return builder.build()
 
     @classmethod
@@ -577,8 +599,7 @@ class EmailChangeConfirmationEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
-        builder.para(".context", {"old_email": self.old_email})
-        builder.para(".instructions")
+        builder.para(".purpose", {"old_email": self.old_email})
         builder.action(self.confirm_url, ".confirm_action")
         return builder.build()
 
@@ -597,7 +618,7 @@ class EmailVerifiedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
-        builder.para(".body")
+        builder.para(".purpose")
         return builder.build()
 
     @classmethod
@@ -698,9 +719,9 @@ class EventCreatedEmail(EmailBase):
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
         if self.community_name:
-            builder.para(".body_with_community", {"community": self.community_name})
+            builder.para(".purpose_with_community", {"user": self.inviting_user.name, "community": self.community_name})
         else:
-            builder.para(".body_no_community")
+            builder.para(".purpose_no_community", {"user": self.inviting_user.name })
         builder.block(self.event_info.get_details_block(loc_context))
         builder.user(self.inviting_user)
         builder.block(self.event_info.get_description_block())
@@ -761,7 +782,6 @@ class EventUpdatedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body")
 
         updated_items_string_keys = list(
             filter(None, (type(self)._updated_item_to_string_key(i) for i in self.updated_items))
@@ -770,9 +790,9 @@ class EventUpdatedEmail(EmailBase):
             updated_items_text = loc_context.localize_list(
                 [self._localize(loc_context, key) for key in updated_items_string_keys]
             )
-            builder.para(".updated_items", {"items_list": updated_items_text})
+            builder.para(".purpose_specific", {"user": self.updating_user.name, "items_list": updated_items_text})
         else:
-            builder.para(".updated_generic")
+            builder.para(".purpose_generic", {"user": self.updating_user.name})
 
         builder.block(self.event_info.get_details_block(loc_context))
         builder.user(self.updating_user)
@@ -833,7 +853,10 @@ class EventUpdatedEmail(EmailBase):
     @classmethod
     def test_instances(cls) -> list[Self]:
         prototype = cls(
-            user_name="Alice", updating_user=UserInfo.dummy_bob(), event_info=EventInfo.dummy(), updated_items=[]
+            user_name="Alice",
+            updating_user=UserInfo.dummy_bob(),
+            event_info=EventInfo.dummy(),
+            updated_items=[],
         )
         return [
             replace(prototype, updated_items=[]),
@@ -861,12 +884,12 @@ class EventOrganizerInvitedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body", {"user": self.inviting_user.name, "title": self.event_info.title})
+        builder.para(".purpose", {"user": self.inviting_user.name, "title": self.event_info.title})
         builder.block(self.event_info.get_details_block(loc_context))
-        builder.user(self.inviting_user, comment_key=".user_card_text")
+        builder.user(self.inviting_user)
         builder.block(self.event_info.get_description_block())
         builder.block(self.event_info.get_view_action_block(loc_context))
-        builder.para(_do_not_reply_request_string_key)
+        builder.para(_do_not_reply_request_string_key, epilogue=True)
         return builder.build()
 
     @classmethod
@@ -902,11 +925,10 @@ class EventCommentEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body", {"author": self.author.name, "title": self.event_info.title})
+        builder.para(".purpose", {"author": self.author.name})
+        builder.block(self.event_info.get_details_block(loc_context))
         builder.user(self.author)
         builder.quote(self.comment_markdown, markdown=True)
-        builder.para(".event_details")
-        builder.block(self.event_info.get_details_block(loc_context))
         builder.block(self.event_info.get_view_action_block(loc_context))
         return builder.build()
 
@@ -946,7 +968,7 @@ class EventReminderEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body")
+        builder.para(".purpose")
         builder.block(self.event_info.get_details_block(loc_context))
         builder.block(self.event_info.get_description_block())
         builder.block(self.event_info.get_view_action_block(loc_context))
@@ -984,9 +1006,9 @@ class EventCancelledEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body")
+        builder.para(".purpose", {"user": self.cancelling_user.name})
         builder.block(self.event_info.get_details_block(loc_context))
-        builder.user(self.cancelling_user, ".user_card_text")
+        builder.user(self.cancelling_user)
         builder.quote(self.event_info.description_markdown, markdown=True)
         builder.block(self.event_info.get_view_action_block(loc_context))
         return builder.build()
@@ -1019,7 +1041,7 @@ class EventDeletedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body")
+        builder.para(".purpose")
         builder.block(self.event_info.get_details_block(loc_context))
         return builder.build()
 
@@ -1059,7 +1081,7 @@ class FriendReferenceReceivedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body", {"name": self.from_user.name})
+        builder.para(".purpose", {"name": self.from_user.name})
         builder.user(self.from_user)
         builder.quote(self.text, markdown=False)
         builder.action(urls.profile_references_link(), "references.received.view_action")
@@ -1095,11 +1117,11 @@ class FriendRequestReceivedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body", {"name": self.befriender.name})
+        builder.para(".purpose", {"name": self.befriender.name})
         builder.user(self.befriender)
         builder.action(urls.friend_requests_link(), ".view_action")
         builder.para(".closing")
-        builder.para(_do_not_reply_request_string_key)
+        builder.para(_do_not_reply_request_string_key, epilogue=True)
         return builder.build()
 
     @classmethod
@@ -1131,7 +1153,7 @@ class FriendRequestAcceptedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body", {"name": self.new_friend.name})
+        builder.para(".purpose", {"name": self.new_friend.name})
         builder.user(self.new_friend)
         builder.action(self.new_friend.profile_url, ".view_action")
         builder.para(".closing")
@@ -1163,7 +1185,7 @@ class GenderChangedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
-        builder.para(".body", {"gender": self.new_gender})
+        builder.para(".purpose", {"gender": self.new_gender})
         return builder.build()
 
     @classmethod
@@ -1188,8 +1210,8 @@ class HostRequestCreatedEmail(EmailBase):
     from_date: date
     to_date: date
     text: str
-    quick_decline_link: str
     view_link: str
+    quick_decline_link: str
 
     @property
     def string_key_base(self) -> str:
@@ -1203,7 +1225,7 @@ class HostRequestCreatedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body", {"surfer_name": self.surfer.name})
+        builder.para(".purpose", {"surfer_name": self.surfer.name})
         builder.user(
             self.surfer,
             "host_requests.generic.date_range",
@@ -1214,9 +1236,9 @@ class HostRequestCreatedEmail(EmailBase):
         )
         builder.quote(self.text, markdown=False)
         builder.action(self.view_link, "host_requests.generic.view_action")
-        builder.action(self.quick_decline_link, ".quick_decline_action")
+        builder.action(self.quick_decline_link, "host_requests.generic.quick_decline_action")
         builder.para(".respond_encouragement")
-        builder.para(_do_not_reply_request_string_key)
+        builder.para(_do_not_reply_request_string_key, epilogue=True)
         return builder.build()
 
     @classmethod
@@ -1227,8 +1249,8 @@ class HostRequestCreatedEmail(EmailBase):
             from_date=date.fromisoformat(data.host_request.from_date),
             to_date=date.fromisoformat(data.host_request.to_date),
             text=data.text,
-            quick_decline_link=generate_quick_decline_link(data.host_request),
             view_link=urls.host_request(host_request_id=data.host_request.host_request_id),
+            quick_decline_link=generate_quick_decline_link(data.host_request),
         )
 
     @classmethod
@@ -1240,8 +1262,8 @@ class HostRequestCreatedEmail(EmailBase):
                 from_date=date(2025, 6, 1),
                 to_date=date(2025, 6, 7),
                 text="Hey, I'd love to stay for a few nights!",
-                quick_decline_link="https://couchers.org/requests/123/decline?token=xxx",
                 view_link="https://couchers.org/requests/123",
+                quick_decline_link="https://couchers.org/requests/123/decline?token=xxx",
             )
         ]
 
@@ -1254,6 +1276,7 @@ class HostRequestReminderEmail(EmailBase):
     from_date: date
     to_date: date
     view_link: str
+    quick_decline_link: str
 
     @property
     def string_key_base(self) -> str:
@@ -1264,7 +1287,7 @@ class HostRequestReminderEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body")
+        builder.para(".purpose", {"surfer_name": self.surfer.name})
         builder.user(
             self.surfer,
             "host_requests.generic.date_range",
@@ -1274,7 +1297,8 @@ class HostRequestReminderEmail(EmailBase):
             },
         )
         builder.action(self.view_link, "host_requests.generic.view_action")
-        builder.para(_do_not_reply_request_string_key)
+        builder.action(self.quick_decline_link, "host_requests.generic.quick_decline_action")
+        builder.para(_do_not_reply_request_string_key, epilogue=True)
         return builder.build()
 
     @classmethod
@@ -1285,6 +1309,7 @@ class HostRequestReminderEmail(EmailBase):
             from_date=date.fromisoformat(data.host_request.from_date),
             to_date=date.fromisoformat(data.host_request.to_date),
             view_link=urls.host_request(host_request_id=data.host_request.host_request_id),
+            quick_decline_link=generate_quick_decline_link(data.host_request),
         )
 
     @classmethod
@@ -1296,6 +1321,7 @@ class HostRequestReminderEmail(EmailBase):
                 from_date=date(2025, 6, 1),
                 to_date=date(2025, 6, 7),
                 view_link="https://couchers.org/requests/123",
+                quick_decline_link="https://couchers.org/requests/123/decline?token=xxx",
             )
         ]
 
@@ -1324,7 +1350,7 @@ class HostRequestMessageEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body", {"other_name": self.other_user.name})
+        builder.para(".purpose", {"other_name": self.other_user.name})
         builder.user(
             self.other_user,
             "host_requests.generic.date_range",
@@ -1335,7 +1361,7 @@ class HostRequestMessageEmail(EmailBase):
         )
         builder.quote(self.text, markdown=False)
         builder.action(self.view_link, "host_requests.generic.view_action")
-        builder.para(_do_not_reply_request_string_key)
+        builder.para(_do_not_reply_request_string_key, epilogue=True)
         return builder.build()
 
     @classmethod
@@ -1384,7 +1410,7 @@ class HostRequestMissedMessagesEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body", {"other_name": self.other_user.name})
+        builder.para(".purpose", {"other_name": self.other_user.name})
         builder.user(
             self.other_user,
             "host_requests.generic.date_range",
@@ -1394,7 +1420,7 @@ class HostRequestMissedMessagesEmail(EmailBase):
             },
         )
         builder.action(self.view_link, "host_requests.generic.view_action")
-        builder.para(_do_not_reply_request_string_key)
+        builder.para(_do_not_reply_request_string_key, epilogue=True)
         return builder.build()
 
     @classmethod
@@ -1451,7 +1477,7 @@ class HostRequestStatusChangedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body", {"other_name": self.other_user.name})
+        builder.para(".purpose", {"other_name": self.other_user.name})
         builder.user(
             self.other_user,
             "host_requests.generic.date_range",
@@ -1461,7 +1487,7 @@ class HostRequestStatusChangedEmail(EmailBase):
             },
         )
         builder.action(self.view_link, "host_requests.generic.view_action")
-        builder.para(_do_not_reply_request_string_key)
+        builder.para(_do_not_reply_request_string_key, epilogue=True)
         return builder.build()
 
     @classmethod
@@ -1545,14 +1571,13 @@ class HostReferenceReceivedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(f".{self.string_role_subkey}.body", {"name": self.from_user.name})
+        builder.para(f".{self.string_role_subkey}.purpose", {"name": self.from_user.name})
         builder.user(self.from_user)
         if self.text:
-            builder.para(".before_quote")
             builder.quote(self.text, markdown=False)
             builder.action(urls.profile_references_link(), ".view_action")
         else:
-            builder.para(".reciprocate_encouragement", {"name": self.from_user.name})
+            builder.para(f".{self.string_role_subkey}.reciprocate_encouragement", {"name": self.from_user.name})
             builder.action(self.leave_reference_url, "references.write_action", {"name": self.from_user.name})
         return builder.build()
 
@@ -1615,16 +1640,14 @@ class HostReferenceReminderEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(f".{self.string_role_subkey}.body_days", {"name": self.other_user.name, "count": self.days_left})
-        builder.para(".no_meeting_note", {"name": self.other_user.name})
+        builder.para(f".{self.string_role_subkey}.purpose_days", {"name": self.other_user.name, "count": self.days_left})
         builder.user(self.other_user)
         builder.action(
             self.leave_reference_url,
             "references.write_action",
             {"name": self.other_user.name},
         )
-        builder.para(".via_messaging_note")
-        builder.para(".importance_note")
+        builder.para(".no_meeting_note", {"name": self.other_user.name})
         builder.para(".visibility_note")
         return builder.build()
 
@@ -1664,7 +1687,10 @@ class ModeratorNoteEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body")
+        builder.para(".purpose")
+        # Users with moderator notes are "jailed": any URL will show the note before
+        # letting them use the platform.
+        builder.action(urls.dashboard_link(), ".view_action")
         return builder.build()
 
     @classmethod
@@ -1692,8 +1718,8 @@ class NewBlogPostEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".intro")
-        builder.para(".post_title", {"title": self.title})
+        builder.para(".purpose")
+        builder.block(ParaBlock(text=Markup(f"<b>{escape(self.title)}</b>")))
         builder.quote(self.blurb, markdown=False)
         builder.action(self.url, ".read_action")
         return builder.build()
@@ -1725,26 +1751,25 @@ class OnboardingReminderEmail(EmailBase):
         return f"onboarding_reminder.{'initial' if self.initial else 'follow_up'}"
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
-        builder = self._body_builder(loc_context, standard_closing=False)
+        builder = self._body_builder(loc_context, default_closing=False)
         edit_profile_url = urls.edit_profile_link()
         if self.initial:
             builder.para(".welcome")
             builder.para(".early_user_role")
             builder.para(".fill_in_profile")
             builder.para(".edit_profile_prompt")
-            builder.action(edit_profile_url, ".edit_profile_action")
+            builder.action(edit_profile_url, "onboarding_reminder.edit_profile_action")
             builder.para(".share_with_friends")
             builder.para(".link", {"url": urls.app_link()})
             builder.para(".platform_under_development")
             builder.para(".thanks_for_joining")
-            builder.para(".signature")
+            builder.para("generic.closing_lines.aapeli")
         else:
             builder.para(".intro")
-            builder.para(".fill_in_profile")
-            builder.action(edit_profile_url, ".edit_profile_action")
-            builder.para(".no_empty_accounts")
-            builder.para(".profile_importance")
-            builder.para(".signature")
+            builder.para(".request")
+            builder.action(edit_profile_url, "onboarding_reminder.edit_profile_action")
+            builder.para("generic.thanks")
+            builder.para("generic.closing_lines.emily")
         return builder.build()
 
     @classmethod
@@ -1763,7 +1788,7 @@ class PasswordChangedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
-        builder.para(".body")
+        builder.para(".purpose")
         return builder.build()
 
     @classmethod
@@ -1781,7 +1806,7 @@ class PasswordResetCompletedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
-        builder.para(".body")
+        builder.para(".purpose")
         return builder.build()
 
     @classmethod
@@ -1801,8 +1826,7 @@ class PasswordResetStartedEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
-        builder.para(".request_description")
-        builder.para(".confirmation_instructions")
+        builder.para(".purpose")
         builder.action(self.password_reset_link, ".reset_action")
         return builder.build()
 
@@ -1831,7 +1855,7 @@ class PhoneNumberChangeEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
-        builder.para(".body", {"phone_number": format_phone_number(self.new_phone_number)})
+        builder.para(".purpose", {"phone_number": format_phone_number(self.new_phone_number)})
         return builder.build()
 
     @classmethod
@@ -1866,12 +1890,13 @@ class PostalVerificationFailedEmail(EmailBase):
         builder = self._body_builder(loc_context, security_warning=True)
         match self.reason:
             case notification_data_pb2.POSTAL_VERIFICATION_FAIL_REASON_CODE_EXPIRED:
-                reason_string_key = ".reason_code_expired"
+                purpose_string_key = ".purpose.code_expired"
             case notification_data_pb2.POSTAL_VERIFICATION_FAIL_REASON_TOO_MANY_ATTEMPTS:
-                reason_string_key = ".reason_too_many_attempts"
+                purpose_string_key = ".purpose.too_many_attempts"
             case _:
-                reason_string_key = ".reason_unknown"
-        builder.para(reason_string_key)
+                purpose_string_key = ".purpose.default"
+        builder.para(purpose_string_key)
+        builder.action(urls.account_settings_link(), ".restart_action")
         return builder.build()
 
     @classmethod
@@ -1904,7 +1929,8 @@ class PostalVerificationPostcardSentEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
-        builder.para(".body", {"city": self.city, "country": self.country})
+        builder.para(".purpose", {"city": self.city, "country": self.country})
+        builder.action(urls.dashboard_link(), ".enter_code_action")
         return builder.build()
 
     @classmethod
@@ -1926,7 +1952,7 @@ class PostalVerificationSucceededEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
-        builder.para(".body")
+        builder.para(".purpose")
         return builder.build()
 
     @classmethod
@@ -1975,8 +2001,7 @@ class SignupContinueEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".request")
-        builder.para(".instructions")
+        builder.para(".purpose")
         builder.action(self.continue_url, ".continue_action")
         builder.para("signup.closing")
         builder.para(".ignore_if_unexpected")
@@ -2001,14 +2026,15 @@ class StrongVerificationFailedEmail(EmailBase):
         builder = self._body_builder(loc_context, security_warning=True)
         match self.reason:
             case notification_data_pb2.SV_FAIL_REASON_WRONG_BIRTHDATE_OR_GENDER:
-                reason_string_key = ".reason_wrong_birthdate_or_gender"
+                purpose_string_key = ".purpose.wrong_birthdate_or_gender"
             case notification_data_pb2.SV_FAIL_REASON_NOT_A_PASSPORT:
-                reason_string_key = ".reason_not_a_passport"
+                purpose_string_key = ".purpose.not_a_passport"
             case notification_data_pb2.SV_FAIL_REASON_DUPLICATE:
-                reason_string_key = ".reason_duplicate"
+                purpose_string_key = ".purpose.duplicate"
             case _:
                 raise Exception("Shouldn't get here")
-        builder.para(reason_string_key)
+        builder.para(purpose_string_key)
+        builder.action(urls.strong_verification_url(), ".restart_action")
         return builder.build()
 
     @classmethod
@@ -2038,7 +2064,7 @@ class StrongVerificationSucceededEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, security_warning=True)
-        builder.para(".success_message")
+        builder.para(".purpose")
         builder.para(".thanks_message")
         builder.para(".cost_explanation")
         builder.para(".donation_request")
@@ -2074,7 +2100,7 @@ class ThreadReplyEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".body", {"author": self.author.name, "parent_context": self.parent_context})
+        builder.para(".purpose", {"author": self.author.name, "parent_context": self.parent_context})
         builder.user(self.author)
         builder.quote(self.markdown_text, markdown=True)
         builder.action(self.view_link, ".view_action")

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -791,7 +791,7 @@ class EventUpdatedEmail(EmailBase):
             updated_items_text = loc_context.localize_list(
                 [self._localize(loc_context, key) for key in updated_items_string_keys]
             )
-            builder.para(".purpose_specific", {"user": self.updating_user.name, "items_list": updated_items_text})
+            builder.para(".purpose_with_items", {"user": self.updating_user.name, "items_list": updated_items_text})
         else:
             builder.para(".purpose_generic", {"user": self.updating_user.name})
 

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -721,7 +721,7 @@ class EventCreatedEmail(EmailBase):
         if self.community_name:
             builder.para(".purpose_with_community", {"user": self.inviting_user.name, "community": self.community_name})
         else:
-            builder.para(".purpose_no_community", {"user": self.inviting_user.name })
+            builder.para(".purpose_no_community", {"user": self.inviting_user.name})
         builder.block(self.event_info.get_details_block(loc_context))
         builder.user(self.inviting_user)
         builder.block(self.event_info.get_description_block())
@@ -1640,7 +1640,9 @@ class HostReferenceReminderEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(f".{self.string_role_subkey}.purpose_days", {"name": self.other_user.name, "count": self.days_left})
+        builder.para(
+            f".{self.string_role_subkey}.purpose_days", {"name": self.other_user.name, "count": self.days_left}
+        )
         builder.user(self.other_user)
         builder.action(
             self.leave_reference_url,

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -16,11 +16,12 @@ Preview line:
 Purpose line of the body (first paragraph after the greeting):
   Usually a single sentence stating the purpose of the email.
   Similar or identical to the subject but may include additional info (e.g. dates).
-  Key pieces of info (names, locations, dates) should be <strong></strong>.
-  Should be punctuated with a period*, or end with a colon ':' if we then quote user content.
+  Should be punctuated with a period*, or end with a colon (':') if we then quote user content.
 
-Rest of body:
-  Omit further prose for day-to-day notifications (the purpose line is enough).
+Other instructions for body text:
+  A single purpose line is enough for day-to-day notifications, no need for further prose.
+  Highlight key pieces of info (names, locations, dates) using <b> tags.
+  Highlight important passages using <strong> tags.
   Provide a link or instructions if the user has follow-up actions.
 
 * Some key emails like new accounts might use an exclamation mark (limit to 1) and more personal prose.

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -1,10 +1,15 @@
 {
   "generic": {
     "greeting_line": "Hi {{name}},",
-    "closing_line": "Best,<br>The Couchers.org Team",
-    "founders_signature": "Aapeli and Itsi,<br>Couchers.org Founders",
-    "security_warning_contact_support": "If you did not initiate this action, please contact us by emailing <a href=\"mailto:support@couchers.org\">support@couchers.org</a> so we can sort this out as soon as possible!",
-    "do_not_reply_request": "<b>Do not reply to this email.</b> Use one of the buttons above to reply to this request.",
+    "security_warning_contact_support": "If you did not initiate this action, please contact us at <a href=\"mailto:support@couchers.org\">support@couchers.org</a> so we can sort this out as soon as possible.",
+    "do_not_reply_request": "Do not reply to this email. Use one of the buttons above to reply to this request.",
+    "thanks": "Thank you!",
+    "closing_lines": {
+      "default": "Best,<br>The Couchers.org Team",
+      "founders": "Aapeli and Itsi,<br>Couchers.org Founders",
+      "aapeli": "Aapeli<br>Couchers.org Co-founder<br><a href=\"mailto:aapeli@couchers.org\">aapeli@couchers.org</a> (feel free to shoot me an email at any time)<br><a href=\"https://couchers.org/user/aapeli\">https://couchers.org/user/aapeli</a>",
+      "emily": "Emily from Couchers.org<br><a href=\"mailto:community@couchers.org\">community@couchers.org</a><br><a href=\"https://couchers.org/user/emily\">https://couchers.org/user/emily</a>"
+    },
     "footer": {
       "received_because": "You're receiving this email because you signed up for Couchers.org.",
       "contact_support": "You can reach our support team at <a href=\"mailto:support@couchers.org\">support@couchers.org</a>.",
@@ -32,117 +37,113 @@
   },
   "account_deletion": {
     "started": {
-      "subject": "Confirm your Couchers.org account deletion",
-      "request_description": "You requested that we delete your account from Couchers.org.",
-      "confirmation_instructions": "To complete this process, please confirm by clicking the following button:",
+      "subject": "Confirm your account deletion",
+      "purpose": "You requested that we delete your Couchers.org account. To complete this process, please click on the following link:",
       "confirm_action": "Confirm account deletion"
     },
     "completed": {
-      "subject": "Your Couchers.org account has been deleted",
-      "confirmation": "You have successfully deleted your account from Couchers.org.",
+      "subject": "Your account has been deleted",
+      "purpose": "You have successfully deleted your Couchers.org account.",
       "farewell": "We are sad to see you go, and wish you the best in your future travels. You are always welcome back on the Couchers.org platform :)",
-      "recovery_instructions_days_one": "If you change your mind, <b>you have {{count}} day to recover your account</b> by clicking the following link:",
-      "recovery_instructions_days_other": "If you change your mind, <b>you have {{count}} days to recover your account</b> by clicking the following link:",
+      "recovery_instructions_days_one": "If you change your mind, <strong>you have {{count}} day to recover your account</strong> by clicking the following link:",
+      "recovery_instructions_days_other": "If you change your mind, <strong>you have {{count}} days to recover your account</strong> by clicking the following link:",
       "recover_action": "Recover account"
     },
     "recovered": {
-      "subject": "Your Couchers.org account has been recovered!",
-      "confirmation": "Your account on Couchers.org has been successfully recovered!",
-      "login_instructions": "We are so glad you decided to stay! To log back in, click the following link:",
+      "subject": "Your account has been recovered!",
+      "confirmation": "Your Couchers.org account has been successfully recovered. We are glad you decided to stay!",
+      "login_instructions": "To log back in, click on the following link:",
       "login_action": "Log back in",
       "redelete_instructions": "If you change your mind, you can delete your account at any time."
     }
   },
   "activeness_probe": {
-    "subject": "Are you still open to hosting on Couchers.org?",
-    "body": "We noticed you haven't logged in for a while and wanted to check if you're still open to hosting surfers.",
-    "instructions_days_one": "To keep your \"Can Host\" status, please log back in within the next {{count}} day. Otherwise, we'll change your hosting status to \"Can't Host.\"",
-    "instructions_days_other": "To keep your \"Can Host\" status, please log back in within the next {{count}} days. Otherwise, we'll change your hosting status to \"Can't Host.\"",
-    "login_action": "Log back in to respond",
+    "subject": "Are you still open to hosting?",
+    "purpose": "We noticed you haven't logged in for a while and wanted to check if you're still open to hosting surfers.",
+    "instructions_days_one": "To keep your \"Can Host\" status, please log back in within the next <b>{{count}} day</b>. Otherwise, we'll change your hosting status to \"Can't Host.\"",
+    "instructions_days_other": "To keep your \"Can Host\" status, please log back in within the next <b>{{count}} days</b>. Otherwise, we'll change your hosting status to \"Can't Host.\"",
+    "login_action": "Log back in",
     "encouragement": "These check-ins help surfers find active hosts more easily and keep response times accurate.",
-    "latest_release": "In case you've missed it, we recently released version {{version}}. Some of the recent updates include new mobile app on iOS and Android, improved dashboard, overhauled messaging and new event features.",
-    "read_blog_action": "Read more on our blog"
+    "latest_release": "In case you've missed it, we recently released version {{version}}. Some of the recent updates include new mobile app on iOS and Android, improved dashboard, overhauled messaging and new event features. Read more on the <a href=\"{{blog_url}}\">Couchers.org blog</a>."
   },
   "api_key_issued": {
     "subject": "Your API key for Couchers.org",
     "header": "You recently requested an API key for Couchers.org. We've issued you with the following API key:",
-    "expiry": "The key expires on {{ datetime }}.",
-    "usage_warning": "This API key is unique to your account; do not share it with anyone, it gives complete access to your account, and you are reponsible for any actions taken using this API key.",
+    "expiry": "The key expires on <b>{{ datetime }}</b>.",
+    "usage_warning": "This API key is unique to your account; do not share it with anyone. It gives complete access to your account, and you are reponsible for any actions taken using this API key.",
     "policy_warning": "Please remember to abide by our Terms of Service, our Community Guidelines, and other policies while using our APIs. All access is logged and analyzed, and we may terminate your access or account if you abuse the service."
   },
   "badges": {
     "added": {
       "subject": "The {{ name }} badge was added to your profile",
-      "body": "The {{ name }} badge was added to your profile."
+      "purpose": "The <b>{{ name }}</b> badge was added to your profile."
     },
     "removed": {
       "subject": "The {{ name }} badge was removed from your profile",
-      "body": "The {{ name }} badge was removed from your profile."
+      "purpose": "The <b>{{ name }}</b> badge was removed from your profile."
     }
   },
   "birthdate_changed": {
     "subject": "Your date of birth was changed",
-    "body": "Your date of birth was changed to <b>{{ date }}</b> by an admin."
+    "purpose": "Your date of birth was changed to <b>{{ date }}</b> by an admin."
   },
   "chat_messages": {
     "received": {
       "direct": {
         "subject": "{{ author }} sent you a message",
-        "body": "{{ author }} sent you a message:",
+        "purpose": "<b>{{ author }}</b> sent you a message:",
         "view_action": "View this message"
       },
       "group": {
-        "subject": "{{ author }} sent a message in \"{{ group }}\"",
-        "body": "{{ author }} sent a message in <b>{{ group }}</b>:",
+        "subject": "{{ author }} sent a message in {{ group }}",
+        "purpose": "<b>{{ author }}</b> sent a message in <b>{{ group }}</b>:",
         "view_action": "View this message"
       }
     },
     "missed": {
-      "subject": "You have unseen messages on Couchers.org!",
-      "in_dm_one": "You missed {{count}} message from {{author}}:",
-      "in_dm_other": "You missed {{count}} messages from {{author}}:",
-      "in_group_one": "You missed {{count}} message in <b>{{group}}</b>:",
-      "in_group_other": "You missed {{count}} messages in <b>{{group}}</b>:",
-      "view_action": "View this message"
+      "subject": "You have unseen messages",
+      "purpose": "You missed some messages since you last visited:",
+      "count_in_dm_one": "{{count}} message from <b>{{author}}</b>:",
+      "count_in_dm_other": "{{count}} messages from <b>{{author}}</b>:",
+      "count_in_group_one": "{{count}} message in <b>{{group}}</b>:",
+      "count_in_group_other": "{{count}} messages in <b>{{group}}</b>:",
+      "view_action": "View messages"
     }
   },
   "discussions": {
     "created": {
       "subject": "{{author}} started a discussion: {{title}}",
-      "body": "<b>{{author}}</b> created a new discussion called <b>{{title}}</b> in <b>{{parent_context}}</b>:",
+      "purpose": "<b>{{author}}</b> started a discussion in <b>{{parent_context}}</b>:",
       "view_action": "View discussion"
     },
     "comment": {
       "subject": "{{author}} commented on {{discussion_title}}",
-      "body": "<b>{{author}}</b> commented on <b>{{discussion_title}}</b> in <b>{{parent_context}}</b>:",
+      "purpose": "<b>{{author}}</b> commented on <b>{{discussion_title}}</b> in <b>{{parent_context}}</b>:",
       "view_action": "View discussion"
     }
   },
   "donation_received": {
     "subject": "Thank you for your donation to Couchers.org!",
-    "thanks_amount": "Thank you so much for your donation of ${{amount}} to Couchers.org.",
-    "purpose": "Your contribution will go towards building and sustaining the Couchers.org platform and community, and is vital for our goal of a completely free and non-profit generation of couch surfing.",
+    "purpose": "Thank you so much for your donation of <b>{{amount_with_currency}}</b> to Couchers.org.",
+    "contribution_impact": "Your contribution will go towards building and sustaining the Couchers.org community, and is vital for our goal of a free and non-profit couch surfing platform.",
     "invoice_receipt_info": "You can download an invoice and receipt for the donation here:",
     "download_invoice": "Download invoice",
     "tax_acknowledgment": "Couchers, Inc. is a 501(c)(3) nonprofit (EIN: 87-1734577) registered in the United States. No goods or services were provided in exchange for this contribution.",
-    "questions_contact": "If you have any questions about your donation, please email us at <a href=\"mailto:donations@couchers.org\">donations@couchers.org</a>.",
-    "generosity_helps": "Your generosity will help deliver the platform for everyone.",
-    "thank_you": "Thank you!"
+    "questions_contact": "If you have any questions about your donation, please email us at <a href=\"mailto:donations@couchers.org\">donations@couchers.org</a>."
   },
   "email_change": {
     "initiated": {
-      "subject": "An email change was initiated on your account",
-      "body": "An email change to the email <b>{{ email_address }}</b> was initiated on your account."
+      "subject": "Email address change initiated",
+      "purpose": "You've requested that your email address be changed to <b>{{ email_address }}</b>. Please review the email we sent to that address to confirm the change."
     },
     "confirmation": {
-      "subject": "Confirm your new email for Couchers.org",
-      "context": "You requested that your email be changed to this email address on Couchers.org. Your old email address is <b>{{ old_email }}</b>. This is the final step in the process.",
-      "instructions": "To complete this change, please confirm your email by clicking the following link:",
+      "subject": "Confirm your new email address",
+      "purpose": "You requested that your email be changed from <b>{{ old_email }}</b> to this email address. To complete this change, please click on the following link:",
       "confirm_action": "Confirm new email"
     },
     "verified": {
       "subject": "Email change completed",
-      "body": "Your new email address has been verified."
+      "purpose": "Your new email address has been verified."
     }
   },
   "events": {
@@ -152,20 +153,20 @@
     },
     "created": {
       "invitation": {
-        "subject": "{{user}} invited you to \"{{title}}\"",
-        "body_with_community": "You've been invited to a new event in the {{community}} community:",
-        "body_no_community": "You've been invited to a new event nearby:"
+        "subject": "{{user}} invited you to {{title}}",
+        "purpose_with_community": "<b>{{user}}</b> invited you to an event in <b>{{community}}</b>:",
+        "purpose_no_community": "<b>{{user}}</b> invited you to an event nearby:"
       },
       "notification": {
-        "subject": "{{user}} created an event called \"{{title}}\"",
-        "body_with_community": "A new event was created in the {{community}} community:",
-        "body_no_community": "A new event was created nearby:"
+        "subject": "{{user}} created an event: {{title}}",
+        "purpose_with_community": "<b>{{user}}</b> created an event in <b>{{community}}</b>:",
+        "purpose_no_community": "<b>{{user}}</b> created an event nearby:"
       }
     },
     "updated": {
-      "subject": "{{user}} updated \"{{title}}\"",
-      "body": "An event you are subscribed to was updated.",
-      "updated_items": "The following information was updated: <b>{{items_list}}</b>. Here is the updated event:",
+      "subject": "{{user}} updated {{title}}",
+      "purpose_generic": "<b>{{user}}</b> updated an event you are subscribed to:",
+      "purpose_specific": "<b>{{user}}</b> updated an event you are subscribed to ({{items_list}}):",
       "updated_generic": "Here is the updated event:",
       "item_names": {
         "title": "title",
@@ -176,109 +177,106 @@
       }
     },
     "organizer_invited": {
-      "subject": "{{user}} invited you to co-organize \"{{title}}\"",
-      "body": "<b>{{user}}</b> invited you to co-organize \"{{title}}\". The event information is below:",
-      "user_card_text": "Invited you to co-organize the event."
+      "subject": "{{user}} invited you to co-organize {{title}}",
+      "purpose": "<b>{{user}}</b> invited you to co-organize an event:"
     },
     "comment": {
-      "subject": "{{author}} commented on \"{{title}}\"",
-      "body": "<b>{{author}}</b> commented on the event <b>{{title}}</b>:",
-      "event_details": "Here are the details of the event:"
+      "subject": "{{author}} commented on {{title}}",
+      "purpose": "<b>{{author}}</b> commented on an event you're subscribed to:"
     },
     "reminder": {
-      "subject": "Reminder: \"{{title}}\" starts soon",
-      "body": "This is a reminder that the following event is starting in less than 24 hours:"
+      "subject": "Reminder: {{title}} starts soon",
+      "purpose": "An event you're subscribed to is starting in less than 24 hours:"
     },
     "cancel": {
-      "subject": "{{user}} cancelled \"{{title}}\"",
-      "body": "An event you are subscribed to has been cancelled:",
-      "user_card_text": "Cancelled the event."
+      "subject": "{{user}} cancelled {{title}}",
+      "purpose": "<b>{{user}}</b> cancelled an event you are subscribed to:"
     },
     "deleted": {
-      "subject": "A moderator deleted \"{{title}}\"",
-      "body": "An event you are subscribed to has been deleted by the moderators:"
+      "subject": "A moderator deleted {{title}}",
+      "purpose": "A moderator deleted an event you are subscribed to:"
     }
   },
   "friend_requests": {
     "received": {
-      "subject": "{{name}} wants to be your friend on Couchers.org!",
-      "body": "You've received a friend request from {{name}}.",
+      "subject": "{{name}} wants to be your friend",
+      "purpose": "<b>{{name}}</b> sent you a friend request.",
       "view_action": "View friend requests",
       "closing": "We hope you make a new friend!"
     },
     "accepted": {
-      "subject": "{{name}} accepted your friend request!",
-      "body": "{{name}} has accepted your friend request.",
+      "subject": "{{name}} accepted your friend request",
+      "purpose": "<b>{{name}}</b> has accepted your friend request.",
       "view_action": "View their profile",
       "closing": "We hope you continue making new friends!"
     }
   },
   "gender_changed": {
     "subject": "Your gender was changed",
-    "body": "Your gender on Couchers.org was changed to <b>{{ gender }}</b> by an admin."
+    "purpose": "Your gender on Couchers.org was changed to <b>{{ gender }}</b> by an admin."
   },
   "host_requests": {
     "created": {
       "subject": "{{surfer_name}} sent you a host request",
-      "body": "<b>{{surfer_name}}</b> sent you a host request:",
-      "quick_decline_action": "Quick decline (no login needed)",
-      "respond_encouragement": "Please respond to this request, even a quick decline is better than no response!"
+      "purpose": "<b>{{surfer_name}}</b> sent you a host request:",
+      "respond_encouragement": "Please respond to this request. Even a quick decline is better than no response!"
     },
     "generic": {
       "date_range": "From <b>{{from_date}}</b> to <b>{{to_date}}</b>.",
-      "view_action": "View host request"
+      "view_action": "View host request",
+      "quick_decline_action": "Quick decline"
     },
     "reminder": {
-      "subject": "You have a pending host request from {{surfer_name}}!",
-      "body": "Please respond to the request!"
+      "subject": "You have a pending host request from {{surfer_name}}",
+      "purpose": "<b>{{surfer_name}}</b> is waiting for your response. Even a quick decline is better than no response!"
     },
     "message": {
       "from_host": {
         "subject": "{{other_name}} sent you a message in your host request",
-        "body": "<b>{{other_name}}</b> sent you a message in your host request:"
+        "purpose": "<b>{{other_name}}</b> sent you a message in your host request:"
       },
       "from_surfer": {
         "subject": "{{other_name}} sent you a message in their host request",
-        "body": "<b>{{other_name}}</b> sent you a message in their host request:"
+        "purpose": "<b>{{other_name}}</b> sent you a message in their host request:"
       }
     },
     "missed_messages": {
       "from_host": {
         "subject": "{{other_name}} sent you message(s) in your host request",
-        "body": "<b>{{other_name}}</b> sent you message(s) in your host request:"
+        "purpose": "<b>{{other_name}}</b> sent you one or more messages in your host request:"
       },
       "from_surfer": {
         "subject": "{{other_name}} sent you message(s) in their host request",
-        "body": "<b>{{other_name}}</b> sent you message(s) in their host request:"
+        "purpose": "<b>{{other_name}}</b> sent you one or more messages in their host request:"
       }
     },
     "status_changed": {
       "accepted_by_host": {
         "subject": "{{other_name}} accepted your host request",
-        "body": "<b>{{other_name}}</b> accepted your host request:"
+        "purpose": "<b>{{other_name}}</b> accepted your host request:"
       },
       "declined_by_host": {
         "subject": "{{other_name}} declined your host request",
-        "body": "<b>{{other_name}}</b> declined your host request:"
+        "purpose": "<b>{{other_name}}</b> declined your host request:"
       },
       "confirmed_by_surfer": {
         "subject": "{{other_name}} confirmed their host request",
-        "body": "<b>{{other_name}}</b> confirmed their host request:"
+        "purpose": "<b>{{other_name}}</b> confirmed their host request:"
       },
       "cancelled_by_surfer": {
         "subject": "{{other_name}} cancelled their host request",
-        "body": "<b>{{other_name}}</b> cancelled their host request:"
+        "purpose": "<b>{{other_name}}</b> cancelled their host request:"
       }
     }
   },
   "moderator_note": {
-    "subject": "You have received a mod note",
-    "body": "You have received an important note from the moderators. You must read and acknowledge it before continuing to use the platform."
+    "subject": "You have received a moderator note",
+    "purpose": "You have received an important note from the moderators. You must read and acknowledge it before continuing to use the platform.",
+    "view_action": "View moderator note"
   },
   "new_blog_post": {
     "subject": "New blog post: {{title}}",
-    "intro": "We published a new blog post:",
-    "post_title": "<b>{{title}}</b>",
+    "purpose": "We published a new blog post:",
     "read_action": "Read the post"
   },
   "onboarding_reminder": {
@@ -288,96 +286,92 @@
       "early_user_role": "We are still a small platform and are growing quickly. As an early user, you have a vital role in shaping the future of the platform. You can help us set the scene and culture as we grow bigger, as well as test functionality and provide feedback as we develop new features.",
       "fill_in_profile": "Please take some time to explore the platform. As a first step, please write a bit about yourself on your profile. Please upload a photo and fill in some profile text, you can even copy your description from your account on other platforms if you're feeling lazy :P",
       "edit_profile_prompt": "To edit your profile, click on the following link:",
-      "edit_profile_action": "Complete your profile",
       "share_with_friends": "Otherwise, please share the link with any of your couch surfing friends that you trust! This platform can only grow with your help bringing the best people to it.",
-      "link": "Link: <a href=\"{{ url }}\">{{ url }}",
+      "link": "Link: <a href=\"{{ url }}\">{{ url }}</a>",
       "platform_under_development": "The platform is still under development, and features are actively being built by our amazing team of Couchers.org contributors around the world. We would like to hear your feedback and thoughts on what we've built and what we're working on.",
-      "thanks_for_joining": "Thanks so much for joining the platform. We're really excited to have you here and as part of our growing community!",
-      "signature": "Aapeli<br>Couchers.org Co-founder<br><a href=\"mailto:aapeli@couchers.org\">aapeli@couchers.org</a> (feel free to shoot me an email at any time)<br><br><a href=\"https://couchers.org/user/aapeli\">https://couchers.org/user/aapeli</a>"
+      "thanks_for_joining": "Thanks so much for joining the platform. We're really excited to have you here and as part of our growing community!"
     },
     "follow_up": {
-      "subject": "Complete your profile on Couchers.org",
+      "subject": "Complete your profile",
       "intro": "I hope you've taken a bit of time to look around the Couchers.org platform!",
-      "fill_in_profile": "We would love to ask one quick favor of you: please take a moment to fill out your profile by adding a photo and some text.",
-      "edit_profile_action": "Go to edit your profile",
-      "no_empty_accounts": "A big problem that some platforms have is that there are so many empty accounts, and we really want to avoid that!",
-      "profile_importance": "We would really appreciate it if you could add a photo and fill in at least the \"Who I am\" section of your profile, although a full profile would be even better! It's an easy way to help showcase the amazing community we're building together, and it means you'll be fully ready to connect, host, or surf as the community thrives.",
-      "signature": "Emily from Couchers.org<br><a href=\"mailto:community@couchers.org\">community@couchers.org</a><br><br><a href=\"https://couchers.org/user/emily\">https://couchers.org/user/emily</a>"
-    }
+      "request": "We would love to ask one quick favor of you: please take a moment to fill out your profile by adding a photo and some text. Full profiles help our community thrive and make others curious to connect with, surf with, or host you."
+    },
+    "edit_profile_action": "Complete your profile"
   },
   "password_changed": {
     "subject": "Your password was changed",
-    "body": "Your login password for Couchers.org was changed."
+    "purpose": "Your password on Couchers.org was changed."
   },
   "password_reset": {
     "started": {
-      "subject": "Reset your Couchers.org password",
-      "request_description": "You asked for your password to be reset on Couchers.org.",
-      "confirmation_instructions": "To complete this change, click on the following link:",
+      "subject": "Reset your password",
+      "purpose": "You asked for your password to be reset on Couchers.org. To complete this change, click on the following link:",
       "reset_action": "Reset your password"
     },
     "completed": {
       "subject": "Your password was successfully reset",
-      "body": "Your password on Couchers.org was changed. If that was you, then no further action is needed."
+      "purpose": "Your password on Couchers.org was reset."
     }
   },
   "phone_number_verification": {
     "started": {
       "subject": "Phone verification started",
-      "body": "You started phone number verification with the number <b>{{ phone_number }}</b>."
+      "purpose": "You started phone number verification with the number <b>{{ phone_number }}</b>."
     },
     "verified": {
       "subject": "Phone successfully verified",
-      "body": "Your phone was successfully verified as <b>{{ phone_number }}</b>."
+      "purpose": "Your phone number was successfully verified as <b>{{ phone_number }}</b>."
     }
   },
   "postal_verification": {
     "postcard_sent": {
       "subject": "Your verification postcard is on its way",
-      "body": "We've sent a postcard with your verification code to {{ city }}, {{ country }}. It should arrive within 1-3 weeks depending on your location. Once it arrives, enter the code on the platform to complete verification."
+      "purpose": "We've sent a postcard with your verification code to <b>{{ city }}, {{ country }}</b>. It should arrive within 1-3 weeks depending on your location. Once it arrives, use the following link to complete verification:",
+      "enter_code_action": "Enter postcard code"
     },
     "succeeded": {
       "subject": "Postal Verification succeeded",
-      "body": "You have been verified with Postal Verification! Your address has been confirmed."
+      "purpose": "Your address has been successfully verified with Postal Verification."
     },
     "failed": {
       "subject": "Postal Verification failed",
-      "reason_code_expired": "Your verification code has expired. Codes are valid for 90 days after the postcard is sent. You can start a new verification attempt.",
-      "reason_too_many_attempts": "Too many incorrect code attempts. You can start a new verification attempt.",
-      "reason_unknown": "Your postal verification attempt has failed. You can start a new verification attempt."
+      "purpose": {
+        "default": "Your Postal Verification attempt has failed for unknown reasons.",
+        "code_expired": "Your Postal Verification attempt has failed because your code has expired. Codes are valid for 90 days after the postcard is sent.",
+        "too_many_attempts": "Your Postal Verification has failed has failed because of too many incorrect code attempts."
+      },
+      "restart_action": "Request a new postcard"
     }
   },
   "references": {
     "received": {
       "friend": {
         "subject": "You've received a friend reference from {{name}}!",
-        "body": "<b>{{name}}</b> wrote a friend reference for you."
+        "purpose": "<b>{{name}}</b> wrote a friend reference for you:"
       },
       "hosted": {
-        "body": "<b>{{name}}</b> just wrote a reference for you from when you hosted them."
+        "purpose": "<b>{{name}}</b> wrote a reference for you from when you hosted them.",
+        "reciprocate_encouragement": "It's now your turn to write a reference for <b>{{name}}</b>. Once you submit it, both references will become visible. Otherwise, <b>{{name}}</b>'s reference will automatically become visible 14 days after their stay, and you will no longer be able to write yours."
       },
       "surfed": {
-        "body": "<b>{{name}}</b> just wrote a reference for you from when you surfed with them."
+        "purpose": "<b>{{name}}</b> wrote a reference for you from when you surfed with them.",
+        "reciprocate_encouragement": "It's now your turn to write a reference for <b>{{name}}</b>. Once you submit it, both references will become visible. Otherwise, <b>{{name}}</b>'s reference will automatically become visible 14 days after your stay, and you will no longer be able to write yours."
       },
       "subject": "You've received a reference from {{name}}!",
-      "before_quote": "This is what they wrote:",
-      "view_action": "View the reference on your profile",
-      "reciprocate_encouragement": "Please go and write a reference for them too. It's a nice gesture and helps us build a community together! When you've both written a reference, both references will become visible. Otherwise {{name}}'s reference will become visible 2 weeks after the end of your interaction, after which you cannot write a reference back."
+      "view_action": "View the reference"
     },
     "reminder": {
-      "subject_days_one": "You have {{count}} day to write a reference for {{name}}!",
-      "subject_days_other": "You have {{count}} days to write a reference for {{name}}!",
+      "subject_days_one": "You have {{count}} day to write a reference for {{name}}",
+      "subject_days_other": "You have {{count}} days to write a reference for {{name}}",
       "hosted": {
-        "body_days_one": "<b>You have {{count}} day left to write a reference for {{name}}</b> from when you hosted them.",
-        "body_days_other": "<b>You have {{count}} days left to write a reference for {{name}}</b> from when you hosted them."
+        "purpose_days_one": "<strong>You have {{count}} day left to write a reference for {{name}}</strong> from when you hosted them. Your reference is vital to keeping the community safe and trustworthy.",
+        "purpose_days_other": "<strong>You have {{count}} days left to write a reference for {{name}}</strong> from when you hosted them. Your reference is vital to keeping the community safe and trustworthy."
       },
       "surfed": {
-        "body_days_one": "<b>You have {{count}} day left to write a reference for {{name}}</b> from when you surfed with them.",
-        "body_days_other": "<b>You have {{count}} days left to write a reference for {{name}}</b> from when you surfed with them."
+        "purpose_days_one": "<strong>You have {{count}} day left to write a reference for {{name}}</strong> from when you surfed with them. Your reference is vital to keeping the community safe and trustworthy.",
+        "purpose_days_other": "<strong>You have {{count}} days left to write a reference for {{name}}</strong> from when you surfed with them. Your reference is vital to keeping the community safe and trustworthy."
       },
-      "importance_note": "Your reference is vital to keeping the community safe, trustworthy, and welcoming. By writing honestly and in detail about your experience with this person, you will directly help other members and contribute to safety and trust in the Couchers community.",
-      "no_meeting_note": "If you didn't end up meeting {{name}}, please use the reference flow to let us know (and we'll stop reminding you to write a reference).",
-      "via_messaging_note": "You can also leave a reference by going to the Messaging tab, locating the request, then clicking on the \"Write Reference\" button at the bottom of the conversation.",
+      "no_meeting_note": "If you didn't end up meeting <b>{{name}}</b>, please use that link to let us know, and we'll stop reminding you.",
       "visibility_note": "References will become visible 2 weeks after the stay, or when you've both written a reference for each other, whichever comes sooner."
     },
     "write_action": "Write a reference for {{name}}"
@@ -387,12 +381,11 @@
     "closing": "See you in a bit :)",
     "verify": {
       "thanks": "Thanks for signing up for Couchers.org!",
-      "instructions": "To finish setting up your account, please click on the following link to confirm your email:",
+      "instructions": "To finish setting up your account, please click on the following link:",
       "confirm_action": "Confirm your email address"
     },
     "continue": {
-      "request": "Please finish signing up for Couchers.org.",
-      "instructions": "Please click on this link to continue:",
+      "purpose": "Please finish signing up for Couchers.org. Click on this link to continue:",
       "continue_action": "Finish signing up",
       "ignore_if_unexpected": "If you did not request a signup, someone else did with your email, and you can safely ignore this message."
     }
@@ -400,22 +393,25 @@
   "strong_verification": {
     "succeeded": {
       "subject": "Strong Verification succeeded",
-      "success_message": "You have been verified with Strong Verification! You will now see a tick next to your name on the platform.",
-      "thanks_message": "Thanks for verifying—you're helping make Couchers.org safer for everyone.",
+      "purpose": "You have been verified with Strong Verification. You will now see a tick next to your name on the platform.",
+      "thanks_message": "Thanks for verifying! You're helping make Couchers.org safer for everyone.",
       "cost_explanation": "Verification is free for you, but it does come at a cost to us. As a nonprofit run by volunteers, we rely on donations to cover expenses like keeping our servers running, verification, and tools for volunteers and community builders.",
       "donation_request": "If you're able, please consider donating to help keep Couchers.org running and growing.",
       "donate_action": "Donate to support Couchers.org"
     },
     "failed": {
       "subject": "Strong Verification failed",
-      "reason_wrong_birthdate_or_gender": "The date of birth or gender on your profile does not match the date of birth or sex on your passport. Please contact the support team to update your date of birth or gender, or if your passport sex does not match your gender identity.",
-      "reason_not_a_passport": "You tried to verify with a document that is not a passport. You can only use a passport for Strong Verification.",
-      "reason_duplicate": "You tried to verify with a passport that has already been used for verification. Please use another passport."
+      "purpose": {
+        "wrong_birthdate_or_gender": "Your Strong Verification attempt has failed because the date of birth or gender on your profile does not match the date of birth or sex on your passport. Please contact the support team to update your date of birth or gender, or if your passport sex does not match your gender identity.",
+        "not_a_passport": "Your Strong Verification attempt has failed because you used a document that is not a passport. You can only use a passport for Strong Verification.",
+        "duplicate": "Your Strong Verification attempt has failed because you used a passport that has already been used on the platform. Please use another passport."
+      },
+      "restart_action": "Restart Strong Verification"
     }
   },
   "thread_reply": {
     "subject": "{{author}} replied in {{parent_context}}",
-    "body": "<b>{{author}}</b> replied in <b>{{parent_context}}</b>:",
+    "purpose": "<b>{{author}}</b> replied in <b>{{parent_context}}</b>:",
     "view_action": "View thread"
   }
 }

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -351,11 +351,11 @@
       },
       "hosted": {
         "purpose": "<b>{{name}}</b> wrote a reference for you from when you hosted them.",
-        "reciprocate_encouragement": "It's now your turn to write a reference for <b>{{name}}</b>. Once you submit it, both references will become visible. Otherwise, <b>{{name}}</b>'s reference will automatically become visible 14 days after their stay, and you will no longer be able to write yours."
+        "reciprocate_encouragement": "It's your turn to write a reference for <b>{{name}}</b>. Once you submit it, both references will become visible. Otherwise, <b>{{name}}</b>'s reference will automatically become visible 14 days after their stay, and you will no longer be able to write a reference."
       },
       "surfed": {
         "purpose": "<b>{{name}}</b> wrote a reference for you from when you surfed with them.",
-        "reciprocate_encouragement": "It's now your turn to write a reference for <b>{{name}}</b>. Once you submit it, both references will become visible. Otherwise, <b>{{name}}</b>'s reference will automatically become visible 14 days after your stay, and you will no longer be able to write yours."
+        "reciprocate_encouragement": "It's your turn to write a reference for <b>{{name}}</b>. Once you submit it, both references will become visible. Otherwise, <b>{{name}}</b>'s reference will automatically become visible 14 days after your stay, and you will no longer be able to write a reference."
       },
       "subject": "You've received a reference from {{name}}!",
       "view_action": "View the reference"
@@ -393,9 +393,9 @@
   "strong_verification": {
     "succeeded": {
       "subject": "Strong Verification succeeded",
-      "purpose": "You have been verified with Strong Verification. You will now see a tick next to your name on the platform.",
-      "thanks_message": "Thanks for verifying! You're helping make Couchers.org safer for everyone.",
-      "cost_explanation": "Verification is free for you, but it does come at a cost to us. As a nonprofit run by volunteers, we rely on donations to cover expenses like keeping our servers running, verification, and tools for volunteers and community builders.",
+      "purpose": "You have been verified with Strong Verification. You will now see a verification symbol next to your name on the platform.",
+      "thanks_message": "Thanks for getting verified! You're helping support trust and safety in the Couchers.org community.",
+      "cost_explanation": "Verification is free for you, but it does come at a cost to us. As a nonprofit run by volunteers, we rely on donations to cover expenses like keeping our servers running, verification, and tools for our software engineers, designers, and safety team.",
       "donation_request": "If you're able, please consider donating to help keep Couchers.org running and growing.",
       "donate_action": "Donate to support Couchers.org"
     },

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -166,8 +166,7 @@
     "updated": {
       "subject": "{{user}} updated {{title}}",
       "purpose_generic": "<b>{{user}}</b> updated an event you are subscribed to:",
-      "purpose_specific": "<b>{{user}}</b> updated an event you are subscribed to ({{items_list}}):",
-      "updated_generic": "Here is the updated event:",
+      "purpose_with_items": "<b>{{user}}</b> updated an event you are subscribed to ({{items_list}}):",
       "item_names": {
         "title": "title",
         "content": "content",

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -293,7 +293,7 @@
     "follow_up": {
       "subject": "Complete your profile",
       "intro": "I hope you've taken a bit of time to look around the Couchers.org platform!",
-      "request": "We would love to ask one quick favor of you: please take a moment to fill out your profile by adding a photo and some text. Filling out your profile makes others more interested in engaging with you and helps our community feel more welcoming."
+      "request": "We would love to ask one quick favor of you: please take a moment to fill out your profile by adding a photo and some text in the 'about me' and 'my home' sections. Filling out your profile makes others more interested in engaging with you and helps our community feel more welcoming."
     },
     "edit_profile_action": "Complete your profile"
   },

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -283,12 +283,12 @@
     "initial": {
       "subject": "Welcome to Couchers.org and the future of couch surfing",
       "welcome": "Welcome to Couchers.org, and our growing worldwide community of couch surfers. We are excited that you have joined us!",
-      "early_user_role": "We are still a small platform and are growing quickly. As an early user, you have a vital role in shaping the future of the platform. You can help us set the scene and culture as we grow bigger, as well as test functionality and provide feedback as we develop new features.",
-      "fill_in_profile": "Please take some time to explore the platform. As a first step, please write a bit about yourself on your profile. Please upload a photo and fill in some profile text, you can even copy your description from your account on other platforms if you're feeling lazy :P",
+      "early_user_role": "We’re an evolving platform experiencing rapid growth. As an early user, you have a vital role in shaping the future of the platform. You can help us set the scene and culture as we grow bigger, as well as test functionality and provide feedback as we develop new features.",
+      "fill_in_profile": "Please take some time to explore the platform. As a first step, please write a bit about yourself on the 'About me' and 'My home' tabs of your profile. Please upload a photo of yourself and fill in some profile text. You can even copy and paste the text from your account on a different couch surfing platform if you're feeling lazy :P",
       "edit_profile_prompt": "To edit your profile, click on the following link:",
       "share_with_friends": "Otherwise, please share the link with any of your couch surfing friends that you trust! This platform can only grow with your help bringing the best people to it.",
       "link": "Link: <a href=\"{{ url }}\">{{ url }}</a>",
-      "platform_under_development": "The platform is still under development, and features are actively being built by our amazing team of Couchers.org contributors around the world. We would like to hear your feedback and thoughts on what we've built and what we're working on.",
+      "platform_under_development": "The platform is still under development, and features are actively being built by our amazing team of Couchers.org volunteers around the world. We would like to hear your feedback and thoughts on what we've built and what we're working on.",
       "thanks_for_joining": "Thanks so much for joining the platform. We're really excited to have you here and as part of our growing community!"
     },
     "follow_up": {

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -294,7 +294,7 @@
     "follow_up": {
       "subject": "Complete your profile",
       "intro": "I hope you've taken a bit of time to look around the Couchers.org platform!",
-      "request": "We would love to ask one quick favor of you: please take a moment to fill out your profile by adding a photo and some text. Full profiles help our community thrive and make others curious to connect with, surf with, or host you."
+      "request": "We would love to ask one quick favor of you: please take a moment to fill out your profile by adding a photo and some text. Filling out your profile makes others more interested in engaging with you and helps our community feel more welcoming."
     },
     "edit_profile_action": "Complete your profile"
   },

--- a/app/backend/src/couchers/urls.py
+++ b/app/backend/src/couchers/urls.py
@@ -15,6 +15,10 @@ def icon_url() -> str:
     return f"{config.BASE_URL}/logo512.png"
 
 
+def dashboard_link() -> str:
+    return f"{config.BASE_URL}/dashboard"
+
+
 def profile_link() -> str:
     return f"{config.BASE_URL}/profile"
 
@@ -116,6 +120,10 @@ def donation_cancelled_url() -> str:
 
 def donation_success_url() -> str:
     return f"{config.BASE_URL}/donate?success=true"
+
+
+def strong_verification_url() -> str:
+    return f"{config.BASE_URL}/strong-verification"
 
 
 def complete_strong_verification_url(*, verification_attempt_token: str) -> str:

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -593,9 +593,9 @@ def test_ChangeEmailV2_sends_proper_emails(db, fast_passwords, push_collector: P
     with session_scope() as session:
         jobs = session.execute(select(BackgroundJob).where(BackgroundJob.job_type == "send_email")).scalars().all()
         assert len(jobs) == 2
-        uq_str1 = b"An email change to the email"
+        uq_str1 = b"Email address change initiated"
         uq_str2 = (
-            b"You requested that your email be changed to this email address on Couchers.org. Your old email address is"
+            b"You requested that your email be changed from"
         )
         assert (uq_str1 in jobs[0].payload and uq_str2 in jobs[1].payload) or (
             uq_str2 in jobs[0].payload and uq_str1 in jobs[1].payload
@@ -651,7 +651,7 @@ def test_DeleteAccount_start(db, email_collector: EmailCollector):
     with account_session(token) as account:
         account.DeleteAccount(account_pb2.DeleteAccountReq(confirm=True, reason=None))
         email = email_collector.pop_for_recipient(user.email, last=True)
-        assert email.subject == "[TEST] Confirm your Couchers.org account deletion"
+        assert email.subject == "[TEST] Confirm your account deletion"
 
     with session_scope() as session:
         deletion_token: AccountDeletionToken = session.execute(
@@ -690,10 +690,10 @@ def test_full_delete_account_with_recovery(db, email_collector: EmailCollector, 
         account.DeleteAccount(account_pb2.DeleteAccountReq(confirm=True))
 
     email = email_collector.pop_for_recipient(user.email, last=True)
-    assert email.subject == "[TEST] Confirm your Couchers.org account deletion"
+    assert email.subject == "[TEST] Confirm your account deletion"
     assert email.recipient == user.email
     assert "account deletion" in email.subject.lower()
-    unique_string = "You requested that we delete your account from Couchers.org."
+    unique_string = "You requested that we delete your Couchers.org account."
     assert unique_string in email.plain
     assert unique_string in email.html
     assert "support@couchers.org" in email.plain

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -727,7 +727,7 @@ def test_full_delete_account_with_recovery(db, email_collector: EmailCollector, 
     email = email_collector.pop_for_recipient(user.email, last=True)
     assert email.recipient == user.email
     assert "account has been deleted" in email.subject.lower()
-    unique_string = "You have successfully deleted your account from Couchers.org."
+    unique_string = "You have successfully deleted your Couchers.org account."
     assert unique_string in email.plain
     assert unique_string in email.html
     assert "7 days" in email.plain

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -594,9 +594,7 @@ def test_ChangeEmailV2_sends_proper_emails(db, fast_passwords, push_collector: P
         jobs = session.execute(select(BackgroundJob).where(BackgroundJob.job_type == "send_email")).scalars().all()
         assert len(jobs) == 2
         uq_str1 = b"Email address change initiated"
-        uq_str2 = (
-            b"You requested that your email be changed from"
-        )
+        uq_str2 = b"You requested that your email be changed from"
         assert (uq_str1 in jobs[0].payload and uq_str2 in jobs[1].payload) or (
             uq_str2 in jobs[0].payload and uq_str1 in jobs[1].payload
         )

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -764,7 +764,7 @@ def test_full_delete_account_with_recovery(db, email_collector: EmailCollector, 
     email = email_collector.pop_for_recipient(user.email, last=True)
     assert email.recipient == user.email
     assert "account has been recovered" in email.subject.lower()
-    unique_string = "Your account on Couchers.org has been successfully recovered!"
+    unique_string = "Your Couchers.org account has been successfully recovered."
     assert unique_string in email.plain
     assert unique_string in email.html
     assert "support@couchers.org" in email.plain

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -966,7 +966,7 @@ def test_friend_request_flow(db, email_collector: EmailCollector, push_collector
 
     email = email_collector.pop_for_recipient(user1.email, last=True)
     assert email.recipient == user1.email
-    assert email.subject == f"[TEST] {user2.name} accepted your friend request!"
+    assert email.subject == f"[TEST] {user2.name} accepted your friend request"
     assert user1.name in email.plain
     assert user1.name in email.html
     assert user2.name in email.plain

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -923,7 +923,7 @@ def test_friend_request_flow(db, email_collector: EmailCollector, push_collector
 
     email = email_collector.pop_for_recipient(user2.email, last=True)
     assert email.recipient == user2.email
-    assert email.subject == f"[TEST] {user1.name} wants to be your friend on Couchers.org!"
+    assert email.subject == f"[TEST] {user1.name} wants to be your friend"
     assert user2.name in email.plain
     assert user2.name in email.html
     assert user1.name in email.plain

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -1015,27 +1015,27 @@ def test_send_reference_reminders(db):
     expected_emails = [
         (
             "user11@couchers.org.invalid",
-            "[TEST] You have 14 days to write a reference for User 12!",
+            "[TEST] You have 14 days to write a reference for User 12",
             ("from when you hosted them", "/leave-reference/hosted/"),
         ),
         (
             "user4@couchers.org.invalid",
-            "[TEST] You have 3 days to write a reference for User 3!",
+            "[TEST] You have 3 days to write a reference for User 3",
             ("from when you surfed with them", "/leave-reference/surfed/"),
         ),
         (
             "user5@couchers.org.invalid",
-            "[TEST] You have 7 days to write a reference for User 6!",
+            "[TEST] You have 7 days to write a reference for User 6",
             ("from when you hosted them", "/leave-reference/hosted/"),
         ),
         (
             "user7@couchers.org.invalid",
-            "[TEST] You have 14 days to write a reference for User 8!",
+            "[TEST] You have 14 days to write a reference for User 8",
             ("from when you surfed with them", "/leave-reference/surfed/"),
         ),
         (
             "user8@couchers.org.invalid",
-            "[TEST] You have 14 days to write a reference for User 7!",
+            "[TEST] You have 14 days to write a reference for User 7",
             ("from when you hosted them", "/leave-reference/hosted/"),
         ),
     ]
@@ -1198,7 +1198,7 @@ def test_send_host_request_reminders(db, moderator):
     expected_emails = [
         (
             "user2@couchers.org.invalid",
-            "[TEST] You have a pending host request from User 1!",
+            "[TEST] You have a pending host request from User 1",
             ("Please respond to the request!", "User 1"),
         )
     ]

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -1199,7 +1199,7 @@ def test_send_host_request_reminders(db, moderator):
         (
             "user2@couchers.org.invalid",
             "[TEST] You have a pending host request from User 1",
-            ("Please respond to the request!", "User 1"),
+            ("User 1", "is waiting for your response"),
         )
     ]
 

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -422,7 +422,7 @@ This is a security email, you cannot unsubscribe from it.
 """
         )
 
-        assert "Thank you so much for your donation of $20 to Couchers.org." in email.html
+        assert "Thank you so much for your donation of <b>$20</b> to Couchers.org." in email.html
         assert email.sender_name == "Couchers.org"
         assert email.sender_email == "notify@couchers.org.invalid"
         assert email.recipient == "testing@couchers.org.invalid"

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -238,8 +238,8 @@ def test_email_changed_confirmation_sent_to_new_email(db, email_collector: Email
     assert user.name in email.html
     assert user.email in email.plain
     assert user.email in email.html
-    assert "Your old email address is" in email.plain
-    assert "Your old email address is" in email.html
+    assert "You requested that your email be changed from " in email.plain
+    assert "You requested that your email be changed from " in email.html
     assert f"http://localhost:3000/confirm-email?token={confirmation_token}" in email.plain
     assert f"http://localhost:3000/confirm-email?token={confirmation_token}" in email.html
     assert "support@couchers.org" in email.plain
@@ -401,7 +401,7 @@ def test_send_donation_email(db, monkeypatch):
 
 Thank you so much for your donation of $20 to Couchers.org.
 
-Your contribution will go towards building and sustaining the Couchers.org platform and community, and is vital for our goal of a completely free and non-profit generation of couch surfing.
+Your contribution will go towards building and sustaining the Couchers.org community, and is vital for our goal of a free and non-profit couch surfing platform.
 
 You can download an invoice and receipt for the donation here:
 
@@ -410,8 +410,6 @@ Download invoice: https://example.com/receipt/12345
 Couchers, Inc. is a 501(c)(3) nonprofit (EIN: 87-1734577) registered in the United States. No goods or services were provided in exchange for this contribution.
 
 If you have any questions about your donation, please email us at donations@couchers.org.
-
-Your generosity will help deliver the platform for everyone.
 
 Thank you!
 

--- a/app/backend/src/tests/test_jail.py
+++ b/app/backend/src/tests/test_jail.py
@@ -286,7 +286,7 @@ def test_modnotes(db, email_collector: EmailCollector, push_collector: PushColle
         )
 
     email = email_collector.pop_for_recipient(user.email, last=True)
-    assert email.subject == "[TEST] You have received a mod note"
+    assert email.subject == "[TEST] You have received a moderator note"
 
     push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "New moderator note"


### PR DESCRIPTION
Emails are about to be exposed for localization so I reviewed our copy holistically to improve it and make it more consistent, as to minimize chances we'll want to tweak the text once that means new work for 10+ translators.

This is by nature quite editorial and hard to do by committee. I wrote the principles I followed so in the emails.py header, where possible, please suggest improvements there rather than on specific instances.

Until CI kicks in, you can review all emails as HTML files here: https://drive.google.com/drive/folders/12HVJ-Gyt-LJCrwQQlXJ4ui6OzDVBA5cb?usp=sharing

The only email I haven't touched is the first onboarding reminder email. It's quite long and could be made more concise, but I didn't want to give it my voice since it's signed by Aapeli.

I also found that we have a first email asking for a reference that says "How was X's stay with you?", a friendlier tone than the "You have X days to write a reference" reminder emails.

(I'll fix the tests after the strings are reviewed since it's just sync'ing the new strings)

Fixes #8966

## Testing
Generated and reviewed all emails using `uv run dump-emails`.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me