### PR TITLE
Backend: fix event list pagination skipping and duplicating events

### DIFF
--- a/app/backend/src/couchers/servicers/communities.py
+++ b/app/backend/src/couchers/servicers/communities.py
@@ -1,6 +1,5 @@
 import logging
 from collections.abc import Sequence
-from datetime import timedelta
 
 import grpc
 from google.protobuf import empty_pb2
@@ -30,11 +29,11 @@ from couchers.models import (
 )
 from couchers.proto import communities_pb2, communities_pb2_grpc, groups_pb2
 from couchers.servicers.discussions import discussion_to_pb
-from couchers.servicers.events import event_to_pb
+from couchers.servicers.events import apply_occurrence_pagination, event_to_pb, occurrences_next_page_token
 from couchers.servicers.groups import group_to_pb
 from couchers.servicers.pages import page_to_pb
 from couchers.sql import to_bool, users_visible, where_moderated_content_visible, where_users_column_visible
-from couchers.utils import Timestamp_from_datetime, dt_from_millis, millis_from_dt, now
+from couchers.utils import Timestamp_from_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -419,8 +418,6 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         self, request: communities_pb2.ListEventsReq, context: CouchersContext, session: Session
     ) -> communities_pb2.ListEventsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
-        # the page token is a unix timestamp of where we left off
-        page_token = dt_from_millis(int(request.page_token)) if request.page_token else now()
 
         node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
         if not node:
@@ -447,19 +444,14 @@ class Communities(communities_pb2_grpc.CommunitiesServicer):
         )
         query = where_moderated_content_visible(query, context, EventOccurrence, is_list_operation=True)
 
-        if request.past:
-            cutoff = page_token + timedelta(seconds=1)
-            query = query.where(EventOccurrence.end_time < cutoff).order_by(EventOccurrence.start_time.desc())
-        else:
-            cutoff = page_token - timedelta(seconds=1)
-            query = query.where(EventOccurrence.end_time > cutoff).order_by(EventOccurrence.start_time.asc())
+        query = apply_occurrence_pagination(query, request.page_token, request.past)
 
         query = query.limit(page_size + 1)
         occurrences = session.execute(query).scalars().all()
 
         return communities_pb2.ListEventsRes(
             events=[event_to_pb(session, occurrence, context) for occurrence in occurrences[:page_size]],
-            next_page_token=str(millis_from_dt(occurrences[-1].end_time)) if len(occurrences) > page_size else None,
+            next_page_token=occurrences_next_page_token(occurrences, page_size),
         )
 
     def ListDiscussions(

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Sequence
 from datetime import datetime, timedelta
 from typing import Any, cast
 from zoneinfo import ZoneInfo
@@ -9,7 +10,7 @@ from google.protobuf import empty_pb2
 from psycopg.types.range import TimestamptzRange
 from sqlalchemy import Select, func, select
 from sqlalchemy.orm import Session
-from sqlalchemy.sql import and_, func, or_, update
+from sqlalchemy.sql import and_, func, or_, tuple_, update
 
 from couchers.context import CouchersContext, make_notification_user_context
 from couchers.db import can_moderate_node, get_parent_node_at_location, session_scope
@@ -48,8 +49,8 @@ from couchers.utils import (
     Timestamp_from_datetime,
     create_coordinate,
     datetime_to_iso8601_local,
-    dt_from_millis,
-    millis_from_dt,
+    dt_id_from_page_token,
+    dt_id_to_page_token,
     not_none,
     now,
 )
@@ -286,6 +287,37 @@ def _check_occurrence_time_validity(start_time: datetime, end_time: datetime, co
         context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "event_too_long")
     if start_time - now() > timedelta(days=365):
         context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "event_too_far_in_future")
