### PR TITLE
Events: Rename EventOfflineInformation to EventLocation

### DIFF
--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -645,7 +645,7 @@ class EventInfo:
             start_time=event.start_time.ToDatetime(tzinfo=UTC),
             end_time=event.end_time.ToDatetime(tzinfo=UTC),
             # Backcompat (2026-06): We might still have queued notifications referencing events with online_information.
-            address=(event.offline_information.address or None) if event.HasField("offline_information") else None,
+            address=(event.location.address or None) if event.HasField("location") else None,
             view_url=urls.event_link(occurrence_id=event.event_id, slug=event.slug),
             description_markdown=event.content or "",
         )

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -149,15 +149,15 @@ def event_to_pb(session: Session, occurrence: EventOccurrence, context: Couchers
         )
     ).scalar_one()
 
-    offline_information: events_pb2.OfflineEventInformation
+    location: events_pb2.EventLocation
     if occurrence.geom:
-        offline_information = events_pb2.OfflineEventInformation(
+        location = events_pb2.EventLocation(
             lat=not_none(occurrence.coordinates)[0], lng=not_none(occurrence.coordinates)[1], address=occurrence.address
         )
     else:
         # Backcompat: Surface legacy online events as offline events.
         # They'll appear at null island, but there are so few we're ok with this.
-        offline_information = events_pb2.OfflineEventInformation(address=occurrence.link, lat=0, lng=0)
+        location = events_pb2.EventLocation(address=occurrence.link, lat=0, lng=0)
 
     return events_pb2.Event(
         event_id=occurrence.id,
@@ -169,7 +169,7 @@ def event_to_pb(session: Session, occurrence: EventOccurrence, context: Couchers
         content=occurrence.content,
         photo_url=occurrence.photo.full_url if occurrence.photo else None,
         photo_key=occurrence.photo_key or "",
-        offline_information=offline_information,
+        location=location,
         created=Timestamp_from_datetime(occurrence.created),
         last_edited=Timestamp_from_datetime(occurrence.last_edited),
         creator_user_id=occurrence.creator_user_id,
@@ -404,16 +404,13 @@ class Events(events_pb2_grpc.EventsServicer):
 
         # As protobuf parses a missing value as 0.0, this is not a permitted event coordinate value
         if not (
-            request.HasField("offline_information")
-            and request.offline_information.address
-            and request.offline_information.lat
-            and request.offline_information.lng
+            request.HasField("location") and request.location.address and request.location.lat and request.location.lng
         ):
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "missing_event_address_or_location")
-        if request.offline_information.lat == 0 and request.offline_information.lng == 0:
+        if request.location.lat == 0 and request.location.lng == 0:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_coordinate")
-        geom = create_coordinate(request.offline_information.lat, request.offline_information.lng)
-        address = request.offline_information.address
+        geom = create_coordinate(request.location.lat, request.location.lng)
+        address = request.location.address
 
         start_time = to_aware_datetime(request.start_time)
         end_time = to_aware_datetime(request.end_time)
@@ -538,16 +535,13 @@ class Events(events_pb2_grpc.EventsServicer):
         if not request.content:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "missing_event_content")
         if not (
-            request.HasField("offline_information")
-            and request.offline_information.address
-            and request.offline_information.lat
-            and request.offline_information.lng
+            request.HasField("location") and request.location.address and request.location.lat and request.location.lng
         ):
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "missing_event_address_or_location")
-        if request.offline_information.lat == 0 and request.offline_information.lng == 0:
+        if request.location.lat == 0 and request.location.lng == 0:
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_coordinate")
-        geom = create_coordinate(request.offline_information.lat, request.offline_information.lng)
-        address = request.offline_information.address
+        geom = create_coordinate(request.location.lat, request.location.lng)
+        address = request.location.address
 
         start_time = to_aware_datetime(request.start_time)
         end_time = to_aware_datetime(request.end_time)
@@ -663,15 +657,13 @@ class Events(events_pb2_grpc.EventsServicer):
         if request.HasField("photo_key"):
             occurrence_update["photo_key"] = request.photo_key.value
 
-        if request.HasField("offline_information"):
+        if request.HasField("location"):
             notify_updated.append(notification_data_pb2.EventUpdateItem.EVENT_UPDATE_ITEM_LOCATION)
             occurrence_update["link"] = None
-            if request.offline_information.lat == 0 and request.offline_information.lng == 0:
+            if request.location.lat == 0 and request.location.lng == 0:
                 context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_coordinate")
-            occurrence_update["geom"] = create_coordinate(
-                request.offline_information.lat, request.offline_information.lng
-            )
-            occurrence_update["address"] = request.offline_information.address
+            occurrence_update["geom"] = create_coordinate(request.location.lat, request.location.lng)
+            occurrence_update["address"] = request.location.address
 
         if request.HasField("start_time") or request.HasField("end_time"):
             if request.update_all_future:

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -755,7 +755,7 @@ def test_DeleteEvent(db):
                 title="Dummy Title",
                 content="Dummy content.",
                 photo_key=None,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,

