### PR TITLE
Fix KeyError on merch shop Stripe webhooks

### DIFF
--- a/app/backend/src/couchers/servicers/donations.py
+++ b/app/backend/src/couchers/servicers/donations.py
@@ -151,16 +151,20 @@ class Stripe(stripe_pb2_grpc.StripeServicer):
         if event_type == "charge.succeeded":
             if metadata.get("site_url") == config.MERCH_SHOP_URL:
                 # merch shop. look up this email and give them the swagster badge
-                customer_email = metadata["customer_email"]
+                customer_email = metadata.get("customer_email") or data_object["billing_details"].get("email")
                 observe_revenue("merch", int(data_object["amount"]))
                 amount = int(data_object["amount"]) // 100
-                user = session.execute(select(User).where(User.email == customer_email)).scalar_one_or_none()
+                user = (
+                    session.execute(select(User).where(User.email == customer_email)).scalar_one_or_none()
+                    if customer_email
+                    else None
+                )
                 if user:
                     user_add_badge(session, user.id, "swagster")
                     user_link = urls.user_link(username=user.username)
                     customer_info = f"<{user_link}|{user.name}>"
                 else:
-                    customer_info = customer_email
+                    customer_info = customer_email or "unknown email"
                 try:
                     send_slack_message(
                         config.SLACK_MERCH_CHANNEL,

--- a/app/backend/src/tests/test_calendar_events.py
+++ b/app/backend/src/tests/test_calendar_events.py
@@ -122,7 +122,7 @@ END:VCALENDAR
     )
 
 
-def _assert_ics_matches_pattern(actual: str, expected_pattern: str) -> str:
+def _assert_ics_matches_pattern(actual: str, expected_pattern: str) -> None:
     """Assert that an ics file's content matches a pattern that includes "***" wildcards."""
     # Normalize whitespace
     actual = actual.replace("\r\n", "\n").strip()

--- a/app/backend/src/tests/test_donations.py
+++ b/app/backend/src/tests/test_donations.py
@@ -380,6 +380,55 @@ def test_slack_notification_on_merch_purchase_unknown_user(db, monkeypatch):
         assert "test@couchers.org.invalid" in call_args[1]
 
 
+def test_merch_purchase_with_customer_email_metadata(db, monkeypatch):
+    """Test that a customer_email in the metadata takes precedence over the emails on the charge."""
+    user, _ = generate_user(email="test@couchers.org.invalid", last_donated=None)
+
+    new_config = config.copy()
+    new_config.STRIPE_API_KEY = "dummy_api_key"
+    new_config.STRIPE_WEBHOOK_SECRET = "dummy_webhook_secret"
+    new_config.MERCH_SHOP_URL = "https://shop.couchershq.org"
+
+    monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
+
+    event = json.loads(STRIPE_WEBHOOK_EVENTS["evt_merch_charge_succeeded"])
+    event["data"]["object"]["metadata"]["customer_email"] = "test@couchers.org.invalid"
+    event["data"]["object"]["billing_details"]["email"] = "someone.else@couchers.org.invalid"
+    event["data"]["object"]["receipt_email"] = "someone.else@couchers.org.invalid"
+
+    fire_stripe_event_data(event)
+
+    with session_scope() as session:
+        badge = session.execute(
+            select(UserBadge).where(UserBadge.user_id == user.id, UserBadge.badge_id == "swagster")
+        ).scalar_one_or_none()
+        assert badge is not None
+
+
+def test_merch_purchase_without_billing_email(db, monkeypatch):
+    """Test that a merch charge with no billing email doesn't error and doesn't grant badges, even if the receipt email
+    matches a user."""
+    generate_user(email="test@couchers.org.invalid", last_donated=None)
+
+    new_config = config.copy()
+    new_config.STRIPE_API_KEY = "dummy_api_key"
+    new_config.STRIPE_WEBHOOK_SECRET = "dummy_webhook_secret"
+    new_config.MERCH_SHOP_URL = "https://shop.couchershq.org"
+
+    monkeypatch.setattr(couchers.servicers.donations, "config", new_config)
+
+    event = json.loads(STRIPE_WEBHOOK_EVENTS["evt_merch_charge_succeeded"])
+    event["data"]["object"]["billing_details"]["email"] = None
+    event["data"]["object"]["receipt_email"] = "test@couchers.org.invalid"
+
+    with patch("couchers.servicers.donations.send_slack_message") as mock_slack:
+        fire_stripe_event_data(event)
+        assert "unknown email" in mock_slack.call_args[0][1]
+
+    with session_scope() as session:
+        assert not session.execute(select(UserBadge).where(UserBadge.badge_id == "swagster")).all()
+
+
 def test_slack_notification_on_one_time_donation(db, monkeypatch):
     """Test that a Slack notification is sent when a one-time donation is received."""
     user, token = generate_user()
