### PR TITLE
Frontend/events: Display using local times

### DIFF
--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -633,16 +633,21 @@ class EventInfo:
     """Common display fields for an event, extracted from its proto representation."""
 
     title: str
-    start_time: datetime
-    end_time: datetime
+    start_time: datetime  # In event timezone
+    end_time: datetime  # In event timezone
     address: str | None  # The None case handles legacy online events
     view_url: str
     description_markdown: str
 
     def get_details_block(self, loc_context: LocalizationContext) -> EmailBlock:
         # TODO(#8695): Support localized time ranges
-        start_time_display = loc_context.localize_datetime(self.start_time, with_year=False, with_day_of_week=True)
-        end_time_display = loc_context.localize_datetime(self.end_time, with_year=False, with_day_of_week=True)
+        # Force using the start/end time timezone (that of the event), not the user's.
+        start_time_display = loc_context.localize_datetime(
+            self.start_time, timezone=self.start_time.tzinfo, with_year=False, with_day_of_week=True
+        )
+        end_time_display = loc_context.localize_datetime(
+            self.end_time, timezone=self.end_time.tzinfo, with_year=False, with_day_of_week=True
+        )
         time_range_display = f"{start_time_display} - {end_time_display}"
 
         html = f"<b>{escape(self.title)}</b>"
