### PR TITLE
Frontend: Use iso8601 values with datetime pickers

### DIFF
--- a/app/web/components/Datepicker.test.tsx
+++ b/app/web/components/Datepicker.test.tsx
@@ -5,11 +5,11 @@ import { userEvent } from "@testing-library/user-event";
 import { useTranslation } from "i18n";
 import { useForm } from "react-hook-form";
 import i18n from "test/i18n";
+import { ISO8601_DATE_FORMAT } from "utils/date";
 import dayjs from "utils/dayjs";
 
 import wrapper from "../test/hookWrapper";
 import Datepicker from "./Datepicker";
-import { ISO8601_DATE_FORMAT } from "../utils/date";
 
 const { t } = i18n;
 

--- a/app/web/components/Datepicker.test.tsx
+++ b/app/web/components/Datepicker.test.tsx
@@ -5,10 +5,11 @@ import { userEvent } from "@testing-library/user-event";
 import { useTranslation } from "i18n";
 import { useForm } from "react-hook-form";
 import i18n from "test/i18n";
-import dayjs, { Dayjs } from "utils/dayjs";
+import dayjs from "utils/dayjs";
 
 import wrapper from "../test/hookWrapper";
 import Datepicker from "./Datepicker";
+import { ISO8601_DATE_FORMAT } from "../utils/date";
 
 const { t } = i18n;
 
@@ -20,7 +21,7 @@ jest.mock("@mui/x-date-pickers", () => {
   };
 });
 
