### PR TITLE
Frontend: Use Temporal PlainDate+PlainTime

### DIFF
--- a/app/web/components/Datepicker.test.tsx
+++ b/app/web/components/Datepicker.test.tsx
@@ -1,3 +1,4 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { act, render, screen } from "@testing-library/react";
@@ -5,7 +6,7 @@ import { userEvent } from "@testing-library/user-event";
 import { useTranslation } from "i18n";
 import { useForm } from "react-hook-form";
 import i18n from "test/i18n";
-import dayjs, { Dayjs } from "utils/dayjs";
+import dayjs from "utils/dayjs";
 
 import wrapper from "../test/hookWrapper";
 import Datepicker from "./Datepicker";
@@ -20,7 +21,11 @@ jest.mock("@mui/x-date-pickers", () => {
   };
 });
 
-const Form = ({ setDate }: { setDate: (date: Dayjs) => void }) => {
+const Form = ({
+  setDate,
+}: {
+  setDate: (date: Temporal.PlainDate | null) => void;
+}) => {
   const { t } = useTranslation();
   const { control, handleSubmit } = useForm();
   const onSubmit = handleSubmit((data) => setDate(data.datefield));
@@ -34,7 +39,7 @@ const Form = ({ setDate }: { setDate: (date: Dayjs) => void }) => {
         testId="datepicker"
         label="Date field"
         name="datefield"
-        defaultValue={dayjs()}
+        defaultValue={Temporal.Now.plainDateISO()}
       />
       <input type="submit" name={t("submit")} />
     </form>
@@ -54,7 +59,7 @@ describe("DatePicker", () => {
   });
 
   it("should submit with proper date for clicking", async () => {
-    let date: Dayjs | undefined = undefined;
+    let date: Temporal.PlainDate | null = null;
     render(<Form setDate={(d) => (date = d)} />, { wrapper });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
@@ -65,12 +70,12 @@ describe("DatePicker", () => {
 
     await user.click(screen.getByRole("button", { name: t("global:submit") }));
 
-    expect(date).toBeDefined();
-    expect(date!.date).toEqual(dayjs("2021-03-23").date);
+    expect(date).not.toBeNull();
+    expect(date).toBe(Temporal.PlainDate.from("2021-03-20"));
   });
 
   it("selecting today works with timezone US/Eastern", async () => {
-    let date: Dayjs | undefined;
+    let date: Temporal.PlainDate | null = null;
     render(<Form setDate={(d) => (date = d)} />, { wrapper });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
@@ -81,13 +86,13 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date?.format("YYYY-MM-DD")).toBe("2021-03-20");
+    expect(date).toBe(Temporal.PlainDate.from("2021-03-20"));
   });
 
   it("selecting today works with timezone UTC", async () => {
     dayjs.tz.setDefault("UTC");
 
-    let date: Dayjs | undefined;
+    let date: Temporal.PlainDate | null = null;
     render(<Form setDate={(d) => (date = d)} />, { wrapper });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
@@ -98,13 +103,13 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date?.format("YYYY-MM-DD")).toBe("2021-03-20");
+    expect(date).toBe(Temporal.PlainDate.from("2021-03-20"));
   });
 
   it("selecting today works with timezone Europe/London", async () => {
     dayjs.tz.setDefault("Europe/London");
 
-    let date: Dayjs | undefined;
+    let date: Temporal.PlainDate | null = null;
     render(<Form setDate={(d) => (date = d)} />, { wrapper });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
@@ -115,13 +120,13 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date?.format("YYYY-MM-DD")).toBe("2021-03-20");
+    expect(date).toBe(Temporal.PlainDate.from("2021-03-20"));
   });
 
   it("selecting today works with timezone Brazil/East", async () => {
     dayjs.tz.setDefault("Brazil/East");
 
-    let date: Dayjs | undefined;
+    let date: Temporal.PlainDate | null = null;
     render(<Form setDate={(d) => (date = d)} />, { wrapper });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
@@ -132,13 +137,13 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date?.format("YYYY-MM-DD")).toBe("2021-03-20");
+    expect(date).toBe(Temporal.PlainDate.from("2021-03-20"));
   });
 
   it("selecting today works with timezone Australia/Adelaide", async () => {
     dayjs.tz.setDefault("Australia/Adelaide");
 
-    let date: Dayjs | undefined;
+    let date: Temporal.PlainDate | null = null;
     render(<Form setDate={(d) => (date = d)} />, { wrapper });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
@@ -149,13 +154,13 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date?.format("YYYY-MM-DD")).toBe("2021-03-20");
+    expect(date).toBe(Temporal.PlainDate.from("2021-03-20"));
   });
 
   it("typing should work in de's DD.MM.YYYY format", async () => {
     i18n.changeLanguage("de");
 
-    let date: Dayjs | undefined = undefined;
+    let date: Temporal.PlainDate | null = null;
     render(<Form setDate={(d) => (date = d)} />, { wrapper });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
@@ -169,15 +174,14 @@ describe("DatePicker", () => {
 
     await user.click(screen.getByRole("button", { name: t("global:submit") }));
 
-    const expectedDate = "2021-03-21";
-    expect(date).toBeDefined();
-    expect(date!.format("YYYY-MM-DD")).toEqual(expectedDate);
+    expect(date).not.toBeNull();
+    expect(date).toEqual(Temporal.PlainDate.from("2021-03-21"));
   });
 
   it("typing should work in en's MM/DD/YYYY format", async () => {
     i18n.changeLanguage("en");
 
-    let date: Dayjs | undefined = undefined;
+    let date: Temporal.PlainDate | null = null;
     render(<Form setDate={(d) => (date = d)} />, { wrapper });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
@@ -191,15 +195,14 @@ describe("DatePicker", () => {
 
     await user.click(screen.getByRole("button", { name: t("global:submit") }));
 
-    const expectedDate = "2021-03-21";
-    expect(date).toBeDefined();
-    expect(date!.format("YYYY-MM-DD")).toEqual(expectedDate);
+    expect(date).not.toBeNull();
+    expect(date).toEqual(Temporal.PlainDate.from("2021-03-21"));
   });
 
   it("typing should work in zh-Hant's YYYY/MM/DD format", async () => {
     i18n.changeLanguage("zh-Hant");
 
-    let date: Dayjs | undefined = undefined;
+    let date: Temporal.PlainDate | null = null;
     render(<Form setDate={(d) => (date = d)} />, { wrapper });
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
@@ -213,9 +216,8 @@ describe("DatePicker", () => {
 
     await user.click(screen.getByRole("button", { name: t("global:submit") }));
 
-    const expectedDate = "2021-03-21";
-    expect(date).toBeDefined();
-    expect(date!.format("YYYY-MM-DD")).toEqual(expectedDate);
+    expect(date).not.toBeNull();
+    expect(date).toEqual(Temporal.PlainDate.from("2021-03-21"));
   });
 
   it("uses the locale date format when no format prop is given", async () => {
@@ -239,7 +241,7 @@ describe("DatePicker", () => {
           testId="datepicker"
           label="Date field"
           name="datefield"
-          defaultValue={dayjs("2021-03-20")}
+          defaultValue={Temporal.PlainDate.from("2021-03-20")}
           pickerInputOnly
         />
       );
@@ -265,7 +267,7 @@ describe("DatePicker", () => {
             testId="datepicker"
             label="Date field"
             name="datefield"
-            defaultValue={dayjs("1990-04-08")}
+            defaultValue={Temporal.PlainDate.from("1990-04-08")}
             pickerInputOnly
           />
         </LocalizationProvider>
@@ -292,7 +294,6 @@ describe("DatePicker", () => {
           testId="datepicker"
           label="Date field"
           name="datefield"
-          defaultValue={null}
           pickerInputOnly
         />
       );

--- a/app/web/components/Datepicker.test.tsx
+++ b/app/web/components/Datepicker.test.tsx
@@ -1,10 +1,10 @@
-import { Temporal } from "@js-temporal/polyfill";
 import { LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { act, render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { useTranslation } from "i18n";
 import { useForm } from "react-hook-form";
+import { Temporal } from "temporal-polyfill";
 import i18n from "test/i18n";
 import dayjs from "utils/dayjs";
 

--- a/app/web/components/Datepicker.test.tsx
+++ b/app/web/components/Datepicker.test.tsx
@@ -70,8 +70,7 @@ describe("DatePicker", () => {
 
     await user.click(screen.getByRole("button", { name: t("global:submit") }));
 
-    expect(date).not.toBeNull();
-    expect(date).toBe(Temporal.PlainDate.from("2021-03-20"));
+    expect(date).toEqual(Temporal.PlainDate.from("2021-03-20"));
   });
 
   it("selecting today works with timezone US/Eastern", async () => {
@@ -86,7 +85,7 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date).toBe(Temporal.PlainDate.from("2021-03-20"));
+    expect(date).toEqual(Temporal.PlainDate.from("2021-03-20"));
   });
 
   it("selecting today works with timezone UTC", async () => {
@@ -103,7 +102,7 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date).toBe(Temporal.PlainDate.from("2021-03-20"));
+    expect(date).toEqual(Temporal.PlainDate.from("2021-03-20"));
   });
 
   it("selecting today works with timezone Europe/London", async () => {
@@ -120,7 +119,7 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date).toBe(Temporal.PlainDate.from("2021-03-20"));
+    expect(date).toEqual(Temporal.PlainDate.from("2021-03-20"));
   });
 
   it("selecting today works with timezone Brazil/East", async () => {
@@ -137,7 +136,7 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date).toBe(Temporal.PlainDate.from("2021-03-20"));
+    expect(date).toEqual(Temporal.PlainDate.from("2021-03-20"));
   });
 
   it("selecting today works with timezone Australia/Adelaide", async () => {
@@ -154,7 +153,7 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date).toBe(Temporal.PlainDate.from("2021-03-20"));
+    expect(date).toEqual(Temporal.PlainDate.from("2021-03-20"));
   });
 
   it("typing should work in de's DD.MM.YYYY format", async () => {
@@ -174,7 +173,6 @@ describe("DatePicker", () => {
 
     await user.click(screen.getByRole("button", { name: t("global:submit") }));
 
-    expect(date).not.toBeNull();
     expect(date).toEqual(Temporal.PlainDate.from("2021-03-21"));
   });
 
@@ -195,7 +193,6 @@ describe("DatePicker", () => {
 
     await user.click(screen.getByRole("button", { name: t("global:submit") }));
 
-    expect(date).not.toBeNull();
     expect(date).toEqual(Temporal.PlainDate.from("2021-03-21"));
   });
 
@@ -216,7 +213,6 @@ describe("DatePicker", () => {
 
     await user.click(screen.getByRole("button", { name: t("global:submit") }));
 
-    expect(date).not.toBeNull();
     expect(date).toEqual(Temporal.PlainDate.from("2021-03-21"));
   });
 

--- a/app/web/components/Datepicker.test.tsx
+++ b/app/web/components/Datepicker.test.tsx
@@ -70,7 +70,7 @@ describe("DatePicker", () => {
 
     await user.click(screen.getByRole("button", { name: t("global:submit") }));
 
-    expect(date).toEqual(Temporal.PlainDate.from("2021-03-20"));
+    expect(date!.toString()).toBe("2021-03-20");
   });
 
   it("selecting today works with timezone US/Eastern", async () => {
@@ -85,7 +85,7 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date).toEqual(Temporal.PlainDate.from("2021-03-20"));
+    expect(date!.toString()).toBe("2021-03-20");
   });
 
   it("selecting today works with timezone UTC", async () => {
@@ -102,7 +102,7 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date).toEqual(Temporal.PlainDate.from("2021-03-20"));
+    expect(date!.toString()).toBe("2021-03-20");
   });
 
   it("selecting today works with timezone Europe/London", async () => {
@@ -119,7 +119,7 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date).toEqual(Temporal.PlainDate.from("2021-03-20"));
+    expect(date!.toString()).toBe("2021-03-20");
   });
 
   it("selecting today works with timezone Brazil/East", async () => {
@@ -136,7 +136,7 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date).toEqual(Temporal.PlainDate.from("2021-03-20"));
+    expect(date!.toString()).toBe("2021-03-20");
   });
 
   it("selecting today works with timezone Australia/Adelaide", async () => {
@@ -153,7 +153,7 @@ describe("DatePicker", () => {
 
     await user.click(submitButton);
 
-    expect(date).toEqual(Temporal.PlainDate.from("2021-03-20"));
+    expect(date!.toString()).toBe("2021-03-20");
   });
 
   it("typing should work in de's DD.MM.YYYY format", async () => {
@@ -173,7 +173,7 @@ describe("DatePicker", () => {
 
     await user.click(screen.getByRole("button", { name: t("global:submit") }));
 
-    expect(date).toEqual(Temporal.PlainDate.from("2021-03-21"));
+    expect(date!.toString()).toBe("2021-03-21");
   });
 
   it("typing should work in en's MM/DD/YYYY format", async () => {
@@ -193,7 +193,7 @@ describe("DatePicker", () => {
 
     await user.click(screen.getByRole("button", { name: t("global:submit") }));
 
-    expect(date).toEqual(Temporal.PlainDate.from("2021-03-21"));
+    expect(date!.toString()).toBe("2021-03-21");
   });
 
   it("typing should work in zh-Hant's YYYY/MM/DD format", async () => {
@@ -213,7 +213,7 @@ describe("DatePicker", () => {
 
     await user.click(screen.getByRole("button", { name: t("global:submit") }));
 
-    expect(date).toEqual(Temporal.PlainDate.from("2021-03-21"));
+    expect(date!.toString()).toBe("2021-03-21");
   });
 
   it("uses the locale date format when no format prop is given", async () => {

--- a/app/web/components/Datepicker.tsx
+++ b/app/web/components/Datepicker.tsx
@@ -157,7 +157,7 @@ const Datepicker = ({
           data-testid={testId}
           {...field}
           label={label}
-          value={field.value ? temporalToDayjs(field.value) : undefined}
+          value={field.value ? temporalToDayjs(field.value) : null}
           minDate={minValue ? temporalToDayjs(minValue) : undefined}
           maxDate={maxValue ? temporalToDayjs(maxValue) : undefined}
           onChange={(valueDayjs: Dayjs | null) => {

--- a/app/web/components/Datepicker.tsx
+++ b/app/web/components/Datepicker.tsx
@@ -1,4 +1,3 @@
-import { Temporal } from "@js-temporal/polyfill";
 import { InputProps, TextField } from "@mui/material";
 import {
   DatePicker,
@@ -8,6 +7,7 @@ import {
 } from "@mui/x-date-pickers";
 import { useTranslation } from "i18n";
 import { Control, Controller, UseControllerProps } from "react-hook-form";
+import { Temporal } from "temporal-polyfill";
 import { getMuiDateFormat } from "utils/date";
 import dayjs, { Dayjs } from "utils/dayjs";
 

--- a/app/web/components/Datepicker.tsx
+++ b/app/web/components/Datepicker.tsx
@@ -1,3 +1,4 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { InputProps, TextField } from "@mui/material";
 import {
   DatePicker,
@@ -14,17 +15,17 @@ interface DatepickerProps {
   className?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   control: Control<any>;
-  defaultValue?: Dayjs | null;
+  defaultValue?: Temporal.PlainDate;
   error: boolean;
   helperText: React.ReactNode;
   id: string;
   rules?: UseControllerProps["rules"];
   label?: string;
   name: string;
-  minDate?: Dayjs;
-  maxDate?: Dayjs;
+  minValue?: Temporal.PlainDate;
+  maxValue?: Temporal.PlainDate;
   openTo?: "year" | "month" | "day";
-  onPostChange?(date: Dayjs | null): void;
+  onPostChange?(value: Temporal.PlainDate | null): void;
   testId?: string;
   variant?: "standard" | "outlined" | "filled";
   inputProps?: InputProps;
@@ -89,6 +90,16 @@ const ReadOnlyDateField = ({
   );
 };
 
+// Convert between our API's Temporal.PlainDate and MUI's expected Dayjs values.
+// Use the browser timezone in case we compare to now, aka dayjs().
+function temporalToDayjs(value: Temporal.PlainDate): Dayjs {
+  return dayjs(value.toString(), "YYYY-MM-DD");
+}
+
+function dayjsToTemporal(value: Dayjs): Temporal.PlainDate {
+  return Temporal.PlainDate.from(value.format("YYYY-MM-DD"));
+}
+
 const Datepicker = ({
   className,
   control,
@@ -98,8 +109,8 @@ const Datepicker = ({
   id,
   rules,
   label,
-  minDate = dayjs(),
-  maxDate,
+  minValue = dayjsToTemporal(dayjs()),
+  maxValue,
   name,
   openTo = "day",
   onPostChange,
@@ -138,7 +149,7 @@ const Datepicker = ({
   return (
     <Controller
       control={control}
-      defaultValue={defaultValue}
+      defaultValue={defaultValue ?? null}
       name={name}
       rules={rules}
       render={({ field }) => (
@@ -146,12 +157,15 @@ const Datepicker = ({
           data-testid={testId}
           {...field}
           label={label}
-          value={field.value}
-          minDate={minDate}
-          maxDate={maxDate}
-          onChange={(date) => {
-            field.onChange(date);
-            onPostChange?.(date);
+          value={field.value ? temporalToDayjs(field.value) : undefined}
+          minDate={minValue ? temporalToDayjs(minValue) : undefined}
+          maxDate={maxValue ? temporalToDayjs(maxValue) : undefined}
+          onChange={(valueDayjs: Dayjs | null) => {
+            const valueTemporal = valueDayjs
+              ? dayjsToTemporal(valueDayjs)
+              : null;
+            field.onChange(valueTemporal);
+            onPostChange?.(valueTemporal);
           }}
           openTo={openTo}
           views={["year", "month", "day"]}

--- a/app/web/components/Datepicker.tsx
+++ b/app/web/components/Datepicker.tsx
@@ -161,9 +161,10 @@ const Datepicker = ({
           minDate={minValue ? temporalToDayjs(minValue) : undefined}
           maxDate={maxValue ? temporalToDayjs(maxValue) : undefined}
           onChange={(valueDayjs: Dayjs | null) => {
-            const valueTemporal = valueDayjs
-              ? dayjsToTemporal(valueDayjs)
-              : null;
+            const valueTemporal =
+              valueDayjs && valueDayjs.isValid()
+                ? dayjsToTemporal(valueDayjs)
+                : null;
             field.onChange(valueTemporal);
             onPostChange?.(valueTemporal);
           }}

--- a/app/web/components/Timepicker.test.tsx
+++ b/app/web/components/Timepicker.test.tsx
@@ -58,7 +58,7 @@ describe("Timepicker", () => {
     await user.keyboard("2359");
 
     await user.click(screen.getByRole("button", { name: "Submit" }));
-    expect(time).toEqual(Temporal.PlainTime.from("23:59"));
+    expect(time!.toString()).toBe("23:59:00");
   });
 
   it("accepts 12-hour time in 12-hour locale (en)", async () => {
@@ -75,7 +75,7 @@ describe("Timepicker", () => {
     await user.keyboard("1200 AM");
 
     await user.click(screen.getByRole("button", { name: "Submit" }));
-    expect(time).toEqual(Temporal.PlainTime.from("00:00"));
+    expect(time!.toString()).toBe("00:00:00");
   });
 
   it("accepts 1:37 PM in 12-hour locale (en)", async () => {
@@ -92,7 +92,7 @@ describe("Timepicker", () => {
     await user.keyboard("0137 PM");
 
     await user.click(screen.getByRole("button", { name: "Submit" }));
-    expect(time).toEqual(Temporal.PlainTime.from("13:37"));
+    expect(time!.toString()).toBe("13:37:00");
   });
 
   it("accepts 13:37 in 24-hour locale (fr)", async () => {
@@ -109,6 +109,6 @@ describe("Timepicker", () => {
     await user.keyboard("1337");
 
     await user.click(screen.getByRole("button", { name: "Submit" }));
-    expect(time).toEqual(Temporal.PlainTime.from("13:37"));
+    expect(time!.toString()).toBe("13:37:00");
   });
 });

--- a/app/web/components/Timepicker.test.tsx
+++ b/app/web/components/Timepicker.test.tsx
@@ -1,7 +1,7 @@
-import { Temporal } from "@js-temporal/polyfill";
 import { act, render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { useForm } from "react-hook-form";
+import { Temporal } from "temporal-polyfill";
 import i18n from "test/i18n";
 
 import wrapper from "../test/hookWrapper";

--- a/app/web/components/Timepicker.test.tsx
+++ b/app/web/components/Timepicker.test.tsx
@@ -1,8 +1,8 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { act, render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { useForm } from "react-hook-form";
 import i18n from "test/i18n";
-import { Dayjs } from "utils/dayjs";
 
 import wrapper from "../test/hookWrapper";
 import Timepicker from "./Timepicker";
@@ -15,7 +15,11 @@ jest.mock("@mui/x-date-pickers", () => {
   };
 });
 
-const Form = ({ setTime }: { setTime: (time: Dayjs | null) => void }) => {
+const Form = ({
+  setTime,
+}: {
+  setTime: (time: Temporal.PlainTime | null) => void;
+}) => {
   const { control, handleSubmit } = useForm();
   const onSubmit = handleSubmit((data) => setTime(data.timefield));
   return (
@@ -28,7 +32,6 @@ const Form = ({ setTime }: { setTime: (time: Dayjs | null) => void }) => {
         testId="timepicker"
         label="Time field"
         name="timefield"
-        defaultValue={null}
       />
       <input type="submit" value="Submit" />
     </form>
@@ -43,7 +46,7 @@ describe("Timepicker", () => {
 
   it("accepts 24-hour time in 24-hour locale (de)", async () => {
     i18n.changeLanguage("de");
-    let time: Dayjs | null = null;
+    let time: Temporal.PlainTime | null = null;
     render(<Form setTime={(t) => (time = t)} />, { wrapper });
 
     const user = userEvent.setup();
@@ -56,13 +59,12 @@ describe("Timepicker", () => {
 
     await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(time).toBeDefined();
-    expect(time!.hour()).toBe(23);
-    expect(time!.minute()).toBe(59);
+    expect(time).toBe(Temporal.PlainTime.from("23:59"));
   });
 
   it("accepts 12-hour time in 12-hour locale (en)", async () => {
     i18n.changeLanguage("en");
-    let time: Dayjs | null = null;
+    let time: Temporal.PlainTime | null = null;
     render(<Form setTime={(t) => (time = t)} />, { wrapper });
 
     const user = userEvent.setup();
@@ -75,13 +77,12 @@ describe("Timepicker", () => {
 
     await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(time).toBeDefined();
-    expect(time!.hour()).toBe(0);
-    expect(time!.minute()).toBe(0);
+    expect(time).toBe(Temporal.PlainTime.from("00:00"));
   });
 
   it("accepts 1:37 PM in 12-hour locale (en)", async () => {
     i18n.changeLanguage("en");
-    let time: Dayjs | null = null;
+    let time: Temporal.PlainTime | null = null;
     render(<Form setTime={(t) => (time = t)} />, { wrapper });
 
     const user = userEvent.setup();
@@ -94,13 +95,12 @@ describe("Timepicker", () => {
 
     await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(time).toBeDefined();
-    expect(time!.hour()).toBe(13);
-    expect(time!.minute()).toBe(37);
+    expect(time).toBe(Temporal.PlainTime.from("13:37"));
   });
 
   it("accepts 13:37 in 24-hour locale (fr)", async () => {
     i18n.changeLanguage("fr");
-    let time: Dayjs | null = null;
+    let time: Temporal.PlainTime | null = null;
     render(<Form setTime={(t) => (time = t)} />, { wrapper });
 
     const user = userEvent.setup();
@@ -113,7 +113,6 @@ describe("Timepicker", () => {
 
     await user.click(screen.getByRole("button", { name: "Submit" }));
     expect(time).toBeDefined();
-    expect(time!.hour()).toBe(13);
-    expect(time!.minute()).toBe(37);
+    expect(time).toBe(Temporal.PlainTime.from("13:37"));
   });
 });

--- a/app/web/components/Timepicker.test.tsx
+++ b/app/web/components/Timepicker.test.tsx
@@ -58,8 +58,7 @@ describe("Timepicker", () => {
     await user.keyboard("2359");
 
     await user.click(screen.getByRole("button", { name: "Submit" }));
-    expect(time).toBeDefined();
-    expect(time).toBe(Temporal.PlainTime.from("23:59"));
+    expect(time).toEqual(Temporal.PlainTime.from("23:59"));
   });
 
   it("accepts 12-hour time in 12-hour locale (en)", async () => {
@@ -76,8 +75,7 @@ describe("Timepicker", () => {
     await user.keyboard("1200 AM");
 
     await user.click(screen.getByRole("button", { name: "Submit" }));
-    expect(time).toBeDefined();
-    expect(time).toBe(Temporal.PlainTime.from("00:00"));
+    expect(time).toEqual(Temporal.PlainTime.from("00:00"));
   });
 
   it("accepts 1:37 PM in 12-hour locale (en)", async () => {
@@ -94,8 +92,7 @@ describe("Timepicker", () => {
     await user.keyboard("0137 PM");
 
     await user.click(screen.getByRole("button", { name: "Submit" }));
-    expect(time).toBeDefined();
-    expect(time).toBe(Temporal.PlainTime.from("13:37"));
+    expect(time).toEqual(Temporal.PlainTime.from("13:37"));
   });
 
   it("accepts 13:37 in 24-hour locale (fr)", async () => {
@@ -112,7 +109,6 @@ describe("Timepicker", () => {
     await user.keyboard("1337");
 
     await user.click(screen.getByRole("button", { name: "Submit" }));
-    expect(time).toBeDefined();
-    expect(time).toBe(Temporal.PlainTime.from("13:37"));
+    expect(time).toEqual(Temporal.PlainTime.from("13:37"));
   });
 });

--- a/app/web/components/Timepicker.tsx
+++ b/app/web/components/Timepicker.tsx
@@ -25,11 +25,12 @@ interface TimepickerProps {
 // Convert between our API's Temporal.PlainTime and MUI's expected Dayjs values.
 // Use the browser timezone in case we compare to now, aka dayjs().
 function temporalToDayjs(value: Temporal.PlainTime): Dayjs {
-  return dayjs(value.toString({ smallestUnit: "minute" }), "HH:mm");
+  const timeString = value.toString({ smallestUnit: "minute" });
+  return dayjs(`1970-01-01T${timeString}`); // We don't care about the date, but dayjs needs one.
 }
 
 function dayjsToTemporal(value: Dayjs): Temporal.PlainTime {
-  return Temporal.PlainTime.from(value.format("YYYY-MM-DD"));
+  return Temporal.PlainTime.from(value.format("HH:mm"));
 }
 
 const Timepicker = ({

--- a/app/web/components/Timepicker.tsx
+++ b/app/web/components/Timepicker.tsx
@@ -63,7 +63,7 @@ const Timepicker = ({
           data-testid={testId}
           {...field}
           label={label}
-          value={field.value ? temporalToDayjs(field.value) : undefined}
+          value={field.value ? temporalToDayjs(field.value) : null}
           onChange={(valueDayjs: Dayjs | null) => {
             const valueTemporal =
               valueDayjs && valueDayjs.isValid()

--- a/app/web/components/Timepicker.tsx
+++ b/app/web/components/Timepicker.tsx
@@ -65,9 +65,10 @@ const Timepicker = ({
           label={label}
           value={field.value ? temporalToDayjs(field.value) : undefined}
           onChange={(valueDayjs: Dayjs | null) => {
-            const valueTemporal = valueDayjs
-              ? dayjsToTemporal(valueDayjs)
-              : null;
+            const valueTemporal =
+              valueDayjs && valueDayjs.isValid()
+                ? dayjsToTemporal(valueDayjs)
+                : null;
             field.onChange(valueTemporal);
             onPostChange?.(valueTemporal);
           }}

--- a/app/web/components/Timepicker.tsx
+++ b/app/web/components/Timepicker.tsx
@@ -1,9 +1,9 @@
-import { Temporal } from "@js-temporal/polyfill";
 import { TimePicker } from "@mui/x-date-pickers";
 import { useTranslation } from "i18n";
 import { GLOBAL } from "i18n/namespaces";
 import React, { useMemo } from "react";
 import { Control, Controller, UseControllerProps } from "react-hook-form";
+import { Temporal } from "temporal-polyfill";
 import { getMuiTimeFormat } from "utils/date";
 import dayjs, { Dayjs } from "utils/dayjs";
 

--- a/app/web/components/Timepicker.tsx
+++ b/app/web/components/Timepicker.tsx
@@ -1,24 +1,35 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { TimePicker } from "@mui/x-date-pickers";
 import { useTranslation } from "i18n";
 import { GLOBAL } from "i18n/namespaces";
 import React, { useMemo } from "react";
 import { Control, Controller, UseControllerProps } from "react-hook-form";
 import { getMuiTimeFormat } from "utils/date";
-import { Dayjs } from "utils/dayjs";
+import dayjs, { Dayjs } from "utils/dayjs";
 
 interface TimepickerProps {
   className?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   control: Control<any>;
-  defaultValue?: Dayjs | null;
+  defaultValue?: Temporal.PlainTime;
   error: boolean;
   helperText: React.ReactNode;
   id: string;
   rules?: UseControllerProps["rules"];
   label?: string;
   name: string;
-  onPostChange?(time: Dayjs | null): void;
+  onPostChange?(value: Temporal.PlainTime | null): void;
   testId?: string;
+}
+
+// Convert between our API's Temporal.PlainTime and MUI's expected Dayjs values.
+// Use the browser timezone in case we compare to now, aka dayjs().
+function temporalToDayjs(value: Temporal.PlainTime): Dayjs {
+  return dayjs(value.toString({ smallestUnit: "minute" }), "HH:mm");
+}
+
+function dayjsToTemporal(value: Dayjs): Temporal.PlainTime {
+  return Temporal.PlainTime.from(value.format("YYYY-MM-DD"));
 }
 
 const Timepicker = ({
@@ -43,7 +54,7 @@ const Timepicker = ({
   return (
     <Controller
       control={control}
-      defaultValue={defaultValue}
+      defaultValue={defaultValue ?? null}
       name={name}
       rules={rules}
       render={({ field }) => (
@@ -51,10 +62,13 @@ const Timepicker = ({
           data-testid={testId}
           {...field}
           label={label}
-          value={field.value}
-          onChange={(time: Dayjs | null) => {
-            field.onChange(time);
-            onPostChange?.(time);
+          value={field.value ? temporalToDayjs(field.value) : undefined}
+          onChange={(valueDayjs: Dayjs | null) => {
+            const valueTemporal = valueDayjs
+              ? dayjsToTemporal(valueDayjs)
+              : null;
+            field.onChange(valueTemporal);
+            onPostChange?.(valueTemporal);
           }}
           format={format}
           ampm={format.includes("a")} // Clock picker uses am/pm iff format also uses it

--- a/app/web/features/auth/signup/AccountForm.test.tsx
+++ b/app/web/features/auth/signup/AccountForm.test.tsx
@@ -1,3 +1,4 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { EditLocationMapProps } from "components/EditLocationMap";
@@ -149,7 +150,7 @@ describe("AccountForm", () => {
           flowToken: "token",
           username: "test",
           password: "a very insecure password",
-          birthdate: "1990-01-01",
+          birthdate: Temporal.PlainDate.from("1990-01-01"),
           gender: "Woman",
           acceptTOS: true,
           optOutOfNewsletter: false,
@@ -190,7 +191,7 @@ describe("AccountForm", () => {
           flowToken: "token",
           username: "test",
           password: "a very insecure password",
-          birthdate: "1990-01-01",
+          birthdate: Temporal.PlainDate.from("1990-01-01"),
           gender: "Woman",
           acceptTOS: true,
           optOutOfNewsletter: false,

--- a/app/web/features/auth/signup/AccountForm.test.tsx
+++ b/app/web/features/auth/signup/AccountForm.test.tsx
@@ -1,4 +1,3 @@
-import { Temporal } from "@js-temporal/polyfill";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { EditLocationMapProps } from "components/EditLocationMap";
@@ -6,6 +5,7 @@ import { hostingStatusLabels } from "features/profile/constants";
 import { StatusCode } from "grpc-web";
 import { HostingStatus } from "proto/api_pb";
 import { service } from "service";
+import { Temporal } from "temporal-polyfill";
 import wrapper from "test/hookWrapper";
 import i18n from "test/i18n";
 import { assertErrorAlert, mockConsoleError, MockedService } from "test/utils";

--- a/app/web/features/auth/signup/AccountForm.tsx
+++ b/app/web/features/auth/signup/AccountForm.tsx
@@ -22,7 +22,6 @@ import EditLocationMap, {
 } from "components/EditLocationMap";
 import Select from "components/Select";
 import TOSLink from "components/TOSLink";
-import dayjs from "dayjs";
 import { useAuthContext } from "features/auth/AuthProvider";
 import {
   StyledButton,
@@ -40,7 +39,6 @@ import {
   lowercaseAndTrimField,
   usernameValidationPattern,
   validatePassword,
-  validatePastDate,
 } from "utils/validation";
 
 export type SignupAccountInputs = {

--- a/app/web/features/auth/signup/AccountForm.tsx
+++ b/app/web/features/auth/signup/AccountForm.tsx
@@ -271,9 +271,11 @@ export default function AccountForm() {
           variant="outlined"
           rules={{
             required: t("auth:account_form.birthday.required_error"),
-            validate: (stringBirthDate: string) => {
-              const birthDate = dayjs(stringBirthDate);
-              const age = Math.abs(dayjs().diff(birthDate, "year")); // confirmed dayjs does the difference correctyly by counting months and days
+            validate: (birthDate: Temporal.PlainDate) => {
+              const age = Temporal.Now.plainDateISO().since(birthDate, {
+                smallestUnit: "year",
+                roundingMode: "floor",
+              }).years;
 
               if (age < 18) {
                 return t("auth:account_form.birthday.too_young_error");
@@ -283,7 +285,12 @@ export default function AccountForm() {
                 return t("auth:account_form.birthday.not_real_date_error");
               }
 
-              if (!validatePastDate(stringBirthDate) || !stringBirthDate) {
+              if (
+                Temporal.PlainDate.compare(
+                  birthDate,
+                  Temporal.Now.plainDateISO(),
+                ) >= 0
+              ) {
                 return t("auth:account_form.birthday.validation_error");
               }
 

--- a/app/web/features/auth/signup/AccountForm.tsx
+++ b/app/web/features/auth/signup/AccountForm.tsx
@@ -1,3 +1,4 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { Visibility, VisibilityOff } from "@mui/icons-material";
 import {
   Checkbox,
@@ -21,7 +22,7 @@ import EditLocationMap, {
 } from "components/EditLocationMap";
 import Select from "components/Select";
 import TOSLink from "components/TOSLink";
-import dayjs, { Dayjs } from "dayjs";
+import dayjs from "dayjs";
 import { useAuthContext } from "features/auth/AuthProvider";
 import {
   StyledButton,
@@ -46,7 +47,7 @@ export type SignupAccountInputs = {
   username: string;
   password: string;
   name: string;
-  birthdate: Dayjs;
+  birthdate: Temporal.PlainDate;
   gender: string;
   acceptTOS: boolean;
   optInToNewsletter: boolean;
@@ -142,7 +143,7 @@ export default function AccountForm() {
         flowToken: authState.flowState!.flowToken,
         username: lowercaseAndTrimField(username),
         password: password,
-        birthdate: birthdate.format().split("T")[0],
+        birthdate,
         gender,
         acceptTOS,
         optOutOfNewsletter: !optInToNewsletter,
@@ -173,7 +174,7 @@ export default function AccountForm() {
 
   const usernameInputRef = useRef<HTMLInputElement>(undefined);
 
-  const handleBirthdateChange = (newBirthdate: Dayjs) => {
+  const handleBirthdateChange = (newBirthdate: Temporal.PlainDate) => {
     setValue("birthdate", newBirthdate, {
       shouldDirty: true,
       shouldValidate: true,
@@ -289,9 +290,8 @@ export default function AccountForm() {
               return true; // Validation passes
             },
           }}
-          minDate={dayjs().subtract(120, "years")}
-          maxDate={dayjs().subtract(18, "years")}
-          defaultValue={null}
+          minValue={Temporal.Now.plainDateISO().add({ years: -120 })}
+          maxValue={Temporal.Now.plainDateISO().add({ years: -18 })}
           openTo="year"
           name="birthdate"
           onPostChange={handleBirthdateChange}

--- a/app/web/features/auth/signup/AccountForm.tsx
+++ b/app/web/features/auth/signup/AccountForm.tsx
@@ -1,4 +1,3 @@
-import { Temporal } from "@js-temporal/polyfill";
 import { Visibility, VisibilityOff } from "@mui/icons-material";
 import {
   Checkbox,
@@ -35,6 +34,7 @@ import { HostingStatus } from "proto/api_pb";
 import { useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { service } from "service";
+import { Temporal } from "temporal-polyfill";
 import {
   lowercaseAndTrimField,
   usernameValidationPattern,

--- a/app/web/features/communities/events/CreateEventPage.test.tsx
+++ b/app/web/features/communities/events/CreateEventPage.test.tsx
@@ -1,9 +1,9 @@
-import { Temporal } from "@js-temporal/polyfill";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import mockRouter from "next-router-mock";
 import { routeToNewEvent } from "routes";
 import { service } from "service";
+import { Temporal } from "temporal-polyfill";
 import events from "test/fixtures/events.json";
 import wrapper, { getHookWrapperWithClient } from "test/hookWrapper";
 import i18n from "test/i18n";

--- a/app/web/features/communities/events/CreateEventPage.test.tsx
+++ b/app/web/features/communities/events/CreateEventPage.test.tsx
@@ -1,3 +1,4 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import mockRouter from "next-router-mock";
@@ -158,8 +159,8 @@ describe("Create event page", () => {
       title: "Test event",
       content: "sick social!",
       photoKey: undefined,
-      startTime: new Date("2021-08-01 01:00 AM"),
-      endTime: new Date("2021-08-01 02:00 AM"),
+      startTime: Temporal.PlainDateTime.from("2021-08-01T01:00"),
+      endTime: Temporal.PlainDateTime.from("2021-08-01T02:00"),
     });
   });
 
@@ -250,8 +251,8 @@ describe("Create event page", () => {
       title: "Test event",
       content: "sick social!",
       photoKey: undefined,
-      startTime: new Date("2021-08-01 01:00 AM"),
-      endTime: new Date("2021-08-01 02:00 AM"),
+      startTime: Temporal.PlainDateTime.from("2021-08-01T01:00"),
+      endTime: Temporal.PlainDateTime.from("2021-08-01T02:00"),
       parentCommunityId: 99,
     });
   });

--- a/app/web/features/communities/events/CreateEventPage.tsx
+++ b/app/web/features/communities/events/CreateEventPage.tsx
@@ -16,10 +16,9 @@ import { dashboardRoute, eventsRoute, routeToEvent } from "routes";
 import { service } from "service";
 import type { CreateEventInput } from "service/events";
 import { theme } from "theme";
-import dayjs from "utils/dayjs";
+import { sendNativeBack, useIsNativeEmbed } from "utils/nativeLink";
 import stringOrFirstString from "utils/stringOrFirstString";
 
-import { sendNativeBack, useIsNativeEmbed } from "../../../utils/nativeLink";
 import { communityEventsBaseKey } from "../../queryKeys";
 import EventForm, { CreateEventVariables } from "./EventForm";
 import { useEvent } from "./hooks";
@@ -72,19 +71,6 @@ export default function CreateEventPage() {
     { parentCommunityId?: number }
   >({
     mutationFn: (data) => {
-      const startTime = dayjs(data.startTime);
-      const endTime = dayjs(data.endTime);
-      const finalStartDate = data.startDate
-        .startOf("day")
-        .add(startTime.get("hour"), "hour")
-        .add(startTime.get("minute"), "minute")
-        .toDate();
-      const finalEndDate = data.endDate
-        .startOf("day")
-        .add(endTime.get("hour"), "hour")
-        .add(endTime.get("minute"), "minute")
-        .toDate();
-
       // Use uploaded photo, or reuse photo from event being duplicated
       const photoKey =
         data.eventImage || eventToDuplicate?.photoKey || undefined;
@@ -93,8 +79,8 @@ export default function CreateEventPage() {
         title: data.title,
         content: data.content,
         photoKey,
-        startTime: finalStartDate,
-        endTime: finalEndDate,
+        startTime: data.startDate.toPlainDateTime(data.startTime),
+        endTime: data.endDate.toPlainDateTime(data.endTime),
         address: data.location.name,
         lat: data.location.location.lat,
         lng: data.location.location.lng,

--- a/app/web/features/communities/events/EditEventPage.test.tsx
+++ b/app/web/features/communities/events/EditEventPage.test.tsx
@@ -1,3 +1,4 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import mockRouter from "next-router-mock";
@@ -117,7 +118,7 @@ describe("Edit event page", () => {
       address: "test city, test county, test country",
       lat: 2,
       lng: 1,
-      endTime: new Date("2021-07-01 03:37"),
+      endTime: Temporal.PlainDateTime.from("2021-07-01T03:37"),
     });
 
     // Verifies that success re-directs user
@@ -147,7 +148,7 @@ describe("Edit event page", () => {
 
     expect(updateEventMock).toHaveBeenCalledWith({
       eventId: 1,
-      startTime: new Date("2021-08-01 02:37"),
+      startTime: Temporal.PlainDateTime.from("2021-08-01T02:37"),
     });
   });
 
@@ -179,7 +180,7 @@ describe("Edit event page", () => {
 
     expect(updateEventMock).toHaveBeenCalledWith({
       eventId: 1,
-      startTime: new Date("2021-06-29 00:00"),
+      startTime: Temporal.PlainDateTime.from("2021-06-29T00:00"),
     });
   });
 

--- a/app/web/features/communities/events/EditEventPage.test.tsx
+++ b/app/web/features/communities/events/EditEventPage.test.tsx
@@ -1,9 +1,9 @@
-import { Temporal } from "@js-temporal/polyfill";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import mockRouter from "next-router-mock";
 import { routeToEditEvent, routeToEvent } from "routes";
 import { service } from "service";
+import { Temporal } from "temporal-polyfill";
 import events from "test/fixtures/events.json";
 import { getHookWrapperWithClient } from "test/hookWrapper";
 import i18n from "test/i18n";

--- a/app/web/features/communities/events/EditEventPage.tsx
+++ b/app/web/features/communities/events/EditEventPage.tsx
@@ -74,7 +74,7 @@ export default function EditEventPage({ eventId }: { eventId: number }) {
             ? data.startDate.toPlainDateTime(data.startTime)
             : undefined,
         endTime:
-          data.dirtyFields.endDate || data.dirtyFields.endDate
+          data.dirtyFields.endDate || data.dirtyFields.endTime
             ? data.endDate.toPlainDateTime(data.endTime)
             : undefined,
         shouldNotify: data.dirtyFields.shouldNotify,

--- a/app/web/features/communities/events/EditEventPage.tsx
+++ b/app/web/features/communities/events/EditEventPage.tsx
@@ -14,7 +14,6 @@ import { useRouter } from "next/router";
 import { service } from "service";
 import type { UpdateEventInput } from "service/events";
 import { theme } from "theme";
-import dayjs from "utils/dayjs";
 import { sendNativeBack, useIsNativeEmbed } from "utils/nativeLink";
 
 import { Event } from "../../../proto/events_pb";
@@ -65,31 +64,18 @@ export default function EditEventPage({ eventId }: { eventId: number }) {
     { parentCommunityId?: number }
   >({
     mutationFn: (data) => {
-      const startTime = dayjs(data.startTime);
-      const endTime = dayjs(data.endTime);
-      const finalStartDate = data.startDate
-        .startOf("day")
-        .add(startTime.get("hour"), "hour")
-        .add(startTime.get("minute"), "minute")
-        .toDate();
-      const finalEndDate = data.endDate
-        .startOf("day")
-        .add(endTime.get("hour"), "hour")
-        .add(endTime.get("minute"), "minute")
-        .toDate();
-
       const updateEventInput: UpdateEventInput = {
         eventId,
         title: data.dirtyFields.title ? data.title : undefined,
         content: data.dirtyFields.content ? data.content : undefined,
         photoKey: data.dirtyFields.eventImage ? data.eventImage : undefined,
         startTime:
-          data.dirtyFields.startTime || data.dirtyFields.startDate
-            ? finalStartDate
+          data.dirtyFields.startDate || data.dirtyFields.startTime
+            ? data.startDate.toPlainDateTime(data.startTime)
             : undefined,
         endTime:
-          data.dirtyFields.endTime || data.dirtyFields.endDate
-            ? finalEndDate
+          data.dirtyFields.endDate || data.dirtyFields.endDate
+            ? data.endDate.toPlainDateTime(data.endTime)
             : undefined,
         shouldNotify: data.dirtyFields.shouldNotify,
         address: data.dirtyFields.location ? data.location.name : undefined,

--- a/app/web/features/communities/events/EventForm.test.tsx
+++ b/app/web/features/communities/events/EventForm.test.tsx
@@ -1,3 +1,4 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { useMutation } from "@tanstack/react-query";
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -265,18 +266,20 @@ describe("Event form", () => {
     expect(serviceFn).toHaveBeenCalledTimes(1);
 
     // Verify the submitted data contains the expected values
-    const submittedData = serviceFn.mock.calls[0][0];
+    const submittedData: CreateEventVariables = serviceFn.mock.calls[0][0];
     expect(submittedData.title).toBe("Test event");
     expect(submittedData.location.name).toBe(
       "test city, test county, test country",
     );
     expect(submittedData.content).toBe("sick social!");
-    expect(submittedData.startTime.toISOString()).toBe(
-      "2021-08-01T01:00:00.000Z",
+    expect(submittedData.startDate).toEqual(
+      Temporal.PlainDate.from("2021-08-01"),
     );
-    expect(submittedData.endTime.toISOString()).toBe(
-      "2021-08-01T02:00:00.000Z",
+    expect(submittedData.startTime).toEqual(Temporal.PlainTime.from("01:00"));
+    expect(submittedData.endDate).toEqual(
+      Temporal.PlainDate.from("2021-08-01"),
     );
+    expect(submittedData.endTime).toEqual(Temporal.PlainTime.from("02:00"));
   });
 
   it("should show an error alert if the form failed to submit", async () => {
@@ -423,17 +426,19 @@ describe("Event form", () => {
     expect(serviceFn).toHaveBeenCalledTimes(1);
 
     // Verify the submitted data contains the expected values
-    const submittedData = serviceFn.mock.calls[0][0];
+    const submittedData: CreateEventVariables = serviceFn.mock.calls[0][0];
     expect(submittedData.title).toBe("Test event");
     expect(submittedData.location.name).toBe(
       "test city, test county, test country",
     );
     expect(submittedData.content).toBe("sick social!");
-    expect(submittedData.startTime.toISOString()).toBe(
-      "2021-08-01T01:00:00.000Z",
+    expect(submittedData.startDate).toEqual(
+      Temporal.PlainDate.from("2021-08-01"),
     );
-    expect(submittedData.endTime.toISOString()).toBe(
-      "2021-08-01T02:00:00.000Z",
+    expect(submittedData.startTime).toEqual(Temporal.PlainTime.from("01:00"));
+    expect(submittedData.endDate).toEqual(
+      Temporal.PlainDate.from("2021-08-01"),
     );
+    expect(submittedData.endTime).toEqual(Temporal.PlainTime.from("02:00"));
   });
 });

--- a/app/web/features/communities/events/EventForm.test.tsx
+++ b/app/web/features/communities/events/EventForm.test.tsx
@@ -1,4 +1,3 @@
-import { Temporal } from "@js-temporal/polyfill";
 import { useMutation } from "@tanstack/react-query";
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -272,14 +271,10 @@ describe("Event form", () => {
       "test city, test county, test country",
     );
     expect(submittedData.content).toBe("sick social!");
-    expect(submittedData.startDate).toEqual(
-      Temporal.PlainDate.from("2021-08-01"),
-    );
-    expect(submittedData.startTime).toEqual(Temporal.PlainTime.from("01:00"));
-    expect(submittedData.endDate).toEqual(
-      Temporal.PlainDate.from("2021-08-01"),
-    );
-    expect(submittedData.endTime).toEqual(Temporal.PlainTime.from("02:00"));
+    expect(submittedData.startDate.toString()).toBe("2021-08-01");
+    expect(submittedData.startTime.toString()).toBe("01:00:00");
+    expect(submittedData.endDate.toString()).toBe("2021-08-01");
+    expect(submittedData.endTime.toString()).toBe("02:00:00");
   });
 
   it("should show an error alert if the form failed to submit", async () => {
@@ -432,13 +427,9 @@ describe("Event form", () => {
       "test city, test county, test country",
     );
     expect(submittedData.content).toBe("sick social!");
-    expect(submittedData.startDate).toEqual(
-      Temporal.PlainDate.from("2021-08-01"),
-    );
-    expect(submittedData.startTime).toEqual(Temporal.PlainTime.from("01:00"));
-    expect(submittedData.endDate).toEqual(
-      Temporal.PlainDate.from("2021-08-01"),
-    );
-    expect(submittedData.endTime).toEqual(Temporal.PlainTime.from("02:00"));
+    expect(submittedData.startDate.toString()).toBe("2021-08-01");
+    expect(submittedData.startTime.toString()).toBe("01:00:00");
+    expect(submittedData.endDate.toString()).toBe("2021-08-01");
+    expect(submittedData.endTime.toString()).toBe("02:00:00");
   });
 });

--- a/app/web/features/communities/events/EventForm.tsx
+++ b/app/web/features/communities/events/EventForm.tsx
@@ -1,4 +1,3 @@
-import { Temporal } from "@js-temporal/polyfill";
 import { Checkbox, FormControlLabel, styled, Typography } from "@mui/material";
 import { UseMutateFunction } from "@tanstack/react-query";
 import Alert from "components/Alert";
@@ -15,6 +14,7 @@ import { LngLat } from "maplibre-gl";
 import { Event } from "proto/events_pb";
 import { useRef } from "react";
 import { DeepMap, useForm } from "react-hook-form";
+import { Temporal } from "temporal-polyfill";
 import { theme } from "theme";
 import type { GeocodeResult } from "utils/hooks";
 

--- a/app/web/features/communities/events/EventForm.tsx
+++ b/app/web/features/communities/events/EventForm.tsx
@@ -1,3 +1,4 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { Checkbox, FormControlLabel, styled, Typography } from "@mui/material";
 import { UseMutateFunction } from "@tanstack/react-query";
 import Alert from "components/Alert";
@@ -15,7 +16,6 @@ import { Event } from "proto/events_pb";
 import { useRef } from "react";
 import { DeepMap, useForm } from "react-hook-form";
 import { theme } from "theme";
-import { Dayjs } from "utils/dayjs";
 import type { GeocodeResult } from "utils/hooks";
 
 import EventTimeChanger from "./EventTimeChanger";
@@ -54,10 +54,10 @@ const StyledEventDetailsContainer = styled("div")(() => ({
 interface EventData {
   content: string;
   title: string;
-  startDate: Dayjs;
-  endDate: Dayjs;
-  startTime: Dayjs;
-  endTime: Dayjs;
+  startDate: Temporal.PlainDate;
+  endDate: Temporal.PlainDate;
+  startTime: Temporal.PlainTime;
+  endTime: Temporal.PlainTime;
   shouldNotify: boolean;
   eventImage?: string;
   parentCommunityId?: number;

--- a/app/web/features/communities/events/EventTimeChanger.test.tsx
+++ b/app/web/features/communities/events/EventTimeChanger.test.tsx
@@ -1,3 +1,4 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Event } from "proto/events_pb";
@@ -478,10 +479,12 @@ describe("Event time changer", () => {
       expect(onValidSubmit).toHaveBeenCalledTimes(1);
       const submittedData = onValidSubmit.mock.calls[0][0];
 
-      expect(submittedData.startDate.format("YYYY-MM-DD")).toBe("2021-08-05");
-      expect(submittedData.startTime.format("HH:mm")).toBe("14:00");
-      expect(submittedData.endDate.format("YYYY-MM-DD")).toBe("2021-08-06");
-      expect(submittedData.endTime.format("HH:mm")).toBe("15:00");
+      expect(submittedData.startDate).toBe(
+        Temporal.PlainDate.from("2021-08-05"),
+      );
+      expect(submittedData.startTime).toBe(Temporal.PlainTime.from("14:00"));
+      expect(submittedData.endDate).toBe(Temporal.PlainDate.from("2021-08-06"));
+      expect(submittedData.endTime).toBe(Temporal.PlainTime.from("15:00"));
     });
   });
 });

--- a/app/web/features/communities/events/EventTimeChanger.test.tsx
+++ b/app/web/features/communities/events/EventTimeChanger.test.tsx
@@ -125,6 +125,7 @@ describe("Event time changer", () => {
 
   it("should show proper error if startDate is today but startTime is in the past", async () => {
     jest.setSystemTime(new Date("2021-08-01 23:00"));
+    expect(Temporal.Now.plainDateISO().toString() == "2021-08-01");
 
     render(<TestForm />, { wrapper });
 

--- a/app/web/features/communities/events/EventTimeChanger.test.tsx
+++ b/app/web/features/communities/events/EventTimeChanger.test.tsx
@@ -479,12 +479,14 @@ describe("Event time changer", () => {
       expect(onValidSubmit).toHaveBeenCalledTimes(1);
       const submittedData = onValidSubmit.mock.calls[0][0];
 
-      expect(submittedData.startDate).toBe(
+      expect(submittedData.startDate).toEqual(
         Temporal.PlainDate.from("2021-08-05"),
       );
-      expect(submittedData.startTime).toBe(Temporal.PlainTime.from("14:00"));
-      expect(submittedData.endDate).toBe(Temporal.PlainDate.from("2021-08-06"));
-      expect(submittedData.endTime).toBe(Temporal.PlainTime.from("15:00"));
+      expect(submittedData.startTime).toEqual(Temporal.PlainTime.from("14:00"));
+      expect(submittedData.endDate).toEqual(
+        Temporal.PlainDate.from("2021-08-06"),
+      );
+      expect(submittedData.endTime).toEqual(Temporal.PlainTime.from("15:00"));
     });
   });
 });

--- a/app/web/features/communities/events/EventTimeChanger.test.tsx
+++ b/app/web/features/communities/events/EventTimeChanger.test.tsx
@@ -1,8 +1,8 @@
-import { Temporal } from "@js-temporal/polyfill";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Event } from "proto/events_pb";
 import { useForm } from "react-hook-form";
+import { Temporal } from "temporal-polyfill";
 import events from "test/fixtures/events.json";
 import wrapper from "test/hookWrapper";
 import i18n from "test/i18n";

--- a/app/web/features/communities/events/EventTimeChanger.tsx
+++ b/app/web/features/communities/events/EventTimeChanger.tsx
@@ -1,4 +1,3 @@
-import { Temporal } from "@js-temporal/polyfill";
 import { styled } from "@mui/material";
 import Datepicker from "components/Datepicker";
 import Timepicker from "components/Timepicker";
@@ -7,6 +6,7 @@ import { useTranslation } from "i18n";
 import { COMMUNITIES } from "i18n/namespaces";
 import { Event } from "proto/events_pb";
 import { UseFormReturn } from "react-hook-form";
+import { Temporal } from "temporal-polyfill";
 import { theme } from "theme";
 import { timestamp2Date } from "utils/date";
 import { timePattern } from "utils/validation";

--- a/app/web/features/communities/events/EventTimeChanger.tsx
+++ b/app/web/features/communities/events/EventTimeChanger.tsx
@@ -1,3 +1,4 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { styled } from "@mui/material";
 import Datepicker from "components/Datepicker";
 import Timepicker from "components/Timepicker";
@@ -7,8 +8,8 @@ import { COMMUNITIES } from "i18n/namespaces";
 import { Event } from "proto/events_pb";
 import { UseFormReturn } from "react-hook-form";
 import { theme } from "theme";
-import { isSameOrFutureDate, timestamp2Date } from "utils/date";
-import dayjs, { Dayjs } from "utils/dayjs";
+import { timestamp2Date } from "utils/date";
+import dayjs from "utils/dayjs";
 import { timePattern } from "utils/validation";
 
 import { CreateEventData } from "./EventForm";
@@ -22,20 +23,6 @@ const StyledContainer = styled("div")(() => ({
   },
 }));
 
-function splitTimestampToDateAndTime(timestamp?: Timestamp.AsObject): {
-  date?: Dayjs;
-  time?: Dayjs;
-} {
-  if (timestamp) {
-    const dayjsDate = dayjs(timestamp2Date(timestamp));
-    return {
-      date: dayjsDate.startOf("day"),
-      time: dayjsDate,
-    };
-  }
-  return {};
-}
-
 interface EventTimeChangerProps
   extends Pick<
     UseFormReturn<CreateEventData>,
@@ -44,6 +31,15 @@ interface EventTimeChangerProps
   dirtyFields: UseFormReturn<CreateEventData>["formState"]["dirtyFields"];
   event?: Event.AsObject;
   errors: UseFormReturn<CreateEventData>["formState"]["errors"];
+}
+
+function toPlainDateTime(
+  timestamp: Timestamp.AsObject,
+): Temporal.PlainDateTime {
+  // FIXME(#8064): Event times should be interpreted in their timezones.
+  return Temporal.PlainDateTime.from(
+    dayjs(timestamp2Date(timestamp)).format("YYYY-MM-DDTHH:mm"),
+  );
 }
 
 export default function EventTimeChanger({
@@ -56,34 +52,36 @@ export default function EventTimeChanger({
 }: EventTimeChangerProps) {
   const { t } = useTranslation([COMMUNITIES]);
 
-  const { date: eventStartDate, time: eventStartTime } =
-    splitTimestampToDateAndTime(event?.startTime);
-  const { date: eventEndDate, time: eventEndTime } =
-    splitTimestampToDateAndTime(event?.endTime);
+  const defaultStartDateTime = event?.startTime
+    ? toPlainDateTime(event.startTime)
+    : undefined;
+  const defaultEndDateTime = event?.endTime
+    ? toPlainDateTime(event.endTime)
+    : undefined;
 
-  const handleStartDateChange = (newStartDate: Dayjs) => {
-    setValue("startDate", newStartDate, {
+  const handleStartDateChange = (value: Temporal.PlainDate) => {
+    setValue("startDate", value, {
       shouldDirty: true,
       shouldValidate: true,
     });
   };
 
-  const handleEndDateChange = (newEndDate: Dayjs) => {
-    setValue("endDate", newEndDate, {
+  const handleEndDateChange = (value: Temporal.PlainDate) => {
+    setValue("endDate", value, {
       shouldDirty: true,
       shouldValidate: true,
     });
   };
 
-  const handleStartTimeChange = (newStartTime: Dayjs) => {
-    setValue("startTime", newStartTime, {
+  const handleStartTimeChange = (value: Temporal.PlainTime) => {
+    setValue("startTime", value, {
       shouldDirty: true,
       shouldValidate: true,
     });
   };
 
-  const handleEndTimeChange = (newEndTime: Dayjs) => {
-    setValue("endTime", newEndTime, {
+  const handleEndTimeChange = (value: Temporal.PlainTime) => {
+    setValue("endTime", value, {
       shouldDirty: true,
       shouldValidate: true,
     });
@@ -94,7 +92,7 @@ export default function EventTimeChanger({
       <StyledContainer>
         <Datepicker
           control={control}
-          defaultValue={eventStartDate ?? null}
+          defaultValue={defaultStartDateTime}
           error={!!errors.startDate?.message}
           helperText={errors.startDate?.message}
           id="startDate"
@@ -103,14 +101,16 @@ export default function EventTimeChanger({
           onPostChange={handleStartDateChange}
           rules={{
             required: t("communities:date_required"),
-            validate: (date: Dayjs) => {
+            validate: (startDate: Temporal.PlainDate) => {
               // Only disable validation temporarily if `event` exists/in the edit event context
               if (event && !dirtyFields.startDate) {
                 return true;
               }
               return (
-                isSameOrFutureDate(date, dayjs()) ||
-                t("communities:past_date_error")
+                Temporal.PlainDate.compare(
+                  startDate,
+                  Temporal.Now.plainDateISO(),
+                ) >= 0 || t("communities:past_date_error")
               );
             },
           }}
@@ -121,14 +121,14 @@ export default function EventTimeChanger({
           control={control}
           name="startTime"
           onPostChange={handleStartTimeChange}
-          defaultValue={eventStartTime || null}
+          defaultValue={defaultStartDateTime}
           rules={{
             required: t("communities:time_required"),
             pattern: {
               message: t("communities:invalid_time"),
               value: timePattern,
             },
-            validate: (time: Dayjs) => {
+            validate: (startTime: Temporal.PlainTime) => {
               if (event && !dirtyFields.startTime) {
                 return true;
               }
@@ -139,17 +139,16 @@ export default function EventTimeChanger({
                 return t("communities:date_required");
               }
 
-              if (!time) {
+              if (!startTime) {
                 return t("communities:time_required");
               }
 
-              const startDateTime = startDate
-                .hour(time.hour())
-                .minute(time.minute());
-
+              const startDateTime = startDate.toPlainDateTime(startTime);
               return (
-                startDateTime.isAfter(dayjs()) ||
-                t("communities:past_time_error")
+                Temporal.PlainDate.compare(
+                  startDateTime,
+                  Temporal.Now.plainDateISO(),
+                ) >= 0 || t("communities:past_time_error")
               );
             },
           }}
@@ -163,7 +162,7 @@ export default function EventTimeChanger({
       <StyledContainer>
         <Datepicker
           control={control}
-          defaultValue={eventEndDate ?? null}
+          defaultValue={defaultEndDateTime}
           error={!!errors.endDate?.message}
           helperText={errors.endDate?.message || ""}
           id="endDate"
@@ -171,20 +170,21 @@ export default function EventTimeChanger({
           name="endDate"
           rules={{
             required: t("communities:date_required"),
-            validate: (date) => {
+            validate: (endDate: Temporal.PlainDate) => {
               if (event && !dirtyFields.endDate) {
                 return true;
               }
 
               const startDate = getValues("startDate");
-
-              if (date.isBefore(startDate)) {
+              if (Temporal.PlainDate.compare(endDate, startDate) < 0) {
                 return t("communities:end_date_error");
               }
 
               return (
-                isSameOrFutureDate(date, dayjs()) ||
-                t("communities:past_date_error")
+                Temporal.PlainDate.compare(
+                  endDate,
+                  Temporal.Now.plainDateISO(),
+                ) >= 0 || t("communities:past_date_error")
               );
             },
           }}
@@ -196,14 +196,14 @@ export default function EventTimeChanger({
           control={control}
           name="endTime"
           onPostChange={handleEndTimeChange}
-          defaultValue={eventEndTime || null}
+          defaultValue={defaultEndDateTime}
           rules={{
             required: t("communities:time_required"),
             pattern: {
               message: t("communities:invalid_time"),
               value: timePattern,
             },
-            validate: (time: Dayjs) => {
+            validate: (endTime: Temporal.PlainTime) => {
               if (event && !dirtyFields.endTime) {
                 return true;
               }
@@ -212,7 +212,7 @@ export default function EventTimeChanger({
               const startDate = getValues("startDate");
               const endDate = getValues("endDate");
 
-              if (!startTime || !time) {
+              if (!startTime || !endTime) {
                 return t("communities:time_required");
               }
 
@@ -220,20 +220,17 @@ export default function EventTimeChanger({
                 return t("communities:date_required");
               }
 
-              const startDateTime = startDate
-                .hour(startTime.hour())
-                .minute(startTime.minute());
-
-              const endDateTime = endDate
-                .hour(time.hour())
-                .minute(time.minute());
-
-              if (!endDateTime.isAfter(startDateTime)) {
+              const startDateTime = startDate.toPlainDateTime(startTime);
+              const endDateTime = endDate.toPlainDateTime(endTime);
+              if (Temporal.PlainDate.compare(endDateTime, startDateTime) < 0) {
                 return t("communities:end_time_error");
               }
 
               return (
-                endDateTime.isAfter(dayjs()) || t("communities:past_time_error")
+                Temporal.PlainDate.compare(
+                  endDateTime,
+                  Temporal.Now.plainDateISO(),
+                ) >= 0 || t("communities:past_time_error")
               );
             },
           }}

--- a/app/web/features/communities/events/EventTimeChanger.tsx
+++ b/app/web/features/communities/events/EventTimeChanger.tsx
@@ -134,7 +134,6 @@ export default function EventTimeChanger({
               }
 
               const startDate = getValues("startDate");
-
               if (!startDate) {
                 return t("communities:date_required");
               }
@@ -145,9 +144,9 @@ export default function EventTimeChanger({
 
               const startDateTime = startDate.toPlainDateTime(startTime);
               return (
-                Temporal.PlainDate.compare(
+                Temporal.PlainDateTime.compare(
                   startDateTime,
-                  Temporal.Now.plainDateISO(),
+                  Temporal.Now.plainDateTimeISO(),
                 ) >= 0 || t("communities:past_time_error")
               );
             },
@@ -176,7 +175,10 @@ export default function EventTimeChanger({
               }
 
               const startDate = getValues("startDate");
-              if (Temporal.PlainDate.compare(endDate, startDate) < 0) {
+              if (
+                startDate &&
+                Temporal.PlainDate.compare(endDate, startDate) < 0
+              ) {
                 return t("communities:end_date_error");
               }
 
@@ -222,14 +224,16 @@ export default function EventTimeChanger({
 
               const startDateTime = startDate.toPlainDateTime(startTime);
               const endDateTime = endDate.toPlainDateTime(endTime);
-              if (Temporal.PlainDate.compare(endDateTime, startDateTime) < 0) {
+              if (
+                Temporal.PlainDateTime.compare(endDateTime, startDateTime) <= 0
+              ) {
                 return t("communities:end_time_error");
               }
 
               return (
-                Temporal.PlainDate.compare(
+                Temporal.PlainDateTime.compare(
                   endDateTime,
-                  Temporal.Now.plainDateISO(),
+                  Temporal.Now.plainDateTimeISO(),
                 ) >= 0 || t("communities:past_time_error")
               );
             },

--- a/app/web/features/communities/events/EventTimeChanger.tsx
+++ b/app/web/features/communities/events/EventTimeChanger.tsx
@@ -9,7 +9,6 @@ import { Event } from "proto/events_pb";
 import { UseFormReturn } from "react-hook-form";
 import { theme } from "theme";
 import { timestamp2Date } from "utils/date";
-import dayjs from "utils/dayjs";
 import { timePattern } from "utils/validation";
 
 import { CreateEventData } from "./EventForm";
@@ -36,10 +35,11 @@ interface EventTimeChangerProps
 function toPlainDateTime(
   timestamp: Timestamp.AsObject,
 ): Temporal.PlainDateTime {
+  const legacyDate = timestamp2Date(timestamp);
+  const instant = Temporal.Instant.fromEpochMilliseconds(legacyDate.getTime());
   // FIXME(#8064): Event times should be interpreted in their timezones.
-  return Temporal.PlainDateTime.from(
-    dayjs(timestamp2Date(timestamp)).format("YYYY-MM-DDTHH:mm"),
-  );
+  const zoned = instant.toZonedDateTimeISO(Temporal.Now.timeZoneId());
+  return zoned.toPlainDateTime();
 }
 
 export default function EventTimeChanger({
@@ -92,7 +92,7 @@ export default function EventTimeChanger({
       <StyledContainer>
         <Datepicker
           control={control}
-          defaultValue={defaultStartDateTime}
+          defaultValue={defaultStartDateTime?.toPlainDate()}
           error={!!errors.startDate?.message}
           helperText={errors.startDate?.message}
           id="startDate"
@@ -121,7 +121,7 @@ export default function EventTimeChanger({
           control={control}
           name="startTime"
           onPostChange={handleStartTimeChange}
-          defaultValue={defaultStartDateTime}
+          defaultValue={defaultStartDateTime?.toPlainTime()}
           rules={{
             required: t("communities:time_required"),
             pattern: {
@@ -162,7 +162,7 @@ export default function EventTimeChanger({
       <StyledContainer>
         <Datepicker
           control={control}
-          defaultValue={defaultEndDateTime}
+          defaultValue={defaultEndDateTime?.toPlainDate()}
           error={!!errors.endDate?.message}
           helperText={errors.endDate?.message || ""}
           id="endDate"
@@ -196,7 +196,7 @@ export default function EventTimeChanger({
           control={control}
           name="endTime"
           onPostChange={handleEndTimeChange}
-          defaultValue={defaultEndDateTime}
+          defaultValue={defaultEndDateTime?.toPlainTime()}
           rules={{
             required: t("communities:time_required"),
             pattern: {

--- a/app/web/features/profile/view/NewHostRequest.tsx
+++ b/app/web/features/profile/view/NewHostRequest.tsx
@@ -1,4 +1,3 @@
-import { Temporal } from "@js-temporal/polyfill";
 import { CardActions, Skeleton, styled, Typography } from "@mui/material";
 import { useMutation } from "@tanstack/react-query";
 import Alert from "components/Alert";
@@ -21,6 +20,7 @@ import { useForm } from "react-hook-form";
 import { howToWriteRequestGuideUrl } from "routes";
 import { service } from "service";
 import { CreateHostRequestWrapper } from "service/requests";
+import { Temporal } from "temporal-polyfill";
 import { theme } from "theme";
 
 const TYPING_GAP_CAP_MS = 3000;

--- a/app/web/features/profile/view/NewHostRequest.tsx
+++ b/app/web/features/profile/view/NewHostRequest.tsx
@@ -1,3 +1,4 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { CardActions, Skeleton, styled, Typography } from "@mui/material";
 import { useMutation } from "@tanstack/react-query";
 import Alert from "components/Alert";
@@ -21,15 +22,13 @@ import { howToWriteRequestGuideUrl } from "routes";
 import { service } from "service";
 import { CreateHostRequestWrapper } from "service/requests";
 import { theme } from "theme";
-import { isSameOrFutureDate } from "utils/date";
-import dayjs from "utils/dayjs";
 
 const TYPING_GAP_CAP_MS = 3000;
 
 interface FormValuesSnapshot {
   text: string;
-  fromDate: dayjs.Dayjs | null;
-  toDate: dayjs.Dayjs | null;
+  fromDate: Temporal.PlainDate | null;
+  toDate: Temporal.PlainDate | null;
 }
 
 function isFormField(target: EventTarget | null): boolean {
@@ -122,8 +121,8 @@ function useHostRequestFormTracking({
         active_typing_ms: Math.round(activeTypingMs),
         keystroke_count: keystrokeCount,
         text_length: text.length,
-        from_date: fromDate ? fromDate.format("YYYY-MM-DD") : null,
-        to_date: toDate ? toDate.format("YYYY-MM-DD") : null,
+        from_date: fromDate?.toString(),
+        to_date: toDate?.toString(),
         ...referrerProps,
       });
     };
@@ -236,21 +235,20 @@ export default function NewHostRequest({
     mutate(data);
   });
 
-  const hostToday = user.timezone
-    ? dayjs().tz(user.timezone).startOf("day")
-    : dayjs().startOf("day");
+  const hostToday = Temporal.Now.plainDateISO(user.timezone);
 
   const watchFromDate = watch("fromDate", undefined);
   const arrivalBeforeHostToday =
-    !!watchFromDate && dayjs(watchFromDate).isBefore(hostToday);
+    !!watchFromDate && Temporal.PlainDate.compare(watchFromDate, hostToday) < 0;
 
   useEffect(() => {
+    const toDate = getValues("toDate");
     if (
       watchFromDate &&
-      getValues("toDate") &&
-      isSameOrFutureDate(watchFromDate, getValues("toDate"))
+      toDate &&
+      Temporal.PlainDate.compare(watchFromDate, toDate) >= 0
     ) {
-      setValue("toDate", watchFromDate.add(1, "day"));
+      setValue("toDate", watchFromDate.add({ days: 1 }));
     }
   });
 
@@ -277,15 +275,17 @@ export default function NewHostRequest({
                 id="from-date"
                 label={t("profile:request_form.arrival_date")}
                 name="fromDate"
-                defaultValue={null}
-                minDate={hostToday}
+                minValue={hostToday}
                 rules={{
                   required: t("profile:request_form.arrival_date_empty"),
                   validate: {
                     notEmpty: (date) => !date || date !== "",
                     notBeforeHostToday: (date) =>
                       !date ||
-                      !dayjs(date).isBefore(hostToday) ||
+                      Temporal.PlainDate.compare(
+                        Temporal.PlainDate.from(date),
+                        hostToday,
+                      ) >= 0 ||
                       t("profile:request_form.arrival_date_before_host_today", {
                         name: user.name,
                       }),
@@ -305,9 +305,12 @@ export default function NewHostRequest({
                 helperText={errors?.toDate?.message}
                 id="to-date"
                 label={t("profile:request_form.departure_date")}
-                minDate={watchFromDate ? watchFromDate.add(1, "day") : dayjs()}
+                minValue={
+                  watchFromDate
+                    ? watchFromDate.add({ days: 1 })
+                    : Temporal.Now.plainDateISO()
+                }
                 name="toDate"
-                defaultValue={null}
                 rules={{
                   required: t("profile:request_form.departure_date_empty"),
                   validate: (stringDate) => stringDate !== "",

--- a/app/web/features/publicTrips/OfferToHostDialog.tsx
+++ b/app/web/features/publicTrips/OfferToHostDialog.tsx
@@ -1,3 +1,4 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { styled } from "@mui/material";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import Alert from "components/Alert";
@@ -21,7 +22,6 @@ import { useForm } from "react-hook-form";
 import { routeToHostRequest } from "routes";
 import { service } from "service";
 import { theme } from "theme";
-import dayjs, { Dayjs } from "utils/dayjs";
 
 // Must match the backend host request minimum (and normal host requests).
 const MESSAGE_MIN_LENGTH = 250;
@@ -29,8 +29,8 @@ const MESSAGE_MIN_LENGTH = 250;
 const DATE_FIELD_ID = "offer-to-host-dates";
 
 interface FormValues {
-  fromDate: Dayjs | null;
-  toDate: Dayjs | null;
+  fromDate: Temporal.PlainDate | null;
+  toDate: Temporal.PlainDate | null;
   text: string;
 }
 
@@ -40,8 +40,8 @@ interface OfferToHostDialogProps {
   tripId: number;
   hostUserId: number;
   hostName: string;
-  tripFromDate: string;
-  tripToDate: string;
+  tripFromDate: Temporal.PlainDate;
+  tripToDate: Temporal.PlainDate;
 }
 
 const FieldStack = styled("div")(({ theme }) => ({
@@ -71,12 +71,11 @@ export default function OfferToHostDialog({
   const router = useRouter();
   const queryClient = useQueryClient();
 
-  const tripFrom = dayjs(tripFromDate);
-  const tripTo = dayjs(tripToDate);
-  const today = dayjs().startOf("day");
+  const today = Temporal.Now.plainDateISO();
   // The host can offer within the trip's window (shorten, not extend), and
   // never in the past. The backend enforces these too.
-  const earliest = tripFrom.isAfter(today) ? tripFrom : today;
+  const earliest =
+    Temporal.PlainDate.compare(tripFromDate, today) > 0 ? tripFromDate : today;
 
   const {
     control,
@@ -87,7 +86,11 @@ export default function OfferToHostDialog({
     formState: { errors },
   } = useForm<FormValues>({
     mode: "onBlur",
-    defaultValues: { fromDate: tripFrom, toDate: tripTo, text: "" },
+    defaultValues: {
+      fromDate: tripFromDate,
+      toDate: tripToDate,
+      text: "",
+    },
   });
 
   const watchFromDate = watch("fromDate");
@@ -104,8 +107,8 @@ export default function OfferToHostDialog({
       service.requests.createHostRequest({
         hostUserId,
         // Both are required by the form, so non-null at submit time.
-        fromDate: fromDate!,
-        toDate: toDate!,
+        fromDate: fromDate!.toString(),
+        toDate: toDate!.toString(),
         text: text.trim(),
         publicTripId: tripId,
         stayType: 0,
@@ -153,9 +156,9 @@ export default function OfferToHostDialog({
                 id={`${DATE_FIELD_ID}-from`}
                 label={t("publicTrips:from_date_label")}
                 name="fromDate"
-                defaultValue={tripFrom}
-                minDate={earliest}
-                maxDate={tripTo}
+                defaultValue={tripFromDate}
+                minValue={earliest}
+                maxValue={tripToDate}
                 rules={{ required: t("publicTrips:from_date_required") }}
               />
               <Datepicker
@@ -165,9 +168,9 @@ export default function OfferToHostDialog({
                 id={`${DATE_FIELD_ID}-to`}
                 label={t("publicTrips:to_date_label")}
                 name="toDate"
-                defaultValue={tripTo}
-                minDate={watchFromDate ?? earliest}
-                maxDate={tripTo}
+                defaultValue={tripToDate}
+                minValue={watchFromDate ?? earliest}
+                maxValue={tripToDate}
                 rules={{ required: t("publicTrips:to_date_required") }}
               />
             </DateRow>

--- a/app/web/features/publicTrips/OfferToHostDialog.tsx
+++ b/app/web/features/publicTrips/OfferToHostDialog.tsx
@@ -107,8 +107,8 @@ export default function OfferToHostDialog({
       service.requests.createHostRequest({
         hostUserId,
         // Both are required by the form, so non-null at submit time.
-        fromDate: fromDate!.toString(),
-        toDate: toDate!.toString(),
+        fromDate: fromDate!,
+        toDate: toDate!,
         text: text.trim(),
         publicTripId: tripId,
         stayType: 0,

--- a/app/web/features/publicTrips/OfferToHostDialog.tsx
+++ b/app/web/features/publicTrips/OfferToHostDialog.tsx
@@ -1,4 +1,3 @@
-import { Temporal } from "@js-temporal/polyfill";
 import { styled } from "@mui/material";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import Alert from "components/Alert";
@@ -21,6 +20,7 @@ import { useRouter } from "next/router";
 import { useForm } from "react-hook-form";
 import { routeToHostRequest } from "routes";
 import { service } from "service";
+import { Temporal } from "temporal-polyfill";
 import { theme } from "theme";
 
 // Must match the backend host request minimum (and normal host requests).

--- a/app/web/features/publicTrips/PublicTripCard.tsx
+++ b/app/web/features/publicTrips/PublicTripCard.tsx
@@ -1,4 +1,3 @@
-import { Temporal } from "@js-temporal/polyfill";
 import {
   HourglassEmptyOutlined,
   PlaceOutlined,
@@ -39,6 +38,7 @@ import Link from "next/link";
 import { PublicTripStatus } from "proto/public_trips_pb";
 import { useCallback, useState } from "react";
 import { routeToCommunity, routeToHostRequest, routeToUser } from "routes";
+import { Temporal } from "temporal-polyfill";
 import { localizeDateTimeRange } from "utils/date";
 import dayjs from "utils/dayjs";
 import { useIsNativeEmbed } from "utils/nativeLink";

--- a/app/web/features/publicTrips/PublicTripCard.tsx
+++ b/app/web/features/publicTrips/PublicTripCard.tsx
@@ -1,3 +1,4 @@
+import { Temporal } from "@js-temporal/polyfill";
 import {
   HourglassEmptyOutlined,
   PlaceOutlined,
@@ -224,8 +225,8 @@ export default function PublicTripCard({
           tripId={trip.tripId}
           hostUserId={user.userId}
           hostName={user.name}
-          tripFromDate={trip.fromDate}
-          tripToDate={trip.toDate}
+          tripFromDate={Temporal.PlainDate.from(trip.fromDate)}
+          tripToDate={Temporal.PlainDate.from(trip.toDate)}
         />
       )}
       {ownerView && (

--- a/app/web/features/publicTrips/PublicTripDialog.tsx
+++ b/app/web/features/publicTrips/PublicTripDialog.tsx
@@ -1,3 +1,4 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { Checkbox, FormControlLabel, styled, Typography } from "@mui/material";
 import Alert from "components/Alert";
 import Button from "components/Button";
@@ -14,7 +15,6 @@ import { useTranslation } from "i18n";
 import { GLOBAL, PUBLIC_TRIPS } from "i18n/namespaces";
 import { useEffect } from "react";
 import { Controller, useForm, useWatch } from "react-hook-form";
-import dayjs, { Dayjs } from "utils/dayjs";
 
 import {
   PublicTrip,
@@ -41,8 +41,8 @@ const DateRow = styled("div")(({ theme }) => ({
 }));
 
 interface FormValues {
-  fromDate: Dayjs | null;
-  toDate: Dayjs | null;
+  fromDate: Temporal.PlainDate | null;
+  toDate: Temporal.PlainDate | null;
   description: string;
   sameGenderOnly: boolean;
 }
@@ -63,8 +63,12 @@ export default function PublicTripDialog(props: PublicTripDialogProps) {
   const getDefaults = (): FormValues =>
     props.mode === "edit"
       ? {
-          fromDate: props.trip.fromDate ? dayjs(props.trip.fromDate) : null,
-          toDate: props.trip.toDate ? dayjs(props.trip.toDate) : null,
+          fromDate: props.trip.fromDate
+            ? Temporal.PlainDate.from(props.trip.fromDate)
+            : null,
+          toDate: props.trip.toDate
+            ? Temporal.PlainDate.from(props.trip.toDate)
+            : null,
           description: props.trip.description,
           sameGenderOnly: props.trip.sameGenderOnly ?? false,
         }
@@ -148,8 +152,8 @@ export default function PublicTripDialog(props: PublicTripDialogProps) {
     ({ fromDate, toDate, description, sameGenderOnly }) => {
       if (!fromDate || !toDate) return;
       const payload = {
-        fromDate: fromDate.format("YYYY-MM-DD"),
-        toDate: toDate.format("YYYY-MM-DD"),
+        fromDate: fromDate.toString(),
+        toDate: toDate.toString(),
         description: description.trim(),
         sameGenderOnly,
       };
@@ -189,7 +193,6 @@ export default function PublicTripDialog(props: PublicTripDialogProps) {
                 id={`${DATE_FIELD_ID}-from`}
                 label={t("publicTrips:from_date_label")}
                 name="fromDate"
-                defaultValue={null}
                 rules={{
                   required: t("publicTrips:from_date_required"),
                 }}
@@ -201,8 +204,7 @@ export default function PublicTripDialog(props: PublicTripDialogProps) {
                 id={`${DATE_FIELD_ID}-to`}
                 label={t("publicTrips:to_date_label")}
                 name="toDate"
-                defaultValue={null}
-                minDate={watchFromDate ? watchFromDate : dayjs()}
+                minValue={watchFromDate ?? Temporal.Now.plainDateISO()}
                 rules={{
                   required: t("publicTrips:to_date_required"),
                 }}

--- a/app/web/features/publicTrips/PublicTripDialog.tsx
+++ b/app/web/features/publicTrips/PublicTripDialog.tsx
@@ -1,4 +1,3 @@
-import { Temporal } from "@js-temporal/polyfill";
 import { Checkbox, FormControlLabel, styled, Typography } from "@mui/material";
 import Alert from "components/Alert";
 import Button from "components/Button";
@@ -15,6 +14,7 @@ import { useTranslation } from "i18n";
 import { GLOBAL, PUBLIC_TRIPS } from "i18n/namespaces";
 import { useEffect } from "react";
 import { Controller, useForm, useWatch } from "react-hook-form";
+import { Temporal } from "temporal-polyfill";
 
 import {
   PublicTrip,

--- a/app/web/jest.config.ts
+++ b/app/web/jest.config.ts
@@ -30,6 +30,7 @@ const customJestConfig: Config = {
   // @TODO(NA) ^^ Fixed in react-query v4, but we are still on v3. Remove this when we upgrade.
   moduleDirectories: ["node_modules", "<rootDir>"],
   reporters: ["default", "jest-junit"],
+  resolver: "<rootDir>/jest.resolver.js",
   setupFilesAfterEnv: ["./test/setupTests.ts"],
   testPathIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/.next/"],
   testEnvironment: "jsdom",
@@ -38,7 +39,6 @@ const customJestConfig: Config = {
     // https://jestjs.io/docs/configuration#transform-objectstring-pathtotransformer--pathtotransformer-object
     "^.+\\.(js|jsx|ts|tsx)$": ["babel-jest", { presets: ["next/babel"] }],
   },
-  transformIgnorePatterns: ["/node_modules/"],
   resetMocks: true,
 };
 

--- a/app/web/jest.resolver.js
+++ b/app/web/jest.resolver.js
@@ -1,0 +1,19 @@
+// temporal-polyfill and temporal-utils only publish an "import" export condition, which
+// Jest's default CJS module resolution doesn't request, so plain `require()` resolution
+// fails with "Cannot find module". Request the "import" condition just for these packages
+// instead of globally (globally breaks other node_modules that pick their unbuilt ESM entry
+// over a CJS one, e.g. dedent).
+const ESM_ONLY_PACKAGES = ["temporal-polyfill", "temporal-utils"];
+
+module.exports = (path, options) => {
+  const isEsmOnly = ESM_ONLY_PACKAGES.some(
+    (name) => path === name || path.startsWith(`${name}/`),
+  );
+  if (isEsmOnly) {
+    return options.defaultResolver(path, {
+      ...options,
+      conditions: [...(options.conditions ?? []), "import"],
+    });
+  }
+  return options.defaultResolver(path, options);
+};

--- a/app/web/next.config.js
+++ b/app/web/next.config.js
@@ -23,6 +23,9 @@ const nextConfig = {
   },
   i18n,
   productionBrowserSourceMaps: true,
+  // ESM-only packages with no CommonJS entry point - Next.js (and next/jest) need to
+  // transpile these themselves rather than treating them as pre-built node_modules.
+  transpilePackages: ["temporal-polyfill", "temporal-utils"],
   webpack: (config, { isServer }) => {
     if (isServer) {
       generateBlogIndex();

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -30,6 +30,7 @@
     "@emotion/styled": "^11.14.1",
     "@growthbook/growthbook": "^1.6.5",
     "@growthbook/growthbook-react": "^1.6.5",
+    "@js-temporal/polyfill": "^0.5.1",
     "@mui/icons-material": "^7.3.9",
     "@mui/lab": "^7.0.0-beta.17",
     "@mui/material": "^7.3.9",

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -30,7 +30,6 @@
     "@emotion/styled": "^11.14.1",
     "@growthbook/growthbook": "^1.6.5",
     "@growthbook/growthbook-react": "^1.6.5",
-    "@js-temporal/polyfill": "^0.5.1",
     "@mui/icons-material": "^7.3.9",
     "@mui/lab": "^7.0.0-beta.17",
     "@mui/material": "^7.3.9",
@@ -71,6 +70,7 @@
     "react-phone-number-input": "^3.4.17",
     "react-simple-maps": "^3.0.0",
     "seamless-scroll-polyfill": "^2.1.8",
+    "temporal-polyfill": "^1.0.1",
     "ts-node": "^10.9.2"
   },
   "devDependencies": {

--- a/app/web/service/auth.ts
+++ b/app/web/service/auth.ts
@@ -1,4 +1,3 @@
-import { Temporal } from "@js-temporal/polyfill";
 import { BoolValue } from "google-protobuf/google/protobuf/wrappers_pb";
 import { HostingStatus } from "proto/api_pb";
 import {
@@ -14,6 +13,7 @@ import {
   UnsubscribeReq,
   UsernameValidReq,
 } from "proto/auth_pb";
+import { Temporal } from "temporal-polyfill";
 
 import client from "./client";
 

--- a/app/web/service/auth.ts
+++ b/app/web/service/auth.ts
@@ -1,3 +1,4 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { BoolValue } from "google-protobuf/google/protobuf/wrappers_pb";
 import { HostingStatus } from "proto/api_pb";
 import {
@@ -47,7 +48,7 @@ interface AccountSignupData {
   flowToken: string;
   username: string;
   password?: string;
-  birthdate: string;
+  birthdate: Temporal.PlainDate;
   gender: string;
   acceptTOS: boolean;
   optOutOfNewsletter: boolean;
@@ -76,7 +77,7 @@ export async function signupFlowAccount({
   req.setFlowToken(flowToken);
   const account = new SignupAccount();
   account.setUsername(username);
-  account.setBirthdate(birthdate);
+  account.setBirthdate(birthdate.toString());
   account.setGender(gender);
   account.setAcceptTos(acceptTOS);
   account.setOptOutOfNewsletter(optOutOfNewsletter);

--- a/app/web/service/events.ts
+++ b/app/web/service/events.ts
@@ -1,4 +1,3 @@
-import { Temporal } from "@js-temporal/polyfill";
 import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
 import {
   Int64Value,
@@ -21,6 +20,7 @@ import {
   SetEventAttendanceReq,
   UpdateEventReq,
 } from "proto/events_pb";
+import { Temporal } from "temporal-polyfill";
 
 import client from "./client";
 

--- a/app/web/service/events.ts
+++ b/app/web/service/events.ts
@@ -21,7 +21,6 @@ import {
   SetEventAttendanceReq,
   UpdateEventReq,
 } from "proto/events_pb";
-import dayjs from "utils/dayjs";
 
 import client from "./client";
 
@@ -130,16 +129,20 @@ interface EventInput {
 
 export type CreateEventInput = EventInput;
 
+function toTimestamp(dateTime: Temporal.PlainDateTime): Timestamp {
+  // FIXME(#8064): Events should be created in their location's timezone
+  const zoned = dateTime.toZonedDateTime(Temporal.Now.timeZoneId());
+  const legacyDate = new Date(zoned.epochMilliseconds);
+  return Timestamp.fromDate(legacyDate);
+}
+
 export async function createEvent(input: CreateEventInput) {
   const req = new CreateEventReq();
   req.setTitle(input.title);
   req.setContent(input.content);
 
-  // FIXME(#8064): Events should be created in their location's timezone
-  req.setStartTime(
-    Timestamp.fromDate(dayjs(input.startTime.toString()).toDate()),
-  );
-  req.setEndTime(Timestamp.fromDate(dayjs(input.endTime.toString()).toDate()));
+  req.setStartTime(toTimestamp(input.startTime));
+  req.setEndTime(toTimestamp(input.endTime));
 
   if (input.photoKey) {
     req.setPhotoKey(input.photoKey);
@@ -175,10 +178,10 @@ export async function updateEvent(input: UpdateEventInput) {
     req.setContent(new StringValue().setValue(input.content));
   }
   if (input.startTime) {
-    req.setStartTime(Timestamp.fromDate(input.startTime));
+    req.setStartTime(toTimestamp(input.startTime));
   }
   if (input.endTime) {
-    req.setEndTime(Timestamp.fromDate(input.endTime));
+    req.setEndTime(toTimestamp(input.endTime));
   }
 
   if (input.photoKey) {

--- a/app/web/service/events.ts
+++ b/app/web/service/events.ts
@@ -1,3 +1,4 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
 import {
   Int64Value,
@@ -20,6 +21,7 @@ import {
   SetEventAttendanceReq,
   UpdateEventReq,
 } from "proto/events_pb";
+import dayjs from "utils/dayjs";
 
 import client from "./client";
 
@@ -118,8 +120,8 @@ interface EventInput {
   content: string;
   photoKey?: string;
   title: string;
-  startTime: Date;
-  endTime: Date;
+  startTime: Temporal.PlainDateTime;
+  endTime: Temporal.PlainDateTime;
   address: string;
   lat: number;
   lng: number;
@@ -132,8 +134,12 @@ export async function createEvent(input: CreateEventInput) {
   const req = new CreateEventReq();
   req.setTitle(input.title);
   req.setContent(input.content);
-  req.setStartTime(Timestamp.fromDate(input.startTime));
-  req.setEndTime(Timestamp.fromDate(input.endTime));
+
+  // FIXME(#8064): Events should be created in their location's timezone
+  req.setStartTime(
+    Timestamp.fromDate(dayjs(input.startTime.toString()).toDate()),
+  );
+  req.setEndTime(Timestamp.fromDate(dayjs(input.endTime.toString()).toDate()));
 
   if (input.photoKey) {
     req.setPhotoKey(input.photoKey);

--- a/app/web/service/requests.ts
+++ b/app/web/service/requests.ts
@@ -1,4 +1,3 @@
-import { Temporal } from "@js-temporal/polyfill";
 import { HostRequestStatus } from "proto/conversations_pb";
 import {
   CreateHostRequestReq,
@@ -14,6 +13,7 @@ import {
   SendHostRequestMessageReq,
   SetHostRequestArchiveStatusReq,
 } from "proto/requests_pb";
+import { Temporal } from "temporal-polyfill";
 
 import client from "./client";
 

--- a/app/web/service/requests.ts
+++ b/app/web/service/requests.ts
@@ -1,4 +1,4 @@
-import { Dayjs } from "dayjs";
+import { Temporal } from "@js-temporal/polyfill";
 import { HostRequestStatus } from "proto/conversations_pb";
 import {
   CreateHostRequestReq,
@@ -106,16 +106,18 @@ export async function getHostRequestMessages(
 export type CreateHostRequestWrapper = Omit<
   Required<CreateHostRequestReq.AsObject>,
   "toDate" | "fromDate" | "publicTripId"
-> & { toDate: Dayjs; fromDate: Dayjs; stayType: number; publicTripId?: number };
+> & {
+  toDate: Temporal.PlainDate;
+  fromDate: Temporal.PlainDate;
+  stayType: number;
+  publicTripId?: number;
+};
 
 export async function createHostRequest(data: CreateHostRequestWrapper) {
   const req = new CreateHostRequestReq();
   req.setHostUserId(data.hostUserId);
-  // Dayjs.format() uses the browser timezone,
-  // which matches the timezone we used to create the
-  // Dayjs object from the year/month/date input fields.
-  req.setFromDate(data.fromDate.format().split("T")[0]);
-  req.setToDate(data.toDate.format().split("T")[0]);
+  req.setFromDate(data.fromDate.toString());
+  req.setToDate(data.toDate.toString());
   req.setText(data.text);
   // Set when this host request is an "offer to host" made in response to a
   // public trip, so the backend links the offer back to the trip.

--- a/app/web/utils/date.test.ts
+++ b/app/web/utils/date.test.ts
@@ -1,15 +1,10 @@
 import {
   getMuiDateFormat,
   getMuiTimeFormat,
-  isSameOrFutureDate,
   localizeDateTime,
   UTC_TIMEZONE,
 } from "utils/date";
 import dayjs from "utils/dayjs";
-
-const FUTURE = dayjs("2025-02-15");
-const PAST = dayjs("1991-10-05");
-const TODAY = dayjs("2021-03-25");
 
 describe("localizeDateTime", () => {
   it("excludes dates when specified", () => {
@@ -222,19 +217,5 @@ describe("getMuiTimeFormat", () => {
 
   it("returns a default value for unsupported locales", () => {
     expect(getMuiTimeFormat("xx")).toEqual("HH:mm");
-  });
-});
-
-describe("isSameOrFutureDate", () => {
-  it("returns true when is same date", () => {
-    expect(isSameOrFutureDate(TODAY, TODAY)).toEqual(true);
-  });
-
-  it("returns true when date is in future", () => {
-    expect(isSameOrFutureDate(FUTURE, TODAY)).toEqual(true);
-  });
-
-  it("returns false when second date is in past", () => {
-    expect(isSameOrFutureDate(PAST, TODAY)).toEqual(false);
   });
 });

--- a/app/web/utils/date.ts
+++ b/app/web/utils/date.ts
@@ -1,7 +1,7 @@
 // format a date
 import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
 
-import daysjs, { Dayjs } from "./dayjs";
+import dayjs, { Dayjs } from "./dayjs";
 import { dayMillis } from "./timeAgo";
 
 // Creating Intl.Segmenter every time is slow, so cache one per locale.
@@ -61,7 +61,7 @@ export function localizeDateTime(
   date: Date | Dayjs,
   args: LocalizeDateTimeParams,
 ): string {
-  if (daysjs.isDayjs(date)) {
+  if (dayjs.isDayjs(date)) {
     date = date.toDate();
   }
   const format = getIntlDateTimeFormat(args);
@@ -97,10 +97,10 @@ export function localizeDateTimeRange(
   end: Date | Dayjs,
   args: LocalizeDateTimeParams,
 ): string {
-  if (daysjs.isDayjs(start)) {
+  if (dayjs.isDayjs(start)) {
     start = start.toDate();
   }
-  if (daysjs.isDayjs(end)) {
+  if (dayjs.isDayjs(end)) {
     end = end.toDate();
   }
   const format = getIntlDateTimeFormat(args);
@@ -167,7 +167,7 @@ export function localizeMonthAbbreviation(
     capitalize?: boolean;
   },
 ): string {
-  if (daysjs.isDayjs(date)) {
+  if (dayjs.isDayjs(date)) {
     date = date.toDate();
   }
   const cacheKey = JSON.stringify(args, (_, v) =>
@@ -259,19 +259,6 @@ function timestamp2Date(timestamp: Timestamp.AsObject): Date {
   return new Date(Math.floor(timestamp.seconds * 1e3 + timestamp.nanos / 1e6));
 }
 
-function isSameDate(date1: Dayjs, date2: Dayjs): boolean {
-  return (
-    date1.month() === date2.month() &&
-    date1.year() === date2.year() &&
-    date1.date() === date2.date()
-  );
-}
-
-/** Compares whether date1 is equal to or in the future of date2 */
-function isSameOrFutureDate(date1: Dayjs, date2: Dayjs): boolean {
-  return isSameDate(date1, date2) || date1.isAfter(date2);
-}
-
 /// Localizes a number of days as a relative time string (e.g. "today", "tomorrow", "in 3 days").
 export function localizeRelativeDays(days: number, locale: string): string {
   return new Intl.RelativeTimeFormat(locale, { numeric: "auto" }).format(
@@ -280,4 +267,4 @@ export function localizeRelativeDays(days: number, locale: string): string {
   );
 }
 
-export { isSameOrFutureDate, numNights, timestamp2Date };
+export { numNights, timestamp2Date };

--- a/app/web/yarn.lock
+++ b/app/web/yarn.lock
@@ -994,6 +994,13 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@js-temporal/polyfill@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@js-temporal/polyfill/-/polyfill-0.5.1.tgz#c9726fdb7fbdbc6419292ba94294b10a08852c32"
+  integrity sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==
+  dependencies:
+    jsbi "^4.3.0"
+
 "@mapbox/jsonlint-lines-primitives@^2.0.2", "@mapbox/jsonlint-lines-primitives@~2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz#ce56e539f83552b58d10d672ea4d6fc9adc7b234"
@@ -6272,6 +6279,11 @@ js-yaml@^4.1.0:
   integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
   dependencies:
     argparse "^2.0.1"
+
+jsbi@^4.3.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-4.3.2.tgz#8a4d05d4e09907d73042135b6aa55a6d161ee955"
+  integrity sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==
 
 jsdom@^20.0.0:
   version "20.0.3"

--- a/app/web/yarn.lock
+++ b/app/web/yarn.lock
@@ -994,13 +994,6 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@js-temporal/polyfill@^0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@js-temporal/polyfill/-/polyfill-0.5.1.tgz#c9726fdb7fbdbc6419292ba94294b10a08852c32"
-  integrity sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==
-  dependencies:
-    jsbi "^4.3.0"
-
 "@mapbox/jsonlint-lines-primitives@^2.0.2", "@mapbox/jsonlint-lines-primitives@~2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz#ce56e539f83552b58d10d672ea4d6fc9adc7b234"
@@ -6280,11 +6273,6 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-jsbi@^4.3.0:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-4.3.2.tgz#8a4d05d4e09907d73042135b6aa55a6d161ee955"
-  integrity sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==
-
 jsdom@^20.0.0:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-20.0.3.tgz#886a41ba1d4726f67a8858028c99489fed6ad4db"
@@ -8417,6 +8405,24 @@ symbol-tree@^3.2.4:
   integrity sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==
   dependencies:
     "@pkgr/core" "^0.2.9"
+
+temporal-polyfill@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/temporal-polyfill/-/temporal-polyfill-1.0.1.tgz#95677df8fa5671a798e8aab3b58f459491880d9f"
+  integrity sha512-N2SoI9olnW7BUsU8RosDphZQl9s+WJ8O7PoJMFCr/e5/1rFkVI4GNOWaSeySG+UoP04foPYsnLWbJmbXOiShZg==
+  dependencies:
+    temporal-spec "1.0.0"
+    temporal-utils "1.0.1"
+
+temporal-spec@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/temporal-spec/-/temporal-spec-1.0.0.tgz#81ea77940b009a7759fd21f447dc0f2b7547c1ca"
+  integrity sha512-00Ahj1e1ifaERTMOIIGpOCdOo9IEk2m6GGSMedsn9a2SIsGLdOTbmME1Htv6IM82b6VHrzSUTIVc7YHy6hdhFQ==
+
+temporal-utils@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/temporal-utils/-/temporal-utils-1.0.1.tgz#faf276e216512ccd1575a4705a58d73a091aeb82"
+  integrity sha512-HAixuesxFQIUaQk3ptX2jhfO/FsOkgVkDDMawvp6n/fkB1q6BKfs3lURw9I+pK/2e2e/q/vrLrxmeqauBoyGMQ==
 
 test-exclude@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Switches most date and time representations to `Temporal.PlainDate/Time` APIs, made available by polyfill, including making our `Datepicker` component use `Temporal.PlainDate` and `Timepicker` use `Temporal.PlainTime` (while internally converting to Dayjs due to MUI requirements).

`Dayjs` objects are problematic because 1. they implicitly use the browser timezone, 2. are not meant to represent date-only or time-only values (timezone agnostic), 3. can represent invalid values. This trickiness lead our events to have incorrect times, and is also inadequate for birthdates (no intrinsic timezone) or host request (host location timezone).

Using `Temporal.PlainDate/Time` objects clearly calls out where we convert plain date/times into a point in time (Dayjs object), scoping down where timezone complexity can get involved (e.g. comparisons with "now").

This also supports #9218 which switches event creation to using iso8601 datetime strings instead of timestamps.

The Temporal polyfill requires some gymnastics to work with jest's module loading (thanks Claude).

There are a few more places we could advantageously replace `Dayjs` with `Temporal` APIs. I might follow-up after this PR.

## Testing
Updated all tests.

Ran locally and signed up with birthdate, created an event with date, updated an event with date, sent a host request with date. All working fine.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me