@@ -665,8 +670,8 @@ class EventInfo:
     def from_proto(cls, event: events_pb2.Event) -> EventInfo:
         return cls(
             title=event.title,
-            start_time=event.start_time.ToDatetime(tzinfo=UTC),
-            end_time=event.end_time.ToDatetime(tzinfo=UTC),
+            start_time=to_aware_datetime(event.start_time, event.timezone),
+            end_time=to_aware_datetime(event.start_time, event.timezone),
             # Backcompat (2026-06): We might still have queued notifications referencing events with online_information.
             address=(event.location.address or None) if event.HasField("location") else None,
             view_url=urls.event_link(occurrence_id=event.event_id, slug=event.slug),

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -29,8 +29,9 @@ Other instructions for body text:
 
 import re
 from dataclasses import dataclass, replace
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, tzinfo
 from typing import Self, assert_never
+from zoneinfo import ZoneInfo
 
 from markupsafe import Markup, escape
 
@@ -633,8 +634,9 @@ class EventInfo:
     """Common display fields for an event, extracted from its proto representation."""
 
     title: str
-    start_time: datetime  # In event timezone
-    end_time: datetime  # In event timezone
+    start_time: datetime
+    end_time: datetime
+    timezone: tzinfo
     address: str | None  # The None case handles legacy online events
     view_url: str
     description_markdown: str
@@ -643,10 +645,10 @@ class EventInfo:
         # TODO(#8695): Support localized time ranges
         # Force using the start/end time timezone (that of the event), not the user's.
         start_time_display = loc_context.localize_datetime(
-            self.start_time, timezone=self.start_time.tzinfo, with_year=False, with_day_of_week=True
+            self.start_time, display_timezone=self.timezone, with_year=False, with_day_of_week=True
         )
         end_time_display = loc_context.localize_datetime(
-            self.end_time, timezone=self.end_time.tzinfo, with_year=False, with_day_of_week=True
+            self.end_time, display_timezone=self.timezone, with_year=False, with_day_of_week=True
         )
         time_range_display = f"{start_time_display} - {end_time_display}"
 
@@ -670,8 +672,9 @@ class EventInfo:
     def from_proto(cls, event: events_pb2.Event) -> EventInfo:
         return cls(
             title=event.title,
-            start_time=to_aware_datetime(event.start_time, event.timezone),
-            end_time=to_aware_datetime(event.start_time, event.timezone),
+            start_time=to_aware_datetime(event.start_time),
+            end_time=to_aware_datetime(event.end_time),
+            timezone=ZoneInfo(event.timezone),
             # Backcompat (2026-06): We might still have queued notifications referencing events with online_information.
             address=(event.location.address or None) if event.HasField("location") else None,
             view_url=urls.event_link(occurrence_id=event.event_id, slug=event.slug),
@@ -684,6 +687,7 @@ class EventInfo:
             title="Berlin Meetup",
             start_time=datetime(2025, 7, 15, 18, 0, 0, tzinfo=UTC),
             end_time=datetime(2025, 7, 15, 21, 0, 0, tzinfo=UTC),
+            timezone=UTC,
             address="Alexanderplatz, Berlin",
             view_url="https://couchers.org/events/123/berlin-community-meetup",
             description_markdown="Come join us for our monthly meetup!",

--- a/app/backend/src/couchers/i18n/context.py
+++ b/app/backend/src/couchers/i18n/context.py
@@ -97,13 +97,16 @@ class LocalizationContext:
         self,
         value: datetime | Timestamp,
         *,
+        timezone: str | tzinfo | None = None,
         abbrev: bool = False,
         with_year: bool = True,
         with_day_of_week: bool = False,
         with_seconds: bool = False,
     ) -> str:
         return localize_datetime(
-            to_timezone(value, self.timezone),
+            # By default we display the datetime in the user's timezone.
+            # The "timezone" parameter overrides this behavior.
+            to_timezone(value, timezone or self.timezone),
             self.babel_locale,
             abbrev=abbrev,
             with_year=with_year,

--- a/app/backend/src/couchers/i18n/context.py
+++ b/app/backend/src/couchers/i18n/context.py
@@ -97,7 +97,7 @@ class LocalizationContext:
         self,
         value: datetime | Timestamp,
         *,
-        timezone: str | tzinfo | None = None,
+        display_timezone: tzinfo | None = None,
         abbrev: bool = False,
         with_year: bool = True,
         with_day_of_week: bool = False,
@@ -106,7 +106,7 @@ class LocalizationContext:
         return localize_datetime(
             # By default we display the datetime in the user's timezone.
             # The "timezone" parameter overrides this behavior.
-            to_timezone(value, timezone or self.timezone),
+            to_timezone(value, display_timezone or self.timezone),
             self.babel_locale,
             abbrev=abbrev,
             with_year=with_year,

--- a/app/backend/src/couchers/i18n/context.py
+++ b/app/backend/src/couchers/i18n/context.py
@@ -103,6 +103,16 @@ class LocalizationContext:
         with_day_of_week: bool = False,
         with_seconds: bool = False,
     ) -> str:
+        """
+        Formats a date and time according to this localization context.
+
+        Params:
+          value: An instant in time to be formatted in date and time components.
+                 datetimes should be timezone-aware so they represent an unambiguous instant,
+                 but their timezones are irrelevant for formatting.
+          display_timezone: The timezone to use when formatting the datetime.
+                            Defaults to the value from this localization context.
+        """
         return localize_datetime(
             # By default we display the datetime in the user's timezone.
             # The "timezone" parameter overrides this behavior.

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -367,7 +367,7 @@ def _render_event__create_any(
         substitutions={
             "title": data.event.title,
             "user": data.inviting_user.name,
-            "date_and_time": _format_event_start_datetime(data.event.start_time, loc_context),
+            "date_and_time": _format_event_start_datetime(data.event.start_time, data.event.timezone, loc_context),
         },
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
@@ -382,7 +382,7 @@ def _render_event__create_approved(
         substitutions={
             "title": data.event.title,
             "user": data.inviting_user.name,
-            "date_and_time": _format_event_start_datetime(data.event.start_time, loc_context),
+            "date_and_time": _format_event_start_datetime(data.event.start_time, data.event.timezone, loc_context),
         },
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
@@ -442,7 +442,7 @@ def _render_event__reminder(
         loc_context,
         substitutions={
             "title": data.event.title,
-            "date_and_time": _format_event_start_datetime(data.event.start_time, loc_context),
+            "date_and_time": _format_event_start_datetime(data.event.start_time, data.event.timezone, loc_context),
         },
         action_url=urls.event_link(occurrence_id=data.event.event_id, slug=data.event.slug),
     )
@@ -871,7 +871,8 @@ def _format_host_request_start_date(date: str, loc_context: LocalizationContext)
     return loc_context.localize_date_from_iso(date, with_year=False, with_day_of_week=True)
 
 
-def _format_event_start_datetime(timestamp: Timestamp, loc_context: LocalizationContext) -> str:
+def _format_event_start_datetime(timestamp: Timestamp, timezone: str, loc_context: LocalizationContext) -> str:
     # Events are typically in the near future future,
     # so the year is not useful but the day of week is.
-    return loc_context.localize_datetime(timestamp, with_year=False, with_day_of_week=True)
+    # Event start/end times are displayed in their local timezone.
+    return loc_context.localize_datetime(timestamp, timezone=timezone, with_year=False, with_day_of_week=True)

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -5,6 +5,7 @@ Renders a Notification model into a localized push notification.
 import logging
 from datetime import date
 from typing import Any, assert_never
+from zoneinfo import ZoneInfo
 
 from google.protobuf.timestamp_pb2 import Timestamp
 
@@ -875,4 +876,6 @@ def _format_event_start_datetime(timestamp: Timestamp, timezone: str, loc_contex
     # Events are typically in the near future future,
     # so the year is not useful but the day of week is.
     # Event start/end times are displayed in their local timezone.
-    return loc_context.localize_datetime(timestamp, timezone=timezone, with_year=False, with_day_of_week=True)
+    return loc_context.localize_datetime(
+        timestamp, display_timezone=ZoneInfo(timezone), with_year=False, with_day_of_week=True
+    )

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -111,19 +111,15 @@ def date_to_api(date_obj: date) -> str:
     return date_obj.isoformat()
 
 
-def to_aware_datetime(ts: Timestamp, timezone: tzinfo | str = UTC) -> datetime:
+def to_aware_datetime(ts: Timestamp) -> datetime:
     """
     Turns a protobuf Timestamp object into a timezone-aware datetime
     """
-    if isinstance(timezone, str):
-        timezone = ZoneInfo(timezone)
-    return ts.ToDatetime(tzinfo=timezone)
+    return ts.ToDatetime(tzinfo=UTC)
 
 
-def to_timezone(value: Timestamp | datetime, timezone: tzinfo | str) -> datetime:
+def to_timezone(value: Timestamp | datetime, timezone: tzinfo) -> datetime:
     """Returns an instant in time as a datetime in a given timezone."""
-    if isinstance(timezone, str):
-        timezone = ZoneInfo(timezone)
     if isinstance(value, Timestamp):
         return value.ToDatetime(timezone)
 

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -111,15 +111,19 @@ def date_to_api(date_obj: date) -> str:
     return date_obj.isoformat()
 
 
-def to_aware_datetime(ts: Timestamp) -> datetime:
+def to_aware_datetime(ts: Timestamp, timezone: tzinfo | str = UTC) -> datetime:
     """
     Turns a protobuf Timestamp object into a timezone-aware datetime
     """
-    return ts.ToDatetime(tzinfo=UTC)
+    if isinstance(timezone, str):
+        timezone = ZoneInfo(timezone)
+    return ts.ToDatetime(tzinfo=timezone)
 
 
-def to_timezone(value: Timestamp | datetime, timezone: tzinfo) -> datetime:
+def to_timezone(value: Timestamp | datetime, timezone: tzinfo | str) -> datetime:
     """Returns an instant in time as a datetime in a given timezone."""
+    if isinstance(timezone, str):
+        timezone = ZoneInfo(timezone)
     if isinstance(value, Timestamp):
         return value.ToDatetime(timezone)
 

--- a/app/backend/src/tests/test_localize.py
+++ b/app/backend/src/tests/test_localize.py
@@ -62,6 +62,14 @@ def test_localize_datetime() -> None:
     assert localize_datetime(value, babel_en) == "January 2, 2000, 2:05 PM"
     assert localize_datetime(value, babel_fr) == "2 janvier 2000, 14:05"
 
+    value_non_utc = datetime(2000, 1, 2, 14, 5, tzinfo=ZoneInfo("Etc/GMT-2"))
+    assert localize_datetime(value_non_utc, babel_en) == "January 2, 2000, 2:05 PM"
+
+    assert localize_datetime(value, babel_en, abbrev=True) == "Jan 2, 2000, 2:05 PM"
+    assert localize_datetime(value, babel_en, with_year=False) == "January 2, 2:05 PM"
+    assert localize_datetime(value, babel_en, with_day_of_week=True) == "Sunday, January 2, 2000, 2:05 PM"
+    assert localize_datetime(value, babel_en, with_seconds=True) == "January 2, 2000, 2:05:00 PM"
+
 
 def test_localize_timezone() -> None:
     assert localize_timezone(ZoneInfo("Europe/London"), babel_en) == "United Kingdom Time"

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -664,7 +664,7 @@ def test_event_reminder_email_sent(db, email_collector: EmailCollector):
     # Saturday, July 5, 2025 at 4:40:00 AM UTC
     start_time = timestamp_pb2.Timestamp(seconds=1751690400)
     timezone = "Etc/GMT-2"  # Etc/GMT-2 means GMT+2
-    expected_time_str = "Saturday, July 5 at 6:40 AM"
+    expected_time_str = "Saturday, July 5, 6:40 AM"
 
     with session_scope() as session:
         user_in_session = session.get_one(User, user.id)

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -15,7 +15,6 @@ from couchers.constants import DATETIME_INFINITY
 from couchers.context import make_background_user_context
 from couchers.crypto import b64decode
 from couchers.db import session_scope
-from couchers.i18n import LocalizationContext
 from couchers.jobs.handlers import check_expo_push_receipts
 from couchers.jobs.worker import process_job
 from couchers.models import (
@@ -661,10 +660,11 @@ def test_get_topic_actions_by_delivery_type(db):
 def test_event_reminder_email_sent(db, email_collector: EmailCollector):
     user, token = generate_user()
     title = "Board Game Night"
-    start_event_time = timestamp_pb2.Timestamp(seconds=1751690400)
 
-    loc_context = LocalizationContext.from_user(user)
-    expected_time_str = loc_context.localize_datetime(start_event_time, with_year=False, with_day_of_week=True)
+    # Saturday, July 5, 2025 at 4:40:00 AM UTC
+    start_time = timestamp_pb2.Timestamp(seconds=1751690400)
+    timezone = "Etc/GMT-2"  # Etc/GMT-2 means GMT+2
+    expected_time_str = "Saturday, July 5 at 6:40 AM"
 
     with session_scope() as session:
         user_in_session = session.get_one(User, user.id)
@@ -676,10 +676,7 @@ def test_event_reminder_email_sent(db, email_collector: EmailCollector):
             key="",
             data=notification_data_pb2.EventReminder(
                 event=events_pb2.Event(
-                    event_id=1,
-                    slug="board-game-night",
-                    title=title,
-                    start_time=start_event_time,
+                    event_id=1, slug="board-game-night", title=title, start_time=start_time, timezone=timezone
                 ),
                 user=user_model_to_pb(user_in_session, session, make_background_user_context(user_id=user.id)),
             ),

--- a/app/web/features/communities/events/EventCard.test.tsx
+++ b/app/web/features/communities/events/EventCard.test.tsx
@@ -19,7 +19,7 @@ describe("Event card", () => {
     ).toBeVisible();
     expect(screen.getByText(firstEvent.location!.address)).toBeVisible();
     expect(
-      screen.getByText("Tue, Jun 29, 2021, 2:37 – 3:37 AM", {
+      screen.getByText("Tue, Jun 29, 2021, 4:37 – 5:37 AM", {
         normalizer: (x) => x, // Match non-breaking spaces and en dashes exactly
       }),
     ).toBeVisible();
@@ -43,7 +43,7 @@ describe("Event card", () => {
     expect(screen.getByText(secondEvent.location!.address)).toBeVisible();
     expect(
       screen.getByText(
-        "Tue, Jun 29, 2021, 9:00 PM – Wed, Jun 30, 2021, 2:00 AM",
+        "Tue, Jun 29, 2021, 11:00 PM – Wed, Jun 30, 2021, 4:00 AM",
         {
           normalizer: (x) => x, // Match non-breaking spaces and en dashes exactly
         },

--- a/app/web/features/communities/events/EventCard.tsx
+++ b/app/web/features/communities/events/EventCard.tsx
@@ -128,9 +128,8 @@ export default function EventCard({ event, className }: EventCardProps) {
   } = useTranslation([COMMUNITIES]);
 
   const dateTimeRangeText = localizeDateTimeRange(
-    // TODO(#8064): Should use the event.timezone, but it's currently incorrect.
-    timestampToPlainDateTime(event.startTime!),
-    timestampToPlainDateTime(event.endTime!),
+    timestampToPlainDateTime(event.startTime!, event.timezone),
+    timestampToPlainDateTime(event.endTime!, event.timezone),
     {
       locale,
       includeDayOfWeek: true,

--- a/app/web/features/communities/events/EventPage.test.tsx
+++ b/app/web/features/communities/events/EventPage.test.tsx
@@ -94,7 +94,7 @@ describe("Event page", () => {
     ).toBeVisible();
     expect(await screen.findByText(firstEvent.location!.address)).toBeVisible();
     expect(
-      await screen.findByText("Tuesday, June 29, 2021, 2:37 – 3:37 AM", {
+      await screen.findByText("Tuesday, June 29, 2021, 4:37 – 5:37 AM", {
         normalizer: (x) => x, // Match non-breaking spaces and en dashes exactly
       }),
     ).toBeVisible();
@@ -140,7 +140,7 @@ describe("Event page", () => {
 
     expect(
       await screen.findByText(
-        "Tuesday, June 29, 2021 at 9:00 PM – Wednesday, June 30, 2021 at 2:00 AM",
+        "Tuesday, June 29, 2021 at 11:00 PM – Wednesday, June 30, 2021 at 4:00 AM",
         {
           normalizer: (x) => x, // Match non-breaking spaces and en dashes exactly
         },

--- a/app/web/features/communities/events/EventPage.tsx
+++ b/app/web/features/communities/events/EventPage.tsx
@@ -414,9 +414,8 @@ export default function EventPage({
                 <StyledCalendarIcon />
                 <Typography variant="body1">
                   {localizeDateTimeRange(
-                    // TODO(#8064): Should use the event.timezone, but it's currently incorrect.
-                    timestampToPlainDateTime(event.startTime!),
-                    timestampToPlainDateTime(event.endTime!),
+                    timestampToPlainDateTime(event.startTime!, event.timezone),
+                    timestampToPlainDateTime(event.endTime!, event.timezone),
                     {
                       locale,
                       includeDayOfWeek: true,

--- a/app/web/features/communities/events/EventTimeChanger.tsx
+++ b/app/web/features/communities/events/EventTimeChanger.tsx
@@ -41,7 +41,6 @@ export default function EventTimeChanger({
 }: EventTimeChangerProps) {
   const { t } = useTranslation([COMMUNITIES]);
 
-  // FIXME(#8064): Event times should be interpreted in their timezones.
   const defaultStartDateTime = event?.startTime
     ? timestampToPlainDateTime(event.startTime, event?.timezone)
     : undefined;

--- a/app/web/features/communities/events/LongEventCard.tsx
+++ b/app/web/features/communities/events/LongEventCard.tsx
@@ -132,9 +132,8 @@ const LongEventCard = ({
   } = useTranslation([COMMUNITIES]);
 
   const dateTimeRangeText = localizeDateTimeRange(
-    // TODO(#8064): Should use the event.timezone, but it's currently incorrect.
-    timestampToPlainDateTime(event.startTime!),
-    timestampToPlainDateTime(event.endTime!),
+    timestampToPlainDateTime(event.startTime!, event.timezone),
+    timestampToPlainDateTime(event.endTime!, event.timezone),
     {
       locale,
       includeDayOfWeek: true,

--- a/app/web/features/dashboard/EventListRow.tsx
+++ b/app/web/features/dashboard/EventListRow.tsx
@@ -9,7 +9,7 @@ import { Temporal } from "temporal-polyfill";
 import {
   localizeDateTime,
   localizeMonthAbbreviation,
-  timestampToPlainDateTime,
+  timestampToZonedDateTime,
 } from "utils/date";
 
 export const EventListContainer = styled("div")({
@@ -172,16 +172,20 @@ export default function EventListRow({ event }: EventListRowProps) {
     i18n: { language: locale },
   } = useTranslation([DASHBOARD]);
 
-  const now = Temporal.Now.plainDateTimeISO();
-  const startDate = timestampToPlainDateTime(event.startTime!);
+  const now = Temporal.Now.zonedDateTimeISO();
+  const startDate = timestampToZonedDateTime(event.startTime!, event.timezone);
   const endDate = event.endTime
-    ? timestampToPlainDateTime(event.endTime)
+    ? timestampToZonedDateTime(event.endTime, event.timezone)
     : null;
   const isOngoing =
     endDate !== null &&
-    Temporal.PlainDateTime.compare(startDate, now) <= 0 &&
-    Temporal.PlainDateTime.compare(endDate, now) >= 0;
-  const isToday = !isOngoing && startDate.toPlainDate() === now.toPlainDate();
+    Temporal.ZonedDateTime.compare(startDate, now) <= 0 &&
+    Temporal.ZonedDateTime.compare(endDate, now) >= 0;
+
+  // Define "today" as: starting on the current day in the current timezone.
+  const isToday =
+    !isOngoing &&
+    startDate.withTimeZone(now.timeZoneId).toPlainDate() === now.toPlainDate();
   const todayLabel = t("dashboard:events.today_label");
   const nowLabel = t("dashboard:now_label");
   const chipLabel = isOngoing ? nowLabel : todayLabel;

--- a/app/web/utils/date.ts
+++ b/app/web/utils/date.ts
@@ -33,10 +33,20 @@ export function daysBetween(
   return date1.until(date2, { largestUnit: "days" }).days;
 }
 
-/// Converts a Temporal.PlainDate[Time] to a Date, interpreting it in UTC timezone.
-function toUTCDate(
-  temporal: Temporal.PlainDate | Temporal.PlainDateTime,
+/// Converts a Temporal date/time object to a Date
+/// such that it displays as expected in the UTC timezone.
+function toDateForUTCDisplay(
+  temporal:
+    | Temporal.ZonedDateTime
+    | Temporal.PlainDate
+    | Temporal.PlainDateTime,
 ): Date {
+  if (temporal instanceof Temporal.ZonedDateTime) {
+    // Discard the timezone, we'll reinterpret it in UTC,
+    // which results in an incorrect timestamp but correct
+    // datetime components for displaying.
+    temporal = temporal.toPlainDateTime();
+  }
   if (temporal instanceof Temporal.PlainDate) {
     temporal = temporal.toPlainDateTime();
   }
@@ -67,11 +77,11 @@ interface LocalizeDateTimeParams {
 
 /// Localizes a date and time, optionally with the day of the week.
 export function localizeDateTime(
-  date: Temporal.PlainDateTime | Temporal.PlainDate,
+  date: Temporal.ZonedDateTime | Temporal.PlainDateTime | Temporal.PlainDate,
   args: LocalizeDateTimeParams,
 ): string {
   const format = getIntlDateTimeFormatUTC(args);
-  const formatted = format.format(toUTCDate(date));
+  const formatted = format.format(toDateForUTCDisplay(date));
   return args.capitalize
     ? capitalizeFirstLetter(formatted, args.locale)
     : formatted;
@@ -97,12 +107,15 @@ export function localizeYearMonth(
 
 /// Localizes a range of date and times as a string.
 export function localizeDateTimeRange(
-  start: Temporal.PlainDateTime | Temporal.PlainDate,
-  end: Temporal.PlainDateTime | Temporal.PlainDate,
+  start: Temporal.ZonedDateTime | Temporal.PlainDateTime | Temporal.PlainDate,
+  end: Temporal.ZonedDateTime | Temporal.PlainDateTime | Temporal.PlainDate,
   args: LocalizeDateTimeParams,
 ): string {
   const format = getIntlDateTimeFormatUTC(args);
-  const formatted = format.formatRange(toUTCDate(start), toUTCDate(end));
+  const formatted = format.formatRange(
+    toDateForUTCDisplay(start),
+    toDateForUTCDisplay(end),
+  );
   return args.capitalize
     ? capitalizeFirstLetter(formatted, args.locale)
     : formatted;
@@ -172,7 +185,7 @@ export function localizeMonthAbbreviation(
     format = Intl.DateTimeFormat(args.locale, options);
     intlDateTimeFormatCache.set(cacheKey, format);
   }
-  const formatted = format.format(toUTCDate(date));
+  const formatted = format.format(toDateForUTCDisplay(date));
   return args.capitalize
     ? capitalizeFirstLetter(formatted, args.locale)
     : formatted;
@@ -300,6 +313,15 @@ export function timestampToPlainDateTime(
   timezone?: string,
 ): Temporal.PlainDateTime {
   return instantToPlainDateTime(timestampToInstant(timestamp), timezone);
+}
+
+export function timestampToZonedDateTime(
+  timestamp: Timestamp.AsObject,
+  timezone: string | undefined,
+): Temporal.ZonedDateTime {
+  return timestampToInstant(timestamp).toZonedDateTimeISO(
+    timezone ?? Temporal.Now.timeZoneId(),
+  );
 }
 
 const APPROX_DAYS_PER_YEAR = 365;


### PR DESCRIPTION
Switches event times to display in the timezone at the event's location, as now reported by the backend after #9218 . This is more useful than seeing an event in your travel destination displayed in the middle of the night because you're still several timezones away.

⚠️ Existing events that were created with a browser timezone different from the timezone at the event location have incorrect timestamps in the database: they appeared correct in the original browser timezone (two wrongs make one right) and incorrect everywhere else. Now they'll be incorrect everywhere, so authors will need to fix the event times. There's nothing we can do about it since we've stored bad data in the database.

Follow-up question: Should we show timezones now?

Fixes #7998

## Testing
Using NEXT, created an event in Addis Ababa at 2pm. This is how it shows up on NEXT (my browser is in Eastern US timezone):

<img width="757" height="225" alt="image" src="https://github.com/user-attachments/assets/06871f51-2910-41f1-b793-bf0267df1d37" />

With the Vercel preview:

<img width="771" height="235" alt="image" src="https://github.com/user-attachments/assets/844bb80c-1d7b-4509-941a-e0c052419f08" />
<img width="555" height="205" alt="image" src="https://github.com/user-attachments/assets/fc72163c-1169-40cd-b24e-5a228b11334f" />
<img width="388" height="147" alt="image" src="https://github.com/user-attachments/assets/865b6676-d789-42d0-bef4-bcb5974df1be" />

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