-const Form = ({ setDate }: { setDate: (date: Dayjs) => void }) => {
+const Form = ({ setDate }: { setDate: (date: string) => void }) => {
   const { t } = useTranslation();
   const { control, handleSubmit } = useForm();
   const onSubmit = handleSubmit((data) => setDate(data.datefield));
@@ -34,7 +35,7 @@ const Form = ({ setDate }: { setDate: (date: Dayjs) => void }) => {
         testId="datepicker"
         label="Date field"
         name="datefield"
-        defaultValue={dayjs()}
+        defaultValueISO8601={dayjs().format(ISO8601_DATE_FORMAT)}
       />
       <input type="submit" name={t("submit")} />
     </form>
@@ -54,8 +55,8 @@ describe("DatePicker", () => {
   });
 
   it("should submit with proper date for clicking", async () => {
-    let date: Dayjs | undefined = undefined;
-    render(<Form setDate={(d) => (date = d)} />, { wrapper });
+    let dateISO8601: string | undefined = undefined;
+    render(<Form setDate={(d) => (dateISO8601 = d)} />, { wrapper });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
@@ -65,13 +66,13 @@ describe("DatePicker", () => {
 
     await user.click(screen.getByRole("button", { name: t("global:submit") }));
 
-    expect(date).toBeDefined();
-    expect(date!.date).toEqual(dayjs("2021-03-23").date);
+    expect(dateISO8601).toBeDefined();
+    expect(dateISO8601).toBe("2021-03-20");
   });
 
   it("selecting today works with timezone US/Eastern", async () => {
-    let date: Dayjs | undefined;
-    render(<Form setDate={(d) => (date = d)} />, { wrapper });
+    let dateISO8601: string | undefined;
+    render(<Form setDate={(d) => (dateISO8601 = d)} />, { wrapper });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
@@ -81,14 +82,14 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date?.format("YYYY-MM-DD")).toBe("2021-03-20");
+    expect(dateISO8601).toBe("2021-03-20");
   });
 
   it("selecting today works with timezone UTC", async () => {
     dayjs.tz.setDefault("UTC");
 
-    let date: Dayjs | undefined;
-    render(<Form setDate={(d) => (date = d)} />, { wrapper });
+    let dateISO8601: string | undefined;
+    render(<Form setDate={(d) => (dateISO8601 = d)} />, { wrapper });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
@@ -98,14 +99,14 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date?.format("YYYY-MM-DD")).toBe("2021-03-20");
+    expect(dateISO8601).toBe("2021-03-20");
   });
 
   it("selecting today works with timezone Europe/London", async () => {
     dayjs.tz.setDefault("Europe/London");
 
-    let date: Dayjs | undefined;
-    render(<Form setDate={(d) => (date = d)} />, { wrapper });
+    let dateISO8601: string | undefined;
+    render(<Form setDate={(d) => (dateISO8601 = d)} />, { wrapper });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
@@ -115,14 +116,14 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date?.format("YYYY-MM-DD")).toBe("2021-03-20");
+    expect(dateISO8601).toBe("2021-03-20");
   });
 
   it("selecting today works with timezone Brazil/East", async () => {
     dayjs.tz.setDefault("Brazil/East");
 
-    let date: Dayjs | undefined;
-    render(<Form setDate={(d) => (date = d)} />, { wrapper });
+    let dateISO8601: string | undefined;
+    render(<Form setDate={(d) => (dateISO8601 = d)} />, { wrapper });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
@@ -132,14 +133,14 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date?.format("YYYY-MM-DD")).toBe("2021-03-20");
+    expect(dateISO8601).toBe("2021-03-20");
   });
 
   it("selecting today works with timezone Australia/Adelaide", async () => {
     dayjs.tz.setDefault("Australia/Adelaide");
 
-    let date: Dayjs | undefined;
-    render(<Form setDate={(d) => (date = d)} />, { wrapper });
+    let dateISO8601: string | undefined;
+    render(<Form setDate={(d) => (dateISO8601 = d)} />, { wrapper });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
@@ -149,14 +150,14 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date?.format("YYYY-MM-DD")).toBe("2021-03-20");
+    expect(dateISO8601).toBe("2021-03-20");
   });
 
   it("typing should work in de's DD.MM.YYYY format", async () => {
     i18n.changeLanguage("de");
 
-    let date: Dayjs | undefined = undefined;
-    render(<Form setDate={(d) => (date = d)} />, { wrapper });
+    let dateISO8601: string | undefined = undefined;
+    render(<Form setDate={(d) => (dateISO8601 = d)} />, { wrapper });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
@@ -169,16 +170,15 @@ describe("DatePicker", () => {
 
     await user.click(screen.getByRole("button", { name: t("global:submit") }));
 
-    const expectedDate = "2021-03-21";
-    expect(date).toBeDefined();
-    expect(date!.format("YYYY-MM-DD")).toEqual(expectedDate);
+    expect(dateISO8601).toBeDefined();
+    expect(dateISO8601).toEqual("2021-03-21");
   });
 
   it("typing should work in en's MM/DD/YYYY format", async () => {
     i18n.changeLanguage("en");
 
-    let date: Dayjs | undefined = undefined;
-    render(<Form setDate={(d) => (date = d)} />, { wrapper });
+    let dateISO8601: string | undefined = undefined;
+    render(<Form setDate={(d) => (dateISO8601 = d)} />, { wrapper });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
@@ -191,16 +191,15 @@ describe("DatePicker", () => {
 
     await user.click(screen.getByRole("button", { name: t("global:submit") }));
 
-    const expectedDate = "2021-03-21";
-    expect(date).toBeDefined();
-    expect(date!.format("YYYY-MM-DD")).toEqual(expectedDate);
+    expect(dateISO8601).toBeDefined();
+    expect(dateISO8601).toEqual("2021-03-21");
   });
 
   it("typing should work in zh-Hant's YYYY/MM/DD format", async () => {
     i18n.changeLanguage("zh-Hant");
 
-    let date: Dayjs | undefined = undefined;
-    render(<Form setDate={(d) => (date = d)} />, { wrapper });
+    let dateISO8601: string | undefined = undefined;
+    render(<Form setDate={(d) => (dateISO8601 = d)} />, { wrapper });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
@@ -213,9 +212,8 @@ describe("DatePicker", () => {
 
     await user.click(screen.getByRole("button", { name: t("global:submit") }));
 
-    const expectedDate = "2021-03-21";
-    expect(date).toBeDefined();
-    expect(date!.format("YYYY-MM-DD")).toEqual(expectedDate);
+    expect(dateISO8601).toBeDefined();
+    expect(dateISO8601).toEqual("2021-03-21");
   });
 
   it("uses the locale date format when no format prop is given", async () => {
@@ -239,7 +237,7 @@ describe("DatePicker", () => {
           testId="datepicker"
           label="Date field"
           name="datefield"
-          defaultValue={dayjs("2021-03-20")}
+          defaultValueISO8601="2021-03-20"
           pickerInputOnly
         />
       );
@@ -265,7 +263,7 @@ describe("DatePicker", () => {
             testId="datepicker"
             label="Date field"
             name="datefield"
-            defaultValue={dayjs("1990-04-08")}
+            defaultValueISO8601="1990-04-08"
             pickerInputOnly
           />
         </LocalizationProvider>
@@ -292,7 +290,6 @@ describe("DatePicker", () => {
           testId="datepicker"
           label="Date field"
           name="datefield"
-          defaultValue={null}
           pickerInputOnly
         />
       );

--- a/app/web/components/Datepicker.tsx
+++ b/app/web/components/Datepicker.tsx
@@ -7,7 +7,7 @@ import {
 } from "@mui/x-date-pickers";
 import { useTranslation } from "i18n";
 import { Control, Controller, UseControllerProps } from "react-hook-form";
-import { getMuiDateFormat,ISO8601_DATE_FORMAT } from "utils/date";
+import { getMuiDateFormat, ISO8601_DATE_FORMAT } from "utils/date";
 import dayjs, { Dayjs } from "utils/dayjs";
 
 interface DatepickerProps {

--- a/app/web/components/Datepicker.tsx
+++ b/app/web/components/Datepicker.tsx
@@ -7,24 +7,24 @@ import {
 } from "@mui/x-date-pickers";
 import { useTranslation } from "i18n";
 import { Control, Controller, UseControllerProps } from "react-hook-form";
-import { getMuiDateFormat } from "utils/date";
+import { ISO8601_DATE_FORMAT, getMuiDateFormat } from "utils/date";
 import dayjs, { Dayjs } from "utils/dayjs";
 
 interface DatepickerProps {
   className?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   control: Control<any>;
-  defaultValue?: Dayjs | null;
+  defaultValueISO8601?: string;
   error: boolean;
   helperText: React.ReactNode;
   id: string;
   rules?: UseControllerProps["rules"];
   label?: string;
   name: string;
-  minDate?: Dayjs;
-  maxDate?: Dayjs;
+  minValueISO8601?: string;
+  maxValueISO8601?: string;
   openTo?: "year" | "month" | "day";
-  onPostChange?(date: Dayjs | null): void;
+  onPostChange?(valueISO8601: string | null): void;
   testId?: string;
   variant?: "standard" | "outlined" | "filled";
   inputProps?: InputProps;
@@ -89,17 +89,26 @@ const ReadOnlyDateField = ({
   );
 };
 
+// Convert between our API's ISO8601 strings and MUI's expected Dayjs values.
+function iso8601ToDayjs(value: string): Dayjs {
+  return dayjs(value, ISO8601_DATE_FORMAT);
+}
+
+function dayjsToISO8601(value: Dayjs): string {
+  return value.format(ISO8601_DATE_FORMAT);
+}
+
 const Datepicker = ({
   className,
   control,
-  defaultValue,
+  defaultValueISO8601,
   error,
   helperText,
   id,
   rules,
   label,
-  minDate = dayjs(),
-  maxDate,
+  minValueISO8601 = dayjsToISO8601(dayjs()),
+  maxValueISO8601,
   name,
   openTo = "day",
   onPostChange,
@@ -138,7 +147,7 @@ const Datepicker = ({
   return (
     <Controller
       control={control}
-      defaultValue={defaultValue}
+      defaultValue={defaultValueISO8601 ?? null}
       name={name}
       rules={rules}
       render={({ field }) => (
@@ -146,12 +155,17 @@ const Datepicker = ({
           data-testid={testId}
           {...field}
           label={label}
-          value={field.value}
-          minDate={minDate}
-          maxDate={maxDate}
-          onChange={(date) => {
-            field.onChange(date);
-            onPostChange?.(date);
+          value={field.value ? iso8601ToDayjs(field.value) : undefined}
+          minDate={
+            minValueISO8601 ? iso8601ToDayjs(minValueISO8601) : undefined
+          }
+          maxDate={
+            maxValueISO8601 ? iso8601ToDayjs(maxValueISO8601) : undefined
+          }
+          onChange={(value: Dayjs | null) => {
+            const valueISO8601 = value ? dayjsToISO8601(value) : null;
+            field.onChange(valueISO8601);
+            onPostChange?.(valueISO8601);
           }}
           openTo={openTo}
           views={["year", "month", "day"]}

--- a/app/web/components/Datepicker.tsx
+++ b/app/web/components/Datepicker.tsx
@@ -7,7 +7,7 @@ import {
 } from "@mui/x-date-pickers";
 import { useTranslation } from "i18n";
 import { Control, Controller, UseControllerProps } from "react-hook-form";
-import { ISO8601_DATE_FORMAT, getMuiDateFormat } from "utils/date";
+import { getMuiDateFormat,ISO8601_DATE_FORMAT } from "utils/date";
 import dayjs, { Dayjs } from "utils/dayjs";
 
 interface DatepickerProps {

--- a/app/web/components/Timepicker.test.tsx
+++ b/app/web/components/Timepicker.test.tsx
@@ -2,7 +2,6 @@ import { act, render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { useForm } from "react-hook-form";
 import i18n from "test/i18n";
-import { Dayjs } from "utils/dayjs";
 
 import wrapper from "../test/hookWrapper";
 import Timepicker from "./Timepicker";
@@ -15,7 +14,7 @@ jest.mock("@mui/x-date-pickers", () => {
   };
 });
 
-const Form = ({ setTime }: { setTime: (time: Dayjs | null) => void }) => {
+const Form = ({ setTime }: { setTime: (time: string | null) => void }) => {
   const { control, handleSubmit } = useForm();
   const onSubmit = handleSubmit((data) => setTime(data.timefield));
   return (
@@ -28,7 +27,6 @@ const Form = ({ setTime }: { setTime: (time: Dayjs | null) => void }) => {
         testId="timepicker"
         label="Time field"
         name="timefield"
-        defaultValue={null}
       />
       <input type="submit" value="Submit" />
     </form>
@@ -43,8 +41,8 @@ describe("Timepicker", () => {
 
   it("accepts 24-hour time in 24-hour locale (de)", async () => {
     i18n.changeLanguage("de");
-    let time: Dayjs | null = null;
-    render(<Form setTime={(t) => (time = t)} />, { wrapper });
+    let timeISO8601: string | null = null;
+    render(<Form setTime={(t) => (timeISO8601 = t)} />, { wrapper });
 
     const user = userEvent.setup();
 
@@ -55,15 +53,14 @@ describe("Timepicker", () => {
     await user.keyboard("2359");
 
     await user.click(screen.getByRole("button", { name: "Submit" }));
-    expect(time).toBeDefined();
-    expect(time!.hour()).toBe(23);
-    expect(time!.minute()).toBe(59);
+    expect(timeISO8601).toBeDefined();
+    expect(timeISO8601).toBe("23:59");
   });
 
   it("accepts 12-hour time in 12-hour locale (en)", async () => {
     i18n.changeLanguage("en");
-    let time: Dayjs | null = null;
-    render(<Form setTime={(t) => (time = t)} />, { wrapper });
+    let timeISO8601: string | null = null;
+    render(<Form setTime={(t) => (timeISO8601 = t)} />, { wrapper });
 
     const user = userEvent.setup();
 
@@ -74,15 +71,14 @@ describe("Timepicker", () => {
     await user.keyboard("1200 AM");
 
     await user.click(screen.getByRole("button", { name: "Submit" }));
-    expect(time).toBeDefined();
-    expect(time!.hour()).toBe(0);
-    expect(time!.minute()).toBe(0);
+    expect(timeISO8601).toBeDefined();
+    expect(timeISO8601).toBe("00:00");
   });
 
   it("accepts 1:37 PM in 12-hour locale (en)", async () => {
     i18n.changeLanguage("en");
-    let time: Dayjs | null = null;
-    render(<Form setTime={(t) => (time = t)} />, { wrapper });
+    let timeISO8601: string | null = null;
+    render(<Form setTime={(t) => (timeISO8601 = t)} />, { wrapper });
 
     const user = userEvent.setup();
 
@@ -93,15 +89,14 @@ describe("Timepicker", () => {
     await user.keyboard("0137 PM");
 
     await user.click(screen.getByRole("button", { name: "Submit" }));
-    expect(time).toBeDefined();
-    expect(time!.hour()).toBe(13);
-    expect(time!.minute()).toBe(37);
+    expect(timeISO8601).toBeDefined();
+    expect(timeISO8601).toBe("13:37");
   });
 
   it("accepts 13:37 in 24-hour locale (fr)", async () => {
     i18n.changeLanguage("fr");
-    let time: Dayjs | null = null;
-    render(<Form setTime={(t) => (time = t)} />, { wrapper });
+    let timeISO8601: string | null = null;
+    render(<Form setTime={(t) => (timeISO8601 = t)} />, { wrapper });
 
     const user = userEvent.setup();
 
@@ -112,8 +107,7 @@ describe("Timepicker", () => {
     await user.keyboard("1337");
 
     await user.click(screen.getByRole("button", { name: "Submit" }));
-    expect(time).toBeDefined();
-    expect(time!.hour()).toBe(13);
-    expect(time!.minute()).toBe(37);
+    expect(timeISO8601).toBeDefined();
+    expect(timeISO8601).toBe("13:37");
   });
 });

--- a/app/web/components/Timepicker.tsx
+++ b/app/web/components/Timepicker.tsx
@@ -4,9 +4,9 @@ import { GLOBAL } from "i18n/namespaces";
 import React, { useMemo } from "react";
 import { Control, Controller, UseControllerProps } from "react-hook-form";
 import {
+  getMuiTimeFormat,
   ISO8601_DATE_FORMAT,
   ISO8601_HOUR_MIN_FORMAT,
-  getMuiTimeFormat,
 } from "utils/date";
 import dayjs, { Dayjs } from "utils/dayjs";
 

--- a/app/web/components/Timepicker.tsx
+++ b/app/web/components/Timepicker.tsx
@@ -3,28 +3,44 @@ import { useTranslation } from "i18n";
 import { GLOBAL } from "i18n/namespaces";
 import React, { useMemo } from "react";
 import { Control, Controller, UseControllerProps } from "react-hook-form";
-import { getMuiTimeFormat } from "utils/date";
-import { Dayjs } from "utils/dayjs";
+import {
+  ISO8601_DATE_FORMAT,
+  ISO8601_HOUR_MIN_FORMAT,
+  getMuiTimeFormat,
+} from "utils/date";
+import dayjs, { Dayjs } from "utils/dayjs";
 
 interface TimepickerProps {
   className?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   control: Control<any>;
-  defaultValue?: Dayjs | null;
+  defaultValueISO8601?: string;
   error: boolean;
   helperText: React.ReactNode;
   id: string;
   rules?: UseControllerProps["rules"];
   label?: string;
   name: string;
-  onPostChange?(time: Dayjs | null): void;
+  onPostChange?(timeISO8601: string | null): void;
   testId?: string;
+}
+
+// Convert between our API's ISO8601 strings and MUI's expected Dayjs values.
+function iso8601ToDayjs(value: string): Dayjs {
+  return dayjs(
+    `1970-01-01T${value}`,
+    `${ISO8601_DATE_FORMAT}T${ISO8601_HOUR_MIN_FORMAT}`,
+  );
+}
+
+function dayjsToISO8601(value: Dayjs): string {
+  return value.format(ISO8601_HOUR_MIN_FORMAT);
 }
 
 const Timepicker = ({
   className,
   control,
-  defaultValue,
+  defaultValueISO8601,
   error,
   helperText,
   id,
@@ -43,7 +59,7 @@ const Timepicker = ({
   return (
     <Controller
       control={control}
-      defaultValue={defaultValue}
+      defaultValue={defaultValueISO8601 ?? null}
       name={name}
       rules={rules}
       render={({ field }) => (
@@ -51,10 +67,11 @@ const Timepicker = ({
           data-testid={testId}
           {...field}
           label={label}
-          value={field.value}
-          onChange={(time: Dayjs | null) => {
-            field.onChange(time);
-            onPostChange?.(time);
+          value={field.value ? iso8601ToDayjs(field.value) : undefined}
+          onChange={(value: Dayjs | null) => {
+            const valueISO8601 = value ? dayjsToISO8601(value) : null;
+            field.onChange(valueISO8601);
+            onPostChange?.(valueISO8601);
           }}
           format={format}
           ampm={format.includes("a")} // Clock picker uses am/pm iff format also uses it

--- a/app/web/features/auth/signup/AccountForm.tsx
+++ b/app/web/features/auth/signup/AccountForm.tsx
@@ -21,7 +21,7 @@ import EditLocationMap, {
 } from "components/EditLocationMap";
 import Select from "components/Select";
 import TOSLink from "components/TOSLink";
-import dayjs, { Dayjs } from "dayjs";
+import dayjs from "dayjs";
 import { useAuthContext } from "features/auth/AuthProvider";
 import {
   StyledButton,
@@ -35,6 +35,7 @@ import { HostingStatus } from "proto/api_pb";
 import { useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { service } from "service";
+import { ISO8601_DATE_FORMAT } from "utils/date";
 import {
   lowercaseAndTrimField,
   usernameValidationPattern,
@@ -46,7 +47,7 @@ export type SignupAccountInputs = {
   username: string;
   password: string;
   name: string;
-  birthdate: Dayjs;
+  birthdate: string;
   gender: string;
   acceptTOS: boolean;
   optInToNewsletter: boolean;
@@ -142,7 +143,7 @@ export default function AccountForm() {
         flowToken: authState.flowState!.flowToken,
         username: lowercaseAndTrimField(username),
         password: password,
-        birthdate: birthdate.format().split("T")[0],
+        birthdate,
         gender,
         acceptTOS,
         optOutOfNewsletter: !optInToNewsletter,
@@ -173,7 +174,7 @@ export default function AccountForm() {
 
   const usernameInputRef = useRef<HTMLInputElement>(undefined);
 
-  const handleBirthdateChange = (newBirthdate: Dayjs) => {
+  const handleBirthdateChange = (newBirthdate: string) => {
     setValue("birthdate", newBirthdate, {
       shouldDirty: true,
       shouldValidate: true,
@@ -289,9 +290,12 @@ export default function AccountForm() {
               return true; // Validation passes
             },
           }}
-          minDate={dayjs().subtract(120, "years")}
-          maxDate={dayjs().subtract(18, "years")}
-          defaultValue={null}
+          minValueISO8601={dayjs()
+            .subtract(120, "years")
+            .format(ISO8601_DATE_FORMAT)}
+          maxValueISO8601={dayjs()
+            .subtract(18, "years")
+            .format(ISO8601_DATE_FORMAT)}
           openTo="year"
           name="birthdate"
           onPostChange={handleBirthdateChange}

--- a/app/web/features/communities/events/CreateEventPage.tsx
+++ b/app/web/features/communities/events/CreateEventPage.tsx
@@ -16,14 +16,13 @@ import { dashboardRoute, eventsRoute, routeToEvent } from "routes";
 import { service } from "service";
 import type { CreateEventInput } from "service/events";
 import { theme } from "theme";
-import dayjs from "utils/dayjs";
+import { iso8601ToDayjs } from "utils/date";
+import { sendNativeBack, useIsNativeEmbed } from "utils/nativeLink";
 import stringOrFirstString from "utils/stringOrFirstString";
 
-import { sendNativeBack, useIsNativeEmbed } from "../../../utils/nativeLink";
 import { communityEventsBaseKey } from "../../queryKeys";
 import EventForm, { CreateEventVariables } from "./EventForm";
 import { useEvent } from "./hooks";
-import { iso8601ToDayjs } from "../../../utils/date";
 
 const StyledBackButton = styled(HeaderButton)(() => ({
   gridArea: "backButton",

--- a/app/web/features/communities/events/CreateEventPage.tsx
+++ b/app/web/features/communities/events/CreateEventPage.tsx
@@ -23,6 +23,7 @@ import { sendNativeBack, useIsNativeEmbed } from "../../../utils/nativeLink";
 import { communityEventsBaseKey } from "../../queryKeys";
 import EventForm, { CreateEventVariables } from "./EventForm";
 import { useEvent } from "./hooks";
+import { iso8601ToDayjs } from "../../../utils/date";
 
 const StyledBackButton = styled(HeaderButton)(() => ({
   gridArea: "backButton",
@@ -72,19 +73,6 @@ export default function CreateEventPage() {
     { parentCommunityId?: number }
   >({
     mutationFn: (data) => {
-      const startTime = dayjs(data.startTime);
-      const endTime = dayjs(data.endTime);
-      const finalStartDate = data.startDate
-        .startOf("day")
-        .add(startTime.get("hour"), "hour")
-        .add(startTime.get("minute"), "minute")
-        .toDate();
-      const finalEndDate = data.endDate
-        .startOf("day")
-        .add(endTime.get("hour"), "hour")
-        .add(endTime.get("minute"), "minute")
-        .toDate();
-
       // Use uploaded photo, or reuse photo from event being duplicated
       const photoKey =
         data.eventImage || eventToDuplicate?.photoKey || undefined;
@@ -93,8 +81,14 @@ export default function CreateEventPage() {
         title: data.title,
         content: data.content,
         photoKey,
-        startTime: finalStartDate,
-        endTime: finalEndDate,
+        startTime: iso8601ToDayjs(
+          data.startDateISO8601,
+          data.startTimeISO8601,
+        ).toDate(),
+        endTime: iso8601ToDayjs(
+          data.endDateISO8601,
+          data.endTimeISO8601,
+        ).toDate(),
         address: data.location.name,
         lat: data.location.location.lat,
         lng: data.location.location.lng,

--- a/app/web/features/communities/events/EditEventPage.tsx
+++ b/app/web/features/communities/events/EditEventPage.tsx
@@ -65,18 +65,8 @@ export default function EditEventPage({ eventId }: { eventId: number }) {
     { parentCommunityId?: number }
   >({
     mutationFn: (data) => {
-      const startTime = dayjs(data.startTime);
-      const endTime = dayjs(data.endTime);
-      const finalStartDate = data.startDate
-        .startOf("day")
-        .add(startTime.get("hour"), "hour")
-        .add(startTime.get("minute"), "minute")
-        .toDate();
-      const finalEndDate = data.endDate
-        .startOf("day")
-        .add(endTime.get("hour"), "hour")
-        .add(endTime.get("minute"), "minute")
-        .toDate();
+      const startDateTimeISO8601 = `${data.startDateISO8601}T${data.startTimeISO8601}`;
+      const endDateTimeISO8601 = `${data.endDateISO8601}T${data.endTimeISO8601}`;
 
       const updateEventInput: UpdateEventInput = {
         eventId,
@@ -84,12 +74,12 @@ export default function EditEventPage({ eventId }: { eventId: number }) {
         content: data.dirtyFields.content ? data.content : undefined,
         photoKey: data.dirtyFields.eventImage ? data.eventImage : undefined,
         startTime:
-          data.dirtyFields.startTime || data.dirtyFields.startDate
-            ? finalStartDate
+          data.dirtyFields.startTimeISO8601 || data.dirtyFields.startDateISO8601
+            ? dayjs(startDateTimeISO8601).toDate()
             : undefined,
         endTime:
-          data.dirtyFields.endTime || data.dirtyFields.endDate
-            ? finalEndDate
+          data.dirtyFields.endTimeISO8601 || data.dirtyFields.endDateISO8601
+            ? dayjs(endDateTimeISO8601).toDate()
             : undefined,
         shouldNotify: data.dirtyFields.shouldNotify,
         address: data.dirtyFields.location ? data.location.name : undefined,

--- a/app/web/features/communities/events/EventForm.tsx
+++ b/app/web/features/communities/events/EventForm.tsx
@@ -15,7 +15,6 @@ import { Event } from "proto/events_pb";
 import { useRef } from "react";
 import { DeepMap, useForm } from "react-hook-form";
 import { theme } from "theme";
-import { Dayjs } from "utils/dayjs";
 import type { GeocodeResult } from "utils/hooks";
 
 import EventTimeChanger from "./EventTimeChanger";
@@ -54,10 +53,10 @@ const StyledEventDetailsContainer = styled("div")(() => ({
 interface EventData {
   content: string;
   title: string;
-  startDate: Dayjs;
-  endDate: Dayjs;
-  startTime: Dayjs;
-  endTime: Dayjs;
+  startDateISO8601: string;
+  endDateISO8601: string;
+  startTimeISO8601: string;
+  endTimeISO8601: string;
   shouldNotify: boolean;
   eventImage?: string;
   parentCommunityId?: number;

--- a/app/web/features/communities/events/EventTimeChanger.test.tsx
+++ b/app/web/features/communities/events/EventTimeChanger.test.tsx
@@ -429,8 +429,8 @@ describe("Event time changer", () => {
       const submittedData = onValidSubmit.mock.calls[0][0];
       expect(submittedData).toBeDefined();
       // The event fixture should have the original event data preserved
-      expect(submittedData.startDate).toBeDefined();
-      expect(submittedData.endDate).toBeDefined();
+      expect(submittedData.startDateISO8601).toBeDefined();
+      expect(submittedData.endDateISO8601).toBeDefined();
     });
   });
 
@@ -478,10 +478,10 @@ describe("Event time changer", () => {
       expect(onValidSubmit).toHaveBeenCalledTimes(1);
       const submittedData = onValidSubmit.mock.calls[0][0];
 
-      expect(submittedData.startDate.format("YYYY-MM-DD")).toBe("2021-08-05");
-      expect(submittedData.startTime.format("HH:mm")).toBe("14:00");
-      expect(submittedData.endDate.format("YYYY-MM-DD")).toBe("2021-08-06");
-      expect(submittedData.endTime.format("HH:mm")).toBe("15:00");
+      expect(submittedData.startDateISO8601).toBe("2021-08-05");
+      expect(submittedData.startTimeISO8601).toBe("14:00");
+      expect(submittedData.endDateISO8601).toBe("2021-08-06");
+      expect(submittedData.endTimeISO8601).toBe("15:00");
     });
   });
 });

--- a/app/web/features/communities/events/EventTimeChanger.tsx
+++ b/app/web/features/communities/events/EventTimeChanger.tsx
@@ -1,14 +1,19 @@
 import { styled } from "@mui/material";
 import Datepicker from "components/Datepicker";
 import Timepicker from "components/Timepicker";
-import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
 import { useTranslation } from "i18n";
 import { COMMUNITIES } from "i18n/namespaces";
 import { Event } from "proto/events_pb";
 import { UseFormReturn } from "react-hook-form";
 import { theme } from "theme";
-import { isSameOrFutureDate, timestamp2Date } from "utils/date";
-import dayjs, { Dayjs } from "utils/dayjs";
+import {
+  ISO8601_DATE_FORMAT,
+  ISO8601_HOUR_MIN_FORMAT,
+  isSameOrFutureDate,
+  iso8601ToDayjs,
+  timestamp2Date,
+} from "utils/date";
+import dayjs from "utils/dayjs";
 import { timePattern } from "utils/validation";
 
 import { CreateEventData } from "./EventForm";
@@ -21,20 +26,6 @@ const StyledContainer = styled("div")(() => ({
     gridTemplateColumns: "1fr 1fr",
   },
 }));
-
-function splitTimestampToDateAndTime(timestamp?: Timestamp.AsObject): {
-  date?: Dayjs;
-  time?: Dayjs;
-} {
-  if (timestamp) {
-    const dayjsDate = dayjs(timestamp2Date(timestamp));
-    return {
-      date: dayjsDate.startOf("day"),
-      time: dayjsDate,
-    };
-  }
-  return {};
-}
 
 interface EventTimeChangerProps
   extends Pick<
@@ -56,34 +47,36 @@ export default function EventTimeChanger({
 }: EventTimeChangerProps) {
   const { t } = useTranslation([COMMUNITIES]);
 
-  const { date: eventStartDate, time: eventStartTime } =
-    splitTimestampToDateAndTime(event?.startTime);
-  const { date: eventEndDate, time: eventEndTime } =
-    splitTimestampToDateAndTime(event?.endTime);
+  const defaultStartDateTime = event?.startTime
+    ? dayjs(timestamp2Date(event.startTime))
+    : undefined;
+  const defaultEndDateTime = event?.endTime
+    ? dayjs(timestamp2Date(event.endTime))
+    : undefined;
 
-  const handleStartDateChange = (newStartDate: Dayjs) => {
-    setValue("startDate", newStartDate, {
+  const handleStartDateChange = (valueISO8601: string) => {
+    setValue("startDateISO8601", valueISO8601, {
       shouldDirty: true,
       shouldValidate: true,
     });
   };
 
-  const handleEndDateChange = (newEndDate: Dayjs) => {
-    setValue("endDate", newEndDate, {
+  const handleEndDateChange = (valueISO8601: string) => {
+    setValue("endDateISO8601", valueISO8601, {
       shouldDirty: true,
       shouldValidate: true,
     });
   };
 
-  const handleStartTimeChange = (newStartTime: Dayjs) => {
-    setValue("startTime", newStartTime, {
+  const handleStartTimeChange = (valueISO8601: string) => {
+    setValue("startTimeISO8601", valueISO8601, {
       shouldDirty: true,
       shouldValidate: true,
     });
   };
 
-  const handleEndTimeChange = (newEndTime: Dayjs) => {
-    setValue("endTime", newEndTime, {
+  const handleEndTimeChange = (valueISO8601: string) => {
+    setValue("endTimeISO8601", valueISO8601, {
       shouldDirty: true,
       shouldValidate: true,
     });
@@ -94,22 +87,24 @@ export default function EventTimeChanger({
       <StyledContainer>
         <Datepicker
           control={control}
-          defaultValue={eventStartDate ?? null}
-          error={!!errors.startDate?.message}
-          helperText={errors.startDate?.message}
+          defaultValueISO8601={defaultStartDateTime?.format(
+            ISO8601_DATE_FORMAT,
+          )}
+          error={!!errors.startDateISO8601?.message}
+          helperText={errors.startDateISO8601?.message}
           id="startDate"
           label={t("communities:start_date")}
-          name="startDate"
+          name="startDateISO8601"
           onPostChange={handleStartDateChange}
           rules={{
             required: t("communities:date_required"),
-            validate: (date: Dayjs) => {
+            validate: (valueISO8601: string) => {
               // Only disable validation temporarily if `event` exists/in the edit event context
-              if (event && !dirtyFields.startDate) {
+              if (event && !dirtyFields.startDateISO8601) {
                 return true;
               }
               return (
-                isSameOrFutureDate(date, dayjs()) ||
+                isSameOrFutureDate(dayjs(valueISO8601), dayjs()) ||
                 t("communities:past_date_error")
               );
             },
@@ -119,33 +114,36 @@ export default function EventTimeChanger({
 
         <Timepicker
           control={control}
-          name="startTime"
+          name="startTimeISO8601"
           onPostChange={handleStartTimeChange}
-          defaultValue={eventStartTime || null}
+          defaultValueISO8601={defaultStartDateTime?.format(
+            ISO8601_HOUR_MIN_FORMAT,
+          )}
           rules={{
             required: t("communities:time_required"),
             pattern: {
               message: t("communities:invalid_time"),
               value: timePattern,
             },
-            validate: (time: Dayjs) => {
-              if (event && !dirtyFields.startTime) {
+            validate: (valueISO8601: string) => {
+              if (event && !dirtyFields.startTimeISO8601) {
                 return true;
               }
 
-              const startDate = getValues("startDate");
+              const startDateISO8601 = getValues("startDateISO8601");
 
-              if (!startDate) {
+              if (!startDateISO8601) {
                 return t("communities:date_required");
               }
 
-              if (!time) {
+              if (!valueISO8601) {
                 return t("communities:time_required");
               }
 
-              const startDateTime = startDate
-                .hour(time.hour())
-                .minute(time.minute());
+              const startDateTime = iso8601ToDayjs(
+                startDateISO8601,
+                valueISO8601,
+              );
 
               return (
                 startDateTime.isAfter(dayjs()) ||
@@ -155,35 +153,34 @@ export default function EventTimeChanger({
           }}
           id="startTime"
           label={t("communities:start_time")}
-          error={!!errors.startTime?.message}
-          helperText={errors.startTime?.message || ""}
+          error={!!errors.startTimeISO8601?.message}
+          helperText={errors.startTimeISO8601?.message || ""}
           testId="startTime"
         />
       </StyledContainer>
       <StyledContainer>
         <Datepicker
           control={control}
-          defaultValue={eventEndDate ?? null}
-          error={!!errors.endDate?.message}
-          helperText={errors.endDate?.message || ""}
+          defaultValueISO8601={defaultEndDateTime?.format(ISO8601_DATE_FORMAT)}
+          error={!!errors.endDateISO8601?.message}
+          helperText={errors.endDateISO8601?.message || ""}
           id="endDate"
           label={t("communities:end_date")}
-          name="endDate"
+          name="endDateISO8601"
           rules={{
             required: t("communities:date_required"),
-            validate: (date) => {
-              if (event && !dirtyFields.endDate) {
+            validate: (valueISO8601: string) => {
+              if (event && !dirtyFields.endDateISO8601) {
                 return true;
               }
 
-              const startDate = getValues("startDate");
-
-              if (date.isBefore(startDate)) {
+              const startDateISO8601 = getValues("startDateISO8601");
+              if (dayjs(valueISO8601).isBefore(dayjs(startDateISO8601))) {
                 return t("communities:end_date_error");
               }
 
               return (
-                isSameOrFutureDate(date, dayjs()) ||
+                isSameOrFutureDate(dayjs(valueISO8601), dayjs()) ||
                 t("communities:past_date_error")
               );
             },
@@ -194,39 +191,39 @@ export default function EventTimeChanger({
 
         <Timepicker
           control={control}
-          name="endTime"
+          name="endTimeISO8601"
           onPostChange={handleEndTimeChange}
-          defaultValue={eventEndTime || null}
+          defaultValueISO8601={defaultEndDateTime?.format(
+            ISO8601_HOUR_MIN_FORMAT,
+          )}
           rules={{
             required: t("communities:time_required"),
             pattern: {
               message: t("communities:invalid_time"),
               value: timePattern,
             },
-            validate: (time: Dayjs) => {
-              if (event && !dirtyFields.endTime) {
+            validate: (valueISO8601: string) => {
+              if (event && !dirtyFields.endTimeISO8601) {
                 return true;
               }
 
-              const startTime = getValues("startTime");
-              const startDate = getValues("startDate");
-              const endDate = getValues("endDate");
+              const startTimeISO8601 = getValues("startTimeISO8601");
+              const startDateISO8601 = getValues("startDateISO8601");
+              const endDateISO8601 = getValues("endDateISO8601");
 
-              if (!startTime || !time) {
+              if (!startTimeISO8601 || !valueISO8601) {
                 return t("communities:time_required");
               }
 
-              if (!startDate || !endDate) {
+              if (!startDateISO8601 || !endDateISO8601) {
                 return t("communities:date_required");
               }
 
-              const startDateTime = startDate
-                .hour(startTime.hour())
-                .minute(startTime.minute());
-
-              const endDateTime = endDate
-                .hour(time.hour())
-                .minute(time.minute());
+              const startDateTime = iso8601ToDayjs(
+                startDateISO8601,
+                startTimeISO8601,
+              );
+              const endDateTime = iso8601ToDayjs(endDateISO8601, valueISO8601);
 
               if (!endDateTime.isAfter(startDateTime)) {
                 return t("communities:end_time_error");
@@ -239,8 +236,8 @@ export default function EventTimeChanger({
           }}
           id="endTime"
           label={t("communities:end_time")}
-          error={!!errors.endTime?.message}
-          helperText={errors.endTime?.message || ""}
+          error={!!errors.endTimeISO8601?.message}
+          helperText={errors.endTimeISO8601?.message || ""}
           testId="endTime"
         />
       </StyledContainer>

--- a/app/web/features/communities/events/EventTimeChanger.tsx
+++ b/app/web/features/communities/events/EventTimeChanger.tsx
@@ -9,8 +9,8 @@ import { theme } from "theme";
 import {
   ISO8601_DATE_FORMAT,
   ISO8601_HOUR_MIN_FORMAT,
-  isSameOrFutureDate,
   iso8601ToDayjs,
+  isSameOrFutureDate,
   timestamp2Date,
 } from "utils/date";
 import dayjs from "utils/dayjs";

--- a/app/web/features/profile/view/NewHostRequest.tsx
+++ b/app/web/features/profile/view/NewHostRequest.tsx
@@ -21,15 +21,15 @@ import { howToWriteRequestGuideUrl } from "routes";
 import { service } from "service";
 import { CreateHostRequestWrapper } from "service/requests";
 import { theme } from "theme";
-import { isSameOrFutureDate } from "utils/date";
+import { ISO8601_DATE_FORMAT, isSameOrFutureDate } from "utils/date";
 import dayjs from "utils/dayjs";
 
 const TYPING_GAP_CAP_MS = 3000;
 
 interface FormValuesSnapshot {
   text: string;
-  fromDate: dayjs.Dayjs | null;
-  toDate: dayjs.Dayjs | null;
+  fromDate: string | null;
+  toDate: string | null;
 }
 
 function isFormField(target: EventTarget | null): boolean {
@@ -122,8 +122,8 @@ function useHostRequestFormTracking({
         active_typing_ms: Math.round(activeTypingMs),
         keystroke_count: keystrokeCount,
         text_length: text.length,
-        from_date: fromDate ? fromDate.format("YYYY-MM-DD") : null,
-        to_date: toDate ? toDate.format("YYYY-MM-DD") : null,
+        from_date: fromDate,
+        to_date: toDate,
         ...referrerProps,
       });
     };
@@ -245,12 +245,16 @@ export default function NewHostRequest({
     !!watchFromDate && dayjs(watchFromDate).isBefore(hostToday);
 
   useEffect(() => {
+    const toDate = getValues("toDate");
     if (
       watchFromDate &&
-      getValues("toDate") &&
-      isSameOrFutureDate(watchFromDate, getValues("toDate"))
+      toDate &&
+      isSameOrFutureDate(dayjs(watchFromDate), dayjs(toDate))
     ) {
-      setValue("toDate", watchFromDate.add(1, "day"));
+      setValue(
+        "toDate",
+        dayjs(watchFromDate).add(1, "day").format(ISO8601_DATE_FORMAT),
+      );
     }
   });
 
@@ -277,8 +281,7 @@ export default function NewHostRequest({
                 id="from-date"
                 label={t("profile:request_form.arrival_date")}
                 name="fromDate"
-                defaultValue={null}
-                minDate={hostToday}
+                minValueISO8601={hostToday.format(ISO8601_DATE_FORMAT)}
                 rules={{
                   required: t("profile:request_form.arrival_date_empty"),
                   validate: {
@@ -305,9 +308,11 @@ export default function NewHostRequest({
                 helperText={errors?.toDate?.message}
                 id="to-date"
                 label={t("profile:request_form.departure_date")}
-                minDate={watchFromDate ? watchFromDate.add(1, "day") : dayjs()}
+                minValueISO8601={(watchFromDate
+                  ? dayjs(watchFromDate).add(1, "day")
+                  : dayjs()
+                ).format(ISO8601_DATE_FORMAT)}
                 name="toDate"
-                defaultValue={null}
                 rules={{
                   required: t("profile:request_form.departure_date_empty"),
                   validate: (stringDate) => stringDate !== "",

--- a/app/web/features/publicTrips/OfferToHostDialog.tsx
+++ b/app/web/features/publicTrips/OfferToHostDialog.tsx
@@ -21,7 +21,8 @@ import { useForm } from "react-hook-form";
 import { routeToHostRequest } from "routes";
 import { service } from "service";
 import { theme } from "theme";
-import dayjs, { Dayjs } from "utils/dayjs";
+import { ISO8601_DATE_FORMAT } from "utils/date";
+import dayjs from "utils/dayjs";
 
 // Must match the backend host request minimum (and normal host requests).
 const MESSAGE_MIN_LENGTH = 250;
@@ -29,8 +30,8 @@ const MESSAGE_MIN_LENGTH = 250;
 const DATE_FIELD_ID = "offer-to-host-dates";
 
 interface FormValues {
-  fromDate: Dayjs | null;
-  toDate: Dayjs | null;
+  fromDate: string | null;
+  toDate: string | null;
   text: string;
 }
 
@@ -87,7 +88,11 @@ export default function OfferToHostDialog({
     formState: { errors },
   } = useForm<FormValues>({
     mode: "onBlur",
-    defaultValues: { fromDate: tripFrom, toDate: tripTo, text: "" },
+    defaultValues: {
+      fromDate: tripFromDate,
+      toDate: tripToDate,
+      text: "",
+    },
   });
 
   const watchFromDate = watch("fromDate");
@@ -153,9 +158,9 @@ export default function OfferToHostDialog({
                 id={`${DATE_FIELD_ID}-from`}
                 label={t("publicTrips:from_date_label")}
                 name="fromDate"
-                defaultValue={tripFrom}
-                minDate={earliest}
-                maxDate={tripTo}
+                defaultValueISO8601={tripFromDate}
+                minValueISO8601={earliest.format(ISO8601_DATE_FORMAT)}
+                maxValueISO8601={tripToDate}
                 rules={{ required: t("publicTrips:from_date_required") }}
               />
               <Datepicker
@@ -165,9 +170,11 @@ export default function OfferToHostDialog({
                 id={`${DATE_FIELD_ID}-to`}
                 label={t("publicTrips:to_date_label")}
                 name="toDate"
-                defaultValue={tripTo}
-                minDate={watchFromDate ?? earliest}
-                maxDate={tripTo}
+                defaultValueISO8601={tripToDate}
+                minValueISO8601={
+                  watchFromDate ?? earliest.format(ISO8601_DATE_FORMAT)
+                }
+                maxValueISO8601={tripToDate}
                 rules={{ required: t("publicTrips:to_date_required") }}
               />
             </DateRow>

--- a/app/web/features/publicTrips/OfferToHostDialog.tsx
+++ b/app/web/features/publicTrips/OfferToHostDialog.tsx
@@ -73,7 +73,6 @@ export default function OfferToHostDialog({
   const queryClient = useQueryClient();
 
   const tripFrom = dayjs(tripFromDate);
-  const tripTo = dayjs(tripToDate);
   const today = dayjs().startOf("day");
   // The host can offer within the trip's window (shorten, not extend), and
   // never in the past. The backend enforces these too.

--- a/app/web/features/publicTrips/PublicTripDialog.tsx
+++ b/app/web/features/publicTrips/PublicTripDialog.tsx
@@ -14,13 +14,14 @@ import { useTranslation } from "i18n";
 import { GLOBAL, PUBLIC_TRIPS } from "i18n/namespaces";
 import { useEffect } from "react";
 import { Controller, useForm, useWatch } from "react-hook-form";
-import dayjs, { Dayjs } from "utils/dayjs";
+import dayjs from "utils/dayjs";
 
 import {
   PublicTrip,
   useCreatePublicTrip,
   useUpdatePublicTrip,
 } from "./useListPublicTrips";
+import { ISO8601_DATE_FORMAT } from "../../utils/date";
 
 const DATE_FIELD_ID = "public-trip-dates";
 // Must match backend (PUBLIC_TRIP_DESCRIPTION_MIN_LENGTH_UTF16)
@@ -41,8 +42,8 @@ const DateRow = styled("div")(({ theme }) => ({
 }));
 
 interface FormValues {
-  fromDate: Dayjs | null;
-  toDate: Dayjs | null;
+  fromDate: string | null;
+  toDate: string | null;
   description: string;
   sameGenderOnly: boolean;
 }
@@ -63,8 +64,8 @@ export default function PublicTripDialog(props: PublicTripDialogProps) {
   const getDefaults = (): FormValues =>
     props.mode === "edit"
       ? {
-          fromDate: props.trip.fromDate ? dayjs(props.trip.fromDate) : null,
-          toDate: props.trip.toDate ? dayjs(props.trip.toDate) : null,
+          fromDate: props.trip.fromDate ?? null,
+          toDate: props.trip.toDate ?? null,
           description: props.trip.description,
           sameGenderOnly: props.trip.sameGenderOnly ?? false,
         }
@@ -148,8 +149,8 @@ export default function PublicTripDialog(props: PublicTripDialogProps) {
     ({ fromDate, toDate, description, sameGenderOnly }) => {
       if (!fromDate || !toDate) return;
       const payload = {
-        fromDate: fromDate.format("YYYY-MM-DD"),
-        toDate: toDate.format("YYYY-MM-DD"),
+        fromDate,
+        toDate,
         description: description.trim(),
         sameGenderOnly,
       };
@@ -189,7 +190,6 @@ export default function PublicTripDialog(props: PublicTripDialogProps) {
                 id={`${DATE_FIELD_ID}-from`}
                 label={t("publicTrips:from_date_label")}
                 name="fromDate"
-                defaultValue={null}
                 rules={{
                   required: t("publicTrips:from_date_required"),
                 }}
@@ -201,8 +201,9 @@ export default function PublicTripDialog(props: PublicTripDialogProps) {
                 id={`${DATE_FIELD_ID}-to`}
                 label={t("publicTrips:to_date_label")}
                 name="toDate"
-                defaultValue={null}
-                minDate={watchFromDate ? watchFromDate : dayjs()}
+                minValueISO8601={
+                  watchFromDate ?? dayjs().format(ISO8601_DATE_FORMAT)
+                }
                 rules={{
                   required: t("publicTrips:to_date_required"),
                 }}

--- a/app/web/features/publicTrips/PublicTripDialog.tsx
+++ b/app/web/features/publicTrips/PublicTripDialog.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from "i18n";
 import { GLOBAL, PUBLIC_TRIPS } from "i18n/namespaces";
 import { useEffect } from "react";
 import { Controller, useForm, useWatch } from "react-hook-form";
+import { ISO8601_DATE_FORMAT } from "utils/date";
 import dayjs from "utils/dayjs";
 
 import {
@@ -21,7 +22,6 @@ import {
   useCreatePublicTrip,
   useUpdatePublicTrip,
 } from "./useListPublicTrips";
-import { ISO8601_DATE_FORMAT } from "../../utils/date";
 
 const DATE_FIELD_ID = "public-trip-dates";
 // Must match backend (PUBLIC_TRIP_DESCRIPTION_MIN_LENGTH_UTF16)

--- a/app/web/service/requests.ts
+++ b/app/web/service/requests.ts
@@ -1,4 +1,3 @@
-import { Dayjs } from "dayjs";
 import { HostRequestStatus } from "proto/conversations_pb";
 import {
   CreateHostRequestReq,
@@ -106,16 +105,18 @@ export async function getHostRequestMessages(
 export type CreateHostRequestWrapper = Omit<
   Required<CreateHostRequestReq.AsObject>,
   "toDate" | "fromDate" | "publicTripId"
-> & { toDate: Dayjs; fromDate: Dayjs; stayType: number; publicTripId?: number };
+> & {
+  toDate: string;
+  fromDate: string;
+  stayType: number;
+  publicTripId?: number;
+};
 
 export async function createHostRequest(data: CreateHostRequestWrapper) {
   const req = new CreateHostRequestReq();
   req.setHostUserId(data.hostUserId);
-  // Dayjs.format() uses the browser timezone,
-  // which matches the timezone we used to create the
-  // Dayjs object from the year/month/date input fields.
-  req.setFromDate(data.fromDate.format().split("T")[0]);
-  req.setToDate(data.toDate.format().split("T")[0]);
+  req.setFromDate(data.fromDate);
+  req.setToDate(data.toDate);
   req.setText(data.text);
   // Set when this host request is an "offer to host" made in response to a
   // public trip, so the backend links the offer back to the trip.

--- a/app/web/utils/date.ts
+++ b/app/web/utils/date.ts
@@ -3,6 +3,10 @@ import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
 
 import daysjs, { Dayjs } from "./dayjs";
 import { dayMillis } from "./timeAgo";
+import dayjs from "./dayjs";
+
+export const ISO8601_DATE_FORMAT = "YYYY-MM-DD";
+export const ISO8601_HOUR_MIN_FORMAT = "HH:mm";
 
 // Creating Intl.Segmenter every time is slow, so cache one per locale.
 const segmenterCache = new Map<string, Intl.Segmenter>();
@@ -188,12 +192,10 @@ export function localizeMonthAbbreviation(
     : formatted;
 }
 
-const isoMuiDateFormat = "YYYY-MM-DD";
-
 /// Gets the date format for a locale using Material UI placeholders.
 export function getMuiDateFormat(locale: string): string {
   if (Intl.DateTimeFormat.supportedLocalesOf(locale).length === 0) {
-    return isoMuiDateFormat;
+    return ISO8601_DATE_FORMAT;
   }
 
   // Format dummy 3333-11-22 date to figure out how it gets laid out.
@@ -210,16 +212,14 @@ export function getMuiDateFormat(locale: string): string {
     .replace("22", "DD");
 
   // Sanity check: There should be no digits left
-  if (/[0-9]/.test(format)) return isoMuiDateFormat;
+  if (/[0-9]/.test(format)) return ISO8601_DATE_FORMAT;
   return format;
 }
-
-const defaultMuiTimeFormat = "HH:mm";
 
 /// Gets a localized time format string compatible with Material UI time pickers.
 export function getMuiTimeFormat(locale: string): string {
   if (Intl.DateTimeFormat.supportedLocalesOf(locale).length === 0) {
-    return defaultMuiTimeFormat;
+    return ISO8601_HOUR_MIN_FORMAT;
   }
 
   const intlFormat = new Intl.DateTimeFormat(locale, {
@@ -270,6 +270,12 @@ function isSameDate(date1: Dayjs, date2: Dayjs): boolean {
 /** Compares whether date1 is equal to or in the future of date2 */
 function isSameOrFutureDate(date1: Dayjs, date2: Dayjs): boolean {
   return isSameDate(date1, date2) || date1.isAfter(date2);
+}
+
+/// Parses an ISO8601 date string (YYYY-MM-DD), with optional time string (HH:mm:ss),
+/// into a dayjs object.
+export function iso8601ToDayjs(date: string, time?: string): Dayjs {
+  return dayjs(`${date}T${time ?? "00:00"}`);
 }
 
 /// Localizes a number of days as a relative time string (e.g. "today", "tomorrow", "in 3 days").

--- a/app/web/utils/date.ts
+++ b/app/web/utils/date.ts
@@ -1,9 +1,8 @@
 // format a date
 import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
 
-import daysjs, { Dayjs } from "./dayjs";
+import dayjs, { Dayjs } from "./dayjs";
 import { dayMillis } from "./timeAgo";
-import dayjs from "./dayjs";
 
 export const ISO8601_DATE_FORMAT = "YYYY-MM-DD";
 export const ISO8601_HOUR_MIN_FORMAT = "HH:mm";
@@ -65,7 +64,7 @@ export function localizeDateTime(
   date: Date | Dayjs,
   args: LocalizeDateTimeParams,
 ): string {
-  if (daysjs.isDayjs(date)) {
+  if (dayjs.isDayjs(date)) {
     date = date.toDate();
   }
   const format = getIntlDateTimeFormat(args);
@@ -101,10 +100,10 @@ export function localizeDateTimeRange(
   end: Date | Dayjs,
   args: LocalizeDateTimeParams,
 ): string {
-  if (daysjs.isDayjs(start)) {
+  if (dayjs.isDayjs(start)) {
     start = start.toDate();
   }
-  if (daysjs.isDayjs(end)) {
+  if (dayjs.isDayjs(end)) {
     end = end.toDate();
   }
   const format = getIntlDateTimeFormat(args);
@@ -171,7 +170,7 @@ export function localizeMonthAbbreviation(
     capitalize?: boolean;
   },
 ): string {
-  if (daysjs.isDayjs(date)) {
+  if (dayjs.isDayjs(date)) {
     date = date.toDate();
   }
   const cacheKey = JSON.stringify(args, (_, v) =>


### PR DESCRIPTION
Switches our `Datepicker`/`Timepicker` components API to use ISO8601 date/time strings (`YYYY-MM-DD` and `HH:mm`) formats, instead of `Dayjs` values.

Rationale: Our datetime pickers are seldom used for picking datetimes in the current timezone:

- Birthdate is timezone-agnostic
- Hosting dates are in the host timezone
- Event dates will soon be in their location's timezone

It's error-prone to represent those as `Dayjs` object because `Dayjs` object will parse the datetime components using the browser timezone and represent it internally as a timestamp that would be incorrect in the real timezone (e.g. for comparison). This has already resulted in bad event time data. By using ISO8601 date/time strings we preserve the timezone-agnosticity of the values entered by the user, and it makes the code call out when we need to turn them into a `Dayjs` for comparison or manipulation.

The underlying MUI `DatePicker`/`TimePicker` still deal in terms of `Dayjs` values, so our wrapper `Datepicker`/`Timepicker` convert internally but otherwise encapsulate this complexity.

It might be valuable to create some `DateOnly` and `TimeOnly` classes that internally use the ISO8601 string as their representation, so the variable names are not as obnoxious.

Fixes #9232

## Testing
Updated tests.

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me