### PR TITLE
Backend/emails: Take links out of loc files.

### DIFF
--- a/app/backend/src/couchers/email/blocks.py
+++ b/app/backend/src/couchers/email/blocks.py
@@ -13,7 +13,7 @@ from couchers import urls
 from couchers.email.locales import get_emails_i18next
 from couchers.i18n import LocalizationContext
 from couchers.i18n.i18next import SubstitutionDict, full_string_key
-from couchers.markup import html_email_link
+from couchers.markup import html_mailto_link
 from couchers.proto import api_pb2
 from couchers.utils import now
 
@@ -59,7 +59,7 @@ class EmailBase(ABC):
             # Not localizing the suggested subject line to encourage folks to use English if they can.
             builder.para(
                 "generic.security_warning_contact_support",
-                {"email_link": html_email_link("support@couchers.org", subject="Action not initiated by me")},
+                {"email_link": html_mailto_link("support@couchers.org", subject="Action not initiated by me")},
                 epilogue=True,
             )
         if default_closing:

--- a/app/backend/src/couchers/email/blocks.py
+++ b/app/backend/src/couchers/email/blocks.py
@@ -13,6 +13,7 @@ from couchers import urls
 from couchers.email.locales import get_emails_i18next
 from couchers.i18n import LocalizationContext
 from couchers.i18n.i18next import SubstitutionDict, full_string_key
+from couchers.markup import html_email_link
 from couchers.proto import api_pb2
 from couchers.utils import now
 
@@ -55,7 +56,12 @@ class EmailBase(ABC):
         if default_greeting:
             builder.para("generic.greeting_line", {"name": self.user_name})
         if security_warning:
