### PR TITLE
Include feature-flags.dev.json in backend Docker build context

### DIFF
--- a/app/backend/.dockerignore
+++ b/app/backend/.dockerignore
@@ -9,6 +9,7 @@
 !templates
 !alembic.ini
 !pyproject.toml
+!feature-flags.dev.json
 
 # It's not included into the final image, but is still needed here
 # for "--mount=type=bind"


### PR DESCRIPTION
The backend `.dockerignore` ignores everything and only allow-lists specific paths. `feature-flags.dev.json` (added in 892f073c1, "Switch to growthbook feature flags") was not in the allow-list, so `COPY . /app` in the Dockerfile silently excluded it from the build context. Because `backend.dev.env` sets `FEATURE_FLAGS_FILE_OVERRIDE_PATH=feature-flags.dev.json`, the backend crashed on startup with `FileNotFoundError: .../feature-flags.dev.json` — and rebuilding with `docker compose up --build` didn't help, since the file was never in the build context to begin with.

This adds `!feature-flags.dev.json` to the allow-list so it gets copied into the image.

## Testing
- `docker compose up --build` and confirm the backend starts without the `FileNotFoundError` from `setup_experimentation()`.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._