### PR TITLE
Backend/emails: Link user card photos to profiles

### DIFF
--- a/app/backend/src/couchers/email/rendering.py
+++ b/app/backend/src/couchers/email/rendering.py
@@ -212,6 +212,7 @@ class HTMLRenderer:
                                 "name": block.info.name,
                                 "age": block.info.age,
                                 "city": block.info.city,
+                                "profile_url": block.info.profile_url,
                                 "avatar_url": block.info.avatar_url,
                                 "comment": block.comment,
                             },

--- a/app/backend/templates/v2/blocks.mjml
+++ b/app/backend/templates/v2/blocks.mjml
@@ -58,7 +58,9 @@
           <mj-table>
             <tr>
               <td style="width: 100px;">
-                <img width="80px" style="border-radius: 80px" src="{{ avatar_url }}" />
+                <a href="{{ profile_url }}">
+                  <img width="80px" style="border-radius: 80px" src="{{ avatar_url }}" />
+                </a>
               </td>
               <td>
                 <b>{{ name }}</b>, {{ age }}<br />

--- a/app/backend/templates/v2/generated_html/blocks.html
+++ b/app/backend/templates/v2/generated_html/blocks.html
@@ -302,7 +302,9 @@
                                   <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
                                     <tr>
                                       <td style="width: 100px;">
-                                        <img width="80px" style="border-radius: 80px" src="{{ avatar_url }}">
+                                        <a href="{{ profile_url }}" style="color: #00a398;">
+                                          <img width="80px" style="border-radius: 80px" src="{{ avatar_url }}">
+                                        </a>
                                       </td>
                                       <td>
                                         <b>{{ name }}</b>, {{ age }}<br>


### PR DESCRIPTION
We trained users to expect that photos link to profiles. Emails should follow suit.

Fixes #9188

## Testing
Ran `uv run dump-emails`

<img width="349" height="280" alt="image" src="https://github.com/user-attachments/assets/b3ba4a36-cdc2-4672-873a-e089df0f8d95" />

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
