### PR TITLE
Backend/i18n: Externalize fallbacks languages from I18Next

### DIFF
--- a/app/backend/src/couchers/email/blocks.py
+++ b/app/backend/src/couchers/email/blocks.py
@@ -51,7 +51,7 @@ class EmailBase(ABC):
         standard_closing: bool = True,
         security_warning: bool = False,
     ) -> EmailBlocksBuilder:
-        builder = EmailBlocksBuilder(locale=loc_context.locale, string_key_base=self.string_key_base)
+        builder = EmailBlocksBuilder(locales=loc_context.locale_list, string_key_base=self.string_key_base)
         if standard_greeting:
             builder.para("generic.greeting_line", {"name": self.user_name})
         if standard_closing:
@@ -78,7 +78,7 @@ class EmailBase(ABC):
         self, loc_context: LocalizationContext, key: str, substitutions: SubstitutionDict | None = None
     ) -> str:
         key = full_string_key(key, relative_base=self.string_key_base)
-        return get_emails_i18next().localize(key, loc_context.locale, substitutions)
+        return loc_context.localize_string(key, i18next=get_emails_i18next(), substitutions=substitutions)
 
 
 @dataclass
@@ -153,13 +153,13 @@ class EmailBlocksBuilder:
     Builder object for constructing a list of localized EmailBlock's to form the body of an email.
     """
 
-    _locale: str
+    _locales: list[str]
     _string_key_base: str
     _blocks: list[EmailBlock]
     _epilogue: list[EmailBlock]
 
-    def __init__(self, locale: str, string_key_base: str):
-        self._locale = locale
+    def __init__(self, locales: list[str], string_key_base: str):
+        self._locales = locales
         self._string_key_base = string_key_base
         self._blocks = []
         self._epilogue = []
@@ -194,11 +194,11 @@ class EmailBlocksBuilder:
 
     def _text(self, key: str, substitutions: SubstitutionDict | None = None) -> str:
         key = full_string_key(key, relative_base=self._string_key_base)
-        return get_emails_i18next().localize(key, self._locale, substitutions)
+        return get_emails_i18next().localize(key, self._locales, substitutions)
 
     def _markup(self, key: str, substitutions: SubstitutionDict | None = None) -> Markup:
         key = full_string_key(key, relative_base=self._string_key_base)
-        return get_emails_i18next().localize_with_markup(key, self._locale, substitutions)
+        return get_emails_i18next().localize_with_markup(key, self._locales, substitutions)
 
 
 @dataclass(kw_only=True)

--- a/app/backend/src/couchers/email/calendar_events.py
+++ b/app/backend/src/couchers/email/calendar_events.py
@@ -42,12 +42,14 @@ def create_host_request_event(
     event.extra.append(ContentLine(name="SEQUENCE", value=str(sequence)))
 
     if hosting:
-        event.name = get_emails_i18next().localize(
-            "calendar_events.host_requests.title_host", loc_context.locale, {"name": other_name}
+        event.name = loc_context.localize_string(
+            "calendar_events.host_requests.title_host", i18next=get_emails_i18next(), substitutions={"name": other_name}
         )
     else:
-        event.name = get_emails_i18next().localize(
-            "calendar_events.host_requests.title_surfer", loc_context.locale, {"name": other_name}
+        event.name = loc_context.localize_string(
+            "calendar_events.host_requests.title_surfer",
+            i18next=get_emails_i18next(),
+            substitutions={"name": other_name},
         )
 
     # Our to_date is inclusive, iCalendar's DTEND is exclusive (for full-day events)
@@ -76,8 +78,8 @@ def create_host_request_cancellation_calendar(
     host_request: HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext
 ) -> Calendar:
     event = create_host_request_event(host_request, other_name, hosting, loc_context, sequence=1)
-    event.name = get_emails_i18next().localize(
-        "calendar_events.title_cancelled", loc_context.locale, {"title": event.name}
+    event.name = loc_context.localize_string(
+        "calendar_events.title_cancelled", i18next=get_emails_i18next(), substitutions={"title": event.name}
     )
     event.status = "CANCELLED"
 

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -633,7 +633,7 @@ class EventInfo:
         html += time_range_display
         if self.online_link:
             html += "<br>"
-            online_link_text = get_emails_i18next().localize("events.generic.online_link", loc_context.locale)
+            online_link_text = loc_context.localize_string("events.generic.online_link", i18next=get_emails_i18next())
             html += f'<i><a href="{escape(self.online_link)}">{escape(online_link_text)}</a></i>'
         elif self.address:
             html += "<br>"
@@ -645,7 +645,7 @@ class EventInfo:
         return QuoteBlock(text=Markup(self.description_markdown), markdown=True)
 
     def get_view_action_block(self, loc_context: LocalizationContext) -> EmailBlock:
-        view_action_text = get_emails_i18next().localize("events.generic.view_action", loc_context.locale)
+        view_action_text = loc_context.localize_string("events.generic.view_action", i18next=get_emails_i18next())
         return ActionBlock(text=view_action_text, target_url=self.view_url)
 
     @classmethod

--- a/app/backend/src/couchers/email/rendering.py
+++ b/app/backend/src/couchers/email/rendering.py
@@ -124,7 +124,7 @@ def _get_footer_template_args(footer: EmailFooter, loc_context: LocalizationCont
 
     def localize(key: str, substitutions: SubstitutionDict | None = None) -> Markup:
         key = full_string_key(key, relative_base="generic.footer")
-        return i18n.localize_with_markup(key, loc_context.locale, substitutions)
+        return i18n.localize_with_markup(key, loc_context.locale_list, substitutions)
 
     args: dict[str, Any] = {
         "received_because": localize(".received_because"),

--- a/app/backend/src/couchers/email/rendering.py
+++ b/app/backend/src/couchers/email/rendering.py
@@ -74,10 +74,10 @@ def render_plaintext_body(*, blocks: list[EmailBlock], footer: EmailFooter, loc_
             case ParaBlock():
                 concat.append(_to_plaintext(block.text))
             case UserBlock():
-                line = get_emails_i18next().localize(
+                line = loc_context.localize_string(
                     "plaintext_formats.user",
-                    loc_context.locale,
-                    {"name": block.info.name, "age": str(block.info.age), "city": block.info.city},
+                    i18next=get_emails_i18next(),
+                    substitutions={"name": block.info.name, "age": str(block.info.age), "city": block.info.city},
                 )
                 concat.append(line)
                 if block.comment:
@@ -87,8 +87,10 @@ def render_plaintext_body(*, blocks: list[EmailBlock], footer: EmailFooter, loc_
                 for line in block.text.splitlines():
                     concat.append(f"> {line}")
             case ActionBlock():
-                line = get_emails_i18next().localize(
-                    "plaintext_formats.action", loc_context.locale, {"text": block.text, "url": block.target_url}
+                line = loc_context.localize_string(
+                    "plaintext_formats.action",
+                    i18next=get_emails_i18next(),
+                    substitutions={"text": block.text, "url": block.target_url},
                 )
                 concat.append(line)
             case _:

--- a/app/backend/src/couchers/i18n/context.py
+++ b/app/backend/src/couchers/i18n/context.py
@@ -7,11 +7,11 @@ from zoneinfo import ZoneInfo
 import babel
 from google.protobuf.timestamp_pb2 import Timestamp
 
-from couchers.i18n.i18next import I18Next
+from couchers.i18n.i18next import I18Next, SubstitutionDict
 from couchers.i18n.locales import (
     DEFAULT_LOCALE,
     get_babel_locale,
-    get_locale_fallbacks,
+    get_locale_chain,
     get_main_i18next,
     is_supported_locale,
 )
@@ -52,7 +52,7 @@ class LocalizationContext:
             raise ValueError(f"Unsupported locale {locale}.")
 
         self.locale = locale
-        self.locale_list = [self.locale] + get_locale_fallbacks(self.locale)
+        self.locale_list = get_locale_chain(self.locale)
         self.timezone = timezone
         self.babel_locale = get_babel_locale(locale)
 
@@ -74,10 +74,10 @@ class LocalizationContext:
         return try_localize_region_name_from_iso3166(code, self.babel_locale)
 
     def localize_string(
-        self, key: str, *, i18next: I18Next | None = None, substitutions: dict[str, str | int] | None = None
+        self, key: str, *, i18next: I18Next | None = None, substitutions: SubstitutionDict | None = None
     ) -> str:
         i18next = i18next or get_main_i18next()
-        return i18next.localize(key, self.locale, substitutions=substitutions)
+        return i18next.localize(key, self.locale_list, substitutions=substitutions)
 
     def localize_list(self, items: Sequence[str]) -> str:
         return localize_list(items, self.babel_locale)

--- a/app/backend/src/couchers/i18n/i18next.py
+++ b/app/backend/src/couchers/i18n/i18next.py
@@ -28,9 +28,6 @@ class I18Next:
     def __init__(self) -> None:
         self.translations_by_locale: dict[str, Translation] = dict()
 
-        # The translation used to look up strings in unsupported locales.
-        self.default_translation: Translation | None = None
-
     def add_translation(self, locale: str, *, json_dict: dict[str, Any] | None = None) -> Translation:
         translation = Translation(babel_locale=babel.Locale.parse(locale, sep="-"))
         self.translations_by_locale[locale] = translation
@@ -38,35 +35,34 @@ class I18Next:
             translation.load_json_dict(json_dict)
         return translation
 
-    def find_string(self, key: str, locale: str, substitutions: SubstitutionDict | None = None) -> String | None:
-        """Find the string that will be localized, applying fallbacks and variant selection."""
-        translation = self.translations_by_locale.get(locale, self.default_translation)
-        candidate_translations = [translation] + translation.fallbacks if translation else []
-        for candidate_translation in candidate_translations:
-            if string := candidate_translation.find_string(key, substitutions):
-                if string.template.can_render(substitutions):
-                    return string
+    def find_string(self, key: str, locales: list[str], substitutions: SubstitutionDict | None = None) -> String | None:
+        """Find the string that will be localized, trying each locale in order."""
+        for locale in locales:
+            if t := self.translations_by_locale.get(locale):
+                if string := t.find_string(key, substitutions):
+                    if string.template.can_render(substitutions):
+                        return string
 
-        raise LocalizationError(locale, key)
+        raise LocalizationError(locales, key)
 
-    def localize(self, string_key: str, locale: str, substitutions: SubstitutionDict | None = None) -> str:
+    def localize(self, string_key: str, locales: list[str], substitutions: SubstitutionDict | None = None) -> str:
         """Finds a translated string in the best matching locale and performs substitutions."""
-        if string := self.find_string(string_key, locale, substitutions):
+        if string := self.find_string(string_key, locales, substitutions):
             return string.render(substitutions)
         else:
-            raise LocalizationError(locale, string_key)
+            raise LocalizationError(locales, string_key)
 
     def localize_with_markup(
-        self, string_key: str, locale: str, substitutions: SubstitutionDict | None = None
+        self, string_key: str, locales: list[str], substitutions: SubstitutionDict | None = None
     ) -> Markup:
         """
         Finds a translated string that might contain markup in the best matching locale,
         and performs substitutions in a way that results in a markup-safe string.
         """
-        if string := self.find_string(string_key, locale, substitutions):
+        if string := self.find_string(string_key, locales, substitutions):
             return string.render_with_markup(substitutions)
         else:
-            raise LocalizationError(locale, string_key)
+            raise LocalizationError(locales, string_key)
 
 
 class Translation:
@@ -76,7 +72,6 @@ class Translation:
         # The Babel library locale for this translation. Used to resolved plural forms.
         self.babel_locale = babel_locale
         self.strings_by_key: dict[str, String] = dict()
-        self.fallbacks: list[Translation] = []
 
     @property
     def locale(self) -> str:
@@ -116,13 +111,13 @@ class Translation:
     def localize(self, string_key: str, substitutions: SubstitutionDict | None = None) -> str:
         string = self.find_string(string_key, substitutions)
         if string is None:
-            raise LocalizationError(locale=self.locale, string_key=string_key)
+            raise LocalizationError(locales=[self.locale], string_key=string_key)
         return string.render(substitutions)
 
     def localize_with_markup(self, string_key: str, substitutions: SubstitutionDict | None = None) -> Markup:
         string = self.find_string(string_key, substitutions)
         if string is None:
-            raise LocalizationError(locale=self.locale, string_key=string_key)
+            raise LocalizationError(locales=[self.locale], string_key=string_key)
         return string.render_with_markup(substitutions)
 
 
@@ -203,12 +198,12 @@ class StringSegment:
 
 
 class LocalizationError(Exception):
-    """Raised failing to localize a string, e.g. if it is not found in any fallback locale."""
+    """Raised failing to localize a string, e.g. if it is not found in any of the given locales."""
 
-    def __init__(self, locale: str, string_key: str):
-        self.locale = locale
+    def __init__(self, locales: list[str], string_key: str):
+        self.locales = locales
         self.string_key = string_key
-        super().__init__(f"Could not localize string {string_key} for locale {locale}")
+        super().__init__(f"Could not localize string {string_key} for locales {locales}")
 
 
 def full_string_key(key: str, *, relative_base: str | None) -> str:

--- a/app/backend/src/couchers/i18n/locales.py
+++ b/app/backend/src/couchers/i18n/locales.py
@@ -63,13 +63,13 @@ def to_supported_locale(locale: str) -> str:
     return DEFAULT_LOCALE
 
 
-def get_locale_fallbacks(locale: str) -> list[str]:
-    """Gets the list of locales to which to fallback to if the given one is unavailable."""
+def get_locale_chain(locale: str) -> list[str]:
+    """Gets the ordered list of locales to try when looking up a string, starting with the given locale."""
     if fallback := _LOCALE_FALLBACKS.get(locale):
-        return [fallback, DEFAULT_LOCALE]
+        return [locale, fallback, DEFAULT_LOCALE]
     if locale == DEFAULT_LOCALE:
-        return []
-    return [DEFAULT_LOCALE]
+        return [locale]
+    return [locale, DEFAULT_LOCALE]
 
 
 def get_babel_locale(locale: str) -> babel.Locale:
@@ -99,12 +99,6 @@ def load_locales(directory: Path) -> I18Next:
     default_translation = i18next.translations_by_locale.get(DEFAULT_LOCALE)
     if default_translation is None:
         raise RuntimeError("English translations must be loaded")
-    i18next.default_translation = default_translation
-
-    # Apply fallbacks
-    for translation in i18next.translations_by_locale.values():
-        for fallback_locale in get_locale_fallbacks(translation.locale):
-            translation.fallbacks.append(i18next.translations_by_locale[fallback_locale])
 
     return i18next
 

--- a/app/backend/src/couchers/i18n/localize.py
+++ b/app/backend/src/couchers/i18n/localize.py
@@ -4,7 +4,7 @@ Most code should use the higher-level couchers.i18n.LocalizationContext object.
 """
 
 import re
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from datetime import date, datetime, time, tzinfo
 from typing import cast
 
