### PR TITLE
Backend: Cache localized GetLanguages/GetRegions responses per locale

### DIFF
--- a/app/backend/src/couchers/i18n/context.py
+++ b/app/backend/src/couchers/i18n/context.py
@@ -21,8 +21,6 @@ from couchers.i18n.localize import (
     localize_list,
     localize_time,
     localize_timezone,
-    try_localize_language_name_from_iso639,
-    try_localize_region_name_from_iso3166,
 )
 from couchers.models.users import User
 from couchers.utils import to_timezone
@@ -66,12 +64,6 @@ class LocalizationContext:
     @property
     def localized_timezone(self) -> str:
         return localize_timezone(self.timezone, self.babel_locale)
-
-    def try_localize_language_name_from_iso639(self, code: str, standalone: bool = False) -> str | None:
-        return try_localize_language_name_from_iso639(code, self.babel_locale, standalone=standalone)
-
-    def try_localize_region_name_from_iso3166(self, code: str) -> str | None:
-        return try_localize_region_name_from_iso3166(code, self.babel_locale)
 
     def localize_string(
         self, key: str, *, i18next: I18Next | None = None, substitutions: SubstitutionDict | None = None

--- a/app/backend/src/couchers/i18n/localize.py
+++ b/app/backend/src/couchers/i18n/localize.py
@@ -4,7 +4,7 @@ Most code should use the higher-level couchers.i18n.LocalizationContext object.
 """
 
 import re
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from datetime import date, datetime, time, tzinfo
 from typing import cast
 
@@ -13,7 +13,7 @@ import phonenumbers
 from babel.dates import get_datetime_format, get_timezone_name, match_skeleton, parse_pattern
 from babel.lists import format_list
 
-from couchers.resources import get_language_dict, get_region_code_iso3166_alpha3_to_alpha2, get_region_dict
+from couchers.resources import get_region_code_iso3166_alpha3_to_alpha2
 
 
 def localize_list(items: Sequence[str], locale: babel.Locale) -> str:
@@ -55,28 +55,6 @@ def try_localize_region_name_from_iso3166(code: str, locale: babel.Locale) -> st
     code = get_region_code_iso3166_alpha3_to_alpha2().get(code, code)
     region_name: str | None = locale.territories.get(code, None)
     return region_name
-
-
-def get_localized_language_names(locale: babel.Locale) -> Mapping[str, str]:
-    """
-    Maps every allowed language code to its standalone display name in the given locale
-    (falling back to English), ordered by code.
-    """
-    return {
-        code: try_localize_language_name_from_iso639(code, locale, standalone=True) or english_name
-        for code, english_name in sorted(get_language_dict().items())
-    }
-
-
-def get_localized_region_names(locale: babel.Locale) -> Mapping[str, str]:
-    """
-    Maps every region alpha3 code to its display name in the given locale
-    (falling back to English), ordered by code.
-    """
-    return {
-        alpha3: try_localize_region_name_from_iso3166(alpha3, locale) or english_name
-        for alpha3, english_name in sorted(get_region_dict().items())
-    }
 
 
 def localize_date(

--- a/app/backend/src/couchers/i18n/localize.py
+++ b/app/backend/src/couchers/i18n/localize.py
@@ -4,7 +4,7 @@ Most code should use the higher-level couchers.i18n.LocalizationContext object.
 """
 
 import re
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import date, datetime, time, tzinfo
 from typing import cast
 
@@ -13,7 +13,7 @@ import phonenumbers
 from babel.dates import get_datetime_format, get_timezone_name, match_skeleton, parse_pattern
 from babel.lists import format_list
 
-from couchers.resources import get_region_code_iso3166_alpha3_to_alpha2
+from couchers.resources import get_language_dict, get_region_code_iso3166_alpha3_to_alpha2, get_region_dict
 
 
 def localize_list(items: Sequence[str], locale: babel.Locale) -> str:
@@ -55,6 +55,28 @@ def try_localize_region_name_from_iso3166(code: str, locale: babel.Locale) -> st
     code = get_region_code_iso3166_alpha3_to_alpha2().get(code, code)
     region_name: str | None = locale.territories.get(code, None)
     return region_name
+
+
+def get_localized_language_names(locale: babel.Locale) -> Mapping[str, str]:
+    """
+    Maps every allowed language code to its standalone display name in the given locale
+    (falling back to English), ordered by code.
+    """
+    return {
+        code: try_localize_language_name_from_iso639(code, locale, standalone=True) or english_name
+        for code, english_name in sorted(get_language_dict().items())
+    }
+
+
+def get_localized_region_names(locale: babel.Locale) -> Mapping[str, str]:
+    """
+    Maps every region alpha3 code to its display name in the given locale
+    (falling back to English), ordered by code.
+    """
+    return {
+        alpha3: try_localize_region_name_from_iso3166(alpha3, locale) or english_name
+        for alpha3, english_name in sorted(get_region_dict().items())
+    }
 
 
 def localize_date(

--- a/app/backend/src/couchers/servicers/resources.py
+++ b/app/backend/src/couchers/servicers/resources.py
@@ -1,17 +1,14 @@
+import functools
 import logging
 
+import babel
 from google.protobuf import empty_pb2
 from sqlalchemy.orm import Session
 
 from couchers.context import CouchersContext
+from couchers.i18n.localize import get_localized_language_names, get_localized_region_names
 from couchers.proto import resources_pb2, resources_pb2_grpc
-from couchers.resources import (
-    get_badge_dict,
-    get_icon,
-    get_language_dict,
-    get_region_dict,
-    get_terms_of_service,
-)
+from couchers.resources import get_badge_dict, get_icon, get_terms_of_service
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +18,29 @@ COMMUNITY_GUIDELINES = [
     {"key": "be_safe", "icon": "shield.svg"},
     {"key": "no_money", "icon": "handshake.svg"},
 ]
+
+
+# These responses are static per locale, and localizing ~300 names costs tens of ms of CPU (mostly
+# babel.Locale.parse), so cache the built protos. Sharing one message across requests is safe as
+# long as nothing mutates responses after return (the tracing interceptor deepcopies before
+# sanitizing).
+@functools.lru_cache
+def _get_regions_res(locale: babel.Locale) -> resources_pb2.GetRegionsRes:
+    return resources_pb2.GetRegionsRes(
+        regions=[
+            resources_pb2.Region(alpha3=alpha3, name=name)
+            for alpha3, name in get_localized_region_names(locale).items()
+        ]
+    )
+
+
+@functools.lru_cache
+def _get_languages_res(locale: babel.Locale) -> resources_pb2.GetLanguagesRes:
+    return resources_pb2.GetLanguagesRes(
+        languages=[
+            resources_pb2.Language(code=code, name=name) for code, name in get_localized_language_names(locale).items()
+        ]
+    )
 
 
 class Resources(resources_pb2_grpc.ResourcesServicer):
@@ -46,29 +66,12 @@ class Resources(resources_pb2_grpc.ResourcesServicer):
     def GetRegions(
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session
     ) -> resources_pb2.GetRegionsRes:
-        return resources_pb2.GetRegionsRes(
-            regions=[
-                resources_pb2.Region(
-                    alpha3=alpha3,
-                    name=context.localization.try_localize_region_name_from_iso3166(alpha3) or english_name,
-                )
-                for alpha3, english_name in sorted(get_region_dict().items())
-            ]
-        )
+        return _get_regions_res(context.localization.babel_locale)
 
     def GetLanguages(
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session
     ) -> resources_pb2.GetLanguagesRes:
-        return resources_pb2.GetLanguagesRes(
-            languages=[
-                resources_pb2.Language(
-                    code=code,
-                    name=context.localization.try_localize_language_name_from_iso639(code, standalone=True)
-                    or english_name,
-                )
-                for code, english_name in sorted(get_language_dict().items())
-            ]
-        )
+        return _get_languages_res(context.localization.babel_locale)
 
     def GetBadges(
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session

--- a/app/backend/src/couchers/servicers/resources.py
+++ b/app/backend/src/couchers/servicers/resources.py
@@ -6,9 +6,9 @@ from google.protobuf import empty_pb2
 from sqlalchemy.orm import Session
 
 from couchers.context import CouchersContext
-from couchers.i18n.localize import get_localized_language_names, get_localized_region_names
+from couchers.i18n.localize import try_localize_language_name_from_iso639, try_localize_region_name_from_iso3166
 from couchers.proto import resources_pb2, resources_pb2_grpc
-from couchers.resources import get_badge_dict, get_icon, get_terms_of_service
+from couchers.resources import get_badge_dict, get_icon, get_language_dict, get_region_dict, get_terms_of_service
 
 logger = logging.getLogger(__name__)
 
@@ -28,8 +28,11 @@ COMMUNITY_GUIDELINES = [
 def _get_regions_res(locale: babel.Locale) -> resources_pb2.GetRegionsRes:
     return resources_pb2.GetRegionsRes(
         regions=[
-            resources_pb2.Region(alpha3=alpha3, name=name)
-            for alpha3, name in get_localized_region_names(locale).items()
+            resources_pb2.Region(
+                alpha3=alpha3,
+                name=try_localize_region_name_from_iso3166(alpha3, locale) or english_name,
+            )
+            for alpha3, english_name in sorted(get_region_dict().items())
         ]
     )
 
@@ -38,7 +41,11 @@ def _get_regions_res(locale: babel.Locale) -> resources_pb2.GetRegionsRes:
 def _get_languages_res(locale: babel.Locale) -> resources_pb2.GetLanguagesRes:
     return resources_pb2.GetLanguagesRes(
         languages=[
-            resources_pb2.Language(code=code, name=name) for code, name in get_localized_language_names(locale).items()
+            resources_pb2.Language(
+                code=code,
+                name=try_localize_language_name_from_iso639(code, locale, standalone=True) or english_name,
+            )
+            for code, english_name in sorted(get_language_dict().items())
         ]
     )
 


### PR DESCRIPTION
Since #9173, `Resources/GetLanguages` localizes all ~300 language names on every request. Each name goes through `babel.Locale.parse`, and ~120 of our ISO639-3 codes aren't known to babel at all — for those, babel does an uncached filesystem stat and raises `UnknownLocaleError` each time. That adds up to ~38ms of pure CPU per request (measured warm), on an endpoint that used to be a cached-dict lookup — which is what caused the backend CPU usage spike starting 2026-06-28.

The responses are fully static per locale, so this caches the built response protos in an `lru_cache` keyed on the babel locale (bounded by the set of supported UI locales). Per-request cost returns to effectively zero; the first request per locale after startup pays the localization cost once. `GetRegions` gets the same treatment (it was cheap, but it's the same shape).

Sharing one proto message across requests is safe here: nothing mutates responses after the servicer returns them — the tracing interceptor's sensitive-field sanitization deepcopies first — and there's a comment in the servicer noting this caveat.

Also removes the now-unused per-code `try_localize_*` wrappers from `LocalizationContext`, since the servicer now calls the module-level functions from `couchers/i18n/localize.py` directly (those remain and are still tested).

## Testing

- Benchmarked the old path warm: ~38ms CPU per `GetLanguages` call (~24ms of that in the exception path for the 122 codes babel doesn't know); the new path is an `lru_cache` hit after the first call per locale.
- `uv run pytest src/tests/test_resources.py src/tests/test_localize.py` — 13 passed. `test_resources.py` already covers localized language/region names for non-English locales, which exercises the cached path.
- `make format` and `make mypy` pass.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug (covered by existing localization tests in `test_resources.py`/`test_localize.py`)
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history (no database changes)

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._