### PR TITLE
Devex: Remove "bug tool" label

### DIFF
--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -202,7 +202,7 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
             f"**Page**: {request.page}\n"
             f"**User**: {user_details} / `{(context._sofa or '')[:12]}`"
         )
-        issue_labels = ["bug tool", "bug: triage needed"]
+        issue_labels = ["bug: triage needed"]
 
         json_body = {"title": issue_title, "body": issue_body, "labels": issue_labels}
 

--- a/app/backend/src/tests/test_bugs.py
+++ b/app/backend/src/tests/test_bugs.py
@@ -69,7 +69,7 @@ results
             assert json == {
                 "title": "subject",
                 "body": expected_body,
-                "labels": ["bug tool", "bug: triage needed"],
+                "labels": ["bug: triage needed"],
             }
 
             class _PostReturn:
@@ -130,7 +130,7 @@ results
             assert json == {
                 "title": "subject",
                 "body": expected_body,
-                "labels": ["bug tool", "bug: triage needed"],
+                "labels": ["bug: triage needed"],
             }
 
             class _PostReturn:


### PR DESCRIPTION
The https://github.com/Couchers-org/bugs/issues repo is for report-a-problem bugs, so they're all "bug tool" and we can save a label.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
