### PR TITLE
Backend/notifications: Fix chat missed_messages mark-seen and reset_preference

### DIFF
--- a/app/backend/src/couchers/notifications/settings.py
+++ b/app/backend/src/couchers/notifications/settings.py
@@ -1,12 +1,11 @@
 import logging
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
 from couchers.db import session_scope
 from couchers.i18n import LocalizationContext
 from couchers.models import (
-    NotificationDelivery,
     NotificationDeliveryType,
     NotificationPreference,
     NotificationTopicAction,
@@ -62,15 +61,12 @@ def reset_preference(
     topic_action: NotificationTopicAction,
     delivery_type: NotificationDeliveryType,
 ) -> None:
-    current_pref = session.execute(
-        select(NotificationPreference)
+    session.execute(
+        delete(NotificationPreference)
         .where(NotificationPreference.user_id == user_id)
         .where(NotificationPreference.topic_action == topic_action)
-        .where(NotificationDelivery.delivery_type == delivery_type)
-    ).scalar_one_or_none()
-    if current_pref:
-        session.delete(current_pref)
-        session.flush()
+        .where(NotificationPreference.delivery_type == delivery_type)
+    )
 
 
 class PreferenceNotUserEditableError(Exception):

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -612,6 +612,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             topic_actions=[NotificationTopicAction.chat__message],
         )
         # chat__missed_messages is a summary across all chats, so it's keyed with an empty string
+        # rather than a chat id: reading any chat counts as acting on it, and it gets marked seen
         mark_notifications_seen(
             session,
             user_id=context.user_id,

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -609,10 +609,14 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             session,
             user_id=context.user_id,
             key=str(request.group_chat_id),
-            topic_actions=[
-                NotificationTopicAction.chat__message,
-                NotificationTopicAction.chat__missed_messages,
-            ],
+            topic_actions=[NotificationTopicAction.chat__message],
+        )
+        # chat__missed_messages is a summary across all chats, so it's keyed with an empty string
+        mark_notifications_seen(
+            session,
+            user_id=context.user_id,
+            key="",
+            topic_actions=[NotificationTopicAction.chat__missed_messages],
         )
 
         return empty_pb2.Empty()

--- a/app/backend/src/tests/fixtures/misc.py
+++ b/app/backend/src/tests/fixtures/misc.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from typing import Any
 from unittest.mock import patch
 
@@ -11,12 +12,17 @@ from couchers.notifications.push import PushNotificationContent
 from couchers.proto import moderation_pb2
 from couchers.proto.internal import jobs_pb2
 from couchers.servicers.threads import unpack_thread_id
+from couchers.utils import now
 from tests.fixtures.sessions import real_moderation_session
 
 
 def process_jobs() -> None:
     while process_job():
         pass
+
+
+def now_5_min_in_future() -> datetime:
+    return now() + timedelta(minutes=5)
 
 
 class EmailCollector:

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -60,14 +60,10 @@ from couchers.proto import conversations_pb2, messages_pb2, requests_pb2
 from couchers.proto.internal import jobs_pb2
 from couchers.utils import now, today
 from tests.fixtures.db import generate_user, make_friends, make_user_block, make_volunteer
-from tests.fixtures.misc import PushCollector, process_jobs
+from tests.fixtures.misc import PushCollector, now_5_min_in_future, process_jobs
 from tests.fixtures.sessions import conversations_session, requests_session
 from tests.test_references import create_host_reference, create_host_request, create_host_request_by_date
 from tests.test_requests import valid_request_text
-
-
-def now_5_min_in_future() -> datetime:
-    return now() + timedelta(minutes=5)
 
 
 def now_1_day_in_future() -> datetime:

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -1,11 +1,13 @@
 from datetime import timedelta
+from unittest.mock import patch
 
 import grpc
 import pytest
-from google.protobuf import wrappers_pb2
+from google.protobuf import empty_pb2, wrappers_pb2
 from sqlalchemy import func, select
 
 from couchers.db import session_scope