+
+
+def apply_occurrence_pagination(
+    query: Select[tuple[EventOccurrence]], page_token: str, past: bool
+) -> Select[tuple[EventOccurrence]]:
+    """
+    Restricts to upcoming (not yet ended) or past occurrences, orders by start time (with id as
+    tiebreaker), and seeks to the (start_time, id) cursor from the page token, if given.
+    """
+    if not past:
+        query = query.where(EventOccurrence.end_time > now()).order_by(
+            EventOccurrence.start_time.asc(), EventOccurrence.id.asc()
+        )
+        if page_token:
+            start_time, occurrence_id = dt_id_from_page_token(page_token)
+            query = query.where(tuple_(EventOccurrence.start_time, EventOccurrence.id) >= (start_time, occurrence_id))
+    else:
+        query = query.where(EventOccurrence.end_time < now()).order_by(
+            EventOccurrence.start_time.desc(), EventOccurrence.id.desc()
+        )
+        if page_token:
+            start_time, occurrence_id = dt_id_from_page_token(page_token)
+            query = query.where(tuple_(EventOccurrence.start_time, EventOccurrence.id) <= (start_time, occurrence_id))
+    return query
+
+
+def occurrences_next_page_token(occurrences: Sequence[EventOccurrence], page_size: int) -> str | None:
+    if len(occurrences) <= page_size:
+        return None
+    next_occurrence = occurrences[page_size]
+    return dt_id_to_page_token(next_occurrence.start_time, next_occurrence.id)
 
 
 def get_users_to_notify_for_new_event(session: Session, occurrence: EventOccurrence) -> tuple[list[User], int | None]:
@@ -886,8 +918,6 @@ class Events(events_pb2_grpc.EventsServicer):
         self, request: events_pb2.ListEventOccurrencesReq, context: CouchersContext, session: Session
     ) -> events_pb2.ListEventOccurrencesRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
-        # the page token is a unix timestamp of where we left off
-        page_token = dt_from_millis(int(request.page_token)) if request.page_token else now()
         initial_query = (
             select(EventOccurrence).where(EventOccurrence.id == request.event_id).where(~EventOccurrence.is_deleted)
         )
@@ -908,19 +938,14 @@ class Events(events_pb2_grpc.EventsServicer):
         if not request.include_cancelled:
             query = query.where(~EventOccurrence.is_cancelled)
 
-        if not request.past:
-            cutoff = page_token - timedelta(seconds=1)
-            query = query.where(EventOccurrence.end_time > cutoff).order_by(EventOccurrence.start_time.asc())
-        else:
-            cutoff = page_token + timedelta(seconds=1)
-            query = query.where(EventOccurrence.end_time < cutoff).order_by(EventOccurrence.start_time.desc())
+        query = apply_occurrence_pagination(query, request.page_token, request.past)
 
         query = query.limit(page_size + 1)
         occurrences = session.execute(query).scalars().all()
 
         return events_pb2.ListEventOccurrencesRes(
             events=[event_to_pb(session, occurrence, context) for occurrence in occurrences[:page_size]],
-            next_page_token=str(millis_from_dt(occurrences[-1].end_time)) if len(occurrences) > page_size else None,
+            next_page_token=occurrences_next_page_token(occurrences, page_size),
         )
 
     def ListEventAttendees(
@@ -1156,10 +1181,8 @@ class Events(events_pb2_grpc.EventsServicer):
         self, request: events_pb2.ListMyEventsReq, context: CouchersContext, session: Session
     ) -> events_pb2.ListMyEventsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
-        # the page token is a unix timestamp of where we left off
-        page_token = (
-            dt_from_millis(int(request.page_token)) if request.page_token and not request.page_number else now()
-        )
+        # the page token is ignored when a page number is given
+        page_token = request.page_token if not request.page_number else ""
         # the page number is the page number we are on
         page_number = request.page_number or 1
         # Calculate the offset for pagination
@@ -1234,12 +1257,7 @@ class Events(events_pb2_grpc.EventsServicer):
         if not request.include_cancelled:
             query = query.where(~EventOccurrence.is_cancelled)
 
-        if not request.past:
-            cutoff = page_token - timedelta(seconds=1)
-            query = query.where(EventOccurrence.end_time > cutoff).order_by(EventOccurrence.start_time.asc())
-        else:
-            cutoff = page_token + timedelta(seconds=1)
-            query = query.where(EventOccurrence.end_time < cutoff).order_by(EventOccurrence.start_time.desc())
+        query = apply_occurrence_pagination(query, page_token, request.past)
         # Count the total number of items for pagination
         total_items = session.execute(select(func.count()).select_from(query.subquery())).scalar()
         # Apply pagination by page number
