### PR TITLE
Backend/emails: v2 copy for onboarding email

### DIFF
--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -41,6 +41,7 @@ from couchers.email.blocks import (
     ActionBlock,
     EmailBase,
     EmailBlock,
+    EmailBlocksBuilder,
     ParaBlock,
     QuoteBlock,
     UserInfo,
@@ -1744,36 +1745,38 @@ class OnboardingReminderEmail(EmailBase):
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context, default_closing=False)
-        edit_profile_url = urls.edit_profile_link()
         if self.initial:
-            builder.para(".welcome")
-            builder.para(".early_user_role")
-            builder.para(".fill_in_profile")
-            builder.para(".edit_profile_prompt")
-            builder.action(edit_profile_url, "onboarding_reminder.edit_profile_action")
-            builder.para(".share_with_friends")
-            builder.para(".link", {"link": html_link(urls.app_link())})
-            builder.para(".platform_under_development")
-            builder.para(".thanks_for_joining")
-            builder.para(
-                "generic.closing_lines.aapeli",
-                {
-                    "profile_link": html_link("https://couchers.org/user/aapeli"),
-                },
-            )
+            self._build_body_initial(builder)
         else:
-            builder.para(".intro")
-            builder.para(".request")
-            builder.action(edit_profile_url, "onboarding_reminder.edit_profile_action")
-            builder.para("generic.thanks")
-            builder.para(
-                "generic.closing_lines.emily",
-                {
-                    "email_link": html_mailto_link("community@couchers.org"),
-                    "profile_link": html_link("https://couchers.org/user/emily"),
-                },
-            )
+            self._build_body_followup(builder)
         return builder.build()
+
+    def _build_body_initial(self, builder: EmailBlocksBuilder) -> None:
+        builder.para(".welcome")
+        builder.para(".early_user_role")
+        builder.para(".complete_profile_request")
+        builder.para(".profile_importance")
+        builder.action(urls.edit_profile_link(), "onboarding_reminder.complete_profile_action")
+        builder.para(".share_request")
+        builder.para(
+            "generic.closing_lines.aapeli",
+            {
+                "profile_link": html_link("https://couchers.org/user/aapeli"),
+            },
+        )
+
+    def _build_body_followup(self, builder: EmailBlocksBuilder) -> None:
+        builder.para(".intro")
+        builder.para(".request")
+        builder.action(urls.edit_profile_link(), "onboarding_reminder.complete_profile_action")
+        builder.para("generic.thanks")
+        builder.para(
+            "generic.closing_lines.emily",
+            {
+                "email_link": html_mailto_link("community@couchers.org"),
+                "profile_link": html_link("https://couchers.org/user/emily"),
+            },
+        )
 
     @classmethod
     def test_instances(cls) -> list[Self]:

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -280,21 +280,18 @@
   "onboarding_reminder": {
     "initial": {
       "subject": "Welcome to Couchers.org and the future of couch surfing",
-      "welcome": "Welcome to Couchers.org, and our growing worldwide community of couch surfers. We are excited that you have joined us!",
-      "early_user_role": "We’re an evolving platform experiencing rapid growth. As an early user, you have a vital role in shaping the future of the platform. You can help us set the scene and culture as we grow bigger, as well as test functionality and provide feedback as we develop new features.",
-      "fill_in_profile": "Please take some time to explore the platform. As a first step, please write a bit about yourself on the 'About me' and 'My home' tabs of your profile. Please upload a photo of yourself and fill in some profile text. You can even copy and paste the text from your account on a different couch surfing platform if you're feeling lazy :P",
-      "edit_profile_prompt": "To edit your profile, click on the following link:",
-      "share_with_friends": "Otherwise, please share the link with any of your couch surfing friends that you trust! This platform can only grow with your help bringing the best people to it.",
-      "link": "Link: {{ link }}",
-      "platform_under_development": "The platform is still under development, and features are actively being built by our amazing team of Couchers.org volunteers around the world. We would like to hear your feedback and thoughts on what we've built and what we're working on.",
-      "thanks_for_joining": "Thanks so much for joining the platform. We're really excited to have you here and as part of our growing community!"
+      "welcome": "Welcome to Couchers.org, and our worldwide couch surfing community!",
+      "early_user_role": "We are growing quickly, and looking back, you will be one of the early users. You therefore have a vital role in shaping the culture and feel of the growing community and our platform. I’m really excited that you found us, and that you decided to join us!",
+      "complete_profile_request": "When you’ve had a chance to look around, please complete your profile by uploading a photo, and writing a bit about yourself (and about your home, if you wish to host).",
+      "profile_importance": "A profile that feels like a real person is what helps someone decide they'd love to meet or stay with you. Try to give the community a sample of your vibe! Don't overthink it: just write like yourself. Share what you're into, how you like to spend your time, and the things that matter to you.",
+      "share_request": "One more thing: please share the word and grow the community! Our best members are those who were invited by someone else."
     },
     "follow_up": {
       "subject": "Complete your profile",
       "intro": "I hope you've taken a bit of time to look around the Couchers.org platform!",
       "request": "We would love to ask one quick favor of you: please take a moment to fill out your profile by adding a photo and some text in the 'about me' and 'my home' sections. Filling out your profile makes others more interested in engaging with you and helps our community feel more welcoming."
     },
-    "edit_profile_action": "Complete your profile"
+    "complete_profile_action": "Complete your profile"
   },
   "password_changed": {
     "subject": "Your password was changed",


### PR DESCRIPTION
As per discussions with @aapeliv .

Minor tweaks to prose:
- uploading a profile picture -> uploading a photo (we use the term photo on the profile)
- Our best members are those ~that~who were invited by someone else.

I also more clearly split the code for the first and second onboarding emails since they're independent.

## Testing
`uv run dump-emails`

<img width="682" height="687" alt="image" src="https://github.com/user-attachments/assets/d22bef3d-1098-47dd-9413-232e4b635284" />

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
