### PR TITLE
Frontend: link "Pending" friend-request button to My Connections

### DIFF
--- a/app/web/features/connections/friends/FriendRequestsReceived.test.tsx
+++ b/app/web/features/connections/friends/FriendRequestsReceived.test.tsx
@@ -33,7 +33,7 @@ beforeEach(() => {
 
 afterEach(() => jest.restoreAllMocks());
 
-describe("FriendRequestsReceived with no ?friend-id query param", () => {
+describe("FriendRequestsReceived with no ?from query param", () => {
   it("shows the empty state message when there are no pending requests", async () => {
     render(<FriendRequestsReceived />, { wrapper });
 
@@ -62,9 +62,9 @@ describe("FriendRequestsReceived with no ?friend-id query param", () => {
   });
 });
 
-describe("FriendRequestsReceived with ?friend-id=<userId> query param", () => {
+describe("FriendRequestsReceived with ?from=<userId> query param", () => {
   it("does not show an alert when the expected request is present", async () => {
-    mockRouter.setCurrentUrl("/connections/friends/?friend-id=3");
+    mockRouter.setCurrentUrl("/connections/friends/?from=3");
     listFriendRequestsMock.mockResolvedValue({
       receivedList: [pendingRequestFromUser3],
       sentList: [],
@@ -79,7 +79,7 @@ describe("FriendRequestsReceived with ?friend-id=<userId> query param", () => {
   });
 
   it("shows an info alert when the expected request is not in the list", async () => {
-    mockRouter.setCurrentUrl("/connections/friends/?friend-id=3");
+    mockRouter.setCurrentUrl("/connections/friends/?from=3");
 
     render(<FriendRequestsReceived />, { wrapper });
 
@@ -91,7 +91,7 @@ describe("FriendRequestsReceived with ?friend-id=<userId> query param", () => {
   });
 
   it("shows an alert when requests exist but none are from the expected user", async () => {
-    mockRouter.setCurrentUrl("/connections/friends/?friend-id=3");
+    mockRouter.setCurrentUrl("/connections/friends/?from=3");
     listFriendRequestsMock.mockResolvedValue({
       receivedList: [
         {

--- a/app/web/features/connections/friends/FriendRequestsReceived.test.tsx
+++ b/app/web/features/connections/friends/FriendRequestsReceived.test.tsx
@@ -33,7 +33,7 @@ beforeEach(() => {
 
 afterEach(() => jest.restoreAllMocks());
 
-describe("FriendRequestsReceived with no ?from query param", () => {
+describe("FriendRequestsReceived with no ?friend-id query param", () => {
   it("shows the empty state message when there are no pending requests", async () => {
     render(<FriendRequestsReceived />, { wrapper });
 
@@ -62,9 +62,9 @@ describe("FriendRequestsReceived with no ?from query param", () => {
   });
 });
 
-describe("FriendRequestsReceived with ?from=<userId> query param", () => {
+describe("FriendRequestsReceived with ?friend-id=<userId> query param", () => {
   it("does not show an alert when the expected request is present", async () => {
-    mockRouter.setCurrentUrl("/connections/friends/?from=3");
+    mockRouter.setCurrentUrl("/connections/friends/?friend-id=3");
     listFriendRequestsMock.mockResolvedValue({
       receivedList: [pendingRequestFromUser3],
       sentList: [],
@@ -79,7 +79,7 @@ describe("FriendRequestsReceived with ?from=<userId> query param", () => {
   });
 
   it("shows an info alert when the expected request is not in the list", async () => {
-    mockRouter.setCurrentUrl("/connections/friends/?from=3");
+    mockRouter.setCurrentUrl("/connections/friends/?friend-id=3");
 
     render(<FriendRequestsReceived />, { wrapper });
 
@@ -91,7 +91,7 @@ describe("FriendRequestsReceived with ?from=<userId> query param", () => {
   });
 
   it("shows an alert when requests exist but none are from the expected user", async () => {
-    mockRouter.setCurrentUrl("/connections/friends/?from=3");
+    mockRouter.setCurrentUrl("/connections/friends/?friend-id=3");
     listFriendRequestsMock.mockResolvedValue({
       receivedList: [
         {

--- a/app/web/features/connections/friends/FriendRequestsReceived.tsx
+++ b/app/web/features/connections/friends/FriendRequestsReceived.tsx
@@ -75,14 +75,14 @@ function FriendRequestsReceived() {
   const { t } = useTranslation([CONNECTIONS]);
   const router = useRouter();
 
-  const friendIdParam = router.query["friend-id"];
-  const friendId = friendIdParam ? Number(friendIdParam) : null;
+  const fromUserId = router.query.from ? Number(router.query.from) : null;
   const requestNotFound =
-    friendId !== null &&
+    fromUserId !== null &&
     !isLoading &&
     data !== undefined &&
-    !data.some((req) => req.userId === friendId);
+    !data.some((req) => req.userId === fromUserId);
 
+  // Scroll to the user id from the URL parameter
   const highlightedCardRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (highlightedCardRef.current) {
@@ -91,7 +91,7 @@ function FriendRequestsReceived() {
         block: "center",
       });
     }
-  }, [friendId, data]);
+  }, [fromUserId, data]);
 
   return (
     <>
@@ -115,7 +115,7 @@ function FriendRequestsReceived() {
               key={friendRequest.friendRequestId}
               friend={friendRequest.friend}
               cardRef={
-                friendRequest.userId === friendId
+                friendRequest.userId === fromUserId
                   ? highlightedCardRef
                   : undefined
               }

--- a/app/web/features/connections/friends/FriendRequestsReceived.tsx
+++ b/app/web/features/connections/friends/FriendRequestsReceived.tsx
@@ -5,6 +5,7 @@ import { CONNECTIONS } from "i18n/namespaces";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { FriendRequest } from "proto/api_pb";
+import { useEffect, useRef } from "react";
 import { useIsMounted, useSafeState } from "utils/hooks";
 
 import type { SetMutationError } from ".";
@@ -74,12 +75,23 @@ function FriendRequestsReceived() {
   const { t } = useTranslation([CONNECTIONS]);
   const router = useRouter();
 
-  const fromUserId = router.query.from ? Number(router.query.from) : null;
+  const friendIdParam = router.query["friend-id"];
+  const friendId = friendIdParam ? Number(friendIdParam) : null;
   const requestNotFound =
-    fromUserId !== null &&
+    friendId !== null &&
     !isLoading &&
     data !== undefined &&
-    !data.some((req) => req.userId === fromUserId);
+    !data.some((req) => req.userId === friendId);
+
+  const highlightedCardRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (highlightedCardRef.current) {
+      highlightedCardRef.current.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
+    }
+  }, [friendId, data]);
 
   return (
     <>
@@ -102,6 +114,11 @@ function FriendRequestsReceived() {
             <FriendSummaryView
               key={friendRequest.friendRequestId}
               friend={friendRequest.friend}
+              cardRef={
+                friendRequest.userId === friendId
+                  ? highlightedCardRef
+                  : undefined
+              }
             >
               <RespondToFriendRequestAction
                 friendRequest={friendRequest}

--- a/app/web/features/connections/friends/FriendSummaryView.tsx
+++ b/app/web/features/connections/friends/FriendSummaryView.tsx
@@ -7,6 +7,7 @@ interface FriendSummaryViewProps {
   children?: React.ReactNode;
   friend?: LiteUser.AsObject | BlockedUser.AsObject;
   isProfileLink?: boolean;
+  cardRef?: React.Ref<HTMLDivElement>;
 }
 
 export const FRIEND_ITEM_TEST_ID = "friend-item";
@@ -33,10 +34,11 @@ function FriendSummaryView({
   children,
   friend,
   isProfileLink,
+  cardRef,
 }: FriendSummaryViewProps) {
   return friend ? (
     <>
-      <StyledFriendItem data-testid={FRIEND_ITEM_TEST_ID}>
+      <StyledFriendItem ref={cardRef} data-testid={FRIEND_ITEM_TEST_ID}>
         <UserSummary
           headlineComponent="h3"
           user={friend}

--- a/app/web/features/profile/actions/FriendActions.tsx
+++ b/app/web/features/profile/actions/FriendActions.tsx
@@ -24,12 +24,7 @@ export default function FriendActions({
     user.pendingFriendRequest &&
     user.pendingFriendRequest.sent === false
   ) {
-    return (
-      <PendingFriendReqButton
-        friendRequest={user.pendingFriendRequest}
-        setMutationError={setMutationError}
-      />
-    );
+    return <PendingFriendReqButton friendRequest={user.pendingFriendRequest} />;
   } else {
     return null;
   }

--- a/app/web/features/profile/actions/PendingFriendReqButton.tsx
+++ b/app/web/features/profile/actions/PendingFriendReqButton.tsx
@@ -20,7 +20,7 @@ function PendingFriendReqButton({
     <Button
       component={Link}
       startIcon={<PersonAddIcon />}
-      href={`${connectionsRoute}?friend-id=${friendRequest.userId}`}
+      href={`${connectionsRoute}?from=${friendRequest.userId}`}
     >
       {t("profile:connection_pending")}
     </Button>

--- a/app/web/features/profile/actions/PendingFriendReqButton.tsx
+++ b/app/web/features/profile/actions/PendingFriendReqButton.tsx
@@ -1,91 +1,29 @@
 import Button from "components/Button";
-import { CheckIcon, CloseIcon, PersonAddIcon } from "components/Icons";
-import Menu, { MenuItem } from "components/Menu";
-import type { SetMutationError } from "features/connections/friends";
-import useRespondToFriendRequest from "features/connections/friends/useRespondToFriendRequest";
+import { PersonAddIcon } from "components/Icons";
 import { PROFILE } from "i18n/namespaces";
+import Link from "next/link";
 import { useTranslation } from "next-i18next";
 import { FriendRequest } from "proto/api_pb";
-import React, { useRef, useState } from "react";
+import React from "react";
+import { connectionsRoute } from "routes";
 
 interface PendingFriendReqButtonProps {
   friendRequest: FriendRequest.AsObject;
-  setMutationError: SetMutationError;
 }
-
-const RESPOND_TO_FRIEND_REQUEST_MENU_ID =
-  "respond-to-friend-request-actions-menu";
 
 function PendingFriendReqButton({
   friendRequest,
-  setMutationError,
 }: PendingFriendReqButtonProps) {
-  const [isOpen, setIsOpen] = useState({
-    accepted: false,
-    declined: false,
-    menu: false,
-  });
-  const { isPending, isSuccess, respondToFriendRequest } =
-    useRespondToFriendRequest();
-  const menuAnchor = useRef<HTMLButtonElement>(null);
-
-  const handleClick = (item: keyof typeof isOpen) => () => {
-    if (item === "accepted") {
-      setIsOpen((prevState) => ({ ...prevState, menu: false }));
-      respondToFriendRequest({
-        accept: true,
-        friendRequest,
-        setMutationError,
-      });
-    } else if (item === "declined") {
-      setIsOpen((prevState) => ({ ...prevState, menu: false }));
-      respondToFriendRequest({
-        accept: false,
-        friendRequest,
-        setMutationError,
-      });
-    } else {
-      setIsOpen((prevState) => ({ ...prevState, menu: true }));
-    }
-  };
-
-  const handleClose = (item: keyof typeof isOpen) => () => {
-    setIsOpen((prevState) => ({ ...prevState, [item]: false }));
-  };
-
   const { t } = useTranslation([PROFILE]);
 
   return (
-    <>
-      {isSuccess ? null : (
-        <>
-          <Button
-            startIcon={<PersonAddIcon />}
-            ref={menuAnchor}
-            onClick={handleClick("menu")}
-            aria-controls={RESPOND_TO_FRIEND_REQUEST_MENU_ID}
-            loading={isPending}
-          >
-            {t("profile:connection_pending")}
-          </Button>
-          <Menu
-            anchorEl={menuAnchor.current}
-            id={RESPOND_TO_FRIEND_REQUEST_MENU_ID}
-            onClose={handleClose("menu")}
-            open={isOpen.menu}
-          >
-            <MenuItem onClick={handleClick("accepted")}>
-              <CheckIcon />
-              {t("profile:actions.accept_friend_label")}
-            </MenuItem>
-            <MenuItem onClick={handleClick("declined")}>
-              <CloseIcon />
-              {t("profile:actions.dismiss_friend_request_menuitem")}
-            </MenuItem>
-          </Menu>
-        </>
-      )}
-    </>
+    <Button
+      component={Link}
+      startIcon={<PersonAddIcon />}
+      href={`${connectionsRoute}?friend-id=${friendRequest.userId}`}
+    >
+      {t("profile:connection_pending")}
+    </Button>
   );
 }
 

--- a/app/web/features/profile/locales/en.json
+++ b/app/web/features/profile/locales/en.json
@@ -5,8 +5,6 @@
     "add_friend": "Add friend",
     "back_to_dashboard": "Back to dashboard",
     "message_label": "Message",
-    "accept_friend_label": "Accept",
-    "dismiss_friend_request_menuitem": "Dismiss",
     "request": "Request"
   },
   "heading": {


### PR DESCRIPTION
When visiting the profile page of user who sent you a friend request, the "pending" button now sends you to My Connections and scrolls to the request of interest.

Resolves #9130.

With help from [Claude Code](https://claude.ai/code)

## Testing
Ran local frontend. Made my browser window tiny to observe the scrolling effect.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me