### PR TITLE
Fix native app client platform attribution and User-Agent

### DIFF
--- a/app/mobile/fingerprint.config.js
+++ b/app/mobile/fingerprint.config.js
@@ -2,7 +2,7 @@ module.exports = {
   sourceSkips: [
     // no native-affecting build scripts, so an npm script shouldn't rebuild
     "PackageJsonScriptsAll",
-    // app.config.js injects a per-commit gitHash into `extra`; nothing native
+    // app.config.js injects per-commit versions into `extra`; nothing native
     "ExpoConfigExtraSection",
     // a version/build-number bump shouldn't break OTA continuity
     "ExpoConfigVersions",

--- a/app/mobile/jest.setup.ts
+++ b/app/mobile/jest.setup.ts
@@ -17,13 +17,15 @@ jest.mock("expo-constants", () => ({
     version: "1.0.0-test",
     extra: {
       eas: { projectId: "test-project-id" },
-      gitHash: "abc12345",
+      displayVersion: "v1.2.3456",
+      debugVersion: "v1.2.3456.abc12345.20260528Z0533",
     },
   },
 }));
 
 // Mock expo-application globally
 jest.mock("expo-application", () => ({
+  nativeApplicationVersion: "1.0.0-test",
   nativeBuildVersion: "42",
 }));
 

--- a/app/mobile/utils/userAgent.ts
+++ b/app/mobile/utils/userAgent.ts
@@ -2,11 +2,11 @@ import * as Application from "expo-application";
 import Constants from "expo-constants";
 import { Platform } from "react-native";
 
-const appVersion = Constants.expoConfig?.version ?? "unknown";
-const gitHash = Constants.expoConfig?.extra?.gitHash ?? "unknown";
-// Constants.nativeBuildVersion was removed in recent Expo SDKs; expo-application
-// reads the build number from the native build at runtime, so it works even
-// with EAS remote/auto-incremented version codes.
+// From the binary, not Constants.expoConfig: after an OTA, expoConfig reports the
+// running bundle's idea of the store version, which the binary may not be.
+const appVersion = Application.nativeApplicationVersion ?? "unknown";
 const nativeBuildVersion = Application.nativeBuildVersion ?? "unknown";
+// Re-baked per OTA, so it identifies the bundle actually serving the request.
+const debugVersion = Constants.expoConfig?.extra?.debugVersion ?? "unknown";
 
-export const applicationNameForUserAgent = `CouchersNative/${appVersion} (${Platform.OS}; build ${nativeBuildVersion}; ${gitHash})`;
+export const applicationNameForUserAgent = `CouchersNative/${appVersion} (${Platform.OS}; build ${nativeBuildVersion}; ${debugVersion})`;

--- a/app/web/utils/clientPlatform.test.ts
+++ b/app/web/utils/clientPlatform.test.ts
@@ -1,0 +1,51 @@
+import { getClientPlatform } from "./clientPlatform";
+
+const IOS_WEBVIEW_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 CouchersNative/1.3.0 (ios; build 81; v1.2.18410.1156180a.20260528Z0533)";
+const ANDROID_WEBVIEW_USER_AGENT =
+  "Mozilla/5.0 (Linux; Android 15; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36 CouchersNative/1.3.0 (android; build 81; v1.2.18410.1156180a.20260528Z0533)";
+const MOBILE_BROWSER_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.7 Mobile/15E148 Safari/604.1";
+
+const originalUserAgent = navigator.userAgent;
+
+function setUserAgent(userAgent: string) {
+  Object.defineProperty(navigator, "userAgent", {
+    value: userAgent,
+    configurable: true,
+  });
+}
+
+function setMobileViewport(matches: boolean) {
+  window.matchMedia = jest.fn().mockReturnValue({ matches }) as never;
+}
+
+afterEach(() => {
+  setUserAgent(originalUserAgent);
+});
+
+describe("getClientPlatform", () => {
+  it("reports app_ios inside the iOS app's web view", () => {
+    setUserAgent(IOS_WEBVIEW_USER_AGENT);
+    setMobileViewport(true);
+    expect(getClientPlatform()).toBe("app_ios");
+  });
+
+  it("reports app_android inside the Android app's web view", () => {
+    setUserAgent(ANDROID_WEBVIEW_USER_AGENT);
+    setMobileViewport(true);
+    expect(getClientPlatform()).toBe("app_android");
+  });
+
+  it("reports web_mobile in a mobile browser", () => {
+    setUserAgent(MOBILE_BROWSER_USER_AGENT);
+    setMobileViewport(true);
+    expect(getClientPlatform()).toBe("web_mobile");
+  });
+
+  it("reports web_desktop on a desktop viewport", () => {
+    setUserAgent(MOBILE_BROWSER_USER_AGENT);
+    setMobileViewport(false);
+    expect(getClientPlatform()).toBe("web_desktop");
+  });
+});

--- a/app/web/utils/clientPlatform.ts
+++ b/app/web/utils/clientPlatform.ts
@@ -6,6 +6,19 @@ export type ClientPlatform =
   | "app_ios"
   | "app_android";
 
+// The native app's web views append this token to the browser user agent
+// (app/mobile/utils/userAgent.ts); it's the only in-app signal every shipped app
+// build already sends.
+const NATIVE_USER_AGENT = /\bCouchersNative\/\S+\s+\((ios|android);/;
+
+function getNativePlatform(): ClientPlatform | null {
+  if (typeof navigator === "undefined") return null;
+  const os = NATIVE_USER_AGENT.exec(navigator.userAgent)?.[1];
+  if (os === "ios") return "app_ios";
+  if (os === "android") return "app_android";
+  return null;
+}
+
 // Matches the app's own "mobile" breakpoint (theme.breakpoints.down("md")).
 function isMobileViewport(): boolean {
   if (typeof window === "undefined" || !window.matchMedia) return false;
@@ -14,9 +27,10 @@ function isMobileViewport(): boolean {
 }
 
 // The client platform a request is coming from, or null when it can't be
-// determined (e.g. during server-side rendering). Requests from web views inside
-// the native app are reported as web_desktop/web_mobile based on viewport.
+// determined (e.g. during server-side rendering).
 export function getClientPlatform(): ClientPlatform | null {
+  const nativePlatform = getNativePlatform();
+  if (nativePlatform) return nativePlatform;
   if (typeof window === "undefined" || !window.matchMedia) return null;
   return isMobileViewport() ? "web_mobile" : "web_desktop";
 }


### PR DESCRIPTION
API calls made from web views inside the native app were being recorded as `web_mobile` in `api_calls` / `user_activity`, e.g.:

```
Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) ... CouchersNative/1.3.0 (ios; build 81; unknown) | web_mobile
```

Two separate bugs, both visible in that one row:

**Attribution.** 9614c4b97 dropped the `nativePlatform` WebView bridge, leaving the web bundle to pick `web_desktop`/`web_mobile` by viewport. Since the app is almost entirely WebView-driven, only the small amount of traffic from the native gRPC client ever declared `app_ios`/`app_android`. The web bundle now reads the platform off our own `CouchersNative/{version} ({os}; ...)` user agent token, which every shipped app build already sends — so this takes effect on a web deploy, with no app release needed and no bridge to keep in sync.

**User-Agent.** The last field read `Constants.expoConfig.extra.gitHash`, which `app.config.js` never sets (it sets `displayVersion` / `debugVersion`), so it has been hardcoded to `unknown` since it shipped. It now carries the running bundle's `debugVersion`, which includes the commit and is re-baked per OTA. The version and build number now both come from `expo-application`, so they describe the installed binary — `Constants.expoConfig.version` is the *running* manifest's idea of the store version, so an OTA built from a commit that bumped the version would claim a version the binary isn't.

The new shape:

```
CouchersNative/1.3.0 (ios; build 81; v1.2.18410.1156180a.20260528Z0533)
```

Note the UA change only takes effect for new bundles (OTA or store); existing installs keep sending `unknown` until they update. The attribution fix applies retroactively to all installs. Historical rows stay misattributed but are recoverable via `user_agent LIKE '%CouchersNative/%'` — no backfill here, since that rewrites analytics history.

## Testing

- Added `app/web/utils/clientPlatform.test.ts`, covering the real iOS and Android WebView user agents plus mobile and desktop browser UAs (4/4 pass).
- Mobile suite passes (155/155), `tsc --noEmit` clean, eslint and prettier clean on touched files. Updated the `expo-application` jest mock with `nativeApplicationVersion` and replaced the stale `gitHash` in the `expo-constants` mock.
- 9 web suites fail and `service/events.ts` has `tsc` errors on `develop` already (stale generated protos, `proto/messages_pb` unresolved) — confirmed pre-existing by stashing.

To verify manually: run the app against a local backend, click around a WebView screen, and check that new `api_calls` rows show `app_ios`/`app_android` rather than `web_mobile`, with the git hash and timestamp in place of `unknown`.

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._