### PR TITLE
Backend: record every SQL query the tests issue and diff it per PR

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -796,6 +796,9 @@ preview:backend:
     - aws s3 rm s3://$AWS_PREVIEW_BUCKET/schema/$CI_COMMIT_REF_SLUG/ --recursive
     - aws s3 cp artifacts/schema_dumps s3://$AWS_PREVIEW_BUCKET/schema/$CI_COMMIT_REF_SLUG/ --recursive
     - echo "Done, schema dumps available at https://$CI_COMMIT_SHORT_SHA--schema.$PREVIEW_DOMAIN/schema.sql and https://$CI_COMMIT_REF_SLUG--schema.$PREVIEW_DOMAIN/schema.sql"
+    # The per-node query logs came in from test:backend alongside preview:backend-coverage's merged data.json.gz,
+    # and only the merged one is worth publishing
+    - find artifacts/test_artifacts/queries -name 'data.*.json.gz' ! -name 'data.json.gz' -delete || true
     # Upload postcard samples
     - aws s3 rm s3://$AWS_PREVIEW_BUCKET/test-artifacts/$CI_COMMIT_SHORT_SHA/ --recursive
     - aws s3 cp artifacts/test_artifacts s3://$AWS_PREVIEW_BUCKET/test-artifacts/$CI_COMMIT_SHORT_SHA/ --recursive 2>/dev/null || true

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -342,7 +342,9 @@ test:backend:
     DATABASE_CONNECTION_STRING: "postgresql://postgres:c765064a49d18a95@postgres/testdb"
     COVERAGE_FILE: /app/.coverage.$CI_NODE_INDEX
   script:
-    - cd /app && pytest --junitxml=junit.xml --cov=src --cov-report= --splits $CI_NODE_TOTAL --group $CI_NODE_INDEX --durations-path src/tests/.test_durations --store-durations src
+    # --query-log records every SQL query into test_artifacts/queries/data.$CI_NODE_INDEX.json, which the
+    # after_script below already picks up along with the rest of test_artifacts
+    - cd /app && pytest --junitxml=junit.xml --cov=src --cov-report= --query-log --splits $CI_NODE_TOTAL --group $CI_NODE_INDEX --durations-path src/tests/.test_durations --store-durations src
     # Move the stored durations to a node-specific file
     - mv src/tests/.test_durations /app/.test_durations.$CI_NODE_INDEX
   after_script:
@@ -710,6 +712,15 @@ preview:backend-coverage:
           json.dump(merged, fp, sort_keys=True, indent=4)
       print(f"Merged {len(merged)} test durations from {len(glob.glob('.test_durations.*'))} files")
       EOF
+    # Merge the per-node SQL query logs, diff against the log develop last published, and render the report.
+    # Writes data.json (which becomes the next baseline), index.html and summary.txt next to the node dumps.
+    - |
+      python3 app/scripts/query_log_report.py \
+        --input artifacts/test_artifacts/queries \
+        --output artifacts/test_artifacts/queries \
+        --baseline-url "https://develop--test-artifacts.$PREVIEW_DOMAIN/queries/data.json" \
+        --summary-file artifacts/test_artifacts/queries/summary.txt \
+        --commit "$CI_COMMIT_SHORT_SHA"
   coverage: '/^TOTAL.+?(\d+\%)$/'
   artifacts:
     reports:
@@ -719,6 +730,7 @@ preview:backend-coverage:
     paths:
       - htmlcov
       - test_durations.json
+      - artifacts/test_artifacts/queries
   rules:
     - if: ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
     - if: ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
@@ -767,7 +779,7 @@ preview:backend:
       fi
     # Upload coverage report to S3
     - |
-      BACKEND_ITEMS=schema,schema-diff,emails
+      BACKEND_ITEMS=schema,schema-diff,emails,queries
       if [ "$CI_COMMIT_BRANCH" = "$RELEASE_BRANCH" ] || [ "$DO_COVERAGE" = "true" ]; then
         aws s3 rm s3://$AWS_PREVIEW_BUCKET/bcov/$CI_COMMIT_SHORT_SHA/ --recursive
         aws s3 cp htmlcov s3://$AWS_PREVIEW_BUCKET/bcov/$CI_COMMIT_SHORT_SHA/ --recursive

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -718,7 +718,7 @@ preview:backend-coverage:
       python3 app/scripts/query_log_report.py \
         --input artifacts/test_artifacts/queries \
         --output artifacts/test_artifacts/queries \
-        --baseline-url "https://develop--test-artifacts.$PREVIEW_DOMAIN/queries/data.json" \
+        --baseline-url "https://develop--test-artifacts.$PREVIEW_DOMAIN/queries/data.json.gz" \
         --summary-file artifacts/test_artifacts/queries/summary.txt \
         --commit "$CI_COMMIT_SHORT_SHA"
   coverage: '/^TOTAL.+?(\d+\%)$/'

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -719,6 +719,9 @@ preview:backend-coverage:
       EOF
     # Merge the per-node SQL query logs, diff against the log develop last published, and render the report.
     # Writes data.json (which becomes the next baseline), index.html and summary.txt next to the node dumps.
+    # Never fatal: this job gates preview:backend, so a broken query log would otherwise take the whole sticky PR
+    # comment - schema, schema diff, sample emails, coverage - down with it. preview:backend drops the comment item
+    # when index.html is missing, so a failure here degrades to the report simply not being linked.
     - |
       if [ "$BACKEND_QUERY_LOG" = "true" ]; then
         python3 app/scripts/query_log_report.py \
@@ -726,7 +729,8 @@ preview:backend-coverage:
           --output artifacts/test_artifacts/queries \
           --baseline-url "https://develop--test-artifacts.$PREVIEW_DOMAIN/queries/data.json.gz" \
           --summary-file artifacts/test_artifacts/queries/summary.txt \
-          --commit "$CI_COMMIT_SHORT_SHA"
+          --commit "$CI_COMMIT_SHORT_SHA" \
+          || echo "query log report failed, continuing without it"
       fi
   coverage: '/^TOTAL.+?(\d+\%)$/'
   artifacts:
@@ -787,7 +791,9 @@ preview:backend:
     # Upload coverage report to S3
     - |
       BACKEND_ITEMS=schema,schema-diff,emails
-      if [ "$BACKEND_QUERY_LOG" = "true" ]; then BACKEND_ITEMS=$BACKEND_ITEMS,queries; fi
+      # Presence of the report is the condition, not BACKEND_QUERY_LOG: it covers the variable being off and the
+      # deliberately non-fatal render step having failed, and never links a report that is not there
+      if [ -f "artifacts/test_artifacts/queries/index.html" ]; then BACKEND_ITEMS=$BACKEND_ITEMS,queries; fi
       if [ "$CI_COMMIT_BRANCH" = "$RELEASE_BRANCH" ] || [ "$DO_COVERAGE" = "true" ]; then
         aws s3 rm s3://$AWS_PREVIEW_BUCKET/bcov/$CI_COMMIT_SHORT_SHA/ --recursive
         aws s3 cp htmlcov s3://$AWS_PREVIEW_BUCKET/bcov/$CI_COMMIT_SHORT_SHA/ --recursive

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -25,7 +25,7 @@ variables:
   BUILD_MOBILE: "true"
   # whether to record the SQL the backend tests issue and diff it against develop's (see docs/query-log.md).
   # set to "false" to turn the whole thing off: the recording, the report and the PR comment item all check it
-  QUERY_LOG: "true"
+  BACKEND_QUERY_LOG: "true"
   PREVIEW_DOMAIN: preview.couchershq.org
   GIT_DEPTH: 1  # Speed up the checkout.
   DOCKER_HOST: tcp://docker:2376
@@ -348,7 +348,7 @@ test:backend:
     # --query-log records every SQL query into test_artifacts/queries/data.$CI_NODE_INDEX.json.gz, which the
     # after_script below already picks up along with the rest of test_artifacts
     - QUERY_LOG_FLAG=""
-    - if [ "$QUERY_LOG" = "true" ]; then QUERY_LOG_FLAG=--query-log; fi
+    - if [ "$BACKEND_QUERY_LOG" = "true" ]; then QUERY_LOG_FLAG=--query-log; fi
     - cd /app && pytest --junitxml=junit.xml --cov=src --cov-report= $QUERY_LOG_FLAG --splits $CI_NODE_TOTAL --group $CI_NODE_INDEX --durations-path src/tests/.test_durations --store-durations src
     # Move the stored durations to a node-specific file
     - mv src/tests/.test_durations /app/.test_durations.$CI_NODE_INDEX
@@ -720,7 +720,7 @@ preview:backend-coverage:
     # Merge the per-node SQL query logs, diff against the log develop last published, and render the report.
     # Writes data.json (which becomes the next baseline), index.html and summary.txt next to the node dumps.
     - |
-      if [ "$QUERY_LOG" = "true" ]; then
+      if [ "$BACKEND_QUERY_LOG" = "true" ]; then
         python3 app/scripts/query_log_report.py \
           --input artifacts/test_artifacts/queries \
           --output artifacts/test_artifacts/queries \
@@ -787,7 +787,7 @@ preview:backend:
     # Upload coverage report to S3
     - |
       BACKEND_ITEMS=schema,schema-diff,emails
-      if [ "$QUERY_LOG" = "true" ]; then BACKEND_ITEMS=$BACKEND_ITEMS,queries; fi
+      if [ "$BACKEND_QUERY_LOG" = "true" ]; then BACKEND_ITEMS=$BACKEND_ITEMS,queries; fi
       if [ "$CI_COMMIT_BRANCH" = "$RELEASE_BRANCH" ] || [ "$DO_COVERAGE" = "true" ]; then
         aws s3 rm s3://$AWS_PREVIEW_BUCKET/bcov/$CI_COMMIT_SHORT_SHA/ --recursive
         aws s3 cp htmlcov s3://$AWS_PREVIEW_BUCKET/bcov/$CI_COMMIT_SHORT_SHA/ --recursive

--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -23,6 +23,9 @@ variables:
   # whether to build web since it's very slow
   BUILD_WEB: "true"
   BUILD_MOBILE: "true"
+  # whether to record the SQL the backend tests issue and diff it against develop's (see docs/query-log.md).
+  # set to "false" to turn the whole thing off: the recording, the report and the PR comment item all check it
+  QUERY_LOG: "true"
   PREVIEW_DOMAIN: preview.couchershq.org
   GIT_DEPTH: 1  # Speed up the checkout.
   DOCKER_HOST: tcp://docker:2376
@@ -342,9 +345,11 @@ test:backend:
     DATABASE_CONNECTION_STRING: "postgresql://postgres:c765064a49d18a95@postgres/testdb"
     COVERAGE_FILE: /app/.coverage.$CI_NODE_INDEX
   script:
-    # --query-log records every SQL query into test_artifacts/queries/data.$CI_NODE_INDEX.json, which the
+    # --query-log records every SQL query into test_artifacts/queries/data.$CI_NODE_INDEX.json.gz, which the
     # after_script below already picks up along with the rest of test_artifacts
-    - cd /app && pytest --junitxml=junit.xml --cov=src --cov-report= --query-log --splits $CI_NODE_TOTAL --group $CI_NODE_INDEX --durations-path src/tests/.test_durations --store-durations src
+    - QUERY_LOG_FLAG=""
+    - if [ "$QUERY_LOG" = "true" ]; then QUERY_LOG_FLAG=--query-log; fi
+    - cd /app && pytest --junitxml=junit.xml --cov=src --cov-report= $QUERY_LOG_FLAG --splits $CI_NODE_TOTAL --group $CI_NODE_INDEX --durations-path src/tests/.test_durations --store-durations src
     # Move the stored durations to a node-specific file
     - mv src/tests/.test_durations /app/.test_durations.$CI_NODE_INDEX
   after_script:
@@ -715,12 +720,14 @@ preview:backend-coverage:
     # Merge the per-node SQL query logs, diff against the log develop last published, and render the report.
     # Writes data.json (which becomes the next baseline), index.html and summary.txt next to the node dumps.
     - |
-      python3 app/scripts/query_log_report.py \
-        --input artifacts/test_artifacts/queries \
-        --output artifacts/test_artifacts/queries \
-        --baseline-url "https://develop--test-artifacts.$PREVIEW_DOMAIN/queries/data.json.gz" \
-        --summary-file artifacts/test_artifacts/queries/summary.txt \
-        --commit "$CI_COMMIT_SHORT_SHA"
+      if [ "$QUERY_LOG" = "true" ]; then
+        python3 app/scripts/query_log_report.py \
+          --input artifacts/test_artifacts/queries \
+          --output artifacts/test_artifacts/queries \
+          --baseline-url "https://develop--test-artifacts.$PREVIEW_DOMAIN/queries/data.json.gz" \
+          --summary-file artifacts/test_artifacts/queries/summary.txt \
+          --commit "$CI_COMMIT_SHORT_SHA"
+      fi
   coverage: '/^TOTAL.+?(\d+\%)$/'
   artifacts:
     reports:
@@ -779,7 +786,8 @@ preview:backend:
       fi
     # Upload coverage report to S3
     - |
-      BACKEND_ITEMS=schema,schema-diff,emails,queries
+      BACKEND_ITEMS=schema,schema-diff,emails
+      if [ "$QUERY_LOG" = "true" ]; then BACKEND_ITEMS=$BACKEND_ITEMS,queries; fi
       if [ "$CI_COMMIT_BRANCH" = "$RELEASE_BRANCH" ] || [ "$DO_COVERAGE" = "true" ]; then
         aws s3 rm s3://$AWS_PREVIEW_BUCKET/bcov/$CI_COMMIT_SHORT_SHA/ --recursive
         aws s3 cp htmlcov s3://$AWS_PREVIEW_BUCKET/bcov/$CI_COMMIT_SHORT_SHA/ --recursive

--- a/app/backend/src/couchers/models/moderation.py
+++ b/app/backend/src/couchers/models/moderation.py
@@ -225,9 +225,13 @@ def get_moderated_models() -> dict[ModerationObjectType, ModeratedModel]:
 
     Discovered from every mapped model that declares __moderation_object_type__, so the moderation
     metadata stays on the models themselves rather than in a separate hand-maintained list.
