### PR TITLE
Backend/SV: Differentiate failures due to birthdate vs gender mismatch

### DIFF
--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -1930,6 +1930,10 @@ class StrongVerificationFailedEmail(EmailBase):
         match self.reason:
             case notification_data_pb2.SV_FAIL_REASON_WRONG_BIRTHDATE_OR_GENDER:
                 reason_string_key = ".reason_wrong_birthdate_or_gender"
+            case notification_data_pb2.SV_FAIL_REASON_WRONG_BIRTHDATE:
+                reason_string_key = ".reason_wrong_birthdate"
+            case notification_data_pb2.SV_FAIL_REASON_WRONG_GENDER:
+                reason_string_key = ".reason_wrong_gender"
             case notification_data_pb2.SV_FAIL_REASON_NOT_A_PASSPORT:
                 reason_string_key = ".reason_not_a_passport"
             case notification_data_pb2.SV_FAIL_REASON_DUPLICATE:
@@ -1951,6 +1955,8 @@ class StrongVerificationFailedEmail(EmailBase):
         )
         return [
             replace(prototype, reason=notification_data_pb2.SV_FAIL_REASON_WRONG_BIRTHDATE_OR_GENDER),
+            replace(prototype, reason=notification_data_pb2.SV_FAIL_REASON_WRONG_BIRTHDATE),
+            replace(prototype, reason=notification_data_pb2.SV_FAIL_REASON_WRONG_GENDER),
             replace(prototype, reason=notification_data_pb2.SV_FAIL_REASON_NOT_A_PASSPORT),
             replace(prototype, reason=notification_data_pb2.SV_FAIL_REASON_DUPLICATE),
         ]

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -388,6 +388,8 @@
     "failed": {
       "subject": "Strong Verification failed",
       "reason_wrong_birthdate_or_gender": "The date of birth or gender on your profile does not match the date of birth or sex on your passport. Please contact the support team to update your date of birth or gender, or if your passport sex does not match your gender identity.",
+      "reason_wrong_birthdate": "The date of birth on your profile does not match the date of birth on your passport. Please contact the support team to update your date of birth.",
+      "reason_wrong_gender": "The gender on your profile does not match the sex on your passport. Please contact the support team to update your gender, or if your passport sex does not match your gender identity.",
       "reason_not_a_passport": "You tried to verify with a document that is not a passport. You can only use a passport for Strong Verification.",
       "reason_duplicate": "You tried to verify with a passport that has already been used for verification. Please use another passport."
     }

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -1011,14 +1011,20 @@ def finalize_strong_verification(payload: jobs_pb2.FinalizeStrongVerificationPay
                 key="",
             )
         else:
