### PR TITLE
Backend: delay missed-message emails for push-capable users

### DIFF
--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -190,9 +190,9 @@ def _message_unseen_long_enough(user_id_column: InstrumentedAttribute[int]) -> C
         .where(PushNotificationSubscription.disabled_at > func.now())
         .exists()
     )
-    return or_(
-        and_(has_active_push_subscription, Message.time < now() - MISSED_MESSAGES_DELAY_WITH_PUSH),
-        and_(not_(has_active_push_subscription), Message.time < now() - MISSED_MESSAGES_DELAY),
+    return Message.time < case(
+        (has_active_push_subscription, now() - MISSED_MESSAGES_DELAY_WITH_PUSH),
+        else_=now() - MISSED_MESSAGES_DELAY,
     )
 
 

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -12,7 +12,7 @@ from typing import Any
 import requests
 from google.protobuf import empty_pb2
 from sqlalchemy import ColumnElement, Float, Function, Integer, select
-from sqlalchemy.orm import aliased
+from sqlalchemy.orm import InstrumentedAttribute, aliased
 from sqlalchemy.sql import (
     and_,
     case,
@@ -170,6 +170,32 @@ def purge_account_deletion_tokens(payload: empty_pb2.Empty) -> None:
         )
 
 
+# how long a message must go unseen before we email the user about it
+MISSED_MESSAGES_DELAY = timedelta(minutes=5)
+# ... unless we could reach them by push, in which case they've already been told about it once
+MISSED_MESSAGES_DELAY_WITH_PUSH = timedelta(hours=24)
+
+
+def _message_unseen_long_enough(user_id_column: InstrumentedAttribute[int]) -> ColumnElement[bool]:
+    """
+    Whether `Message` has gone unseen long enough to email the given user about it.
+
+    Note that a subscription we can still push to is not proof the user sees those pushes: they may
+    have revoked notification permission in their OS settings without the token going stale. Such
+    users still get the email, just a day late.
+    """
+    has_active_push_subscription = (
+        select(PushNotificationSubscription.id)
+        .where(PushNotificationSubscription.user_id == user_id_column)
+        .where(PushNotificationSubscription.disabled_at > func.now())
+        .exists()
+    )
+    return or_(
+        and_(has_active_push_subscription, Message.time < now() - MISSED_MESSAGES_DELAY_WITH_PUSH),
+        and_(not_(has_active_push_subscription), Message.time < now() - MISSED_MESSAGES_DELAY),
+    )
+
+
 def send_message_notifications(payload: empty_pb2.Empty) -> None:
     """
     Sends out email notifications for messages that have been unseen for a long enough time
@@ -195,7 +221,7 @@ def send_message_notifications(payload: empty_pb2.Empty) -> None:
                 .where(or_(Message.time <= GroupChatSubscription.left, GroupChatSubscription.left == None))
                 .where(Message.id > User.last_notified_message_id)
                 .where(Message.id > GroupChatSubscription.last_seen_message_id)
-                .where(Message.time < now() - timedelta(minutes=5))
+                .where(_message_unseen_long_enough(User.id))
                 .where(Message.message_type == MessageType.text)  # TODO: only text messages for now
             )
             .scalars()
@@ -292,7 +318,7 @@ def send_request_notifications(payload: empty_pb2.Empty) -> None:
             .where(User.is_visible)
             .where(Message.id > HostRequest.initiator_last_seen_message_id)
             .where(Message.id > User.last_notified_request_message_id)
-            .where(Message.time < now() - timedelta(minutes=5))
+            .where(_message_unseen_long_enough(User.id))
             .where(Message.message_type == MessageType.text)
         )
         host_ids = (
@@ -302,7 +328,7 @@ def send_request_notifications(payload: empty_pb2.Empty) -> None:
             .where(User.is_visible)
             .where(Message.id > HostRequest.recipient_last_seen_message_id)
             .where(Message.id > User.last_notified_request_message_id)
-            .where(Message.time < now() - timedelta(minutes=5))
+            .where(_message_unseen_long_enough(User.id))
             .where(Message.message_type == MessageType.text)
         )
         candidate_user_ids = session.execute(union_all(surfer_ids, host_ids)).scalars().unique().all()
@@ -326,7 +352,7 @@ def send_request_notifications(payload: empty_pb2.Empty) -> None:
                 .join(Message, Message.conversation_id == HostRequest.conversation_id)
                 .where(Message.id > HostRequest.initiator_last_seen_message_id)
                 .where(Message.id > User.last_notified_request_message_id)
-                .where(Message.time < now() - timedelta(minutes=5))
+                .where(_message_unseen_long_enough(User.id))
                 .where(Message.message_type == MessageType.text)
                 .group_by(User, HostRequest)  # type: ignore[arg-type]
             ).all()
@@ -347,7 +373,7 @@ def send_request_notifications(payload: empty_pb2.Empty) -> None:
                 .join(Message, Message.conversation_id == HostRequest.conversation_id)
                 .where(Message.id > HostRequest.recipient_last_seen_message_id)
                 .where(Message.id > User.last_notified_request_message_id)
-                .where(Message.time < now() - timedelta(minutes=5))
+                .where(_message_unseen_long_enough(User.id))
                 .where(Message.message_type == MessageType.text)
                 .group_by(User, HostRequest)  # type: ignore[arg-type]
             ).all()

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -41,6 +41,7 @@ from couchers.models import (
     AccountDeletionToken,
     BackgroundJob,
     BackgroundJobState,
+    DeviceType,
     Email,
     HostRequest,
     HostRequestStatus,
@@ -48,6 +49,8 @@ from couchers.models import (
     Message,
     MessageType,
     PasswordResetToken,
+    PushNotificationPlatform,
+    PushNotificationSubscription,
     User,
     UserBadge,
     UserBlock,
@@ -65,6 +68,32 @@ from tests.test_requests import valid_request_text
 
 def now_5_min_in_future() -> datetime:
     return now() + timedelta(minutes=5)
+
+
+def now_1_day_in_future() -> datetime:
+    return now() + timedelta(hours=25)
+
+
+def _add_mobile_push_subscription(user_id: int, *, disabled: bool = False) -> None:
+    with session_scope() as session:
+        sub = PushNotificationSubscription(
+            user_id=user_id,
+            platform=PushNotificationPlatform.expo,
+            token=f"ExponentPushToken[{user_id}]",
+            device_name="Test phone",
+            device_type=DeviceType.ios,
+        )
+        session.add(sub)
+        if disabled:
+            session.flush()
+            sub.disabled_at = now()
+
+
+def _count_queued_emails() -> int:
+    with session_scope() as session:
+        return session.execute(
+            select(func.count()).select_from(BackgroundJob).where(BackgroundJob.job_type == "send_email")
+        ).scalar_one()
 
 
 @pytest.fixture(autouse=True)
@@ -661,6 +690,57 @@ def test_send_message_notifications_muted(db, moderator):
         )
 
 
+def _send_one_chat_message(token: str, recipient_id: int, moderator) -> None:
+    with conversations_session(token) as c:
+        group_chat_id = c.CreateGroupChat(
+            conversations_pb2.CreateGroupChatReq(recipient_user_ids=[recipient_id])
+        ).group_chat_id
+    moderator.approve_group_chat(group_chat_id)
+
+    with conversations_session(token) as c:
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message 1"))
+
+    with session_scope() as session:
+        session.execute(delete(BackgroundJob).execution_options(synchronize_session=False))
+
+
+def test_send_message_notifications_delayed_for_push_capable_users(db, moderator, push_collector: PushCollector):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    make_friends(user1, user2)
+    _add_mobile_push_subscription(user2.id)
+
+    _send_one_chat_message(token1, user2.id, moderator)
+
+    # user2 already got a push about this, so the usual 5 minute delay doesn't apply to them
+    with patch("couchers.jobs.handlers.now", now_5_min_in_future):
+        send_message_notifications(empty_pb2.Empty())
+        process_jobs()
+    assert _count_queued_emails() == 0
+
+    with patch("couchers.jobs.handlers.now", now_1_day_in_future):
+        send_message_notifications(empty_pb2.Empty())
+        process_jobs()
+    assert _count_queued_emails() == 1
+
+
+def test_send_message_notifications_not_delayed_when_push_subscription_disabled(
+    db, moderator, push_collector: PushCollector
+):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    make_friends(user1, user2)
+    # e.g. the device unregistered, so we can't reach user2 by push and the email is all they'll get
+    _add_mobile_push_subscription(user2.id, disabled=True)
+
+    _send_one_chat_message(token1, user2.id, moderator)
+
+    with patch("couchers.jobs.handlers.now", now_5_min_in_future):
+        send_message_notifications(empty_pb2.Empty())
+        process_jobs()
+    assert _count_queued_emails() == 1
+
+
 def test_send_request_notifications_host_request(db, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
@@ -832,6 +912,45 @@ def test_send_request_notifications_two_requests_one_with_followup(db, moderator
             ).scalar_one()
             == 1
         )
+
+
+def test_send_request_notifications_delayed_for_push_capable_users(db, moderator, push_collector: PushCollector):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    _add_mobile_push_subscription(user1.id)
+
+    today_plus_2 = (today() + timedelta(days=2)).isoformat()
+    today_plus_3 = (today() + timedelta(days=3)).isoformat()
+
+    with requests_session(token1) as requests:
+        host_request_id = requests.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=user2.id, from_date=today_plus_2, to_date=today_plus_3, text=valid_request_text()
+            )
+        ).host_request_id
+    moderator.approve_host_request(host_request_id)
+
+    with requests_session(token2) as requests:
+        requests.RespondHostRequest(
+            requests_pb2.RespondHostRequestReq(
+                host_request_id=host_request_id,
+                status=messages_pb2.HOST_REQUEST_STATUS_ACCEPTED,
+                text="Test request",
+            )
+        )
+
+    with session_scope() as session:
+        session.execute(delete(BackgroundJob).execution_options(synchronize_session=False))
+
+    with patch("couchers.jobs.handlers.now", now_5_min_in_future):
+        send_request_notifications(empty_pb2.Empty())
+        process_jobs()
+    assert _count_queued_emails() == 0
+
+    with patch("couchers.jobs.handlers.now", now_1_day_in_future):
+        send_request_notifications(empty_pb2.Empty())
+        process_jobs()
+    assert _count_queued_emails() == 1
 
 
 def test_send_message_notifications_seen(db, moderator):


### PR DESCRIPTION
If you have the app and someone messages you, you get a push immediately and then a "you missed messages" email 5-8 minutes later. Now that the app exists that's just double-notifying people who saw the push and decided to reply later.

We can't simply turn the email off — `digest` delivery is still a stub (`notifications/background.py:218`), so `chat:missed_messages` is the only email anyone gets about a message. Instead this makes the delay depend on whether we can reach the user by push:

- no active push subscription → 5 minutes, unchanged
- active push subscription → 24 hours

`_message_unseen_long_enough()` uses the same `disabled_at > now()` predicate as `_push_to_user`, so "reachable by push" means what the push sender means by it. The `last_seen_message_id` check still applies, so anyone who opens the chat within the day gets no email at all. Applied to both `send_message_notifications` and `send_request_notifications`. Thresholds are two constants at the top of the handler.

Caveat: an active subscription isn't proof the user sees pushes — revoking notification permission leaves a token APNs still accepts. Those users get the email a day late rather than not at all.

## Testing

`make mypy` clean, `make format` applied. Three new tests in `test_bg_jobs.py` covering the 24h delay for chat and host requests, and that a disabled subscription restores the 5 minute behaviour. The full suite was green before I stripped an earlier `last_active` hunk from this branch, but hasn't been re-run since — letting CI confirm.

To reproduce by hand: register a mobile push subscription for a user, send them a chat message from another account, then run `send_message_notifications` — no email is queued until the message is over a day old.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes — n/a, no schema changes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

🤖 Generated with [Claude Code](https://claude.com/claude-code)