+
+    Ordered by model class name. registry.mappers is a frozenset, so iterating it orders Mapper objects by id(), which
+    varies per process; callers build one OR branch per entry, so without sorting the same logical query is emitted
+    with its branches in a different order in every process. That splits it across pg_stat_statements entries.
     """
     models: dict[ModerationObjectType, ModeratedModel] = {}
-    for mapper in Base.registry.mappers:
+    for mapper in sorted(Base.registry.mappers, key=lambda m: m.class_.__name__):
         cls = mapper.class_
         if not hasattr(cls, "__moderation_object_type__"):
             continue

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import re
 from collections.abc import Generator
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 from unittest.mock import patch
@@ -21,7 +22,9 @@ if "DATABASE_CONNECTION_STRING" not in os.environ:  # pragma: no cover
 
 from couchers import experimentation  # noqa: E402
 from couchers.config import config  # noqa: E402
+from couchers.db import _get_base_engine  # noqa: E402
 from couchers.models import Base  # noqa: E402
+from tests.fixtures import query_log  # noqa: E402
 from tests.fixtures.db import (  # noqa: E402
     autocommit_engine,
     create_schema_from_models,
@@ -29,6 +32,37 @@ from tests.fixtures.db import (  # noqa: E402
     populate_testing_resources,
 )
 from tests.fixtures.misc import EmailCollector, Moderator, PushCollector  # noqa: E402
+
+QUERY_LOG_DIR = Path(__file__).resolve().parents[2] / "test_artifacts" / "queries"
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--query-log",
+        action="store_true",
+        help="record every SQL query, grouped by test and by the RPC that issued it, into test_artifacts/queries",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    if config.getoption("--query-log"):
+        query_log.enable(_get_base_engine())
+
+
+def pytest_sessionfinish(session: pytest.Session) -> None:
+    if session.config.getoption("--query-log"):
+        print(f"\nquery log written to {query_log.dump(QUERY_LOG_DIR)}")
+
+
+@pytest.fixture(autouse=True)
+def _record_queries_for_test(request: pytest.FixtureRequest) -> Generator[None]:
+    """Attributes every query to the running test. Cheap no-op unless --query-log is on."""
+    if not request.config.getoption("--query-log"):
+        yield
+        return
+    query_log.set_current_test(request.node.nodeid)
+    yield
+    query_log.set_current_test(None)
 
 
 @pytest.fixture(scope="session")

--- a/app/backend/src/tests/fixtures/misc.py
+++ b/app/backend/src/tests/fixtures/misc.py
@@ -13,12 +13,17 @@ from couchers.proto import moderation_pb2
 from couchers.proto.internal import jobs_pb2
 from couchers.servicers.threads import unpack_thread_id
 from couchers.utils import now
+from tests.fixtures import query_log
 from tests.fixtures.sessions import real_moderation_session
 
 
 def process_jobs() -> None:
-    while process_job():
-        pass
+    # One span for the whole drain, not one per job type: Job is a frozen dataclass deriving its name and payload
+    # type from the handler's __name__ and type hints, so wrapping handlers to name them breaks get_type_hints.
+    # Splitting these out wants a span alongside the existing tracer span in worker.process_job.
+    with query_log.span("job", "process_jobs"):
+        while process_job():
+            pass
 
 
 def now_5_min_in_future() -> datetime:

--- a/app/backend/src/tests/fixtures/query_log.py
+++ b/app/backend/src/tests/fixtures/query_log.py
@@ -1,0 +1,213 @@
+"""Records every SQL query the suite issues, grouped by test and by the RPC (or background job) that issued it.
+
+Off unless --query-log is passed, so ordinary local runs pay nothing. CI dumps one JSON file per pytest-split node;
+app/scripts/query_log_report.py merges those, diffs them against develop's and renders the browsable report.
+
+Each query is stored twice: a fingerprint with the bound parameters replaced by "?" (the stable key used for
+grouping and diffing) and one concrete rendering with the values inlined by psycopg, so it can be copy-pasted
+straight into a psql prompt.
+"""
+
+import hashlib
+import json
+import os
+import re
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import psycopg
+from sqlalchemy import Engine, event
+
+# Bind parameters as psycopg's pyformat paramstyle renders them, plus positional %s for good measure.
+_PARAM_RE = re.compile(r"%\([^)]*\)s|%s")
+# Trailing sqlcommenter-style comments. Nothing emits these in tests today (tracing is only set up in prod), but a
+# future change that turns the commenter on would otherwise invalidate every fingerprint at once.
+_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+# Expanded IN (...) lists, whose length varies with the test data.
+_PARAM_LIST_RE = re.compile(r"\?(?:\s*,\s*\?)+")
+_WHITESPACE_RE = re.compile(r"\s+")
+_WRITE_RE = re.compile(r"^\s*(INSERT|UPDATE|DELETE)\b", re.IGNORECASE)
+
+
+@dataclass(slots=True)
+class _Shape:
+    id: str
+    sql: str
+    example: str
+    params: str | None
+    write: bool
+    # The test that first produced this shape. Kept only to make the choice of `example` deterministic.
+    first_seen_in: str
+
+
+@dataclass(slots=True)
+class _Span:
+    kind: str
+    name: str | None
+    queries: list[str] = field(default_factory=list)
+
+
+_lock = threading.Lock()
+_local = threading.local()
+
+_enabled = False
+_current_test: str | None = None
+_shapes: dict[str, _Shape] = {}
+_tests: dict[str, list[_Span]] = {}
+
+
+def _fingerprint(statement: str) -> str:
+    sql = _COMMENT_RE.sub("", statement)
+    sql = _PARAM_RE.sub("?", sql)
+    sql = _PARAM_LIST_RE.sub("?", sql)
+    return _WHITESPACE_RE.sub(" ", sql).strip()
+
+
+def _shape_id(fingerprint: str) -> str:
+    # Content-addressed, so the three pytest-split nodes agree on ids and merging is a plain dict union. A counter
+    # would be assigned in per-node encounter order and collide across nodes.
+    return hashlib.blake2b(fingerprint.encode(), digest_size=6).hexdigest()
+
+
+def _render_example(conn: Any, statement: str, parameters: Any) -> tuple[str, str | None]:
+    """Inline the bound values so the statement can be pasted into psql.
+
+    psycopg's ClientCursor.mogrify applies the same adaptation and escaping the driver would otherwise do
+    server-side, which is far more faithful than re-implementing literal binding for bytea, arrays and PostGIS
+    geometries. It is purely client-side, so it issues nothing on the connection.
+    """
+    # executemany passes a sequence of parameter sets; one row is enough to have something runnable.
+    if isinstance(parameters, (list, tuple)) and parameters and isinstance(parameters[0], (dict, list, tuple)):
+        parameters = parameters[0]
+    try:
+        params = json.dumps(parameters, default=repr) if parameters else None
+    except TypeError, ValueError:
+        params = None
+    try:
+        cursor = psycopg.ClientCursor(conn.connection.driver_connection)
+        return cursor.mogrify(statement, parameters), params
+    except Exception:
+        # Not worth losing the whole entry over; the fingerprint plus the parameters is still pasteable by hand.
+        return statement, params
+
+
+def _current_span() -> _Span | None:
+    return getattr(_local, "span", None)
+
+
+def _after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+    test = _current_test
+    if test is None:
+        return
+    fingerprint = _fingerprint(statement)
+    with _lock:
+        shape = _shapes.get(fingerprint)
+        if shape is None or test < shape.first_seen_in:
+            example, params = _render_example(conn, statement, parameters)
+            is_write = bool(
+                (context is not None and (context.isinsert or context.isupdate or context.isdelete))
+                or _WRITE_RE.match(statement)
+            )
+            _shapes[fingerprint] = _Shape(
+                id=_shape_id(fingerprint),
+                sql=fingerprint,
+                example=example,
+                params=params,
+                write=is_write,
+                first_seen_in=test,
+            )
+            shape = _shapes[fingerprint]
+
+        span = _current_span()
+        if span is None:
+            # A query outside any RPC or job: fixture setup, or the test body using session_scope() directly.
+            spans = _tests.setdefault(test, [])
+            if spans and spans[-1].kind == "body":
+                span = spans[-1]
+            else:
+                span = _Span(kind="body", name=None)
+                spans.append(span)
+        span.queries.append(shape.id)
+
+
+class _SpanScope:
+    """Marks the queries issued inside it as belonging to one RPC call or background job run.
+
+    The span is registered against the current test on entry, so the recorded order matches call order. It is held
+    in a thread-local because the real-server sessions run handlers on a gRPC executor thread while the test body
+    runs on the main thread; FakeChannel runs them inline, and the same thread-local covers that too.
+    """
+
+    def __init__(self, kind: str, name: str | None):
+        self._span = _Span(kind=kind, name=name)
+        self._previous: _Span | None = None
+
+    def __enter__(self) -> _SpanScope:
+        if _current_test is not None:
+            with _lock:
+                _tests.setdefault(_current_test, []).append(self._span)
+        self._previous = _current_span()
+        _local.span = self._span
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        _local.span = self._previous
+
+
+def span(kind: str, name: str | None) -> Any:
+    """Open a recording span. A no-op unless --query-log is active, so callers need no guard of their own."""
+    if not _enabled:
+        return _NULL_SPAN
+    return _SpanScope(kind, name)
+
+
+class _NullSpan:
+    def __enter__(self) -> _NullSpan:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        pass
+
+
+_NULL_SPAN = _NullSpan()
+
+
+def enable(engine: Engine) -> None:
+    global _enabled
+    _enabled = True
+    event.listen(engine, "after_cursor_execute", _after_cursor_execute)
+
+
+def set_current_test(test_id: str | None) -> None:
+    global _current_test
+    _current_test = test_id
+    _local.span = None
+
+
+def dump(directory: Path) -> Path:
+    """Write this node's recording. The node suffix keeps the parallel CI jobs from overwriting each other."""
+    node = os.environ.get("CI_NODE_INDEX", "local")
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"data.{node}.json"
+    with _lock:
+        data = {
+            "shapes": {
+                shape.id: {
+                    "sql": shape.sql,
+                    "example": shape.example,
+                    "params": shape.params,
+                    "write": shape.write,
+                    # The merge step uses this to pick the same `example` the single-node run would have picked.
+                    "first_seen_in": shape.first_seen_in,
+                }
+                for shape in _shapes.values()
+            },
+            "tests": {
+                test: [{"kind": s.kind, "name": s.name, "queries": s.queries} for s in spans]
+                for test, spans in sorted(_tests.items())
+            },
+        }
+    path.write_text(json.dumps(data, indent=1, sort_keys=True))
+    return path

--- a/app/backend/src/tests/fixtures/query_log.py
+++ b/app/backend/src/tests/fixtures/query_log.py
@@ -45,7 +45,9 @@ _MAX_SQL_CHARS = 4096
 _TRUNCATION_MARKER = " /* truncated by the query log */"
 
 # test_db rebuilds the schema from migrations to diff it against the models. That is schema plumbing rather than an
-# access pattern, it is already covered by the schema-diff artifact, and in CI it loads the real timezone_areas.sql.
+# access pattern, and it is already covered by the schema-diff artifact. Note this is not what keeps the real
+# timezone_areas.sql out of the recording: test_migrations is skipped in test:backend anyway, because the backend
+# image has no pg_dump. What bounds the artifact is _MAX_SQL_CHARS.
 _EXCLUDED_MODULES = ("src/tests/test_db.py",)
 
 # How many of our own frames to keep for a query's call site. The innermost is the line that issued it; the next

--- a/app/backend/src/tests/fixtures/query_log.py
+++ b/app/backend/src/tests/fixtures/query_log.py
@@ -12,9 +12,11 @@ import hashlib
 import json
 import os
 import re
+import sys
 import threading
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import CodeType, FrameType
 from typing import Any
 
 import psycopg
@@ -45,6 +47,13 @@ _TRUNCATION_MARKER = " /* truncated by the query log */"
 # access pattern, it is already covered by the schema-diff artifact, and in CI it loads the real timezone_areas.sql.
 _EXCLUDED_MODULES = ("src/tests/test_db.py",)
 
+# How many of our own frames to keep for a query's call site. The innermost is the line that issued it; the next
+# couple show the chain that got there, which is usually what tells you whether a repeat is a loop.
+_CALLSITE_FRAMES = 3
+# Frames from these are plumbing between our code and the driver, so they never make a useful call site. The
+# recorder's own path is spelled out: a bare "query_log.py" would also swallow test_query_log.py.
+_CALLSITE_SKIP = ("/sqlalchemy/", "/psycopg", "/alembic/", "/fixtures/query_log.py")
+
 
 @dataclass(slots=True)
 class _Shape:
@@ -62,6 +71,9 @@ class _Span:
     kind: str
     name: str | None
     queries: list[str] = field(default_factory=list)
+    # Parallel to queries: the call site each execution came from. Kept as a separate array so the diff, which reads
+    # only `queries`, cannot be perturbed by line numbers shifting under an unrelated edit.
+    sites: list[str] = field(default_factory=list)
 
 
 _lock = threading.Lock()
@@ -71,6 +83,15 @@ _enabled = False
 _current_test: str | None = None
 _shapes: dict[str, _Shape] = {}
 _tests: dict[str, list[_Span]] = {}
+_sites: dict[str, str] = {}
+_site_ids: dict[str, str] = {}
+_frame_cache: dict[str, int] = {}
+
+# Everything under the backend's src/ is ours; paths are reported relative to it. couchers/ is application code,
+# anything else under src/ is test scaffolding.
+_SRC_ROOT = "/src/"
+_APP_ROOT = "/src/couchers/"
+_SKIP, _APP, _TEST = 0, 1, 2
 
 
 def _truncate(sql: str) -> str:
@@ -118,6 +139,54 @@ def _render_example(conn: Any, statement: str, parameters: Any) -> tuple[str, st
         return _truncate(statement), params
 
 
+def _frame_kind(code: CodeType) -> int:
+    """_APP, _TEST or _SKIP. Cached by filename, which is all the answer depends on: this runs on every frame of
+    every execution, and the string work is what would otherwise make stack walking too expensive to leave on.
+
+    Keyed by filename rather than by the code object, because code objects compare equal without regard to
+    co_filename, so two same-bodied functions in different files would share an entry.
+    """
+    filename = code.co_filename
+    known = _frame_cache.get(filename)
+    if known is None:
+        if any(part in filename for part in _CALLSITE_SKIP) or _SRC_ROOT not in filename:
+            known = _SKIP
+        else:
+            known = _APP if _APP_ROOT in filename else _TEST
+        _frame_cache[filename] = known
+    return known
+
+
+def _callsite() -> str:
+    """The innermost few application frames, innermost first, as "path:line in func".
+
+    Only couchers/ frames: the test and the fixture handler that got here are already implied by the test and span
+    this is recorded under, and including them multiplies the number of distinct call sites for no added meaning.
+    Test frames are used only when a query has no application frame at all, as fixture setup often does not.
+    """
+    frames: list[str] = []
+    fallback = ""
+    frame: FrameType | None = sys._getframe(1)
+    while frame is not None and len(frames) < _CALLSITE_FRAMES:
+        code = frame.f_code
+        kind = _frame_kind(code)
+        if kind != _SKIP:
+            path = code.co_filename.split(_SRC_ROOT, 1)[-1]
+            rendered_frame = f"{path}:{frame.f_lineno} in {code.co_name}"
+            if kind == _APP:
+                frames.append(rendered_frame)
+            elif not fallback:
+                fallback = rendered_frame
+        frame = frame.f_back
+    rendered = " <- ".join(frames) or fallback
+    site_id = _site_ids.get(rendered)
+    if site_id is None:
+        site_id = _shape_id(rendered)
+        _site_ids[rendered] = site_id
+        _sites[site_id] = rendered
+    return site_id
+
+
 def _current_span() -> _Span | None:
     return getattr(_local, "span", None)
 
@@ -155,6 +224,7 @@ def _after_cursor_execute(conn, cursor, statement, parameters, context, executem
                 span = _Span(kind="body", name=None)
                 spans.append(span)
         span.queries.append(shape.id)
+        span.sites.append(_callsite())
 
 
 class _SpanScope:
@@ -229,8 +299,9 @@ def dump(directory: Path) -> Path:
                 }
                 for shape in _shapes.values()
             },
+            "sites": dict(sorted(_sites.items())),
             "tests": {
-                test: [{"kind": s.kind, "name": s.name, "queries": s.queries} for s in spans]
+                test: [{"kind": s.kind, "name": s.name, "queries": s.queries, "sites": s.sites} for s in spans]
                 for test, spans in sorted(_tests.items())
             },
         }

--- a/app/backend/src/tests/fixtures/query_log.py
+++ b/app/backend/src/tests/fixtures/query_log.py
@@ -27,8 +27,23 @@ _PARAM_RE = re.compile(r"%\([^)]*\)s|%s")
 _COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
 # Expanded IN (...) lists, whose length varies with the test data.
 _PARAM_LIST_RE = re.compile(r"\?(?:\s*,\s*\?)+")
+# Repeated VALUES tuples from a multi-row insert, whose count varies with the test data.
+_VALUES_LIST_RE = re.compile(r"\(\?\)(?:\s*,\s*\(\?\))+")
+# Literals inlined into the statement text rather than bound. Bulk resource loads do this: the real
+# timezone_areas.sql applied by the migrations is a few hundred INSERTs each carrying megabytes of WKB hex, so
+# without collapsing them every row becomes its own multi-megabyte shape.
+_LONG_LITERAL_RE = re.compile(r"'[^']{64,}'")
 _WHITESPACE_RE = re.compile(r"\s+")
 _WRITE_RE = re.compile(r"^\s*(INSERT|UPDATE|DELETE)\b", re.IGNORECASE)
