### PR TITLE
Frontend/public trips: "offers" -> "invitations"

### DIFF
--- a/app/web/features/dashboard/DashboardPublicTripCard.tsx
+++ b/app/web/features/dashboard/DashboardPublicTripCard.tsx
@@ -176,8 +176,8 @@ function OffersChip({ count }: { count: number }) {
         <HourglassEmptyOutlined sx={{ fontSize: "15px" }} />
       )}
       {hasOffers
-        ? t("dashboard:public_trips.offers_count", { count })
-        : t("dashboard:public_trips.no_offers")}
+        ? t("dashboard:public_trips.invitations_count", { count })
+        : t("dashboard:public_trips.no_invitations")}
     </Box>
   );
 }

--- a/app/web/features/dashboard/locales/en.json
+++ b/app/web/features/dashboard/locales/en.json
@@ -64,11 +64,11 @@
     "when_now": "Now",
     "when_today": "Today",
     "when_tomorrow": "Tomorrow",
-    "empty_description": "Heading somewhere? Post a public trip in a community to receive offers from nearby hosts.",
+    "empty_description": "Heading somewhere? Post a public trip in a community to receive invitations from nearby hosts.",
     "same_gender_only_indicator": "Same gender",
-    "offers_count_one": "{{count}} offer",
-    "offers_count_other": "{{count}} offers",
-    "no_offers": "No offers yet"
+    "invitations_count_one": "{{count}} invitation",
+    "invitations_count_other": "{{count}} invitations",
+    "no_invitations": "No invitations yet"
   },
   "stays": {
     "upcoming_trips_header": "Your upcoming stays",

--- a/app/web/features/publicTrips/PublicTripCard.tsx
+++ b/app/web/features/publicTrips/PublicTripCard.tsx
@@ -462,10 +462,10 @@ export default function PublicTripCard({
                           <HourglassEmptyOutlined sx={{ fontSize: "1rem" }} />
                         )}
                         {trip.offersCount > 0
-                          ? t("publicTrips:offers_count", {
+                          ? t("publicTrips:invitations_count", {
                               count: trip.offersCount,
                             })
-                          : t("publicTrips:no_offers")}
+                          : t("publicTrips:no_invitations")}
                       </Box>
                     )}
                   </Box>


### PR DESCRIPTION
From discussions with translators where "receive offers" could be understood as receiving ads/promotions. "invitations" feels less transactional too.

## Testing
*Explain how you tested this PR and give clear steps so the reviewer can replicate.*

<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
