### PR TITLE
Frontend/bugfix/tweak date formatting

### DIFF
--- a/app/web/features/auth/logins/LoginCard.tsx
+++ b/app/web/features/auth/logins/LoginCard.tsx
@@ -52,14 +52,14 @@ export default function LoginsPage({
     timestampToPlainDateTime(session.created!),
     {
       locale,
-      includeSeconds: true
+      includeSeconds: true,
     },
   );
   const expiryDisplay = localizeDateTime(
     timestampToPlainDateTime(session.expiry!),
     {
       locale,
-      includeTime: false
+      includeTime: false,
     },
   );
   const queryClient = useQueryClient();

--- a/app/web/features/auth/logins/LoginCard.tsx
+++ b/app/web/features/auth/logins/LoginCard.tsx
@@ -52,16 +52,14 @@ export default function LoginsPage({
     timestampToPlainDateTime(session.created!),
     {
       locale,
-      includeSeconds: true,
-      abbreviate: true,
+      includeSeconds: true
     },
   );
   const expiryDisplay = localizeDateTime(
     timestampToPlainDateTime(session.expiry!),
     {
       locale,
-      includeTime: false,
-      abbreviate: true,
+      includeTime: false
     },
   );
   const queryClient = useQueryClient();

--- a/app/web/features/profile/view/userLabels.tsx
+++ b/app/web/features/profile/view/userLabels.tsx
@@ -285,7 +285,6 @@ export const RemainingAboutLabels = ({ user }: Props) => {
                 timestampToPlainDateTime(user.joined).toPlainDate(),
                 {
                   locale,
-                  abbreviate: true,
                   capitalize: true,
                 },
               )


### PR DESCRIPTION
Minor cosmetic tweak to not abbreviate dates that don't need to be.

## Testing
Compared next and vercel preview:

<img width="697" height="315" alt="image" src="https://github.com/user-attachments/assets/6abb62ee-c913-43f7-ab6d-f320884063d9" />
<img width="682" height="311" alt="image" src="https://github.com/user-attachments/assets/d9d64c05-427d-4701-b551-db18d1210b7b" />

<img width="647" height="125" alt="image" src="https://github.com/user-attachments/assets/6dea77c7-b3ea-4954-8766-d001d9c0f7bf" />
<img width="563" height="83" alt="image" src="https://github.com/user-attachments/assets/c13681de-d794-4126-b694-f290ad281e3a" />

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me