+
+# Hard cap on what is stored per statement. Nothing this long is an access pattern worth diffing, and the cap is
+# what bounds the artifact: uncapped, the timezone_areas load alone took a CI node's dump to 495 MB.
+_MAX_SQL_CHARS = 4096
+_TRUNCATION_MARKER = " /* truncated by the query log */"
+
+# test_db rebuilds the schema from migrations to diff it against the models. That is schema plumbing rather than an
+# access pattern, it is already covered by the schema-diff artifact, and in CI it loads the real timezone_areas.sql.
+_EXCLUDED_MODULES = ("src/tests/test_db.py",)
 
 
 @dataclass(slots=True)
@@ -58,11 +73,17 @@ _shapes: dict[str, _Shape] = {}
 _tests: dict[str, list[_Span]] = {}
 
 
+def _truncate(sql: str) -> str:
+    return sql if len(sql) <= _MAX_SQL_CHARS else sql[:_MAX_SQL_CHARS] + _TRUNCATION_MARKER
+
+
 def _fingerprint(statement: str) -> str:
     sql = _COMMENT_RE.sub("", statement)
     sql = _PARAM_RE.sub("?", sql)
     sql = _PARAM_LIST_RE.sub("?", sql)
-    return _WHITESPACE_RE.sub(" ", sql).strip()
+    sql = _VALUES_LIST_RE.sub("(?)", sql)
+    sql = _LONG_LITERAL_RE.sub("'...'", sql)
+    return _truncate(_WHITESPACE_RE.sub(" ", sql).strip())
 
 
 def _shape_id(fingerprint: str) -> str:
@@ -85,12 +106,16 @@ def _render_example(conn: Any, statement: str, parameters: Any) -> tuple[str, st
         params = json.dumps(parameters, default=repr) if parameters else None
     except TypeError, ValueError:
         params = None
+    if params is not None:
+        params = _truncate(params)
     try:
         cursor = psycopg.ClientCursor(conn.connection.driver_connection)
-        return cursor.mogrify(statement, parameters), params
+        # Truncated past the cap, so the marker is a SQL comment: the result is visibly not runnable rather than
+        # silently invalid.
+        return _truncate(cursor.mogrify(statement, parameters)), params
     except Exception:
         # Not worth losing the whole entry over; the fingerprint plus the parameters is still pasteable by hand.
-        return statement, params
+        return _truncate(statement), params
 
 
 def _current_span() -> _Span | None:
@@ -99,7 +124,7 @@ def _current_span() -> _Span | None:
 
 def _after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
     test = _current_test
-    if test is None:
+    if test is None or test.startswith(_EXCLUDED_MODULES):
         return
     fingerprint = _fingerprint(statement)
     with _lock:
@@ -209,5 +234,5 @@ def dump(directory: Path) -> Path:
                 for test, spans in sorted(_tests.items())
             },
         }
-    path.write_text(json.dumps(data, indent=1, sort_keys=True))
+    path.write_text(json.dumps(data, separators=(",", ":"), sort_keys=True))
     return path

--- a/app/backend/src/tests/fixtures/query_log.py
+++ b/app/backend/src/tests/fixtures/query_log.py
@@ -23,39 +23,10 @@ from typing import Any
 import psycopg
 from sqlalchemy import Engine, event
 
-# Bind parameters as psycopg's pyformat paramstyle renders them, plus positional %s for good measure.
-_PARAM_RE = re.compile(r"%\([^)]*\)s|%s")
-# Trailing sqlcommenter-style comments. Nothing emits these in tests today (tracing is only set up in prod), but a
-# future change that turns the commenter on would otherwise invalidate every fingerprint at once.
-_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
-# Expanded IN (...) lists, whose length varies with the test data.
-_PARAM_LIST_RE = re.compile(r"\?(?:\s*,\s*\?)+")
-# Repeated VALUES tuples from a multi-row insert, whose count varies with the test data.
-_VALUES_LIST_RE = re.compile(r"\(\?\)(?:\s*,\s*\(\?\))+")
-# Literals inlined into the statement text rather than bound. Bulk resource loads do this: the real
-# timezone_areas.sql applied by the migrations is a few hundred INSERTs each carrying megabytes of WKB hex, so
-# without collapsing them every row becomes its own multi-megabyte shape.
-_LONG_LITERAL_RE = re.compile(r"'[^']{64,}'")
-_WHITESPACE_RE = re.compile(r"\s+")
-_WRITE_RE = re.compile(r"^\s*(INSERT|UPDATE|DELETE)\b", re.IGNORECASE)
-
 # Hard cap on what is stored per statement. Nothing this long is an access pattern worth diffing, and the cap is
 # what bounds the artifact: uncapped, the timezone_areas load alone took a CI node's dump to 495 MB.
 _MAX_SQL_CHARS = 4096
 _TRUNCATION_MARKER = " /* truncated by the query log */"
-
-# test_db rebuilds the schema from migrations to diff it against the models. That is schema plumbing rather than an
-# access pattern, and it is already covered by the schema-diff artifact. Note this is not what keeps the real
-# timezone_areas.sql out of the recording: test_migrations is skipped in test:backend anyway, because the backend
-# image has no pg_dump. What bounds the artifact is _MAX_SQL_CHARS.
-_EXCLUDED_MODULES = ("src/tests/test_db.py",)
-
-# How many of our own frames to keep for a query's call site. The innermost is the line that issued it; the next
-# couple show the chain that got there, which is usually what tells you whether a repeat is a loop.
-_CALLSITE_FRAMES = 3
-# Frames from these are plumbing between our code and the driver, so they never make a useful call site. The
-# recorder's own path is spelled out: a bare "query_log.py" would also swallow test_query_log.py.
-_CALLSITE_SKIP = ("/sqlalchemy/", "/psycopg", "/alembic/", "/fixtures/query_log.py")
 
 
 @dataclass(slots=True)
@@ -90,24 +61,31 @@ _sites: dict[str, str] = {}
 _site_ids: dict[str, str] = {}
 _frame_cache: dict[str, int] = {}
 
-# Everything under the backend's src/ is ours; paths are reported relative to it. couchers/ is application code,
-# anything else under src/ is test scaffolding.
-_SRC_ROOT = "/src/"
-_APP_ROOT = "/src/couchers/"
-_SKIP, _APP, _TEST = 0, 1, 2
-
 
 def _truncate(sql: str) -> str:
     return sql if len(sql) <= _MAX_SQL_CHARS else sql[:_MAX_SQL_CHARS] + _TRUNCATION_MARKER
 
 
 def _fingerprint(statement: str) -> str:
-    sql = _COMMENT_RE.sub("", statement)
-    sql = _PARAM_RE.sub("?", sql)
-    sql = _PARAM_LIST_RE.sub("?", sql)
-    sql = _VALUES_LIST_RE.sub("(?)", sql)
-    sql = _LONG_LITERAL_RE.sub("'...'", sql)
-    return _truncate(_WHITESPACE_RE.sub(" ", sql).strip())
+    """The statement with everything that varies with the test data taken out, which is the key we group and diff on.
+
+    Anything left in here that moves between two identical runs turns the whole report into noise, so each step
+    below is pinned by a test in test_query_log.py.
+    """
+    # sqlcommenter-style comments. Nothing emits these in tests today (tracing is only set up in prod), but a future
+    # change that turns the commenter on would otherwise invalidate every fingerprint at once.
+    sql = re.sub(r"/\*.*?\*/", "", statement, flags=re.DOTALL)
+    # Bind parameters, as psycopg's pyformat paramstyle renders them, plus positional %s for good measure.
+    sql = re.sub(r"%\([^)]*\)s|%s", "?", sql)
+    # An expanded IN (...) list, whose length tracks the test data.
+    sql = re.sub(r"\?(?:\s*,\s*\?)+", "?", sql)
+    # Repeated VALUES tuples from a multi-row insert, whose count tracks the batch size.
+    sql = re.sub(r"\(\?\)(?:\s*,\s*\(\?\))+", "(?)", sql)
+    # Literals inlined into the statement text rather than bound. Bulk resource loads do this: the real
+    # timezone_areas.sql is a few hundred INSERTs each carrying megabytes of WKB hex, so without collapsing them
+    # every row becomes its own multi-megabyte shape.
+    sql = re.sub(r"'[^']{64,}'", "'...'", sql)
+    return _truncate(re.sub(r"\s+", " ", sql).strip())
 
 
 def _shape_id(fingerprint: str) -> str:
