### PR TITLE
Backend/events: Add GetEventCalendarFile API

### DIFF
--- a/app/backend/src/couchers/email/calendar_events.py
+++ b/app/backend/src/couchers/email/calendar_events.py
@@ -110,6 +110,9 @@ def create_event_ics_event(event: events_pb2.Event, loc_context: LocalizationCon
     # Google Calendar™ will hide the URL if there is a location, so also include it in the description
     ics_event.description = markdown_to_plaintext(event.content) + "\n\n" + url
 
+    if event.is_cancelled:
+        ics_event.status = "CANCELLED"
+
     return ics_event
 
 

--- a/app/backend/src/couchers/email/calendar_events.py
+++ b/app/backend/src/couchers/email/calendar_events.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from email.headerregistry import Address
 from typing import Literal
 
@@ -41,7 +42,7 @@ def create_host_request_ics_event(
 
     event = Event()
     event.uid = _event_uid(host_request.host_request_id, kind="host_request")
-    event.extra.append(_monotonic_sequence_number())
+    _set_sequence_timestamp(event, now())
 
     title: str
     if hosting:
@@ -92,13 +93,14 @@ def create_event_ics_event(event: events_pb2.Event, loc_context: LocalizationCon
 
     ics_event = Event()
     ics_event.uid = _event_uid(event.event_id, kind="event")
-    ics_event.extra.append(_monotonic_sequence_number())
+    ics_event.last_modified = to_aware_datetime(event.last_edited)
+    _set_sequence_timestamp(ics_event, to_aware_datetime(event.last_edited))
     ics_event.name = _final_title(event.title, loc_context, is_cancelled=event.is_cancelled)
 
     ics_event.begin = to_aware_datetime(event.start_time, event.timezone)
     ics_event.end = to_aware_datetime(event.start_time, event.timezone)
 
-    ics_event.location = event.location
+    ics_event.location = event.location.address
     url = urls.event_link(occurrence_id=event.event_id, slug=event.slug)
     ics_event.url = url
     # Google Calendar™ will hide the URL if there is a location, so also include it in the description
@@ -120,8 +122,11 @@ def _event_uid(item_id: int, *, kind: Literal["host_request"] | Literal["event"]
     return f"{kind}.{item_id}@{uid_domain}"
 
 
-def _monotonic_sequence_number() -> ContentLine:
-    return ContentLine(name="SEQUENCE", value=str(round(now().timestamp())))
+def _set_sequence_timestamp(event: Event, dt: datetime) -> None:
+    # SEQUENCE is 32-bit, so only support second granularity to avoid overflows
+    # A better implementation would need to reply on a stored sequence number.
+    timestamp = round(dt.timestamp())
+    event.extra.append(ContentLine(name="SEQUENCE", value=str(timestamp)))
 
 
 def get_sequence_number(event: Event) -> int | None:

--- a/app/backend/src/couchers/email/calendar_events.py
+++ b/app/backend/src/couchers/email/calendar_events.py
@@ -1,4 +1,5 @@
 from email.headerregistry import Address
+from typing import Literal
 
 from ics import Calendar, Event
 from ics.grammar.parse import ContentLine  # type: ignore[import-untyped]
@@ -7,50 +8,58 @@ from couchers import urls
 from couchers.config import config
 from couchers.email.locales import get_emails_i18next
 from couchers.i18n import LocalizationContext
+from couchers.markup import markdown_to_plaintext
+from couchers.proto import events_pb2, messages_pb2, requests_pb2
 from couchers.proto.internal.jobs_pb2 import EmailPart
-from couchers.proto.requests_pb2 import HostRequest
+from couchers.utils import now, to_aware_datetime
 
 HOST_REQUEST_ICS_FILENAME = "host_request.ics"
 
 
 def create_host_request_attachment(
-    host_request: HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext
+    host_request: requests_pb2.HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext
 ) -> EmailPart:
-    calendar = create_host_request_calendar(host_request, other_name, hosting, loc_context)
-    return calendar_to_attachment(calendar, HOST_REQUEST_ICS_FILENAME)
+    calendar = create_host_request_ics_calendar(host_request, other_name, hosting, loc_context)
+    return ics_calendar_to_attachment(calendar, HOST_REQUEST_ICS_FILENAME)
 
 
-def create_host_request_calendar(
-    host_request: HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext
+def create_host_request_ics_calendar(
+    host_request: requests_pb2.HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext
 ) -> Calendar:
-    event = create_host_request_event(host_request, other_name, hosting, loc_context)
+    event = create_host_request_ics_event(host_request, other_name, hosting, loc_context)
 
     # METHOD:PUBLISH means this is part of a stream of calendar event information.
     # It allows for later cancellation, and doesn't expose accept/decline functionality.
-    return event_to_calendar(event, "PUBLISH", loc_context)
+    # METHOD:CANCEL might leave the event in cancelled state or not work.
+    return ics_event_to_calendar(event, "PUBLISH", loc_context)
 
 
-def create_host_request_event(
-    host_request: HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext, sequence: int = 0
+def create_host_request_ics_event(
+    host_request: requests_pb2.HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext
 ) -> Event:
     """Creates an ics event for a host request."""
 
     event = Event()
-    event.uid = get_host_request_event_uid(host_request.host_request_id)
+    event.uid = _event_uid(host_request.host_request_id, kind="host_request")
+    event.extra.append(_monotonic_sequence_number())
 
-    # Explicitly allow later sequencing of a cancellation with SEQUENCE:1
-    event.extra.append(ContentLine(name="SEQUENCE", value=str(sequence)))
-
+    title: str
     if hosting:
-        event.name = loc_context.localize_string(
+        title = loc_context.localize_string(
             "calendar_events.host_requests.title_host", i18next=get_emails_i18next(), substitutions={"name": other_name}
         )
     else:
-        event.name = loc_context.localize_string(
+        title = loc_context.localize_string(
             "calendar_events.host_requests.title_surfer",
             i18next=get_emails_i18next(),
             substitutions={"name": other_name},
         )
+
+    event.name = _final_title(
+        title,
+        loc_context,
+        is_cancelled=host_request.status == messages_pb2.HostRequestStatus.HOST_REQUEST_STATUS_CANCELLED,
+    )
 
     # Our to_date is inclusive, iCalendar's DTEND is exclusive (for full-day events)
     # make_all_day will adjust the end date by one day accordingly.
@@ -64,32 +73,66 @@ def create_host_request_event(
     # Google Calendar™ will hide the URL if there is a location, so also include it in the description
     event.description = event.url
 
+    if host_request.status == messages_pb2.HostRequestStatus.HOST_REQUEST_STATUS_CANCELLED:
+        event.status = "CANCELLED"
+
     return event
 
 
-def create_host_request_cancellation_attachment(
-    host_request: HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext
-) -> EmailPart:
-    calendar = create_host_request_cancellation_calendar(host_request, other_name, hosting, loc_context)
-    return calendar_to_attachment(calendar, HOST_REQUEST_ICS_FILENAME)
-
-
-def create_host_request_cancellation_calendar(
-    host_request: HostRequest, other_name: str, hosting: bool, loc_context: LocalizationContext
-) -> Calendar:
-    event = create_host_request_event(host_request, other_name, hosting, loc_context, sequence=1)
-    event.name = loc_context.localize_string(
-        "calendar_events.title_cancelled", i18next=get_emails_i18next(), substitutions={"title": event.name}
-    )
-    event.status = "CANCELLED"
+def create_event_ics_calendar(event: events_pb2.Event, loc_context: LocalizationContext) -> Calendar:
+    ics_event = create_event_ics_event(event, loc_context)
 
     # METHOD:PUBLISH means this is part of a stream of calendar event information.
-    # Gmail™ will immediately remove the event from the user's calendar.
-    # METHOD:CANCEL might leave the event in cancelled state or not work.
-    return event_to_calendar(event, "PUBLISH", loc_context)
+    # It allows for later cancellation, and doesn't expose accept/decline functionality.
+    return ics_event_to_calendar(ics_event, "PUBLISH", loc_context)
 
 
-def event_to_calendar(event: Event, method: str | None, loc_context: LocalizationContext) -> Calendar:
+def create_event_ics_event(event: events_pb2.Event, loc_context: LocalizationContext) -> Event:
+    """Creates an ics event for a host request."""
+
+    ics_event = Event()
+    ics_event.uid = _event_uid(event.event_id, kind="event")
+    ics_event.extra.append(_monotonic_sequence_number())
+    ics_event.name = _final_title(event.title, loc_context, is_cancelled=event.is_cancelled)
+
+    ics_event.begin = to_aware_datetime(event.start_time, event.timezone)
+    ics_event.end = to_aware_datetime(event.start_time, event.timezone)
+    ics_event.timezone = event.timezone
+
+    ics_event.location = event.location
+    url = urls.event_link(occurrence_id=event.event_id, slug=event.slug)
+    ics_event.url = url
+    # Google Calendar™ will hide the URL if there is a location, so also include it in the description
+    ics_event.description = markdown_to_plaintext(event.content) + "\n\n" + url
+
+    return ics_event
+
+
+def _final_title(title: str, loc_context: LocalizationContext, *, is_cancelled: bool) -> str:
+    if is_cancelled:
+        title = loc_context.localize_string(
+            "calendar_events.title_cancelled", i18next=get_emails_i18next(), substitutions={"title": title}
+        )
+    return title
+
+
+def _event_uid(item_id: int, *, kind: Literal["host_request"] | Literal["event"]) -> str:
+    uid_domain = Address(addr_spec=config.NOTIFICATION_EMAIL_ADDRESS).domain
+    return f"{kind}.{item_id}@{uid_domain}"
+
+
+def _monotonic_sequence_number() -> ContentLine:
+    return ContentLine(name="SEQUENCE", value=str(round(now().timestamp())))
+
+
+def get_sequence_number(event: Event) -> int | None:
+    for extra in event.extra:
+        if extra.name == "SEQUENCE":
+            return int(extra.value)
+    return None
+
+
+def ics_event_to_calendar(event: Event, method: str | None, loc_context: LocalizationContext) -> Calendar:
     # PRODID is mandatory and generally follows "-//[Organization]//[Product Name]//[Language]"
     calendar = Calendar(creator=f"-//Couchers.org//Couchers//{loc_context.locale.upper()}")
     if method:
@@ -98,7 +141,7 @@ def event_to_calendar(event: Event, method: str | None, loc_context: Localizatio
     return calendar
 
 
-def calendar_to_attachment(calendar: Calendar, filename: str) -> EmailPart:
+def ics_calendar_to_attachment(calendar: Calendar, filename: str) -> EmailPart:
     data = calendar.serialize().encode("utf-8")
     content_disposition = f'attachment; filename="{filename}"'
     content_type = 'text/calendar; charset="utf-8"'
@@ -108,8 +151,3 @@ def calendar_to_attachment(calendar: Calendar, filename: str) -> EmailPart:
         content_type += f"; method={calendar.method}"
 
     return EmailPart(data=data, content_disposition=content_disposition, content_type=content_type)
-
-
-def get_host_request_event_uid(host_request_id: int) -> str:
-    uid_domain = Address(addr_spec=config.NOTIFICATION_EMAIL_ADDRESS).domain
-    return f"host_request.{host_request_id}@{uid_domain}"

--- a/app/backend/src/couchers/email/calendar_events.py
+++ b/app/backend/src/couchers/email/calendar_events.py
@@ -97,7 +97,6 @@ def create_event_ics_event(event: events_pb2.Event, loc_context: LocalizationCon
 
     ics_event.begin = to_aware_datetime(event.start_time, event.timezone)
     ics_event.end = to_aware_datetime(event.start_time, event.timezone)
-    ics_event.timezone = event.timezone
 
     ics_event.location = event.location
     url = urls.event_link(occurrence_id=event.event_id, slug=event.slug)

--- a/app/backend/src/couchers/email/calendar_events.py
+++ b/app/backend/src/couchers/email/calendar_events.py
@@ -1,8 +1,9 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from email.headerregistry import Address
 from typing import Literal
+from zoneinfo import ZoneInfo
 
-from ics import Calendar, Event
+from ics import Calendar, Event, Geo
 from ics.grammar.parse import ContentLine  # type: ignore[import-untyped]
 
 from couchers import urls
@@ -93,14 +94,17 @@ def create_event_ics_event(event: events_pb2.Event, loc_context: LocalizationCon
 
     ics_event = Event()
     ics_event.uid = _event_uid(event.event_id, kind="event")
-    ics_event.last_modified = to_aware_datetime(event.last_edited)
-    _set_sequence_timestamp(ics_event, to_aware_datetime(event.last_edited))
     ics_event.name = _final_title(event.title, loc_context, is_cancelled=event.is_cancelled)
 
-    ics_event.begin = to_aware_datetime(event.start_time, event.timezone)
-    ics_event.end = to_aware_datetime(event.start_time, event.timezone)
+    last_update_datetime = to_aware_datetime(event.created if event.last_edited.seconds == 0 else event.last_edited)
+    ics_event.last_modified = last_update_datetime
+    _set_sequence_timestamp(ics_event, last_update_datetime)
+
+    _set_datetime_with_timezone(ics_event, "DTSTART", to_aware_datetime(event.start_time, event.timezone))
+    _set_datetime_with_timezone(ics_event, "DTEND", to_aware_datetime(event.end_time, event.timezone))
 
     ics_event.location = event.location.address
+    ics_event.geo = Geo(event.location.lat, event.location.lng)
     url = urls.event_link(occurrence_id=event.event_id, slug=event.slug)
     ics_event.url = url
     # Google Calendar™ will hide the URL if there is a location, so also include it in the description
@@ -129,11 +133,20 @@ def _set_sequence_timestamp(event: Event, dt: datetime) -> None:
     event.extra.append(ContentLine(name="SEQUENCE", value=str(timestamp)))
 
 
-def get_sequence_number(event: Event) -> int | None:
-    for extra in event.extra:
-        if extra.name == "SEQUENCE":
-            return int(extra.value)
-    return None
+def _set_datetime_with_timezone(event: Event, name: str, dt: datetime) -> None:
+    """
+    Adds a property whose value is a datetime with a timezone.
+    Working around that ics's native Event.begin/end properties don't encode the timezone.
+    """
+    datetime_format = "%Y%m%dT%H%M%S"
+    params: dict[str, list[str]] = {}
+    value: str
+    if isinstance(dt.tzinfo, ZoneInfo) and dt.tzinfo.key != "Etc/UTC":
+        params["TZID"] = [dt.tzinfo.key]
+        value = dt.strftime(datetime_format)
+    else:
+        value = dt.astimezone(UTC).strftime(datetime_format) + "Z"
+    event.extra.append(ContentLine(name, params, value=value))
 
 
 def ics_event_to_calendar(event: Event, method: str | None, loc_context: LocalizationContext) -> Calendar:

--- a/app/backend/src/couchers/email/calendar_events.py
+++ b/app/backend/src/couchers/email/calendar_events.py
@@ -100,8 +100,9 @@ def create_event_ics_event(event: events_pb2.Event, loc_context: LocalizationCon
     ics_event.last_modified = last_update_datetime
     _set_sequence_timestamp(ics_event, last_update_datetime)
 
-    _set_datetime_with_timezone(ics_event, "DTSTART", to_aware_datetime(event.start_time, event.timezone))
-    _set_datetime_with_timezone(ics_event, "DTEND", to_aware_datetime(event.end_time, event.timezone))
+    timezone = ZoneInfo(event.timezone)
+    _set_datetime_with_timezone(ics_event, "DTSTART", to_aware_datetime(event.start_time).astimezone(timezone))
+    _set_datetime_with_timezone(ics_event, "DTEND", to_aware_datetime(event.end_time).astimezone(timezone))
 
     ics_event.location = event.location.address
     ics_event.geo = Geo(event.location.lat, event.location.lng)

--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -6,7 +6,7 @@ import couchers.email.emails as emails
 from couchers import urls
 from couchers.config import config
 from couchers.email.blocks import EmailBase, EmailFooter, UnsubscribeInfo, UnsubscribeLink
-from couchers.email.calendar_events import create_host_request_attachment, create_host_request_cancellation_attachment
+from couchers.email.calendar_events import create_host_request_attachment
 from couchers.email.rendering import render_email
 from couchers.i18n import LocalizationContext
 from couchers.models import Notification, NotificationTopicAction, User
@@ -184,7 +184,7 @@ def get_ics_attachment(notification: Notification, loc_context: LocalizationCont
     elif notification.topic_action == NotificationTopicAction.host_request__cancel:
         # Caveat: only the party getting cancelled receives this notification,
         # we have no opportunity to provide the cancelling party with a cancelled ics attachment.
-        return create_host_request_cancellation_attachment(
+        return create_host_request_attachment(
             data.host_request, other_name=data.surfer.name, hosting=True, loc_context=loc_context
         )
     else:

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -39,6 +39,7 @@ from couchers.models.static import TimezoneArea
 from couchers.moderation.utils import create_moderation
 from couchers.notifications.notify import notify
 from couchers.proto import events_pb2, events_pb2_grpc, notification_data_pb2
+from couchers.proto.google.api import httpbody_pb2
 from couchers.proto.internal import jobs_pb2
 from couchers.servicers.api import user_model_to_pb
 from couchers.servicers.blocking import is_not_visible
@@ -1370,7 +1371,7 @@ class Events(events_pb2_grpc.EventsServicer):
 
     def GetEventCalendarFile(
         self, request: events_pb2.GetEventCalendarFileReq, context: CouchersContext, session: Session
-    ) -> events_pb2.GetEventCalendarFileRes:
+    ) -> httpbody_pb2.HttpBody:
         res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id, context=context)
         if not res:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
@@ -1379,4 +1380,4 @@ class Events(events_pb2_grpc.EventsServicer):
 
         event_pb = event_to_pb(session, occurrence_db, context)
         ics_data = create_event_ics_calendar(event_pb, context.localization).serialize().encode("utf-8")
-        return events_pb2.GetEventCalendarFileRes(data=ics_data)
+        return httpbody_pb2.HttpBody(content_type="text/calendar", data=ics_data)

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -13,6 +13,7 @@ from sqlalchemy.sql import and_, func, or_, update
 
 from couchers.context import CouchersContext, make_notification_user_context
 from couchers.db import can_moderate_node, get_parent_node_at_location, session_scope
+from couchers.email.calendar_events import create_event_ics_calendar
 from couchers.event_log import log_event
 from couchers.helpers.completed_profile import has_completed_profile
 from couchers.jobs.enqueue import queue_job
@@ -1366,3 +1367,16 @@ class Events(events_pb2_grpc.EventsServicer):
         session.delete(organizer_to_remove)
 
         return empty_pb2.Empty()
+
+    def GetEventCalendarFile(
+        self, request: events_pb2.GetEventCalendarFileReq, context: CouchersContext, session: Session
+    ) -> events_pb2.GetEventCalendarFileRes:
+        res = _get_event_and_occurrence_one_or_none(session, occurrence_id=request.event_id, context=context)
+        if not res:
+            context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
+
+        _, occurrence_db = res
+
+        event_pb = event_to_pb(session, occurrence_db, context)
+        ics_data = create_event_ics_calendar(event_pb, context.localization).serialize().encode("utf-8")
+        return events_pb2.GetEventCalendarFileRes(data=ics_data)

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -111,13 +111,11 @@ def date_to_api(date_obj: date) -> str:
     return date_obj.isoformat()
 
 
-def to_aware_datetime(ts: Timestamp, timezone: str | tzinfo = UTC) -> datetime:
+def to_aware_datetime(ts: Timestamp) -> datetime:
     """
     Turns a protobuf Timestamp object into a timezone-aware datetime
     """
-    if isinstance(timezone, str):
-        timezone = ZoneInfo(timezone)
-    return ts.ToDatetime(tzinfo=timezone)
+    return ts.ToDatetime(tzinfo=UTC)
 
 
 def to_timezone(value: Timestamp | datetime, timezone: tzinfo) -> datetime:

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -111,11 +111,13 @@ def date_to_api(date_obj: date) -> str:
     return date_obj.isoformat()
 
 
-def to_aware_datetime(ts: Timestamp) -> datetime:
+def to_aware_datetime(ts: Timestamp, timezone: str | tzinfo = UTC) -> datetime:
     """
     Turns a protobuf Timestamp object into a timezone-aware datetime
     """
-    return ts.ToDatetime(tzinfo=UTC)
+    if isinstance(timezone, str):
+        timezone = ZoneInfo(timezone)
+    return ts.ToDatetime(tzinfo=timezone)
 
 
 def to_timezone(value: Timestamp | datetime, timezone: tzinfo) -> datetime:

--- a/app/backend/src/tests/test_calendar_events.py
+++ b/app/backend/src/tests/test_calendar_events.py
@@ -27,23 +27,26 @@ def test_host_request_ics_content():
     ics: str = create_host_request_ics_calendar(
         host_request, other_name="Bob", hosting=True, loc_context=LocalizationContext.en_utc()
     ).serialize()
-    assert _normalize_ics(ics) == _normalize_ics("""
+    assert _assert_ics_matches_pattern(
+        ics,
+        """
 BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Couchers.org//Couchers//EN
 BEGIN:VEVENT
-SEQUENCE:<stripped>
+SEQUENCE:***
 DTSTART;VALUE=DATE:20000101
 DTEND;VALUE=DATE:20000103
-DESCRIPTION:<stripped>/42
+DESCRIPTION:***/42
 LOCATION:New York
 SUMMARY:Hosting Bob
-UID:host_request.42@<stripped>
-URL:<stripped>/42
+UID:host_request.42@***
+URL:***/42
 END:VEVENT
 METHOD:PUBLISH
 END:VCALENDAR
-    """)
+    """,
+    )
 
 
 def test_host_request_cancelled_ics_content():
@@ -58,24 +61,27 @@ def test_host_request_cancelled_ics_content():
     ics: str = create_host_request_ics_calendar(
         host_request, other_name="Bob", hosting=True, loc_context=LocalizationContext.en_utc()
     ).serialize()
-    assert _normalize_ics(ics) == _normalize_ics("""
+    assert _assert_ics_matches_pattern(
+        ics,
+        """
 BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Couchers.org//Couchers//EN
 BEGIN:VEVENT
-SEQUENCE:<stripped>
+SEQUENCE:***
 DTSTART;VALUE=DATE:20000101
 DTEND;VALUE=DATE:20000103
-DESCRIPTION:<stripped>/42
+DESCRIPTION:***/42
 LOCATION:New York
 STATUS:CANCELLED
 SUMMARY:Cancelled: Hosting Bob
-UID:host_request.42@<stripped>
-URL:<stripped>/42
+UID:host_request.42@***
+URL:***/42
 END:VEVENT
 METHOD:PUBLISH
 END:VCALENDAR
-    """)
+    """,
+    )
 
 
 def test_event_ics_content():
@@ -84,47 +90,41 @@ def test_event_ics_content():
         title="Event Title",
         slug="event-slug",
         content="Event description",
-        start_time=Timestamp_from_datetime(datetime(2000, 1, 1, tzinfo=UTC)),
-        end_time=Timestamp_from_datetime(datetime(2000, 1, 2, tzinfo=UTC)),
+        start_time=Timestamp_from_datetime(datetime(2000, 1, 1, 12, 0, tzinfo=UTC)),
+        end_time=Timestamp_from_datetime(datetime(2000, 1, 2, 12, 0, tzinfo=UTC)),
         location=events_pb2.EventLocation(address="City, Country", lat=0.1, lng=0.1),
     )
 
     ics: str = create_event_ics_calendar(event, loc_context=LocalizationContext.en_utc()).serialize()
-    assert _normalize_ics(ics) == _normalize_ics("""
+    assert _assert_ics_matches_pattern(
+        ics,
+        """
 BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Couchers.org//Couchers//EN
 BEGIN:VEVENT
-SEQUENCE:<stripped>
-DTSTART;VALUE=DATE:20000101
-DTEND;VALUE=DATE:20000102
+SEQUENCE:***
+DTSTART;20000101T120000Z
+DTEND;20000102T120000Z
 DESCRIPTION:Event description
 LOCATION:City, Country
 STATUS:CANCELLED
 SUMMARY:Event Title
-UID:event.42@<stripped>
-URL:<stripped>/42
+UID:event.42@***
+URL:***/42
 END:VEVENT
 METHOD:PUBLISH
 END:VCALENDAR
-    """)
-
-
-def _normalize_ics(ics: str) -> str:
-    # Normalize whitespace:
-    # - The ics library produces '\r\n', in-code literals are '\n'
-    # - In-code literals have start/end newlines and indentation.
-    ics = ics.replace("\r\n", "\n").strip()
-
-    # Strip the domain in the UID, which depends on environment variables
-    ics = re.sub(
-        r"^UID:.*@(.*)$", lambda match: match[0].removesuffix(match[1]) + "<stripped>", ics, flags=re.MULTILINE
+    """,
     )
 
-    # Strip the domain in the URL and DESCRIPTION, which depends on environment variables
-    ics = re.sub(r"^(DESCRIPTION|URL):(.*)/(\d+)", r"\1:<stripped>/\3", ics, flags=re.MULTILINE)
 
-    return ics
+def _assert_ics_matches_pattern(actual: str, expected_pattern: str) -> str:
+    actual = actual.replace("\r\n", "\n").strip()
+    expected_pattern = expected_pattern.strip()
+
+    expected_pattern = re.escape(expected_pattern).replace("\*\*\*", ".*?")
+    return re.fullmatch(expected_pattern, actual)
 
 
 def test_host_request_attachments(db, email_collector: EmailCollector, moderator: Moderator):

--- a/app/backend/src/tests/test_calendar_events.py
+++ b/app/backend/src/tests/test_calendar_events.py
@@ -120,10 +120,11 @@ END:VCALENDAR
 
 
 def _assert_ics_matches_pattern(actual: str, expected_pattern: str) -> str:
+    """Assert that an ics file's content matches a pattern that includes "***" wildcards."""
     actual = actual.replace("\r\n", "\n").strip()
     expected_pattern = expected_pattern.strip()
 
-    expected_pattern = re.escape(expected_pattern).replace("\*\*\*", ".*?")
+    expected_pattern = re.escape(expected_pattern).replace("\\*\\*\\*", ".*?")
     return re.fullmatch(expected_pattern, actual)
 
 

--- a/app/backend/src/tests/test_calendar_events.py
+++ b/app/backend/src/tests/test_calendar_events.py
@@ -201,7 +201,8 @@ def test_host_request_attachments(db, email_collector: EmailCollector, moderator
     email = email_collector.pop_for_recipient(host.email, last=True)
     assert "cancel" in email.subject and surfer.name in email.subject
     cancelled_ics_event = _get_email_ics_attachment_calendar_event(email)
-    assert (_get_ics_event_sequence(cancelled_ics_event) or 0) > (_get_ics_event_sequence(accepted_ics_event) or 0)
+    # Ideally the sequence number are strictly ascending, but they are based on timestamps so in tests they could be equal.
+    assert (_get_ics_event_sequence(cancelled_ics_event) or 0) >= (_get_ics_event_sequence(accepted_ics_event) or 0)
     assert cancelled_ics_event.status == "CANCELLED"
 
 

--- a/app/backend/src/tests/test_calendar_events.py
+++ b/app/backend/src/tests/test_calendar_events.py
@@ -1,14 +1,13 @@
 import re
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 
 import ics
 import pytest
 
-from couchers.email.calendar_events import create_host_request_calendar, create_host_request_cancellation_calendar
+from couchers.email.calendar_events import create_event_ics_calendar, create_host_request_ics_calendar
 from couchers.i18n.context import LocalizationContext
-from couchers.proto import messages_pb2, requests_pb2
-from couchers.proto.requests_pb2 import HostRequest
-from couchers.utils import today
+from couchers.proto import events_pb2, messages_pb2, requests_pb2
+from couchers.utils import Timestamp_from_datetime, today
 from tests.fixtures.db import generate_user
 from tests.fixtures.misc import EmailCollector, Moderator
 from tests.fixtures.sessions import requests_session
@@ -20,12 +19,12 @@ def _(testconfig):
     pass
 
 
-def test_initial_ics_content():
-    host_request = HostRequest(
+def test_host_request_ics_content():
+    host_request = requests_pb2.HostRequest(
         host_request_id=42, from_date="2000-01-01", to_date="2000-01-02", hosting_city="New York"
     )
 
-    ics: str = create_host_request_calendar(
+    ics: str = create_host_request_ics_calendar(
         host_request, other_name="Bob", hosting=True, loc_context=LocalizationContext.en_utc()
     ).serialize()
     assert _normalize_ics(ics) == _normalize_ics("""
@@ -33,7 +32,7 @@ BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Couchers.org//Couchers//EN
 BEGIN:VEVENT
-SEQUENCE:0
+SEQUENCE:<stripped>
 DTSTART;VALUE=DATE:20000101
 DTEND;VALUE=DATE:20000103
 DESCRIPTION:<stripped>/42
@@ -47,12 +46,16 @@ END:VCALENDAR
     """)
 
 
-def test_cancellation_ics_content():
-    host_request = HostRequest(
-        host_request_id=42, from_date="2000-01-01", to_date="2000-01-02", hosting_city="New York"
+def test_host_request_cancelled_ics_content():
+    host_request = requests_pb2.HostRequest(
+        host_request_id=42,
+        from_date="2000-01-01",
+        to_date="2000-01-02",
+        hosting_city="New York",
+        status=messages_pb2.HostRequestStatus.HOST_REQUEST_STATUS_CANCELLED,
     )
 
-    ics: str = create_host_request_cancellation_calendar(
+    ics: str = create_host_request_ics_calendar(
         host_request, other_name="Bob", hosting=True, loc_context=LocalizationContext.en_utc()
     ).serialize()
     assert _normalize_ics(ics) == _normalize_ics("""
@@ -60,7 +63,7 @@ BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Couchers.org//Couchers//EN
 BEGIN:VEVENT
-SEQUENCE:1
+SEQUENCE:<stripped>
 DTSTART;VALUE=DATE:20000101
 DTEND;VALUE=DATE:20000103
 DESCRIPTION:<stripped>/42
@@ -68,6 +71,38 @@ LOCATION:New York
 STATUS:CANCELLED
 SUMMARY:Cancelled: Hosting Bob
 UID:host_request.42@<stripped>
+URL:<stripped>/42
+END:VEVENT
+METHOD:PUBLISH
+END:VCALENDAR
+    """)
+
+
+def test_event_ics_content():
+    event = events_pb2.Event(
+        event_id=42,
+        title="Event Title",
+        slug="event-slug",
+        content="Event description",
+        start_time=Timestamp_from_datetime(datetime(2000, 1, 1, tzinfo=UTC)),
+        end_time=Timestamp_from_datetime(datetime(2000, 1, 2, tzinfo=UTC)),
+        location=events_pb2.EventLocation(address="City, Country", lat=0.1, lng=0.1),
+    )
+
+    ics: str = create_event_ics_calendar(event, loc_context=LocalizationContext.en_utc()).serialize()
+    assert _normalize_ics(ics) == _normalize_ics("""
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Couchers.org//Couchers//EN
+BEGIN:VEVENT
+SEQUENCE:<stripped>
+DTSTART;VALUE=DATE:20000101
+DTEND;VALUE=DATE:20000102
+DESCRIPTION:Event description
+LOCATION:City, Country
+STATUS:CANCELLED
+SUMMARY:Event Title
+UID:event.42@<stripped>
 URL:<stripped>/42
 END:VEVENT
 METHOD:PUBLISH

--- a/app/backend/src/tests/test_calendar_events.py
+++ b/app/backend/src/tests/test_calendar_events.py
@@ -93,6 +93,7 @@ def test_event_ics_content():
         start_time=Timestamp_from_datetime(datetime(2000, 1, 1, 12, 0, tzinfo=UTC)),
         end_time=Timestamp_from_datetime(datetime(2000, 1, 2, 12, 0, tzinfo=UTC)),
         location=events_pb2.EventLocation(address="City, Country", lat=0.1, lng=0.1),
+        timezone="Etc/UTC",
     )
 
     ics: str = create_event_ics_calendar(event, loc_context=LocalizationContext.en_utc()).serialize()
@@ -164,13 +165,12 @@ def test_host_request_attachments(db, email_collector: EmailCollector, moderator
 
     email = email_collector.pop_for_recipient(surfer.email, last=True)
     assert "accept" in email.subject and host.name in email.subject
-    ics_event = _get_email_ics_attachment_calendar_event(email)
-    assert _get_ics_event_sequence(ics_event) == 0
-    assert not ics_event.status
-    assert ics_event.begin.date() == from_date
-    assert ics_event.end.date() == (to_date + timedelta(days=1))
-    assert ics_event.name == f"Surfing with {host.name}"
-    assert ics_event.location == host.city
+    accepted_ics_event = _get_email_ics_attachment_calendar_event(email)
+    assert not accepted_ics_event.status
+    assert accepted_ics_event.begin.date() == from_date
+    assert accepted_ics_event.end.date() == (to_date + timedelta(days=1))
+    assert accepted_ics_event.name == f"Surfing with {host.name}"
+    assert accepted_ics_event.location == host.city
 
     # Surfer confirms, host gets a calendar attachment
     with requests_session(surfer_token) as api:
@@ -184,10 +184,9 @@ def test_host_request_attachments(db, email_collector: EmailCollector, moderator
 
     email = email_collector.pop_for_recipient(host.email, last=True)
     assert "confirm" in email.subject and surfer.name in email.subject
-    ics_event = _get_email_ics_attachment_calendar_event(email)
-    assert _get_ics_event_sequence(ics_event) == 0
-    assert not ics_event.status
-    assert ics_event.name == f"Hosting {surfer.name}"
+    confirmed_ics_event = _get_email_ics_attachment_calendar_event(email)
+    assert not confirmed_ics_event.status
+    assert confirmed_ics_event.name == f"Hosting {surfer.name}"
 
     # Surfer cancels, host gets a calendar attachment
     with requests_session(surfer_token) as api:
@@ -201,9 +200,9 @@ def test_host_request_attachments(db, email_collector: EmailCollector, moderator
 
     email = email_collector.pop_for_recipient(host.email, last=True)
     assert "cancel" in email.subject and surfer.name in email.subject
-    ics_event = _get_email_ics_attachment_calendar_event(email)
-    assert _get_ics_event_sequence(ics_event) == 1
-    assert ics_event.status == "CANCELLED"
+    cancelled_ics_event = _get_email_ics_attachment_calendar_event(email)
+    assert (_get_ics_event_sequence(cancelled_ics_event) or 0) > (_get_ics_event_sequence(accepted_ics_event) or 0)
+    assert cancelled_ics_event.status == "CANCELLED"
 
 
 def test_host_request_attachments_disabled(db, email_collector: EmailCollector, feature_flags, moderator: Moderator):

--- a/app/backend/src/tests/test_calendar_events.py
+++ b/app/backend/src/tests/test_calendar_events.py
@@ -27,7 +27,7 @@ def test_host_request_ics_content():
     ics: str = create_host_request_ics_calendar(
         host_request, other_name="Bob", hosting=True, loc_context=LocalizationContext.en_utc()
     ).serialize()
-    assert _assert_ics_matches_pattern(
+    _assert_ics_matches_pattern(
         ics,
         """
 BEGIN:VCALENDAR
@@ -61,7 +61,7 @@ def test_host_request_cancelled_ics_content():
     ics: str = create_host_request_ics_calendar(
         host_request, other_name="Bob", hosting=True, loc_context=LocalizationContext.en_utc()
     ).serialize()
-    assert _assert_ics_matches_pattern(
+    _assert_ics_matches_pattern(
         ics,
         """
 BEGIN:VCALENDAR
@@ -90,29 +90,31 @@ def test_event_ics_content():
         title="Event Title",
         slug="event-slug",
         content="Event description",
-        start_time=Timestamp_from_datetime(datetime(2000, 1, 1, 12, 0, tzinfo=UTC)),
-        end_time=Timestamp_from_datetime(datetime(2000, 1, 2, 12, 0, tzinfo=UTC)),
+        created=Timestamp_from_datetime(datetime(2000, 1, 1, 0, 0, tzinfo=UTC)),
+        start_time=Timestamp_from_datetime(datetime(2000, 1, 2, 12, 0, tzinfo=UTC)),
+        end_time=Timestamp_from_datetime(datetime(2000, 1, 3, 12, 0, tzinfo=UTC)),
         location=events_pb2.EventLocation(address="City, Country", lat=0.1, lng=0.1),
-        timezone="Etc/UTC",
+        timezone="Etc/GMT-1",  # Confusingly represents GMT+1, no DST
     )
 
     ics: str = create_event_ics_calendar(event, loc_context=LocalizationContext.en_utc()).serialize()
-    assert _assert_ics_matches_pattern(
+    _assert_ics_matches_pattern(
         ics,
         """
 BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Couchers.org//Couchers//EN
 BEGIN:VEVENT
-SEQUENCE:***
-DTSTART;20000101T120000Z
-DTEND;20000102T120000Z
-DESCRIPTION:Event description
-LOCATION:City, Country
-STATUS:CANCELLED
-SUMMARY:Event Title
 UID:event.42@***
-URL:***/42
+SEQUENCE:***
+SUMMARY:Event Title
+DESCRIPTION:Event description***/event/42/event-slug
+DTSTART;TZID=Etc/GMT-1:20000102T130000
+DTEND;TZID=Etc/GMT-1:20000103T130000
+LAST-MODIFIED:20000101T000000Z
+LOCATION:City\\, Country
+GEO:0.100000;0.100000
+URL:***/event/42/event-slug
 END:VEVENT
 METHOD:PUBLISH
 END:VCALENDAR
@@ -122,11 +124,18 @@ END:VCALENDAR
 
 def _assert_ics_matches_pattern(actual: str, expected_pattern: str) -> str:
     """Assert that an ics file's content matches a pattern that includes "***" wildcards."""
+    # Normalize whitespace
     actual = actual.replace("\r\n", "\n").strip()
     expected_pattern = expected_pattern.strip()
 
-    expected_pattern = re.escape(expected_pattern).replace("\\*\\*\\*", ".*?")
-    return re.fullmatch(expected_pattern, actual)
+    # The ics library writes properties in an order that's hard to make sense of, and not important.
+    # So approximate by sorting lines, and test them one at a time so we know which one fails.
+    actual_lines = sorted(actual.splitlines())
+    expected_pattern_lines = sorted(expected_pattern.splitlines())
+    for actual_line, expected_pattern_line in zip(actual_lines, expected_pattern_lines, strict=True):
+        # Convert the expected pattern from *** wildcards to a regex
+        expected_line_regex = re.escape(expected_pattern_line).replace("\\*\\*\\*", ".*?")
+        assert re.fullmatch(expected_line_regex, actual_line)
 
 
 def test_host_request_attachments(db, email_collector: EmailCollector, moderator: Moderator):

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -1985,6 +1985,8 @@ def test_GetEventCalendarFile(db, moderator: Moderator):
         assert ics_event.name == "Dummy Title"
         assert ics_event.description == "Dummy content."
         assert ics_event.location == "Near Null Island"
+        assert ics_event.begin.isoformat() == start_time.isoformat()
+        assert ics_event.end.isoformat() == end_time.isoformat()
         assert ics_event.status != "CANCELLED"
 
         api.CancelEvent(events_pb2.CancelEventReq(event_id=event_id))

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -1980,6 +1980,7 @@ def test_GetEventCalendarFile(db, moderator: Moderator):
 
     with events_session(token1) as api:
         file_res = api.GetEventCalendarFile(events_pb2.GetEventCalendarFileReq(event_id=event_id))
+        assert file_res.content_type == "text/calendar"
         ics_string = file_res.data.decode("utf-8")
         assert "SUMMARY:Dummy Title" in ics_string
         assert "DESCRIPTION:Dummy content." in ics_string

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -1991,7 +1991,7 @@ def test_GetEventCalendarFile(db, moderator: Moderator):
 
         file_res = api.GetEventCalendarFile(events_pb2.GetEventCalendarFileReq(event_id=event_id))
         ics_string = file_res.data.decode("utf-8")
-        assert "SUMMARY:Dummy Title" in ics_string  # Other props have not changed
+        assert "SUMMARY:Cancelled: Dummy Title" in ics_string
         assert "STATUS:CANCELLED" in ics_string
         post_cancel_sequence = int(re.search(r"SEQUENCE:(\d+)", ics_string).group(1))
         # Ideally the sequence number are strictly ascending, but they are based on timestamps so in tests they could be equal.

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -1,8 +1,8 @@
+import re
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 import grpc
-import ics
 import pytest
 from google.protobuf import empty_pb2, wrappers_pb2
 from psycopg.types.range import TimestamptzRange
@@ -10,7 +10,6 @@ from sqlalchemy import select
 from sqlalchemy.sql.expression import update
 
 from couchers.db import session_scope
-from couchers.email.calendar_events import get_sequence_number
 from couchers.jobs.handlers import send_event_reminders
 from couchers.models import (
     BackgroundJob,
@@ -1981,22 +1980,22 @@ def test_GetEventCalendarFile(db, moderator: Moderator):
 
     with events_session(token1) as api:
         file_res = api.GetEventCalendarFile(events_pb2.GetEventCalendarFileReq(event_id=event_id))
-        ics_event: ics.Event = next(ics.Calendar(file_res.data.decode("utf-8")).events)
-        assert ics_event.name == "Dummy Title"
-        assert ics_event.description == "Dummy content."
-        assert ics_event.location == "Near Null Island"
-        assert ics_event.begin.isoformat() == start_time.isoformat()
-        assert ics_event.end.isoformat() == end_time.isoformat()
-        assert ics_event.status != "CANCELLED"
+        ics_string = file_res.data.decode("utf-8")
+        assert "SUMMARY:Dummy Title" in ics_string
+        assert "DESCRIPTION:Dummy content." in ics_string
+        assert "LOCATION:Near Null Island" in ics_string
+        assert "STATUS:CANCELLED" not in ics_string
+        pre_cancel_sequence = int(re.match(r"SEQUENCE:(\d+)", ics_string).group(1))
 
         api.CancelEvent(events_pb2.CancelEventReq(event_id=event_id))
 
         file_res = api.GetEventCalendarFile(events_pb2.GetEventCalendarFileReq(event_id=event_id))
-        cancelled_ics_event: ics.Event = next(ics.Calendar(file_res.data.decode("utf-8")).events)
-        assert cancelled_ics_event.name == "Dummy Title"  # Other props have not changed
-        assert cancelled_ics_event.status == "CANCELLED"
+        ics_string = file_res.data.decode("utf-8")
+        assert "SUMMARY:Dummy Title" in ics_string  # Other props have not changed
+        assert "STATUS:CANCELLED" in ics_string
+        post_cancel_sequence = int(re.match(r"SEQUENCE:(\d+)", ics_string).group(1))
         # Ideally the sequence number are strictly ascending, but they are based on timestamps so in tests they could be equal.
-        assert (get_sequence_number(cancelled_ics_event) or 0) >= (get_sequence_number(ics_event) or 0)
+        assert post_cancel_sequence >= pre_cancel_sequence
 
 
 def test_event_threads(db, push_collector: PushCollector, moderator: Moderator):

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -1985,7 +1985,7 @@ def test_GetEventCalendarFile(db, moderator: Moderator):
         assert "DESCRIPTION:Dummy content." in ics_string
         assert "LOCATION:Near Null Island" in ics_string
         assert "STATUS:CANCELLED" not in ics_string
-        pre_cancel_sequence = int(re.match(r"SEQUENCE:(\d+)", ics_string).group(1))
+        pre_cancel_sequence = int(re.search(r"SEQUENCE:(\d+)", ics_string).group(1))
 
         api.CancelEvent(events_pb2.CancelEventReq(event_id=event_id))
 
@@ -1993,7 +1993,7 @@ def test_GetEventCalendarFile(db, moderator: Moderator):
         ics_string = file_res.data.decode("utf-8")
         assert "SUMMARY:Dummy Title" in ics_string  # Other props have not changed
         assert "STATUS:CANCELLED" in ics_string
-        post_cancel_sequence = int(re.match(r"SEQUENCE:(\d+)", ics_string).group(1))
+        post_cancel_sequence = int(re.search(r"SEQUENCE:(\d+)", ics_string).group(1))
         # Ideally the sequence number are strictly ascending, but they are based on timestamps so in tests they could be equal.
         assert post_cancel_sequence >= pre_cancel_sequence
 

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -1951,11 +1951,11 @@ def test_ListEventAttendees_regression(db):
 
 
 def test_GetEventCalendarFile(db, moderator: Moderator):
-    # event creator
     user1, token1 = generate_user()
+    user2, token2 = generate_user()
 
     with session_scope() as session:
-        c_id = create_community(session, 0, 2, "Community", [], [], None).id
+        c_id = create_community(session, 0, 2, "Community", [user2], [], None).id
 
     start_time = now() + timedelta(hours=2)
     end_time = start_time + timedelta(hours=3)

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 import grpc
+import ics
 import pytest
 from google.protobuf import empty_pb2, wrappers_pb2
 from psycopg.types.range import TimestamptzRange
@@ -9,6 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.sql.expression import update
 
 from couchers.db import session_scope
+from couchers.email.calendar_events import get_sequence_number
 from couchers.jobs.handlers import send_event_reminders
 from couchers.models import (
     BackgroundJob,
@@ -1946,6 +1948,52 @@ def test_ListEventAttendees_regression(db):
         res = api.ListEventAttendees(events_pb2.ListEventAttendeesReq(event_id=event_id))
         assert len(res.attendee_user_ids) == 1
         assert res.attendee_user_ids[0] == user1.id
+
+
+def test_GetEventCalendarFile(db, moderator: Moderator):
+    # event creator
+    user1, token1 = generate_user()
+
+    with session_scope() as session:
+        c_id = create_community(session, 0, 2, "Community", [], [], None).id
+
+    start_time = now() + timedelta(hours=2)
+    end_time = start_time + timedelta(hours=3)
+
+    with events_session(token1) as api:
+        created_event: events_pb2.Event = api.CreateEvent(
+            events_pb2.CreateEventReq(
+                title="Dummy Title",
+                content="Dummy content.",
+                parent_community_id=c_id,
+                location=events_pb2.EventLocation(
+                    address="Near Null Island",
+                    lat=0.1,
+                    lng=0.2,
+                ),
+                start_datetime_iso8601_local=datetime_to_iso8601_local(start_time),
+                end_datetime_iso8601_local=datetime_to_iso8601_local(end_time),
+            )
+        )
+        event_id = created_event.event_id
+
+    moderator.approve_event_occurrence(event_id)
+
+    with events_session(token1) as api:
+        file_res = api.GetEventCalendarFile(events_pb2.GetEventCalendarFileReq(event_id=event_id))
+        ics_event: ics.Event = next(ics.Calendar(file_res.data.decode("utf-8")).events)
+        assert ics_event.name == "Dummy Title"
+        assert ics_event.description == "Dummy content."
+        assert ics_event.location == "Near Null Island"
+        assert ics_event.status != "CANCELLED"
+
+        api.CancelEvent(events_pb2.CancelEventReq(event_id=event_id))
+
+        file_res = api.GetEventCalendarFile(events_pb2.GetEventCalendarFileReq(event_id=event_id))
+        cancelled_ics_event: ics.Event = next(ics.Calendar(file_res.data.decode("utf-8")).events)
+        assert cancelled_ics_event.name == "Dummy Title"  # Other props have not changed
+        assert cancelled_ics_event.status == "CANCELLED"
+        assert (get_sequence_number(cancelled_ics_event) or 0) > (get_sequence_number(ics_event) or 0)
 
 
 def test_event_threads(db, push_collector: PushCollector, moderator: Moderator):

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -1995,7 +1995,8 @@ def test_GetEventCalendarFile(db, moderator: Moderator):
         cancelled_ics_event: ics.Event = next(ics.Calendar(file_res.data.decode("utf-8")).events)
         assert cancelled_ics_event.name == "Dummy Title"  # Other props have not changed
         assert cancelled_ics_event.status == "CANCELLED"
-        assert (get_sequence_number(cancelled_ics_event) or 0) > (get_sequence_number(ics_event) or 0)
+        # Ideally the sequence number are strictly ascending, but they are based on timestamps so in tests they could be equal.
+        assert (get_sequence_number(cancelled_ics_event) or 0) >= (get_sequence_number(ics_event) or 0)
 
 
 def test_event_threads(db, push_collector: PushCollector, moderator: Moderator):

--- a/app/proto/events.proto
+++ b/app/proto/events.proto
@@ -80,7 +80,9 @@ service Events {
     // Lists all events
   }
 
-  // TODO: DownloadCalendarInvite
+  rpc GetEventCalendarFile(GetEventCalendarFileReq) returns (GetEventCalendarFileRes) {
+    // Downloads a calendar file for an event
+  }
 }
 
 message EventLocation {
@@ -348,4 +350,12 @@ message InviteEventOrganizerReq {
 message RemoveEventOrganizerReq {
   int64 event_id = 1;
   google.protobuf.Int64Value user_id = 2;
+}
+
+message GetEventCalendarFileReq {
+  int64 event_id = 1;
+}
+
+message GetEventCalendarFileRes {
+  bytes data = 1;
 }

--- a/app/proto/events.proto
+++ b/app/proto/events.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package org.couchers.api.events;
 
+import "google/api/annotations.proto";
+import "google/api/httpbody.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
@@ -80,8 +82,11 @@ service Events {
     // Lists all events
   }
 
-  rpc GetEventCalendarFile(GetEventCalendarFileReq) returns (GetEventCalendarFileRes) {
+  rpc GetEventCalendarFile(GetEventCalendarFileReq) returns (google.api.HttpBody) {
     // Downloads a calendar file for an event
+    option (google.api.http) = {
+      get : "/events/{event_id}/calendar"
+    };
   }
 }
 
@@ -354,8 +359,4 @@ message RemoveEventOrganizerReq {
 
 message GetEventCalendarFileReq {
   int64 event_id = 1;
-}
-
-message GetEventCalendarFileRes {
-  bytes data = 1;
 }


### PR DESCRIPTION
This API will support a button on the frontend to download a calendar file for the event.

Includes some refactoring of the ics generation code and tests, the biggest visible result being that we now create a sequence number based on a timestamp to support an arbitrary number of updates.

Fixes #9328

## Testing
Added & updated tests.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
