### PR TITLE
Frontend: Split key/labels in ProfileTagInput

### DIFF
--- a/app/web/features/profile/ProfileTagInput.tsx
+++ b/app/web/features/profile/ProfileTagInput.tsx
@@ -155,7 +155,10 @@ export default function ProfileTagInput({
 }: ProfileTagInputProps) {
   const { t } = useTranslation(PROFILE);
 
-  // If any value doesn't map to an option, add a fake option for it.
+  // In case some value doesn't map to an option, add a fake option for it.
+  // For example if value is [en, xx] and options is { en: "English", fr: "French" },
+  // then we extend to { en: "English", fr: "French", xx: "xx" },
+  // so the all values can be displayed.
   const effectiveOptions: Record<string, string> = {
     ...Object.fromEntries(value.map((k) => [k, k])),
     ...options,

--- a/app/web/features/profile/ProfileTagInput.tsx
+++ b/app/web/features/profile/ProfileTagInput.tsx
@@ -19,13 +19,18 @@ import React, { useRef, useState } from "react";
 import { ControllerRenderProps } from "react-hook-form";
 import { theme } from "theme";
 
+interface ProfileTagOption {
+  key: string;
+  label: string;
+}
+
 interface ProfileTagInputProps {
   onChange: (_: unknown, value: string[]) => void;
   value: string[];
-  options: string[];
+  // Possible options keys and their labels
+  options: Record<string, string>;
   label: string;
   id: string;
-  allowCsv?: boolean;
   className?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   inputFieldProps?: ControllerRenderProps<any, string>;
@@ -150,6 +155,12 @@ export default function ProfileTagInput({
 }: ProfileTagInputProps) {
   const { t } = useTranslation(PROFILE);
 
+  // If any value doesn't map to an option, add a fake option for it.
+  const effectiveOptions: Record<string, string> = {
+    ...Object.fromEntries(value.map((k) => [k, k])),
+    ...options,
+  };
+
   const [open, setOpen] = useState<boolean>(false);
   const anchorEl = useRef<null | HTMLButtonElement>(null);
   const [pendingValue, setPendingValue] = useState<string[]>([]);
@@ -170,10 +181,10 @@ export default function ProfileTagInput({
     setOpen(false);
   };
 
-  const handleRemove = (tag: string) => {
+  const handleRemove = (key: string) => {
     onChange(
       null,
-      value.filter((v) => v !== tag),
+      value.filter((v) => v !== key),
     );
   };
 
@@ -191,29 +202,32 @@ export default function ProfileTagInput({
         <ExpandMoreIcon />
       </StyledButtonBase>
       <StyledTagsContainer>
-        {value.map((tag) => (
-          <StyledTagWrapper key={tag}>
-            <IconButton
-              aria-label={t("profile_tag_input.remove_button_a11y_text", {
-                tag,
-              })}
-              edge="start"
-              onClick={() => handleRemove(tag)}
-              size="small"
-              sx={{
-                color: "var(--mui-palette-common-white)",
-                padding: 0.5,
-                "&:hover": {
-                  backgroundColor: "var(--mui-palette-primary-dark)",
+        {value.map((key) => {
+          const label = effectiveOptions[key];
+          return (
+            <StyledTagWrapper key={key}>
+              <IconButton
+                aria-label={t("profile_tag_input.remove_button_a11y_text", {
+                  tag: label,
+                })}
+                edge="start"
+                onClick={() => handleRemove(key)}
+                size="small"
+                sx={{
                   color: "var(--mui-palette-common-white)",
-                },
-              }}
-            >
-              <CloseIcon fontSize="small" />
-            </IconButton>
-            <StyledTagLabel>{tag}</StyledTagLabel>
-          </StyledTagWrapper>
-        ))}
+                  padding: 0.5,
+                  "&:hover": {
+                    backgroundColor: "var(--mui-palette-primary-dark)",
+                    color: "var(--mui-palette-common-white)",
+                  },
+                }}
+              >
+                <CloseIcon fontSize="small" />
+              </IconButton>
+              <StyledTagLabel>{label}</StyledTagLabel>
+            </StyledTagWrapper>
+          );
+        })}
       </StyledTagsContainer>
       {open && anchorEl.current && (
         <StyledPopper
@@ -222,28 +236,28 @@ export default function ProfileTagInput({
           anchorEl={anchorEl.current}
           placement="bottom-start"
         >
-          <Autocomplete
+          <Autocomplete<ProfileTagOption, true>
             {...inputFieldProps}
             open
             onClose={handleClose}
             multiple
             onChange={(_, newValue) => {
-              let uniqueValues: Set<string>;
               if (Array.isArray(newValue) && newValue.length) {
                 // For some reason I came across situations when there were undefined values in this array.
                 newValue = newValue.filter((element) => element !== undefined);
-
-                uniqueValues = new Set(newValue);
+                setPendingValue(
+                  Array.from(new Set(newValue.map((o) => o.key))),
+                );
               } else {
-                uniqueValues = new Set([]);
+                setPendingValue([]);
               }
-              setPendingValue(
-                Array.from(uniqueValues).filter(
-                  (value) => !/^\s*$/.test(value),
-                ),
-              );
             }}
-            value={pendingValue}
+            value={pendingValue.map((key) => ({
+              key,
+              label: effectiveOptions[key],
+            }))}
+            isOptionEqualToValue={(option, val) => option.key === val.key}
+            getOptionLabel={(option) => option.label}
             renderInput={(params) => (
               <StyledInputBase
                 ref={params.InputProps.ref}
@@ -253,9 +267,9 @@ export default function ProfileTagInput({
             )}
             disableCloseOnSelect
             disablePortal
-            options={options
-              .concat(pendingValue.filter((item) => options.indexOf(item) < 0))
-              .sort((a, b) => -b.localeCompare(a))}
+            options={Object.entries(effectiveOptions)
+              .map(([key, label]) => ({ key, label }))
+              .sort((a, b) => a.label.localeCompare(b.label))}
             renderOption={(props, option, { selected }) => {
               const { key, ...rest } = props;
 
@@ -267,7 +281,7 @@ export default function ProfileTagInput({
                     checked={selected}
                   />
 
-                  {option}
+                  {option.label}
                 </StyledAutocompleteOption>
               );
             }}

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -278,8 +278,8 @@ export default function EditProfileForm() {
     useState(false);
   const [showSuccessToast, setShowSuccessToast] = useState(false);
   const galleryEditorRef = useRef<HTMLDivElement>(null);
-  const { regions, regionsLookup } = useRegions();
-  const { languages, languagesLookup } = useLanguages();
+  const { regions } = useRegions();
+  const { languages } = useLanguages();
 
   const initialFormValues =
     user && languages && regions
@@ -292,14 +292,10 @@ export default function EditProfileForm() {
           hostingStatus: user.hostingStatus,
           meetupStatus: user.meetupStatus,
           fluentLanguages: user.languageAbilitiesList
-            .map((ability) => languages[ability.code] || "")
+            .map((ability) => ability.code)
             .filter(Boolean),
-          regionsVisited: user.regionsVisitedList
-            .map((region) => regions[region] || "")
-            .filter(Boolean),
-          regionsLived: user.regionsLivedList
-            .map((region) => regions[region] || "")
-            .filter(Boolean),
+          regionsVisited: user.regionsVisitedList,
+          regionsLived: user.regionsLivedList,
           aboutMe: user.aboutMe,
           thingsILike: user.thingsILike || DEFAULT_HOBBIES_HEADINGS,
           additionalInformation: user.additionalInformation,
@@ -378,15 +374,11 @@ export default function EditProfileForm() {
           profileData: {
             ...location,
             ...restData,
-            regionsVisited: regionsVisited.map(
-              (region) => (regionsLookup || {})[region],
-            ),
-            regionsLived: regionsLived.map(
-              (region) => (regionsLookup || {})[region],
-            ),
+            regionsVisited,
+            regionsLived,
             languageAbilities: {
               valueList: fluentLanguages.map((language) => ({
-                code: (languagesLookup || {})[language],
+                code: language,
                 fluency: LanguageAbility.Fluency.FLUENCY_FLUENT,
               })),
             },
@@ -848,7 +840,7 @@ export default function EditProfileForm() {
                   <Controller
                     control={control}
                     defaultValue={user.languageAbilitiesList.map(
-                      (ability) => languages[ability.code],
+                      (ability) => ability.code,
                     )}
                     name="fluentLanguages"
                     render={({ field }) => (
@@ -856,7 +848,7 @@ export default function EditProfileForm() {
                         inputFieldProps={field}
                         onChange={(_, value) => field.onChange(value)}
                         value={field.value}
-                        options={Object.values(languages)}
+                        options={languages}
                         label={t(
                           "profile:edit_profile_headings.languages_spoken",
                         )}
@@ -991,16 +983,14 @@ export default function EditProfileForm() {
                 <FieldGroup>
                   <Controller
                     control={control}
-                    defaultValue={user.regionsVisitedList.map(
-                      (region) => regions[region],
-                    )}
+                    defaultValue={user.regionsVisitedList}
                     name="regionsVisited"
                     render={({ field }) => (
                       <ProfileTagInput
                         inputFieldProps={field}
                         onChange={(_, values) => field.onChange(values)}
                         value={field.value}
-                        options={Object.values(regions)}
+                        options={regions}
                         label={t(
                           "profile:edit_profile_headings.regions_visited",
                         )}
@@ -1013,16 +1003,14 @@ export default function EditProfileForm() {
                 <FieldGroup>
                   <Controller
                     control={control}
-                    defaultValue={user.regionsLivedList.map(
-                      (region) => regions[region],
-                    )}
+                    defaultValue={user.regionsLivedList}
                     name="regionsLived"
                     render={({ field }) => (
                       <ProfileTagInput
                         inputFieldProps={field}
                         onChange={(_, values) => field.onChange(values)}
                         value={field.value}
-                        options={Object.values(regions)}
+                        options={regions}
                         label={t("profile:edit_profile_headings.regions_lived")}
                         id="regions-lived"
                       />

--- a/app/web/features/profile/hooks/useLanguages.ts
+++ b/app/web/features/profile/hooks/useLanguages.ts
@@ -3,27 +3,17 @@ import { languagesKey } from "features/queryKeys";
 import { service } from "service";
 
 export const useLanguages = () => {
-  const { data: { languages, languagesLookup } = {}, ...rest } = useQuery({
+  const { data: languages, ...rest } = useQuery({
     queryKey: [languagesKey],
     queryFn: () =>
-      service.resources.getLanguages().then((result) =>
-        result.languagesList.reduce(
-          (languagesResult, { code, name }) => {
-            languagesResult.languages[code] = name;
-            languagesResult.languagesLookup[name] = code;
-            return languagesResult;
-          },
-          {
-            languages: {} as { [code: string]: string },
-            languagesLookup: {} as { [name: string]: string },
-          },
+      service.resources
+        .getLanguages()
+        .then((result) =>
+          Object.fromEntries(
+            result.languagesList.map(({ code, name }) => [code, name]),
+          ),
         ),
-      ),
   });
 
-  return {
-    languages,
-    languagesLookup,
-    ...rest,
-  };
+  return { languages, ...rest };
 };

--- a/app/web/features/profile/hooks/useRegions.ts
+++ b/app/web/features/profile/hooks/useRegions.ts
@@ -3,27 +3,17 @@ import { regionsKey } from "features/queryKeys";
 import { service } from "service";
 
 export const useRegions = () => {
-  const { data, ...rest } = useQuery({
+  const { data: regions, ...rest } = useQuery({
     queryKey: [regionsKey],
     queryFn: () =>
-      service.resources.getRegions().then((result) =>
-        result.regionsList.reduce(
-          (regionsResult, { alpha3, name }) => {
-            regionsResult.regions[alpha3] = name;
-            regionsResult.regionsLookup[name] = alpha3;
-            return regionsResult;
-          },
-          {
-            regions: {} as { [code: string]: string },
-            regionsLookup: {} as { [name: string]: string },
-          },
+      service.resources
+        .getRegions()
+        .then((result) =>
+          Object.fromEntries(
+            result.regionsList.map(({ alpha3, name }) => [alpha3, name]),
+          ),
         ),
-      ),
   });
 
-  return {
-    regions: data?.regions,
-    regionsLookup: data?.regionsLookup,
-    ...rest,
-  };
+  return { regions, ...rest };
 };


### PR DESCRIPTION
Refactors `ProfileTagInput` to take key:label pairs as the list of options, for example `{ en: "English", fr: "French" }`. We still display the labels, but only expose the keys to consuming code since those are what the business logic needs. This way consumers don't need to map and reverse-map display strings.

This is related to and motivated by #8424: it will then make it trivial to translate spoken languages by providing a dictionary like `{ en: "Anglais", fr: "Français" }` since we have translation keys for (some) language codes.

No functional changes.

## Testing
Edited profile using the Vercel link on this PR.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
