### PR TITLE
Frontend/notifs/i18n: Improve filters string keys

### DIFF
--- a/app/web/features/notifications/NotificationsFeed/NotificationsFeed.tsx
+++ b/app/web/features/notifications/NotificationsFeed/NotificationsFeed.tsx
@@ -251,7 +251,7 @@ const NotificationsFeed = ({
               },
             }}
           >
-            {t("notifications:all")}
+            {t("notifications:notifications_filters.all_button")}
           </Pill>
           <Pill
             variant="rounded"
@@ -272,7 +272,7 @@ const NotificationsFeed = ({
               },
             }}
           >
-            {t("notifications:unread")}
+            {t("notifications:notifications_filters.unread_button")}
           </Pill>
         </StyledPills>
       </TopContentWrapper>

--- a/app/web/features/notifications/locales/en.json
+++ b/app/web/features/notifications/locales/en.json
@@ -1,6 +1,8 @@
 {
-  "all": "All",
-  "unread": "Unread",
+  "notifications_filters": {
+    "all_button": "All",
+    "unread_button": "Unread"
+  },
   "error_loading": "Error loading notifications",
   "error_updating_notifications": "Error updating notifications",
   "mark_unread": "Mark unread",


### PR DESCRIPTION
"unread" is ambiguous as to number and gender, so some translations were incorrect. Add more context to the string keys and force relocalization.

"notifications" in the string key is not strictly needed since the component is about notifications, but this isn't the most obvious in weblate so it doesn't hurt to be a little redundant.

## Testing
Vercel preview is not broken

<img width="476" height="261" alt="image" src="https://github.com/user-attachments/assets/b84e90e3-52fe-4ccc-95c9-f10db62a16e3" />

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me