### PR TITLE
Backend/emails: Link to terms of service

### DIFF
--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -204,7 +204,7 @@ class APIKeyIssuedEmail(EmailBase):
         builder.quote(self.api_key, markdown=False)
         builder.para(".expiry", {"datetime": loc_context.localize_datetime(self.expiry)})
         builder.para(".usage_warning")
-        builder.para(".policy_warning", { "terms_url": urls.terms_of_service_url() })
+        builder.para(".policy_warning", {"terms_url": urls.terms_of_service_url()})
         return builder.build()
 
     @classmethod

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -204,7 +204,7 @@ class APIKeyIssuedEmail(EmailBase):
         builder.quote(self.api_key, markdown=False)
         builder.para(".expiry", {"datetime": loc_context.localize_datetime(self.expiry)})
         builder.para(".usage_warning")
-        builder.para(".policy_warning")
+        builder.para(".policy_warning", { "terms_url": urls.terms_of_service_url() })
         return builder.build()
 
     @classmethod

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -71,7 +71,7 @@
     "header": "You recently requested an API key for Couchers.org. We've issued you with the following API key:",
     "expiry": "The key expires on <b>{{ datetime }}</b>.",
     "usage_warning": "This API key is unique to your account; do not share it with anyone. It gives complete access to your account, and you are reponsible for any actions taken using this API key.",
-    "policy_warning": "Please remember to abide by our Terms of Service, our Community Guidelines, and other policies while using our APIs. All access is logged and analyzed, and we may terminate your access or account if you abuse the service."
+    "policy_warning": "Please remember to abide by our <a href=\"{{terms_url}}\">Terms of Service</a>, our Community Guidelines, and other policies while using our APIs. All access is logged and analyzed, and we may terminate your access or account if you abuse the service."
   },
   "badges": {
     "added": {

--- a/app/backend/src/couchers/urls.py
+++ b/app/backend/src/couchers/urls.py
@@ -160,3 +160,7 @@ def invite_code_link(*, code: str) -> str:
 
 def postal_verification_link(*, code: str) -> str:
     return f"{config.BASE_URL}/verify-postal?c={code}"
+
+
+def terms_of_service_url() -> str:
+    return f"{config.BASE_URL}/terms"


### PR DESCRIPTION
I'll follow-up separately for the community guideline since the URL is less obvious.

It's backwards compatible to add a string placeholder: existing translated strings will simply not make use of it.

## Testing
Check generated emails linked in this PR. https://02a9ef80--test-artifacts.preview.couchershq.org/emails/index.html

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