@@ -1248,7 +1266,7 @@ class Events(events_pb2_grpc.EventsServicer):
 
         return events_pb2.ListMyEventsRes(
             events=[event_to_pb(session, occurrence, context) for occurrence in occurrences[:page_size]],
-            next_page_token=str(millis_from_dt(occurrences[-1].end_time)) if len(occurrences) > page_size else None,
+            next_page_token=occurrences_next_page_token(occurrences, page_size),
             total_items=total_items,
         )
 
@@ -1256,8 +1274,6 @@ class Events(events_pb2_grpc.EventsServicer):
         self, request: events_pb2.ListAllEventsReq, context: CouchersContext, session: Session
     ) -> events_pb2.ListAllEventsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
-        # the page token is a unix timestamp of where we left off
-        page_token = dt_from_millis(int(request.page_token)) if request.page_token else now()
 
         query = select(EventOccurrence).where(~EventOccurrence.is_deleted)
         query = where_moderated_content_visible(query, context, EventOccurrence, is_list_operation=True)
@@ -1265,19 +1281,14 @@ class Events(events_pb2_grpc.EventsServicer):
         if not request.include_cancelled:
             query = query.where(~EventOccurrence.is_cancelled)
 
-        if not request.past:
-            cutoff = page_token - timedelta(seconds=1)
-            query = query.where(EventOccurrence.end_time > cutoff).order_by(EventOccurrence.start_time.asc())
-        else:
-            cutoff = page_token + timedelta(seconds=1)
-            query = query.where(EventOccurrence.end_time < cutoff).order_by(EventOccurrence.start_time.desc())
+        query = apply_occurrence_pagination(query, request.page_token, request.past)
 
         query = query.limit(page_size + 1)
         occurrences = session.execute(query).scalars().all()
 
         return events_pb2.ListAllEventsRes(
             events=[event_to_pb(session, occurrence, context) for occurrence in occurrences[:page_size]],
-            next_page_token=str(millis_from_dt(occurrences[-1].end_time)) if len(occurrences) > page_size else None,
+            next_page_token=occurrences_next_page_token(occurrences, page_size),
         )
 
     def InviteEventOrganizer(

--- a/app/backend/src/couchers/servicers/groups.py
+++ b/app/backend/src/couchers/servicers/groups.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import timedelta
 
 import grpc
 from google.protobuf import empty_pb2
@@ -23,10 +22,10 @@ from couchers.models import (
 )
 from couchers.proto import groups_pb2, groups_pb2_grpc
 from couchers.servicers.discussions import discussion_to_pb
-from couchers.servicers.events import event_to_pb
+from couchers.servicers.events import apply_occurrence_pagination, event_to_pb, occurrences_next_page_token
 from couchers.servicers.pages import page_to_pb
 from couchers.sql import users_visible, where_moderated_content_visible, where_users_column_visible
-from couchers.utils import Timestamp_from_datetime, dt_from_millis, millis_from_dt, now
+from couchers.utils import Timestamp_from_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -231,8 +230,6 @@ class Groups(groups_pb2_grpc.GroupsServicer):
         self, request: groups_pb2.ListEventsReq, context: CouchersContext, session: Session
     ) -> groups_pb2.ListEventsRes:
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
-        # the page token is a unix timestamp of where we left off
-        page_token = dt_from_millis(int(request.page_token)) if request.page_token else now()
 
         cluster = session.execute(
             select(Cluster).where(~Cluster.is_official_cluster).where(Cluster.id == request.group_id)
@@ -247,19 +244,14 @@ class Groups(groups_pb2_grpc.GroupsServicer):
         )
         query = where_moderated_content_visible(query, context, EventOccurrence, is_list_operation=True)
 
