### PR TITLE
Frontend/requests: Tweak decline reasons string keys to avoid plural autodetection

### DIFF
--- a/app/web/features/messages/locales/en.json
+++ b/app/web/features/messages/locales/en.json
@@ -27,10 +27,12 @@
     "quality_okay": "Okay",
     "quality_low": "Low quality",
     "decline_reason_label": "Why did you decline?",
-    "reason_didnt_read_profile": "Didn't read my profile",
-    "reason_dont_want_to_host": "I don't want to host this person",
-    "reason_not_available": "I'm not available to host then",
-    "reason_other": "Other",
+    "decline_reason_options": {
+      "didnt_read_profile": "Didn't read my profile",
+      "dont_want_to_host": "I don't want to host this person",
+      "not_available": "I'm not available to host then",
+      "other": "Other"
+    },
     "reason_other_placeholder": "Please tell us more...",
     "privacy_notice": "Your responses are private and will not be shared with the user. We may use them in an aggregated and anonymous form—combined with many others—to improve feedback for all users.",
     "skip_button": "Skip",

--- a/app/web/features/messages/requests/HostRequestFeedbackCard.tsx
+++ b/app/web/features/messages/requests/HostRequestFeedbackCard.tsx
@@ -195,7 +195,9 @@ export default function HostRequestFeedbackCard({
                   onChange={() => toggleReason(reason)}
                 />
               }
-              label={t(`private_feedback_card.reason_${reason}`)}
+              label={t(
+                `private_feedback_card.decline_reason_options.${reason}`,
+              )}
             />
           ))}
         </FormGroup>


### PR DESCRIPTION
Weblate assumed the "reason_other" string to be a plural due to i18next json format limitations where an `_other` suffix denotes a plural form. Renamed string keys to avoid the issue and improve searchability (no "reason_" prefix concatenation).

(translators will need to retranslate those strings, but can use Weblate's translation memory)

<img width="398" height="647" alt="image" src="https://github.com/user-attachments/assets/198053d5-fbb5-4b42-a10f-1a23481286c6" />

## Testing
Checked with Vercel preview

<img width="570" height="346" alt="image" src="https://github.com/user-attachments/assets/8a09214e-ae85-4460-9a2c-cb2fe1e849c4" />

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
