### PR TITLE
Backend/i18n: Make exclude_attending error string less technical.

### DIFF
--- a/app/backend/src/couchers/i18n/locales/en.json
+++ b/app/backend/src/couchers/i18n/locales/en.json
@@ -66,7 +66,7 @@
     "event_cant_update_old_event": "You can't modify, subscribe to, or attend to an event that's more than 1 day old.",
     "event_community_invite_already_approved": "A community invite has already been sent out for this event.",
     "event_community_invite_already_requested": "You have already requested a community invite for this event.",
-    "cannot_combine_attending_and_exclude_attending": "You cannot set both attending and exclude_attending.",
+    "cannot_combine_attending_and_exclude_attending": "Your filters cannot both include and exclude events you are attending.",
     "event_community_invite_not_found": "Couldn't find that event community invite.",
     "event_edit_permission_denied": "You're not allowed to edit that event.",
     "event_ends_before_starts": "The event must end after it starts.",


### PR DESCRIPTION
Reported by @c-kreuz . Those backend servicer errors should be user-readable even if the conditions are from a bug in our code.

## Testing
N/A, string only change

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