@@ -142,6 +120,16 @@ def _render_example(conn: Any, statement: str, parameters: Any) -> tuple[str, st
         return _truncate(statement), params
 
 
+# Everything under the backend's src/ is ours; paths are reported relative to it. couchers/ is application code,
+# anything else under src/ is test scaffolding.
+_SRC_ROOT = "/src/"
+_APP_ROOT = "/src/couchers/"
+_SKIP, _APP, _TEST = 0, 1, 2
+# Frames from these are plumbing between our code and the driver, so they never make a useful call site. The
+# recorder's own path is spelled out: a bare "query_log.py" would also swallow test_query_log.py.
+_CALLSITE_SKIP = ("/sqlalchemy/", "/psycopg", "/alembic/", "/fixtures/query_log.py")
+
+
 def _frame_kind(code: CodeType) -> int:
     """_APP, _TEST or _SKIP. Cached by filename, which is all the answer depends on: this runs on every frame of
     every execution, and the string work is what would otherwise make stack walking too expensive to leave on.
@@ -158,6 +146,11 @@ def _frame_kind(code: CodeType) -> int:
             known = _APP if _APP_ROOT in filename else _TEST
         _frame_cache[filename] = known
     return known
+
+
+# How many of our own frames to keep. The innermost is the line that issued the query; the next couple show the
+# chain that got there, which is usually what tells you whether a repeat is a loop.
+_CALLSITE_FRAMES = 3
 
 
 def _callsite() -> str:
@@ -194,6 +187,13 @@ def _current_span() -> _Span | None:
     return getattr(_local, "span", None)
 
 
+# test_db rebuilds the schema from migrations to diff it against the models. That is schema plumbing rather than an
+# access pattern, and it is already covered by the schema-diff artifact. Note this is not what keeps the real
+# timezone_areas.sql out of the recording: test_migrations is skipped in test:backend anyway, because the backend
+# image has no pg_dump. What bounds the artifact is _MAX_SQL_CHARS.
+_EXCLUDED_MODULES = ("src/tests/test_db.py",)
+
+
 def _after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
     test = _current_test
     if test is None or test.startswith(_EXCLUDED_MODULES):
@@ -203,9 +203,10 @@ def _after_cursor_execute(conn, cursor, statement, parameters, context, executem
         shape = _shapes.get(fingerprint)
         if shape is None or test < shape.first_seen_in:
             example, params = _render_example(conn, statement, parameters)
+            # The context knows for ORM-issued statements; fall back to reading the statement for the rest.
             is_write = bool(
                 (context is not None and (context.isinsert or context.isupdate or context.isdelete))
-                or _WRITE_RE.match(statement)
+                or re.match(r"^\s*(INSERT|UPDATE|DELETE)\b", statement, re.IGNORECASE)
             )
             _shapes[fingerprint] = _Shape(
                 id=_shape_id(fingerprint),

--- a/app/backend/src/tests/fixtures/query_log.py
+++ b/app/backend/src/tests/fixtures/query_log.py
@@ -8,6 +8,7 @@ grouping and diffing) and one concrete rendering with the values inlined by psyc
 straight into a psql prompt.
 """
 
+import gzip
 import hashlib
 import json
 import os
@@ -282,10 +283,14 @@ def set_current_test(test_id: str | None) -> None:
 
 
 def dump(directory: Path) -> Path:
-    """Write this node's recording. The node suffix keeps the parallel CI jobs from overwriting each other."""
+    """Write this node's recording. The node suffix keeps the parallel CI jobs from overwriting each other.
+
+    Gzipped: it is mostly repeated SQL and compresses about fifteen-fold, and this file is carried between CI jobs as
+    an artifact. Read it with `gunzip -c`, or let query_log_report.py merge it.
+    """
     node = os.environ.get("CI_NODE_INDEX", "local")
     directory.mkdir(parents=True, exist_ok=True)
-    path = directory / f"data.{node}.json"
+    path = directory / f"data.{node}.json.gz"
     with _lock:
         data = {
             "shapes": {
@@ -305,5 +310,6 @@ def dump(directory: Path) -> Path:
                 for test, spans in sorted(_tests.items())
             },
         }
-    path.write_text(json.dumps(data, separators=(",", ":"), sort_keys=True))
+    # mtime=0 keeps the bytes reproducible, so two identical runs produce byte-identical dumps.
+    path.write_bytes(gzip.compress(json.dumps(data, separators=(",", ":"), sort_keys=True).encode(), mtime=0))
     return path

--- a/app/backend/src/tests/fixtures/sessions.py
+++ b/app/backend/src/tests/fixtures/sessions.py
@@ -80,6 +80,7 @@ from couchers.servicers.requests import Requests
 from couchers.servicers.resources import Resources
 from couchers.servicers.search import Search
 from couchers.servicers.threads import Threads
+from tests.fixtures import query_log
 
 
 class _MockCouchersContext:
@@ -112,6 +113,35 @@ class MetadataKeeperInterceptor(grpc.UnaryUnaryClientInterceptor):
         self.latest_headers = dict(call.initial_metadata())
         self.latest_header_raw = call.initial_metadata()
         return call
+
+
+class QuerySpanInterceptor(grpc.ServerInterceptor):
+    """Attributes the queries a handler issues to the RPC being served.
+
+    Wraps only the returned handler, not the continuation, so the downstream middleware's auth lookups stay out of
+    the span. The wrapper runs on the thread that services the call, which is what query_log's thread-local needs.
+    """
+
+    def intercept_service(self, continuation, handler_call_details):
+        method = handler_call_details.method
+        # The downstream middleware authenticates inside its own intercept_service, so this span covers the auth
+        # lookups. They're a real per-call cost and worth seeing, just not conflated with the handler's own work.
+        with query_log.span("auth", method):
+            handler = continuation(handler_call_details)
+        if handler is None or handler.unary_unary is None:
+            return handler
+
+        inner = handler.unary_unary
+
+        def wrapper(request, context):
+            with query_log.span("rpc", method):
+                return inner(request, context)
+
+        return grpc.unary_unary_rpc_method_handler(
+            wrapper,
+            request_deserializer=handler.request_deserializer,
+            response_serializer=handler.response_serializer,
+        )
 
 
 class FakeRpcError(grpc.RpcError):
@@ -167,14 +197,15 @@ class FakeChannel:
         handler = self.handlers[method]
 
         def fake_handler(request):
-            auth_info = _try_get_and_update_user_details(
-                self._token,
-                is_api_key=False,
-                ip_address="127.0.0.1",
-                user_agent="Testing User-Agent",
-                sofa=None,
-                client_platform=None,
-            )
+            with query_log.span("auth", method):
+                auth_info = _try_get_and_update_user_details(
+                    self._token,
+                    is_api_key=False,
+                    ip_address="127.0.0.1",
+                    user_agent="Testing User-Agent",
+                    sofa=None,
+                    client_platform=None,
+                )
             auth_level = find_auth_level(self._pool, method)
             check_permissions(auth_info, auth_level)
 
@@ -182,7 +213,9 @@ class FakeChannel:
             # response to catch accidental use of unserializable data.
             request = handler.request_deserializer(request_serializer(request))
 
-            with session_scope() as session:
+            # Span covers the handler and its session but not the auth lookup above, matching the boundary
+            # couchers.perf uses in prod and the real-server sessions below.
+            with query_log.span("rpc", method), session_scope() as session:
                 context = make_interactive_context(
                     grpc_context=MockGrpcContext(),
                     user_id=auth_info.user_id if auth_info else None,
@@ -211,7 +244,7 @@ def run_server(grpc_channel_options=(), token: str | None = None):
         else:
             creds = grpc.local_channel_credentials()
 
-        srv = grpc.server(executor, interceptors=[CouchersMiddlewareInterceptor()])
+        srv = grpc.server(executor, interceptors=[QuerySpanInterceptor(), CouchersMiddlewareInterceptor()])
         port = srv.add_secure_port("localhost:0", grpc.local_server_credentials())
         srv.start()
 

--- a/app/backend/src/tests/test_query_log.py
+++ b/app/backend/src/tests/test_query_log.py
@@ -67,6 +67,34 @@ def test_shape_id_is_content_addressed():
     assert query_log._shape_id(sql) != query_log._shape_id("SELECT 2 FROM users WHERE id = ?")
 
 
+def test_callsite_falls_back_to_test_frames():
+    """Fixture setup often issues queries with no application frame on the stack, and should still be attributed."""
+    site_id = query_log._callsite()
+    assert query_log._sites[site_id].startswith("tests/test_query_log.py:")
+    assert "test_callsite_falls_back_to_test_frames" in query_log._sites[site_id]
+
+
+def test_callsite_ids_are_stable_and_content_addressed():
+    """Node dumps are merged by site id, so the same chain must produce the same id everywhere."""
+    first = query_log._callsite()
+    second = query_log._callsite()
+    # Different lines, so different sites, but each id is the hash of its own rendering.
+    assert first != second
+    assert first == query_log._shape_id(query_log._sites[first])
+
+
+def test_frame_kind_separates_application_from_test_and_plumbing():
+    assert query_log._frame_kind(_dummy_code("/app/backend/src/couchers/servicers/api.py")) == query_log._APP
+    assert query_log._frame_kind(_dummy_code("/app/backend/src/tests/fixtures/db.py")) == query_log._TEST
+    assert query_log._frame_kind(_dummy_code("/venv/lib/sqlalchemy/orm/session.py")) == query_log._SKIP
+    assert query_log._frame_kind(_dummy_code("/app/backend/src/tests/fixtures/query_log.py")) == query_log._SKIP
+
+
+def _dummy_code(filename: str):
+    """A code object with a chosen co_filename, to exercise the frame classifier without building real frames."""
+    return compile("pass", filename, "exec")
+
+
 def test_span_is_inert_when_recording_is_off(monkeypatch):
     """Ordinary runs go through the same span() calls, so being disabled must record nothing and raise nothing.
 

--- a/app/backend/src/tests/test_query_log.py
+++ b/app/backend/src/tests/test_query_log.py
@@ -26,6 +26,34 @@ def test_fingerprint_normalises_whitespace_and_strips_comments():
     assert query_log._fingerprint(sql) == "SELECT 1 FROM users WHERE id = ?"
 
 
+def test_fingerprint_collapses_repeated_values_tuples():
+    """A multi-row insert's tuple count tracks the batch size, which varies with the test data."""
+    two = query_log._fingerprint("INSERT INTO users (a, b) VALUES (%(a)s, %(b)s), (%(a_1)s, %(b_1)s)")
+    four = query_log._fingerprint(
+        "INSERT INTO users (a, b) VALUES (%(a)s, %(b)s), (%(a_1)s, %(b_1)s), (%(a_2)s, %(b_2)s), (%(a_3)s, %(b_3)s)"
+    )
+    assert two == four == "INSERT INTO users (a, b) VALUES (?)"
+
+
+def test_fingerprint_collapses_bulk_inlined_literals():
+    """The real timezone_areas.sql inlines WKB hex as literals, so each row would otherwise be its own shape."""
+    a = query_log._fingerprint(
+        "INSERT INTO timezone_areas (tzid, geom) VALUES ('Etc/UTC', '0106000020E6" + "A" * 300 + "')"
+    )
+    b = query_log._fingerprint(
+        "INSERT INTO timezone_areas (tzid, geom) VALUES ('Etc/UTC', '0106000020E6" + "B" * 900 + "')"
+    )
+    assert a == b
+    assert len(a) < 100
+
+
+def test_fingerprint_is_capped():
+    """The cap is what bounds the artifact: uncapped, the timezone_areas load took one CI node's dump to 495 MB."""
+    huge = query_log._fingerprint("SELECT " + "x" * 100_000)
+    assert len(huge) == query_log._MAX_SQL_CHARS + len(query_log._TRUNCATION_MARKER)
+    assert huge.endswith(query_log._TRUNCATION_MARKER)
+
+
 def test_fingerprint_keeps_distinct_queries_distinct():
     a = query_log._fingerprint("SELECT users.id FROM users WHERE users.id = %(id_1)s")
     b = query_log._fingerprint("SELECT users.id FROM users WHERE users.username = %(username_1)s")

--- a/app/backend/src/tests/test_query_log.py
+++ b/app/backend/src/tests/test_query_log.py
@@ -1,0 +1,51 @@
+"""Tests for the SQL query recorder.
+
+The fingerprint is the key the CI report groups and diffs on, so anything that makes it vary between runs turns the
+whole report into noise. These pin the normalisations it relies on.
+"""
+
+from tests.fixtures import query_log
+
+
+def test_fingerprint_replaces_bound_parameters():
+    sql = "SELECT users.id FROM users WHERE users.id = %(id_1)s AND users.username = %(username_1)s"
+    assert query_log._fingerprint(sql) == "SELECT users.id FROM users WHERE users.id = ? AND users.username = ?"
+
+
+def test_fingerprint_collapses_expanded_in_lists():
+    """An IN list's length tracks the test data, so two runs must not produce different shapes for one query."""
+    two = query_log._fingerprint("SELECT 1 FROM users WHERE users.id IN (%(id_1)s, %(id_2)s)")
+    five = query_log._fingerprint(
+        "SELECT 1 FROM users WHERE users.id IN (%(id_1)s, %(id_2)s, %(id_3)s, %(id_4)s, %(id_5)s)"
+    )
+    assert two == five == "SELECT 1 FROM users WHERE users.id IN (?)"
+
+
+def test_fingerprint_normalises_whitespace_and_strips_comments():
+    sql = "SELECT 1\n  FROM users\n WHERE id = %(id_1)s /* traceparent='00-abc' */"
+    assert query_log._fingerprint(sql) == "SELECT 1 FROM users WHERE id = ?"
+
+
+def test_fingerprint_keeps_distinct_queries_distinct():
+    a = query_log._fingerprint("SELECT users.id FROM users WHERE users.id = %(id_1)s")
+    b = query_log._fingerprint("SELECT users.id FROM users WHERE users.username = %(username_1)s")
+    assert a != b
+
+
+def test_shape_id_is_content_addressed():
+    """Ids must depend only on the fingerprint: the pytest-split nodes assign them independently."""
+    sql = "SELECT 1 FROM users WHERE id = ?"
+    assert query_log._shape_id(sql) == query_log._shape_id(sql)
+    assert query_log._shape_id(sql) != query_log._shape_id("SELECT 2 FROM users WHERE id = ?")
+
+
+def test_span_is_inert_when_recording_is_off(monkeypatch):
+    """Ordinary runs go through the same span() calls, so being disabled must record nothing and raise nothing.
+
+    Forced off rather than asserted off, so this holds whether or not the suite itself was given --query-log.
+    """
+    monkeypatch.setattr(query_log, "_enabled", False)
+    before = {test: list(spans) for test, spans in query_log._tests.items()}
+    with query_log.span("rpc", "/org.couchers.api.core.API/GetUser"):
+        pass
+    assert query_log._tests == before

--- a/app/scripts/pr_preview_comment.py
+++ b/app/scripts/pr_preview_comment.py
@@ -35,7 +35,7 @@ USER_AGENT = "couchers-preview-bot"
 LAYOUT = [
     ("Mobile", "rich", ["mobile"]),
     ("Web (Vercel)", "rich", ["web"]),
-    ("Backend", "table", ["schema", "schema-diff", "emails"]),
+    ("Backend", "table", ["schema", "schema-diff", "emails", "queries"]),
     ("Other", "table", ["protos", "bcov", "wcov"]),
 ]
 ITEM_KEYS = [key for _, _, keys in LAYOUT for key in keys]
@@ -204,6 +204,19 @@ def item_mobile(_sha):
     return mobile_block(short_sha, domain, platforms)
 
 
+def item_queries(_sha):
+    """Links the SQL query log report, with its headline delta inline so the common case needs no click."""
+    url = preview_url("test-artifacts", "queries/index.html")
+    try:
+        with open("artifacts/test_artifacts/queries/summary.txt") as f:
+            summary = f.read().strip()
+    except OSError:
+        summary = ""
+    cell = link("SQL query log", url)
+    # Cells are joined into one markdown table row, so the summary must not contain a pipe.
+    return f"{cell}<br>{summary.replace('|', '/')}" if summary else cell
+
+
 def item_web(sha):
     try:
         url = resolve_web_preview_url(env("CI_COMMIT_BRANCH"), sha)
@@ -220,6 +233,7 @@ ITEM_BUILDERS = {
     "schema": lambda _sha: link("Schema", preview_url("schema", "schema.sql")),
     "schema-diff": lambda _sha: link("Schema diff", preview_url("schema", "diff.html")),
     "emails": lambda _sha: link("Sample emails", preview_url("test-artifacts", "emails/index.html")),
+    "queries": item_queries,
     "protos": lambda _sha: link("Protos", preview_url("protos")),
     "bcov": lambda _sha: link("Backend coverage", preview_url("bcov")),
     "wcov": lambda _sha: link("Web coverage", preview_url("wcov")),

--- a/app/scripts/query_log_report.py
+++ b/app/scripts/query_log_report.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Merges the per-node SQL query logs from the backend test run, diffs them against develop's and renders a report.
+
+The recorder is src/tests/fixtures/query_log.py, which writes one data.<node>.json per pytest-split node. This script
+unions those, compares against the baseline published by the last develop pipeline, and writes:
+
+  data.json    the merged log, which becomes the next baseline
+  index.html   a self-contained browsable report, by test and by RPC, defaulting to what changed
+
+Usage:
+  query_log_report.py --input DIR --output DIR [--baseline data.json] [--summary-file FILE]
+
+Diffing canonicalises each span to a multiset of query shapes. Ordering within a span is not stable: background jobs
+are drained with ORDER BY priority DESC, next_attempt_after ASC, and jobs queued in one transaction tie on both, so
+Postgres picks freely. The report still displays the real recorded order.
+"""
+
+import argparse
+import collections
+import difflib
+import html
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+Span = dict[str, Any]
+
+
+def merge_nodes(input_dir: Path) -> dict[str, Any]:
+    shapes: dict[str, dict[str, Any]] = {}
+    tests: dict[str, list[Span]] = {}
+    files = sorted(input_dir.glob("data.*.json"))
+    if not files:
+        raise SystemExit(f"no data.*.json found in {input_dir}")
+    for path in files:
+        data = json.loads(path.read_text())
+        for shape_id, shape in data["shapes"].items():
+            existing = shapes.get(shape_id)
+            # Shape ids are content hashes so nodes agree on them; pick the same `example` a single-node run
+            # would have, i.e. the one from the lexicographically first test that produced it.
+            if existing is None or shape["first_seen_in"] < existing["first_seen_in"]:
+                shapes[shape_id] = shape
+        # pytest-split gives each test to exactly one node, so this cannot collide.
+        tests.update(data["tests"])
+    print(f"merged {len(files)} node files: {len(tests)} tests, {len(shapes)} distinct query shapes")
+    return {"shapes": shapes, "tests": dict(sorted(tests.items()))}
+
+
+def canonical(span: Span) -> tuple[Any, ...]:
+    counts = tuple(sorted(collections.Counter(span["queries"]).items()))
+    return (span["kind"], span["name"], counts)
+
+
+def diff(current: dict[str, Any], baseline: dict[str, Any] | None) -> dict[str, Any]:
+    if baseline is None:
+        return {"has_baseline": False, "tests": {}, "added_shapes": [], "removed_shapes": [], "rpcs": {}}
+
+    cur_shape_ids, base_shape_ids = set(current["shapes"]), set(baseline["shapes"])
+    added_shapes = sorted(cur_shape_ids - base_shape_ids)
+    removed_shapes = [
+        {"id": sid, "sql": baseline["shapes"][sid]["sql"]} for sid in sorted(base_shape_ids - cur_shape_ids)
+    ]
+
+    per_test: dict[str, Any] = {}
+    for test, spans in current["tests"].items():
+        base_spans = baseline["tests"].get(test)
+        if base_spans is None:
+            per_test[test] = {"status": "added", "spans": [{"status": "new"} for _ in spans], "removed": []}
+            continue
+        cur_keys = [canonical(s) for s in spans]
+        base_keys = [canonical(s) for s in base_spans]
+        if cur_keys == base_keys:
+            continue
+
+        annotations: list[dict[str, Any]] = [{"status": "same"} for _ in spans]
+        removed: list[dict[str, Any]] = []
+        matcher = difflib.SequenceMatcher(a=base_keys, b=cur_keys, autojunk=False)
+        for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+            if tag == "equal":
+                continue
+            if tag in ("insert", "replace"):
+                for offset, j in enumerate(range(j1, j2)):
+                    # Within a replace block, pair positionally so the before-counts line up where they can.
+                    before_index = i1 + offset
+                    if tag == "replace" and before_index < i2:
+                        annotations[j] = {
+                            "status": "changed",
+                            "before": len(base_spans[before_index]["queries"]),
+                            "before_counts": dict(collections.Counter(base_spans[before_index]["queries"])),
+                        }
+                    else:
+                        annotations[j] = {"status": "new"}
+            if tag in ("delete", "replace"):
+                for i in range(i1 + (j2 - j1) if tag == "replace" else i1, i2):
+                    if i < len(base_spans):
+                        span = base_spans[i]
+                        removed.append({"kind": span["kind"], "name": span["name"], "count": len(span["queries"])})
+        per_test[test] = {"status": "changed", "spans": annotations, "removed": removed}
+
+    for test in baseline["tests"]:
+        if test not in current["tests"]:
+            per_test[test] = {"status": "removed", "spans": [], "removed": []}
+
+    return {
+        "has_baseline": True,
+        "tests": per_test,
+        "added_shapes": added_shapes,
+        "removed_shapes": removed_shapes,
+        "rpcs": rpc_rollup(current, baseline),
+    }
+
+
+def rpc_rollup(current: dict[str, Any], baseline: dict[str, Any] | None) -> dict[str, Any]:
+    """Per-RPC totals. Max queries in a single call is the useful N+1 signal; averages hide it."""
+
+    def totals(data: dict[str, Any]) -> dict[str, dict[str, int]]:
+        out: dict[str, dict[str, int]] = {}
+        for spans in data["tests"].values():
+            for span in spans:
+                if span["kind"] != "rpc":
+                    continue
+                name = (span["name"] or "").split("/")[-1]
+                entry = out.setdefault(name, {"calls": 0, "total": 0, "max": 0})
+                entry["calls"] += 1
+                entry["total"] += len(span["queries"])
+                entry["max"] = max(entry["max"], len(span["queries"]))
+        return out
+
+    cur = totals(current)
+    base = totals(baseline) if baseline else {}
+    rolled: dict[str, Any] = {}
+    for name in sorted(set(cur) | set(base)):
+        c = cur.get(name, {"calls": 0, "total": 0, "max": 0})
+        b = base.get(name, {"calls": 0, "total": 0, "max": 0})
+        if c != b:
+            rolled[name] = {"current": c, "baseline": b}
+    return rolled
+
+
+def summarise(report: dict[str, Any]) -> str:
+    if not report["has_baseline"]:
+        return "no develop baseline to compare against"
+    changed = [t for t, v in report["tests"].items() if v["status"] == "changed"]
+    added = [t for t, v in report["tests"].items() if v["status"] == "added"]
+    removed = [t for t, v in report["tests"].items() if v["status"] == "removed"]
+    parts = [f"+{len(report['added_shapes'])}/-{len(report['removed_shapes'])} query shapes"]
+    if changed:
+        parts.append(f"{len(changed)} test{'s' if len(changed) != 1 else ''} changed")
+    if added or removed:
+        parts.append(f"{len(added)} added, {len(removed)} removed")
+    worst = None
+    for name, v in report["rpcs"].items():
+        delta = v["current"]["max"] - v["baseline"]["max"]
+        if v["baseline"]["calls"] and (worst is None or delta > worst[1]):
+            worst = (name, delta, v)
+    if worst and worst[1] > 0:
+        name, _, v = worst
+        parts.append(f"worst: {name} {v['baseline']['max']}->{v['current']['max']} queries/call")
+    if not changed and not added and not removed and not report["added_shapes"]:
+        return "no change in DB access patterns"
+    return " · ".join(parts)
+
+
+PAGE_CSS = """
+:root { color-scheme: light dark; --bg:#fff; --fg:#1a1a1a; --muted:#666; --line:#e2e2e2;
+        --card:#fafafa; --add:#1a7f37; --del:#b3261e; --chg:#8a5a00; --code:#f6f8fa; }
+@media (prefers-color-scheme: dark) {
+  :root { --bg:#131313; --fg:#e8e8e8; --muted:#9a9a9a; --line:#2e2e2e;
+          --card:#1b1b1b; --add:#4ec36f; --del:#ef6f66; --chg:#d9a441; --code:#1e1e1e; }
+}
+* { box-sizing:border-box; }
+body { margin:0; padding:1.5rem; background:var(--bg); color:var(--fg);
+       font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; }
+h1 { font-size:1.3rem; margin:0 0 .25rem; }
+.sub { color:var(--muted); margin-bottom:1rem; }
+.bar { display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; margin-bottom:1rem;
+       position:sticky; top:0; background:var(--bg); padding:.5rem 0; border-bottom:1px solid var(--line); z-index:2; }
+button, input { font:inherit; color:inherit; background:var(--card);
+                border:1px solid var(--line); border-radius:6px; padding:.35rem .7rem; }
+button { cursor:pointer; }
+button.on { background:var(--fg); color:var(--bg); border-color:var(--fg); }
+input[type=search] { flex:1; min-width:12rem; }
+.summary { background:var(--card); border:1px solid var(--line); border-radius:8px;
+           padding:.75rem 1rem; margin-bottom:1rem; }
+.summary b { font-weight:600; }
+details { border:1px solid var(--line); border-radius:8px; margin-bottom:.5rem; background:var(--card); }
+details > summary { cursor:pointer; padding:.6rem .8rem; list-style:none; display:flex;
+                    gap:.5rem; align-items:center; flex-wrap:wrap; }
+details > summary::-webkit-details-marker { display:none; }
+.name { font-weight:600; }
+.tag { font-size:.75rem; padding:.1rem .45rem; border-radius:99px; border:1px solid var(--line); color:var(--muted); }
+.tag.new { color:var(--add); border-color:var(--add); }
+.tag.changed { color:var(--chg); border-color:var(--chg); }
+.tag.removed { color:var(--del); border-color:var(--del); }
+.body { padding:0 .8rem .8rem; }
+.span { border-top:1px solid var(--line); padding:.5rem 0; }
+.span-head { display:flex; gap:.5rem; align-items:center; flex-wrap:wrap; }
+.kind { font-size:.7rem; text-transform:uppercase; letter-spacing:.04em; color:var(--muted); }
+.q { margin:.35rem 0 0 0; padding:.4rem .6rem; background:var(--code);
+     border:1px solid var(--line); border-radius:6px; }
+.q-head { display:flex; gap:.5rem; align-items:center; }
+.q pre { margin:.35rem 0 0; overflow-x:auto; white-space:pre-wrap; word-break:break-word;
+         font:12px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace; max-height:22em; overflow-y:auto; }
+.rep { font-weight:600; color:var(--chg); }
+.copy { padding:.15rem .5rem; font-size:.75rem; }
+.muted { color:var(--muted); }
+table { border-collapse:collapse; width:100%; }
+th, td { text-align:left; padding:.3rem .6rem; border-bottom:1px solid var(--line); }
+th { color:var(--muted); font-weight:600; }
+.num { text-align:right; font-variant-numeric:tabular-nums; }
+.up { color:var(--del); font-weight:600; }
+.down { color:var(--add); }
+.hidden { display:none; }
+"""
+
+PAGE_JS = r"""
+const $ = s => document.querySelector(s);
+const diff = DIFF;
+let shapes = {}, tests = {}, byRpc = {};
+
+let mode = 'test', changedOnly = diff.has_baseline, showRunnable = true, filter = '';
+
+function buildIndex() {
+  // RPC -> [{test, spanIndex}]. The second index: same recording, read the other direction.
+  byRpc = {};
+  for (const [test, spans] of Object.entries(tests))
+    spans.forEach((s, i) => {
+      if (s.kind !== 'rpc') return;
+      const name = (s.name || '').split('/').pop();
+      (byRpc[name] = byRpc[name] || []).push({test, spanIndex: i});
+    });
+}
+
+const esc = s => s.replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
+const testStatus = t => (diff.tests[t] || {}).status || 'same';
+const spanAnn = (t, i) => ((diff.tests[t] || {}).spans || [])[i] || {status: 'same'};
+
+function shapeHtml(id, reps) {
+  const sh = shapes[id];
+  if (!sh) return '';
+  const sql = showRunnable ? sh.example : sh.sql;
+  const repBadge = reps > 1 ? `<span class="rep">×${reps}</span>` : '';
+  const nPlusOne = reps > 3 ? `<span class="tag changed">possible N+1</span>` : '';
+  const write = sh.write ? '<span class="tag">write</span>' : '';
+  const isNew = diff.added_shapes && diff.added_shapes.includes(id) ? '<span class="tag new">new shape</span>' : '';
+  return `<div class="q"><div class="q-head">${repBadge}${nPlusOne}${write}${isNew}
+    <button class="copy" data-sql="${esc(sql).replace(/"/g, '&quot;')}">copy</button></div>
+    <pre>${esc(sql)}</pre></div>`;
+}
+
+function spanHtml(test, span, i) {
+  const ann = spanAnn(test, i);
+  const label = span.kind === 'body' ? 'test body' : (span.name || '').split('/').pop();
+  let delta = '';
+  if (ann.status === 'changed') delta = `<span class="tag changed">${ann.before} → ${span.queries.length}</span>`;
+  if (ann.status === 'new') delta = `<span class="tag new">new</span>`;
+  // Collapse consecutive repeats so an N+1 reads as one row with a count.
+  const runs = [];
+  for (const id of span.queries) {
+    const last = runs[runs.length - 1];
+    if (last && last.id === id) last.n++; else runs.push({id, n: 1});
+  }
+  return `<div class="span"><div class="span-head"><span class="kind">${span.kind}</span>
+    <span class="name">${esc(label)}</span><span class="muted">${span.queries.length} queries</span>${delta}</div>
+    ${runs.map(r => shapeHtml(r.id, r.n)).join('')}</div>`;
+}
+
+function renderByTest() {
+  const names = Object.keys(tests).filter(t => {
+    if (changedOnly && testStatus(t) === 'same') return false;
+    return !filter || t.toLowerCase().includes(filter);
+  });
+  if (!names.length) return '<p class="muted">Nothing matches.</p>';
+  return names.map(t => {
+    const st = testStatus(t);
+    const spans = tests[t];
+    const tag = st === 'same' ? '' : `<span class="tag ${st}">${st}</span>`;
+    const rem = ((diff.tests[t] || {}).removed || []).map(r =>
+      `<div class="span"><span class="tag removed">removed</span> <span class="name">${esc((r.name || r.kind))}</span>
+       <span class="muted">${r.count} queries</span></div>`).join('');
+    const total = spans.reduce((a, s) => a + s.queries.length, 0);
+    return `<details><summary><span class="name">${esc(t)}</span>${tag}
+      <span class="muted">${spans.length} spans, ${total} queries</span></summary>
+      <div class="body">${spans.map((s, i) => spanHtml(t, s, i)).join('')}${rem}</div></details>`;
+  }).join('');
+}
+
+function renderByRpc() {
+  const names = Object.keys(byRpc).sort().filter(n => {
+    if (changedOnly && !(diff.rpcs && diff.rpcs[n])) return false;
+    return !filter || n.toLowerCase().includes(filter);
+  });
+  if (!names.length) return '<p class="muted">Nothing matches.</p>';
+  return names.map(n => {
+    const callers = byRpc[n];
+    const d = diff.rpcs && diff.rpcs[n];
+    let tag = '';
+    if (d) {
+      const cls = d.current.max > d.baseline.max ? 'up' : 'down';
+      tag = `<span class="tag changed">max/call <span class="${cls}">${d.baseline.max} → ${d.current.max}</span></span>`;
+    }
+    const worst = Math.max(...callers.map(c => tests[c.test][c.spanIndex].queries.length));
+    const inner = callers
+      .sort((a, b) => tests[b.test][b.spanIndex].queries.length - tests[a.test][a.spanIndex].queries.length)
+      .map(c => `<div class="span"><div class="span-head"><span class="kind">called from</span>
+        <span class="name">${esc(c.test)}</span>
+        <span class="muted">${tests[c.test][c.spanIndex].queries.length} queries</span>
+        ${testStatus(c.test) !== 'same' ? `<span class="tag ${testStatus(c.test)}">${testStatus(c.test)}</span>` : ''}
+        </div>${(() => {
+          const span = tests[c.test][c.spanIndex];
+          const runs = [];
+          for (const id of span.queries) {
+            const last = runs[runs.length - 1];
+            if (last && last.id === id) last.n++; else runs.push({id, n: 1});
+          }
+          return runs.map(r => shapeHtml(r.id, r.n)).join('');
+        })()}</div>`).join('');
+    return `<details><summary><span class="name">${esc(n)}</span>${tag}
+      <span class="muted">${callers.length} calls, worst ${worst} queries</span></summary>
+      <div class="body">${inner}</div></details>`;
+  }).join('');
+}
+
+function render() {
+  $('#list').innerHTML = mode === 'test' ? renderByTest() : renderByRpc();
+  $('#m-test').classList.toggle('on', mode === 'test');
+  $('#m-rpc').classList.toggle('on', mode === 'rpc');
+  $('#changed').classList.toggle('on', changedOnly);
+  $('#runnable').classList.toggle('on', showRunnable);
+  $('#runnable').textContent = showRunnable ? 'runnable SQL' : 'parameterized';
+}
+
+$('#m-test').onclick = () => { mode = 'test'; render(); };
+$('#m-rpc').onclick = () => { mode = 'rpc'; render(); };
+$('#changed').onclick = () => { changedOnly = !changedOnly; render(); };
+$('#runnable').onclick = () => { showRunnable = !showRunnable; render(); };
+$('#q').oninput = e => { filter = e.target.value.toLowerCase(); render(); };
+document.addEventListener('click', e => {
+  const b = e.target.closest('.copy');
+  if (!b) return;
+  navigator.clipboard.writeText(b.dataset.sql).then(() => {
+    b.textContent = 'copied'; setTimeout(() => { b.textContent = 'copy'; }, 1200);
+  });
+});
+
+// The log runs to tens of megabytes, so it is fetched rather than inlined. data.json doubles as the baseline
+// the next develop pipeline compares against.
+fetch('data.json').then(r => r.json()).then(d => {
+  shapes = d.shapes; tests = d.tests;
+  buildIndex();
+  render();
+}).catch(err => {
+  $('#list').innerHTML = `<p class="muted">Could not load data.json (${esc(String(err))}).
+    Opening this file over file:// will not work; serve the directory over HTTP.</p>`;
+});
+"""
+
+
+def render_html(current: dict[str, Any], report: dict[str, Any], commit: str) -> str:
+    n_tests = len(current["tests"])
+    n_shapes = len(current["shapes"])
+    summary_rows = ""
+    if report["has_baseline"] and report["rpcs"]:
+        rows = []
+        for name, v in sorted(
+            report["rpcs"].items(), key=lambda kv: kv[1]["baseline"]["max"] - kv[1]["current"]["max"]
+        ):
+            cur, base = v["current"], v["baseline"]
+            cls = "up" if cur["max"] > base["max"] else "down" if cur["max"] < base["max"] else ""
+            rows.append(
+                f"<tr><td>{html.escape(name)}</td>"
+                f"<td class='num'>{base['calls']} → {cur['calls']}</td>"
+                f"<td class='num'>{base['total']} → {cur['total']}</td>"
+                f"<td class='num {cls}'>{base['max']} → {cur['max']}</td></tr>"
+            )
+        summary_rows = (
+            "<table><tr><th>RPC</th><th class='num'>calls</th><th class='num'>total queries</th>"
+            f"<th class='num'>max/call</th></tr>{''.join(rows)}</table>"
+        )
+    baseline_note = (
+        "Compared against the last <code>develop</code> pipeline."
+        if report["has_baseline"]
+        else "<b>No baseline available</b> — showing this run only."
+    )
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>SQL query log — {html.escape(commit)}</title>
+<style>{PAGE_CSS}</style></head><body>
+<h1>SQL query log</h1>
+<div class="sub">{n_tests} tests · {n_shapes} distinct query shapes · commit <code>{html.escape(commit)}</code></div>
+<div class="summary"><b>{html.escape(summarise(report))}</b><div class="sub">{baseline_note}
+Ordering within a span is not compared: background jobs tie on their queue ordering, so the drain order varies
+between runs. Query counts and shapes are compared.</div>{summary_rows}</div>
+<div class="bar">
+  <button id="m-test">by test</button><button id="m-rpc">by RPC</button>
+  <button id="changed">changed only</button><button id="runnable">runnable SQL</button>
+  <input type="search" id="q" placeholder="filter by test or RPC name">
+</div>
+<div id="list"><p class="muted">Loading…</p></div>
+<script>const DIFF = {json.dumps(report, separators=(",", ":"))};</script>
+<script>{PAGE_JS}</script>
+</body></html>
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path, help="directory holding data.<node>.json files")
+    parser.add_argument("--output", required=True, type=Path, help="directory to write data.json and index.html to")
+    parser.add_argument("--baseline", type=Path, help="develop's merged data.json, if available")
+    parser.add_argument("--baseline-url", help="fetch the baseline from here instead; missing or broken is not fatal")
+    parser.add_argument("--summary-file", type=Path, help="write the one-line summary here for the PR comment")
+    parser.add_argument("--commit", default="", help="commit sha, shown in the report header")
+    args = parser.parse_args()
+
+    current = merge_nodes(args.input)
+    baseline = None
+    if args.baseline and args.baseline.exists() and args.baseline.stat().st_size:
+        baseline = json.loads(args.baseline.read_text())
+    elif args.baseline_url:
+        # Absent until develop has published one, and a broken baseline must not fail the pipeline: the report
+        # simply falls back to describing this run.
+        try:
+            with urllib.request.urlopen(args.baseline_url, timeout=60) as response:
+                baseline = json.loads(response.read())
+        except (urllib.error.URLError, TimeoutError, ValueError) as e:
+            print(f"could not fetch baseline from {args.baseline_url}: {e}")
+    if baseline is not None:
+        print(f"baseline: {len(baseline['tests'])} tests, {len(baseline['shapes'])} shapes")
+    else:
+        print("no usable baseline; reporting this run only")
+
+    report = diff(current, baseline)
+    summary = summarise(report)
+    print(f"summary: {summary}")
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    (args.output / "data.json").write_text(json.dumps(current, separators=(",", ":"), sort_keys=True))
+    (args.output / "index.html").write_text(render_html(current, report, args.commit))
+    if args.summary_file:
+        args.summary_file.write_text(summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/scripts/query_log_report.py
+++ b/app/scripts/query_log_report.py
@@ -27,6 +27,10 @@ from typing import Any
 
 Span = dict[str, Any]
 
+# Not fatal, just loud: the recorder caps individual statements, so exceeding this means something new is bloating
+# the recording and is worth looking at before it reaches half a gigabyte again.
+SIZE_WARN_MB = 50
+
 
 def merge_nodes(input_dir: Path) -> dict[str, Any]:
     shapes: dict[str, dict[str, Any]] = {}
@@ -438,10 +442,21 @@ def main() -> None:
     print(f"summary: {summary}")
 
     args.output.mkdir(parents=True, exist_ok=True)
-    (args.output / "data.json").write_text(json.dumps(current, separators=(",", ":"), sort_keys=True))
+    data_path = args.output / "data.json"
+    data_path.write_text(json.dumps(current, separators=(",", ":"), sort_keys=True))
     (args.output / "index.html").write_text(render_html(current, report, args.commit))
     if args.summary_file:
         args.summary_file.write_text(summary)
+
+    # The recording is published and then fetched by every viewer, so runaway growth matters. A statement carrying
+    # bulk inlined data once took a single node's dump to 495 MB, and the job published it without complaint.
+    size_mb = data_path.stat().st_size / 1048576
+    print(f"wrote {data_path} ({size_mb:.1f} MB)")
+    if size_mb > SIZE_WARN_MB:
+        biggest = sorted(current["shapes"].values(), key=lambda s: -len(s["example"]))[:5]
+        print(f"WARNING: the query log is {size_mb:.1f} MB, over the {SIZE_WARN_MB} MB mark. Largest shapes:")
+        for shape in biggest:
+            print(f"  {len(shape['example']):>9} bytes  {shape['sql'][:100]}")
 
 
 if __name__ == "__main__":

--- a/app/scripts/query_log_report.py
+++ b/app/scripts/query_log_report.py
@@ -18,6 +18,7 @@ Postgres picks freely. The report still displays the real recorded order.
 import argparse
 import collections
 import difflib
+import gzip
 import html
 import json
 import urllib.error
@@ -34,6 +35,7 @@ SIZE_WARN_MB = 50
 
 def merge_nodes(input_dir: Path) -> dict[str, Any]:
     shapes: dict[str, dict[str, Any]] = {}
+    sites: dict[str, str] = {}
     tests: dict[str, list[Span]] = {}
     files = sorted(input_dir.glob("data.*.json"))
     if not files:
@@ -46,10 +48,19 @@ def merge_nodes(input_dir: Path) -> dict[str, Any]:
             # would have, i.e. the one from the lexicographically first test that produced it.
             if existing is None or shape["first_seen_in"] < existing["first_seen_in"]:
                 shapes[shape_id] = shape
+        # Site ids are content hashes too, so identical chains from different nodes coincide.
+        sites.update(data.get("sites", {}))
         # pytest-split gives each test to exactly one node, so this cannot collide.
         tests.update(data["tests"])
-    print(f"merged {len(files)} node files: {len(tests)} tests, {len(shapes)} distinct query shapes")
-    return {"shapes": shapes, "tests": dict(sorted(tests.items()))}
+    print(f"merged {len(files)} node files: {len(tests)} tests, {len(shapes)} shapes, {len(sites)} call sites")
+    return {"shapes": shapes, "sites": sites, "tests": dict(sorted(tests.items()))}
+
+
+def _decode(payload: bytes) -> dict[str, Any]:
+    """Read a recording, gzipped or not. urllib does not inflate for us the way a browser would."""
+    if payload[:2] == b"\x1f\x8b":
+        payload = gzip.decompress(payload)
+    return json.loads(payload)
 
 
 def canonical(span: Span) -> tuple[Any, ...]:
@@ -208,6 +219,8 @@ details > summary::-webkit-details-marker { display:none; }
 .q pre { margin:.35rem 0 0; overflow-x:auto; white-space:pre-wrap; word-break:break-word;
          font:12px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace; max-height:22em; overflow-y:auto; }
 .rep { font-weight:600; color:var(--chg); }
+.site { font:12px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace; color:var(--muted);
+        margin-top:.25rem; overflow-x:auto; white-space:nowrap; }
 .copy { padding:.15rem .5rem; font-size:.75rem; }
 .muted { color:var(--muted); }
 table { border-collapse:collapse; width:100%; }
@@ -222,7 +235,7 @@ th { color:var(--muted); font-weight:600; }
 PAGE_JS = r"""
 const $ = s => document.querySelector(s);
 const diff = DIFF;
-let shapes = {}, tests = {}, byRpc = {};
+let shapes = {}, sites = {}, tests = {}, byRpc = {};
 
 let mode = 'test', changedOnly = diff.has_baseline, showRunnable = true, filter = '';
 
@@ -241,7 +254,7 @@ const esc = s => s.replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c
 const testStatus = t => (diff.tests[t] || {}).status || 'same';
 const spanAnn = (t, i) => ((diff.tests[t] || {}).spans || [])[i] || {status: 'same'};
 
-function shapeHtml(id, reps) {
+function shapeHtml(id, reps, siteId) {
   const sh = shapes[id];
   if (!sh) return '';
   const sql = showRunnable ? sh.example : sh.sql;
@@ -249,9 +262,23 @@ function shapeHtml(id, reps) {
   const nPlusOne = reps > 3 ? `<span class="tag changed">possible N+1</span>` : '';
   const write = sh.write ? '<span class="tag">write</span>' : '';
   const isNew = diff.added_shapes && diff.added_shapes.includes(id) ? '<span class="tag new">new shape</span>' : '';
+  const site = sites[siteId] ? `<div class="site">${esc(sites[siteId])}</div>` : '';
   return `<div class="q"><div class="q-head">${repBadge}${nPlusOne}${write}${isNew}
     <button class="copy" data-sql="${esc(sql).replace(/"/g, '&quot;')}">copy</button></div>
-    <pre>${esc(sql)}</pre></div>`;
+    ${site}<pre>${esc(sql)}</pre></div>`;
+}
+
+// Consecutive executions of the same query from the same line collapse into one row with a count, so an N+1 reads
+// as a single entry saying where it came from and how many times it ran.
+function queryRunsHtml(span) {
+  const runs = [];
+  span.queries.forEach((id, i) => {
+    const site = (span.sites || [])[i] || '';
+    const last = runs[runs.length - 1];
+    if (last && last.id === id && last.site === site) last.n++;
+    else runs.push({id, site, n: 1});
+  });
+  return runs.map(r => shapeHtml(r.id, r.n, r.site)).join('');
 }
 
 function spanHtml(test, span, i) {
@@ -260,15 +287,9 @@ function spanHtml(test, span, i) {
   let delta = '';
   if (ann.status === 'changed') delta = `<span class="tag changed">${ann.before} → ${span.queries.length}</span>`;
   if (ann.status === 'new') delta = `<span class="tag new">new</span>`;
-  // Collapse consecutive repeats so an N+1 reads as one row with a count.
-  const runs = [];
-  for (const id of span.queries) {
-    const last = runs[runs.length - 1];
-    if (last && last.id === id) last.n++; else runs.push({id, n: 1});
-  }
   return `<div class="span"><div class="span-head"><span class="kind">${span.kind}</span>
     <span class="name">${esc(label)}</span><span class="muted">${span.queries.length} queries</span>${delta}</div>
-    ${runs.map(r => shapeHtml(r.id, r.n)).join('')}</div>`;
+    ${queryRunsHtml(span)}</div>`;
 }
 
 function renderByTest() {
@@ -312,15 +333,7 @@ function renderByRpc() {
         <span class="name">${esc(c.test)}</span>
         <span class="muted">${tests[c.test][c.spanIndex].queries.length} queries</span>
         ${testStatus(c.test) !== 'same' ? `<span class="tag ${testStatus(c.test)}">${testStatus(c.test)}</span>` : ''}
-        </div>${(() => {
-          const span = tests[c.test][c.spanIndex];
-          const runs = [];
-          for (const id of span.queries) {
-            const last = runs[runs.length - 1];
-            if (last && last.id === id) last.n++; else runs.push({id, n: 1});
-          }
-          return runs.map(r => shapeHtml(r.id, r.n)).join('');
-        })()}</div>`).join('');
+        </div>${queryRunsHtml(tests[c.test][c.spanIndex])}</div>`).join('');
     return `<details><summary><span class="name">${esc(n)}</span>${tag}
       <span class="muted">${callers.length} calls, worst ${worst} queries</span></summary>
       <div class="body">${inner}</div></details>`;
@@ -349,14 +362,28 @@ document.addEventListener('click', e => {
   });
 });
 
-// The log runs to tens of megabytes, so it is fetched rather than inlined. data.json doubles as the baseline
-// the next develop pipeline compares against.
-fetch('data.json').then(r => r.json()).then(d => {
-  shapes = d.shapes; tests = d.tests;
+// Several megabytes raw, so it is fetched gzipped and inflated here rather than inlined. data.json.gz doubles as
+// the baseline the next develop pipeline compares against.
+async function load() {
+  const response = await fetch('data.json.gz');
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const buffer = await response.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+  // A host that sets Content-Encoding: gzip will have inflated it already, in which case these are plain JSON
+  // bytes and piping them through DecompressionStream would fail.
+  if (bytes[0] === 0x1f && bytes[1] === 0x8b) {
+    const stream = new Blob([buffer]).stream().pipeThrough(new DecompressionStream('gzip'));
+    return await new Response(stream).json();
+  }
+  return JSON.parse(new TextDecoder().decode(bytes));
+}
+
+load().then(d => {
+  shapes = d.shapes; sites = d.sites || {}; tests = d.tests;
   buildIndex();
   render();
 }).catch(err => {
-  $('#list').innerHTML = `<p class="muted">Could not load data.json (${esc(String(err))}).
+  $('#list').innerHTML = `<p class="muted">Could not load data.json.gz (${esc(String(err))}).
     Opening this file over file:// will not work; serve the directory over HTTP.</p>`;
 });
 """
@@ -423,14 +450,14 @@ def main() -> None:
     current = merge_nodes(args.input)
     baseline = None
     if args.baseline and args.baseline.exists() and args.baseline.stat().st_size:
-        baseline = json.loads(args.baseline.read_text())
+        baseline = _decode(args.baseline.read_bytes())
     elif args.baseline_url:
         # Absent until develop has published one, and a broken baseline must not fail the pipeline: the report
         # simply falls back to describing this run.
         try:
-            with urllib.request.urlopen(args.baseline_url, timeout=60) as response:
-                baseline = json.loads(response.read())
-        except (urllib.error.URLError, TimeoutError, ValueError) as e:
+            with urllib.request.urlopen(args.baseline_url, timeout=120) as response:
+                baseline = _decode(response.read())
+        except (urllib.error.URLError, TimeoutError, ValueError, OSError) as e:
             print(f"could not fetch baseline from {args.baseline_url}: {e}")
     if baseline is not None:
         print(f"baseline: {len(baseline['tests'])} tests, {len(baseline['shapes'])} shapes")
@@ -442,8 +469,11 @@ def main() -> None:
     print(f"summary: {summary}")
 
     args.output.mkdir(parents=True, exist_ok=True)
-    data_path = args.output / "data.json"
-    data_path.write_text(json.dumps(current, separators=(",", ":"), sort_keys=True))
+    raw = json.dumps(current, separators=(",", ":"), sort_keys=True).encode()
+    # Stored gzipped and inflated in the browser: it is mostly repeated SQL, so it compresses about tenfold, and
+    # the page fetches the whole thing on load. mtime=0 keeps the bytes reproducible across runs.
+    data_path = args.output / "data.json.gz"
+    data_path.write_bytes(gzip.compress(raw, mtime=0))
     (args.output / "index.html").write_text(render_html(current, report, args.commit))
     if args.summary_file:
         args.summary_file.write_text(summary)
@@ -451,7 +481,7 @@ def main() -> None:
     # The recording is published and then fetched by every viewer, so runaway growth matters. A statement carrying
     # bulk inlined data once took a single node's dump to 495 MB, and the job published it without complaint.
     size_mb = data_path.stat().st_size / 1048576
-    print(f"wrote {data_path} ({size_mb:.1f} MB)")
+    print(f"wrote {data_path} ({size_mb:.1f} MB gzipped, {len(raw) / 1048576:.1f} MB raw)")
     if size_mb > SIZE_WARN_MB:
         biggest = sorted(current["shapes"].values(), key=lambda s: -len(s["example"]))[:5]
         print(f"WARNING: the query log is {size_mb:.1f} MB, over the {SIZE_WARN_MB} MB mark. Largest shapes:")

--- a/app/scripts/query_log_report.py
+++ b/app/scripts/query_log_report.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
 """Merges the per-node SQL query logs from the backend test run, diffs them against develop's and renders a report.
 
-The recorder is src/tests/fixtures/query_log.py, which writes one data.<node>.json per pytest-split node. This script
+The recorder is src/tests/fixtures/query_log.py, which writes one data.<node>.json.gz per pytest-split node. This script
 unions those, compares against the baseline published by the last develop pipeline, and writes:
 
-  data.json    the merged log, which becomes the next baseline
+  data.json.gz the merged log, which becomes the next baseline
   index.html   a self-contained browsable report, by test and by RPC, defaulting to what changed
 
 Usage:
   query_log_report.py --input DIR --output DIR [--baseline data.json] [--summary-file FILE]
 
 Diffing canonicalises each span to a multiset of query shapes. Ordering within a span is not stable: background jobs
-are drained with ORDER BY priority DESC, next_attempt_after ASC, and jobs queued in one transaction tie on both, so
-Postgres picks freely. The report still displays the real recorded order.
+are drained with ORDER BY priority DESC, next_attempt_after ASC and jobs queued in one transaction tie on both, and
+SQLAlchemy emits a selectinload() fan-out in an order that varies between processes. The report still displays the
+real recorded order.
 """
 
 import argparse
@@ -37,11 +38,11 @@ def merge_nodes(input_dir: Path) -> dict[str, Any]:
     shapes: dict[str, dict[str, Any]] = {}
     sites: dict[str, str] = {}
     tests: dict[str, list[Span]] = {}
-    files = sorted(input_dir.glob("data.*.json"))
+    files = sorted(input_dir.glob("data.*.json.gz"))
     if not files:
-        raise SystemExit(f"no data.*.json found in {input_dir}")
+        raise SystemExit(f"no data.*.json.gz found in {input_dir}")
     for path in files:
-        data = json.loads(path.read_text())
+        data = _decode(path.read_bytes())
         for shape_id, shape in data["shapes"].items():
             existing = shapes.get(shape_id)
             # Shape ids are content hashes so nodes agree on them; pick the same `example` a single-node run
@@ -423,8 +424,8 @@ def render_html(current: dict[str, Any], report: dict[str, Any], commit: str) ->
 <h1>SQL query log</h1>
 <div class="sub">{n_tests} tests · {n_shapes} distinct query shapes · commit <code>{html.escape(commit)}</code></div>
 <div class="summary"><b>{html.escape(summarise(report))}</b><div class="sub">{baseline_note}
-Ordering within a span is not compared: background jobs tie on their queue ordering, so the drain order varies
-between runs. Query counts and shapes are compared.</div>{summary_rows}</div>
+Ordering within a span is not compared: background jobs tie on their queue ordering and SQLAlchemy varies the order
+of a selectinload() fan-out, so the sequence differs between runs. Query counts and shapes are compared.</div>{summary_rows}</div>
 <div class="bar">
   <button id="m-test">by test</button><button id="m-rpc">by RPC</button>
   <button id="changed">changed only</button><button id="runnable">runnable SQL</button>
@@ -439,8 +440,8 @@ between runs. Query counts and shapes are compared.</div>{summary_rows}</div>
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--input", required=True, type=Path, help="directory holding data.<node>.json files")
-    parser.add_argument("--output", required=True, type=Path, help="directory to write data.json and index.html to")
+    parser.add_argument("--input", required=True, type=Path, help="directory holding data.<node>.json.gz files")
+    parser.add_argument("--output", required=True, type=Path, help="directory to write data.json.gz and index.html to")
     parser.add_argument("--baseline", type=Path, help="develop's merged data.json, if available")
     parser.add_argument("--baseline-url", help="fetch the baseline from here instead; missing or broken is not fatal")
     parser.add_argument("--summary-file", type=Path, help="write the one-line summary here for the PR comment")

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -13,6 +13,7 @@ Note on slugs: each branch has a slug generated from the branch name, normally y
 * Web as at `develop`: <https://develop--web.preview.couchershq.org/>
 * Current backend test coverage on `develop`: <https://develop--bcov.preview.couchershq.org/>
 * Current web test coverage on `develop`: <https://develop--wcov.preview.couchershq.org/>
+* SQL queries the backend tests issue on `develop`: <https://develop--test-artifacts.preview.couchershq.org/queries/index.html> (see [docs/query-log.md](query-log.md))
 
 ## Tests
 

--- a/docs/query-log.md
+++ b/docs/query-log.md
@@ -1,28 +1,16 @@
 # SQL query log
 
-Every backend test run can record every SQL query it issues, grouped by the test that ran and by the RPC that issued
-it. CI diffs that recording against the one `develop` last published and links a browsable report from the PR comment,
-so a pull request can be reviewed for how it changes database access patterns before it merges.
+Every backend test run can record every SQL query it issues, grouped by the test that ran and by the RPC that issued it. CI diffs that recording against the one `develop` last published and links a browsable report from the sticky PR comment, so a pull request can be reviewed for how it changes database access patterns before it merges.
 
-The recording answers two questions from the same data:
+The same recording reads two ways: by test (this test called `WriteFriendReference`, which ran these 25 queries, then `ModerateContent`, which ran these 17) and by RPC (`ListReferences` was called from these tests, and this is what it ran in each). Each query is stored twice, once with the bound parameters replaced by `?`, which is the key used for grouping and diffing, and once with the values inlined so it can be pasted straight into a `psql` prompt.
 
-- **By test** — this test called `WriteFriendReference`, which ran these 25 queries, then called `ModerateContent`,
-  which ran these 17.
-- **By RPC** — `ListReferences` was called from these tests, and this is what it ran in each.
-
-The queries are stored twice: once with the bound parameters replaced by `?`, which is the key used for grouping and
-diffing, and once with the values inlined, so a query can be copied out of the report and pasted straight into a
-`psql` prompt to run `EXPLAIN ANALYZE` against real data.
-
-Every execution also records the line that issued it, as the innermost few `couchers/` frames:
+Every execution also records the innermost few `couchers/` frames that issued it:
 
 ```
 couchers/db.py:164 in are_friends <- couchers/servicers/references.py:243 in WriteFriendReference
 ```
 
-Consecutive executions of the same query from the same line collapse into one row with a count, so an N+1 shows up as
-a single entry naming the line responsible. Call sites are deliberately kept out of the diff key: line numbers move
-whenever anything above them is edited, and a diff that flags every query in a touched file is useless.
+Consecutive executions of the same query from the same line collapse into one row with a count, so an N+1 shows up as a single entry naming the line responsible. Call sites are deliberately kept out of the diff key: line numbers move whenever anything above them is edited, and a diff that flags every query in a touched file is useless.
 
 ## Running it locally
 
@@ -32,109 +20,45 @@ From `/app/backend`:
 uv run pytest --query-log src
 ```
 
-This writes `test_artifacts/queries/data.local.json.gz` (gitignored; read it with `gunzip -c`). Without the flag
-nothing is recorded and the overhead is nil, so ordinary runs are unaffected.
-
-To render the report locally, then browse it over HTTP (the page fetches its data, so `file://` will not work):
+This writes `test_artifacts/queries/data.local.json.gz` (gitignored; read it with `gunzip -c`). Without the flag nothing is recorded, so ordinary runs are unaffected. To render the report and browse it over HTTP (the page fetches its data, so `file://` will not work):
 
 ```bash
 uv run python ../scripts/query_log_report.py --input test_artifacts/queries --output test_artifacts/queries
 python3 -m http.server --directory test_artifacts/queries
 ```
 
-Passing `--baseline path/to/other/data.json` compares two recordings, which is how the CI diff works.
+Passing `--baseline path/to/other/data.json.gz` compares two recordings, which is how the CI diff works.
 
-## Turning it on and off
+## In CI
 
-Locally it is off unless you pass `--query-log`, and costs nothing when off.
-
-In CI it is governed by the `BACKEND_QUERY_LOG` pipeline variable, alongside `DO_CHECKS` and `BUILD_WEB` at the top
-of `app/.gitlab-ci.yml`. Set it to anything other than `"true"` and the recording, the report and the PR comment
-item all drop out together; nothing else in the pipeline changes. Override it for a single run from GitLab's "Run
-pipeline" form without editing the file.
-
-Nothing here can break the rest of the pipeline. `preview:backend-coverage` gates `preview:backend`, which writes the
-whole sticky PR comment — schema, schema diff, emails, coverage — so the report step is run with `|| echo` and cannot
-fail the job, whether the input directory is empty, the baseline is malformed or the script has a bug. The comment
-item is added only when `index.html` actually exists, so a failed report degrades to not being linked, and the
-failure is visible in the `preview:backend-coverage` log.
-
-Turning it off leaves the query log item sitting in the comment on any PR that already has one, since each writer
-only rewrites the items it owns. New comments simply will not have it.
-
-## How it fits together
+Governed by the `BACKEND_QUERY_LOG` pipeline variable, alongside `DO_CHECKS` and `BUILD_WEB` at the top of `app/.gitlab-ci.yml`. Set it to anything other than `"true"` and the recording, the report and the PR comment item all drop out together; nothing else in the pipeline changes. Override it for a single run from GitLab's "Run pipeline" form without editing the file.
 
 | Piece | What it does |
 | --- | --- |
 | `src/tests/fixtures/query_log.py` | Records queries via a SQLAlchemy `after_cursor_execute` listener, writes `data.<node>.json.gz` |
 | `src/tests/conftest.py` | Registers `--query-log`, attributes queries to the running test, dumps at session end |
 | `app/scripts/query_log_report.py` | Merges the per-node dumps, diffs against the baseline, renders `index.html` |
-| `test:backend` | Runs pytest with `--query-log` when `BACKEND_QUERY_LOG` is on; the existing `after_script` collects `test_artifacts` |
+| `test:backend` | Runs pytest with `--query-log`; the existing `after_script` collects `test_artifacts` |
 | `preview:backend-coverage` | Merges, fetches develop's baseline, renders the report |
 | `preview:backend` | Uploads it to the preview bucket and adds the PR comment item |
 
-The report is published at `https://<sha>--test-artifacts.preview.couchershq.org/queries/index.html`. Its
-`data.json.gz` is what the next pipeline compares against, fetched from the `develop--test-artifacts` host.
+The report is published at `https://<sha>--test-artifacts.preview.couchershq.org/queries/index.html`, and its `data.json.gz` is what the next pipeline compares against. To read one by hand: `curl -s https://develop--test-artifacts.preview.couchershq.org/queries/data.json.gz | gunzip | jq keys`.
 
-The recording is stored gzipped and inflated in the browser with `DecompressionStream`, because it is mostly repeated
-SQL and compresses about twenty-fold — a few megabytes raw becomes a couple of hundred kilobytes over the wire. The
-page copes with a host that sets `Content-Encoding: gzip` and inflates it in transit, and `query_log_report.py`
-accepts a baseline either way, since `urllib` does not inflate the way a browser does. To read it by hand:
+The render step cannot fail its job, and the comment item is added only when the report actually exists, so a broken query log never takes the rest of the sticky PR comment — schema, schema diff, emails, coverage — down with it.
 
-```bash
-curl -s https://develop--test-artifacts.preview.couchershq.org/queries/data.json.gz | gunzip | jq keys
-```
-
-## Attribution
+## Reading a report
 
 Queries are grouped into spans, in the order they occurred:
 
 - `rpc` — the handler and its session, for both the `FakeChannel` sessions and the real-server ones
-- `auth` — the token lookup that precedes a handler. Kept separate so a constant per-call cost is not mistaken for
-  the handler's own work; this matches the boundary `couchers/perf.py` uses in production
-- `job` — a `process_jobs()` drain
+- `auth` — the token lookup that precedes a handler, kept separate so a constant per-call cost is not mistaken for the handler's own work; this matches the boundary `couchers/perf.py` uses in production
+- `job` — a `process_jobs()` drain, not split by job type
 - `body` — anything else: fixture setup, or a test using `session_scope()` directly
 
-## Caveats worth knowing
+Caveats worth knowing:
 
-**Ordering within a span is not compared.** The diff compares the multiset of queries in a span, not their sequence.
-The report still displays the real recorded order. Two sources make the sequence vary between otherwise identical
-runs:
-
-- Background jobs are drained with `ORDER BY priority DESC, next_attempt_after ASC`, and jobs queued in one
-  transaction tie on both columns, so Postgres is free to pick either.
-- SQLAlchemy emits the `selectinload()` fan-out for a query in an order that is not stable across processes.
-  `GetPublicUser` loads four relationships this way and their four `SELECT`s come out in a different order between
-  runs. It is deterministic when `test_public.py` runs on its own, so it depends on state built up earlier in the
-  session rather than on anything we pass in.
-
-Two full-suite runs currently differ in the sequence of 4 of 960 recorded tests, and in the multiset of none of
-them.
-
-**The inlined values come from a truncated test database.** `RESTART IDENTITY` runs before each test, so ids are small
-integers and a query reads `WHERE users.id = 3`. That user has no friends, no references and no messages, and may not
-exist in production at all. Treat the values as a template: swap in a representative row before drawing conclusions
-from a plan, or the planner will make a choice that has nothing to do with production.
-
-**Job spans are not split by job type.** `Job` is a frozen dataclass that derives its name and payload type from the
-handler's `__name__` and type hints, so wrapping handlers to name them breaks `get_type_hints`. Splitting these out
-wants a span alongside the existing tracer span in `couchers/jobs/worker.py`.
-
-**Statements are capped, and bulk loads are collapsed.** Some SQL inlines its data as literals in the statement text
-rather than binding it — the real `timezone_areas.sql` applied by the migrations is a few hundred `INSERT`s each
-carrying megabytes of WKB hex. Nothing can group those by parameter, so the recorder collapses long quoted literals
-and repeated `VALUES` tuples, and caps each stored statement at 4 KB with a `/* truncated by the query log */`
-marker so an over-long entry is visibly not runnable rather than silently invalid. Without this a single CI node's
-dump reached 495 MB. `query_log_report.py` warns if the merged recording exceeds 50 MB.
-
-**`src/tests/test_db.py` is not recorded.** It rebuilds the schema from migrations to diff it against the models,
-which is schema plumbing rather than an access pattern and is already covered by the schema-diff artifact. This is
-not what keeps the real `timezone_areas.sql` out of the recording — `test_migrations` is skipped in `test:backend`
-regardless, since the backend image has no `pg_dump` — the statement cap above is what bounds the artifact.
-
-**The baseline is `develop`'s latest, not your merge base.** A branch that is behind will show `develop`'s own
-changes back to front, as if the branch had reverted them. Rebase before reading a diff that looks surprising.
-
-**A shared fixture change moves everything.** Adding one query to `generate_user()` shifts every test at once. That is
-real, but it drowns the report, so treat a diff that touches most tests as a signal to look at the fixture rather than
-the tests.
+- **Ordering within a span is not compared**, only the multiset of queries. Background jobs tie on their queue ordering and SQLAlchemy varies the order of a `selectinload()` fan-out, so the sequence differs between otherwise identical runs. The report still displays the real recorded order.
+- **The inlined values come from a truncated test database.** `RESTART IDENTITY` runs before each test, so a query reads `WHERE users.id = 3`, and that user has no friends, references or messages. Treat the values as a template and swap in a representative row before drawing conclusions from a plan.
+- **The baseline is `develop`'s latest, not your merge base.** A branch that is behind shows `develop`'s own changes back to front, as if the branch had reverted them. Rebase before reading a diff that looks surprising.
+- **A shared fixture change moves everything.** Adding one query to `generate_user()` shifts every test at once. That is real, but it drowns the report, so treat a diff that touches most tests as a signal to look at the fixture rather than the tests.
+- **Statements are capped at 4 KB and long inlined literals are collapsed.** Some SQL carries its data as literals in the statement text rather than binding it, and nothing can group those by parameter; without the cap a single CI node's dump reached 495 MB. `src/tests/test_db.py` is not recorded at all, being schema plumbing already covered by the schema diff.

--- a/docs/query-log.md
+++ b/docs/query-log.md
@@ -32,8 +32,8 @@ From `/app/backend`:
 uv run pytest --query-log src
 ```
 
-This writes `test_artifacts/queries/data.local.json` (gitignored). Without the flag nothing is recorded and the
-overhead is nil, so ordinary runs are unaffected.
+This writes `test_artifacts/queries/data.local.json.gz` (gitignored; read it with `gunzip -c`). Without the flag
+nothing is recorded and the overhead is nil, so ordinary runs are unaffected.
 
 To render the report locally, then browse it over HTTP (the page fetches its data, so `file://` will not work):
 
@@ -48,7 +48,7 @@ Passing `--baseline path/to/other/data.json` compares two recordings, which is h
 
 | Piece | What it does |
 | --- | --- |
-| `src/tests/fixtures/query_log.py` | Records queries via a SQLAlchemy `after_cursor_execute` listener, writes `data.<node>.json` |
+| `src/tests/fixtures/query_log.py` | Records queries via a SQLAlchemy `after_cursor_execute` listener, writes `data.<node>.json.gz` |
 | `src/tests/conftest.py` | Registers `--query-log`, attributes queries to the running test, dumps at session end |
 | `app/scripts/query_log_report.py` | Merges the per-node dumps, diffs against the baseline, renders `index.html` |
 | `test:backend` | Runs pytest with `--query-log`; the existing `after_script` collects `test_artifacts` |
@@ -79,10 +79,19 @@ Queries are grouped into spans, in the order they occurred:
 
 ## Caveats worth knowing
 
-**Ordering within a span is not compared.** Background jobs are drained with
-`ORDER BY priority DESC, next_attempt_after ASC`, and jobs queued in one transaction tie on both columns, so Postgres
-is free to pick either. The diff therefore compares the multiset of queries in a span, not their sequence. The report
-still displays the real recorded order.
+**Ordering within a span is not compared.** The diff compares the multiset of queries in a span, not their sequence.
+The report still displays the real recorded order. Two sources make the sequence vary between otherwise identical
+runs:
+
+- Background jobs are drained with `ORDER BY priority DESC, next_attempt_after ASC`, and jobs queued in one
+  transaction tie on both columns, so Postgres is free to pick either.
+- SQLAlchemy emits the `selectinload()` fan-out for a query in an order that is not stable across processes.
+  `GetPublicUser` loads four relationships this way and their four `SELECT`s come out in a different order between
+  runs. It is deterministic when `test_public.py` runs on its own, so it depends on state built up earlier in the
+  session rather than on anything we pass in.
+
+Two full-suite runs currently differ in the sequence of 4 of 960 recorded tests, and in the multiset of none of
+them.
 
 **The inlined values come from a truncated test database.** `RESTART IDENTITY` runs before each test, so ids are small
 integers and a query reads `WHERE users.id = 3`. That user has no friends, no references and no messages, and may not

--- a/docs/query-log.md
+++ b/docs/query-log.md
@@ -110,8 +110,12 @@ marker so an over-long entry is visibly not runnable rather than silently invali
 dump reached 495 MB. `query_log_report.py` warns if the merged recording exceeds 50 MB.
 
 **`src/tests/test_db.py` is not recorded.** It rebuilds the schema from migrations to diff it against the models,
-which is schema plumbing rather than an access pattern, is already covered by the schema-diff artifact, and is what
-pulls in the real `timezone_areas.sql` in CI.
+which is schema plumbing rather than an access pattern and is already covered by the schema-diff artifact. This is
+not what keeps the real `timezone_areas.sql` out of the recording — `test_migrations` is skipped in `test:backend`
+regardless, since the backend image has no `pg_dump` — the statement cap above is what bounds the artifact.
+
+**The baseline is `develop`'s latest, not your merge base.** A branch that is behind will show `develop`'s own
+changes back to front, as if the branch had reverted them. Rebase before reading a diff that looks surprising.
 
 **A shared fixture change moves everything.** Adding one query to `generate_user()` shifts every test at once. That is
 real, but it drowns the report, so treat a diff that touches most tests as a signal to look at the fixture rather than

--- a/docs/query-log.md
+++ b/docs/query-log.md
@@ -14,6 +14,16 @@ The queries are stored twice: once with the bound parameters replaced by `?`, wh
 diffing, and once with the values inlined, so a query can be copied out of the report and pasted straight into a
 `psql` prompt to run `EXPLAIN ANALYZE` against real data.
 
+Every execution also records the line that issued it, as the innermost few `couchers/` frames:
+
+```
+couchers/db.py:164 in are_friends <- couchers/servicers/references.py:243 in WriteFriendReference
+```
+
+Consecutive executions of the same query from the same line collapse into one row with a count, so an N+1 shows up as
+a single entry naming the line responsible. Call sites are deliberately kept out of the diff key: line numbers move
+whenever anything above them is edited, and a diff that flags every query in a touched file is useless.
+
 ## Running it locally
 
 From `/app/backend`:
@@ -45,8 +55,17 @@ Passing `--baseline path/to/other/data.json` compares two recordings, which is h
 | `preview:backend-coverage` | Merges, fetches develop's baseline, renders the report |
 | `preview:backend` | Uploads it to the preview bucket and adds the PR comment item |
 
-The report is published at `https://<sha>--test-artifacts.preview.couchershq.org/queries/index.html`. Its `data.json`
-is what the next pipeline compares against, fetched from the `develop--test-artifacts` host.
+The report is published at `https://<sha>--test-artifacts.preview.couchershq.org/queries/index.html`. Its
+`data.json.gz` is what the next pipeline compares against, fetched from the `develop--test-artifacts` host.
+
+The recording is stored gzipped and inflated in the browser with `DecompressionStream`, because it is mostly repeated
+SQL and compresses about twenty-fold — a few megabytes raw becomes a couple of hundred kilobytes over the wire. The
+page copes with a host that sets `Content-Encoding: gzip` and inflates it in transit, and `query_log_report.py`
+accepts a baseline either way, since `urllib` does not inflate the way a browser does. To read it by hand:
+
+```bash
+curl -s https://develop--test-artifacts.preview.couchershq.org/queries/data.json.gz | gunzip | jq keys
+```
 
 ## Attribution
 

--- a/docs/query-log.md
+++ b/docs/query-log.md
@@ -53,9 +53,11 @@ of `app/.gitlab-ci.yml`. Set it to anything other than `"true"` and the recordin
 item all drop out together; nothing else in the pipeline changes. Override it for a single run from GitLab's "Run
 pipeline" form without editing the file.
 
-Turn all three off together rather than one of them. The report step treats an empty input directory as an error, so
-recording without reporting fails `preview:backend-coverage`, which blocks `preview:backend` and takes the whole
-sticky PR comment — schema, schema diff, emails, coverage — with it.
+Nothing here can break the rest of the pipeline. `preview:backend-coverage` gates `preview:backend`, which writes the
+whole sticky PR comment — schema, schema diff, emails, coverage — so the report step is run with `|| echo` and cannot
+fail the job, whether the input directory is empty, the baseline is malformed or the script has a bug. The comment
+item is added only when `index.html` actually exists, so a failed report degrades to not being linked, and the
+failure is visible in the `preview:backend-coverage` log.
 
 Turning it off leaves the query log item sitting in the comment on any PR that already has one, since each writer
 only rewrites the items it owns. New comments simply will not have it.

--- a/docs/query-log.md
+++ b/docs/query-log.md
@@ -44,6 +44,22 @@ python3 -m http.server --directory test_artifacts/queries
 
 Passing `--baseline path/to/other/data.json` compares two recordings, which is how the CI diff works.
 
+## Turning it on and off
+
+Locally it is off unless you pass `--query-log`, and costs nothing when off.
+
+In CI it is governed by the `QUERY_LOG` pipeline variable, alongside `DO_CHECKS` and `BUILD_WEB` at the top of
+`app/.gitlab-ci.yml`. Set it to anything other than `"true"` and the recording, the report and the PR comment item
+all drop out together; nothing else in the pipeline changes. Override it for a single run from GitLab's "Run
+pipeline" form without editing the file.
+
+Turn all three off together rather than one of them. The report step treats an empty input directory as an error, so
+recording without reporting fails `preview:backend-coverage`, which blocks `preview:backend` and takes the whole
+sticky PR comment — schema, schema diff, emails, coverage — with it.
+
+Turning it off leaves the query log item sitting in the comment on any PR that already has one, since each writer
+only rewrites the items it owns. New comments simply will not have it.
+
 ## How it fits together
 
 | Piece | What it does |
@@ -51,7 +67,7 @@ Passing `--baseline path/to/other/data.json` compares two recordings, which is h
 | `src/tests/fixtures/query_log.py` | Records queries via a SQLAlchemy `after_cursor_execute` listener, writes `data.<node>.json.gz` |
 | `src/tests/conftest.py` | Registers `--query-log`, attributes queries to the running test, dumps at session end |
 | `app/scripts/query_log_report.py` | Merges the per-node dumps, diffs against the baseline, renders `index.html` |
-| `test:backend` | Runs pytest with `--query-log`; the existing `after_script` collects `test_artifacts` |
+| `test:backend` | Runs pytest with `--query-log` when `QUERY_LOG` is on; the existing `after_script` collects `test_artifacts` |
 | `preview:backend-coverage` | Merges, fetches develop's baseline, renders the report |
 | `preview:backend` | Uploads it to the preview bucket and adds the PR comment item |
 

--- a/docs/query-log.md
+++ b/docs/query-log.md
@@ -48,9 +48,9 @@ Passing `--baseline path/to/other/data.json` compares two recordings, which is h
 
 Locally it is off unless you pass `--query-log`, and costs nothing when off.
 
-In CI it is governed by the `QUERY_LOG` pipeline variable, alongside `DO_CHECKS` and `BUILD_WEB` at the top of
-`app/.gitlab-ci.yml`. Set it to anything other than `"true"` and the recording, the report and the PR comment item
-all drop out together; nothing else in the pipeline changes. Override it for a single run from GitLab's "Run
+In CI it is governed by the `BACKEND_QUERY_LOG` pipeline variable, alongside `DO_CHECKS` and `BUILD_WEB` at the top
+of `app/.gitlab-ci.yml`. Set it to anything other than `"true"` and the recording, the report and the PR comment
+item all drop out together; nothing else in the pipeline changes. Override it for a single run from GitLab's "Run
 pipeline" form without editing the file.
 
 Turn all three off together rather than one of them. The report step treats an empty input directory as an error, so
@@ -67,7 +67,7 @@ only rewrites the items it owns. New comments simply will not have it.
 | `src/tests/fixtures/query_log.py` | Records queries via a SQLAlchemy `after_cursor_execute` listener, writes `data.<node>.json.gz` |
 | `src/tests/conftest.py` | Registers `--query-log`, attributes queries to the running test, dumps at session end |
 | `app/scripts/query_log_report.py` | Merges the per-node dumps, diffs against the baseline, renders `index.html` |
-| `test:backend` | Runs pytest with `--query-log` when `QUERY_LOG` is on; the existing `after_script` collects `test_artifacts` |
+| `test:backend` | Runs pytest with `--query-log` when `BACKEND_QUERY_LOG` is on; the existing `after_script` collects `test_artifacts` |
 | `preview:backend-coverage` | Merges, fetches develop's baseline, renders the report |
 | `preview:backend` | Uploads it to the preview bucket and adds the PR comment item |
 

--- a/docs/query-log.md
+++ b/docs/query-log.md
@@ -74,6 +74,17 @@ from a plan, or the planner will make a choice that has nothing to do with produ
 handler's `__name__` and type hints, so wrapping handlers to name them breaks `get_type_hints`. Splitting these out
 wants a span alongside the existing tracer span in `couchers/jobs/worker.py`.
 
+**Statements are capped, and bulk loads are collapsed.** Some SQL inlines its data as literals in the statement text
+rather than binding it — the real `timezone_areas.sql` applied by the migrations is a few hundred `INSERT`s each
+carrying megabytes of WKB hex. Nothing can group those by parameter, so the recorder collapses long quoted literals
+and repeated `VALUES` tuples, and caps each stored statement at 4 KB with a `/* truncated by the query log */`
+marker so an over-long entry is visibly not runnable rather than silently invalid. Without this a single CI node's
+dump reached 495 MB. `query_log_report.py` warns if the merged recording exceeds 50 MB.
+
+**`src/tests/test_db.py` is not recorded.** It rebuilds the schema from migrations to diff it against the models,
+which is schema plumbing rather than an access pattern, is already covered by the schema-diff artifact, and is what
+pulls in the real `timezone_areas.sql` in CI.
+
 **A shared fixture change moves everything.** Adding one query to `generate_user()` shifts every test at once. That is
 real, but it drowns the report, so treat a diff that touches most tests as a signal to look at the fixture rather than
 the tests.

--- a/docs/query-log.md
+++ b/docs/query-log.md
@@ -1,0 +1,79 @@
+# SQL query log
+
+Every backend test run can record every SQL query it issues, grouped by the test that ran and by the RPC that issued
+it. CI diffs that recording against the one `develop` last published and links a browsable report from the PR comment,
+so a pull request can be reviewed for how it changes database access patterns before it merges.
+
+The recording answers two questions from the same data:
+
+- **By test** — this test called `WriteFriendReference`, which ran these 25 queries, then called `ModerateContent`,
+  which ran these 17.
+- **By RPC** — `ListReferences` was called from these tests, and this is what it ran in each.
+
+The queries are stored twice: once with the bound parameters replaced by `?`, which is the key used for grouping and
+diffing, and once with the values inlined, so a query can be copied out of the report and pasted straight into a
+`psql` prompt to run `EXPLAIN ANALYZE` against real data.
+
+## Running it locally
+
+From `/app/backend`:
+
+```bash
+uv run pytest --query-log src
+```
+
+This writes `test_artifacts/queries/data.local.json` (gitignored). Without the flag nothing is recorded and the
+overhead is nil, so ordinary runs are unaffected.
+
+To render the report locally, then browse it over HTTP (the page fetches its data, so `file://` will not work):
+
+```bash
+uv run python ../scripts/query_log_report.py --input test_artifacts/queries --output test_artifacts/queries
+python3 -m http.server --directory test_artifacts/queries
+```
+
+Passing `--baseline path/to/other/data.json` compares two recordings, which is how the CI diff works.
+
+## How it fits together
+
+| Piece | What it does |
+| --- | --- |
+| `src/tests/fixtures/query_log.py` | Records queries via a SQLAlchemy `after_cursor_execute` listener, writes `data.<node>.json` |
+| `src/tests/conftest.py` | Registers `--query-log`, attributes queries to the running test, dumps at session end |
+| `app/scripts/query_log_report.py` | Merges the per-node dumps, diffs against the baseline, renders `index.html` |
+| `test:backend` | Runs pytest with `--query-log`; the existing `after_script` collects `test_artifacts` |
+| `preview:backend-coverage` | Merges, fetches develop's baseline, renders the report |
+| `preview:backend` | Uploads it to the preview bucket and adds the PR comment item |
+
+The report is published at `https://<sha>--test-artifacts.preview.couchershq.org/queries/index.html`. Its `data.json`
+is what the next pipeline compares against, fetched from the `develop--test-artifacts` host.
+
+## Attribution
+
+Queries are grouped into spans, in the order they occurred:
+
+- `rpc` — the handler and its session, for both the `FakeChannel` sessions and the real-server ones
+- `auth` — the token lookup that precedes a handler. Kept separate so a constant per-call cost is not mistaken for
+  the handler's own work; this matches the boundary `couchers/perf.py` uses in production
+- `job` — a `process_jobs()` drain
+- `body` — anything else: fixture setup, or a test using `session_scope()` directly
+
+## Caveats worth knowing
+
+**Ordering within a span is not compared.** Background jobs are drained with
+`ORDER BY priority DESC, next_attempt_after ASC`, and jobs queued in one transaction tie on both columns, so Postgres
+is free to pick either. The diff therefore compares the multiset of queries in a span, not their sequence. The report
+still displays the real recorded order.
+
+**The inlined values come from a truncated test database.** `RESTART IDENTITY` runs before each test, so ids are small
+integers and a query reads `WHERE users.id = 3`. That user has no friends, no references and no messages, and may not
+exist in production at all. Treat the values as a template: swap in a representative row before drawing conclusions
+from a plan, or the planner will make a choice that has nothing to do with production.
+
+**Job spans are not split by job type.** `Job` is a frozen dataclass that derives its name and payload type from the
+handler's `__name__` and type hints, so wrapping handlers to name them breaks `get_type_hints`. Splitting these out
+wants a span alongside the existing tracer span in `couchers/jobs/worker.py`.
+
+**A shared fixture change moves everything.** Adding one query to `generate_user()` shifts every test at once. That is
+real, but it drowns the report, so treat a diff that touches most tests as a signal to look at the fixture rather than
+the tests.


### PR DESCRIPTION
Makes it possible to review a PR for how it changes database access patterns, before it merges.

An opt-in `--query-log` flag records every SQL query the backend suite issues, grouped both by the test that ran and by the RPC that issued it, in order. CI diffs that recording against the one `develop` last published and links a browsable report from the sticky PR comment, with the headline delta inline so the common case needs no click:

> `SQL query log` — +3/-1 query shapes · 4 tests changed · worst: ListReferences 1->14 queries/call

Each query is stored twice: fingerprinted with parameters replaced by `?` (the key used for grouping and diffing), and with the values inlined by psycopg's `ClientCursor.mogrify`, so a query reads `WHERE "references".from_user_id = 2::BIGINT AND ... = 'friend'` and can be copy-pasted into psql to explain it against real data. The report defaults to what changed, collapses consecutive repeats of one shape to `×14` as a likely N+1, and toggles between the runnable and parameterized forms.

This reuses the pipeline the schema diff already uses — per-node artifact, merge, fetch develop's baseline, render, publish, comment — so there is **no new CI job**. Overhead is ~5-8% on the test run and one ~9 MB artifact.

**This also fixes a pre-existing nondeterminism in generated SQL.** `get_moderated_models()` iterates `Base.registry.mappers`, which is a `frozenset`, so `Mapper` objects come out ordered by `id()` — addresses that vary per process. Callers build one `OR` branch per entry, so the moderation visibility predicate was emitted with its branches in a different order in every process. That made **83 of 943 tests** differ between two identical runs, and in production splits one logical query across several `pg_stat_statements` entries, defeating the aggregation you want when investigating query performance. Sorting the mappers fixes it.

Docs in `docs/query-log.md`, including the caveats: ordering within a span is deliberately not compared (background jobs tie on their queue ordering, so drain order varies), the inlined values come from a truncated test database and are a template rather than a query, and job spans are not yet split by job type.

## Testing

`uv run pytest --query-log src` locally, then verified:

- **Determinism** (the gate — if the recording is not stable, everything downstream is noise): two full-suite runs produce **0/943 canonical differences** and identical shape sets (1474 shapes). Before the moderation ordering fix this was 83/943 and 16 shapes apart. The 5 remaining strict-order differences are all background-job drain order, which the diff ignores by design.
- **No false positives**: two independent full runs diff to *"no change in DB access patterns"*.
- **Real changes are caught**: synthetic N+1, new shape, added and removed test all reported correctly, including `worst: WriteFriendReference 26->38 queries/call`.
- **3-node merge**: splitting a real recording into three node files and merging reconstructs the single-process recording exactly, including the `first_seen_in` tie-break that picks each stored example.
- Full suite green: **1228 passed**. `make format` and `make mypy` clean (464 files).

Not verified locally: the GitLab job stanzas themselves. The recorder, merge, diff, viewer and comment-item rendering are all exercised, but whether the CI wiring hangs together needs a real pipeline — hence the draft.

To see the report locally:

```bash
cd app/backend
uv run pytest --query-log src
uv run python ../scripts/query_log_report.py --input test_artifacts/queries --output test_artifacts/queries
python3 -m http.server --directory test_artifacts/queries   # the page fetches its data, so file:// won't work
```

Two drive-by mypy fixes are included (`test_events.py`, `test_calendar_events.py`) — pre-existing errors on `develop` from the `GetEventCalendarFile` commit, unrelated to this change but needed for mypy to pass. Happy to split them out.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works — full test suite passes, but I did not launch the server; the changes are test infrastructure, CI, and one ordering fix in query construction
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history — no database changes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._