@@ -13,23 +13,7 @@ import phonenumbers
 from babel.dates import get_datetime_format, get_timezone_name, match_skeleton, parse_pattern
 from babel.lists import format_list
 
-from couchers.i18n.locales import DEFAULT_LOCALE, get_main_i18next
 from couchers.resources import get_region_code_iso3166_alpha3_to_alpha2
-
-
-def localize_string(lang: str | None, key: str, *, substitutions: Mapping[str, str | int] | None = None) -> str:
-    """
-    Retrieves a translated string and performs substitutions.
-
-    Args:
-        lang: Language code (e.g., "en", "pt-BR"). If None, defaults to the default fallback language ("en")
-        key: The key for the string to be looked up.
-        substitutions: Dictionary of variable substitutions for the string (e.g., {"hours": 24})
-
-    Returns:
-        The translated string with substitutions applied
-    """
-    return get_main_i18next().localize(key, lang or DEFAULT_LOCALE, substitutions)
 
 
 def localize_list(items: Sequence[str], locale: babel.Locale) -> str:

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -195,7 +195,7 @@ def _get_string(
         full_key = f"{string_group.topic}.{string_group.action}.push.{key}"
     else:
         full_key = f"{string_group}.{key}"
-    return get_notifs_i18next().localize(full_key, loc_context.locale, substitutions)
+    return get_notifs_i18next().localize(full_key, loc_context.locale_list, substitutions)
 
 
 def _avatar_url_or_default(user: api_pb2.User) -> str:

--- a/app/backend/src/couchers/notifications/settings.py
+++ b/app/backend/src/couchers/notifications/settings.py
@@ -337,7 +337,7 @@ def get_user_setting_groups(
                 actions = []
                 for topic_action in items:
                     delivery_types = get_preference(session, user_id, topic_action)
-                    description = get_topic_action_description(topic_action, locale=loc_context.locale)
+                    description = get_topic_action_description(topic_action, locales=loc_context.locale_list)
                     actions.append(
                         notifications_pb2.NotificationItem(
                             action=topic_action.action,

--- a/app/backend/src/couchers/notifications/utils.py
+++ b/app/backend/src/couchers/notifications/utils.py
@@ -17,6 +17,6 @@ def can_notify_deleted_user(topic_action: NotificationTopicAction) -> bool:
     return topic_action in _DELETED_USER_NOTIFICATIONS
 
 
-def get_topic_action_description(topic_action: NotificationTopicAction, locale: str) -> str:
+def get_topic_action_description(topic_action: NotificationTopicAction, locales: list[str]) -> str:
     description_key = f"{topic_action.topic}.{topic_action.action}.event_description"
-    return get_notifs_i18next().localize(description_key, locale)
+    return get_notifs_i18next().localize(description_key, locales)

--- a/app/backend/src/tests/test_i18n_locales.py
+++ b/app/backend/src/tests/test_i18n_locales.py
@@ -3,6 +3,7 @@ import pytest
 from couchers.i18n.locales import (
     DEFAULT_LOCALE,
     get_babel_locale,
+    get_locale_chain,
     get_main_i18next,
     get_supported_locales,
     to_supported_locale,
@@ -51,17 +52,11 @@ def test_all_supported_locales_have_babel_locales():
         assert get_babel_locale(locale), f"Locale {locale} does not have a valid Babel locale"
 
 
-def test_fallback_chain():
+def test_get_locale_chain():
     """Test that fallbacks are correctly set up"""
-    i18next = get_main_i18next()
-
-    # Example: fr-CA should fallback to fr, which should fallback to en
-    fr_CA = i18next.translations_by_locale["fr-CA"]
-    fr = i18next.translations_by_locale["fr"]
-    en = i18next.translations_by_locale["en"]
-
-    assert fr_CA.fallbacks == [fr, en]
-    assert fr.fallbacks == [en]
-    assert en.fallbacks == []
-
-    assert i18next.default_translation == en
+    assert get_locale_chain("en") == ["en"]
+    assert get_locale_chain("pl") == ["pl", "en"]
+    assert get_locale_chain("xx") == ["xx", "en"]
+    assert get_locale_chain("fr-CA") == ["fr-CA", "fr", "en"]
+    assert get_locale_chain("pt") == ["pt", "pt-BR", "en"]
+    assert get_locale_chain("pt-BR") == ["pt-BR", "pt", "en"]

--- a/app/backend/src/tests/test_i18next.py
+++ b/app/backend/src/tests/test_i18next.py
@@ -8,19 +8,19 @@ from couchers.i18n.i18next import I18Next, LocalizationError, full_string_key
 def test_lookup():
     i18next = I18Next()
     i18next.add_translation("en").add_string("greeting", "hello")
-    assert i18next.localize("greeting", "en") == "hello"
+    assert i18next.localize("greeting", ["en"]) == "hello"
 
 
 def test_substitution():
     i18next = I18Next()
     i18next.add_translation("en").add_string("greeting", "hello {{name}}!")
-    assert i18next.localize("greeting", "en", {"name": "world"}) == "hello world!"
+    assert i18next.localize("greeting", ["en"], {"name": "world"}) == "hello world!"
 
 
 def test_placeholder_with_spacing():
     i18next = I18Next()
     i18next.add_translation("en").add_string("greeting", "hello {{ name }}!")
-    assert i18next.localize("greeting", "en", {"name": "world"}) == "hello world!"
+    assert i18next.localize("greeting", ["en"], {"name": "world"}) == "hello world!"
 
 
 def test_localized():
@@ -29,17 +29,15 @@ def test_localized():
     en.add_string("greeting", "hello")
     fr = i18next.add_translation("fr")
     fr.add_string("greeting", "bonjour")
-    fr.fallbacks.append(en)
-    assert i18next.localize("greeting", "fr") == "bonjour"
+    assert i18next.localize("greeting", ["fr", "en"]) == "bonjour"
 
 
 def test_fallback():
     i18next = I18Next()
     en = i18next.add_translation("en")
     en.add_string("greeting", "hello")
-    fr = i18next.add_translation("fr")
-    fr.fallbacks.append(en)
-    assert i18next.localize("greeting", "fr") == "hello"
+    i18next.add_translation("fr")
+    assert i18next.localize("greeting", ["fr", "en"]) == "hello"
 
 
 def test_mutual_fallback():
@@ -48,10 +46,8 @@ def test_mutual_fallback():
     pt_pt.add_string("greeting", "olá")
     pt_br = i18next.add_translation("pt-BR")
     pt_br.add_string("farewell", "tchau")
-    pt_pt.fallbacks.append(pt_br)
-    pt_br.fallbacks.append(pt_pt)
-    assert i18next.localize("greeting", "pt-BR") == "olá"
-    assert i18next.localize("farewell", "pt-PT") == "tchau"
+    assert i18next.localize("greeting", ["pt-BR", "pt-PT"]) == "olá"
+    assert i18next.localize("farewell", ["pt-PT", "pt-BR"]) == "tchau"
 
 
 def test_plural_suffixes():
@@ -59,8 +55,8 @@ def test_plural_suffixes():
     en = i18next.add_translation("en")
     en.add_string("apples_one", "{{count}} apple")
     en.add_string("apples_other", "{{count}} apples")
-    assert i18next.localize("apples", "en", {"count": 1}) == "1 apple"
-    assert i18next.localize("apples", "en", {"count": 2}) == "2 apples"
+    assert i18next.localize("apples", ["en"], {"count": 1}) == "1 apple"
+    assert i18next.localize("apples", ["en"], {"count": 2}) == "2 apples"
 
 
 def test_plural_suffix_fallback():
@@ -68,8 +64,8 @@ def test_plural_suffix_fallback():
     en = i18next.add_translation("en")
     en.add_string("apples", "{{count}} apples")
     en.add_string("apples_one", "{{count}} apple")
-    assert i18next.localize("apples", "en", {"count": 1}) == "1 apple"
-    assert i18next.localize("apples", "en", {"count": 2}) == "2 apples"
+    assert i18next.localize("apples", ["en"], {"count": 1}) == "1 apple"
+    assert i18next.localize("apples", ["en"], {"count": 2}) == "2 apples"
 
 
 def test_plural_no_count():
@@ -77,8 +73,8 @@ def test_plural_no_count():
     en = i18next.add_translation("en")
     en.add_string("apples_one", "apple")
     en.add_string("apples_other", "apples")
-    assert i18next.localize("apples", "en", {"count": 1}) == "apple"
-    assert i18next.localize("apples", "en", {"count": 2}) == "apples"
+    assert i18next.localize("apples", ["en"], {"count": 1}) == "apple"
+    assert i18next.localize("apples", ["en"], {"count": 2}) == "apples"
 
 
 def test_missing_babel_locale():
@@ -92,22 +88,14 @@ def test_load_simple_json():
     i18next = I18Next()
     en = i18next.add_translation("en")
     en.load_json_dict({"greeting": "hello"})
-    assert i18next.localize("greeting", "en") == "hello"
+    assert i18next.localize("greeting", ["en"]) == "hello"
 
 
 def test_load_nested_json():
     i18next = I18Next()
     en = i18next.add_translation("en")
     en.load_json_dict({"greeting": {"short": "hi"}})
-    assert i18next.localize("greeting.short", "en") == "hi"
-
-
-def test_fallback_locale():
-    i18next = I18Next()
-    en = i18next.add_translation("en")
-    en.add_string("greeting", "hello")
-    i18next.default_translation = en
-    assert i18next.localize("greeting", "fr") == "hello"
+    assert i18next.localize("greeting.short", ["en"]) == "hi"
 
 
 # An empty string in a translation should be considered as the lack of a string,
@@ -115,16 +103,15 @@ def test_fallback_locale():
 def test_fallback_on_empty_string():
     i18next = I18Next()
     en = i18next.add_translation("en", json_dict={"greeting": "hello"})
-    fr = i18next.add_translation("fr", json_dict={"greeting": ""})
-    fr.fallbacks.append(en)
-    assert i18next.localize("greeting", "fr") == "hello"
+    i18next.add_translation("fr", json_dict={"greeting": ""})
+    assert i18next.localize("greeting", ["fr", "en"]) == "hello"
 
 
 def test_missing_locale():
     i18next = I18Next()
     with pytest.raises(LocalizationError) as raised:
-        i18next.localize("greeting", "en")
-    assert raised.value.locale == "en"
+        i18next.localize("greeting", ["en"])
+    assert raised.value.locales == ["en"]
     assert raised.value.string_key == "greeting"
 
 
@@ -132,8 +119,8 @@ def test_missing_string():
     i18next = I18Next()
     i18next.add_translation("en")
     with pytest.raises(LocalizationError) as raised:
-        i18next.localize("greeting", "en")
-    assert raised.value.locale == "en"
+        i18next.localize("greeting", ["en"])
+    assert raised.value.locales == ["en"]
     assert raised.value.string_key == "greeting"
 
 
@@ -141,25 +128,25 @@ def test_missing_plural_form():
     i18next = I18Next()
     en = i18next.add_translation("en")
     en.add_string("apples_one", "{{count}} apple")
-    assert i18next.localize("apples", "en", {"count": 1}) == "1 apple"
+    assert i18next.localize("apples", ["en"], {"count": 1}) == "1 apple"
     with pytest.raises(LocalizationError) as raised:
-        i18next.localize("apples", "en", {"count": 2})
-    assert raised.value.locale == "en"
+        i18next.localize("apples", ["en"], {"count": 2})
+    assert raised.value.locales == ["en"]
     assert raised.value.string_key == "apples"
 
 
 def test_extra_substitution():
     i18next = I18Next()
     i18next.add_translation("en").add_string("greeting", "hello")
-    assert i18next.localize("greeting", "en", substitutions={"e": "mc2"})
+    assert i18next.localize("greeting", ["en"], substitutions={"e": "mc2"})
 
 
 def test_missing_substitution():
     i18next = I18Next()
     i18next.add_translation("en").add_string("greeting", "hello {{name}}")
     with pytest.raises(LocalizationError) as raised:
-        i18next.localize("greeting", "en")
-    assert raised.value.locale == "en"
+        i18next.localize("greeting", ["en"])
+    assert raised.value.locales == ["en"]
     assert raised.value.string_key == "greeting"
 
 
@@ -169,8 +156,7 @@ def test_missing_substitution_fallback():
     en.add_string("greeting", "hello {{name}}")
     fr = i18next.add_translation("fr")
     fr.add_string("greeting", "bonjour {{nom}}")
-    fr.fallbacks.append(en)
-    assert i18next.localize("greeting", "fr", substitutions={"name": "world"}) == "hello world"
+    assert i18next.localize("greeting", ["fr", "en"], substitutions={"name": "world"}) == "hello world"
 
 
 def test_escaping():
@@ -180,16 +166,17 @@ def test_escaping():
     # localize returns an str, which is considered untrusted for markup,
     # so it can contain tags because the renderer is resposible for escaping them.
     # Markup in this context is unescaped back into plaintext to avoid double-escaping.
-    assert i18next.localize("greeting", "en", substitutions={"name": "<script/>"}) == "hello <script/>"
-    assert i18next.localize("greeting", "en", substitutions={"name": Markup("&lt;script/&gt;")}) == "hello <script/>"
+    assert i18next.localize("greeting", ["en"], substitutions={"name": "<script/>"}) == "hello <script/>"
+    assert i18next.localize("greeting", ["en"], substitutions={"name": Markup("&lt;script/&gt;")}) == "hello <script/>"
 
     # localize_with_markup returns a Markup object, which is considered trusted for markup,
     # so it can only interpolate tags if they are also trusted, and otherwise will escape them.
     assert (
-        i18next.localize_with_markup("greeting", "en", substitutions={"name": "<script/>"}) == "hello &lt;script/&gt;"
+        i18next.localize_with_markup("greeting", ["en"], substitutions={"name": "<script/>"}) == "hello &lt;script/&gt;"
     )
     assert (
-        i18next.localize_with_markup("greeting", "en", substitutions={"name": Markup("<script/>")}) == "hello <script/>"
+        i18next.localize_with_markup("greeting", ["en"], substitutions={"name": Markup("<script/>")})
+        == "hello <script/>"
     )
 
 

--- a/app/backend/src/tests/test_notification_settings.py
+++ b/app/backend/src/tests/test_notification_settings.py
@@ -33,7 +33,7 @@ def test_all_notifications_appear_in_settings() -> None:
 def test_all_notifications_have_descriptions() -> None:
     for topic_action in NotificationTopicAction:
         # Will throw if there's no string
-        assert get_topic_action_description(topic_action, locale=DEFAULT_LOCALE) != ""
+        assert get_topic_action_description(topic_action, locales=[DEFAULT_LOCALE]) != ""
 
 
 def test_topic_action_unsubscribe_text_iff_unsubscribable() -> None:


### PR DESCRIPTION
Instead of baking the locale fallbacks into the `I18Next` object, pass a locales list when localizing strings.

This allows implementing all-or-nothing localization, say for emails, as follows (pseudocode):

```py
  try:
    return localize_emails(locales=["fr-CA", "fr"]) # No fallback to English, will raise an error.
  except LocalizationError:
    return localize_emails(locales=["en"])
```

It also splits the responsibility of knowing our fallback chain from the implementation of the I18Next format.

## Testing
Updated tests.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