+            birthdate_ok = verification_attempt.matches_birthdate(user)
+            gender_ok = verification_attempt.matches_gender(user)
+            if not birthdate_ok and not gender_ok:
+                reason = notification_data_pb2.SV_FAIL_REASON_WRONG_BIRTHDATE_OR_GENDER
+            elif not birthdate_ok:
+                reason = notification_data_pb2.SV_FAIL_REASON_WRONG_BIRTHDATE
+            else:
+                reason = notification_data_pb2.SV_FAIL_REASON_WRONG_GENDER
             notify(
                 session,
                 user_id=verification_attempt.user_id,
                 topic_action=NotificationTopicAction.verification__sv_fail,
                 key="",
-                data=notification_data_pb2.VerificationSVFail(
-                    reason=notification_data_pb2.SV_FAIL_REASON_WRONG_BIRTHDATE_OR_GENDER
-                ),
+                data=notification_data_pb2.VerificationSVFail(reason=reason),
             )
 
 

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -953,12 +953,6 @@ def finalize_strong_verification(payload: jobs_pb2.FinalizeStrongVerificationPay
         nationality = json_data["nationality"]
         last_three_document_chars = json_data["document_number"][-3:]
 
-        verification_attempt.has_minimal_data = True
-        verification_attempt.passport_expiry_date = expiry_date
-        verification_attempt.passport_nationality = nationality
-        verification_attempt.passport_last_three_document_chars = last_three_document_chars
-
-        # Check whether there was already an attempt with this passport.
         existing_attempt = session.execute(
             select(StrongVerificationAttempt)
             .where(StrongVerificationAttempt.passport_expiry_date == expiry_date)
@@ -967,6 +961,11 @@ def finalize_strong_verification(payload: jobs_pb2.FinalizeStrongVerificationPay
             .order_by(StrongVerificationAttempt.id)
             .limit(1)
         ).scalar_one_or_none()
+
+        verification_attempt.has_minimal_data = True
+        verification_attempt.passport_expiry_date = expiry_date
+        verification_attempt.passport_nationality = nationality
+        verification_attempt.passport_last_three_document_chars = last_three_document_chars
 
         if existing_attempt:
             verification_attempt.status = StrongVerificationAttemptStatus.duplicate

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -953,6 +953,12 @@ def finalize_strong_verification(payload: jobs_pb2.FinalizeStrongVerificationPay
         nationality = json_data["nationality"]
         last_three_document_chars = json_data["document_number"][-3:]
 
+        verification_attempt.has_minimal_data = True
+        verification_attempt.passport_expiry_date = expiry_date
+        verification_attempt.passport_nationality = nationality
+        verification_attempt.passport_last_three_document_chars = last_three_document_chars
+
+        # Check whether there was already an attempt with this passport.
         existing_attempt = session.execute(
             select(StrongVerificationAttempt)
             .where(StrongVerificationAttempt.passport_expiry_date == expiry_date)
@@ -961,11 +967,6 @@ def finalize_strong_verification(payload: jobs_pb2.FinalizeStrongVerificationPay
             .order_by(StrongVerificationAttempt.id)
             .limit(1)
         ).scalar_one_or_none()
-
-        verification_attempt.has_minimal_data = True
-        verification_attempt.passport_expiry_date = expiry_date
-        verification_attempt.passport_nationality = nationality
-        verification_attempt.passport_last_three_document_chars = last_three_document_chars
 
         if existing_attempt:
             verification_attempt.status = StrongVerificationAttemptStatus.duplicate

--- a/app/backend/src/couchers/notifications/locales/en.json
+++ b/app/backend/src/couchers/notifications/locales/en.json
@@ -482,6 +482,8 @@
         "title": "Strong Verification failed",
         "ios_title": "Strong Verification Failed",
         "body_wrong_birthdate_gender": "The date of birth or gender on your profile does not match the date of birth or sex on your passport. Please contact the support team to update your date of birth or gender, or if your passport sex does not match your gender identity.",
+        "body_wrong_birthdate": "The date of birth on your profile does not match the date of birth on your passport. Please contact the support team to update your date of birth.",
+        "body_wrong_gender": "The gender on your profile does not match the sex on your passport. Please contact the support team to update your gender, or if your passport sex does not match your gender identity.",
         "body_not_a_passport": "You used a document other than a passport. You can only use a passport for Strong Verification.",
         "body_duplicate": "You used a passport that has already been used for verification. Please use another passport."
       }

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -850,6 +850,10 @@ def _render_verification__sv_fail(
     match data.reason:
         case notification_data_pb2.SV_FAIL_REASON_WRONG_BIRTHDATE_OR_GENDER:
             body_key = "body_wrong_birthdate_gender"
+        case notification_data_pb2.SV_FAIL_REASON_WRONG_BIRTHDATE:
+            body_key = "body_wrong_birthdate"
+        case notification_data_pb2.SV_FAIL_REASON_WRONG_GENDER:
+            body_key = "body_wrong_gender"
         case notification_data_pb2.SV_FAIL_REASON_NOT_A_PASSPORT:
             body_key = "body_not_a_passport"
         case notification_data_pb2.SV_FAIL_REASON_DUPLICATE:

--- a/app/backend/src/couchers/servicers/account.py
+++ b/app/backend/src/couchers/servicers/account.py
@@ -516,6 +516,7 @@ class Account(account_pb2_grpc.AccountServicer):
             StrongVerificationAttemptStatus.in_progress_waiting_on_user_in_app: account_pb2.STRONG_VERIFICATION_ATTEMPT_STATUS_IN_PROGRESS_WAITING_ON_USER_IN_APP,
             StrongVerificationAttemptStatus.in_progress_waiting_on_backend: account_pb2.STRONG_VERIFICATION_ATTEMPT_STATUS_IN_PROGRESS_WAITING_ON_BACKEND,
             StrongVerificationAttemptStatus.failed: account_pb2.STRONG_VERIFICATION_ATTEMPT_STATUS_FAILED,
+            StrongVerificationAttemptStatus.duplicate: account_pb2.STRONG_VERIFICATION_ATTEMPT_STATUS_FAILED,
         }
         return account_pb2.GetStrongVerificationAttemptStatusRes(
             status=status_to_pb.get(

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -806,7 +806,7 @@ def test_strong_verification_non_passport(db, monkeypatch, push_collector: PushC
     _, superuser_token = generate_user(is_superuser=True)
 
     MockSVFlow(user=user, token=token).process_iris_callbacks(
-        document_type="IDENTITY_CARD", expected_status=StrongVerificationAttemptStatus.failed
+        document_type="IDENTITY_CARD"
     )
 
     push = push_collector.pop_for_user(user.id, last=True)
@@ -823,7 +823,7 @@ def test_strong_verification_wrong_birthdate(db, monkeypatch, push_collector: Pu
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
 
     MockSVFlow(user=user, token=token).process_iris_callbacks(
-        date_of_birth=date.fromisoformat("1999-12-31"), expected_status=StrongVerificationAttemptStatus.failed
+        date_of_birth=date.fromisoformat("1999-12-31")
     )
 
     push = push_collector.pop_for_user(user.id, last=True)
@@ -840,7 +840,7 @@ def test_strong_verification_wrong_gender(db, monkeypatch, push_collector: PushC
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
 
     MockSVFlow(user=user, token=token).process_iris_callbacks(
-        sex=PassportSex.female, expected_status=StrongVerificationAttemptStatus.failed
+        sex=PassportSex.female
     )
 
     push = push_collector.pop_for_user(user.id, last=True)
@@ -860,7 +860,6 @@ def test_strong_verification_wrong_birthdate_and_gender(db, monkeypatch, push_co
     MockSVFlow(user=user, token=token).process_iris_callbacks(
         date_of_birth=date.fromisoformat("1999-12-31"),
         sex=PassportSex.female,
-        expected_status=StrongVerificationAttemptStatus.failed,
     )
 
     push = push_collector.pop_for_user(user.id, last=True)

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -816,8 +816,8 @@ def test_strong_verification_non_passport(db, monkeypatch, push_collector: PushC
     _, superuser_token = generate_user(is_superuser=True)
 
     MockSVFlow(user=user, token=token).process_iris_callbacks(
-        document_type="IDENTITY_CARD",
-        expected_status=StrongVerificationAttemptStatus.failed)
+        document_type="IDENTITY_CARD", expected_status=StrongVerificationAttemptStatus.failed
+    )
 
     push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Strong Verification failed"
@@ -832,9 +832,7 @@ def test_strong_verification_wrong_birthdate(db, monkeypatch, push_collector: Pu
 
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
 
-    MockSVFlow(user=user, token=token).process_iris_callbacks(
-        date_of_birth=date.fromisoformat("1999-12-31")
-    )
+    MockSVFlow(user=user, token=token).process_iris_callbacks(date_of_birth=date.fromisoformat("1999-12-31"))
 
     push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Strong Verification failed"
@@ -849,9 +847,7 @@ def test_strong_verification_wrong_gender(db, monkeypatch, push_collector: PushC
 
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
 
-    MockSVFlow(user=user, token=token).process_iris_callbacks(
-        sex=PassportSex.female
-    )
+    MockSVFlow(user=user, token=token).process_iris_callbacks(sex=PassportSex.female)
 
     push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Strong Verification failed"

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -1011,3 +1011,110 @@ def test_strong_verification_non_passport(db, monkeypatch, push_collector: PushC
         push.content.body
         == "You used a document other than a passport. You can only use a passport for Strong Verification."
     )
+
+
+def _run_sv_passport_mismatch(user, token, verification_id, sex, dob):
+    """Drive a passport SV attempt through to the final data pull with the given (mismatching) passport data."""
+    reference_data = do_and_check_sv(
+        user,
+        token,
+        verification_id=verification_id,
+        sex=sex,
+        dob=dob,
+        document_type="PASSPORT",
+        document_number="31195855",
+        document_expiry=default_expiry,
+        nationality="US",
+        return_after="APPROVED",
+    )
+
+    with patch("couchers.jobs.handlers.requests.post") as mock:
+        json_resp = {
+            "id": verification_id,
+            "created": "2024-05-11T15:46:46Z",
+            "expires": "2024-05-11T16:17:26Z",
+            "state": "APPROVED",
+            "reference": reference_data,
+            "user_ip": "10.123.123.123",
+            "user_agent": "Iris%20ID/168357896 CFNetwork/1494.0.7 Darwin/23.4.0",
+            "given_names": "John Wayne",
+            "surname": "Doe",
+            "nationality": "US",
+            "sex": sex,
+            "date_of_birth": dob,
+            "document_type": "PASSPORT",
+            "document_number": "31195855",
+            "expiry_date": default_expiry.isoformat(),
+            "issuing_country": "US",
+            "issuer": "Department of State, U.S. Government",
+            "portrait": "dGVzdHRlc3R0ZXN0...",
+        }
+        mock.return_value = type(
+            "__MockResponse",
+            (),
+            {
+                "status_code": 200,
+                "text": json.dumps(json_resp),
+                "json": lambda: json_resp,
+            },
+        )
+        while process_job():
+            pass
+
+    # the attempt itself succeeds, but the data doesn't match the profile so no badge is granted
+    with session_scope() as session:
+        verification_attempt = session.execute(
+            select(StrongVerificationAttempt).where(StrongVerificationAttempt.iris_session_id == verification_id)
+        ).scalar_one()
+        assert verification_attempt.user_id == user.id
+        assert verification_attempt.status == StrongVerificationAttemptStatus.succeeded
+
+
+def test_strong_verification_wrong_birthdate(db, monkeypatch, push_collector: PushCollector):
+    monkeypatch_sv_config(monkeypatch)
+
+    user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
+
+    # passport sex matches gender, but the date of birth doesn't match the profile
+    _run_sv_passport_mismatch(user, token, verification_id=5731012934821984, sex="MALE", dob="1999-12-31")
+
+    push = push_collector.pop_for_user(user.id, last=True)
+    assert push.content.title == "Strong Verification failed"
+    assert push.content.body == (
+        "The date of birth on your profile does not match the date of birth on your passport. "
+        "Please contact the support team to update your date of birth."
+    )
+
+
+def test_strong_verification_wrong_gender(db, monkeypatch, push_collector: PushCollector):
+    monkeypatch_sv_config(monkeypatch)
+
+    user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
+
+    # date of birth matches, but the passport sex doesn't match the gender on the profile
+    _run_sv_passport_mismatch(user, token, verification_id=5731012934821984, sex="FEMALE", dob="1988-01-01")
+
+    push = push_collector.pop_for_user(user.id, last=True)
+    assert push.content.title == "Strong Verification failed"
+    assert push.content.body == (
+        "The gender on your profile does not match the sex on your passport. "
+        "Please contact the support team to update your gender, or if your passport sex does not "
+        "match your gender identity."
+    )
+
+
+def test_strong_verification_wrong_birthdate_and_gender(db, monkeypatch, push_collector: PushCollector):
+    monkeypatch_sv_config(monkeypatch)
+
+    user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
+
+    # neither the date of birth nor the passport sex match the profile
+    _run_sv_passport_mismatch(user, token, verification_id=5731012934821984, sex="FEMALE", dob="1999-12-31")
+
+    push = push_collector.pop_for_user(user.id, last=True)
+    assert push.content.title == "Strong Verification failed"
+    assert push.content.body == (
+        "The date of birth or gender on your profile does not match the date of birth or sex on your "
+        "passport. Please contact the support team to update your date of birth or gender, or if your "
+        "passport sex does not match your gender identity."
+    )

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -173,7 +173,7 @@ class MockSVFlow:
         if document_expiry is None:
             document_expiry = date.today() + timedelta(days=5 * 365)
 
-        self._emulate_iris_callback("COMPLETED")
+        self._emulate_iris_callback("APPROVED")
 
         with account_session(self.token) as account:
             assert (

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -251,17 +251,27 @@ class MockSVFlow:
             ).scalar_one()
 
             assert verification_attempt.user_id == self.user.id
-            assert verification_attempt.status == expected_status
-            assert verification_attempt.has_full_data
-            assert verification_attempt.passport_encrypted_data
-            assert verification_attempt.passport_date_of_birth == date_of_birth
-            assert verification_attempt.passport_sex == sex
-            assert verification_attempt.has_minimal_data
-            assert verification_attempt.passport_expiry_date == document_expiry
-            assert verification_attempt.passport_nationality == nationality
-            assert verification_attempt.passport_last_three_document_chars == document_number[-3:]
             assert verification_attempt.iris_token == self.iris_token
             assert verification_attempt.iris_session_id == self.verification_id
+            assert verification_attempt.status == expected_status
+
+            # Check minimal data
+            if verification_attempt.status != StrongVerificationAttemptStatus.failed:
+                assert verification_attempt.has_minimal_data
+                assert verification_attempt.passport_expiry_date == document_expiry
+                assert verification_attempt.passport_nationality == nationality
+                assert verification_attempt.passport_last_three_document_chars == document_number[-3:]
+            else:
+                assert not verification_attempt.has_minimal_data
+
+            # Check full data
+            if verification_attempt.status == StrongVerificationAttemptStatus.succeeded:
+                assert verification_attempt.has_full_data
+                assert verification_attempt.passport_encrypted_data
+                assert verification_attempt.passport_date_of_birth == date_of_birth
+                assert verification_attempt.passport_sex == sex
+            else:
+                assert not verification_attempt.has_full_data
 
             # We should have gone through all IRIS callbacks
             private_key = bytes.fromhex("e6c2fbf3756b387bc09a458a7b85935718ef3eb1c2777ef41d335c9f6c0ab272")
@@ -806,8 +816,8 @@ def test_strong_verification_non_passport(db, monkeypatch, push_collector: PushC
     _, superuser_token = generate_user(is_superuser=True)
 
     MockSVFlow(user=user, token=token).process_iris_callbacks(
-        document_type="IDENTITY_CARD"
-    )
+        document_type="IDENTITY_CARD",
+        expected_status=StrongVerificationAttemptStatus.failed)
 
     push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Strong Verification failed"

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -270,14 +270,14 @@ class MockSVFlow:
                 assert verification_attempt.passport_encrypted_data
                 assert verification_attempt.passport_date_of_birth == date_of_birth
                 assert verification_attempt.passport_sex == sex
+
+                private_key = bytes.fromhex("e6c2fbf3756b387bc09a458a7b85935718ef3eb1c2777ef41d335c9f6c0ab272")
+                decrypted_data = json.loads(asym_decrypt(private_key, verification_attempt.passport_encrypted_data))
+                assert decrypted_data == json_resp
             else:
                 assert not verification_attempt.has_full_data
 
             # We should have gone through all IRIS callbacks
-            private_key = bytes.fromhex("e6c2fbf3756b387bc09a458a7b85935718ef3eb1c2777ef41d335c9f6c0ab272")
-            decrypted_data = json.loads(asym_decrypt(private_key, verification_attempt.passport_encrypted_data))
-            assert decrypted_data == json_resp
-
             callbacks = (
                 session.execute(
                     select(StrongVerificationCallbackEvent.iris_status)

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -36,204 +36,260 @@ def _(testconfig):
     pass
 
 
-def _emulate_iris_callback(session_id, session_state, reference):
-    assert session_state in ["CREATED", "INITIATED", "FAILED", "ABORTED", "COMPLETED", "REJECTED", "APPROVED"]
-    with real_iris_session() as iris:
-        data = json.dumps(
-            {"session_id": session_id, "session_state": session_state, "session_reference": reference}
-        ).encode("ascii")
-        iris.Webhook(httpbody_pb2.HttpBody(content_type="application/json", data=data))
+class MockSVFlow:
+    """Simulates the strong verification flow, including all IRIS callbacks."""
 
+    def __init__(self, user: User, token: str, verification_id: int = 5731012934821983) -> None:
+        self.user = user
+        self.token = token
+        self.verification_id = verification_id
 
-default_expiry = date.today() + timedelta(days=5 * 365)
+        iris_token_data = {
+            "merchant_id": 5731012934821982,
+            "session_id": self.verification_id,
+            "seed": 1674246339,
+            "face_verification": False,
+            "host": "https://passportreader.app",
+        }
+        self.iris_token = b64encode_unpadded(json.dumps(iris_token_data).encode("utf8"))
 
+        with account_session(self.token) as account:
+            # start by initiation
+            with patch("couchers.servicers.account.requests.post") as mock:
+                json_resp1 = {
+                    "id": self.verification_id,
+                    "token": self.iris_token,
+                }
+                mock.return_value = type(
+                    "__MockResponse",
+                    (),
+                    {
+                        "status_code": 200,
+                        "text": json.dumps(json_resp1),
+                        "json": lambda: json_resp1,
+                    },
+                )
+                res = account.InitiateStrongVerification(empty_pb2.Empty())
 
-def do_and_check_sv(
-    user,
-    token,
-    verification_id,
-    sex,
-    dob,
-    document_type,
-    document_number,
-    document_expiry,
-    nationality,
-    return_after=None,
-):
-    iris_token_data = {
-        "merchant_id": 5731012934821982,
-        "session_id": verification_id,
-        "seed": 1674246339,
-        "face_verification": False,
-        "host": "https://passportreader.app",
-    }
-    iris_token = b64encode_unpadded(json.dumps(iris_token_data).encode("utf8"))
+            mock.assert_called_once_with(
+                "https://passportreader.app/api/v1/session.create",
+                auth=("dummy_pubkey", "dummy_secret"),
+                json={
+                    "callback_url": "http://localhost:8888/iris/webhook",
+                    "face_verification": False,
+                    "passport_only": True,
+                    "reference": ANY,
+                },
+                timeout=10,
+                verify="/etc/ssl/certs/ca-certificates.crt",
+            )
+            self.reference_data = mock.call_args.kwargs["json"]["reference"]
+            self.verification_attempt_token = res.verification_attempt_token
+            return_url = f"http://localhost:3000/complete-strong-verification?verification_attempt_token={self.verification_attempt_token}"
+            assert res.redirect_url == "https://passportreader.app/open?" + urlencode(
+                {"token": self.iris_token, "redirect_url": return_url}
+            )
 
-    with account_session(token) as account:
-        # start by initiation
-        with patch("couchers.servicers.account.requests.post") as mock:
-            json_resp1 = {
-                "id": verification_id,
-                "token": iris_token,
+            assert (
+                account.GetStrongVerificationAttemptStatus(
+                    account_pb2.GetStrongVerificationAttemptStatusReq(
+                        verification_attempt_token=self.verification_attempt_token
+                    )
+                ).status
+                == account_pb2.STRONG_VERIFICATION_ATTEMPT_STATUS_IN_PROGRESS_WAITING_ON_USER_TO_OPEN_APP
+            )
+
+    def process_iris_callbacks(
+        self,
+        *,
+        nationality: str = "US",
+        sex: PassportSex | None = None,
+        date_of_birth: date | None = None,
+        document_type: str = "PASSPORT",
+        document_number: str = "31195855",
+        document_expiry: date | None = None,
+        expected_status: StrongVerificationAttemptStatus = StrongVerificationAttemptStatus.succeeded,
+    ) -> None:
+        self.process_iris_initiated_callback()
+        self.process_iris_completed_callback()
+        self.process_iris_approved_callback(
+            nationality=nationality,
+            sex=sex,
+            date_of_birth=date_of_birth,
+            document_type=document_type,
+            document_number=document_number,
+            document_expiry=document_expiry,
+            expected_status=expected_status,
+        )
+
+    def process_iris_initiated_callback(self) -> None:
+        # ok, now the user downloads the app, scans their id, and Iris ID sends callbacks to the server
+        self._emulate_iris_callback("INITIATED")
+
+        with account_session(self.token) as account:
+            assert (
+                account.GetStrongVerificationAttemptStatus(
+                    account_pb2.GetStrongVerificationAttemptStatusReq(
+                        verification_attempt_token=self.verification_attempt_token
+                    )
+                ).status
+                == account_pb2.STRONG_VERIFICATION_ATTEMPT_STATUS_IN_PROGRESS_WAITING_ON_USER_IN_APP
+            )
+
+    def process_iris_completed_callback(self) -> None:
+        self._emulate_iris_callback("COMPLETED")
+
+        with account_session(self.token) as account:
+            assert (
+                account.GetStrongVerificationAttemptStatus(
+                    account_pb2.GetStrongVerificationAttemptStatusReq(
+                        verification_attempt_token=self.verification_attempt_token
+                    )
+                ).status
+                == account_pb2.STRONG_VERIFICATION_ATTEMPT_STATUS_IN_PROGRESS_WAITING_ON_BACKEND
+            )
+
+    def process_iris_approved_callback(
+        self,
+        *,
+        nationality: str = "US",
+        sex: PassportSex | None = None,
+        date_of_birth: date | None = None,
+        document_type: str = "PASSPORT",
+        document_number: str = "31195855",
+        document_expiry: date | None = None,
+        expected_status: StrongVerificationAttemptStatus = StrongVerificationAttemptStatus.succeeded,
+    ) -> None:
+        if sex is None:
+            match self.user.gender:
+                case "Man":
+                    sex = PassportSex.male
+                case "Woman":
+                    sex = PassportSex.female
+                case _:
+                    sex = PassportSex.unspecified
+        if date_of_birth is None:
+            date_of_birth = self.user.birthdate
+        if document_expiry is None:
+            document_expiry = date.today() + timedelta(days=5 * 365)
+
+        self._emulate_iris_callback("COMPLETED")
+
+        with account_session(self.token) as account:
+            assert (
+                account.GetStrongVerificationAttemptStatus(
+                    account_pb2.GetStrongVerificationAttemptStatusReq(
+                        verification_attempt_token=self.verification_attempt_token
+                    )
+                ).status
+                == account_pb2.STRONG_VERIFICATION_ATTEMPT_STATUS_IN_PROGRESS_WAITING_ON_BACKEND
+            )
+
+        with patch("couchers.jobs.handlers.requests.post") as mock:
+            json_resp = {
+                "id": self.verification_id,
+                "created": "2024-05-11T15:46:46Z",
+                "expires": "2024-05-11T16:17:26Z",
+                "state": "APPROVED",
+                "reference": self.reference_data,
+                "user_ip": "10.123.123.123",
+                "user_agent": "Iris%20ID/168357896 CFNetwork/1494.0.7 Darwin/23.4.0",
+                "given_names": "John Wayne",
+                "surname": "Doe",
+                "nationality": nationality,
+                "sex": sex.name.upper(),
+                "date_of_birth": date_of_birth.isoformat(),
+                "document_type": document_type,
+                "document_number": document_number,
+                "expiry_date": document_expiry.isoformat(),
+                "issuing_country": nationality,
+                "issuer": "Department of State, U.S. Government",
+                "portrait": "dGVzdHRlc3R0ZXN0...",
             }
             mock.return_value = type(
                 "__MockResponse",
                 (),
                 {
                     "status_code": 200,
-                    "text": json.dumps(json_resp1),
-                    "json": lambda: json_resp1,
+                    "text": json.dumps(json_resp),
+                    "json": lambda: json_resp,
                 },
             )
-            res = account.InitiateStrongVerification(empty_pb2.Empty())
+            while process_job():
+                pass
+
         mock.assert_called_once_with(
-            "https://passportreader.app/api/v1/session.create",
+            "https://passportreader.app/api/v1/session.get",
             auth=("dummy_pubkey", "dummy_secret"),
-            json={
-                "callback_url": "http://localhost:8888/iris/webhook",
-                "face_verification": False,
-                "passport_only": True,
-                "reference": ANY,
-            },
+            json={"id": self.verification_id},
             timeout=10,
             verify="/etc/ssl/certs/ca-certificates.crt",
         )
-        reference_data = mock.call_args.kwargs["json"]["reference"]
-        verification_attempt_token = res.verification_attempt_token
-        return_url = f"http://localhost:3000/complete-strong-verification?verification_attempt_token={verification_attempt_token}"
-        assert res.redirect_url == "https://passportreader.app/open?" + urlencode(
-            {"token": iris_token, "redirect_url": return_url}
-        )
 
-        assert (
-            account.GetStrongVerificationAttemptStatus(
-                account_pb2.GetStrongVerificationAttemptStatusReq(verification_attempt_token=verification_attempt_token)
-            ).status
-            == account_pb2.STRONG_VERIFICATION_ATTEMPT_STATUS_IN_PROGRESS_WAITING_ON_USER_TO_OPEN_APP
-        )
-
-    # ok, now the user downloads the app, scans their id, and Iris ID sends callbacks to the server
-    _emulate_iris_callback(verification_id, "INITIATED", reference_data)
-
-    with account_session(token) as account:
-        assert (
-            account.GetStrongVerificationAttemptStatus(
-                account_pb2.GetStrongVerificationAttemptStatusReq(verification_attempt_token=verification_attempt_token)
-            ).status
-            == account_pb2.STRONG_VERIFICATION_ATTEMPT_STATUS_IN_PROGRESS_WAITING_ON_USER_IN_APP
-        )
-
-    if return_after == "INITIATED":
-        return reference_data
-
-    _emulate_iris_callback(verification_id, "COMPLETED", reference_data)
-
-    with account_session(token) as account:
-        assert (
-            account.GetStrongVerificationAttemptStatus(
-                account_pb2.GetStrongVerificationAttemptStatusReq(verification_attempt_token=verification_attempt_token)
-            ).status
-            == account_pb2.STRONG_VERIFICATION_ATTEMPT_STATUS_IN_PROGRESS_WAITING_ON_BACKEND
-        )
-
-    if return_after == "COMPLETED":
-        return reference_data
-
-    _emulate_iris_callback(verification_id, "APPROVED", reference_data)
-
-    with account_session(token) as account:
-        assert (
-            account.GetStrongVerificationAttemptStatus(
-                account_pb2.GetStrongVerificationAttemptStatusReq(verification_attempt_token=verification_attempt_token)
-            ).status
-            == account_pb2.STRONG_VERIFICATION_ATTEMPT_STATUS_IN_PROGRESS_WAITING_ON_BACKEND
-        )
-
-    if return_after == "APPROVED":
-        return reference_data
-
-    with patch("couchers.jobs.handlers.requests.post") as mock:
-        json_resp2 = {
-            "id": verification_id,
-            "created": "2024-05-11T15:46:46Z",
-            "expires": "2024-05-11T16:17:26Z",
-            "state": "APPROVED",
-            "reference": reference_data,
-            "user_ip": "10.123.123.123",
-            "user_agent": "Iris%20ID/168357896 CFNetwork/1494.0.7 Darwin/23.4.0",
-            "given_names": "John Wayne",
-            "surname": "Doe",
-            "nationality": nationality,
-            "sex": sex,
-            "date_of_birth": dob,
-            "document_type": document_type,
-            "document_number": document_number,
-            "expiry_date": document_expiry.isoformat(),
-            "issuing_country": nationality,
-            "issuer": "Department of State, U.S. Government",
-            "portrait": "dGVzdHRlc3R0ZXN0...",
-        }
-        mock.return_value = type(
-            "__MockResponse",
-            (),
-            {
-                "status_code": 200,
-                "text": json.dumps(json_resp2),
-                "json": lambda: json_resp2,
-            },
-        )
-        while process_job():
-            pass
-
-    mock.assert_called_once_with(
-        "https://passportreader.app/api/v1/session.get",
-        auth=("dummy_pubkey", "dummy_secret"),
-        json={"id": verification_id},
-        timeout=10,
-        verify="/etc/ssl/certs/ca-certificates.crt",
-    )
-
-    with account_session(token) as account:
-        assert (
-            account.GetStrongVerificationAttemptStatus(
-                account_pb2.GetStrongVerificationAttemptStatusReq(verification_attempt_token=verification_attempt_token)
-            ).status
-            == account_pb2.STRONG_VERIFICATION_ATTEMPT_STATUS_SUCCEEDED
-        )
-
-    with session_scope() as session:
-        verification_attempt = session.execute(
-            select(StrongVerificationAttempt).where(
-                StrongVerificationAttempt.verification_attempt_token == verification_attempt_token
+        # The API should now report success or failure
+        with account_session(self.token) as account:
+            expected_pb_status = (
+                account_pb2.STRONG_VERIFICATION_ATTEMPT_STATUS_SUCCEEDED
+                if expected_status == StrongVerificationAttemptStatus.succeeded
+                else account_pb2.STRONG_VERIFICATION_ATTEMPT_STATUS_FAILED
             )
-        ).scalar_one()
-        assert verification_attempt.user_id == user.id
-        assert verification_attempt.status == StrongVerificationAttemptStatus.succeeded
-        assert verification_attempt.has_full_data
-        assert verification_attempt.passport_encrypted_data
-        # assert verification_attempt.passport_date_of_birth == date(1988, 1, 1)
-        # assert verification_attempt.passport_sex == PassportSex.male
-        assert verification_attempt.has_minimal_data
-        assert verification_attempt.passport_expiry_date == document_expiry
-        assert verification_attempt.passport_nationality == nationality
-        assert verification_attempt.passport_last_three_document_chars == document_number[-3:]
-        assert verification_attempt.iris_token == iris_token
-        assert verification_attempt.iris_session_id == verification_id
-
-        private_key = bytes.fromhex("e6c2fbf3756b387bc09a458a7b85935718ef3eb1c2777ef41d335c9f6c0ab272")
-        decrypted_data = json.loads(asym_decrypt(private_key, verification_attempt.passport_encrypted_data))
-        assert decrypted_data == json_resp2
-
-        callbacks = (
-            session.execute(
-                select(StrongVerificationCallbackEvent.iris_status)
-                .where(StrongVerificationCallbackEvent.verification_attempt_id == verification_attempt.id)
-                .order_by(StrongVerificationCallbackEvent.created.asc())
+            assert (
+                account.GetStrongVerificationAttemptStatus(
+                    account_pb2.GetStrongVerificationAttemptStatusReq(
+                        verification_attempt_token=self.verification_attempt_token
+                    )
+                ).status
+                == expected_pb_status
             )
-            .scalars()
-            .all()
-        )
-        assert callbacks == ["INITIATED", "COMPLETED", "APPROVED"]
+
+        # The StrongVerificationAttempt row should now reflect data from the IRIS callback
+        with session_scope() as session:
+            verification_attempt = session.execute(
+                select(StrongVerificationAttempt).where(
+                    StrongVerificationAttempt.verification_attempt_token == self.verification_attempt_token
+                )
+            ).scalar_one()
+
+            assert verification_attempt.user_id == self.user.id
+            assert verification_attempt.status == expected_status
+            assert verification_attempt.has_full_data
+            assert verification_attempt.passport_encrypted_data
+            assert verification_attempt.passport_date_of_birth == date_of_birth
+            assert verification_attempt.passport_sex == sex
+            assert verification_attempt.has_minimal_data
+            assert verification_attempt.passport_expiry_date == document_expiry
+            assert verification_attempt.passport_nationality == nationality
+            assert verification_attempt.passport_last_three_document_chars == document_number[-3:]
+            assert verification_attempt.iris_token == self.iris_token
+            assert verification_attempt.iris_session_id == self.verification_id
+
+            # We should have gone through all IRIS callbacks
+            private_key = bytes.fromhex("e6c2fbf3756b387bc09a458a7b85935718ef3eb1c2777ef41d335c9f6c0ab272")
+            decrypted_data = json.loads(asym_decrypt(private_key, verification_attempt.passport_encrypted_data))
+            assert decrypted_data == json_resp
+
+            callbacks = (
+                session.execute(
+                    select(StrongVerificationCallbackEvent.iris_status)
+                    .where(StrongVerificationCallbackEvent.verification_attempt_id == verification_attempt.id)
+                    .order_by(StrongVerificationCallbackEvent.created.asc())
+                )
+                .scalars()
+                .all()
+            )
+            assert callbacks == ["INITIATED", "COMPLETED", "APPROVED"]
+
+    def _emulate_iris_callback(self, session_state: str):
+        assert session_state in ["CREATED", "INITIATED", "FAILED", "ABORTED", "COMPLETED", "REJECTED", "APPROVED"]
+        with real_iris_session() as iris:
+            data = json.dumps(
+                {
+                    "session_id": self.verification_id,
+                    "session_state": session_state,
+                    "session_reference": self.reference_data,
+                }
+            ).encode("ascii")
+            iris.Webhook(httpbody_pb2.HttpBody(content_type="application/json", data=data))
 
 
 def monkeypatch_sv_config(monkeypatch):
@@ -270,16 +326,14 @@ def test_strong_verification_happy_path(db, monkeypatch):
             == res.has_strong_verification
         )
 
-    do_and_check_sv(
-        user,
-        token,
-        verification_id=5731012934821983,
-        sex="MALE",
-        dob="1988-01-01",
-        document_type="PASSPORT",
-        document_number="31195855",
-        document_expiry=default_expiry,
+    expiry = date.today() + timedelta(days=5 * 365)
+
+    MockSVFlow(user=user, token=token).process_iris_callbacks(
         nationality="US",
+        sex=PassportSex.male,
+        date_of_birth=date.fromisoformat("1988-01-01"),
+        document_number="31195855",
+        document_expiry=expiry,
     )
 
     with session_scope() as session:
@@ -289,7 +343,7 @@ def test_strong_verification_happy_path(db, monkeypatch):
         assert verification_attempt.status == StrongVerificationAttemptStatus.succeeded
         assert verification_attempt.passport_date_of_birth == date(1988, 1, 1)
         assert verification_attempt.passport_sex == PassportSex.male
-        assert verification_attempt.passport_expiry_date == default_expiry
+        assert verification_attempt.passport_expiry_date == expiry
         assert verification_attempt.passport_nationality == "US"
         assert verification_attempt.passport_last_three_document_chars == "855"
 
@@ -448,17 +502,7 @@ def test_strong_verification_delete_data(db, monkeypatch):
     with account_session(token) as account:
         account.DeleteStrongVerificationData(empty_pb2.Empty())
 
-    do_and_check_sv(
-        user,
-        token,
-        verification_id=5731012934821983,
-        sex="MALE",
-        dob="1988-01-01",
-        document_type="PASSPORT",
-        document_number="31195855",
-        document_expiry=default_expiry,
-        nationality="US",
-    )
+    MockSVFlow(user=user, token=token).process_iris_callbacks()
 
     refresh_materialized_views_rapid(empty_pb2.Empty())
 
@@ -517,19 +561,7 @@ def test_strong_verification_expiry(db, monkeypatch):
             == api.GetUser(api_pb2.GetUserReq(user=user.username)).has_strong_verification
         )
 
-    expiry = date.today() + timedelta(days=10)
-
-    do_and_check_sv(
-        user,
-        token,
-        verification_id=5731012934821983,
-        sex="MALE",
-        dob="1988-01-01",
-        document_type="PASSPORT",
-        document_number="31195855",
-        document_expiry=expiry,
-        nationality="US",
-    )
+    MockSVFlow(user=user, token=token).process_iris_callbacks(document_expiry=date.today() + timedelta(days=10))
 
     # the user should now have strong verification
     with api_session(token) as api:
@@ -552,16 +584,8 @@ def test_strong_verification_expiry(db, monkeypatch):
         assert not res.has_strong_verification
         assert not res.has_strong_verification
 
-    do_and_check_sv(
-        user,
-        token,
-        verification_id=5731012934821985,
-        sex="MALE",
-        dob="1988-01-01",
-        document_type="PASSPORT",
-        document_number="PA41323412",
-        document_expiry=date.today() + timedelta(days=365),
-        nationality="AU",
+    MockSVFlow(user=user, token=token, verification_id=5731012934821985).process_iris_callbacks(
+        nationality="AU", document_number="PA41323412", document_expiry=date.today() + timedelta(days=365)
     )
 
     refresh_materialized_views_rapid(empty_pb2.Empty())
@@ -579,18 +603,8 @@ def test_strong_verification_regression(db, monkeypatch):
 
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
 
-    do_and_check_sv(
-        user,
-        token,
-        verification_id=5731012934821983,
-        sex="MALE",
-        dob="1988-01-01",
-        document_type="PASSPORT",
-        document_number="31195855",
-        document_expiry=default_expiry,
-        nationality="US",
-        return_after="INITIATED",
-    )
+    sv_flow = MockSVFlow(user=user, token=token)
+    sv_flow.process_iris_initiated_callback()
 
     with api_session(token) as api:
         api.Ping(api_pb2.PingReq())
@@ -601,30 +615,11 @@ def test_strong_verification_regression2(db, monkeypatch):
 
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
 
-    do_and_check_sv(
-        user,
-        token,
-        verification_id=5731012934821983,
-        sex="MALE",
-        dob="1988-01-01",
-        document_type="PASSPORT",
-        document_number="31195855",
-        document_expiry=default_expiry,
-        nationality="US",
-        return_after="INITIATED",
-    )
+    sv_flow = MockSVFlow(user=user, token=token, verification_id=5731012934821983)
+    sv_flow.process_iris_initiated_callback()
 
-    do_and_check_sv(
-        user,
-        token,
-        verification_id=5731012934821985,
-        sex="MALE",
-        dob="1988-01-01",
-        document_type="PASSPORT",
-        document_number="PA41323412",
-        document_expiry=default_expiry,
-        nationality="AU",
-    )
+    sv_flow = MockSVFlow(user=user, token=token, verification_id=5731012934821985)
+    sv_flow.process_iris_callbacks(nationality="AU", document_number="PA41323412")
 
     refresh_materialized_views_rapid(empty_pb2.Empty())
 
@@ -662,17 +657,7 @@ def test_strong_verification_delete_data_cant_reverify(db, monkeypatch, push_col
             == api.GetUser(api_pb2.GetUserReq(user=user.username)).has_strong_verification
         )
 
-    do_and_check_sv(
-        user,
-        token,
-        verification_id=5731012934821983,
-        sex="MALE",
-        dob="1988-01-01",
-        document_type="PASSPORT",
-        document_number="31195855",
-        document_expiry=default_expiry,
-        nationality="US",
-    )
+    MockSVFlow(user=user, token=token).process_iris_callbacks()
 
     refresh_materialized_views_rapid(empty_pb2.Empty())
 
@@ -718,66 +703,9 @@ def test_strong_verification_delete_data_cant_reverify(db, monkeypatch, push_col
             == 0
         )
 
-    reference_data = do_and_check_sv(
-        user,
-        token,
-        verification_id=5731012934821984,
-        sex="MALE",
-        dob="1988-01-01",
-        document_type="PASSPORT",
-        document_number="31195855",
-        document_expiry=default_expiry,
-        nationality="US",
-        return_after="APPROVED",
+    MockSVFlow(user=user, token=token, verification_id=5731012934821984).process_iris_callbacks(
+        expected_status=StrongVerificationAttemptStatus.duplicate
     )
-
-    with patch("couchers.jobs.handlers.requests.post") as mock:
-        json_resp2 = {
-            "id": 5731012934821984,
-            "created": "2024-05-11T15:46:46Z",
-            "expires": "2024-05-11T16:17:26Z",
-            "state": "APPROVED",
-            "reference": reference_data,
-            "user_ip": "10.123.123.123",
-            "user_agent": "Iris%20ID/168357896 CFNetwork/1494.0.7 Darwin/23.4.0",
-            "given_names": "John Wayne",
-            "surname": "Doe",
-            "nationality": "US",
-            "sex": "MALE",
-            "date_of_birth": "1988-01-01",
-            "document_type": "PASSPORT",
-            "document_number": "31195855",
-            "expiry_date": default_expiry.isoformat(),
-            "issuing_country": "US",
-            "issuer": "Department of State, U.S. Government",
-            "portrait": "dGVzdHRlc3R0ZXN0...",
-        }
-        mock.return_value = type(
-            "__MockResponse",
-            (),
-            {
-                "status_code": 200,
-                "text": json.dumps(json_resp2),
-                "json": lambda: json_resp2,
-            },
-        )
-        while process_job():
-            pass
-
-    mock.assert_called_once_with(
-        "https://passportreader.app/api/v1/session.get",
-        auth=("dummy_pubkey", "dummy_secret"),
-        json={"id": 5731012934821984},
-        timeout=10,
-        verify="/etc/ssl/certs/ca-certificates.crt",
-    )
-
-    with session_scope() as session:
-        verification_attempt = session.execute(
-            select(StrongVerificationAttempt).where(StrongVerificationAttempt.iris_session_id == 5731012934821984)
-        ).scalar_one()
-        assert verification_attempt.user_id == user.id
-        assert verification_attempt.status == StrongVerificationAttemptStatus.duplicate
 
     push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Strong Verification failed"
@@ -816,17 +744,7 @@ def test_strong_verification_duplicate_other_user(db, monkeypatch, push_collecto
     with account_session(token) as account:
         account.DeleteStrongVerificationData(empty_pb2.Empty())
 
-    do_and_check_sv(
-        user,
-        token,
-        verification_id=5731012934821983,
-        sex="MALE",
-        dob="1988-01-01",
-        document_type="PASSPORT",
-        document_number="31195855",
-        document_expiry=default_expiry,
-        nationality="US",
-    )
+    MockSVFlow(user=user, token=token).process_iris_callbacks(nationality="US", document_number="31195855")
 
     refresh_materialized_views_rapid(empty_pb2.Empty())
 
@@ -869,66 +787,9 @@ def test_strong_verification_duplicate_other_user(db, monkeypatch, push_collecto
             == 0
         )
 
-    reference_data = do_and_check_sv(
-        user2,
-        token2,
-        verification_id=5731012934821984,
-        sex="MALE",
-        dob="1988-01-01",
-        document_type="PASSPORT",
-        document_number="31195855",
-        document_expiry=default_expiry,
-        nationality="US",
-        return_after="APPROVED",
+    MockSVFlow(user=user2, token=token2, verification_id=5731012934821984).process_iris_callbacks(
+        nationality="US", document_number="31195855", expected_status=StrongVerificationAttemptStatus.duplicate
     )
-
-    with patch("couchers.jobs.handlers.requests.post") as mock:
-        json_resp2 = {
-            "id": 5731012934821984,
-            "created": "2024-05-11T15:46:46Z",
-            "expires": "2024-05-11T16:17:26Z",
-            "state": "APPROVED",
-            "reference": reference_data,
-            "user_ip": "10.123.123.123",
-            "user_agent": "Iris%20ID/168357896 CFNetwork/1494.0.7 Darwin/23.4.0",
-            "given_names": "John Wayne",
-            "surname": "Doe",
-            "nationality": "US",
-            "sex": "MALE",
-            "date_of_birth": "1988-01-01",
-            "document_type": "PASSPORT",
-            "document_number": "31195855",
-            "expiry_date": default_expiry.isoformat(),
-            "issuing_country": "US",
-            "issuer": "Department of State, U.S. Government",
-            "portrait": "dGVzdHRlc3R0ZXN0...",
-        }
-        mock.return_value = type(
-            "__MockResponse",
-            (),
-            {
-                "status_code": 200,
-                "text": json.dumps(json_resp2),
-                "json": lambda: json_resp2,
-            },
-        )
-        while process_job():
-            pass
-
-    mock.assert_called_once_with(
-        "https://passportreader.app/api/v1/session.get",
-        auth=("dummy_pubkey", "dummy_secret"),
-        json={"id": 5731012934821984},
-        timeout=10,
-        verify="/etc/ssl/certs/ca-certificates.crt",
-    )
-
-    with session_scope() as session:
-        verification_attempt = session.execute(
-            select(StrongVerificationAttempt).where(StrongVerificationAttempt.iris_session_id == 5731012934821984)
-        ).scalar_one()
-        assert verification_attempt.user_id == user2.id
-        assert verification_attempt.status == StrongVerificationAttemptStatus.duplicate
 
     push = push_collector.pop_for_user(user2.id, last=True)
     assert push.content.title == "Strong Verification failed"
@@ -944,66 +805,9 @@ def test_strong_verification_non_passport(db, monkeypatch, push_collector: PushC
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
     _, superuser_token = generate_user(is_superuser=True)
 
-    reference_data = do_and_check_sv(
-        user,
-        token,
-        verification_id=5731012934821984,
-        sex="MALE",
-        dob="1988-01-01",
-        document_type="IDENTITY_CARD",
-        document_number="31195855",
-        document_expiry=default_expiry,
-        nationality="US",
-        return_after="APPROVED",
+    MockSVFlow(user=user, token=token).process_iris_callbacks(
+        document_type="IDENTITY_CARD", expected_status=StrongVerificationAttemptStatus.failed
     )
-
-    with patch("couchers.jobs.handlers.requests.post") as mock:
-        json_resp2 = {
-            "id": 5731012934821984,
-            "created": "2024-05-11T15:46:46Z",
-            "expires": "2024-05-11T16:17:26Z",
-            "state": "APPROVED",
-            "reference": reference_data,
-            "user_ip": "10.123.123.123",
-            "user_agent": "Iris%20ID/168357896 CFNetwork/1494.0.7 Darwin/23.4.0",
-            "given_names": "John Wayne",
-            "surname": "Doe",
-            "nationality": "US",
-            "sex": "MALE",
-            "date_of_birth": "1988-01-01",
-            "document_type": "IDENTITY_CARD",
-            "document_number": "31195855",
-            "expiry_date": default_expiry.isoformat(),
-            "issuing_country": "US",
-            "issuer": "Department of State, U.S. Government",
-            "portrait": "dGVzdHRlc3R0ZXN0...",
-        }
-        mock.return_value = type(
-            "__MockResponse",
-            (),
-            {
-                "status_code": 200,
-                "text": json.dumps(json_resp2),
-                "json": lambda: json_resp2,
-            },
-        )
-        while process_job():
-            pass
-
-    mock.assert_called_once_with(
-        "https://passportreader.app/api/v1/session.get",
-        auth=("dummy_pubkey", "dummy_secret"),
-        json={"id": 5731012934821984},
-        timeout=10,
-        verify="/etc/ssl/certs/ca-certificates.crt",
-    )
-
-    with session_scope() as session:
-        verification_attempt = session.execute(
-            select(StrongVerificationAttempt).where(StrongVerificationAttempt.iris_session_id == 5731012934821984)
-        ).scalar_one()
-        assert verification_attempt.user_id == user.id
-        assert verification_attempt.status == StrongVerificationAttemptStatus.failed
 
     push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Strong Verification failed"
@@ -1013,70 +817,14 @@ def test_strong_verification_non_passport(db, monkeypatch, push_collector: PushC
     )
 
 
-def _run_sv_passport_mismatch(user, token, verification_id, sex, dob):
-    """Drive a passport SV attempt through to the final data pull with the given (mismatching) passport data."""
-    reference_data = do_and_check_sv(
-        user,
-        token,
-        verification_id=verification_id,
-        sex=sex,
-        dob=dob,
-        document_type="PASSPORT",
-        document_number="31195855",
-        document_expiry=default_expiry,
-        nationality="US",
-        return_after="APPROVED",
-    )
-
-    with patch("couchers.jobs.handlers.requests.post") as mock:
-        json_resp = {
-            "id": verification_id,
-            "created": "2024-05-11T15:46:46Z",
-            "expires": "2024-05-11T16:17:26Z",
-            "state": "APPROVED",
-            "reference": reference_data,
-            "user_ip": "10.123.123.123",
-            "user_agent": "Iris%20ID/168357896 CFNetwork/1494.0.7 Darwin/23.4.0",
-            "given_names": "John Wayne",
-            "surname": "Doe",
-            "nationality": "US",
-            "sex": sex,
-            "date_of_birth": dob,
-            "document_type": "PASSPORT",
-            "document_number": "31195855",
-            "expiry_date": default_expiry.isoformat(),
-            "issuing_country": "US",
-            "issuer": "Department of State, U.S. Government",
-            "portrait": "dGVzdHRlc3R0ZXN0...",
-        }
-        mock.return_value = type(
-            "__MockResponse",
-            (),
-            {
-                "status_code": 200,
-                "text": json.dumps(json_resp),
-                "json": lambda: json_resp,
-            },
-        )
-        while process_job():
-            pass
-
-    # the attempt itself succeeds, but the data doesn't match the profile so no badge is granted
-    with session_scope() as session:
-        verification_attempt = session.execute(
-            select(StrongVerificationAttempt).where(StrongVerificationAttempt.iris_session_id == verification_id)
-        ).scalar_one()
-        assert verification_attempt.user_id == user.id
-        assert verification_attempt.status == StrongVerificationAttemptStatus.succeeded
-
-
 def test_strong_verification_wrong_birthdate(db, monkeypatch, push_collector: PushCollector):
     monkeypatch_sv_config(monkeypatch)
 
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
 
-    # passport sex matches gender, but the date of birth doesn't match the profile
-    _run_sv_passport_mismatch(user, token, verification_id=5731012934821984, sex="MALE", dob="1999-12-31")
+    MockSVFlow(user=user, token=token).process_iris_callbacks(
+        date_of_birth=date.fromisoformat("1999-12-31"), expected_status=StrongVerificationAttemptStatus.failed
+    )
 
     push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Strong Verification failed"
@@ -1091,8 +839,9 @@ def test_strong_verification_wrong_gender(db, monkeypatch, push_collector: PushC
 
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
 
-    # date of birth matches, but the passport sex doesn't match the gender on the profile
-    _run_sv_passport_mismatch(user, token, verification_id=5731012934821984, sex="FEMALE", dob="1988-01-01")
+    MockSVFlow(user=user, token=token).process_iris_callbacks(
+        sex=PassportSex.female, expected_status=StrongVerificationAttemptStatus.failed
+    )
 
     push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Strong Verification failed"
@@ -1108,8 +857,11 @@ def test_strong_verification_wrong_birthdate_and_gender(db, monkeypatch, push_co
 
     user, token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
 
-    # neither the date of birth nor the passport sex match the profile
-    _run_sv_passport_mismatch(user, token, verification_id=5731012934821984, sex="FEMALE", dob="1999-12-31")
+    MockSVFlow(user=user, token=token).process_iris_callbacks(
+        date_of_birth=date.fromisoformat("1999-12-31"),
+        sex=PassportSex.female,
+        expected_status=StrongVerificationAttemptStatus.failed,
+    )
 
     push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "Strong Verification failed"

--- a/app/proto/notification_data.proto
+++ b/app/proto/notification_data.proto
@@ -188,12 +188,16 @@ message EventReminder {
 
 enum SVFailReason {
   SV_FAIL_REASON_UNKNOWN = 0;
-  // birthdate doesn't match profile or gender
+  // both birthdate and gender don't match the profile
   SV_FAIL_REASON_WRONG_BIRTHDATE_OR_GENDER = 1;
   // not a passport (e.g. used a ID card)
   SV_FAIL_REASON_NOT_A_PASSPORT = 2;
   // this passport is already used by someone else or the same user
   SV_FAIL_REASON_DUPLICATE = 3;
+  // only the birthdate doesn't match the profile
+  SV_FAIL_REASON_WRONG_BIRTHDATE = 4;
+  // only the gender doesn't match the profile
+  SV_FAIL_REASON_WRONG_GENDER = 5;
 }
 
 message VerificationSVFail {


### PR DESCRIPTION
Users were confused from the message saying that their passport date of birth or gender mismatched their profile, so add enumerants that differentiate those cases and update notifications.

To avoid duplicating more test code, I refactored the IRIS callback mocking logic (see changes to existing tests).

Also fixes `GetStrongVerificationAttemptStatus` returning `UNKNOWN` in the duplicate status case.

With help from [Claude Code](https://claude.ai/code)

Closes #9174.

## Testing
Added tests.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