--- a/app/backend/src/tests/test_communities.py
+++ b/app/backend/src/tests/test_communities.py
@@ -210,7 +210,7 @@ def create_event(
             events_pb2.CreateEventReq(
                 title=title,
                 content=content,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -513,7 +513,7 @@ def test_email_deleted_users_regression(db, email_collector: EmailCollector, mod
                 content="Dummy content.",
                 photo_key=None,
                 parent_community_id=c_id,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,

--- a/app/backend/src/tests/test_event_log.py
+++ b/app/backend/src/tests/test_event_log.py
@@ -783,7 +783,7 @@ def test_event_created_event(db):
             events_pb2.CreateEventReq(
                 title="Test Meetup",
                 content="Let's hang out",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="123 Main St",
                     lat=0.1,
                     lng=0.2,

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -65,7 +65,7 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
                 title="Dummy Title",
                 content="Dummy content.",
                 photo_key=None,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -81,10 +81,10 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
         assert res.slug == "dummy-title"
         assert res.content == "Dummy content."
         assert not res.photo_url
-        assert res.HasField("offline_information")
-        assert res.offline_information.lat == 0.1
-        assert res.offline_information.lng == 0.2
-        assert res.offline_information.address == "Near Null Island"
+        assert res.HasField("location")
+        assert res.location.lat == 0.1
+        assert res.location.lng == 0.2
+        assert res.location.address == "Near Null Island"
         assert time_before <= to_aware_datetime(res.created) <= now()
         assert time_before <= to_aware_datetime(res.last_edited) <= now()
         assert res.creator_user_id == user1.id
@@ -117,10 +117,10 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
         assert res.slug == "dummy-title"
         assert res.content == "Dummy content."
         assert not res.photo_url
-        assert res.HasField("offline_information")
-        assert res.offline_information.lat == 0.1
-        assert res.offline_information.lng == 0.2
-        assert res.offline_information.address == "Near Null Island"
+        assert res.HasField("location")
+        assert res.location.lat == 0.1
+        assert res.location.lng == 0.2
+        assert res.location.address == "Near Null Island"
         assert time_before <= to_aware_datetime(res.created) <= now()
         assert time_before <= to_aware_datetime(res.last_edited) <= now()
         assert res.creator_user_id == user1.id
@@ -148,10 +148,10 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
         assert res.slug == "dummy-title"
         assert res.content == "Dummy content."
         assert not res.photo_url
-        assert res.HasField("offline_information")
-        assert res.offline_information.lat == 0.1
-        assert res.offline_information.lng == 0.2
-        assert res.offline_information.address == "Near Null Island"
+        assert res.HasField("location")
+        assert res.location.lat == 0.1
+        assert res.location.lng == 0.2
+        assert res.location.address == "Near Null Island"
         assert time_before <= to_aware_datetime(res.created) <= now()
         assert time_before <= to_aware_datetime(res.last_edited) <= now()
         assert res.creator_user_id == user1.id
@@ -179,7 +179,7 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
                     # title="Dummy Title",
                     content="Dummy content.",
                     photo_key=None,
-                    offline_information=events_pb2.OfflineEventInformation(
+                    location=events_pb2.EventLocation(
                         address="Near Null Island",
                         lat=0.1,
                         lng=0.2,
@@ -198,7 +198,7 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
                     title="Dummy Title",
                     # content="Dummy content.",
                     photo_key=None,
-                    offline_information=events_pb2.OfflineEventInformation(
+                    location=events_pb2.EventLocation(
                         address="Near Null Island",
                         lat=0.1,
                         lng=0.2,
@@ -217,7 +217,7 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
                     title="Dummy Title",
                     content="Dummy content.",
                     photo_key="nonexistent",
-                    offline_information=events_pb2.OfflineEventInformation(
+                    location=events_pb2.EventLocation(
                         address="Near Null Island",
                         lat=0.1,
                         lng=0.2,
@@ -235,7 +235,7 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
                 events_pb2.CreateEventReq(
                     title="Dummy Title",
                     content="Dummy content.",
-                    offline_information=events_pb2.OfflineEventInformation(
+                    location=events_pb2.EventLocation(
                         address="Near Null Island",
                     ),
                     start_time=Timestamp_from_datetime(start_time),
@@ -251,7 +251,7 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
                 events_pb2.CreateEventReq(
                     title="Dummy Title",
                     content="Dummy content.",
-                    offline_information=events_pb2.OfflineEventInformation(
+                    location=events_pb2.EventLocation(
                         lat=0.1,
                         lng=0.1,
                     ),
@@ -268,7 +268,7 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
                 events_pb2.CreateEventReq(
                     title="Dummy Title",
                     content="Dummy content.",
-                    offline_information=events_pb2.OfflineEventInformation(
+                    location=events_pb2.EventLocation(
                         address="Near Null Island",
                         lat=0.1,
                         lng=0.2,
@@ -286,7 +286,7 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
                 events_pb2.CreateEventReq(
                     title="Dummy Title",
                     content="Dummy content.",
-                    offline_information=events_pb2.OfflineEventInformation(
+                    location=events_pb2.EventLocation(
                         address="Near Null Island",
                         lat=0.1,
                         lng=0.2,
@@ -304,7 +304,7 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
                 events_pb2.CreateEventReq(
                     title="Dummy Title",
                     content="Dummy content.",
-                    offline_information=events_pb2.OfflineEventInformation(
+                    location=events_pb2.EventLocation(
                         address="Near Null Island",
                         lat=0.1,
                         lng=0.2,
@@ -322,7 +322,7 @@ def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
                 events_pb2.CreateEventReq(
                     title="Dummy Title",
                     content="Dummy content.",
-                    offline_information=events_pb2.OfflineEventInformation(
+                    location=events_pb2.EventLocation(
                         address="Near Null Island",
                         lat=0.1,
                         lng=0.2,
@@ -353,7 +353,7 @@ def test_CreateEvent_incomplete_profile(db):
                     title="Dummy Title",
                     content="Dummy content.",
                     photo_key=None,
-                    offline_information=events_pb2.OfflineEventInformation(
+                    location=events_pb2.EventLocation(
                         address="Near Null Island",
                         lat=0.1,
                         lng=0.2,
@@ -386,7 +386,7 @@ def test_ScheduleEvent(db):
                 title="Dummy Title",
                 content="Dummy content.",
                 parent_community_id=c_id,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -404,7 +404,7 @@ def test_ScheduleEvent(db):
             events_pb2.ScheduleEventReq(
                 event_id=res.event_id,
                 content="New event occurrence",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="A bit further but still near Null Island",
                     lat=0.3,
                     lng=0.2,
@@ -422,10 +422,10 @@ def test_ScheduleEvent(db):
         assert res.slug == "dummy-title"
         assert res.content == "New event occurrence"
         assert not res.photo_url
-        assert res.HasField("offline_information")
-        assert res.offline_information.lat == 0.3
-        assert res.offline_information.lng == 0.2
-        assert res.offline_information.address == "A bit further but still near Null Island"
+        assert res.HasField("location")
+        assert res.location.lat == 0.3
+        assert res.location.lng == 0.2
+        assert res.location.address == "A bit further but still near Null Island"
         assert time_before <= to_aware_datetime(res.created) <= now()
         assert time_before <= to_aware_datetime(res.last_edited) <= now()
         assert res.creator_user_id == user.id
@@ -460,7 +460,7 @@ def test_cannot_overlap_occurrences_schedule(db):
                 title="Dummy Title",
                 content="Dummy content.",
                 parent_community_id=c_id,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -476,7 +476,7 @@ def test_cannot_overlap_occurrences_schedule(db):
                 events_pb2.ScheduleEventReq(
                     event_id=res.event_id,
                     content="New event occurrence",
-                    offline_information=events_pb2.OfflineEventInformation(
+                    location=events_pb2.EventLocation(
                         address="A bit further but still near Null Island",
                         lat=0.3,
                         lng=0.2,
@@ -504,7 +504,7 @@ def test_cannot_overlap_occurrences_update(db):
                 title="Dummy Title",
                 content="Dummy content.",
                 parent_community_id=c_id,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -519,7 +519,7 @@ def test_cannot_overlap_occurrences_update(db):
             events_pb2.ScheduleEventReq(
                 event_id=res.event_id,
                 content="New event occurrence",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="A bit further but still near Null Island",
                     lat=0.3,
                     lng=0.2,
@@ -580,7 +580,7 @@ def test_UpdateEvent_single(db, moderator: Moderator):
                 title="Dummy Title",
                 content="Dummy content.",
                 parent_community_id=c_id,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -623,10 +623,10 @@ def test_UpdateEvent_single(db, moderator: Moderator):
         assert res.slug == "dummy-title"
         assert res.content == "Dummy content."
         assert not res.photo_url
-        assert res.HasField("offline_information")
-        assert res.offline_information.lat == 0.1
-        assert res.offline_information.lng == 0.2
-        assert res.offline_information.address == "Near Null Island"
+        assert res.HasField("location")
+        assert res.location.lat == 0.1
+        assert res.location.lng == 0.2
+        assert res.location.address == "Near Null Island"
         assert time_before <= to_aware_datetime(res.created) <= time_before_update
         assert time_before_update <= to_aware_datetime(res.last_edited) <= now()
         assert res.creator_user_id == user1.id
@@ -654,10 +654,10 @@ def test_UpdateEvent_single(db, moderator: Moderator):
         assert res.slug == "dummy-title"
         assert res.content == "Dummy content."
         assert not res.photo_url
-        assert res.HasField("offline_information")
-        assert res.offline_information.lat == 0.1
-        assert res.offline_information.lng == 0.2
-        assert res.offline_information.address == "Near Null Island"
+        assert res.HasField("location")
+        assert res.location.lat == 0.1
+        assert res.location.lng == 0.2
+        assert res.location.address == "Near Null Island"
         assert time_before <= to_aware_datetime(res.created) <= time_before_update
         assert time_before_update <= to_aware_datetime(res.last_edited) <= now()
         assert res.creator_user_id == user1.id
@@ -685,10 +685,10 @@ def test_UpdateEvent_single(db, moderator: Moderator):
         assert res.slug == "dummy-title"
         assert res.content == "Dummy content."
         assert not res.photo_url
-        assert res.HasField("offline_information")
-        assert res.offline_information.lat == 0.1
-        assert res.offline_information.lng == 0.2
-        assert res.offline_information.address == "Near Null Island"
+        assert res.HasField("location")
+        assert res.location.lat == 0.1
+        assert res.location.lng == 0.2
+        assert res.location.address == "Near Null Island"
         assert time_before <= to_aware_datetime(res.created) <= time_before_update
         assert time_before_update <= to_aware_datetime(res.last_edited) <= now()
         assert res.creator_user_id == user1.id
@@ -712,7 +712,7 @@ def test_UpdateEvent_single(db, moderator: Moderator):
         res = api.UpdateEvent(
             events_pb2.UpdateEventReq(
                 event_id=event_id,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Nearer Null Island",
                     lat=0.01,
                     lng=0.02,
@@ -723,10 +723,10 @@ def test_UpdateEvent_single(db, moderator: Moderator):
     with events_session(token3) as api:
         res = api.GetEvent(events_pb2.GetEventReq(event_id=event_id))
 
-        assert res.HasField("offline_information")
-        assert res.offline_information.address == "Nearer Null Island"
-        assert res.offline_information.lat == 0.01
-        assert res.offline_information.lng == 0.02
+        assert res.HasField("location")
+        assert res.location.address == "Nearer Null Island"
+        assert res.location.lat == 0.01
+        assert res.location.lng == 0.02
 
 
 def test_GetEvent_online(db, moderator: Moderator):
@@ -746,7 +746,7 @@ def test_GetEvent_online(db, moderator: Moderator):
                 title="Dummy Title",
                 content="Dummy content.",
                 parent_community_id=c_id,
-                offline_information=events_pb2.OfflineEventInformation(address="Near Null Island", lat=0.1, lng=0.2),
+                location=events_pb2.EventLocation(address="Near Null Island", lat=0.1, lng=0.2),
                 start_time=Timestamp_from_datetime(start_time),
                 end_time=Timestamp_from_datetime(end_time),
                 timezone="UTC",
@@ -769,10 +769,10 @@ def test_GetEvent_online(db, moderator: Moderator):
         get_res: events_pb2.Event = api.GetEvent(events_pb2.GetEventReq(event_id=event_id))
 
         assert get_res.title == "Dummy Title"
-        assert get_res.HasField("offline_information")
-        assert get_res.offline_information.address == "https://couchers.org/meet/"
-        assert get_res.offline_information.lng == 0
-        assert get_res.offline_information.lat == 0
+        assert get_res.HasField("location")
+        assert get_res.location.address == "https://couchers.org/meet/"
+        assert get_res.location.lng == 0
+        assert get_res.location.lat == 0
 
 
 def test_UpdateEvent_all(db, moderator: Moderator):
@@ -800,7 +800,7 @@ def test_UpdateEvent_all(db, moderator: Moderator):
             events_pb2.CreateEventReq(
                 title="Dummy Title",
                 content="0th occurrence",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -833,7 +833,7 @@ def test_UpdateEvent_all(db, moderator: Moderator):
                 events_pb2.ScheduleEventReq(
                     event_id=event_ids[-1],
                     content=f"{i + 1}th occurrence",
-                    offline_information=events_pb2.OfflineEventInformation(
+                    location=events_pb2.EventLocation(
                         address="Near Null Island",
                         lat=0.1,
                         lng=0.2,
@@ -860,7 +860,7 @@ def test_UpdateEvent_all(db, moderator: Moderator):
                 event_id=updated_event_id,
                 title=wrappers_pb2.StringValue(value="New Title"),
                 content=wrappers_pb2.StringValue(value="New content."),
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     lat=0.2,
                     lng=0.2,
                 ),
@@ -906,7 +906,7 @@ def test_GetEvent(db, moderator: Moderator):
             events_pb2.CreateEventReq(
                 title="Dummy Title",
                 content="Dummy content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -940,10 +940,10 @@ def test_GetEvent(db, moderator: Moderator):
         assert res.slug == "dummy-title"
         assert res.content == "Dummy content."
         assert not res.photo_url
-        assert res.HasField("offline_information")
-        assert res.offline_information.lat == 0.1
-        assert res.offline_information.lng == 0.2
-        assert res.offline_information.address == "Near Null Island"
+        assert res.HasField("location")
+        assert res.location.lat == 0.1
+        assert res.location.lng == 0.2
+        assert res.location.address == "Near Null Island"
         assert time_before <= to_aware_datetime(res.created) <= now()
         assert time_before <= to_aware_datetime(res.last_edited) <= now()
         assert res.creator_user_id == user1.id
@@ -971,10 +971,10 @@ def test_GetEvent(db, moderator: Moderator):
         assert res.slug == "dummy-title"
         assert res.content == "Dummy content."
         assert not res.photo_url
-        assert res.HasField("offline_information")
-        assert res.offline_information.lat == 0.1
-        assert res.offline_information.lng == 0.2
-        assert res.offline_information.address == "Near Null Island"
+        assert res.HasField("location")
+        assert res.location.lat == 0.1
+        assert res.location.lng == 0.2
+        assert res.location.address == "Near Null Island"
         assert time_before <= to_aware_datetime(res.created) <= now()
         assert time_before <= to_aware_datetime(res.last_edited) <= now()
         assert res.creator_user_id == user1.id
@@ -1002,10 +1002,10 @@ def test_GetEvent(db, moderator: Moderator):
         assert res.slug == "dummy-title"
         assert res.content == "Dummy content."
         assert not res.photo_url
-        assert res.HasField("offline_information")
-        assert res.offline_information.lat == 0.1
-        assert res.offline_information.lng == 0.2
-        assert res.offline_information.address == "Near Null Island"
+        assert res.HasField("location")
+        assert res.location.lat == 0.1
+        assert res.location.lng == 0.2
+        assert res.location.address == "Near Null Island"
         assert time_before <= to_aware_datetime(res.created) <= now()
         assert time_before <= to_aware_datetime(res.last_edited) <= now()
         assert res.creator_user_id == user1.id
@@ -1048,7 +1048,7 @@ def test_CancelEvent(db, moderator: Moderator):
             events_pb2.CreateEventReq(
                 title="Dummy Title",
                 content="Dummy content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -1166,7 +1166,7 @@ def test_ListEventAttendees(db, moderator: Moderator):
             events_pb2.CreateEventReq(
                 title="Dummy Title",
                 content="Dummy content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -1221,7 +1221,7 @@ def test_ListEventSubscribers(db, moderator: Moderator):
             events_pb2.CreateEventReq(
                 title="Dummy Title",
                 content="Dummy content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -1274,7 +1274,7 @@ def test_ListEventOrganizers(db, moderator: Moderator):
             events_pb2.CreateEventReq(
                 title="Dummy Title",
                 content="Dummy content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -1326,7 +1326,7 @@ def test_TransferEvent(db):
             events_pb2.CreateEventReq(
                 title="Dummy Title",
                 content="Dummy content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -1361,7 +1361,7 @@ def test_TransferEvent(db):
             events_pb2.CreateEventReq(
                 title="Dummy Title",
                 content="Dummy content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -1405,7 +1405,7 @@ def test_SetEventSubscription(db, moderator: Moderator):
             events_pb2.CreateEventReq(
                 title="Dummy Title",
                 content="Dummy content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -1438,7 +1438,7 @@ def test_SetEventAttendance(db, moderator: Moderator):
             events_pb2.CreateEventReq(
                 title="Dummy Title",
                 content="Dummy content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -1484,7 +1484,7 @@ def test_InviteEventOrganizer(db, moderator: Moderator):
             events_pb2.CreateEventReq(
                 title="Dummy Title",
                 content="Dummy content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -1532,7 +1532,7 @@ def test_ListEventOccurrences(db):
                 title="First occurrence",
                 content="Dummy content.",
                 parent_community_id=c_id,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -1550,7 +1550,7 @@ def test_ListEventOccurrences(db):
                 events_pb2.ScheduleEventReq(
                     event_id=event_ids[-1],
                     content=f"{i}th occurrence",
-                    offline_information=events_pb2.OfflineEventInformation(
+                    location=events_pb2.EventLocation(
                         address="Near Null Island",
                         lat=0.1,
                         lng=0.2,
@@ -1605,9 +1605,9 @@ def test_ListMyEvents(db, moderator: Moderator):
 
     def new_event(hours_from_now: int, community_id: int) -> events_pb2.CreateEventReq:
         return events_pb2.CreateEventReq(
-            title="Dummy Offline Title",
+            title="Dummy Title",
             content="Dummy content.",
-            offline_information=events_pb2.OfflineEventInformation(
+            location=events_pb2.EventLocation(
                 address="Near Null Island",
                 lat=0.1,
                 lng=0.2,
@@ -1781,7 +1781,7 @@ def test_list_my_events_exclude_attending(db, moderator: Moderator):
         return events_pb2.CreateEventReq(
             title="Test Event",
             content="Test content.",
-            offline_information=events_pb2.OfflineEventInformation(
+            location=events_pb2.EventLocation(
                 address="Near Null Island",
                 lat=0.1,
                 lng=0.2,
@@ -1854,7 +1854,7 @@ def test_RemoveEventOrganizer(db, moderator: Moderator):
             events_pb2.CreateEventReq(
                 title="Dummy Title",
                 content="Dummy content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -1964,7 +1964,7 @@ def test_ListEventAttendees_regression(db):
             events_pb2.CreateEventReq(
                 title="Dummy Title",
                 content="Dummy content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2015,7 +2015,7 @@ def test_event_threads(db, push_collector: PushCollector, moderator: Moderator):
             events_pb2.CreateEventReq(
                 title="Dummy Title",
                 content="Dummy content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2083,7 +2083,7 @@ def test_can_overlap_other_events_schedule_regression(db):
                 title="Dummy Title",
                 content="Dummy content.",
                 parent_community_id=c_id,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2100,7 +2100,7 @@ def test_can_overlap_other_events_schedule_regression(db):
                 title="Dummy Title",
                 content="Dummy content.",
                 parent_community_id=c_id,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2116,7 +2116,7 @@ def test_can_overlap_other_events_schedule_regression(db):
             events_pb2.ScheduleEventReq(
                 event_id=res.event_id,
                 content="New event occurrence",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="A bit further but still near Null Island",
                     lat=0.3,
                     lng=0.2,
@@ -2143,7 +2143,7 @@ def test_can_overlap_other_events_update_regression(db):
                 title="Dummy Title",
                 content="Dummy content.",
                 parent_community_id=c_id,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2159,7 +2159,7 @@ def test_can_overlap_other_events_update_regression(db):
                 title="Dummy Title",
                 content="Dummy content.",
                 parent_community_id=c_id,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2174,7 +2174,7 @@ def test_can_overlap_other_events_update_regression(db):
             events_pb2.ScheduleEventReq(
                 event_id=res.event_id,
                 content="New event occurrence",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="A bit further but still near Null Island",
                     lat=0.3,
                     lng=0.2,
@@ -2218,7 +2218,7 @@ def test_list_past_events_regression(db):
                 title="Dummy Title",
                 content="Dummy content.",
                 parent_community_id=c_id,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2262,7 +2262,7 @@ def test_community_invite_requests(db, email_collector: EmailCollector, moderato
                 title="Dummy Title",
                 content="Dummy content.",
                 parent_community_id=c_id,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2348,7 +2348,7 @@ def test_update_event_should_notify_queues_job():
                 title="Dummy Title",
                 content="Dummy content.",
                 parent_community_id=c_id,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=1.0,
                     lng=2.0,
@@ -2417,7 +2417,7 @@ def test_event_photo_key(db):
                 title="Event Without Photo",
                 content="No photo content.",
                 photo_key=None,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2437,7 +2437,7 @@ def test_event_photo_key(db):
                 title="Event With Photo",
                 content="Has photo content.",
                 photo_key="test_event_photo_key_123",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2474,7 +2474,7 @@ def test_event_created_with_shadowed_visibility(db):
             events_pb2.CreateEventReq(
                 title="Test UMS Event",
                 content="UMS content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2510,7 +2510,7 @@ def test_shadowed_event_visible_to_creator_only(db):
             events_pb2.CreateEventReq(
                 title="Shadowed Event",
                 content="Content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2550,7 +2550,7 @@ def test_event_visible_after_approval(db, moderator: Moderator):
             events_pb2.CreateEventReq(
                 title="Approved Event",
                 content="Content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2593,7 +2593,7 @@ def test_shadowed_event_hidden_from_list_for_non_creator(db, moderator: Moderato
             events_pb2.CreateEventReq(
                 title="List Test Event",
                 content="Content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2646,7 +2646,7 @@ def test_event_create_notification_deferred_until_approval(db, push_collector: P
             events_pb2.CreateEventReq(
                 title="Deferred Event",
                 content="Content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2700,7 +2700,7 @@ def test_event_update_notification_has_moderation_state(db, push_collector: Push
             events_pb2.CreateEventReq(
                 title="Update Test",
                 content="Content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2761,7 +2761,7 @@ def test_event_cancel_notification_has_moderation_state(db, push_collector: Push
             events_pb2.CreateEventReq(
                 title="Cancel Test",
                 content="Content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2815,7 +2815,7 @@ def test_event_reminder_notification_has_moderation_state(db, push_collector: Pu
             events_pb2.CreateEventReq(
                 title="Reminder Test",
                 content="Content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2869,7 +2869,7 @@ def test_event_reminder_not_sent_for_cancelled_event(db, push_collector: PushCol
             events_pb2.CreateEventReq(
                 title="Cancelled Reminder Test",
                 content="Content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2928,7 +2928,7 @@ def test_event_reminder_not_sent_for_invisible_attendee(
             events_pb2.CreateEventReq(
                 title="Invisible Attendee Reminder Test",
                 content="Content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2978,7 +2978,7 @@ def test_ListEventOccurrences_does_not_leak_other_events(db, moderator: Moderato
                 title="Event A",
                 content="Content A.",
                 parent_community_id=c_id,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2994,7 +2994,7 @@ def test_ListEventOccurrences_does_not_leak_other_events(db, moderator: Moderato
                 events_pb2.ScheduleEventReq(
                     event_id=event_a_ids[-1],
                     content=f"A occurrence {i}",
-                    offline_information=events_pb2.OfflineEventInformation(
+                    location=events_pb2.EventLocation(
                         address="Near Null Island",
                         lat=0.1,
                         lng=0.2,
@@ -3014,7 +3014,7 @@ def test_ListEventOccurrences_does_not_leak_other_events(db, moderator: Moderato
                 title="Event B",
                 content="Content B.",
                 parent_community_id=c_id,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -3029,7 +3029,7 @@ def test_ListEventOccurrences_does_not_leak_other_events(db, moderator: Moderato
             events_pb2.ScheduleEventReq(
                 event_id=event_b_ids[-1],
                 content="B occurrence 1",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -3074,7 +3074,7 @@ def test_event_comment_notification_has_moderation_state(db, push_collector: Pus
                 title="Comment Test",
                 content="Content.",
                 parent_community_id=c_id,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -3132,7 +3132,7 @@ def test_event_thread_reply_notification_has_moderation_state(db, push_collector
             events_pb2.CreateEventReq(
                 title="Reply Test",
                 content="Content.",
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,

--- a/app/backend/src/tests/test_moderation.py
+++ b/app/backend/src/tests/test_moderation.py
@@ -2764,7 +2764,7 @@ def test_event_moderation_state_content(db):
                 title="My Event Title",
                 content="My event description.",
                 photo_key=None,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,
@@ -2898,7 +2898,7 @@ def test_SetUserContentVisibility_event_occurrence(db):
                 title="Event",
                 content="Event description.",
                 photo_key=None,
-                offline_information=events_pb2.OfflineEventInformation(
+                location=events_pb2.EventLocation(
                     address="Near Null Island",
                     lat=0.1,
                     lng=0.2,

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -412,7 +412,7 @@ def sample_event_data() -> dict[str, Any]:
         "title": "Dummy Title",
         "content": "Dummy content.",
         "photo_key": None,
-        "offline_information": events_pb2.OfflineEventInformation(address="Near Null Island", lat=0.1, lng=0.2),
+        "location": events_pb2.EventLocation(address="Near Null Island", lat=0.1, lng=0.2),
         "start_time": Timestamp_from_datetime(start_time),
         "end_time": Timestamp_from_datetime(end_time),
         "timezone": "UTC",
@@ -517,7 +517,7 @@ def test_event_search_by_circle(sample_community, create_event):
             create_event(
                 api,
                 title=f"Inside area {i}",
-                offline_information=events_pb2.OfflineEventInformation(lat=lat, lng=lng, address=f"Inside area {i}"),
+                location=events_pb2.EventLocation(lat=lat, lng=lng, address=f"Inside area {i}"),
             )
 
         outside_pts = [(1, 0.1), (0.1, 1), (10, 1)]
@@ -525,7 +525,7 @@ def test_event_search_by_circle(sample_community, create_event):
             create_event(
                 api,
                 title=f"Outside area {i}",
-                offline_information=events_pb2.OfflineEventInformation(lat=lat, lng=lng, address=f"Outside area {i}"),
+                location=events_pb2.EventLocation(lat=lat, lng=lng, address=f"Outside area {i}"),
             )
 
     with search_session(token) as api:
@@ -544,7 +544,7 @@ def test_event_search_by_rectangle(sample_community, create_event):
             create_event(
                 api,
                 title=f"Inside area {i}",
-                offline_information=events_pb2.OfflineEventInformation(lat=lat, lng=lng, address=f"Inside area {i}"),
+                location=events_pb2.EventLocation(lat=lat, lng=lng, address=f"Inside area {i}"),
             )
 
         outside_pts = [(-1, 0.1), (0.1, 0.01), (-0.01, 0.01), (0.1, 1.2), (10, 1)]
@@ -552,7 +552,7 @@ def test_event_search_by_rectangle(sample_community, create_event):
             create_event(
                 api,
                 title=f"Outside area {i}",
-                offline_information=events_pb2.OfflineEventInformation(lat=lat, lng=lng, address=f"Outside area {i}"),
+                location=events_pb2.EventLocation(lat=lat, lng=lng, address=f"Outside area {i}"),
             )
 
     with search_session(token) as api:
@@ -676,7 +676,7 @@ def test_event_search_filter_subscription_attendance_organizing_my_communities(
         create_event(
             api,
             title="Other community event",
-            offline_information=events_pb2.OfflineEventInformation(lat=58, lng=1, address="Somewhere"),
+            location=events_pb2.EventLocation(lat=58, lng=1, address="Somewhere"),
         )
 
     # Approve all events so they're visible to other users
@@ -742,7 +742,7 @@ def test_event_search_exclude_attending(sample_community, create_event, moderato
         create_event(
             api,
             title="Other community event",
-            offline_information=events_pb2.OfflineEventInformation(lat=58, lng=1, address="Somewhere"),
+            location=events_pb2.EventLocation(lat=58, lng=1, address="Somewhere"),
         )
 
     with session_scope() as session:

--- a/app/backend/src/tests/test_upload_uses.py
+++ b/app/backend/src/tests/test_upload_uses.py
@@ -78,7 +78,7 @@ def test_get_upload_uses_event(db):
                 title="Event With Photo",
                 content="content",
                 photo_key="event_key",
-                offline_information=events_pb2.OfflineEventInformation(address="Null Island", lat=0.1, lng=0.2),
+                location=events_pb2.EventLocation(address="Null Island", lat=0.1, lng=0.2),
                 start_time=Timestamp_from_datetime(start_time),
                 end_time=Timestamp_from_datetime(end_time),
                 timezone="UTC",

--- a/app/proto/events.proto
+++ b/app/proto/events.proto
@@ -83,13 +83,8 @@ service Events {
   // TODO: DownloadCalendarInvite
 }
 
-message OnlineEventInformation {
-  // videoconferencing link, etc
-  string link = 1;
-}
-
-message OfflineEventInformation {
-  // in-person events must have address + location
+message EventLocation {
+  // Events must have address + coordinates
   string address = 1;
   double lat = 2;
   double lng = 3;
@@ -119,7 +114,7 @@ message Event {
   string photo_key = 35;
 
   reserved 9; // Formerly online_information.
-  OfflineEventInformation offline_information = 10;
+  EventLocation location = 10;
 
   google.protobuf.Timestamp created = 13;
   google.protobuf.Timestamp last_edited = 14;
@@ -166,7 +161,7 @@ message CreateEventReq {
   // from media server
   string photo_key = 3;
   reserved 4; // Formerly online_information.
-  OfflineEventInformation offline_information = 5;
+  EventLocation location = 5;
   int64 parent_community_id = 8; // Optional, can be auto-filled from the location
   // timestamps are in UTC
   google.protobuf.Timestamp start_time = 9;
@@ -181,7 +176,7 @@ message ScheduleEventReq {
   // from media server
   string photo_key = 3;
   reserved 4; // Formerly online_information.
-  OfflineEventInformation offline_information = 5;
+  EventLocation location = 5;
   // timestamps are in UTC
   google.protobuf.Timestamp start_time = 8;
   google.protobuf.Timestamp end_time = 9;
@@ -198,7 +193,7 @@ message UpdateEventReq {
   // from media server, set to empty string to clear
   google.protobuf.StringValue photo_key = 5;
   reserved 6; // Formerly online_information.
-  OfflineEventInformation offline_information = 7;
+  EventLocation location = 7;
   google.protobuf.Timestamp start_time = 9;
   google.protobuf.Timestamp end_time = 10;
   // the tzdata timezone identifier

--- a/app/web/features/communities/events/CreateEventPage.test.tsx
+++ b/app/web/features/communities/events/CreateEventPage.test.tsx
@@ -71,7 +71,7 @@ describe("Create event page", () => {
     jest.useRealTimers();
   });
 
-  it("creates on offline event with no route state correctly", async () => {
+  it("creates on event with no route state correctly", async () => {
     renderPageWithState();
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
@@ -163,7 +163,7 @@ describe("Create event page", () => {
     });
   });
 
-  it("creates on offline event with route state correctly", async () => {
+  it("creates on event with route state correctly", async () => {
     renderPageWithState({ communityId: 99 });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });

--- a/app/web/features/communities/events/EventCard.test.tsx
+++ b/app/web/features/communities/events/EventCard.test.tsx
@@ -11,15 +11,13 @@ const [firstEvent, secondEvent] = events;
 const cancelledEvent = events[3];
 
 describe("Event card", () => {
-  it("renders an offline event card details correctly with the same start and end day", async () => {
+  it("renders an event card details correctly with the same start and end day", async () => {
     render(<EventCard event={firstEvent} />, { wrapper });
 
     expect(
       screen.getByRole("heading", { name: firstEvent.title }),
     ).toBeVisible();
-    expect(
-      screen.getByText(firstEvent.offlineInformation!.address),
-    ).toBeVisible();
+    expect(screen.getByText(firstEvent.location!.address)).toBeVisible();
     expect(
       screen.getByText("Tue, Jun 29, 2021, 2:37 – 3:37 AM", {
         normalizer: (x) => x, // Match non-breaking spaces and en dashes exactly
@@ -42,9 +40,7 @@ describe("Event card", () => {
     expect(
       screen.getByRole("heading", { name: secondEvent.title }),
     ).toBeVisible();
-    expect(
-      screen.getByText(secondEvent.offlineInformation!.address),
-    ).toBeVisible();
+    expect(screen.getByText(secondEvent.location!.address)).toBeVisible();
     expect(
       screen.getByText(
         "Tue, Jun 29, 2021, 9:00 PM – Wed, Jun 30, 2021, 2:00 AM",

--- a/app/web/features/communities/events/EventCard.tsx
+++ b/app/web/features/communities/events/EventCard.tsx
@@ -200,7 +200,7 @@ export default function EventCard({ event, className }: EventCardProps) {
               maxWidth: "25em",
             }}
           >
-            {event.offlineInformation?.address}
+            {event.location?.address}
           </Typography>
           {event.isCancelled && (
             <CancelledChip label={t("communities:cancelled")} />

--- a/app/web/features/communities/events/EventForm.test.tsx
+++ b/app/web/features/communities/events/EventForm.test.tsx
@@ -179,7 +179,7 @@ describe("Event form", () => {
     expect(serviceFn).not.toHaveBeenCalled();
   });
 
-  it("should not submit if location is missing for an offline event", async () => {
+  it("should not submit if location is missing for an event", async () => {
     renderForm();
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
@@ -353,7 +353,7 @@ describe("Event form", () => {
     await assertErrorAlert(errorMessage);
   });
 
-  it("should submit an offline event successfully", async () => {
+  it("should submit an event successfully", async () => {
     renderForm();
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });

--- a/app/web/features/communities/events/EventForm.tsx
+++ b/app/web/features/communities/events/EventForm.tsx
@@ -109,14 +109,11 @@ export default function EventForm({
   });
 
   const locationDefaultValue = useRef(
-    event?.offlineInformation
+    event?.location
       ? {
-          name: event.offlineInformation.address,
-          simplifiedName: event.offlineInformation.address,
-          location: new LngLat(
-            event.offlineInformation.lng,
-            event.offlineInformation.lat,
-          ),
+          name: event.location.address,
+          simplifiedName: event.location.address,
+          location: new LngLat(event.location.lng, event.location.lat),
           bbox: [0, 0, 0, 0] as Coordinates,
         }
       : ("" as const),

--- a/app/web/features/communities/events/EventPage.test.tsx
+++ b/app/web/features/communities/events/EventPage.test.tsx
@@ -86,15 +86,13 @@ describe("Event page", () => {
     jest.useRealTimers();
   });
 
-  it("renders an offline event successfully", async () => {
+  it("renders an event successfully", async () => {
     renderEventPage();
 
     expect(
       await screen.findByRole("heading", { name: firstEvent.title }),
     ).toBeVisible();
-    expect(
-      await screen.findByText(firstEvent.offlineInformation!.address),
-    ).toBeVisible();
+    expect(await screen.findByText(firstEvent.location!.address)).toBeVisible();
     expect(
       await screen.findByText("Tuesday, June 29, 2021, 2:37 – 3:37 AM", {
         normalizer: (x) => x, // Match non-breaking spaces and en dashes exactly

--- a/app/web/features/communities/events/EventPage.tsx
+++ b/app/web/features/communities/events/EventPage.tsx
@@ -344,7 +344,7 @@ export default function EventPage({
               <StyledTitle>
                 <Typography variant="h1">{event.title}</Typography>
                 <StyledEventTypeText variant="body1">
-                  {event.offlineInformation?.address}
+                  {event.location?.address}
                 </StyledEventTypeText>
                 {event.isCancelled && (
                   <StyledCancelledChip label={t("communities:cancelled")} />

--- a/app/web/features/communities/events/LongEventCard.tsx
+++ b/app/web/features/communities/events/LongEventCard.tsx
@@ -191,7 +191,7 @@ const LongEventCard = ({
 
           <Row>
             <EventInfo>
-              {event.offlineInformation?.address}
+              {event.location?.address}
               <div>{dateTimeRangeText}</div>
             </EventInfo>
             <ActivityStatsWrapper>

--- a/app/web/features/dashboard/EventListRow.tsx
+++ b/app/web/features/dashboard/EventListRow.tsx
@@ -228,7 +228,7 @@ export default function EventListRow({ event }: EventListRowProps) {
           </MetaItem>
           <MetaItem>
             <Place sx={{ fontSize: "12px" }} />
-            <MetaText>{event.offlineInformation?.address}</MetaText>
+            <MetaText>{event.location?.address}</MetaText>
           </MetaItem>
         </MetaLine>
       </ContentWrapper>

--- a/app/web/service/events.ts
+++ b/app/web/service/events.ts
@@ -8,13 +8,13 @@ import {
   AttendanceState,
   CancelEventReq,
   CreateEventReq,
+  EventLocation,
   GetEventReq,
   InviteEventOrganizerReq,
   ListAllEventsReq,
   ListEventAttendeesReq,
   ListEventOrganizersReq,
   ListMyEventsReq,
-  OfflineEventInformation,
   RemoveEventOrganizerReq,
   RequestCommunityInviteReq,
   SetEventAttendanceReq,
@@ -139,11 +139,11 @@ export async function createEvent(input: CreateEventInput) {
     req.setPhotoKey(input.photoKey);
   }
 
-  const offlineEventInfo = new OfflineEventInformation();
-  offlineEventInfo.setAddress(input.address);
-  offlineEventInfo.setLat(input.lat);
-  offlineEventInfo.setLng(input.lng);
-  req.setOfflineInformation(offlineEventInfo);
+  const location = new EventLocation();
+  location.setAddress(input.address);
+  location.setLat(input.lat);
+  location.setLng(input.lng);
+  req.setLocation(location);
 
   if (input.parentCommunityId) {
     req.setParentCommunityId(input.parentCommunityId);
@@ -180,11 +180,11 @@ export async function updateEvent(input: UpdateEventInput) {
   }
 
   if (input.address && input.lat && input.lng) {
-    const offlineEventInfo = new OfflineEventInformation();
-    offlineEventInfo.setAddress(input.address);
-    offlineEventInfo.setLat(input.lat);
-    offlineEventInfo.setLng(input.lng);
-    req.setOfflineInformation(offlineEventInfo);
+    const location = new EventLocation();
+    location.setAddress(input.address);
+    location.setLat(input.lat);
+    location.setLng(input.lng);
+    req.setLocation(location);
   }
 
   if (input.shouldNotify) {

--- a/app/web/test/fixtures/events.json
+++ b/app/web/test/fixtures/events.json
@@ -22,7 +22,7 @@
     "canEdit": false,
     "canModerate": false,
     "isNext": false,
-    "offlineInformation": {
+    "location": {
       "address": "Concertgebouw",
       "lat": 1,
       "lng": 2
@@ -58,7 +58,7 @@
     "canEdit": false,
     "canModerate": false,
     "isNext": false,
-    "offlineInformation": {
+    "location": {
       "address": "Mayjor A. Colijnweg 68, Amstelveen",
       "lat": 53,
       "lng": 26
@@ -94,7 +94,7 @@
     "canEdit": false,
     "canModerate": false,
     "isNext": false,
-    "offlineInformation": {
+    "location": {
       "address": "Amsterdam",
       "lat": 1,
       "lng": 2
@@ -130,7 +130,7 @@
     "canEdit": false,
     "canModerate": false,
     "isNext": false,
-    "offlineInformation": {
+    "location": {
       "address": "Mayjor A. Colijnweg 68, Amstelveen",
       "lat": 53,
       "lng": 26


### PR DESCRIPTION
Follow-up to #9133 . Since we don't have online events anymore, we can rename `EventOfflineInformation` to the more descriptive `EventLocation`. This is safe as names are not part of the serialized protobuf format.

## Testing
Ran linting+mypy

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
