### PR TITLE
Frontend/search: Show strong verif badges

### DIFF
--- a/app/web/components/StrongVerificationBadge.tsx
+++ b/app/web/components/StrongVerificationBadge.tsx
@@ -4,10 +4,10 @@ import { useTranslation } from "i18n";
 import { GLOBAL } from "i18n/namespaces";
 import React from "react";
 
-const StyledSpan = styled("span")(({ theme }) => ({
-  display: "inline-block",
+const StyledSpan = styled("span")(() => ({
+  display: "inline-flex",
+  alignItems: "center",
   verticalAlign: "middle",
-  marginLeft: theme.spacing(0.5),
 }));
 
 export default function StrongVerificationBadge() {

--- a/app/web/components/UserSummary.tsx
+++ b/app/web/components/UserSummary.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   ListItemAvatar,
   ListItemText,
   Skeleton,
@@ -16,6 +17,13 @@ import React, { useState } from "react";
 import useIsScreenSizeOrSmaller from "utils/useIsScreenSizeOrSmaller";
 
 import StrongVerificationBadge from "./StrongVerificationBadge";
+
+// It could be BlockedUser.AsObject or LiteUser.AsObject and only LiteUser has hasStrongVerification
+function isLiteUser(
+  user: LiteUser.AsObject | BlockedUser.AsObject,
+): user is LiteUser.AsObject {
+  return "hasStrongVerification" in user;
+}
 
 const StyledWrapper = styled("div")({
   display: "flex",
@@ -125,16 +133,14 @@ export default function UserSummary({
             sx={{ maxWidth: 300 }}
           />
         ) : (
-          <>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
             {nameOnly
               ? nameValue
               : `${nameValue}${user && "age" in user ? `, ${user.age}` : ""}`}
-            {user &&
-            "hasStrongVerification" in user &&
-            user.hasStrongVerification ? (
+            {isLiteUser(user) && user.hasStrongVerification && (
               <StrongVerificationBadge />
-            ) : null}
-          </>
+            )}
+          </Box>
         )}
       </Typography>
     </Tooltip>

--- a/app/web/features/profile/view/UserOverview.tsx
+++ b/app/web/features/profile/view/UserOverview.tsx
@@ -126,11 +126,9 @@ export default function UserOverview({
       )}
 
       <StyledWrapper>
-        <StyledIntro variant="h1">
-          <span>
-            {user.name}
-            {user.hasStrongVerification && <StrongVerificationBadge />}
-          </span>
+        <StyledIntro variant="h1" gap={0.5}>
+          {user.name}
+          {user.hasStrongVerification && <StrongVerificationBadge />}
         </StyledIntro>
         <StyledLink
           href={routeToUser(user.username)}

--- a/app/web/features/profile/view/UserOverview.tsx
+++ b/app/web/features/profile/view/UserOverview.tsx
@@ -129,7 +129,7 @@ export default function UserOverview({
         <StyledIntro variant="h1">
           <span>
             {user.name}
-            {user.hasStrongVerification ? <StrongVerificationBadge /> : null}
+            {user.hasStrongVerification && <StrongVerificationBadge />}
           </span>
         </StyledIntro>
         <StyledLink

--- a/app/web/features/search/SeachResultUserCard.tsx
+++ b/app/web/features/search/SeachResultUserCard.tsx
@@ -3,6 +3,7 @@ import { FlexboxProps, useMediaQuery } from "@mui/system";
 import Avatar from "components/Avatar";
 import { OpenInNewIcon } from "components/Icons";
 import ProfileLink from "components/ProfileLink/ProfileLink";
+import StrongVerificationBadge from "components/StrongVerificationBadge";
 import StyledLink from "components/StyledLink";
 import { useImpressionRef, useLogEvent } from "features/analytics/hooks";
 import { useSearchAnalytics } from "features/analytics/searchAnalyticsContext";
@@ -291,6 +292,10 @@ const SearchResultUserCard = ({
                   }}
                 >
                   {user.name}
+                  {"hasStrongVerification" in user &&
+                  user.hasStrongVerification ? (
+                    <StrongVerificationBadge />
+                  ) : null}
                 </Typography>
               </ProfileLink>
             </FlexRow>

--- a/app/web/features/search/SeachResultUserCard.tsx
+++ b/app/web/features/search/SeachResultUserCard.tsx
@@ -292,10 +292,7 @@ const SearchResultUserCard = ({
                   }}
                 >
                   {user.name}
-                  {"hasStrongVerification" in user &&
-                  user.hasStrongVerification ? (
-                    <StrongVerificationBadge />
-                  ) : null}
+                  {user.hasStrongVerification && <StrongVerificationBadge />}
                 </Typography>
               </ProfileLink>
             </FlexRow>

--- a/app/web/features/search/SeachResultUserCard.tsx
+++ b/app/web/features/search/SeachResultUserCard.tsx
@@ -292,9 +292,9 @@ const SearchResultUserCard = ({
                   }}
                 >
                   {user.name}
-                  {user.hasStrongVerification && <StrongVerificationBadge />}
                 </Typography>
               </ProfileLink>
+              {user.hasStrongVerification && <StrongVerificationBadge />}
             </FlexRow>
             {!isNativeEmbed && !isMobile && (
               <StyledLink


### PR DESCRIPTION
We forgot to show the strong verification badge in search results, where it's quite useful.

## Testing
Since NEXT doesn't have strong verified users, I injected `user.hasStrongVerification = true` for testing:

<img width="412" height="737" alt="image" src="https://github.com/user-attachments/assets/596728f2-3959-4354-a2ff-f9a6bf7fb783" />

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
