### PR TITLE
Revert "Frontend/i18n: Tweak date formatting"

### DIFF
--- a/app/web/features/auth/logins/LoginCard.tsx
+++ b/app/web/features/auth/logins/LoginCard.tsx
@@ -52,14 +52,16 @@ export default function LoginsPage({
     timestampToPlainDateTime(session.created!),
     {
       locale,
-      includeSeconds: true
+      includeSeconds: true,
+      abbreviate: true,
     },
   );
   const expiryDisplay = localizeDateTime(
     timestampToPlainDateTime(session.expiry!),
     {
       locale,
-      includeTime: false
+      includeTime: false,
+      abbreviate: true,
     },
   );
   const queryClient = useQueryClient();

--- a/app/web/features/profile/view/userLabels.tsx
+++ b/app/web/features/profile/view/userLabels.tsx
@@ -285,6 +285,7 @@ export const RemainingAboutLabels = ({ user }: Props) => {
                 timestampToPlainDateTime(user.joined).toPlainDate(),
                 {
                   locale,
+                  abbreviate: true,
                   capitalize: true,
                 },
               )


### PR DESCRIPTION
This reverts commit 18c8993c4b2705d844fdb59a6a3a6a4f4b7c9baa.

I mistakenly pushed to main via github.dev, and it failed validation due to formatting :/. Mea culpa.