### PR TITLE
Backend: add TRACE level to AdminActionLevel

### DIFF
--- a/app/backend/src/couchers/migrations/versions/0169_add_trace_admin_action_level.py
+++ b/app/backend/src/couchers/migrations/versions/0169_add_trace_admin_action_level.py
@@ -1,0 +1,25 @@
+"""Add trace to AdminActionLevel
+
+Revision ID: 0169
+Revises: 0168
+Create Date: 2026-06-20 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0169"
+down_revision = "0168"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 'trace' sorts below 'debug' so the enum's intrinsic ordering matches its severity
+    op.execute("ALTER TYPE adminactionlevel ADD VALUE IF NOT EXISTS 'trace' BEFORE 'debug'")
+
+
+def downgrade() -> None:
+    # PostgreSQL cannot drop a value from an enum type, so this is a no-op.
+    pass

--- a/app/backend/src/couchers/models/admin.py
+++ b/app/backend/src/couchers/models/admin.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 
 class AdminActionLevel(enum.Enum):
+    trace = enum.auto()
     debug = enum.auto()
     normal = enum.auto()
     high = enum.auto()

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -77,12 +77,14 @@ MAX_PAGINATION_LENGTH = 250
 
 
 adminactionlevel2api = {
+    AdminActionLevel.trace: admin_pb2.ADMIN_ACTION_LEVEL_TRACE,
     AdminActionLevel.debug: admin_pb2.ADMIN_ACTION_LEVEL_DEBUG,
     AdminActionLevel.normal: admin_pb2.ADMIN_ACTION_LEVEL_NORMAL,
     AdminActionLevel.high: admin_pb2.ADMIN_ACTION_LEVEL_HIGH,
 }
 
 api2adminactionlevel = {
+    admin_pb2.ADMIN_ACTION_LEVEL_TRACE: AdminActionLevel.trace,
     admin_pb2.ADMIN_ACTION_LEVEL_DEBUG: AdminActionLevel.debug,
     admin_pb2.ADMIN_ACTION_LEVEL_NORMAL: AdminActionLevel.normal,
     admin_pb2.ADMIN_ACTION_LEVEL_HIGH: AdminActionLevel.high,

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -1277,6 +1277,17 @@ def test_admin_actions_level(db):
         assert len(res.admin_actions) == 3
         assert res.admin_actions[2].level == admin_pb2.ADMIN_ACTION_LEVEL_HIGH
 
+        # Explicitly set to TRACE
+        res = api.AddAdminNote(
+            admin_pb2.AddAdminNoteReq(
+                user=normal_user.username,
+                admin_note="trace note",
+                level=admin_pb2.ADMIN_ACTION_LEVEL_TRACE,
+            )
+        )
+        assert len(res.admin_actions) == 4
+        assert res.admin_actions[3].level == admin_pb2.ADMIN_ACTION_LEVEL_TRACE
+
 
 def test_admin_actions_on_mutations(db, push_collector: PushCollector):
     super_user, super_token = generate_user(is_superuser=True)

--- a/app/proto/admin.proto
+++ b/app/proto/admin.proto
@@ -11,6 +11,7 @@ import "api.proto";
 
 enum AdminActionLevel {
   ADMIN_ACTION_LEVEL_UNSPECIFIED = 0;
+  ADMIN_ACTION_LEVEL_TRACE = 4;    // firehose, below debug
   ADMIN_ACTION_LEVEL_DEBUG = 1;    // low-importance chatter
   ADMIN_ACTION_LEVEL_NORMAL = 2;   // regular admin work
   ADMIN_ACTION_LEVEL_HIGH = 3;     // significant state changes


### PR DESCRIPTION
Adds a new `TRACE` admin action level below `DEBUG`, intended for firehose-level admin notes that are even lower importance than `DEBUG`.

Changes:
- `ADMIN_ACTION_LEVEL_TRACE` proto enum value (number `4`, new unused tag)
- `trace` member on the `AdminActionLevel` model enum (ordered first so its intrinsic enum ordering matches severity)
- Servicer mappings in both `adminactionlevel2api` and `api2adminactionlevel`
- Migration `0169` extending the postgres `adminactionlevel` enum type with `'trace'` BEFORE `'debug'`

## Testing
Extended `test_admin_actions_level` to add an admin note explicitly at `ADMIN_ACTION_LEVEL_TRACE` and assert it is persisted and returned. Ran `make format`, `make mypy` (clean), and the targeted test passes.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._