### PR TITLE
Frontend: Fix duplicate edit profile button

### DIFF
--- a/app/web/components/ProfileIncompleteDialog/ProfileIncompleteDialog.tsx
+++ b/app/web/components/ProfileIncompleteDialog/ProfileIncompleteDialog.tsx
@@ -70,9 +70,6 @@ export default function ProfileIncompleteDialog({
         <Button component={Link} href={routeToEditProfile()}>
           {t("profile:complete_profile_dialog.edit_profile_button")}
         </Button>
-        <Button component={Link} href={routeToEditProfile()}>
-          {t("dashboard:complete_profile_dialog.edit_profile_button")}
-        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/app/web/features/dashboard/locales/en.json
+++ b/app/web/features/dashboard/locales/en.json
@@ -3,7 +3,6 @@
   "please_complete_profile": "Please complete your profile and ensure you show up in search:",
   "fill_in_who_i_am": "1. Fill in your \"Who I am\" section with a few sentences about yourself",
   "upload_photo": "2. Upload a photo (by clicking on the avatar on the edit page)",
-  "edit_profile_button_text": "Edit your profile",
   "complete_profile_explanation": "Don't you hate how other platforms have empty \"ghost\" profiles with no information. Please don't ghost us! 👻👻👻",
   "your_communities_heading": "Your communities",
   "all_communities_heading": "All communities",


### PR DESCRIPTION
The edit profile button was mysteriously duplicated in #8317, with a bad string key too. Also the dashboard string was unreferenced.

## Testing
After fix:

<img width="1128" height="572" alt="image" src="https://github.com/user-attachments/assets/6b003fe5-e8c0-4fe5-8b8b-06b2fbc5bae1" />

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