@@ -482,7 +531,10 @@ def test_revenue_metric_on_merch(db, monkeypatch):
 
 
 def fire_stripe_event(event_id):
-    event = json.loads(STRIPE_WEBHOOK_EVENTS[event_id])
+    fire_stripe_event_data(json.loads(STRIPE_WEBHOOK_EVENTS[event_id]))
+
+
+def fire_stripe_event_data(event):
     with real_stripe_session() as api:
         with patch("couchers.servicers.donations.stripe") as mock:
             mock.Webhook.construct_event.return_value = event
@@ -516,7 +568,7 @@ STRIPE_WEBHOOK_EVENTS = {
     "evt_3P5EmzIfR5z29g5k0bxxQl9f": '{"id": "evt_3P5EmzIfR5z29g5k0bxxQl9f", "object": "event", "api_version": "2024-04-10", "created": 1713046273, "data": {"object": {"id": "pi_3P5EmzIfR5z29g5k0uVvI3kX", "object": "payment_intent", "amount": 2500, "amount_capturable": 0, "amount_details": {"tip": {}}, "amount_received": 0, "application": null, "application_fee_amount": null, "automatic_payment_methods": null, "canceled_at": null, "cancellation_reason": null, "capture_method": "automatic", "client_secret": "pi_3P5EmzIfR5z29g5k0uVvI3kX_secret_mw1JYS1lig6dYcy922zoeyzkK", "confirmation_method": "automatic", "created": 1713046273, "currency": "usd", "customer": "cus_Pv4w8dxBpTVUsQ", "description": "Subscription creation", "invoice": "in_1P5EmzIfR5z29g5kNwA5fIXq", "last_payment_error": null, "latest_charge": null, "livemode": false, "metadata": {}, "next_action": null, "on_behalf_of": null, "payment_method": null, "payment_method_configuration_details": null, "payment_method_options": {"card": {"installments": null, "mandate_options": null, "network": null, "request_three_d_secure": "automatic"}, "cashapp": {}}, "payment_method_types": ["card", "cashapp"], "processing": null, "receipt_email": "aapeli@couchers.org", "review": null, "setup_future_usage": "off_session", "shipping": null, "source": null, "statement_descriptor": null, "statement_descriptor_suffix": null, "status": "requires_payment_method", "transfer_data": null, "transfer_group": null}}, "livemode": false, "pending_webhooks": 2, "request": {"id": "req_x1PqgmCHBOPD0i", "idempotency_key": "44ec8acd-be18-4de0-af2e-715760e96725"}, "type": "payment_intent.created"}',
     "evt_3P5EmzIfR5z29g5k0taFsMsl": '{"id": "evt_3P5EmzIfR5z29g5k0taFsMsl", "object": "event", "api_version": "2024-04-10", "created": 1713046274, "data": {"object": {"id": "pi_3P5EmzIfR5z29g5k0uVvI3kX", "object": "payment_intent", "amount": 2500, "amount_capturable": 0, "amount_details": {"tip": {}}, "amount_received": 2500, "application": null, "application_fee_amount": null, "automatic_payment_methods": null, "canceled_at": null, "cancellation_reason": null, "capture_method": "automatic", "client_secret": "pi_3P5EmzIfR5z29g5k0uVvI3kX_secret_mw1JYS1lig6dYcy922zoeyzkK", "confirmation_method": "automatic", "created": 1713046273, "currency": "usd", "customer": "cus_Pv4w8dxBpTVUsQ", "description": "Subscription creation", "invoice": "in_1P5EmzIfR5z29g5kNwA5fIXq", "last_payment_error": null, "latest_charge": "ch_3P5EmzIfR5z29g5k05Mw6ZV2", "livemode": false, "metadata": {}, "next_action": null, "on_behalf_of": null, "payment_method": "pm_1P5EmyIfR5z29g5kAIZoJcSv", "payment_method_configuration_details": null, "payment_method_options": {"card": {"installments": null, "mandate_options": null, "network": null, "request_three_d_secure": "automatic", "setup_future_usage": "off_session"}, "cashapp": {}}, "payment_method_types": ["card", "cashapp"], "processing": null, "receipt_email": "aapeli@couchers.org", "review": null, "setup_future_usage": "off_session", "shipping": null, "source": null, "statement_descriptor": null, "statement_descriptor_suffix": null, "status": "succeeded", "transfer_data": null, "transfer_group": null}}, "livemode": false, "pending_webhooks": 3, "request": {"id": "req_x1PqgmCHBOPD0i", "idempotency_key": "44ec8acd-be18-4de0-af2e-715760e96725"}, "type": "payment_intent.succeeded"}',
     # External shop purchase event
-    "evt_merch_charge_succeeded": '{"id": "evt_merch_charge_succeeded", "object": "event", "api_version": "2024-04-10", "created": 1713046154, "data": {"object": {"id": "ch_merch_test_12345", "object": "charge", "amount": 5000, "amount_captured": 5000, "amount_refunded": 0, "application": null, "application_fee": null, "application_fee_amount": null, "balance_transaction": "txn_merch_test", "billing_details": {"address": {"city": null, "country": "US", "line1": null, "line2": null, "postal_code": "10001", "state": null}, "email": "test@example.org", "name": "Test User", "phone": null}, "calculated_statement_descriptor": "COUCHERS.ORG", "captured": true, "created": 1713046154, "currency": "usd", "customer": "cus_Pv4uq0gT0rDZWN", "description": null, "destination": null, "dispute": null, "disputed": false, "failure_balance_transaction": null, "failure_code": null, "failure_message": null, "fraud_details": {}, "invoice": null, "livemode": false, "metadata": {"site_url": "https://shop.couchershq.org", "order_id": "12345", "customer_email": "test@couchers.org.invalid"}, "on_behalf_of": null, "order": null, "outcome": {"network_status": "approved_by_network", "reason": null, "risk_level": "normal", "risk_score": 31, "seller_message": "Payment complete.", "type": "authorized"}, "paid": true, "payment_intent": "pi_merch_test_12345", "payment_method": "pm_merch_test", "payment_method_details": {"card": {"amount_authorized": 5000, "brand": "visa", "checks": {"address_line1_check": null, "address_postal_code_check": "pass", "cvc_check": "pass"}, "country": "US", "exp_month": 12, "exp_year": 2050, "extended_authorization": {"status": "disabled"}, "fingerprint": "2uVHwVtZ157kRjpi", "funding": "credit", "incremental_authorization": {"status": "unavailable"}, "installments": null, "last4": "4242", "mandate": null, "multicapture": {"status": "unavailable"}, "network": "visa", "network_token": {"used": false}, "overcapture": {"maximum_amount_capturable": 5000, "status": "unavailable"}, "three_d_secure": null, "wallet": null}, "type": "card"}, "radar_options": {}, "receipt_email": "test@example.org", "receipt_number": null, "receipt_url": "https://pay.stripe.com/receipts/merch_test", "refunded": false, "review": null, "shipping": null, "source": null, "source_transfer": null, "statement_descriptor": null, "statement_descriptor_suffix": null, "status": "succeeded", "transfer_data": null, "transfer_group": null}}, "livemode": false, "pending_webhooks": 2, "request": {"id": "req_merch_test", "idempotency_key": "merch-test-key"}, "type": "charge.succeeded"}',
+    "evt_merch_charge_succeeded": '{"id": "evt_merch_charge_succeeded", "object": "event", "api_version": "2024-04-10", "created": 1713046154, "data": {"object": {"id": "ch_merch_test_12345", "object": "charge", "amount": 5000, "amount_captured": 5000, "amount_refunded": 0, "application": null, "application_fee": null, "application_fee_amount": null, "balance_transaction": "txn_merch_test", "billing_details": {"address": {"city": null, "country": "US", "line1": null, "line2": null, "postal_code": "10001", "state": null}, "email": "test@couchers.org.invalid", "name": "Test User", "phone": null}, "calculated_statement_descriptor": "COUCHERS.ORG", "captured": true, "created": 1713046154, "currency": "usd", "customer": null, "description": null, "destination": null, "dispute": null, "disputed": false, "failure_balance_transaction": null, "failure_code": null, "failure_message": null, "fraud_details": {}, "invoice": null, "livemode": false, "metadata": {"checkout_type": "adaptive_pricing_checkout", "site_url": "https://shop.couchershq.org", "payment_type": "single"}, "on_behalf_of": null, "order": null, "outcome": {"network_status": "approved_by_network", "reason": null, "risk_level": "normal", "risk_score": 31, "seller_message": "Payment complete.", "type": "authorized"}, "paid": true, "payment_intent": "pi_merch_test_12345", "payment_method": "pm_merch_test", "payment_method_details": {"card": {"amount_authorized": 5000, "brand": "visa", "checks": {"address_line1_check": null, "address_postal_code_check": "pass", "cvc_check": "pass"}, "country": "US", "exp_month": 12, "exp_year": 2050, "extended_authorization": {"status": "disabled"}, "fingerprint": "2uVHwVtZ157kRjpi", "funding": "credit", "incremental_authorization": {"status": "unavailable"}, "installments": null, "last4": "4242", "mandate": null, "multicapture": {"status": "unavailable"}, "network": "visa", "network_token": {"used": false}, "overcapture": {"maximum_amount_capturable": 5000, "status": "unavailable"}, "three_d_secure": null, "wallet": null}, "type": "card"}, "radar_options": {}, "receipt_email": "test@example.org", "receipt_number": null, "receipt_url": "https://pay.stripe.com/receipts/merch_test", "refunded": false, "review": null, "shipping": null, "source": null, "source_transfer": null, "statement_descriptor": null, "statement_descriptor_suffix": null, "status": "succeeded", "transfer_data": null, "transfer_group": null}}, "livemode": false, "pending_webhooks": 2, "request": {"id": "req_merch_test", "idempotency_key": "merch-test-key"}, "type": "charge.succeeded"}',
 }
 
 one_time_STRIPE_SESSION = json.loads(

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -1986,7 +1986,9 @@ def test_GetEventCalendarFile(db, moderator: Moderator):
         assert "DESCRIPTION:Dummy content." in ics_string
         assert "LOCATION:Near Null Island" in ics_string
         assert "STATUS:CANCELLED" not in ics_string
-        pre_cancel_sequence = int(re.search(r"SEQUENCE:(\d+)", ics_string).group(1))
+        pre_cancel_match = re.search(r"SEQUENCE:(\d+)", ics_string)
+        assert pre_cancel_match is not None
+        pre_cancel_sequence = int(pre_cancel_match.group(1))
 
         api.CancelEvent(events_pb2.CancelEventReq(event_id=event_id))
 
@@ -1994,7 +1996,9 @@ def test_GetEventCalendarFile(db, moderator: Moderator):
         ics_string = file_res.data.decode("utf-8")
         assert "SUMMARY:Cancelled: Dummy Title" in ics_string
         assert "STATUS:CANCELLED" in ics_string
-        post_cancel_sequence = int(re.search(r"SEQUENCE:(\d+)", ics_string).group(1))
+        post_cancel_match = re.search(r"SEQUENCE:(\d+)", ics_string)
+        assert post_cancel_match is not None
+        post_cancel_sequence = int(post_cancel_match.group(1))
         # Ideally the sequence number are strictly ascending, but they are based on timestamps so in tests they could be equal.
         assert post_cancel_sequence >= pre_cancel_sequence
 


### PR DESCRIPTION
`charge.succeeded` webhooks from the merch shop raised `KeyError: 'customer_email'` — the shop no longer puts `customer_email` in the charge metadata (live payloads only carry `checkout_type`, `site_url` and `payment_type`). Since the lookup happened before anything else in that branch, we lost both the merch revenue metric and the swagster badge for every merch purchase.

This isn't a Stripe API change: `metadata` is entirely merchant-set, and the event is still on our pinned `2024-04-10` API version. So we now take the customer email from `metadata.customer_email` when the shop does send it, and otherwise fall back to the charge's own `billing_details.email`. `billing_details.email` is nullable, so a charge with no email at all no longer looks up a user or grants a badge — it just posts "Merch purchase: $X from unknown email" to Slack, and the revenue metric is still recorded.

The existing merch test fixture was fabricated with a `customer_email` metadata key that Stripe never sends, which is why this wasn't caught — it's been replaced with the shape we see in production.

Also fixes three unrelated mypy errors in the event calendar tests (`Missing return statement`, and two `re.search(...).group()` calls on an optional match), which were failing `make mypy` on `develop`.

closes #9344

## Testing

`make mypy` passes and `pytest src/tests/test_donations.py` passes (14 tests). Test changes:

- The `evt_merch_charge_succeeded` fixture now matches a real production payload: no `customer_email` in metadata, buyer email on `billing_details.email`, `customer: null`.
- New `test_merch_purchase_with_customer_email_metadata` — a `customer_email` in metadata wins over a different address on the charge.
- New `test_merch_purchase_without_billing_email` — a charge with no billing email grants no badge and reports "unknown email", even though its `receipt_email` matches a user (we deliberately don't trust `receipt_email`).
- `fire_stripe_event_data()` extracted from `fire_stripe_event()` so tests can fire a modified event.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._
