### PR TITLE
Frontend/i18n: Remove inline <Trans> text

### DIFF
--- a/app/web/components/Navigation/ReportDialog.tsx
+++ b/app/web/components/Navigation/ReportDialog.tsx
@@ -111,7 +111,7 @@ export default function ReportDialog({ open, onClose }: DialogProps) {
                 </StyledLink>
               ),
             }}
-          ></Trans>
+          />
         </Snackbar>
       )}
       <Dialog aria-labelledby="bug-reporter" open={open} onClose={handleClose}>

--- a/app/web/components/ProfileIncompleteDialog/ProfileIncompleteDialog.tsx
+++ b/app/web/components/ProfileIncompleteDialog/ProfileIncompleteDialog.tsx
@@ -46,21 +46,17 @@ export default function ProfileIncompleteDialog({
       </DialogTitle>
       <DialogContent>
         <DialogContentText>
-          <Trans i18nKey="profile:complete_profile_dialog.description_1">
-            Before you can {{ action_name: action_text }}, you must{" "}
-            <strong>write a bit about yourself</strong> in your profile and{" "}
-            <strong>upload a profile photo</strong>.
-          </Trans>
+          <Trans
+            i18nKey="profile:complete_profile_dialog.description_1"
+            values={{ action_name: action_text }}
+            components={{ 4: <strong />, 7: <strong /> }}
+          />
         </DialogContentText>
         <DialogContentText>
-          <Trans i18nKey="profile:complete_profile_dialog.description_2">
-            This helps build a trusted community and reduce spam. For more
-            information,{" "}
-            <StyledLink href={howToCompleteProfileUrl}>
-              please refer to this help page
-            </StyledLink>
-            . Thank you for your help!
-          </Trans>
+          <Trans
+            i18nKey="profile:complete_profile_dialog.description_2"
+            components={{ 2: <StyledLink href={howToCompleteProfileUrl} /> }}
+          />
         </DialogContentText>
       </DialogContent>
       <DialogActions>

--- a/app/web/features/auth/email/ChangeEmail.tsx
+++ b/app/web/features/auth/email/ChangeEmail.tsx
@@ -79,11 +79,8 @@ export default function ChangeEmail({ className, email }: ChangeEmailProps) {
           <Trans
             i18nKey="auth:change_email_form.current_email_message"
             values={{ email }}
-          >
-            {`Your email address is currently `}
-            <strong>{email}</strong>
-            {`.`}
-          </Trans>
+            components={{ 1: <strong /> }}
+          />
         </Typography>
         {changeEmailError && (
           <Alert severity="error">{changeEmailError.message}</Alert>

--- a/app/web/features/auth/phone/ChangePhone.tsx
+++ b/app/web/features/auth/phone/ChangePhone.tsx
@@ -156,10 +156,7 @@ export default function ChangePhone({
               components={{
                 2: <StyledLink href={howToDonateUrl} />,
               }}
-            >
-              You need to <StyledLink href={howToDonateUrl}>donate</StyledLink>
-              before you can complete phone verification.
-            </Trans>
+            />
           </Typography>
         ) : (
           <StyledForm onSubmit={onChangeSubmit}>

--- a/app/web/features/auth/signup/AccountForm.tsx
+++ b/app/web/features/auth/signup/AccountForm.tsx
@@ -426,9 +426,10 @@ export default function AccountForm() {
           )}
         />
         <Typography variant="body1">
-          <Trans i18nKey="auth:account_form.tos_prompt">
-            To continue, please read and accept the <TOSLink />.
-          </Trans>
+          <Trans
+            i18nKey="auth:account_form.tos_prompt"
+            components={{ 1: <TOSLink /> }}
+          />
         </Typography>
         <FormControlLabel
           control={

--- a/app/web/features/auth/signup/ResendVerificationEmailForm.tsx
+++ b/app/web/features/auth/signup/ResendVerificationEmailForm.tsx
@@ -34,19 +34,20 @@ export default function ResendVerificationEmailForm() {
       </Typography>
       <Typography variant="body1">
         {!resent ? (
-          <Trans i18nKey="auth:sign_up_resend_verification_email_help">
-            Didn't receive the email? Click{" "}
-            <StyledLink
-              href="#"
-              onClick={(e) => {
-                e.preventDefault();
-                mutation.mutateAsync();
-              }}
-            >
-              here to resend the verification link
-            </StyledLink>
-            .
-          </Trans>
+          <Trans
+            i18nKey="auth:sign_up_resend_verification_email_help"
+            components={{
+              2: (
+                <StyledLink
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    mutation.mutateAsync();
+                  }}
+                />
+              ),
+            }}
+          />
         ) : (
           <>{t("auth:sign_up_resend_verification_done")}</>
         )}

--- a/app/web/features/auth/signup/Signup.tsx
+++ b/app/web/features/auth/signup/Signup.tsx
@@ -180,10 +180,10 @@ export default function Signup() {
             <SignupFormContent inviteCode={inviteCode || undefined} />
           )}
           <Typography sx={{ marginTop: theme.spacing(2) }}>
-            <Trans i18nKey="auth:basic_sign_up_form.existing_user_prompt">
-              Already have an account?{" "}
-              <StyledLink href={loginRoute}>Log in</StyledLink>
-            </Trans>
+            <Trans
+              i18nKey="auth:basic_sign_up_form.existing_user_prompt"
+              components={{ 2: <StyledLink href={loginRoute} /> }}
+            />
           </Typography>
         </StyledFormWrapper>
       </PageContainer>

--- a/app/web/features/auth/signup/SignupFormContent.tsx
+++ b/app/web/features/auth/signup/SignupFormContent.tsx
@@ -81,18 +81,19 @@ export default function SignupFormContent({
           submitText={t("global:create_account")}
         />
         <Typography variant="caption">
-          <Trans i18nKey="auth:basic_sign_up_form.sign_up_agreement_explainer">
-            By continuing, you agree to our{" "}
-            <StyledLink
-              href={tosRoute}
-              target={isNativeEmbed ? undefined : "_blank"}
-              variant="caption"
-              sx={{ fontWeight: 700 }}
-            >
-              Terms of Service
-            </StyledLink>
-            , including our cookie, email, and data handling policies.
-          </Trans>
+          <Trans
+            i18nKey="auth:basic_sign_up_form.sign_up_agreement_explainer"
+            components={{
+              2: (
+                <StyledLink
+                  href={tosRoute}
+                  target={isNativeEmbed ? undefined : "_blank"}
+                  variant="caption"
+                  sx={{ fontWeight: 700 }}
+                />
+              ),
+            }}
+          />
         </Typography>
       </>
     );

--- a/app/web/features/auth/verification/StrongVerificationPage.tsx
+++ b/app/web/features/auth/verification/StrongVerificationPage.tsx
@@ -96,24 +96,13 @@ export default function StrongVerificationInstructions() {
             }}
           >
             <li>
-              <Trans i18nKey="auth:strong_verification.instructions.before_you_start.nfc_check">
-                Your phone must have <strong>NFC capability</strong> — most
-                phones do. Check your phone settings to make sure NFC is turned
-                on.
-              </Trans>
+              <Trans i18nKey="auth:strong_verification.instructions.before_you_start.nfc_check" />
             </li>
             <li>
-              <Trans i18nKey="auth:strong_verification.instructions.before_you_start.passport_check">
-                Your passport must be a <strong>biometric passport</strong> —
-                look for the gold chip symbol on the cover. Older passports
-                without this symbol won't work.
-              </Trans>
+              <Trans i18nKey="auth:strong_verification.instructions.before_you_start.passport_check" />
             </li>
             <li>
-              <Trans i18nKey="auth:strong_verification.instructions.before_you_start.remove_case">
-                <strong>Remove your phone case before starting</strong> — even
-                thin cases can block the NFC signal and cause the scan to fail.
-              </Trans>
+              <Trans i18nKey="auth:strong_verification.instructions.before_you_start.remove_case" />
             </li>
           </Box>
         </Box>
@@ -134,19 +123,14 @@ export default function StrongVerificationInstructions() {
         >
           <ListItem sx={{ display: "list-item", paddingY: 0.5 }}>
             <Typography variant="body1" sx={{ marginBottom: 1 }}>
-              <Trans i18nKey="auth:strong_verification.instructions.step1">
-                Download the <strong>IRIS ID</strong> app
-              </Trans>
+              <Trans i18nKey="auth:strong_verification.instructions.step1" />
             </Typography>
             <Typography
               variant="body2"
               color="text.secondary"
               sx={{ marginTop: 1, marginBottom: 1 }}
             >
-              <Trans i18nKey="auth:strong_verification.instructions.step1_apple_note">
-                <strong>Apple users:</strong> You can skip the download and use
-                your browser instead. Just click "Open" when prompted.
-              </Trans>
+              <Trans i18nKey="auth:strong_verification.instructions.step1_apple_note" />
             </Typography>
             <Box
               sx={{
@@ -187,10 +171,7 @@ export default function StrongVerificationInstructions() {
           </ListItem>
           <ListItem sx={{ display: "list-item", paddingY: 0.5 }}>
             <Typography variant="body1">
-              <Trans i18nKey="auth:strong_verification.instructions.step2">
-                Click <strong>"Start Strong Verification"</strong> below (opens
-                in new tab)
-              </Trans>
+              <Trans i18nKey="auth:strong_verification.instructions.step2" />
             </Typography>
           </ListItem>
           <ListItem sx={{ display: "list-item", paddingY: 0.5 }}>
@@ -205,9 +186,7 @@ export default function StrongVerificationInstructions() {
           </ListItem>
           <ListItem sx={{ display: "list-item", paddingY: 0.5 }}>
             <Typography variant="body1">
-              <Trans i18nKey="auth:strong_verification.instructions.step5">
-                Select <strong>Passport</strong> (ID cards not supported)
-              </Trans>
+              <Trans i18nKey="auth:strong_verification.instructions.step5" />
             </Typography>
           </ListItem>
           <ListItem sx={{ display: "list-item", paddingY: 0.5 }}>
@@ -217,11 +196,7 @@ export default function StrongVerificationInstructions() {
           </ListItem>
           <ListItem sx={{ display: "list-item", paddingY: 0.5 }}>
             <Typography variant="body1">
-              <Trans i18nKey="auth:strong_verification.instructions.step7">
-                Hold your phone against the passport page with the NFC chip and
-                <strong>keep completely still for at least 5 seconds</strong> —
-                moving too early is the most common cause of failure
-              </Trans>
+              <Trans i18nKey="auth:strong_verification.instructions.step7" />
             </Typography>
           </ListItem>
           <ListItem sx={{ display: "list-item", paddingY: 0.5 }}>
@@ -269,20 +244,13 @@ export default function StrongVerificationInstructions() {
             }}
           >
             <li>
-              <Trans i18nKey="auth:strong_verification.instructions.chip_location.us_germany_mexico">
-                <strong>US, Germany (2016), Mexico:</strong> Back page
-              </Trans>
+              <Trans i18nKey="auth:strong_verification.instructions.chip_location.us_germany_mexico" />
             </li>
             <li>
-              <Trans i18nKey="auth:strong_verification.instructions.chip_location.finland_germany_new">
-                <strong>Finland, Germany (2017+):</strong> Picture page
-              </Trans>
+              <Trans i18nKey="auth:strong_verification.instructions.chip_location.finland_germany_new" />
             </li>
             <li>
-              <Trans i18nKey="auth:strong_verification.instructions.chip_location.australia">
-                <strong>Australia:</strong> Middle page (marked with symbol +
-                "chip name")
-              </Trans>
+              <Trans i18nKey="auth:strong_verification.instructions.chip_location.australia" />
             </li>
           </Box>
         </Box>
@@ -325,35 +293,19 @@ export default function StrongVerificationInstructions() {
             }}
           >
             <li>
-              <Trans i18nKey="auth:strong_verification.instructions.scanning_tips.remove_case">
-                <strong>Remove your phone case</strong> — even thin cases can
-                block the NFC signal
-              </Trans>
+              <Trans i18nKey="auth:strong_verification.instructions.scanning_tips.remove_case" />
             </li>
             <li>
-              <Trans i18nKey="auth:strong_verification.instructions.scanning_tips.hold_still">
-                <strong>Hold your phone completely still</strong> for at least 5
-                seconds — moving too early is the most common cause of failure
-              </Trans>
+              <Trans i18nKey="auth:strong_verification.instructions.scanning_tips.hold_still" />
             </li>
             <li>
-              <Trans i18nKey="auth:strong_verification.instructions.scanning_tips.flat_surface">
-                <strong>Place your passport on a flat surface</strong> — don't
-                hold it in your hand
-              </Trans>
+              <Trans i18nKey="auth:strong_verification.instructions.scanning_tips.flat_surface" />
             </li>
             <li>
-              <Trans i18nKey="auth:strong_verification.instructions.scanning_tips.nfc_location">
-                <strong>Find your phone's NFC antenna</strong> — it's usually
-                near the top-center on the back of the phone. Try different
-                positions if it doesn't connect
-              </Trans>
+              <Trans i18nKey="auth:strong_verification.instructions.scanning_tips.nfc_location" />
             </li>
             <li>
-              <Trans i18nKey="auth:strong_verification.instructions.scanning_tips.no_metal">
-                <strong>Avoid metal surfaces</strong> — don't place your
-                passport on a metal table or laptop
-              </Trans>
+              <Trans i18nKey="auth:strong_verification.instructions.scanning_tips.no_metal" />
             </li>
             <li>
               {t("auth:strong_verification.instructions.scanning_tips.retry")}
@@ -388,13 +340,14 @@ export default function StrongVerificationInstructions() {
             </li>
           </Box>
           <Typography variant="body1">
-            <Trans i18nKey="auth:strong_verification.instructions.didnt_work.contact">
-              If you're still having trouble,
-              <StyledLink href="mailto:support@couchers.org?subject=Strong%20Verification%20Help">
-                let us know
-              </StyledLink>
-              and we'll help.
-            </Trans>
+            <Trans
+              i18nKey="auth:strong_verification.instructions.didnt_work.contact"
+              components={{
+                1: (
+                  <StyledLink href="mailto:support@couchers.org?subject=Strong%20Verification%20Help" />
+                ),
+              }}
+            />
           </Typography>
         </Box>
 

--- a/app/web/features/communities/CommunitiesPage/CommunitiesPage.tsx
+++ b/app/web/features/communities/CommunitiesPage/CommunitiesPage.tsx
@@ -91,17 +91,19 @@ const CommunitiesPage = () => {
         <Trans i18nKey="dashboard:communities_intro" />
       </StyledTypography>
       <StyledTypography variant="body1" paragraph>
-        <Trans i18nKey="dashboard:community_builder">
-          {`Want to be an ambassador for your community and help it grow? Become a `}
-          <MuiLink
-            href={helpCenterCommunityBuilderURL}
-            target="_blank"
-            rel="noreferrer noopener"
-            underline="hover"
-          >
-            Community Builder!
-          </MuiLink>
-        </Trans>
+        <Trans
+          i18nKey="dashboard:community_builder"
+          components={{
+            1: (
+              <MuiLink
+                href={helpCenterCommunityBuilderURL}
+                target="_blank"
+                rel="noreferrer noopener"
+                underline="hover"
+              />
+            ),
+          }}
+        />
       </StyledTypography>
 
       <MainTitle variant="h1">
@@ -112,17 +114,19 @@ const CommunitiesPage = () => {
       <MainTitle variant="h1">{t("dashboard:find_your_community")}</MainTitle>
 
       <StyledTypography variant="body1" paragraph>
-        <Trans i18nKey="dashboard:find_your_community_intro_simplified">
-          {`Search for your community or browse below. `}
-          <MuiLink
-            href={communityCreationFormURL(accountInfo?.username)}
-            target="_blank"
-            rel="noreferrer noopener"
-            underline="hover"
-          >
-            Don't see yours? Request it!
-          </MuiLink>
-        </Trans>
+        <Trans
+          i18nKey="dashboard:find_your_community_intro_simplified"
+          components={{
+            1: (
+              <MuiLink
+                href={communityCreationFormURL(accountInfo?.username)}
+                target="_blank"
+                rel="noreferrer noopener"
+                underline="hover"
+              />
+            ),
+          }}
+        />
       </StyledTypography>
 
       <NewCommunities />

--- a/app/web/features/dashboard/CommunitiesList.tsx
+++ b/app/web/features/dashboard/CommunitiesList.tsx
@@ -133,7 +133,12 @@ export default function CommunitiesList() {
         <Trans
           i18nKey="dashboard:your_communities_helper_text"
           components={{
-            1: <StyledBrowseCommunitiesLink href="/communities" underline="hover" />,
+            1: (
+              <StyledBrowseCommunitiesLink
+                href="/communities"
+                underline="hover"
+              />
+            ),
           }}
         />
       </Typography>

--- a/app/web/features/dashboard/CommunitiesList.tsx
+++ b/app/web/features/dashboard/CommunitiesList.tsx
@@ -130,13 +130,12 @@ export default function CommunitiesList() {
           marginBottom: "16px",
         }}
       >
-        <Trans i18nKey="dashboard:your_communities_helper_text">
-          {`You have been added to all communities based on your location. Feel free to `}
-          <StyledBrowseCommunitiesLink href="/communities" underline="hover">
-            browse communities
-          </StyledBrowseCommunitiesLink>
-          {` in other locations as well.`}
-        </Trans>
+        <Trans
+          i18nKey="dashboard:your_communities_helper_text"
+          components={{
+            1: <StyledBrowseCommunitiesLink href="/communities" underline="hover" />,
+          }}
+        />
       </Typography>
       {error?.message && <Alert severity="error">{error.message}</Alert>}
       {isPending ? (

--- a/app/web/features/dashboard/CommunitiesSection.tsx
+++ b/app/web/features/dashboard/CommunitiesSection.tsx
@@ -18,17 +18,19 @@ export default function CommunitiesSection() {
     <>
       <CommunitiesList />
       <StyledCreateCommunityText variant="body1" paragraph>
-        <Trans i18nKey="dashboard:your_communities_helper_text2">
-          {`Don't see your community? `}
-          <MuiLink
-            href={communityCreationFormURL(accountInfo?.username)}
-            target="_blank"
-            rel="noreferrer noopener"
-            underline="hover"
-          >
-            Get it started!
-          </MuiLink>
-        </Trans>
+        <Trans
+          i18nKey="dashboard:your_communities_helper_text2"
+          components={{
+            1: (
+              <MuiLink
+                href={communityCreationFormURL(accountInfo?.username)}
+                target="_blank"
+                rel="noreferrer noopener"
+                underline="hover"
+              />
+            ),
+          }}
+        />
       </StyledCreateCommunityText>
     </>
   );

--- a/app/web/features/dashboard/Hero/HeroImageAttribution.tsx
+++ b/app/web/features/dashboard/Hero/HeroImageAttribution.tsx
@@ -38,28 +38,29 @@ export default function HeroImageAttribution() {
     <StyledEngineProvider injectFirst>
       <ThemeProvider theme={heroBackgroundTheme}>
         <StyledAttribution color="textPrimary" variant="body2">
-          <Trans i18nKey="dashboard:hero_image_attribution">
-            {`Photo by `}
-            <MuiLink
-              href={authorUrl}
-              variant="inherit"
-              rel="noreferrer noopener"
-              target="_blank"
-              underline="hover"
-            >
-              Mesut Kaya
-            </MuiLink>
-            {` on `}
-            <MuiLink
-              href={unsplashUrl}
-              variant="inherit"
-              rel="noreferrer noopener"
-              target="_blank"
-              underline="hover"
-            >
-              Unsplash
-            </MuiLink>
-          </Trans>
+          <Trans
+            i18nKey="dashboard:hero_image_attribution"
+            components={{
+              1: (
+                <MuiLink
+                  href={authorUrl}
+                  variant="inherit"
+                  rel="noreferrer noopener"
+                  target="_blank"
+                  underline="hover"
+                />
+              ),
+              3: (
+                <MuiLink
+                  href={unsplashUrl}
+                  variant="inherit"
+                  rel="noreferrer noopener"
+                  target="_blank"
+                  underline="hover"
+                />
+              ),
+            }}
+          />
         </StyledAttribution>
       </ThemeProvider>
     </StyledEngineProvider>

--- a/app/web/features/markdown/MarkdownPage.tsx
+++ b/app/web/features/markdown/MarkdownPage.tsx
@@ -296,14 +296,15 @@ export default function MarkdownPage({
               <Trans
                 i18nKey="blog.byline_with_author"
                 values={{ date: frontmatter.date }}
-              >
-                {"Written by "}
-                <AuthorList
-                  author={frontmatter.author}
-                  authorUsername={frontmatter.author_username}
-                />
-                {". Published on {{date}}."}
-              </Trans>
+                components={{
+                  1: (
+                    <AuthorList
+                      author={frontmatter.author}
+                      authorUsername={frontmatter.author_username}
+                    />
+                  ),
+                }}
+              />
             ) : (
               t("blog.byline_without_author", { date: frontmatter.date })
             )}
@@ -314,13 +315,13 @@ export default function MarkdownPage({
             variant="body1"
             sx={{ fontWeight: "bold", marginTop: theme.spacing(3) }}
           >
-            <Trans i18nKey="blog.cta_message">
-              {"Want to help write our blog or volunteer? "}
-              <Link href="/volunteer">Sign up</Link>
-              {" and let us know. Volunteers and "}
-              <Link href="/donate">donations</Link>
-              {" are what make Couchers.org possible!"}
-            </Trans>
+            <Trans
+              i18nKey="blog.cta_message"
+              components={{
+                1: <Link href="/volunteer" />,
+                3: <Link href="/donate" />,
+              }}
+            />
           </Typography>
         )}
         {frontmatter.is_blog_post && (

--- a/app/web/features/messages/requests/HostRequestGuideLinks.tsx
+++ b/app/web/features/messages/requests/HostRequestGuideLinks.tsx
@@ -36,12 +36,12 @@ export default function HostRequestGuideLinks({
     return (
       <StyledHelpTextContainer>
         <Typography variant="body1">
-          <Trans i18nKey="messages:host_pending_request_help_text">
-            <StyledLink variant="body1" href={howToRespondRequestGuideUrl}>
-              Things to consider
-            </StyledLink>{" "}
-            before responding.
-          </Trans>
+          <Trans
+            i18nKey="messages:host_pending_request_help_text"
+            components={{
+              0: <StyledLink variant="body1" href={howToRespondRequestGuideUrl} />,
+            }}
+          />
         </Typography>
       </StyledHelpTextContainer>
     );
@@ -49,12 +49,12 @@ export default function HostRequestGuideLinks({
     return (
       <StyledHelpTextContainer>
         <Typography variant="body1">
-          <Trans i18nKey="messages:surfer_declined_request_help_text">
-            <StyledLink variant="body1" href={howToWriteRequestGuideUrl}>
-              Read our guide
-            </StyledLink>{" "}
-            on how to write a request that will get accepted.
-          </Trans>
+          <Trans
+            i18nKey="messages:surfer_declined_request_help_text"
+            components={{
+              0: <StyledLink variant="body1" href={howToWriteRequestGuideUrl} />,
+            }}
+          />
         </Typography>
       </StyledHelpTextContainer>
     );

--- a/app/web/features/messages/requests/HostRequestGuideLinks.tsx
+++ b/app/web/features/messages/requests/HostRequestGuideLinks.tsx
@@ -39,7 +39,12 @@ export default function HostRequestGuideLinks({
           <Trans
             i18nKey="messages:host_pending_request_help_text"
             components={{
-              0: <StyledLink variant="body1" href={howToRespondRequestGuideUrl} />,
+              0: (
+                <StyledLink
+                  variant="body1"
+                  href={howToRespondRequestGuideUrl}
+                />
+              ),
             }}
           />
         </Typography>
@@ -52,7 +57,9 @@ export default function HostRequestGuideLinks({
           <Trans
             i18nKey="messages:surfer_declined_request_help_text"
             components={{
-              0: <StyledLink variant="body1" href={howToWriteRequestGuideUrl} />,
+              0: (
+                <StyledLink variant="body1" href={howToWriteRequestGuideUrl} />
+              ),
             }}
           />
         </Typography>

--- a/app/web/features/notifications/PushNotificationSettings.test.tsx
+++ b/app/web/features/notifications/PushNotificationSettings.test.tsx
@@ -20,7 +20,7 @@ jest.mock("platform/sentry", () => ({
 
 jest.mock("i18n", () => ({
   useTranslation: jest.fn(),
-  Trans: ({ children }: { children: React.ReactNode }) => children, // Mock the Trans component to return its children
+  Trans: ({ i18nKey }: { i18nKey: string }) => i18nKey, // Mock the Trans component to return loc keys
 }));
 
 jest.mock("service/notifications", () => ({
@@ -111,7 +111,11 @@ describe("PushNotificationSettings Component", () => {
     render(<PushNotificationSettings />, { wrapper });
 
     await waitFor(() => {
-      expect(screen.getByText("enabled")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "notifications:notification_settings.push_notifications.enabled_message",
+        ),
+      ).toBeInTheDocument();
     });
   });
 
@@ -136,7 +140,11 @@ describe("PushNotificationSettings Component", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("disabled")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "notifications:notification_settings.push_notifications.disabled_message",
+        ),
+      ).toBeInTheDocument();
     });
   });
 
@@ -159,7 +167,11 @@ describe("PushNotificationSettings Component", () => {
     render(<PushNotificationSettings />, { wrapper });
 
     await waitFor(() => {
-      expect(screen.getByText("disabled")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "notifications:notification_settings.push_notifications.disabled_message",
+        ),
+      ).toBeInTheDocument();
     });
 
     fireEvent.click(document.querySelector("input[type='checkbox']")!);
@@ -241,7 +253,11 @@ describe("PushNotificationSettings Component", () => {
     render(<PushNotificationSettings />, { wrapper });
 
     await waitFor(() => {
-      expect(screen.getByText("enabled")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "notifications:notification_settings.push_notifications.enabled_message",
+        ),
+      ).toBeInTheDocument();
     });
 
     fireEvent.click(document.querySelector("input[type='checkbox']")!);
@@ -334,7 +350,11 @@ describe("PushNotificationSettings Component", () => {
 
     await waitFor(() => {
       expect(checkPushEnabled).toHaveBeenCalled();
-      expect(screen.getByText("enabled")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "notifications:notification_settings.push_notifications.enabled_message",
+        ),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/app/web/features/notifications/PushNotificationSettings.tsx
+++ b/app/web/features/notifications/PushNotificationSettings.tsx
@@ -112,13 +112,15 @@ export default function PushNotificationSettings() {
       )}
       <Typography variant="body1" sx={{ marginBottom: theme.spacing(2) }}>
         {isPushEnabled ? (
-          <Trans i18nKey="notifications:notification_settings.push_notifications.enabled_message">
-            You currently have push notifications <strong>enabled</strong>.
-          </Trans>
+          <Trans
+            i18nKey="notifications:notification_settings.push_notifications.enabled_message"
+            components={{ 1: <strong /> }}
+          />
         ) : (
-          <Trans i18nKey="notifications:notification_settings.push_notifications.disabled_message">
-            You currently have push notifications <strong>disabled</strong>.
-          </Trans>
+          <Trans
+            i18nKey="notifications:notification_settings.push_notifications.disabled_message"
+            components={{ 1: <strong /> }}
+          />
         )}
       </Typography>
       <Typography variant="body1">

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -453,7 +453,12 @@ export default function EditProfileForm() {
               <Trans
                 i18nKey="profile:edit_profile_helper_text"
                 components={{
-                  2: <StyledLink variant="body1" href={howToMakeGreatProfileUrl} />,
+                  2: (
+                    <StyledLink
+                      variant="body1"
+                      href={howToMakeGreatProfileUrl}
+                    />
+                  ),
                 }}
               />
             </Typography>

--- a/app/web/features/profile/edit/EditProfile.tsx
+++ b/app/web/features/profile/edit/EditProfile.tsx
@@ -450,13 +450,12 @@ export default function EditProfileForm() {
         <>
           <HelpTextContainer>
             <Typography>
-              <Trans i18nKey="profile:edit_profile_helper_text">
-                Looking for some inspiration on where to start?{" "}
-                <StyledLink variant="body1" href={howToMakeGreatProfileUrl}>
-                  Check out our guide on creating an awesome profile
-                </StyledLink>
-                .
-              </Trans>
+              <Trans
+                i18nKey="profile:edit_profile_helper_text"
+                components={{
+                  2: <StyledLink variant="body1" href={howToMakeGreatProfileUrl} />,
+                }}
+              />
             </Typography>
           </HelpTextContainer>
 

--- a/app/web/features/profile/view/NewHostRequest.tsx
+++ b/app/web/features/profile/view/NewHostRequest.tsx
@@ -316,12 +316,12 @@ export default function NewHostRequest({
             </StyledDateRow>
           </StyledRequestRow>
           <StyledHelpText variant="body1">
-            <Trans i18nKey="profile:request_form.guide_link_help_text">
-              <StyledLink variant="body1" href={howToWriteRequestGuideUrl}>
-                Read our guide
-              </StyledLink>{" "}
-              on how to write a request that will get accepted.
-            </Trans>
+            <Trans
+              i18nKey="profile:request_form.guide_link_help_text"
+              components={{
+                0: <StyledLink variant="body1" href={howToWriteRequestGuideUrl} />,
+              }}
+            />
           </StyledHelpText>
 
           <StyledRequestField

--- a/app/web/features/profile/view/NewHostRequest.tsx
+++ b/app/web/features/profile/view/NewHostRequest.tsx
@@ -319,7 +319,12 @@ export default function NewHostRequest({
             <Trans
               i18nKey="profile:request_form.guide_link_help_text"
               components={{
-                0: <StyledLink variant="body1" href={howToWriteRequestGuideUrl} />,
+                0: (
+                  <StyledLink
+                    variant="body1"
+                    href={howToWriteRequestGuideUrl}
+                  />
+                ),
               }}
             />
           </StyledHelpText>

--- a/app/web/features/profile/view/leaveReference/formSteps/PrivateFeedback.tsx
+++ b/app/web/features/profile/view/leaveReference/formSteps/PrivateFeedback.tsx
@@ -214,7 +214,12 @@ export default function PrivateFeedback({
                 <Trans
                   i18nKey="profile:leave_reference.private_text_explanation_2"
                   components={{
-                    2: <StyledLink href={helpCenterPrivateFeedbackUrl} sx={{ fontWeight: 600 }} />,
+                    2: (
+                      <StyledLink
+                        href={helpCenterPrivateFeedbackUrl}
+                        sx={{ fontWeight: 600 }}
+                      />
+                    ),
                   }}
                 />
               </Typography>

--- a/app/web/features/profile/view/leaveReference/formSteps/PrivateFeedback.tsx
+++ b/app/web/features/profile/view/leaveReference/formSteps/PrivateFeedback.tsx
@@ -211,18 +211,12 @@ export default function PrivateFeedback({
                 {t("profile:leave_reference.private_text_explanation_1")}
               </Typography>
               <Typography sx={{ marginTop: theme.spacing(2) }}>
-                <Trans i18nKey="profile:leave_reference.private_text_explanation_2">
-                  This will only be seen by our Safety Team and will stay
-                  private. The more details the better, but even a short
-                  explanation can help a lot. Read more{" "}
-                  <StyledLink
-                    href={helpCenterPrivateFeedbackUrl}
-                    sx={{ fontWeight: 600 }}
-                  >
-                    here
-                  </StyledLink>
-                  .
-                </Trans>
+                <Trans
+                  i18nKey="profile:leave_reference.private_text_explanation_2"
+                  components={{
+                    2: <StyledLink href={helpCenterPrivateFeedbackUrl} sx={{ fontWeight: 600 }} />,
+                  }}
+                />
               </Typography>
               <Typography sx={{ marginTop: theme.spacing(2) }}>
                 {t("profile:leave_reference.private_text_explanation_3")}

--- a/app/web/features/profile/view/leaveReference/formSteps/submit/ThankYouReference.tsx
+++ b/app/web/features/profile/view/leaveReference/formSteps/submit/ThankYouReference.tsx
@@ -32,17 +32,17 @@ const ThankYouReference = () => {
         {t("profile:leave_reference.thank_you_references_available")}
       </Typography>
       <Typography sx={{ marginTop: theme.spacing(3) }}>
-        <Trans i18nKey="profile:leave_reference.thank_you_donation_prompt">
-          Consider{" "}
-          <StyledLink
-            href={`${donationsRoute}?utm_source=leave-reference-thank-you`}
-            sx={{ fontWeight: 600 }}
-          >
-            making a donation
-          </StyledLink>
-          ! Couchers.org is a 501(c)(3) non-profit organization and we need
-          donations to keep our servers running
-        </Trans>
+        <Trans
+          i18nKey="profile:leave_reference.thank_you_donation_prompt"
+          components={{
+            2: (
+              <StyledLink
+                href={`${donationsRoute}?utm_source=leave-reference-thank-you`}
+                sx={{ fontWeight: 600 }}
+              />
+            ),
+          }}
+        />
       </Typography>
       <Typography sx={{ marginTop: theme.spacing(3) }}>
         {t("profile:leave_reference.thank_you_support")}


### PR DESCRIPTION
Our `<Trans>` tags often included a copy of the string from `en.json`, which unavoidably lead to the two drifting apart as noted in #9008. It turns out we don't have to do that and can simply provide the components to be instantiated by the string without duplicating the text.

Closes #9008

## Testing
Used vercel preview to spot check:

`ProfileIncompleteDialog`

<img width="702" height="340" alt="image" src="https://github.com/user-attachments/assets/cbe8f947-9818-469a-b150-584388fdeeae" />

`StrongVerificationPage` (note the text is from the more recent `en.json`, the inline text was stale)

<img width="1117" height="822" alt="image" src="https://github.com/user-attachments/assets/2c5fbccc-a812-4ee3-b606-fdeeb6e7ba2f" />

`PushNotificationSetting`

<img width="1085" height="167" alt="image" src="https://github.com/user-attachments/assets/3108f7e3-9508-49a4-90df-aa679b54ca73" />

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
