### PR TITLE
Frontend/i18n: Use Temporal in localizeDateTime

### DIFF
--- a/app/web/features/auth/InviteCodesPage.tsx
+++ b/app/web/features/auth/InviteCodesPage.tsx
@@ -164,9 +164,7 @@ export default function InviteCodesPage() {
                         <>
                           {t("global:invites.created_datetime", {
                             datetime: localizeDateTime(
-                              timestampToPlainDateTime(c.created, {
-                                timezone: undefined,
-                              }),
+                              timestampToPlainDateTime(c.created),
                               {
                                 locale: locale,
                                 abbreviate: true,
@@ -180,9 +178,7 @@ export default function InviteCodesPage() {
                           {" • "}
                           {t("global:invites.disabled_datetime", {
                             datetime: localizeDateTime(
-                              timestampToPlainDateTime(c.disabled, {
-                                timezone: undefined,
-                              }),
+                              timestampToPlainDateTime(c.disabled),
                               {
                                 locale,
                                 abbreviate: true,

--- a/app/web/features/auth/InviteCodesPage.tsx
+++ b/app/web/features/auth/InviteCodesPage.tsx
@@ -19,7 +19,7 @@ import { ListInviteCodesRes } from "proto/account_pb";
 import React from "react";
 import { inviteRoute } from "routes";
 import { service } from "service";
-import { localizeDateTime } from "utils/date";
+import { localizeDateTime, timestampToPlainDateTime } from "utils/date";
 
 import { inviteCodesKey } from "../queryKeys";
 
@@ -164,7 +164,9 @@ export default function InviteCodesPage() {
                         <>
                           {t("global:invites.created_datetime", {
                             datetime: localizeDateTime(
-                              new Date(c.created.seconds * 1000),
+                              timestampToPlainDateTime(c.created, {
+                                timezone: undefined,
+                              }),
                               {
                                 locale: locale,
                                 abbreviate: true,
@@ -178,7 +180,9 @@ export default function InviteCodesPage() {
                           {" • "}
                           {t("global:invites.disabled_datetime", {
                             datetime: localizeDateTime(
-                              new Date(c.disabled.seconds * 1000),
+                              timestampToPlainDateTime(c.disabled, {
+                                timezone: undefined,
+                              }),
                               {
                                 locale,
                                 abbreviate: true,

--- a/app/web/features/auth/jail/ModNoteCard.tsx
+++ b/app/web/features/auth/jail/ModNoteCard.tsx
@@ -34,7 +34,7 @@ export default function ModNoteCard({ note, updateJailed }: ModNoteCardProps) {
   const [loading, setLoading] = useState(false);
 
   const formattedTime = localizeDateTime(
-    timestampToPlainDateTime(note.created!, { timezone: undefined }),
+    timestampToPlainDateTime(note.created!),
     {
       locale,
       abbreviate: true,

--- a/app/web/features/auth/jail/ModNoteCard.tsx
+++ b/app/web/features/auth/jail/ModNoteCard.tsx
@@ -7,7 +7,7 @@ import { ModNote } from "proto/account_pb";
 import { useState } from "react";
 import { service } from "service";
 import { theme } from "theme";
-import { localizeDateTime, timestamp2Date } from "utils/date";
+import { localizeDateTime, timestampToPlainDateTime } from "utils/date";
 
 const StyledNoteContainer = styled("div")(() => ({
   marginBottom: theme.spacing(4),
@@ -33,10 +33,13 @@ export default function ModNoteCard({ note, updateJailed }: ModNoteCardProps) {
   const [acknowledged, setAcknowledged] = useState(false);
   const [loading, setLoading] = useState(false);
 
-  const formattedTime = localizeDateTime(timestamp2Date(note.created!), {
-    locale,
-    abbreviate: true,
-  });
+  const formattedTime = localizeDateTime(
+    timestampToPlainDateTime(note.created!, { timezone: undefined }),
+    {
+      locale,
+      abbreviate: true,
+    },
+  );
 
   const acknowledge = async () => {
     setLoading(true);

--- a/app/web/features/auth/logins/LoginCard.tsx
+++ b/app/web/features/auth/logins/LoginCard.tsx
@@ -21,7 +21,11 @@ import { AUTH, GLOBAL } from "i18n/namespaces";
 import { useTranslation } from "next-i18next";
 import { ActiveSession } from "proto/account_pb";
 import { service } from "service";
-import { localizeDateTime, timestamp2Date } from "utils/date";
+import {
+  localizeDateTime,
+  timestamp2Date,
+  timestampToPlainDateTime,
+} from "utils/date";
 import { timeAgo } from "utils/timeAgo";
 
 const StyledCard = styled(Card)(({ theme }) => ({
@@ -44,16 +48,22 @@ export default function LoginsPage({
     t,
     locale,
   });
-  const createdDisplay = localizeDateTime(timestamp2Date(session.created!), {
-    locale,
-    includeSeconds: true,
-    abbreviate: true,
-  });
-  const expiryDisplay = localizeDateTime(timestamp2Date(session.expiry!), {
-    locale,
-    includeTime: false,
-    abbreviate: true,
-  });
+  const createdDisplay = localizeDateTime(
+    timestampToPlainDateTime(session.created!, { timezone: undefined }),
+    {
+      locale,
+      includeSeconds: true,
+      abbreviate: true,
+    },
+  );
+  const expiryDisplay = localizeDateTime(
+    timestampToPlainDateTime(session.expiry!, { timezone: undefined }),
+    {
+      locale,
+      includeTime: false,
+      abbreviate: true,
+    },
+  );
   const queryClient = useQueryClient();
 
   const {

--- a/app/web/features/auth/logins/LoginCard.tsx
+++ b/app/web/features/auth/logins/LoginCard.tsx
@@ -49,7 +49,7 @@ export default function LoginsPage({
     locale,
   });
   const createdDisplay = localizeDateTime(
-    timestampToPlainDateTime(session.created!, { timezone: undefined }),
+    timestampToPlainDateTime(session.created!),
     {
       locale,
       includeSeconds: true,
@@ -57,7 +57,7 @@ export default function LoginsPage({
     },
   );
   const expiryDisplay = localizeDateTime(
-    timestampToPlainDateTime(session.expiry!, { timezone: undefined }),
+    timestampToPlainDateTime(session.expiry!),
     {
       locale,
       includeTime: false,

--- a/app/web/features/auth/timezone/Timezone.tsx
+++ b/app/web/features/auth/timezone/Timezone.tsx
@@ -1,8 +1,8 @@
 import { Typography } from "@mui/material";
 import { Trans, useTranslation } from "i18n";
 import { AUTH } from "i18n/namespaces";
+import { Temporal } from "temporal-polyfill";
 import { localizeDateTime } from "utils/date";
-import dayjs from "utils/dayjs";
 
 interface TimezoneProps {
   className?: string;
@@ -24,27 +24,18 @@ export default function Timezone({ className, timezone }: TimezoneProps) {
         <Trans
           t={t}
           i18nKey="account_settings_page.timezone_section.description"
+          components={{
+            1: <strong />,
+            4: <strong />,
+          }}
           values={{
             timezone: timezone,
-            time: localizeDateTime(dayjs(), {
-              timezone,
+            time: localizeDateTime(Temporal.Now.plainDateTimeISO(timezone), {
               locale,
               includeDate: false,
             }),
           }}
-        >
-          {`Your timezone is `}
-          <strong>{timezone}</strong>. Based on this, your local time is
-          approximately{` `}
-          <strong>
-            {localizeDateTime(dayjs(), {
-              timezone,
-              locale,
-              includeDate: false,
-            })}
-          </strong>
-          {`.`}
-        </Trans>
+        />
       </Typography>
       <Typography variant="body1">
         {t("account_settings_page.timezone_section.explanation")}

--- a/app/web/features/communities/discussions/DiscussionPage.tsx
+++ b/app/web/features/communities/discussions/DiscussionPage.tsx
@@ -293,7 +293,6 @@ export default function DiscussionPage({
                                   dateOnly: localizeDateTime(
                                     timestampToPlainDateTime(
                                       discussion.created!,
-                                      { timezone: undefined },
                                     ),
                                     {
                                       locale,

--- a/app/web/features/communities/discussions/DiscussionPage.tsx
+++ b/app/web/features/communities/discussions/DiscussionPage.tsx
@@ -24,7 +24,11 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { service } from "service";
 import { theme } from "theme";
-import { localizeDateTime, timestamp2Date } from "utils/date";
+import {
+  localizeDateTime,
+  timestamp2Date,
+  timestampToPlainDateTime,
+} from "utils/date";
 import { timeAgo } from "utils/timeAgo";
 
 import { sendNativeBack, useIsNativeEmbed } from "../../../utils/nativeLink";
@@ -287,7 +291,10 @@ export default function DiscussionPage({
                               <Typography variant="body2">
                                 {t("communities:discussion_creation_date", {
                                   dateOnly: localizeDateTime(
-                                    timestamp2Date(discussion.created!),
+                                    timestampToPlainDateTime(
+                                      discussion.created!,
+                                      { timezone: undefined },
+                                    ),
                                     {
                                       locale,
                                       includeTime: false,

--- a/app/web/features/communities/events/EventCard.tsx
+++ b/app/web/features/communities/events/EventCard.tsx
@@ -129,8 +129,8 @@ export default function EventCard({ event, className }: EventCardProps) {
 
   const dateTimeRangeText = localizeDateTimeRange(
     // TODO(#8064): Should use the event.timezone, but it's currently incorrect.
-    timestampToPlainDateTime(event.startTime!, { timezone: undefined }),
-    timestampToPlainDateTime(event.endTime!, { timezone: undefined }),
+    timestampToPlainDateTime(event.startTime!),
+    timestampToPlainDateTime(event.endTime!),
     {
       locale,
       includeDayOfWeek: true,

--- a/app/web/features/communities/events/EventCard.tsx
+++ b/app/web/features/communities/events/EventCard.tsx
@@ -16,12 +16,7 @@ import Link from "next/link";
 import { Event } from "proto/events_pb";
 import { useMemo } from "react";
 import { routeToEvent } from "routes";
-import {
-  BROWSER_TIMEZONE,
-  localizeDateTimeRange,
-  timestamp2Date,
-} from "utils/date";
-import dayjs from "utils/dayjs";
+import { localizeDateTimeRange, timestampToPlainDateTime } from "utils/date";
 import stripMarkdown from "utils/stripMarkdown";
 
 const StyledCard = styled(Card, {
@@ -133,11 +128,10 @@ export default function EventCard({ event, className }: EventCardProps) {
   } = useTranslation([COMMUNITIES]);
 
   const dateTimeRangeText = localizeDateTimeRange(
-    dayjs(timestamp2Date(event.startTime!)),
-    dayjs(timestamp2Date(event.endTime!)),
+    // TODO(#8064): Should use the event.timezone, but it's currently incorrect.
+    timestampToPlainDateTime(event.startTime!, { timezone: undefined }),
+    timestampToPlainDateTime(event.endTime!, { timezone: undefined }),
     {
-      // TODO(#8064): Should use the event.timezone, but it's currently incorrect.
-      timezone: BROWSER_TIMEZONE,
       locale,
       includeDayOfWeek: true,
       abbreviate: true,

--- a/app/web/features/communities/events/EventPage.tsx
+++ b/app/web/features/communities/events/EventPage.tsx
@@ -412,12 +412,8 @@ export default function EventPage({
                 <Typography variant="body1">
                   {localizeDateTimeRange(
                     // TODO(#8064): Should use the event.timezone, but it's currently incorrect.
-                    timestampToPlainDateTime(event.startTime!, {
-                      timezone: undefined,
-                    }),
-                    timestampToPlainDateTime(event.endTime!, {
-                      timezone: undefined,
-                    }),
+                    timestampToPlainDateTime(event.startTime!),
+                    timestampToPlainDateTime(event.endTime!),
                     {
                       locale,
                       includeDayOfWeek: true,

--- a/app/web/features/communities/events/EventPage.tsx
+++ b/app/web/features/communities/events/EventPage.tsx
@@ -34,9 +34,9 @@ import {
 import { service } from "service";
 import { theme } from "theme";
 import {
-  BROWSER_TIMEZONE,
   localizeDateTimeRange,
   timestamp2Date,
+  timestampToPlainDateTime,
 } from "utils/date";
 import dayjs from "utils/dayjs";
 import { sendNativeBack, useIsNativeEmbed } from "utils/nativeLink";
@@ -411,11 +411,14 @@ export default function EventPage({
                 <StyledCalendarIcon />
                 <Typography variant="body1">
                   {localizeDateTimeRange(
-                    dayjs(timestamp2Date(event.startTime!)),
-                    dayjs(timestamp2Date(event.endTime!)),
+                    // TODO(#8064): Should use the event.timezone, but it's currently incorrect.
+                    timestampToPlainDateTime(event.startTime!, {
+                      timezone: undefined,
+                    }),
+                    timestampToPlainDateTime(event.endTime!, {
+                      timezone: undefined,
+                    }),
                     {
-                      // TODO(#8064): Should use the event.timezone, but it's currently incorrect.
-                      timezone: BROWSER_TIMEZONE,
                       locale,
                       includeDayOfWeek: true,
                       capitalize: true,

--- a/app/web/features/communities/events/EventTimeChanger.tsx
+++ b/app/web/features/communities/events/EventTimeChanger.tsx
@@ -43,10 +43,10 @@ export default function EventTimeChanger({
 
   // FIXME(#8064): Event times should be interpreted in their timezones.
   const defaultStartDateTime = event?.startTime
-    ? timestampToPlainDateTime(event.startTime, { timezone: undefined })
+    ? timestampToPlainDateTime(event.startTime)
     : undefined;
   const defaultEndDateTime = event?.endTime
-    ? timestampToPlainDateTime(event.endTime, { timezone: undefined })
+    ? timestampToPlainDateTime(event.endTime)
     : undefined;
 
   const handleStartDateChange = (value: Temporal.PlainDate) => {

--- a/app/web/features/communities/events/EventTimeChanger.tsx
+++ b/app/web/features/communities/events/EventTimeChanger.tsx
@@ -1,14 +1,13 @@
 import { styled } from "@mui/material";
 import Datepicker from "components/Datepicker";
 import Timepicker from "components/Timepicker";
-import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
 import { useTranslation } from "i18n";
 import { COMMUNITIES } from "i18n/namespaces";
 import { Event } from "proto/events_pb";
 import { UseFormReturn } from "react-hook-form";
 import { Temporal } from "temporal-polyfill";
 import { theme } from "theme";
-import { timestamp2Date } from "utils/date";
+import { timestampToPlainDateTime } from "utils/date";
 import { timePattern } from "utils/validation";
 
 import { CreateEventData } from "./EventForm";
@@ -32,16 +31,6 @@ interface EventTimeChangerProps
   errors: UseFormReturn<CreateEventData>["formState"]["errors"];
 }
 
-function toPlainDateTime(
-  timestamp: Timestamp.AsObject,
-): Temporal.PlainDateTime {
-  const legacyDate = timestamp2Date(timestamp);
-  const instant = Temporal.Instant.fromEpochMilliseconds(legacyDate.getTime());
-  // FIXME(#8064): Event times should be interpreted in their timezones.
-  const zoned = instant.toZonedDateTimeISO(Temporal.Now.timeZoneId());
-  return zoned.toPlainDateTime();
-}
-
 export default function EventTimeChanger({
   control,
   dirtyFields,
@@ -52,11 +41,12 @@ export default function EventTimeChanger({
 }: EventTimeChangerProps) {
   const { t } = useTranslation([COMMUNITIES]);
 
+  // FIXME(#8064): Event times should be interpreted in their timezones.
   const defaultStartDateTime = event?.startTime
-    ? toPlainDateTime(event.startTime)
+    ? timestampToPlainDateTime(event.startTime, { timezone: undefined })
     : undefined;
   const defaultEndDateTime = event?.endTime
-    ? toPlainDateTime(event.endTime)
+    ? timestampToPlainDateTime(event.endTime, { timezone: undefined })
     : undefined;
 
   const handleStartDateChange = (value: Temporal.PlainDate) => {

--- a/app/web/features/communities/events/LongEventCard.tsx
+++ b/app/web/features/communities/events/LongEventCard.tsx
@@ -133,8 +133,8 @@ const LongEventCard = ({
 
   const dateTimeRangeText = localizeDateTimeRange(
     // TODO(#8064): Should use the event.timezone, but it's currently incorrect.
-    timestampToPlainDateTime(event.startTime!, { timezone: undefined }),
-    timestampToPlainDateTime(event.endTime!, { timezone: undefined }),
+    timestampToPlainDateTime(event.startTime!),
+    timestampToPlainDateTime(event.endTime!),
     {
       locale,
       includeDayOfWeek: true,

--- a/app/web/features/communities/events/LongEventCard.tsx
+++ b/app/web/features/communities/events/LongEventCard.tsx
@@ -15,12 +15,7 @@ import { COMMUNITIES } from "i18n/namespaces";
 import Link from "next/link";
 import { Event } from "proto/events_pb";
 import { routeToEvent } from "routes";
-import {
-  BROWSER_TIMEZONE,
-  localizeDateTimeRange,
-  timestamp2Date,
-} from "utils/date";
-import dayjs from "utils/dayjs";
+import { localizeDateTimeRange, timestampToPlainDateTime } from "utils/date";
 
 const StyledCard = styled(Card)(({ theme }) => ({
   margin: 0,
@@ -137,11 +132,10 @@ const LongEventCard = ({
   } = useTranslation([COMMUNITIES]);
 
   const dateTimeRangeText = localizeDateTimeRange(
-    dayjs(timestamp2Date(event.startTime!)),
-    dayjs(timestamp2Date(event.endTime!)),
+    // TODO(#8064): Should use the event.timezone, but it's currently incorrect.
+    timestampToPlainDateTime(event.startTime!, { timezone: undefined }),
+    timestampToPlainDateTime(event.endTime!, { timezone: undefined }),
     {
-      // TODO(#8064): Should use the event.timezone, but it's currently incorrect.
-      timezone: BROWSER_TIMEZONE,
       locale,
       includeDayOfWeek: true,
       includeTime: true,

--- a/app/web/features/dashboard/DashboardPublicTripCard.tsx
+++ b/app/web/features/dashboard/DashboardPublicTripCard.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "i18n";
 import { DASHBOARD, PUBLIC_TRIPS } from "i18n/namespaces";
 import Link from "next/link";
 import { myPublicTripsRoute, routeToCommunity } from "routes";
+import { Temporal } from "temporal-polyfill";
 import { localizeDateTimeRange, localizeRelativeDays } from "utils/date";
 import dayjs from "utils/dayjs";
 
@@ -202,8 +203,8 @@ export function DashboardPublicTripCard({
   );
 
   const dateRange = localizeDateTimeRange(
-    new Date(trip.fromDate + "T00:00:00"),
-    new Date(trip.toDate + "T00:00:00"),
+    Temporal.PlainDateTime.from(trip.fromDate),
+    Temporal.PlainDateTime.from(trip.toDate),
     { locale, includeTime: false, abbreviate: true },
   );
 

--- a/app/web/features/dashboard/EventListRow.tsx
+++ b/app/web/features/dashboard/EventListRow.tsx
@@ -173,11 +173,9 @@ export default function EventListRow({ event }: EventListRowProps) {
   } = useTranslation([DASHBOARD]);
 
   const now = Temporal.Now.plainDateTimeISO();
-  const startDate = timestampToPlainDateTime(event.startTime!, {
-    timezone: undefined,
-  });
+  const startDate = timestampToPlainDateTime(event.startTime!);
   const endDate = event.endTime
-    ? timestampToPlainDateTime(event.endTime, { timezone: undefined })
+    ? timestampToPlainDateTime(event.endTime)
     : null;
   const isOngoing =
     endDate !== null &&

--- a/app/web/features/dashboard/EventListRow.tsx
+++ b/app/web/features/dashboard/EventListRow.tsx
@@ -5,11 +5,11 @@ import { DASHBOARD } from "i18n/namespaces";
 import Link from "next/link";
 import { Event } from "proto/events_pb";
 import { routeToEvent } from "routes";
+import { Temporal } from "temporal-polyfill";
 import {
-  BROWSER_TIMEZONE,
   localizeDateTime,
   localizeMonthAbbreviation,
-  timestamp2Date,
+  timestampToPlainDateTime,
 } from "utils/date";
 
 export const EventListContainer = styled("div")({
@@ -172,26 +172,31 @@ export default function EventListRow({ event }: EventListRowProps) {
     i18n: { language: locale },
   } = useTranslation([DASHBOARD]);
 
-  const now = new Date();
-  const startDate = timestamp2Date(event.startTime!);
-  const endDate = event.endTime ? timestamp2Date(event.endTime) : null;
-  const isOngoing = endDate !== null && startDate <= now && endDate >= now;
-  const isToday = !isOngoing && startDate.toDateString() === now.toDateString();
+  const now = Temporal.Now.plainDateTimeISO();
+  const startDate = timestampToPlainDateTime(event.startTime!, {
+    timezone: undefined,
+  });
+  const endDate = event.endTime
+    ? timestampToPlainDateTime(event.endTime, { timezone: undefined })
+    : null;
+  const isOngoing =
+    endDate !== null &&
+    Temporal.PlainDateTime.compare(startDate, now) <= 0 &&
+    Temporal.PlainDateTime.compare(endDate, now) >= 0;
+  const isToday = !isOngoing && startDate.toPlainDate() === now.toPlainDate();
   const todayLabel = t("dashboard:events.today_label");
   const nowLabel = t("dashboard:now_label");
   const chipLabel = isOngoing ? nowLabel : todayLabel;
   const chipFontSize =
     chipLabel.length <= 5 ? 9 : chipLabel.length <= 7 ? 8 : 7;
-  const month = localizeMonthAbbreviation(startDate, {
+  const month = localizeMonthAbbreviation(startDate.toPlainDate(), {
     locale,
-    timezone: BROWSER_TIMEZONE,
     capitalize: true,
   });
-  const day = startDate.getDate();
+  const day = startDate.day;
 
   const timeStr = localizeDateTime(startDate, {
     locale,
-    timezone: BROWSER_TIMEZONE,
     includeDate: false,
     includeTime: true,
   });

--- a/app/web/features/dashboard/UpcomingStayCard.tsx
+++ b/app/web/features/dashboard/UpcomingStayCard.tsx
@@ -10,6 +10,7 @@ import { DASHBOARD } from "i18n/namespaces";
 import Link from "next/link";
 import { HostRequest } from "proto/requests_pb";
 import { routeToHostRequest } from "routes";
+import { Temporal } from "temporal-polyfill";
 import {
   localizeDateTimeRange,
   localizeRelativeDays,
@@ -156,12 +157,15 @@ export default function UpcomingStayCard({
     return label.charAt(0).toUpperCase() + label.slice(1);
   })();
 
-  const dateRange = localizeDateTimeRange(fromDate, toDate, {
-    timezone: UTC_TIMEZONE,
-    locale,
-    includeTime: false,
-    abbreviate: true,
-  });
+  const dateRange = localizeDateTimeRange(
+    Temporal.PlainDateTime.from(hostRequest.fromDate),
+    Temporal.PlainDateTime.from(hostRequest.toDate),
+    {
+      locale,
+      includeTime: false,
+      abbreviate: true,
+    },
+  );
 
   const primary = isLoading ? (
     <Skeleton width={80} />

--- a/app/web/features/messages/requests/HostRequestListItem.tsx
+++ b/app/web/features/messages/requests/HostRequestListItem.tsx
@@ -30,8 +30,9 @@ import { MESSAGES } from "i18n/namespaces";
 import { HostRequest } from "proto/requests_pb";
 import React, { useState } from "react";
 import { service } from "service";
+import { Temporal } from "temporal-polyfill";
 import { theme } from "theme";
-import { localizeDateTimeRange, UTC_TIMEZONE } from "utils/date";
+import { localizeDateTimeRange } from "utils/date";
 import dayjs from "utils/dayjs";
 import { firstName } from "utils/names";
 
@@ -238,12 +239,9 @@ export default function HostRequestListItem({
               <StyledDateAndBadgeContainer>
                 <Typography component="div" display="inline" variant="h3">
                   {localizeDateTimeRange(
-                    // Host request are plain dates (no time),
-                    // just make sure to parse and format them in the same timezone.
-                    dayjs.tz(hostRequest.fromDate, UTC_TIMEZONE),
-                    dayjs.tz(hostRequest.toDate, UTC_TIMEZONE),
+                    Temporal.PlainDateTime.from(hostRequest.fromDate),
+                    Temporal.PlainDateTime.from(hostRequest.toDate),
                     {
-                      timezone: UTC_TIMEZONE,
                       locale,
                       includeTime: false,
                     },

--- a/app/web/features/messages/requests/HostRequestUserSummarySection.tsx
+++ b/app/web/features/messages/requests/HostRequestUserSummarySection.tsx
@@ -11,9 +11,9 @@ import { useTranslation } from "i18n";
 import { MESSAGES } from "i18n/namespaces";
 import { LiteUser } from "proto/api_pb";
 import { HostRequest } from "proto/requests_pb";
+import { Temporal } from "temporal-polyfill";
 import { theme } from "theme";
-import { localizeDateTimeRange, numNights, UTC_TIMEZONE } from "utils/date";
-import dayjs from "utils/dayjs";
+import { localizeDateTimeRange, numNights } from "utils/date";
 import truncateTextEllipsis from "utils/truncateTextEllipsis";
 
 const StyledRequestedDatesWrapper = styled("div")(({ theme }) => ({
@@ -96,12 +96,9 @@ const HostRequestUserSummarySection = ({
             sx={{ paddingRight: theme.spacing(1) }}
           >
             {localizeDateTimeRange(
-              // Host request are plain dates (no time),
-              // just make sure to parse and format them in the same timezone.
-              dayjs.tz(hostRequest.fromDate, UTC_TIMEZONE),
-              dayjs.tz(hostRequest.toDate, UTC_TIMEZONE),
+              Temporal.PlainDateTime.from(hostRequest.fromDate),
+              Temporal.PlainDateTime.from(hostRequest.toDate),
               {
-                timezone: UTC_TIMEZONE,
                 locale,
                 includeTime: false,
                 abbreviate: true,
@@ -124,12 +121,9 @@ const HostRequestUserSummarySection = ({
               sx={{ paddingRight: theme.spacing(1) }}
             >
               {localizeDateTimeRange(
-                // Host request are plain dates (no time),
-                // just make sure to parse and format them in the same timezone.
-                dayjs.tz(hostRequest.fromDate, UTC_TIMEZONE),
-                dayjs.tz(hostRequest.toDate, UTC_TIMEZONE),
+                Temporal.PlainDateTime.from(hostRequest.fromDate),
+                Temporal.PlainDateTime.from(hostRequest.toDate),
                 {
-                  timezone: UTC_TIMEZONE,
                   locale,
                   includeTime: false,
                 },

--- a/app/web/features/profile/view/ReferenceListItem.tsx
+++ b/app/web/features/profile/view/ReferenceListItem.tsx
@@ -7,7 +7,7 @@ import { COMMUNITIES, GLOBAL } from "i18n/namespaces";
 import { useTranslation } from "next-i18next";
 import { LiteUser } from "proto/api_pb";
 import { Reference } from "proto/references_pb";
-import { localizeYearMonth, timestamp2Date } from "utils/date";
+import { localizeYearMonth, timestampToPlainDateTime } from "utils/date";
 
 export const REFERENCE_LIST_ITEM_TEST_ID = "reference-list-item";
 
@@ -63,11 +63,16 @@ export default function ReferenceListItem({
           )}
           {reference.writtenTime && (
             <Pill variant="rounded">
-              {localizeYearMonth(timestamp2Date(reference.writtenTime), {
-                locale,
-                abbreviate: true,
-                capitalize: true,
-              })}
+              {localizeYearMonth(
+                timestampToPlainDateTime(reference.writtenTime, {
+                  timezone: undefined,
+                }).toPlainDate(),
+                {
+                  locale,
+                  abbreviate: true,
+                  capitalize: true,
+                },
+              )}
             </Pill>
           )}
         </StyledBadgesContainer>

--- a/app/web/features/profile/view/ReferenceListItem.tsx
+++ b/app/web/features/profile/view/ReferenceListItem.tsx
@@ -64,9 +64,7 @@ export default function ReferenceListItem({
           {reference.writtenTime && (
             <Pill variant="rounded">
               {localizeYearMonth(
-                timestampToPlainDateTime(reference.writtenTime, {
-                  timezone: undefined,
-                }).toPlainDate(),
+                timestampToPlainDateTime(reference.writtenTime).toPlainDate(),
                 {
                   locale,
                   abbreviate: true,

--- a/app/web/features/profile/view/userLabels.tsx
+++ b/app/web/features/profile/view/userLabels.tsx
@@ -282,9 +282,7 @@ export const RemainingAboutLabels = ({ user }: Props) => {
         text={
           user.joined
             ? localizeYearMonth(
-                timestampToPlainDateTime(user.joined, {
-                  timezone: undefined,
-                }).toPlainDate(),
+                timestampToPlainDateTime(user.joined).toPlainDate(),
                 {
                   locale,
                   abbreviate: true,
@@ -297,9 +295,7 @@ export const RemainingAboutLabels = ({ user }: Props) => {
       <LabelAndText
         label={t("profile:heading.local_time")}
         text={localizeDateTime(
-          Temporal.Now.zonedDateTimeISO(
-            user.timezone || UTC_TIMEZONE,
-          ).toPlainDateTime(),
+          Temporal.Now.plainDateTimeISO(user.timezone || UTC_TIMEZONE),
           {
             locale,
             includeDate: false,

--- a/app/web/features/profile/view/userLabels.tsx
+++ b/app/web/features/profile/view/userLabels.tsx
@@ -9,11 +9,13 @@ import {
   GenderVerificationStatus,
   User,
 } from "proto/api_pb";
+import { Temporal } from "temporal-polyfill";
 import { theme } from "theme";
 import {
   localizeDateTime,
   localizeYearMonth,
   timestamp2Date,
+  timestampToPlainDateTime,
   UTC_TIMEZONE,
 } from "utils/date";
 import dayjs, { i18nToDayjsLocale } from "utils/dayjs";
@@ -279,21 +281,30 @@ export const RemainingAboutLabels = ({ user }: Props) => {
         label={t("profile:heading.joined")}
         text={
           user.joined
-            ? localizeYearMonth(timestamp2Date(user.joined), {
-                locale,
-                abbreviate: true,
-                capitalize: true,
-              })
+            ? localizeYearMonth(
+                timestampToPlainDateTime(user.joined, {
+                  timezone: undefined,
+                }).toPlainDate(),
+                {
+                  locale,
+                  abbreviate: true,
+                  capitalize: true,
+                },
+              )
             : ""
         }
       />
       <LabelAndText
         label={t("profile:heading.local_time")}
-        text={localizeDateTime(dayjs(), {
-          timezone: user.timezone || UTC_TIMEZONE,
-          locale,
-          includeDate: false,
-        })}
+        text={localizeDateTime(
+          Temporal.Now.zonedDateTimeISO(
+            user.timezone || UTC_TIMEZONE,
+          ).toPlainDateTime(),
+          {
+            locale,
+            includeDate: false,
+          },
+        )}
       />
     </>
   );

--- a/app/web/features/publicTrips/PublicTripCard.tsx
+++ b/app/web/features/publicTrips/PublicTripCard.tsx
@@ -353,8 +353,8 @@ export default function PublicTripCard({
               <MetaItem>
                 <CalendarIcon />
                 {localizeDateTimeRange(
-                  new Date(trip.fromDate + "T00:00:00"),
-                  new Date(trip.toDate + "T00:00:00"),
+                  Temporal.PlainDateTime.from(trip.fromDate),
+                  Temporal.PlainDateTime.from(trip.toDate),
                   {
                     locale,
                     includeTime: false,

--- a/app/web/test/fixtures/events.json
+++ b/app/web/test/fixtures/events.json
@@ -30,8 +30,8 @@
     "photoKey": "",
     "photoUrl": "https://loremflickr.com/500/120/amsterdam",
     "slug": "weekly-meetup",
-    "startTime": { "nanos": 732000000, "seconds": 1624934247 },
-    "endTime": { "nanos": 0, "seconds": 1624937847 },
+    "startTime": { "nanos": 0, "seconds": 1624934220 },
+    "endTime": { "nanos": 0, "seconds": 1624937820 },
     "title": "Weekly Meetup",
     "timezone": "Europe/Amsterdam"
   },
@@ -66,7 +66,7 @@
     "photoKey": "",
     "photoUrl": "",
     "slug": "cherry-blossom-bike-ride",
-    "startTime": { "nanos": 0, "seconds": 1625000420 },
+    "startTime": { "nanos": 0, "seconds": 1625000400 },
     "endTime": { "nanos": 0, "seconds": 1625018400 },
     "title": "Cherry Blossom Bike Ride around the entire Amsterdam because I like to write long event titles",
     "timezone": "Europe/Amsterdam"
@@ -102,7 +102,7 @@
     "photoKey": "",
     "photoUrl": "https://loremflickr.com/500/120/amsterdam",
     "slug": "planting-season-meetup",
-    "startTime": { "nanos": 0, "seconds": 1625000420 },
+    "startTime": { "nanos": 0, "seconds": 1625000400 },
     "endTime": { "nanos": 0, "seconds": 1625004020 },
     "title": "Planting Season Meetup",
     "timezone": "Europe/Amsterdam"
@@ -138,7 +138,7 @@
     "photoKey": "",
     "photoUrl": "",
     "slug": "cherry-blossom-bike-ride",
-    "startTime": { "nanos": 0, "seconds": 1625000420 },
+    "startTime": { "nanos": 0, "seconds": 1625000400 },
     "endTime": { "nanos": 0, "seconds": 1625018400 },
     "title": "A cancelled event",
     "timezone": "Europe/Amsterdam"

--- a/app/web/test/fixtures/events.json
+++ b/app/web/test/fixtures/events.json
@@ -30,7 +30,7 @@
     "photoKey": "",
     "photoUrl": "https://loremflickr.com/500/120/amsterdam",
     "slug": "weekly-meetup",
-    "startTime": { "nanos": 0, "seconds": 1624934247.732 },
+    "startTime": { "nanos": 732000000, "seconds": 1624934247 },
     "endTime": { "nanos": 0, "seconds": 1624937847 },
     "title": "Weekly Meetup",
     "timezone": "Europe/Amsterdam"

--- a/app/web/utils/date.test.ts
+++ b/app/web/utils/date.test.ts
@@ -1,22 +1,21 @@
+import { Temporal } from "temporal-polyfill";
 import {
   getMuiDateFormat,
   getMuiTimeFormat,
   localizeDateTime,
-  UTC_TIMEZONE,
 } from "utils/date";
-import dayjs from "utils/dayjs";
+
+const janFirst2000 = Temporal.PlainDateTime.from("2000-01-01");
 
 describe("localizeDateTime", () => {
   it("excludes dates when specified", () => {
     expect(
-      localizeDateTime(dayjs("2000-01-01"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000, {
         locale: "en",
       }),
     ).toContain("2000");
     expect(
-      localizeDateTime(dayjs("2000-01-01"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000, {
         locale: "en",
         includeDate: false,
       }),
@@ -25,14 +24,12 @@ describe("localizeDateTime", () => {
 
   it("honors abbreviated month names", () => {
     expect(
-      localizeDateTime(dayjs("2000-01-01"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000, {
         locale: "en",
       }),
     ).toContain("January");
     expect(
-      localizeDateTime(dayjs("2000-01-01"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000, {
         locale: "en",
         abbreviate: true,
       }),
@@ -41,22 +38,19 @@ describe("localizeDateTime", () => {
 
   it("includes the day of week when specified", () => {
     expect(
-      localizeDateTime(dayjs("2000-01-01"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000, {
         locale: "en",
         includeDayOfWeek: false,
       }),
     ).not.toContain("Sat");
     expect(
-      localizeDateTime(dayjs("2000-01-01"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000, {
         locale: "en",
         includeDayOfWeek: true,
       }),
     ).toContain("Saturday");
     expect(
-      localizeDateTime(dayjs("2000-01-01"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000, {
         locale: "en",
         includeDayOfWeek: true,
         abbreviate: true,
@@ -66,14 +60,12 @@ describe("localizeDateTime", () => {
 
   it("excludes times when specified", () => {
     expect(
-      localizeDateTime(dayjs("2000-01-01").add(11, "hours"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000.add({ hours: 11 }), {
         locale: "en",
       }),
     ).toContain("11");
     expect(
-      localizeDateTime(dayjs("2000-01-01").add(11, "hours"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000.add({ hours: 11 }), {
         locale: "en",
         includeTime: false,
       }),
@@ -82,15 +74,13 @@ describe("localizeDateTime", () => {
 
   it("includes seconds when specified", () => {
     expect(
-      localizeDateTime(dayjs("2000-01-01").add(42, "seconds"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000.add({ seconds: 42 }), {
         locale: "en",
         includeSeconds: false,
       }),
     ).not.toContain("42");
     expect(
-      localizeDateTime(dayjs("2000-01-01").add(42, "seconds"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000.add({ seconds: 42 }), {
         locale: "en",
         includeSeconds: true,
       }),
@@ -99,50 +89,42 @@ describe("localizeDateTime", () => {
 
   it("honors the locale", () => {
     expect(
-      localizeDateTime(dayjs("2000-01-01"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000, {
         locale: "en",
       }),
     ).toContain("January");
     expect(
-      localizeDateTime(dayjs("2000-01-01"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000, {
         locale: "en-US",
       }),
     ).toContain("January");
     expect(
-      localizeDateTime(dayjs("2000-01-01"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000, {
         locale: "es",
       }),
     ).toContain("enero");
     expect(
-      localizeDateTime(dayjs("2000-01-01"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000, {
         locale: "de",
       }),
     ).toContain("Januar");
     expect(
-      localizeDateTime(dayjs("2000-01-01"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000, {
         locale: "pt-BR",
       }),
     ).toContain("janeiro");
     expect(
-      localizeDateTime(dayjs("2000-01-01"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000, {
         locale: "ca",
       }),
     ).toContain("gener");
     expect(
-      localizeDateTime(dayjs("2000-01-01"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000, {
         locale: "zh-Hans",
       }),
     ).toContain("1月");
     expect(
-      localizeDateTime(dayjs("2000-01-01"), {
-        timezone: UTC_TIMEZONE,
+      localizeDateTime(janFirst2000, {
         locale: "zh-Hant",
       }),
     ).toContain("1月");
@@ -150,8 +132,7 @@ describe("localizeDateTime", () => {
 
   it("does not capitalize day/month names by default (assumed mid-sentence)", () => {
     // Spanish weekday + month stay lowercase when the date may be part of a sentence.
-    const formatted = localizeDateTime(dayjs("2000-01-01"), {
-      timezone: UTC_TIMEZONE,
+    const formatted = localizeDateTime(janFirst2000, {
       locale: "es",
       includeDayOfWeek: true,
       includeTime: false,
@@ -161,8 +142,7 @@ describe("localizeDateTime", () => {
   });
 
   it("capitalizes only the first letter when capitalize is set (standalone date)", () => {
-    const formatted = localizeDateTime(dayjs("2000-01-01"), {
-      timezone: UTC_TIMEZONE,
+    const formatted = localizeDateTime(janFirst2000, {
       locale: "es",
       includeDayOfWeek: true,
       includeTime: false,
@@ -175,8 +155,7 @@ describe("localizeDateTime", () => {
 
   it("leaves a non-letter first grapheme unchanged when capitalize is set", () => {
     // Spanish dates without a weekday start with the day number.
-    const formatted = localizeDateTime(dayjs("2000-01-01"), {
-      timezone: UTC_TIMEZONE,
+    const formatted = localizeDateTime(janFirst2000, {
       locale: "es",
       includeTime: false,
       capitalize: true,

--- a/app/web/utils/date.ts
+++ b/app/web/utils/date.ts
@@ -1,7 +1,7 @@
 // format a date
 import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
+import { Temporal } from "temporal-polyfill";
 
-import dayjs, { Dayjs } from "./dayjs";
 import { dayMillis } from "./timeAgo";
 
 // Creating Intl.Segmenter every time is slow, so cache one per locale.
@@ -29,15 +29,22 @@ const numNights = (date1: string, date2: string) => {
   return diffDays;
 };
 
-/// Allow call sites to explicitly reference the browser's timezone (clearer than "undefined").
-export const BROWSER_TIMEZONE: unique symbol = Symbol("browser-timezone");
+/// Converts a Temporal.PlainDate[Time] to a Date, interpreting it in UTC timezone.
+function toUTCDate(
+  temporal: Temporal.PlainDate | Temporal.PlainDateTime,
+): Date {
+  if (temporal instanceof Temporal.PlainDate) {
+    temporal = temporal.toPlainDateTime();
+  }
+  const zoned = temporal.toZonedDateTime("Etc/UTC");
+  return new Date(zoned.epochMilliseconds);
+}
+
 export const UTC_TIMEZONE: string = "Etc/UTC";
 
 interface LocalizeDateTimeParams {
   /// The locale to localize in.
   locale: string;
-  /// The timezone to be used to figure the date components (defaults to the browser's).
-  timezone?: string | typeof BROWSER_TIMEZONE;
   /// Whether to include the date (defaults to true).
   includeDate?: boolean;
   /// If including the date, whether to include the day (defaults to true).
@@ -58,14 +65,11 @@ interface LocalizeDateTimeParams {
 
 /// Localizes a date and time, optionally with the day of the week.
 export function localizeDateTime(
-  date: Date | Dayjs,
+  date: Temporal.PlainDateTime,
   args: LocalizeDateTimeParams,
 ): string {
-  if (dayjs.isDayjs(date)) {
-    date = date.toDate();
-  }
-  const format = getIntlDateTimeFormat(args);
-  const formatted = format.format(date);
+  const format = getIntlDateTimeFormatUTC(args);
+  const formatted = format.format(toUTCDate(date));
   return args.capitalize
     ? capitalizeFirstLetter(formatted, args.locale)
     : formatted;
@@ -73,16 +77,14 @@ export function localizeDateTime(
 
 /// Localizes only the year and month of a date.
 export function localizeYearMonth(
-  date: Date | Dayjs,
+  date: Temporal.PlainDate,
   args: {
-    timezone?: string | typeof BROWSER_TIMEZONE;
     locale: string;
     abbreviate?: boolean;
     capitalize?: boolean;
   },
 ): string {
-  return localizeDateTime(date, {
-    timezone: args.timezone,
+  return localizeDateTime(date.toPlainDateTime(), {
     locale: args.locale,
     abbreviate: args.abbreviate,
     capitalize: args.capitalize,
@@ -93,18 +95,12 @@ export function localizeYearMonth(
 
 /// Localizes a range of date and times as a string.
 export function localizeDateTimeRange(
-  start: Date | Dayjs,
-  end: Date | Dayjs,
+  start: Temporal.PlainDateTime,
+  end: Temporal.PlainDateTime,
   args: LocalizeDateTimeParams,
 ): string {
-  if (dayjs.isDayjs(start)) {
-    start = start.toDate();
-  }
-  if (dayjs.isDayjs(end)) {
-    end = end.toDate();
-  }
-  const format = getIntlDateTimeFormat(args);
-  const formatted = format.formatRange(start, end);
+  const format = getIntlDateTimeFormatUTC(args);
+  const formatted = format.formatRange(toUTCDate(start), toUTCDate(end));
   return args.capitalize
     ? capitalizeFirstLetter(formatted, args.locale)
     : formatted;
@@ -114,7 +110,7 @@ export function localizeDateTimeRange(
 const intlDateTimeFormatCache = new Map<string, Intl.DateTimeFormat>();
 
 /// Gets an Intl.DateTimeFormat based on params.
-function getIntlDateTimeFormat(
+function getIntlDateTimeFormatUTC(
   args: LocalizeDateTimeParams,
 ): Intl.DateTimeFormat {
   // We can't use args as the Map key as it uses reference equality.
@@ -125,13 +121,13 @@ function getIntlDateTimeFormat(
   const cached = intlDateTimeFormatCache.get(cacheKey);
   if (cached) return cached;
 
-  const format = createIntlDateTimeFormat(args);
+  const format = createIntlDateTimeFormatUTC(args);
   intlDateTimeFormatCache.set(cacheKey, format);
   return format;
 }
 
 /// Creates a new Intl.DateTimeFormat object based on params.
-function createIntlDateTimeFormat(
+function createIntlDateTimeFormatUTC(
   args: LocalizeDateTimeParams,
 ): Intl.DateTimeFormat {
   const options: Intl.DateTimeFormatOptions = {};
@@ -152,37 +148,29 @@ function createIntlDateTimeFormat(
       options.second = "numeric";
     }
   }
-  if (args.timezone && args.timezone !== BROWSER_TIMEZONE) {
-    options.timeZone = args.timezone;
-  }
+  options.timeZone = "Etc/UTC";
   return Intl.DateTimeFormat(args.locale, options);
 }
 
 /// Localizes just the abbreviated month name of a date (e.g. "Jan", "Mai" in German).
 export function localizeMonthAbbreviation(
-  date: Date | Dayjs,
+  date: Temporal.PlainDate,
   args: {
     locale: string;
-    timezone?: string | typeof BROWSER_TIMEZONE;
     capitalize?: boolean;
   },
 ): string {
-  if (dayjs.isDayjs(date)) {
-    date = date.toDate();
-  }
   const cacheKey = JSON.stringify(args, (_, v) =>
     typeof v === "symbol" ? v.toString() : v,
   );
   let format = intlDateTimeFormatCache.get(cacheKey);
   if (!format) {
     const options: Intl.DateTimeFormatOptions = { month: "short" };
-    if (args.timezone && args.timezone !== BROWSER_TIMEZONE) {
-      options.timeZone = args.timezone;
-    }
+    options.timeZone = "Etc/UTC";
     format = Intl.DateTimeFormat(args.locale, options);
     intlDateTimeFormatCache.set(cacheKey, format);
   }
-  const formatted = format.format(date);
+  const formatted = format.format(toUTCDate(date));
   return args.capitalize
     ? capitalizeFirstLetter(formatted, args.locale)
     : formatted;
@@ -253,6 +241,34 @@ export function getMuiTimeFormat(locale: string): string {
     format += " a";
   }
   return format;
+}
+
+/// Converts a protobuf Timestamp to a Temporal.Instant value (timezone-agnostic).
+export function timestampToInstant(
+  timestamp: Timestamp.AsObject,
+): Temporal.Instant {
+  const nanos =
+    BigInt(timestamp.nanos) + BigInt(timestamp.seconds) * 1_000_000_000n;
+  return new Temporal.Instant(nanos);
+}
+
+/// Converts a Temporal Instant to a PlainDateTime in the browser's timezone.
+export function instantToPlainDateTime(
+  instant: Temporal.Instant,
+  // Require callers to explicitly specify the timezone or undefined for clarity.
+  options: { timezone: string | undefined },
+): Temporal.PlainDateTime {
+  return instant
+    .toZonedDateTimeISO(options.timezone ?? Temporal.Now.timeZoneId())
+    .toPlainDateTime();
+}
+
+/// Converts a protobuf Timestamp to a PlainDateTime in the browser's timezone.
+export function timestampToPlainDateTime(
+  timestamp: Timestamp.AsObject,
+  options: { timezone: string | undefined },
+): Temporal.PlainDateTime {
+  return instantToPlainDateTime(timestampToInstant(timestamp), options);
 }
 
 function timestamp2Date(timestamp: Timestamp.AsObject): Date {

--- a/app/web/utils/date.ts
+++ b/app/web/utils/date.ts
@@ -247,28 +247,30 @@ export function getMuiTimeFormat(locale: string): string {
 export function timestampToInstant(
   timestamp: Timestamp.AsObject,
 ): Temporal.Instant {
+  // By protobuf, seconds and nanos should be integers.
+  // Just in case, drop decimals otherwise BigInt will blow up.
   const nanos =
-    BigInt(timestamp.nanos) + BigInt(timestamp.seconds) * 1_000_000_000n;
+    BigInt(Math.floor(timestamp.nanos)) +
+    BigInt(Math.floor(timestamp.seconds)) * 1_000_000_000n;
   return new Temporal.Instant(nanos);
 }
 
 /// Converts a Temporal Instant to a PlainDateTime in the browser's timezone.
 export function instantToPlainDateTime(
   instant: Temporal.Instant,
-  // Require callers to explicitly specify the timezone or undefined for clarity.
-  options: { timezone: string | undefined },
+  timezone?: string,
 ): Temporal.PlainDateTime {
   return instant
-    .toZonedDateTimeISO(options.timezone ?? Temporal.Now.timeZoneId())
+    .toZonedDateTimeISO(timezone ?? Temporal.Now.timeZoneId())
     .toPlainDateTime();
 }
 
 /// Converts a protobuf Timestamp to a PlainDateTime in the browser's timezone.
 export function timestampToPlainDateTime(
   timestamp: Timestamp.AsObject,
-  options: { timezone: string | undefined },
+  timezone?: string,
 ): Temporal.PlainDateTime {
-  return instantToPlainDateTime(timestampToInstant(timestamp), options);
+  return instantToPlainDateTime(timestampToInstant(timestamp), timezone);
 }
 
 function timestamp2Date(timestamp: Timestamp.AsObject): Date {


### PR DESCRIPTION
Updates our `localizeDateTime` function and variants to take `Temporal.PlainDateTime` objects, which means timezones become irrelevant at that layer. This decouples locale formatting from timezone logic and removes many uses of `dayjs`.

For example, we can format a hosting start/end date ("YYYY-MM-DD" string) directly instead of having to interpreting it in an arbitrary timezone and then formatting it by specifying the same timezone again (error prone). E.g. we don't need these comments anymore:

I also updated the test events to have times at minute granularity since that's what the backend allows and that's what gets displayed. Besides `1624934247.732` was not a valid `seconds` value; by protobuf it should be an integer.

```js
// Host request are plain dates (no time),
// just make sure to parse and format them in the same timezone.
```

Next up after this merge I'll look at `timeAgo`.

## Testing
Compared Vercel preview with next. Event times are the same, my timezone and local time are the same, another user's local time are the same, host request dates are the same, current login times are the same.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