-            builder.para("generic.security_warning_contact_support", epilogue=True)
+            # Not localizing the suggested subject line to encourage folks to use English if they can.
+            builder.para(
+                "generic.security_warning_contact_support",
+                {"email_link": html_email_link("support@couchers.org", subject="Action not initiated by me")},
+                epilogue=True,
+            )
         if default_closing:
             builder.para("generic.closing_lines.default", epilogue=True)
         return builder

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -48,7 +48,7 @@ from couchers.email.blocks import (
 from couchers.email.locales import get_emails_i18next
 from couchers.i18n import LocalizationContext
 from couchers.i18n.localize import format_phone_number
-from couchers.markup import markdown_to_plaintext
+from couchers.markup import html_email_link, html_link, markdown_to_plaintext
 from couchers.notifications.quick_links import generate_quick_decline_link
 from couchers.proto import conversations_pb2, events_pb2, notification_data_pb2
 from couchers.utils import now, to_aware_datetime
@@ -549,7 +549,7 @@ class DonationReceivedEmail(EmailBase):
         builder.para(".invoice_receipt_info")
         builder.action(self.receipt_url, ".download_invoice")
         builder.para(".tax_acknowledgment")
-        builder.para(".questions_contact")
+        builder.para(".questions_contact", {"email": html_email_link("donations@couchers.org")})
         builder.para("generic.thanks")
         builder.para("generic.closing_lines.founders")
         return builder.build()
@@ -1752,16 +1752,28 @@ class OnboardingReminderEmail(EmailBase):
             builder.para(".edit_profile_prompt")
             builder.action(edit_profile_url, "onboarding_reminder.edit_profile_action")
             builder.para(".share_with_friends")
-            builder.para(".link", {"url": urls.app_link()})
+            builder.para(".link", {"link": html_link(urls.app_link())})
             builder.para(".platform_under_development")
             builder.para(".thanks_for_joining")
-            builder.para("generic.closing_lines.aapeli")
+            builder.para(
+                "generic.closing_lines.aapeli",
+                {
+                    "email_link": html_email_link("aapeli@couchers.org"),
+                    "profile_link": html_link("https://couchers.org/user/aapeli"),
+                },
+            )
         else:
             builder.para(".intro")
             builder.para(".request")
             builder.action(edit_profile_url, "onboarding_reminder.edit_profile_action")
             builder.para("generic.thanks")
-            builder.para("generic.closing_lines.emily")
+            builder.para(
+                "generic.closing_lines.emily",
+                {
+                    "email_link": html_email_link("community@couchers.org"),
+                    "profile_link": html_link("https://couchers.org/user/emily"),
+                },
+            )
         return builder.build()
 
     @classmethod

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -48,7 +48,7 @@ from couchers.email.blocks import (
 from couchers.email.locales import get_emails_i18next
 from couchers.i18n import LocalizationContext
 from couchers.i18n.localize import format_phone_number
-from couchers.markup import html_email_link, html_link, markdown_to_plaintext
+from couchers.markup import html_link, html_mailto_link, markdown_to_plaintext
 from couchers.notifications.quick_links import generate_quick_decline_link
 from couchers.proto import conversations_pb2, events_pb2, notification_data_pb2
 from couchers.utils import now, to_aware_datetime
@@ -549,7 +549,7 @@ class DonationReceivedEmail(EmailBase):
         builder.para(".invoice_receipt_info")
         builder.action(self.receipt_url, ".download_invoice")
         builder.para(".tax_acknowledgment")
-        builder.para(".questions_contact", {"email": html_email_link("donations@couchers.org")})
+        builder.para(".questions_contact", {"email_link": html_mailto_link("donations@couchers.org")})
         builder.para("generic.thanks")
         builder.para("generic.closing_lines.founders")
         return builder.build()
@@ -1769,7 +1769,7 @@ class OnboardingReminderEmail(EmailBase):
             builder.para(
                 "generic.closing_lines.emily",
                 {
-                    "email_link": html_email_link("community@couchers.org"),
+                    "email_link": html_mailto_link("community@couchers.org"),
                     "profile_link": html_link("https://couchers.org/user/emily"),
                 },
             )

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -1758,7 +1758,6 @@ class OnboardingReminderEmail(EmailBase):
             builder.para(
                 "generic.closing_lines.aapeli",
                 {
-                    "email_link": html_email_link("aapeli@couchers.org"),
                     "profile_link": html_link("https://couchers.org/user/aapeli"),
                 },
             )

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -1,7 +1,7 @@
 {
   "generic": {
     "greeting_line": "Hi {{name}},",
-    "security_warning_contact_support": "If you did not initiate this action, please contact us at <a href=\"mailto:support@couchers.org\">support@couchers.org</a> so we can sort this out as soon as possible.",
+    "security_warning_contact_support": "If you did not initiate this action, please contact us at {{ email_link }} so we can sort this out as soon as possible.",
     "do_not_reply_request": "Do not reply to this email. Use one of the buttons above to reply to this request.",
     "thanks": "Thank you!",
     "closing_lines": {
@@ -12,7 +12,7 @@
     },
     "footer": {
       "received_because": "You're receiving this email because you signed up for Couchers.org.",
-      "contact_support": "You can reach our support team at <a href=\"mailto:support@couchers.org\">support@couchers.org</a>.",
+      "contact_support": "You can reach our support team at {{ email_link }}.",
       "timezone_note": "All times are in {{ timezone }}, based on your profile location.",
       "donate_link": "Donate",
       "volunteer_link": "Volunteer",
@@ -129,7 +129,7 @@
     "invoice_receipt_info": "You can download an invoice and receipt for the donation here:",
     "download_invoice": "Download invoice",
     "tax_acknowledgment": "Couchers, Inc. is a 501(c)(3) nonprofit (EIN: 87-1734577) registered in the United States. No goods or services were provided in exchange for this contribution.",
-    "questions_contact": "If you have any questions about your donation, please email us at <a href=\"mailto:donations@couchers.org\">donations@couchers.org</a>."
+    "questions_contact": "If you have any questions about your donation, please email us at {{ email }}."
   },
   "email_change": {
     "initiated": {
@@ -285,7 +285,7 @@
       "fill_in_profile": "Please take some time to explore the platform. As a first step, please write a bit about yourself on the 'About me' and 'My home' tabs of your profile. Please upload a photo of yourself and fill in some profile text. You can even copy and paste the text from your account on a different couch surfing platform if you're feeling lazy :P",
       "edit_profile_prompt": "To edit your profile, click on the following link:",
       "share_with_friends": "Otherwise, please share the link with any of your couch surfing friends that you trust! This platform can only grow with your help bringing the best people to it.",
-      "link": "Link: <a href=\"{{ url }}\">{{ url }}</a>",
+      "link": "Link: {{ link }}",
       "platform_under_development": "The platform is still under development, and features are actively being built by our amazing team of Couchers.org volunteers around the world. We would like to hear your feedback and thoughts on what we've built and what we're working on.",
       "thanks_for_joining": "Thanks so much for joining the platform. We're really excited to have you here and as part of our growing community!"
     },

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -129,7 +129,7 @@
     "invoice_receipt_info": "You can download an invoice and receipt for the donation here:",
     "download_invoice": "Download invoice",
     "tax_acknowledgment": "Couchers, Inc. is a 501(c)(3) nonprofit (EIN: 87-1734577) registered in the United States. No goods or services were provided in exchange for this contribution.",
-    "questions_contact": "If you have any questions about your donation, please email us at {{ email }}."
+    "questions_contact": "If you have any questions about your donation, please email us at {{ email_link }}."
   },
   "email_change": {
     "initiated": {

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -7,8 +7,8 @@
     "closing_lines": {
       "default": "Best,<br>The Couchers.org Team",
       "founders": "Aapeli and Itsi,<br>Couchers.org Founders",
-      "aapeli": "Aapeli<br>Couchers.org Co-founder<br><a href=\"mailto:aapeli@couchers.org\">aapeli@couchers.org</a> (feel free to shoot me an email at any time)<br><a href=\"https://couchers.org/user/aapeli\">https://couchers.org/user/aapeli</a>",
-      "emily": "Emily from Couchers.org<br><a href=\"mailto:community@couchers.org\">community@couchers.org</a><br><a href=\"https://couchers.org/user/emily\">https://couchers.org/user/emily</a>"
+      "aapeli": "Aapeli<br>Couchers.org Co-founder<br>{{ profile_link }}",
+      "emily": "Emily from Couchers.org<br>{{ email_link }}<br>{{ profile_link }}"
     },
     "footer": {
       "received_because": "You're receiving this email because you signed up for Couchers.org.",

--- a/app/backend/src/couchers/email/rendering.py
+++ b/app/backend/src/couchers/email/rendering.py
@@ -17,7 +17,7 @@ from couchers.email.locales import get_emails_i18next
 from couchers.email.smtp import embed_html_relative_images
 from couchers.i18n import LocalizationContext
 from couchers.i18n.i18next import SubstitutionDict, full_string_key
-from couchers.markup import html_email_link, html_to_plaintext, markdown_to_html
+from couchers.markup import html_mailto_link, html_to_plaintext, markdown_to_html
 from couchers.proto.internal import jobs_pb2
 from couchers.templating import Jinja2Template
 
@@ -128,7 +128,7 @@ def _get_footer_template_args(footer: EmailFooter, loc_context: LocalizationCont
 
     args: dict[str, Any] = {
         "received_because": localize(".received_because"),
-        "contact_support": localize(".contact_support", {"email_link": html_email_link("support@couchers.org")}),
+        "contact_support": localize(".contact_support", {"email_link": html_mailto_link("support@couchers.org")}),
         "timezone_note": localize(".timezone_note", {"timezone": footer.timezone_name}),
         "copyright_year": footer.copyright_year,
         "donate_link": localize(".donate_link"),

--- a/app/backend/src/couchers/email/rendering.py
+++ b/app/backend/src/couchers/email/rendering.py
@@ -17,7 +17,7 @@ from couchers.email.locales import get_emails_i18next
 from couchers.email.smtp import embed_html_relative_images
 from couchers.i18n import LocalizationContext
 from couchers.i18n.i18next import SubstitutionDict, full_string_key
-from couchers.markup import html_to_plaintext, markdown_to_html
+from couchers.markup import html_email_link, html_to_plaintext, markdown_to_html
 from couchers.proto.internal import jobs_pb2
 from couchers.templating import Jinja2Template
 
@@ -128,7 +128,7 @@ def _get_footer_template_args(footer: EmailFooter, loc_context: LocalizationCont
 
     args: dict[str, Any] = {
         "received_because": localize(".received_because"),
-        "contact_support": localize(".contact_support"),
+        "contact_support": localize(".contact_support", {"email_link": html_email_link("support@couchers.org")}),
         "timezone_note": localize(".timezone_note", {"timezone": footer.timezone_name}),
         "copyright_year": footer.copyright_year,
         "donate_link": localize(".donate_link"),

--- a/app/backend/src/couchers/markup.py
+++ b/app/backend/src/couchers/markup.py
@@ -1,8 +1,9 @@
 from html.parser import HTMLParser
 from typing import Any
+from urllib.parse import urlencode
 
 from markdown_it import MarkdownIt
-from markupsafe import Markup
+from markupsafe import Markup, escape
 
 # Markdown config should match frontend's MarkdownNoSSR component.
 _markdown = MarkdownIt(
@@ -60,3 +61,15 @@ class _HTMLToPlaintext(HTMLParser):
     def handle_data(self, data: str) -> None:
         # Escapes have already been unescaped
         self.plaintext += data.replace("\n", "")  # Newlines in html are meaningless
+
+
+def html_email_link(email: str, subject: str | None = None) -> Markup:
+    url = f"mailto:{email}"
+    if subject:
+        query = {"subject": subject}
+        url += f"?{urlencode(query)}"
+    return html_link(url, text=email)
+
+
+def html_link(url: str, *, text: str | None = None) -> Markup:
+    return Markup(f'<a href="{escape(url)}">{escape(text or url)}</a>')

--- a/app/backend/src/couchers/markup.py
+++ b/app/backend/src/couchers/markup.py
@@ -63,7 +63,7 @@ class _HTMLToPlaintext(HTMLParser):
         self.plaintext += data.replace("\n", "")  # Newlines in html are meaningless
 
 
-def html_email_link(email: str, subject: str | None = None) -> Markup:
+def html_mailto_link(email: str, subject: str | None = None) -> Markup:
     url = f"mailto:{email}"
     if subject:
         query = {"subject": subject}


### PR DESCRIPTION
Having html links in loc strings introduces risks that translators make mistakes with the syntax, and makes it more difficult to modify the URLs. It's more maintainable to interpolate the links from the code.

## Testing
Checked at generated emails on this PR:

<img width="817" height="522" alt="image" src="https://github.com/user-attachments/assets/96ec2101-248a-41b0-9dd1-bfc04ecaf1fa" />

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
