### PR TITLE
Backend/db: Migrate online events to offline

### DIFF
--- a/app/backend/src/couchers/migrations/versions/0171_migrate_online_events_to_offline.py
+++ b/app/backend/src/couchers/migrations/versions/0171_migrate_online_events_to_offline.py
@@ -1,0 +1,72 @@
+"""Migrate online events to offline
+
+Revision ID: 0171
+Revises: 0170
+Create Date: 2026-07-15 08:37:59.486024
+
+"""
+
+import geoalchemy2
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0171"
+down_revision = "0170"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Drop mutually exclusive constraints (raw DDL operations, naming convention doesn't apply)
+    op.drop_constraint("ck_event_occurrences_geom_iff_address", "event_occurrences", type_="check")
+    op.drop_constraint("ck_event_occurrences_link_or_geom", "event_occurrences", type_="check")
+    # Migrate link to dummy geom+address
+    op.execute(
+        """
+        UPDATE event_occurrences
+        SET address = link, geom = ST_SetSRID(ST_MakePoint(0, 0), 4326)
+        WHERE link IS NOT NULL
+        """
+    )
+    op.drop_column("event_occurrences", "link")
+    # Make geom+address non-nullable
+    op.alter_column(
+        "event_occurrences",
+        "geom",
+        existing_type=geoalchemy2.types.Geometry(
+            geometry_type="POINT",
+            srid=4326,
+            from_text="ST_GeomFromEWKT",
+            name="geometry",
+            _spatial_index_reflected=True,
+        ),
+        nullable=False,
+    )
+    op.alter_column("event_occurrences", "address", existing_type=sa.VARCHAR(), nullable=False)
+
+
+def downgrade() -> None:
+    # Add back link
+    op.add_column("event_occurrences", sa.Column("link", sa.VARCHAR(), autoincrement=False, nullable=True))
+    # Make address/geom nullable again
+    op.alter_column("event_occurrences", "address", existing_type=sa.VARCHAR(), nullable=True)
+    op.alter_column(
+        "event_occurrences",
+        "geom",
+        existing_type=geoalchemy2.types.Geometry(
+            geometry_type="POINT",
+            srid=4326,
+            from_text="ST_GeomFromEWKT",
+            name="geometry",
+            _spatial_index_reflected=True,
+        ),
+        nullable=True,
+    )
+    # Add back mutually exclusive constraints (raw DDL operations, naming convention doesn't apply)
+    op.create_check_constraint(
+        "ck_event_occurrences_geom_iff_address", "event_occurrences", "(geom IS NULL) = (address IS NULL)"
+    )
+    op.create_check_constraint(
+        "ck_event_occurrences_link_or_geom", "event_occurrences", "(geom IS NULL) <> (link IS NULL)"
+    )

--- a/app/backend/src/couchers/migrations/versions/0171_migrate_online_events_to_offline.py
+++ b/app/backend/src/couchers/migrations/versions/0171_migrate_online_events_to_offline.py
@@ -18,9 +18,9 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Drop mutually exclusive constraints (raw DDL operations, naming convention doesn't apply)
-    op.drop_constraint("ck_event_occurrences_geom_iff_address", "event_occurrences", type_="check")
-    op.drop_constraint("ck_event_occurrences_link_or_geom", "event_occurrences", type_="check")
+    # Drop mutually exclusive constraints
+    op.drop_constraint(op.f("ck_event_occurrences_geom_iff_address"), "event_occurrences", type_="check")
+    op.drop_constraint(op.f("ck_event_occurrences_link_or_geom"), "event_occurrences", type_="check")
     # Migrate link to dummy geom+address
     op.execute(
         """
@@ -63,10 +63,10 @@ def downgrade() -> None:
         ),
         nullable=True,
     )
-    # Add back mutually exclusive constraints (raw DDL operations, naming convention doesn't apply)
+    # Add back mutually exclusive constraints
     op.create_check_constraint(
-        "ck_event_occurrences_geom_iff_address", "event_occurrences", "(geom IS NULL) = (address IS NULL)"
+        op.f("ck_event_occurrences_geom_iff_address"), "event_occurrences", "(geom IS NULL) = (address IS NULL)"
     )
     op.create_check_constraint(
-        "ck_event_occurrences_link_or_geom", "event_occurrences", "(geom IS NULL) <> (link IS NULL)"
+        op.f("ck_event_occurrences_link_or_geom"), "event_occurrences", "(geom IS NULL) <> (link IS NULL)"
     )

--- a/app/backend/src/couchers/models/events.py
+++ b/app/backend/src/couchers/models/events.py
@@ -168,7 +168,7 @@ class EventOccurrence(Base, kw_only=True):
     )
 
     @property
-    def coordinates(self) -> tuple[float, float] | None:
+    def coordinates(self) -> tuple[float, float]:
         # returns (lat, lng) or None
         return get_coordinates(self.geom)
 

--- a/app/backend/src/couchers/models/events.py
+++ b/app/backend/src/couchers/models/events.py
@@ -129,12 +129,10 @@ class EventOccurrence(Base, kw_only=True):
     is_cancelled: Mapped[bool] = mapped_column(Boolean, default=False, server_default=expression.false())
     is_deleted: Mapped[bool] = mapped_column(Boolean, default=False, server_default=expression.false())
 
-    # a null geom is a legacy online-only event
-    geom: Mapped[Geom | None] = mapped_column(Geometry(geometry_type="POINT", srid=4326), default=None)
-    # physical address, iff geom is not null
-    address: Mapped[str | None] = mapped_column(String, default=None)
-    # videoconferencing link, etc, must be specified if no geom, otherwise optional
-    link: Mapped[str | None] = mapped_column(String, default=None)
+    # The GPS coordinates of the event location
+    geom: Mapped[Geom] = mapped_column(Geometry(geometry_type="POINT", srid=4326))
+    # The physical address string. Legacy online events have been migrated to put the link in here.
+    address: Mapped[str] = mapped_column(String)
 
     timezone = "Etc/UTC"
 
@@ -165,18 +163,6 @@ class EventOccurrence(Base, kw_only=True):
     moderation_state: Mapped[ModerationState] = relationship(init=False)
 
     __table_args__ = (
-        # Geom and address go together
-        CheckConstraint(
-            # geom and address are either both null or neither of them are null
-            "(geom IS NULL) = (address IS NULL)",
-            name="geom_iff_address",
-        ),
-        # Online-only events need a link, note that online events may also have a link
-        CheckConstraint(
-            # exactly oen of geom or link is non-null
-            "(geom IS NULL) <> (link IS NULL)",
-            name="link_or_geom",
-        ),
         # Can't have overlapping occurrences in the same Event
         ExcludeConstraint(("event_id", "="), ("during", "&&"), name="event_occurrences_event_id_during_excl"),
     )

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -649,7 +649,6 @@ class Events(events_pb2_grpc.EventsServicer):
 
         if request.HasField("location"):
             notify_updated.append(notification_data_pb2.EventUpdateItem.EVENT_UPDATE_ITEM_LOCATION)
-            occurrence_update["link"] = None
             if request.location.lat == 0 and request.location.lng == 0:
                 context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_coordinate")
             occurrence_update["geom"] = create_coordinate(request.location.lat, request.location.lng)

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -149,16 +149,6 @@ def event_to_pb(session: Session, occurrence: EventOccurrence, context: Couchers
         )
     ).scalar_one()
 
-    location: events_pb2.EventLocation
-    if occurrence.geom:
-        location = events_pb2.EventLocation(
-            lat=not_none(occurrence.coordinates)[0], lng=not_none(occurrence.coordinates)[1], address=occurrence.address
-        )
-    else:
-        # Backcompat: Surface legacy online events as offline events.
-        # They'll appear at null island, but there are so few we're ok with this.
-        location = events_pb2.EventLocation(address=occurrence.link, lat=0, lng=0)
-
     return events_pb2.Event(
         event_id=occurrence.id,
         is_next=False if not next_occurrence else occurrence.id == next_occurrence.id,
@@ -169,7 +159,9 @@ def event_to_pb(session: Session, occurrence: EventOccurrence, context: Couchers
         content=occurrence.content,
         photo_url=occurrence.photo.full_url if occurrence.photo else None,
         photo_key=occurrence.photo_key or "",
-        location=location,
+        location=events_pb2.EventLocation(
+            lat=occurrence.coordinates[0], lng=occurrence.coordinates[1], address=occurrence.address
+        ),
         created=Timestamp_from_datetime(occurrence.created),
         last_edited=Timestamp_from_datetime(occurrence.last_edited),
         creator_user_id=occurrence.creator_user_id,
@@ -460,7 +452,6 @@ class Events(events_pb2_grpc.EventsServicer):
                 content=request.content,
                 geom=geom,
                 address=address,
-                link=None,
                 photo_key=request.photo_key if request.photo_key != "" else None,
                 # timezone=timezone,
                 during=TimestamptzRange(start_time, end_time),
@@ -591,7 +582,6 @@ class Events(events_pb2_grpc.EventsServicer):
                 content=request.content,
                 geom=geom,
                 address=address,
-                link=None,
                 photo_key=request.photo_key if request.photo_key != "" else None,
                 # timezone=timezone,
                 during=during,

--- a/app/backend/src/couchers/servicers/search.py
+++ b/app/backend/src/couchers/servicers/search.py
@@ -329,7 +329,7 @@ def _search_events(
         next_rank,
         page_size,
         [Event.title],
-        [EventOccurrence.address, EventOccurrence.link],
+        [EventOccurrence.address],
         [],
         [EventOccurrence.content],
     )

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -729,52 +729,6 @@ def test_UpdateEvent_single(db, moderator: Moderator):
         assert res.location.lng == 0.02
 
 
-def test_GetEvent_online(db, moderator: Moderator):
-    """Validate that legacy online events are surfaced as offline events through the API."""
-    user1, token1 = generate_user()
-
-    with session_scope() as session:
-        c_id = create_community(session, 0, 2, "Community", [user1], [], None).id
-
-    start_time = now() + timedelta(hours=2)
-    end_time = start_time + timedelta(hours=3)
-
-    # Create as an offline event since the API doesn't support online events anymore.
-    with events_session(token1) as api:
-        create_res: events_pb2.Event = api.CreateEvent(
-            events_pb2.CreateEventReq(
-                title="Dummy Title",
-                content="Dummy content.",
-                parent_community_id=c_id,
-                location=events_pb2.EventLocation(address="Near Null Island", lat=0.1, lng=0.2),
-                start_time=Timestamp_from_datetime(start_time),
-                end_time=Timestamp_from_datetime(end_time),
-                timezone="UTC",
-            )
-        )
-
-    event_id = create_res.event_id
-
-    moderator.approve_event_occurrence(event_id)
-
-    # Tweak the DB object to turn it into a legacy online event
-    with session_scope() as session:
-        occurrence = session.execute(select(EventOccurrence).where(EventOccurrence.id == event_id)).scalar_one()
-        occurrence.geom = None
-        occurrence.address = None
-        occurrence.link = "https://couchers.org/meet/"
-
-    # Backend should surface it as an offline event
-    with events_session(token1) as api:
-        get_res: events_pb2.Event = api.GetEvent(events_pb2.GetEventReq(event_id=event_id))
-
-        assert get_res.title == "Dummy Title"
-        assert get_res.HasField("location")
-        assert get_res.location.address == "https://couchers.org/meet/"
-        assert get_res.location.lng == 0
-        assert get_res.location.lat == 0
-
-
 def test_UpdateEvent_all(db, moderator: Moderator):
     # event creator
     user1, token1 = generate_user()


### PR DESCRIPTION
Follow-up to #9133 which removed online events from the API but kept the DB representation of online events. This migrates online events in the DB to offline events at (0,0) coords.

## Testing
Ran the backend + frontend locally. Navigated to and viewed an event's details.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