-        if not request.past:
-            cutoff = page_token - timedelta(seconds=1)
-            query = query.where(EventOccurrence.end_time > cutoff).order_by(EventOccurrence.start_time.asc())
-        else:
-            cutoff = page_token + timedelta(seconds=1)
-            query = query.where(EventOccurrence.end_time < cutoff).order_by(EventOccurrence.start_time.desc())
+        query = apply_occurrence_pagination(query, request.page_token, request.past)
 
         query = query.limit(page_size + 1)
         occurrences = session.execute(query).scalars().all()
 
         return groups_pb2.ListEventsRes(
             events=[event_to_pb(session, occurrence, context) for occurrence in occurrences[:page_size]],
-            next_page_token=str(millis_from_dt(occurrences[-1].end_time)) if len(occurrences) > page_size else None,
+            next_page_token=occurrences_next_page_token(occurrences, page_size),
         )
 
     def ListDiscussions(

--- a/app/backend/src/couchers/servicers/search.py
+++ b/app/backend/src/couchers/servicers/search.py
@@ -2,7 +2,6 @@
 See //docs/search.md for an overview.
 """
 
-from datetime import timedelta
 from typing import Any, cast
 
 import grpc
@@ -50,18 +49,15 @@ from couchers.servicers.api import (
     user_model_to_pb,
 )
 from couchers.servicers.communities import community_to_pb
-from couchers.servicers.events import event_to_pb
+from couchers.servicers.events import apply_occurrence_pagination, event_to_pb, occurrences_next_page_token
 from couchers.servicers.groups import group_to_pb
 from couchers.servicers.pages import page_to_pb
 from couchers.sql import to_bool, users_visible, where_moderated_content_visible, where_users_column_visible
 from couchers.utils import (
     Timestamp_from_datetime,
     create_coordinate,
-    dt_from_millis,
     get_coordinates,
     last_active_coarsen,
-    millis_from_dt,
-    now,
     to_aware_datetime,
 )
 
@@ -919,20 +915,13 @@ class Search(search_pb2_grpc.SearchServicer):
             statement = statement.where(EventOccurrence.end_time < before_time)
 
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
-        # the page token is a unix timestamp of where we left off
-        page_token = (
-            dt_from_millis(int(request.page_token)) if request.page_token and not request.page_number else now()
-        )
+        # the page token is ignored when a page number is given
+        page_token = request.page_token if not request.page_number else ""
         page_number = request.page_number or 1
         # Calculate the offset for pagination
         offset = (page_number - 1) * page_size
 
-        if not request.past:
-            cutoff = page_token - timedelta(seconds=1)
-            statement = statement.where(EventOccurrence.end_time > cutoff).order_by(EventOccurrence.start_time.asc())
-        else:
-            cutoff = page_token + timedelta(seconds=1)
-            statement = statement.where(EventOccurrence.end_time < cutoff).order_by(EventOccurrence.start_time.desc())
+        statement = apply_occurrence_pagination(statement, page_token, request.past)
 
         total_items = session.execute(select(func.count()).select_from(statement.subquery())).scalar()
         # Apply pagination by page number
@@ -941,6 +930,6 @@ class Search(search_pb2_grpc.SearchServicer):
 
         return search_pb2.EventSearchRes(
             events=[event_to_pb(session, occurrence, context) for occurrence in occurrences[:page_size]],
-            next_page_token=(str(millis_from_dt(occurrences[-1].end_time)) if len(occurrences) > page_size else None),
+            next_page_token=occurrences_next_page_token(occurrences, page_size),
             total_items=total_items,
         )

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -453,6 +453,16 @@ def dt_from_page_token(page_token: str) -> datetime:
     return datetime.fromtimestamp(int(decrypt_page_token(page_token)) / 1_000_000, tz=UTC)
 
 
+def dt_id_to_page_token(dt: datetime, id_: int) -> str:
+    # see above comment about resolution
+    return encrypt_page_token(f"{round(1_000_000 * dt.timestamp())}:{id_}")
+
+
+def dt_id_from_page_token(page_token: str) -> tuple[datetime, int]:
+    micros, id_ = decrypt_page_token(page_token).split(":")
+    return datetime.fromtimestamp(int(micros) / 1_000_000, tz=UTC), int(id_)
+
+
 def last_active_coarsen(dt: datetime) -> datetime:
     """
     Coarsens a "last active" time to the accuracy we use for last active times, currently to the last hour, e.g. if the current time is 27th June 2021, 16:53 UTC, this returns 27th June 2021, 16:00 UTC

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -1721,6 +1721,89 @@ def test_ListMyEvents(db, moderator: Moderator):
         assert [event.event_id for event in res.events] == [e1, e2, e3, e4, e5, e6]
 
 
+def _paginate_my_events(api, page_size: int) -> list[int]:
+    event_ids = []
+    page_token = ""
+    for _ in range(10):
+        res = api.ListMyEvents(events_pb2.ListMyEventsReq(page_size=page_size, page_token=page_token))
+        event_ids += [event.event_id for event in res.events]
+        page_token = res.next_page_token
+        if not page_token:
+            return event_ids
+    raise AssertionError("pagination did not terminate")
+
+
+def test_ListMyEvents_pagination_overlapping_durations(db, moderator: Moderator):
+    user, token = generate_user()
+
+    with session_scope() as session:
+        c_id = create_community(session, 0, 2, "Community", [user], [], None).id
+
+    start = now()
+
+    def new_event(start_offset: timedelta, duration: timedelta) -> events_pb2.CreateEventReq:
+        return events_pb2.CreateEventReq(
+            title="Dummy Title",
+            content="Dummy content.",
+            location=events_pb2.EventLocation(
+                address="Near Null Island",
+                lat=0.1,
+                lng=0.2,
+            ),
+            parent_community_id=c_id,
+            start_datetime_iso8601_local=datetime_to_iso8601_local(start + start_offset),
+            end_datetime_iso8601_local=datetime_to_iso8601_local(start + start_offset + duration),
+        )
+
+    with events_session(token) as api:
+        # a multi-day event overlapping all the short events below: it ends last but starts first,
+        # so an end time based cursor would repeat it on every page and skip the short events
+        long_event = api.CreateEvent(new_event(timedelta(hours=1), timedelta(days=3))).event_id
+        short_events = [
+            api.CreateEvent(new_event(timedelta(hours=2 + i), timedelta(hours=1))).event_id for i in range(4)
+        ]
+
+    for event_id in [long_event, *short_events]:
+        moderator.approve_event_occurrence(event_id)
+
+    with events_session(token) as api:
+        assert _paginate_my_events(api, page_size=2) == [long_event, *short_events]
+
+
+def test_ListMyEvents_pagination_identical_start_times(db, moderator: Moderator):
+    user, token = generate_user()
+
+    with session_scope() as session:
+        c_id = create_community(session, 0, 2, "Community", [user], [], None).id
+
+    start = now()
+
+    with events_session(token) as api:
+        event_ids = [
+            api.CreateEvent(
+                events_pb2.CreateEventReq(
+                    title="Dummy Title",
+                    content="Dummy content.",
+                    location=events_pb2.EventLocation(
+                        address="Near Null Island",
+                        lat=0.1,
+                        lng=0.2,
+                    ),
+                    parent_community_id=c_id,
+                    start_datetime_iso8601_local=datetime_to_iso8601_local(start + timedelta(hours=1)),
+                    end_datetime_iso8601_local=datetime_to_iso8601_local(start + timedelta(hours=2)),
+                )
+            ).event_id
+            for _ in range(5)
+        ]
+
+    for event_id in event_ids:
+        moderator.approve_event_occurrence(event_id)
+
+    with events_session(token) as api:
+        assert _paginate_my_events(api, page_size=2) == event_ids
+
+
 def test_list_my_events_exclude_attending(db, moderator: Moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -4,19 +4,14 @@ from typing import Any
 import grpc
 import pytest
 from google.protobuf import empty_pb2, wrappers_pb2
+from psycopg.types.range import TimestamptzRange
 from sqlalchemy import select
 
 from couchers.db import session_scope
 from couchers.materialized_views import refresh_materialized_views, refresh_materialized_views_rapid
 from couchers.models import EventOccurrence, HostingStatus, LanguageAbility, LanguageFluency, MeetupStatus
 from couchers.proto import api_pb2, communities_pb2, events_pb2, search_pb2
-from couchers.utils import (
-    Timestamp_from_datetime,
-    create_coordinate,
-    datetime_to_iso8601_local,
-    millis_from_dt,
-    now,
-)
+from couchers.utils import Timestamp_from_datetime, create_coordinate, datetime_to_iso8601_local, now
 from tests.fixtures.db import generate_user
 from tests.fixtures.misc import Moderator
 from tests.fixtures.sessions import communities_session, events_session, search_session
@@ -576,7 +571,7 @@ def test_event_search_pagination(sample_community, create_event):
     Check that
      - <page_size> events are returned, if available
      - sort order is applied (default: past=False)
-     - the next page token is correct
+     - the next page token continues where the previous page left off
     """
     user, token = generate_user()
 
@@ -594,25 +589,31 @@ def test_event_search_pagination(sample_community, create_event):
         res = api.EventSearch(search_pb2.EventSearchReq(past=False, page_size=4))
         assert len(res.events) == 4
         assert [event.title for event in res.events] == ["Event 1", "Event 2", "Event 3", "Event 4"]
-        assert res.next_page_token == str(millis_from_dt(anchor_time + timedelta(hours=5, minutes=30)))
+        assert res.next_page_token
 
         res = api.EventSearch(search_pb2.EventSearchReq(page_size=4, page_token=res.next_page_token))
         assert len(res.events) == 1
         assert res.events[0].title == "Event 5"
         assert res.next_page_token == ""
 
-        res = api.EventSearch(
-            search_pb2.EventSearchReq(
-                past=True, page_size=2, page_token=str(millis_from_dt(anchor_time + timedelta(hours=4, minutes=30)))
+    # move all the events into the past to test past pagination
+    with session_scope() as session:
+        for occurrence in session.execute(select(EventOccurrence)).scalars().all():
+            occurrence.during = TimestamptzRange(
+                occurrence.start_time - timedelta(days=30), occurrence.end_time - timedelta(days=30)
             )
-        )
-        assert len(res.events) == 2
-        assert [event.title for event in res.events] == ["Event 4", "Event 3"]
-        assert res.next_page_token == str(millis_from_dt(anchor_time + timedelta(hours=2, minutes=30)))
+
+    with search_session(token) as api:
+        res = api.EventSearch(search_pb2.EventSearchReq(past=True, page_size=2))
+        assert [event.title for event in res.events] == ["Event 5", "Event 4"]
+        assert res.next_page_token
 
         res = api.EventSearch(search_pb2.EventSearchReq(past=True, page_size=2, page_token=res.next_page_token))
-        assert len(res.events) == 2
-        assert [event.title for event in res.events] == ["Event 2", "Event 1"]
+        assert [event.title for event in res.events] == ["Event 3", "Event 2"]
+        assert res.next_page_token
+
+        res = api.EventSearch(search_pb2.EventSearchReq(past=True, page_size=2, page_token=res.next_page_token))
+        assert [event.title for event in res.events] == ["Event 1"]
         assert res.next_page_token == ""
 
 


### PR DESCRIPTION
All six event listing endpoints (`ListEventOccurrences`, `ListMyEvents`, `ListAllEvents`, community and group `ListEvents`, `EventSearch`) ordered occurrences by `start_time` but paginated with an `end_time`-based cursor. Whenever event durations vary — e.g. a multi-day event overlapping shorter ones — the two orders disagree: the long event was repeated on every page and shorter events that started later but ended earlier were skipped entirely.

The fix paginates on the same key the lists are sorted by:
- A shared `apply_occurrence_pagination` helper applies a fixed upcoming/past window (`end_time` vs `now()`, so ongoing events still count as upcoming) plus an exact `(start_time, id)` cursor, ordered by `(start_time, id)`. The id tiebreaker makes pagination exact when start times tie (events commonly start on the hour), removing the old ±1 second fudges.
- Page tokens now encode the cursor encrypted with the existing page token helpers (like `ListCommunities`), via new `dt_id_to_page_token`/`dt_id_from_page_token` utils.
- The `page_number` offset paths in `ListMyEvents` and `EventSearch` are unchanged.

## Testing

- New regression tests: `test_ListMyEvents_pagination_overlapping_durations` (a multi-day event overlapping four short ones — the old cursor repeated the long event and dropped the short ones) and `test_ListMyEvents_pagination_identical_start_times` (five events with the same start time — the old cursor looped). Both verified to fail on the old code.
- `test_event_search_pagination` previously asserted the token's plaintext contents and hand-built a millis token as a fake past cutoff; rewritten to walk pages via returned tokens, including past pagination over backdated occurrences.
- `pytest src/tests/test_events.py src/tests/test_search.py src/tests/test_communities.py src/tests/test_groups.py` passes (102 tests), `make mypy` and `make format` clean.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._