### PR TITLE
Make clear who cancelled a request in message list view #9170

### DIFF
--- a/app/web/features/messages/locales/en.json
+++ b/app/web/features/messages/locales/en.json
@@ -191,13 +191,13 @@
     "host_status": {
       "accepted": "You have accepted this request",
       "accepted_waiting": "You have accepted this request — waiting for the surfer to confirm.",
-      "cancelled": "You have cancelled this request",
+      "cancelled": "The surfer has cancelled this request",
       "confirmed": "Have fun! You have accepted and the surfer has confirmed this request.",
       "rejected": "You have declined this request"
     },
     "surfer_status": {
       "accepted": "Have fun! {{name}} has accepted the request.",
-      "cancelled": "Your request was cancelled",
+      "cancelled": "You have cancelled this request",
       "confirmed": "Have fun! {{name}} accepted and you confirmed this request.",
       "rejected": "Your request was declined"
     }


### PR DESCRIPTION
Fixes https://github.com/Couchers-org/couchers/issues/9170

Was:

<img width="396" height="127" alt="image" src="https://github.com/user-attachments/assets/a8850cd1-e42b-471a-b718-ad1a8d67ac49" />


Now:

<img width="405" height="150" alt="image" src="https://github.com/user-attachments/assets/f9900e22-1df6-41c5-8429-44a0fd0222fe" />