+from couchers.jobs.handlers import send_message_notifications
 from couchers.jobs.worker import process_job
 from couchers.models import (
     GroupChatRole,
@@ -16,12 +18,11 @@ from couchers.models import (
     NotificationTopicAction,
     RateLimitAction,
 )
-from couchers.notifications.notify import notify
 from couchers.proto import api_pb2, conversations_pb2, notification_data_pb2, notifications_pb2
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_HOURS
 from couchers.utils import Duration_from_timedelta, now, to_aware_datetime
 from tests.fixtures.db import generate_user, make_friends, make_user_block, make_user_invisible
-from tests.fixtures.misc import EmailCollector, Moderator, PushCollector, process_jobs
+from tests.fixtures.misc import EmailCollector, Moderator, PushCollector, now_5_min_in_future, process_jobs
 from tests.fixtures.sessions import api_session, conversations_session, notifications_session
 
 
@@ -1474,6 +1475,21 @@ def test_mark_last_seen_clears_missed_messages_notification(db, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
 
+    # this notification is email-only by default, and the in-app feed only shows push-enabled ones
+    with notifications_session(token2) as n:
+        n.SetNotificationSettings(
+            notifications_pb2.SetNotificationSettingsReq(
+                preferences=[
+                    notifications_pb2.SingleNotificationPreference(
+                        topic=NotificationTopicAction.chat__missed_messages.topic,
+                        action=NotificationTopicAction.chat__missed_messages.action,
+                        delivery_method="push",
+                        enabled=True,
+                    )
+                ]
+            )
+        )
+
     with conversations_session(token1) as c:
         gcid = c.CreateGroupChat(
             conversations_pb2.CreateGroupChatReq(
@@ -1483,40 +1499,30 @@ def test_mark_last_seen_clears_missed_messages_notification(db, moderator):
 
     moderator.approve_group_chat(gcid)
 
-    with session_scope() as session:
-        notify(
-            session,
-            user_id=user2.id,
-            topic_action=NotificationTopicAction.chat__missed_messages,
-            key="",
-            data=notification_data_pb2.ChatMissedMessages(
-                messages=[
-                    notification_data_pb2.ChatMessage(
-                        author=api_pb2.User(name="Test User", user_id=user1.id, username=user1.username),
-                        text="Hello!",
-                        group_chat_id=gcid,
-                        unseen_count=1,
-                    ),
-                ],
-            ),
-        )
+    with conversations_session(token1) as c:
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=gcid, text="Hello!"))
 
-    def unseen_missed_messages_count():
-        with session_scope() as session:
-            return session.execute(
-                select(func.count())
-                .select_from(Notification)
-                .where(Notification.user_id == user2.id)
-                .where(Notification.topic_action == NotificationTopicAction.chat__missed_messages)
-                .where(Notification.is_seen == False)
-            ).scalar_one()
+    # the job only picks up messages that have been unseen for five minutes
+    with patch("couchers.jobs.handlers.now", now_5_min_in_future):
+        send_message_notifications(empty_pb2.Empty())
+        process_jobs()
 
-    assert unseen_missed_messages_count() == 1
+    def unseen_missed_messages():
+        with notifications_session(token2) as n:
+            res = n.ListNotifications(notifications_pb2.ListNotificationsReq(only_unread=True))
+        return [
+            notification
+            for notification in res.notifications
+            if notification.topic == NotificationTopicAction.chat__missed_messages.topic
+            and notification.action == NotificationTopicAction.chat__missed_messages.action
+        ]
+
+    assert len(unseen_missed_messages()) == 1
 
     with conversations_session(token2) as c:
         c.MarkLastSeenGroupChat(conversations_pb2.MarkLastSeenGroupChatReq(group_chat_id=gcid, last_seen_message_id=1))
 
-    assert unseen_missed_messages_count() == 0
+    assert unseen_missed_messages() == []
 
 
 def test_one_dm_per_pair(db, moderator):

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -16,6 +16,7 @@ from couchers.models import (
     NotificationTopicAction,
     RateLimitAction,
 )
+from couchers.notifications.notify import notify
 from couchers.proto import api_pb2, conversations_pb2, notification_data_pb2, notifications_pb2
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_HOURS
 from couchers.utils import Duration_from_timedelta, now, to_aware_datetime
@@ -1463,6 +1464,59 @@ def test_mark_last_seen_clears_notifications(db, moderator):
         c.MarkLastSeenGroupChat(conversations_pb2.MarkLastSeenGroupChatReq(group_chat_id=gcid, last_seen_message_id=1))
 
     assert unseen_notification_count(user2.id) == 0
+
+
+def test_mark_last_seen_clears_missed_messages_notification(db, moderator):
+    """
+    Regression test: chat__missed_messages is a summary keyed with "" rather than a chat id, so it
+    needs to be marked seen separately from the per-chat chat__message notifications.
+    """
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    with conversations_session(token1) as c:
+        gcid = c.CreateGroupChat(
+            conversations_pb2.CreateGroupChatReq(
+                recipient_user_ids=[user2.id], title=wrappers_pb2.StringValue(value="Test chat")
+            )
+        ).group_chat_id
+
+    moderator.approve_group_chat(gcid)
+
+    with session_scope() as session:
+        notify(
+            session,
+            user_id=user2.id,
+            topic_action=NotificationTopicAction.chat__missed_messages,
+            key="",
+            data=notification_data_pb2.ChatMissedMessages(
+                messages=[
+                    notification_data_pb2.ChatMessage(
+                        author=api_pb2.User(name="Test User", user_id=user1.id, username=user1.username),
+                        text="Hello!",
+                        group_chat_id=gcid,
+                        unseen_count=1,
+                    ),
+                ],
+            ),
+        )
+
+    def unseen_missed_messages_count():
+        with session_scope() as session:
+            return session.execute(
+                select(func.count())
+                .select_from(Notification)
+                .where(Notification.user_id == user2.id)
+                .where(Notification.topic_action == NotificationTopicAction.chat__missed_messages)
+                .where(Notification.is_seen == False)
+            ).scalar_one()
+
+    assert unseen_missed_messages_count() == 1
+
+    with conversations_session(token2) as c:
+        c.MarkLastSeenGroupChat(conversations_pb2.MarkLastSeenGroupChatReq(group_chat_id=gcid, last_seen_message_id=1))
+
+    assert unseen_missed_messages_count() == 0
 
 
 def test_one_dm_per_pair(db, moderator):

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -8,7 +8,7 @@ from urllib.parse import parse_qs, urlparse
 import grpc
 import pytest
 from google.protobuf import empty_pb2, timestamp_pb2
-from sqlalchemy import func, select, update
+from sqlalchemy import select, update
 
 from couchers.config import config
 from couchers.constants import DATETIME_INFINITY
@@ -24,7 +24,6 @@ from couchers.models import (
     Notification,
     NotificationDelivery,
     NotificationDeliveryType,
-    NotificationPreference,
     NotificationTopicAction,
     PushNotificationDeliveryAttempt,
     PushNotificationDeliveryOutcome,
@@ -35,12 +34,7 @@ from couchers.models import (
 from couchers.notifications.background import handle_notification
 from couchers.notifications.expo_api import get_expo_push_receipts
 from couchers.notifications.notify import notify
-from couchers.notifications.settings import (
-    get_preference,
-    get_topic_actions_by_delivery_type,
-    reset_preference,
-    set_preference,
-)
+from couchers.notifications.settings import get_topic_actions_by_delivery_type, reset_preference
 from couchers.proto import (
     api_pb2,
     auth_pb2,
@@ -667,30 +661,49 @@ def test_reset_preference(db):
     user, token = generate_user()
 
     topic_action = NotificationTopicAction.event__create_any
+    # neither delivery type is on by default, so enabling both leaves two overrides to tell apart
     assert NotificationDeliveryType.push not in topic_action.defaults
+    assert NotificationDeliveryType.email not in topic_action.defaults
 
-    with session_scope() as session:
-        set_preference(session, user.id, topic_action, NotificationDeliveryType.push, True)
-        set_preference(session, user.id, topic_action, NotificationDeliveryType.email, False)
+    def get_setting() -> notifications_pb2.NotificationItem:
+        with notifications_session(token) as notifications:
+            res = notifications.GetNotificationSettings(notifications_pb2.GetNotificationSettingsReq())
+        items: list[notifications_pb2.NotificationItem] = [
+            item
+            for group in res.groups
+            for topic in group.topics
+            if topic.topic == topic_action.topic
+            for item in topic.items
+            if item.action == topic_action.action
+        ]
+        (item,) = items
+        return item
 
-    with session_scope() as session:
-        assert get_preference(session, user.id, topic_action) == [NotificationDeliveryType.push]
+    with notifications_session(token) as notifications:
+        notifications.SetNotificationSettings(
+            notifications_pb2.SetNotificationSettingsReq(
+                preferences=[
+                    notifications_pb2.SingleNotificationPreference(
+                        topic=topic_action.topic,
+                        action=topic_action.action,
+                        delivery_method=delivery_method,
+                        enabled=True,
+                    )
+                    for delivery_method in ["push", "email"]
+                ]
+            )
+        )
 
-    # only the push override should go, leaving the email one in place
+    assert get_setting().push
+    assert get_setting().email
+
+    # there is no API for clearing an override back to its default, it's only reachable internally
     with session_scope() as session:
         reset_preference(session, user.id, topic_action, NotificationDeliveryType.push)
 
-    with session_scope() as session:
-        assert get_preference(session, user.id, topic_action) == []
-        assert (
-            session.execute(
-                select(func.count())
-                .select_from(NotificationPreference)
-                .where(NotificationPreference.user_id == user.id)
-                .where(NotificationPreference.topic_action == topic_action)
-            ).scalar_one()
-            == 1
-        )
+    # only the push override should go, leaving the email one in place
+    assert not get_setting().push
+    assert get_setting().email
 
 
 def test_event_reminder_email_sent(db, email_collector: EmailCollector):

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -8,7 +8,7 @@ from urllib.parse import parse_qs, urlparse
 import grpc
 import pytest
 from google.protobuf import empty_pb2, timestamp_pb2
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 
 from couchers.config import config
 from couchers.constants import DATETIME_INFINITY
@@ -24,6 +24,7 @@ from couchers.models import (
     Notification,
     NotificationDelivery,
     NotificationDeliveryType,
+    NotificationPreference,
     NotificationTopicAction,
     PushNotificationDeliveryAttempt,
     PushNotificationDeliveryOutcome,
@@ -34,7 +35,12 @@ from couchers.models import (
 from couchers.notifications.background import handle_notification
 from couchers.notifications.expo_api import get_expo_push_receipts
 from couchers.notifications.notify import notify
-from couchers.notifications.settings import get_topic_actions_by_delivery_type
+from couchers.notifications.settings import (
+    get_preference,
+    get_topic_actions_by_delivery_type,
+    reset_preference,
+    set_preference,
+)
 from couchers.proto import (
     api_pb2,
     auth_pb2,
@@ -655,6 +661,36 @@ def test_get_topic_actions_by_delivery_type(db):
         assert NotificationTopicAction.event__create_any in deliver
         assert NotificationTopicAction.discussion__create not in deliver
         assert NotificationTopicAction.account_deletion__start in deliver
+
+
+def test_reset_preference(db):
+    user, token = generate_user()
+
+    topic_action = NotificationTopicAction.event__create_any
+    assert NotificationDeliveryType.push not in topic_action.defaults
+
+    with session_scope() as session:
+        set_preference(session, user.id, topic_action, NotificationDeliveryType.push, True)
+        set_preference(session, user.id, topic_action, NotificationDeliveryType.email, False)
+
+    with session_scope() as session:
+        assert get_preference(session, user.id, topic_action) == [NotificationDeliveryType.push]
+
+    # only the push override should go, leaving the email one in place
+    with session_scope() as session:
+        reset_preference(session, user.id, topic_action, NotificationDeliveryType.push)
+
+    with session_scope() as session:
+        assert get_preference(session, user.id, topic_action) == []
+        assert (
+            session.execute(
+                select(func.count())
+                .select_from(NotificationPreference)
+                .where(NotificationPreference.user_id == user.id)
+                .where(NotificationPreference.topic_action == topic_action)
+            ).scalar_one()
+            == 1
+        )
 
 
 def test_event_reminder_email_sent(db, email_collector: EmailCollector):


### PR DESCRIPTION
Fixes two small notification bugs.

**`chat__missed_messages` was never marked seen.** `MarkLastSeenGroupChat` marked both `chat__message` and `chat__missed_messages` seen using `key=str(group_chat_id)`, but `chat__missed_messages` is a summary across *all* chats and is created with `key=""` (`jobs/handlers.py`), so the update never matched a row. Split into two `mark_notifications_seen` calls with the right key for each. Impact is low today because both `ListNotifications` and the `Ping` unseen count filter the in-app feed to push-enabled topic actions and this one defaults to email-only — but a user who enables push for it would get a notification stuck unread forever.

For the record, the equivalent call in `requests.py` is *not* affected: `host_request__missed_messages` really is created with `key=str(conversation_id)`, so its key matches.

**`reset_preference` filtered on the wrong table.** It used `NotificationDelivery.delivery_type` where it meant `NotificationPreference.delivery_type`, giving an accidental cross join with `notification_delivery`. With that table empty the query returns no rows and the function silently deletes nothing; with multiple matching rows it would raise `MultipleResultsFound`. The function is currently uncalled, so there is no user-visible impact. Also drops the now-unused `NotificationDelivery` import.

**Unrelated drive-by:** three pre-existing mypy errors in `test_events.py` / `test_calendar_events.py` (a wrong `-> str` annotation and two unguarded `re.search(...).group(1)` calls) — `make mypy` did not pass on `develop` without these.

## Testing

Added a regression test for each bug and confirmed both fail against the unfixed code:

- `test_mark_last_seen_clears_missed_messages_notification` (`test_conversations.py`) — creates a `chat__missed_messages` notification, calls `MarkLastSeenGroupChat`, asserts it becomes seen.
- `test_reset_preference` (`test_notifications.py`) — sets push and email overrides for a topic action, resets only push, asserts the push override is gone and the email one survives.

`make format` and `make mypy` pass clean. Ran `test_conversations.py`, `test_requests.py`, `test_notifications.py`, `test_notification_settings.py`, `test_bg_jobs.py`, `test_email.py`, `test_events.py` and `test_calendar_events.py` — all pass.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history — n/a, no schema changes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._