### PR TITLE
Frontend/i18n: Hide date year when this year

### DIFF
--- a/app/web/features/communities/events/EventCard.tsx
+++ b/app/web/features/communities/events/EventCard.tsx
@@ -132,6 +132,7 @@ export default function EventCard({ event, className }: EventCardProps) {
     timestampToPlainDateTime(event.endTime!, event.timezone),
     {
       locale,
+      includeYear: "auto",
       includeDayOfWeek: true,
       abbreviate: true,
       capitalize: true,

--- a/app/web/features/communities/events/EventPage.test.tsx
+++ b/app/web/features/communities/events/EventPage.test.tsx
@@ -94,7 +94,7 @@ describe("Event page", () => {
     ).toBeVisible();
     expect(await screen.findByText(firstEvent.location!.address)).toBeVisible();
     expect(
-      await screen.findByText("Tuesday, June 29, 2021, 4:37 – 5:37 AM", {
+      await screen.findByText("Tuesday, June 29, 4:37 – 5:37 AM", {
         normalizer: (x) => x, // Match non-breaking spaces and en dashes exactly
       }),
     ).toBeVisible();
@@ -140,7 +140,7 @@ describe("Event page", () => {
 
     expect(
       await screen.findByText(
-        "Tuesday, June 29, 2021 at 11:00 PM – Wednesday, June 30, 2021 at 4:00 AM",
+        "Tuesday, June 29 at 11:00 PM – Wednesday, June 30 at 4:00 AM",
         {
           normalizer: (x) => x, // Match non-breaking spaces and en dashes exactly
         },

--- a/app/web/features/communities/events/EventPage.tsx
+++ b/app/web/features/communities/events/EventPage.tsx
@@ -418,6 +418,7 @@ export default function EventPage({
                     timestampToPlainDateTime(event.endTime!, event.timezone),
                     {
                       locale,
+                      includeYear: "auto",
                       includeDayOfWeek: true,
                       capitalize: true,
                     },

--- a/app/web/features/communities/events/LongEventCard.tsx
+++ b/app/web/features/communities/events/LongEventCard.tsx
@@ -136,6 +136,7 @@ const LongEventCard = ({
     timestampToPlainDateTime(event.endTime!, event.timezone),
     {
       locale,
+      includeYear: "auto",
       includeDayOfWeek: true,
       includeTime: true,
       capitalize: true,

--- a/app/web/features/dashboard/UpcomingStayCard.tsx
+++ b/app/web/features/dashboard/UpcomingStayCard.tsx
@@ -159,6 +159,7 @@ export default function UpcomingStayCard({
 
   const dateRange = localizeDateTimeRange(fromDate, toDate, {
     locale,
+    includeYear: "auto",
     includeTime: false,
     abbreviate: true,
   });

--- a/app/web/features/messages/requests/HostRequestListItem.tsx
+++ b/app/web/features/messages/requests/HostRequestListItem.tsx
@@ -247,6 +247,7 @@ export default function HostRequestListItem({
                     Temporal.PlainDateTime.from(hostRequest.toDate),
                     {
                       locale,
+                      includeYear: "auto",
                       includeTime: false,
                     },
                   )}

--- a/app/web/features/messages/requests/HostRequestUserSummarySection.tsx
+++ b/app/web/features/messages/requests/HostRequestUserSummarySection.tsx
@@ -100,6 +100,7 @@ const HostRequestUserSummarySection = ({
               Temporal.PlainDateTime.from(hostRequest.toDate),
               {
                 locale,
+                includeYear: "auto",
                 includeTime: false,
                 abbreviate: true,
               },
@@ -125,6 +126,7 @@ const HostRequestUserSummarySection = ({
                 Temporal.PlainDateTime.from(hostRequest.toDate),
                 {
                   locale,
+                  includeYear: "auto",
                   includeTime: false,
                 },
               )}

--- a/app/web/utils/date.test.ts
+++ b/app/web/utils/date.test.ts
@@ -15,6 +15,11 @@ import {
 const janFirst2000 = Temporal.PlainDateTime.from("2000-01-01");
 
 describe("localizeDateTime", () => {
+  afterEach(() => {
+    // Clean up after tests that mock the system clock.
+    jest.useRealTimers();
+  });
+
   it("excludes dates when specified", () => {
     expect(
       localizeDateTime(janFirst2000, {
@@ -27,6 +32,37 @@ describe("localizeDateTime", () => {
         includeDate: false,
       }),
     ).not.toContain("2000");
+  });
+
+  it("supports all includeYear modes", () => {
+    expect(
+      localizeDateTime(janFirst2000, {
+        locale: "en",
+        includeYear: true,
+      }),
+    ).toContain("2000");
+    expect(
+      localizeDateTime(janFirst2000, {
+        locale: "en",
+        includeYear: false,
+      }),
+    ).not.toContain("2000");
+
+    // includeYear: "auto" depends on the system date
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2001-01-01T00:00:00Z"));
+    expect(
+      localizeDateTime(janFirst2000, {
+        locale: "en",
+        includeYear: "auto",
+      }),
+    ).toContain("2000");
+    expect(
+      localizeDateTime(Temporal.PlainDateTime.from("2001-01-01"), {
+        locale: "en",
+        includeYear: "auto",
+      }),
+    ).not.toContain("2001");
   });
 
   it("honors abbreviated month names", () => {

--- a/app/web/utils/date.ts
+++ b/app/web/utils/date.ts
@@ -59,6 +59,9 @@ interface LocalizeDateTimeParams {
   locale: string;
   /// Whether to include the date (defaults to true).
   includeDate?: boolean;
+  /// Whether to include the year (defaults to true).
+  /// "auto" omits the year if it matches the current year (browser timezone).
+  includeYear?: boolean | "auto";
   /// If including the date, whether to include the day (defaults to true).
   includeDay?: boolean;
   /// If including the date, whether to include the day of week (defaults to false).
@@ -80,7 +83,7 @@ export function localizeDateTime(
   date: Temporal.ZonedDateTime | Temporal.PlainDateTime | Temporal.PlainDate,
   args: LocalizeDateTimeParams,
 ): string {
-  const format = getIntlDateTimeFormatUTC(args);
+  const format = getIntlDateTimeFormatUTC(args, { year: date.year });
   const formatted = format.format(toDateForUTCDisplay(date));
   return args.capitalize
     ? capitalizeFirstLetter(formatted, args.locale)
@@ -111,7 +114,9 @@ export function localizeDateTimeRange(
   end: Temporal.ZonedDateTime | Temporal.PlainDateTime | Temporal.PlainDate,
   args: LocalizeDateTimeParams,
 ): string {
-  const format = getIntlDateTimeFormatUTC(args);
+  const format = getIntlDateTimeFormatUTC(args, {
+    year: start.year == end.year ? start.year : undefined,
+  });
   const formatted = format.formatRange(
     toDateForUTCDisplay(start),
     toDateForUTCDisplay(end),
@@ -127,12 +132,20 @@ const intlDateTimeFormatCache = new Map<string, Intl.DateTimeFormat>();
 /// Gets an Intl.DateTimeFormat based on params.
 function getIntlDateTimeFormatUTC(
   args: LocalizeDateTimeParams,
+  options: { year: number | undefined },
 ): Intl.DateTimeFormat {
+  // Resolve the auto option since the Intl.DateTimeFormat needs a boolean.
+  if (args.includeYear === "auto") {
+    args = {
+      ...args,
+      includeYear:
+        options.year === undefined || options.year != new Date().getFullYear(),
+    };
+  }
+
   // We can't use args as the Map key as it uses reference equality.
-  // Convert it to a json string. The Symbol type requires special handling.
-  const cacheKey = JSON.stringify(args, (_, v) =>
-    typeof v === "symbol" ? v.toString() : v,
-  );
+  // Convert it to a json string.
+  const cacheKey = JSON.stringify(args);
   const cached = intlDateTimeFormatCache.get(cacheKey);
   if (cached) return cached;
 
@@ -147,7 +160,9 @@ function createIntlDateTimeFormatUTC(
 ): Intl.DateTimeFormat {
   const options: Intl.DateTimeFormatOptions = {};
   if (args.includeDate !== false) {
-    options.year = "numeric";
+    if (args.includeYear !== false) {
+      options.year = "numeric";
+    }
     options.month = args.abbreviate ? "short" : "long";
     if (args.includeDay !== false) {
       options.day = "numeric";
@@ -175,9 +190,7 @@ export function localizeMonthAbbreviation(
     capitalize?: boolean;
   },
 ): string {
-  const cacheKey = JSON.stringify(args, (_, v) =>
-    typeof v === "symbol" ? v.toString() : v,
-  );
+  const cacheKey = JSON.stringify(args);
   let format = intlDateTimeFormatCache.get(cacheKey);
   if (!format) {
     const options: Intl.DateTimeFormatOptions = { month: "short" };


### PR DESCRIPTION
Event datetime ranges can be a mouthful because they include so many pieces of information. We can make it more digestible by only showing the year when it's not the current year.

Next: We could do the same thing and omit minutes if they are 00 (i.e. just show "8 PM to 10 PM")

Fixes #9314

PS: Please review #9335 first!

## Testing
Added tests + ran frontend locally. See the difference between those two events:

<img width="1482" height="481" alt="image" src="https://github.com/user-attachments/assets/6e796f88-4e96-4470-8a5a-7f99e027b6cb" />

Compare the verbosity on NEXT:

<img width="1477" height="462" alt="image" src="https://github.com/user-attachments/assets/73fabaea-4fb1-4cb6-958f-cc7e8ad11f33" />

VS with this change:

<img width="1477" height="471" alt="image" src="https://github.com/user-attachments/assets/66f1f377-a1f9-4d01-9a7c-021d5ce525c1" />

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me