### PR TITLE
Backend: order ListUserCommunities by node type, most specific first

### DIFF
--- a/app/backend/src/couchers/servicers/communities.py
+++ b/app/backend/src/couchers/servicers/communities.py
@@ -6,7 +6,7 @@ import grpc
 from google.protobuf import empty_pb2
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
-from sqlalchemy.sql import delete, func, or_
+from sqlalchemy.sql import and_, delete, func, or_
 
 from couchers.constants import COMMUNITIES_SEARCH_FUZZY_SIMILARITY_THRESHOLD
 from couchers.context import CouchersContext
@@ -570,27 +570,34 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         self, request: communities_pb2.ListUserCommunitiesReq, context: CouchersContext, session: Session
     ) -> communities_pb2.ListUserCommunitiesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
-        next_node_id = int(request.page_token) if request.page_token else 0
         user_id = request.user_id or context.user_id
-        nodes = (
-            session.execute(
-                select(Node)
-                .join(Cluster, Cluster.parent_node_id == Node.id)
-                .join(ClusterSubscription, ClusterSubscription.cluster_id == Cluster.id)
-                .where(ClusterSubscription.user_id == user_id)
-                .where(Cluster.is_official_cluster)
-                .where(Node.id >= next_node_id)
-                .order_by(Node.id)
-                .limit(page_size + 1)
-                .options(selectinload(Node.official_cluster))
-            )
-            .scalars()
-            .all()
+        # most specific communities first: node_type desc (sublocality -> world), then id asc
+        statement = (
+            select(Node)
+            .join(Cluster, Cluster.parent_node_id == Node.id)
+            .join(ClusterSubscription, ClusterSubscription.cluster_id == Cluster.id)
+            .where(ClusterSubscription.user_id == user_id)
+            .where(Cluster.is_official_cluster)
+            .order_by(Node.node_type.desc(), Node.id)
+            .limit(page_size + 1)
+            .options(selectinload(Node.official_cluster))
         )
+        if request.page_token:
+            node_type_ordinal, next_node_id = (int(v) for v in decrypt_page_token(request.page_token).split(","))
+            next_node_type = NodeType(node_type_ordinal)
+            statement = statement.where(
+                or_(
+                    Node.node_type < next_node_type,
+                    and_(Node.node_type == next_node_type, Node.id >= next_node_id),
+                )
+            )
+        nodes = session.execute(statement).scalars().all()
 
         return communities_pb2.ListUserCommunitiesRes(
             communities=communities_to_pb(session, nodes[:page_size], context),
-            next_page_token=str(nodes[-1].id) if len(nodes) > page_size else None,
+            next_page_token=encrypt_page_token(f"{nodes[-1].node_type.value},{nodes[-1].id}")
+            if len(nodes) > page_size
+            else None,
         )
 
     def ListAllCommunities(

--- a/app/backend/src/tests/test_communities.py
+++ b/app/backend/src/tests/test_communities.py
@@ -520,14 +520,31 @@ class TestCommunities:
         with communities_session(token2) as api:
             res = api.ListUserCommunities(communities_pb2.ListUserCommunitiesReq())
             assert [c.community_id for c in res.communities] == [
-                w_id,
-                c1_id,
-                c1r1_id,
                 c1r1c1_id,
                 c1r1c2_id,
-                c1r2_id,
                 c1r2c1_id,
+                c1r1_id,
+                c1r2_id,
+                c1_id,
+                w_id,
             ]
+
+            # paginated, with pages crossing node type boundaries
+            res = api.ListUserCommunities(communities_pb2.ListUserCommunitiesReq(page_size=2))
+            assert [c.community_id for c in res.communities] == [c1r1c1_id, c1r1c2_id]
+            res = api.ListUserCommunities(
+                communities_pb2.ListUserCommunitiesReq(page_size=2, page_token=res.next_page_token)
+            )
+            assert [c.community_id for c in res.communities] == [c1r2c1_id, c1r1_id]
+            res = api.ListUserCommunities(
+                communities_pb2.ListUserCommunitiesReq(page_size=2, page_token=res.next_page_token)
+            )
+            assert [c.community_id for c in res.communities] == [c1r2_id, c1_id]
+            res = api.ListUserCommunities(
+                communities_pb2.ListUserCommunitiesReq(page_size=2, page_token=res.next_page_token)
+            )
+            assert [c.community_id for c in res.communities] == [w_id]
+            assert not res.next_page_token
 
     @staticmethod
     def test_ListOtherUserCommunities(testing_communities):
@@ -546,13 +563,13 @@ class TestCommunities:
         with communities_session(token1) as api:
             res = api.ListUserCommunities(communities_pb2.ListUserCommunitiesReq(user_id=user2_id))
             assert [c.community_id for c in res.communities] == [
-                w_id,
-                c1_id,
-                c1r1_id,
                 c1r1c1_id,
                 c1r1c2_id,
-                c1r2_id,
                 c1r2c1_id,
+                c1r1_id,
+                c1r2_id,
+                c1_id,
+                w_id,
             ]
 
     @staticmethod
@@ -1293,7 +1310,7 @@ def test_enforce_community_memberships_for_user(testing_communities):
 
     with communities_session(token) as api:
         res = api.ListUserCommunities(communities_pb2.ListUserCommunitiesReq())
-        assert [c.community_id for c in res.communities] == [w_id, c1_id, c1r1_id, c1r1c2_id]
+        assert [c.community_id for c in res.communities] == [c1r1c2_id, c1r1_id, c1_id, w_id]
 
 
 # TODO: requires transferring of content


### PR DESCRIPTION
`ListUserCommunities` was ordered by `Node.id` asc, which generally meant the World community first, then continents, countries, and so on — the least useful order for the user. This changes the ordering to `(node_type desc, Node.id asc)` so the most specific communities (sublocality → … → world) come first, and stores the resulting double cursor `(node_type, node_id)` in an encrypted page token, following the existing `encrypt_page_token`/`decrypt_page_token` pattern used by `ListCommunities`.

The Postgres `nodetype` enum sort order matches the Python ordinals (migration 0136 inserted `macroregion` with `AFTER 'world'`), so `node_type DESC` in SQL sorts sublocality first and world last.

## Testing
- Updated the expected order in `test_ListUserCommunities`, `test_ListOtherUserCommunities`, and `test_enforce_community_memberships_for_user`.
- Added pagination coverage to `test_ListUserCommunities`: pages through with `page_size=2`, passing `next_page_token` forward across node-type boundaries to exercise both legs of the cursor condition, and asserts the final page returns no token.
- All 25 tests in `test_communities.py` pass; `make format` and `make mypy` are clean.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._