### PR TITLE
Frontend/i18n: Localize list separators

### DIFF
--- a/app/web/features/messages/groupchats/GroupChatListItem.tsx
+++ b/app/web/features/messages/groupchats/GroupChatListItem.tsx
@@ -67,7 +67,10 @@ export default function GroupChatListItem({
   className,
   isArchived = false,
 }: GroupChatListItemProps) {
-  const { t } = useTranslation(MESSAGES);
+  const {
+    t,
+    i18n: { language: locale },
+  } = useTranslation(MESSAGES);
   const currentUserId = useAuthContext().authState.userId!;
   const latestMessageAuthorId = groupChat.latestMessage?.authorUserId;
 
@@ -93,6 +96,7 @@ export default function GroupChatListItem({
     groupChatMembersQuery,
     currentUserId,
     t,
+    locale,
   );
   //text is the control message text or message text
   let text = "";

--- a/app/web/features/messages/groupchats/GroupChatView.tsx
+++ b/app/web/features/messages/groupchats/GroupChatView.tsx
@@ -97,7 +97,10 @@ export default function GroupChatView({
   chatId: number;
   embedded?: boolean;
 }) {
-  const { t } = useTranslation([GLOBAL, MESSAGES]);
+  const {
+    t,
+    i18n: { language: locale },
+  } = useTranslation([GLOBAL, MESSAGES]);
   const isNativeEmbed = useIsNativeEmbed();
 
   const queryClient = useQueryClient();
@@ -163,7 +166,13 @@ export default function GroupChatView({
   );
 
   const title = groupChat
-    ? groupChatTitleText(groupChat, groupChatMembersQuery, currentUserId, t)
+    ? groupChatTitleText(
+        groupChat,
+        groupChatMembersQuery,
+        currentUserId,
+        t,
+        locale,
+      )
     : undefined;
 
   const hasError = groupChatError || messagesError || sendMutation.error;

--- a/app/web/features/messages/utils.ts
+++ b/app/web/features/messages/utils.ts
@@ -1,4 +1,5 @@
 import { useLiteUsers } from "features/userQueries/useLiteUsers";
+import { localizeList } from "i18n/lists";
 import { TFunction } from "i18next";
 import { GroupChat, Message } from "proto/conversations_pb";
 import { HostRequest } from "proto/requests_pb";
@@ -88,20 +89,23 @@ export function groupChatTitleText(
   groupChatMembersQuery: ReturnType<typeof useLiteUsers>,
   currentUserId: number,
   t: TFunction<"messages", undefined>,
+  locale: string,
 ) {
   return groupChat.title
     ? groupChat.title
     : groupChatMembersQuery.isLoading
       ? "Chat"
-      : Array.from(groupChatMembersQuery.data?.values() ?? [])
-          .filter((user) => user?.userId !== currentUserId)
-          .map((user) => {
-            const firstNameUser = firstName(user?.name);
-            return firstNameUser === ""
-              ? t("messages:unknown_user")
-              : firstNameUser;
-          })
-          .join(", ");
+      : localizeList(
+          Array.from(groupChatMembersQuery.data?.values() ?? [])
+            .filter((user) => user?.userId !== currentUserId)
+            .map((user) => {
+              const firstNameUser = firstName(user?.name);
+              return firstNameUser === ""
+                ? t("messages:unknown_user")
+                : firstNameUser;
+            }),
+          { locale },
+        );
 }
 
 /** Returns the other user's username, or null if there are more than 2 users. */

--- a/app/web/features/messages/utils.ts
+++ b/app/web/features/messages/utils.ts
@@ -1,5 +1,5 @@
 import { useLiteUsers } from "features/userQueries/useLiteUsers";
-import { localizeList } from "i18n/lists";
+import { listSeparatorForLocale } from "i18n/lists";
 import { TFunction } from "i18next";
 import { GroupChat, Message } from "proto/conversations_pb";
 import { HostRequest } from "proto/requests_pb";
@@ -95,17 +95,15 @@ export function groupChatTitleText(
     ? groupChat.title
     : groupChatMembersQuery.isLoading
       ? "Chat"
-      : localizeList(
-          Array.from(groupChatMembersQuery.data?.values() ?? [])
-            .filter((user) => user?.userId !== currentUserId)
-            .map((user) => {
-              const firstNameUser = firstName(user?.name);
-              return firstNameUser === ""
-                ? t("messages:unknown_user")
-                : firstNameUser;
-            }),
-          { locale },
-        );
+      : Array.from(groupChatMembersQuery.data?.values() ?? [])
+          .filter((user) => user?.userId !== currentUserId)
+          .map((user) => {
+            const firstNameUser = firstName(user?.name);
+            return firstNameUser === ""
+              ? t("messages:unknown_user")
+              : firstNameUser;
+          })
+          .join(listSeparatorForLocale(locale));
 }
 
 /** Returns the other user's username, or null if there are more than 2 users. */

--- a/app/web/features/profile/view/About.tsx
+++ b/app/web/features/profile/view/About.tsx
@@ -2,6 +2,7 @@ import { styled, Typography, useTheme } from "@mui/material";
 import Divider from "components/Divider";
 import Markdown from "components/Markdown";
 import { useTranslation } from "i18n";
+import { localizeList } from "i18n/lists";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
 import { User } from "proto/api_pb";
 import { ComposableMap, Geographies, Geography } from "react-simple-maps";
@@ -23,7 +24,10 @@ const StyledDivider = styled(Divider)(({ theme }) => ({
 }));
 
 export default function About({ user }: AboutProps) {
-  const { t } = useTranslation([GLOBAL, PROFILE]);
+  const {
+    t,
+    i18n: { language: locale },
+  } = useTranslation([GLOBAL, PROFILE]);
   const theme = useTheme();
   const { regions } = useRegions();
   return (
@@ -75,16 +79,20 @@ export default function About({ user }: AboutProps) {
       </Typography>
       <Typography variant="body1">
         {regions && user.regionsVisitedList.length > 0
-          ? user.regionsVisitedList
-              .map((country) => regions[country])
-              .join(`, `)
+          ? localizeList(
+              user.regionsVisitedList.map((country) => regions[country]),
+              { locale },
+            )
           : t("profile:regions_empty_state")}
       </Typography>
       <StyledDivider />
       <Typography variant="h1">{t("profile:heading.lived_section")}</Typography>
       <Typography variant="body1">
         {regions && user.regionsLivedList.length > 0
-          ? user.regionsLivedList.map((country) => regions[country]).join(`, `)
+          ? localizeList(
+              user.regionsLivedList.map((country) => regions[country]),
+              { locale },
+            )
           : t("profile:regions_empty_state")}
       </Typography>
       <StyledDivider />

--- a/app/web/features/profile/view/About.tsx
+++ b/app/web/features/profile/view/About.tsx
@@ -2,7 +2,7 @@ import { styled, Typography, useTheme } from "@mui/material";
 import Divider from "components/Divider";
 import Markdown from "components/Markdown";
 import { useTranslation } from "i18n";
-import { localizeList } from "i18n/lists";
+import { listSeparatorForLocale } from "i18n/lists";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
 import { User } from "proto/api_pb";
 import { ComposableMap, Geographies, Geography } from "react-simple-maps";
@@ -79,20 +79,18 @@ export default function About({ user }: AboutProps) {
       </Typography>
       <Typography variant="body1">
         {regions && user.regionsVisitedList.length > 0
-          ? localizeList(
-              user.regionsVisitedList.map((country) => regions[country]),
-              { locale },
-            )
+          ? user.regionsVisitedList
+              .map((country) => regions[country])
+              .join(listSeparatorForLocale(locale))
           : t("profile:regions_empty_state")}
       </Typography>
       <StyledDivider />
       <Typography variant="h1">{t("profile:heading.lived_section")}</Typography>
       <Typography variant="body1">
         {regions && user.regionsLivedList.length > 0
-          ? localizeList(
-              user.regionsLivedList.map((country) => regions[country]),
-              { locale },
-            )
+          ? user.regionsLivedList
+              .map((country) => regions[country])
+              .join(listSeparatorForLocale(locale))
           : t("profile:regions_empty_state")}
       </Typography>
       <StyledDivider />

--- a/app/web/features/profile/view/userLabels.tsx
+++ b/app/web/features/profile/view/userLabels.tsx
@@ -3,7 +3,7 @@ import { CheckCircleIcon, ErrorIcon } from "components/Icons";
 import LabelAndText from "components/LabelAndText";
 import { useLanguages } from "features/profile/hooks/useLanguages";
 import { useTranslation } from "i18n";
-import { localizeList } from "i18n/lists";
+import { listSeparatorForLocale } from "i18n/lists";
 import { COMMUNITIES, GLOBAL, PROFILE } from "i18n/namespaces";
 import {
   BirthdateVerificationStatus,
@@ -250,12 +250,10 @@ export const AgeGenderLanguagesLabels = ({ user }: Props) => {
         <LabelAndText
           label={t("heading.languages_fluent")}
           text={
-            localizeList(
-              user.languageAbilitiesList.map(
-                (ability) => languages[ability.code],
-              ),
-              { locale },
-            ) || t("languages_fluent_false")
+            user.languageAbilitiesList
+              .map((ability) => languages[ability.code])
+              .join(listSeparatorForLocale(locale)) ||
+            t("languages_fluent_false")
           }
         />
       )}

--- a/app/web/features/profile/view/userLabels.tsx
+++ b/app/web/features/profile/view/userLabels.tsx
@@ -3,6 +3,7 @@ import { CheckCircleIcon, ErrorIcon } from "components/Icons";
 import LabelAndText from "components/LabelAndText";
 import { useLanguages } from "features/profile/hooks/useLanguages";
 import { useTranslation } from "i18n";
+import { localizeList } from "i18n/lists";
 import { COMMUNITIES, GLOBAL, PROFILE } from "i18n/namespaces";
 import {
   BirthdateVerificationStatus,
@@ -233,7 +234,10 @@ const AgeAndGenderRenderer = ({ user }: Props) => {
 };
 
 export const AgeGenderLanguagesLabels = ({ user }: Props) => {
-  const { t } = useTranslation("profile");
+  const {
+    t,
+    i18n: { language: locale },
+  } = useTranslation("profile");
   const { languages } = useLanguages();
 
   return (
@@ -246,9 +250,12 @@ export const AgeGenderLanguagesLabels = ({ user }: Props) => {
         <LabelAndText
           label={t("heading.languages_fluent")}
           text={
-            user.languageAbilitiesList
-              .map((ability) => languages[ability.code])
-              .join(", ") || t("languages_fluent_false")
+            localizeList(
+              user.languageAbilitiesList.map(
+                (ability) => languages[ability.code],
+              ),
+              { locale },
+            ) || t("languages_fluent_false")
           }
         />
       )}

--- a/app/web/i18n/lists.test.ts
+++ b/app/web/i18n/lists.test.ts
@@ -1,0 +1,13 @@
+import { listSeparatorForLocale } from "i18n/lists";
+
+describe("listSeparatorForLocale", () => {
+  it("works with known locales", () => {
+    expect(listSeparatorForLocale("en")).toEqual(", ");
+    expect(listSeparatorForLocale("fr")).toEqual(", ");
+    expect(listSeparatorForLocale("zh")).toEqual("、");
+  });
+
+  it("defaults to commas for unknown locales", () => {
+    expect(listSeparatorForLocale("xx")).toEqual(", ");
+  });
+});

--- a/app/web/i18n/lists.ts
+++ b/app/web/i18n/lists.ts
@@ -6,7 +6,8 @@ export function listSeparatorForLocale(locale: string) {
   if (!separator) {
     // Intl.ListFormat doesn't have a way to format a list without using "and"/"or".
     // But we can extract the mid-list separator it uses, which is robust for Western, CJK and Arabic.
-    const formatter = new Intl.ListFormat(locale, {
+    // If the local is unknown, fallback to English, which uses commas.
+    const formatter = new Intl.ListFormat([locale, "en"], {
       type: "conjunction",
       style: "long",
     });

--- a/app/web/i18n/lists.ts
+++ b/app/web/i18n/lists.ts
@@ -1,23 +1,18 @@
-const cache = new Map<string, Intl.ListFormat>();
+const cache = new Map<string, string>();
 
-/// Localizes a list of items with appropriate commas and such.
-export function localizeList(
-  items: string[],
-  {
-    locale,
-    type = "conjunction",
-    style = "long",
-  }: {
-    locale: string;
-    type?: Intl.ListFormatType;
-    style?: Intl.ListFormatStyle;
-  },
-): string {
-  const cacheKey = JSON.stringify({ locale, type, style });
-  let formatter = cache.get(cacheKey);
-  if (!formatter) {
-    formatter = new Intl.ListFormat(locale, { type, style });
-    cache.set(cacheKey, formatter);
+/// Gets the list separator for the given locale.
+export function listSeparatorForLocale(locale: string) {
+  let separator = cache.get(locale);
+  if (!separator) {
+    // Intl.ListFormat doesn't have a way to format a list without using "and"/"or".
+    // But we can extract the mid-list separator it uses, which is robust for Western, CJK and Arabic.
+    const formatter = new Intl.ListFormat(locale, {
+      type: "conjunction",
+      style: "long",
+    });
+    const formatParts = formatter.formatToParts(["a", "b", "c"]);
+    separator = formatParts.find((p) => p.type === "literal")?.value || ", ";
+    cache.set(locale, separator);
   }
-  return formatter.format(items);
+  return separator;
 }

--- a/app/web/i18n/lists.ts
+++ b/app/web/i18n/lists.ts
@@ -1,0 +1,23 @@
+const cache = new Map<string, Intl.ListFormat>();
+
+/// Localizes a list of items with appropriate commas and such.
+export function localizeList(
+  items: string[],
+  {
+    locale,
+    type = "conjunction",
+    style = "long",
+  }: {
+    locale: string;
+    type?: Intl.ListFormatType;
+    style?: Intl.ListFormatStyle;
+  },
+): string {
+  const cacheKey = JSON.stringify({ locale, type, style });
+  let formatter = cache.get(cacheKey);
+  if (!formatter) {
+    formatter = new Intl.ListFormat(locale, { type, style });
+    cache.set(cacheKey, formatter);
+  }
+  return formatter.format(items);
+}


### PR DESCRIPTION
Not all languages use the western comma. I'm not using `Intl.ListFormat` directly because it will always add "and" / "or", which we don't want in our current contexts.

## Testing
View a profile with regions visited:

<img width="288" height="78" alt="image" src="https://github.com/user-attachments/assets/5e1ecf4e-431f-4dac-9508-b23ecd63f2ab" />
<img width="252" height="77" alt="image" src="https://github.com/user-attachments/assets/c0f54ed9-ffdd-44b4-810c-756d9300fe94" />

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
