### PR TITLE
Add timewarp test fixture for shifting the clock

### DIFF
--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -40,6 +40,7 @@ from couchers.native_updates import (
 )
 from couchers.proto import bugs_pb2, bugs_pb2_grpc
 from couchers.proto.google.api import httpbody_pb2
+from couchers.utils import now
 
 logger = logging.getLogger(__name__)
 
@@ -285,7 +286,7 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
             except json.JSONDecodeError, ValueError:
                 context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_diagnostics_json")
 
-            occurred = info.occurred.ToDatetime(tzinfo=UTC) if info.HasField("occurred") else datetime.now(UTC)
+            occurred = info.occurred.ToDatetime(tzinfo=UTC) if info.HasField("occurred") else now()
 
             events.append(
                 {
@@ -322,9 +323,9 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
             request.launch_source,
             request.debug_json,
         )
-        now = datetime.now(UTC)
+        checked_at = now()
         banned = _is_update_id_banned(session, info)
-        decision = decide_native_update(context, info, now, banned=banned)
+        decision = decide_native_update(context, info, checked_at, banned=banned)
 
         # An OTA block with no newer bundle to serve would loop the client on the block screen
         # forever, so refuse to serve it: raise (pages via Sentry) and the client, which ignores
@@ -343,7 +344,7 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
                     f"newest_non_banned_created_at={None if newest is None else newest.manifest_created_at})"
                 )
 
-        _observe_native_check_metrics(request, info, decision, now, banned=banned)
+        _observe_native_check_metrics(request, info, decision, checked_at, banned=banned)
 
         if context.is_logged_in():
             session.add(NativeClientUser(eas_client_id=info.eas_client_id, user_id=context.user_id))

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -138,8 +138,14 @@ def datetime_to_iso8601_local(value: datetime) -> str:
     return value.replace(tzinfo=None).isoformat()
 
 
-def now() -> datetime:
+def _real_now() -> datetime:
     return datetime.now(tz=UTC)
+
+
+def now() -> datetime:
+    # everything that reads the clock goes through this call, so tests can move it in one place
+    # by swapping _real_now; see the timewarp fixture
+    return _real_now()
 
 
 def minimum_allowed_birthdate() -> date:
@@ -162,7 +168,7 @@ def now_in_timezone(tz: str) -> datetime:
     """
     tz should be tzdata identifier, e.g. America/New_York
     """
-    return datetime.now(ZoneInfo(tz))
+    return now().astimezone(ZoneInfo(tz))
 
 
 def today_in_timezone(tz: str) -> date:

--- a/app/backend/src/couchers/utils.py
+++ b/app/backend/src/couchers/utils.py
@@ -138,14 +138,14 @@ def datetime_to_iso8601_local(value: datetime) -> str:
     return value.replace(tzinfo=None).isoformat()
 
 
-def _real_now() -> datetime:
+def _mockable_now() -> datetime:
     return datetime.now(tz=UTC)
 
 
 def now() -> datetime:
     # everything that reads the clock goes through this call, so tests can move it in one place
-    # by swapping _real_now; see the timewarp fixture
-    return _real_now()
+    # by swapping _mockable_now; see the timewarp fixture
+    return _mockable_now()
 
 
 def minimum_allowed_birthdate() -> date:

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -27,11 +27,21 @@ from couchers.models import Base  # noqa: E402
 from tests.fixtures import query_log  # noqa: E402
 from tests.fixtures.db import (  # noqa: E402
     autocommit_engine,
+    create_mock_clock,
     create_schema_from_models,
     generate_user,
     populate_testing_resources,
 )
 from tests.fixtures.misc import EmailCollector, Moderator, PushCollector  # noqa: E402
+from tests.fixtures.timewarp import Timewarp, install_timewarp  # noqa: E402
+
+
+@pytest.fixture
+def timewarp() -> Generator[Timewarp]:
+    """
+    Lets a test move the clock; see Timewarp. Request `db` alongside it for the postgres side.
+    """
+    yield from install_timewarp()
 
 QUERY_LOG_DIR = Path(__file__).resolve().parents[2] / "test_artifacts" / "queries"
 
@@ -125,6 +135,13 @@ def setup_testdb(postgres_conn: Connection, testdb_engine: Engine) -> None:
     postgres_conn.execute(text("DROP DATABASE IF EXISTS testdb WITH (FORCE)"))
     postgres_conn.execute(text("CREATE DATABASE testdb"))
 
+    # A column DEFAULT resolves now() once, when the column is created, and stores the function
+    # identity forever after; later search_path changes don't reach it. So mock.now() has to
+    # already shadow pg_catalog.now() on every connection before any DDL runs, which means
+    # setting this at the database level here, ahead of the first connect. The mock schema
+    # doesn't exist yet, which postgres tolerates in a search_path.
+    postgres_conn.execute(text("ALTER DATABASE testdb SET search_path = public, mock, pg_catalog"))
+
     with testdb_engine.connect() as conn:
         conn.execute(
             text(
@@ -135,6 +152,7 @@ def setup_testdb(postgres_conn: Connection, testdb_engine: Engine) -> None:
                 "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"
             )
         )
+        create_mock_clock(conn)
 
         create_schema_from_models(testdb_engine)
         populate_testing_resources(conn)

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -27,21 +27,19 @@ from couchers.models import Base  # noqa: E402
 from tests.fixtures import query_log  # noqa: E402
 from tests.fixtures.db import (  # noqa: E402
     autocommit_engine,
-    create_mock_clock,
     create_schema_from_models,
     generate_user,
     populate_testing_resources,
 )
 from tests.fixtures.misc import EmailCollector, Moderator, PushCollector  # noqa: E402
-from tests.fixtures.timewarp import Timewarp, install_timewarp  # noqa: E402
-
-
-@pytest.fixture
-def timewarp() -> Generator[Timewarp]:
-    """
-    Lets a test move the clock; see Timewarp. Request `db` alongside it for the postgres side.
-    """
-    yield from install_timewarp()
+from tests.fixtures.timewarp import (  # noqa: E402
+    FROZEN_TEST_TIME,
+    MOCK_SEARCH_PATH,
+    FrozenTimewarp,
+    Timewarp,
+    create_mock_clock,
+    install_timewarp,
+)
 
 QUERY_LOG_DIR = Path(__file__).resolve().parents[2] / "test_artifacts" / "queries"
 
@@ -140,7 +138,7 @@ def setup_testdb(postgres_conn: Connection, testdb_engine: Engine) -> None:
     # already shadow pg_catalog.now() on every connection before any DDL runs, which means
     # setting this at the database level here, ahead of the first connect. The mock schema
     # doesn't exist yet, which postgres tolerates in a search_path.
-    postgres_conn.execute(text("ALTER DATABASE testdb SET search_path = public, mock, pg_catalog"))
+    postgres_conn.execute(text(f"ALTER DATABASE testdb SET search_path = {MOCK_SEARCH_PATH}"))
 
     with testdb_engine.connect() as conn:
         conn.execute(
@@ -198,6 +196,26 @@ def db_class(setup_testdb: None, testdb_conn: Connection) -> None:
     The same as above, but with a different scope. Used in test_communities.py.
     """
     _truncate_non_static_tables(testdb_conn)
+
+
+@pytest.fixture
+def timewarp() -> Generator[Timewarp]:
+    """
+    Lets a test move the clock, which keeps running from wherever it's put; see Timewarp.
+
+    Works without `db`, for a test that only reads the clock from python: nothing connects until
+    something runs a query.
+    """
+    yield from install_timewarp(Timewarp())
+
+
+@pytest.fixture
+def frozen_timewarp() -> Generator[FrozenTimewarp]:
+    """
+    Like `timewarp`, but the clock is stopped dead at 2020-01-01 UTC and stays stopped wherever it's
+    moved to, so both python and postgres read back exactly the instant the test asked for.
+    """
+    yield from install_timewarp(FrozenTimewarp(FROZEN_TEST_TIME))
 
 
 # Production gates forced True so tests run as "everything enabled". Used by testconfig and the `flags`

--- a/app/backend/src/tests/fixtures/db.py
+++ b/app/backend/src/tests/fixtures/db.py
@@ -1,5 +1,5 @@
 import subprocess
-from collections.abc import Sequence
+from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from datetime import date, timedelta
 from pathlib import Path
@@ -41,6 +41,30 @@ from couchers.models import (
 from couchers.servicers.auth import create_session
 from couchers.utils import create_coordinate, now
 from tests.fixtures.sessions import _MockCouchersContext
+
+
+def create_mock_clock(conn: Connection) -> None:
+    """
+    Installs mock.now(), the postgres half of the timewarp fixture.
+
+    This lives outside create_schema_from_models because it has to exist before *either* way of
+    building the schema runs, and survive drop_database() in between, so that migrations and
+    models bake the same function into their column defaults.
+    """
+    conn.execute(
+        text("""
+        CREATE SCHEMA mock;
+
+        CREATE FUNCTION mock.now() RETURNS timestamptz
+        LANGUAGE sql STABLE AS $$
+          SELECT pg_catalog.now() + coalesce(
+            nullif(current_setting('mock.offset', true), '')::interval,
+            interval '0'
+          );
+        $$;
+        """)
+    )
+    conn.commit()
 
 
 def create_schema_from_models(engine: Engine | None = None) -> None:
@@ -149,6 +173,39 @@ def drop_database() -> None:
                 "CREATE EXTENSION pg_stat_statements;"
             )
         )
+
+
+@contextmanager
+def without_mock_clock() -> Generator[None]:
+    """
+    Takes mock.now() out of the picture so the schema built inside looks like production's.
+
+    Column defaults bind whichever now() the search_path resolved at DDL time, so a schema built
+    with the mock installed reads DEFAULT mock.now() and doesn't represent prod. The schema is
+    rebuilt with the mock back in place on the way out, since later tests in the session inherit
+    whatever this leaves behind.
+    """
+    engine = _get_base_engine()
+
+    def set_search_path(path: str) -> None:
+        with engine.connect() as conn:
+            conn.execute(text(f"ALTER DATABASE testdb SET search_path = {path}"))
+            conn.commit()
+        # existing pooled connections keep the old search_path
+        engine.dispose()
+
+    with engine.connect() as conn:
+        conn.execute(text("DROP SCHEMA IF EXISTS mock CASCADE"))
+        conn.commit()
+    set_search_path("public, pg_catalog")
+    try:
+        yield
+    finally:
+        set_search_path("public, mock, pg_catalog")
+        with engine.connect() as conn:
+            create_mock_clock(conn)
+        drop_database()
+        create_schema_from_models()
 
 
 @contextmanager

--- a/app/backend/src/tests/fixtures/db.py
+++ b/app/backend/src/tests/fixtures/db.py
@@ -1,5 +1,5 @@
 import subprocess
-from collections.abc import Generator, Sequence
+from collections.abc import Sequence
 from contextlib import contextmanager
 from datetime import date, timedelta
 from pathlib import Path
@@ -173,39 +173,6 @@ def drop_database() -> None:
                 "CREATE EXTENSION pg_stat_statements;"
             )
         )
-
-
-@contextmanager
-def without_mock_clock() -> Generator[None]:
-    """
-    Takes mock.now() out of the picture so the schema built inside looks like production's.
-
-    Column defaults bind whichever now() the search_path resolved at DDL time, so a schema built
-    with the mock installed reads DEFAULT mock.now() and doesn't represent prod. The schema is
-    rebuilt with the mock back in place on the way out, since later tests in the session inherit
-    whatever this leaves behind.
-    """
-    engine = _get_base_engine()
-
-    def set_search_path(path: str) -> None:
-        with engine.connect() as conn:
-            conn.execute(text(f"ALTER DATABASE testdb SET search_path = {path}"))
-            conn.commit()
-        # existing pooled connections keep the old search_path
-        engine.dispose()
-
-    with engine.connect() as conn:
-        conn.execute(text("DROP SCHEMA IF EXISTS mock CASCADE"))
-        conn.commit()
-    set_search_path("public, pg_catalog")
-    try:
-        yield
-    finally:
-        set_search_path("public, mock, pg_catalog")
-        with engine.connect() as conn:
-            create_mock_clock(conn)
-        drop_database()
-        create_schema_from_models()
 
 
 @contextmanager

--- a/app/backend/src/tests/fixtures/db.py
+++ b/app/backend/src/tests/fixtures/db.py
@@ -43,30 +43,6 @@ from couchers.utils import create_coordinate, now
 from tests.fixtures.sessions import _MockCouchersContext
 
 
-def create_mock_clock(conn: Connection) -> None:
-    """
-    Installs mock.now(), the postgres half of the timewarp fixture.
-
-    This lives outside create_schema_from_models because it has to exist before *either* way of
-    building the schema runs, and survive drop_database() in between, so that migrations and
-    models bake the same function into their column defaults.
-    """
-    conn.execute(
-        text("""
-        CREATE SCHEMA mock;
-
-        CREATE FUNCTION mock.now() RETURNS timestamptz
-        LANGUAGE sql STABLE AS $$
-          SELECT pg_catalog.now() + coalesce(
-            nullif(current_setting('mock.offset', true), '')::interval,
-            interval '0'
-          );
-        $$;
-        """)
-    )
-    conn.commit()
-
-
 def create_schema_from_models(engine: Engine | None = None) -> None:
     """
     Create everything from the current models, not incrementally

--- a/app/backend/src/tests/fixtures/timewarp.py
+++ b/app/backend/src/tests/fixtures/timewarp.py
@@ -1,0 +1,83 @@
+from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+from sqlalchemy import Connection, event
+
+from couchers import utils
+from couchers.db import _get_base_engine
+
+
+class Timewarp:
+    """
+    Shifts the clock that both python and postgres read, for tests that need to sit at a particular
+    date or jump around in time.
+
+        timewarp.set_time(datetime(2024, 2, 29, 12, tzinfo=UTC))
+        timewarp.add_time(timedelta(days=30))
+
+    Both clocks keep running, they're just displaced by an offset. Each side applies that offset to
+    its own clock, so the two stay as (im)perfectly aligned as they normally are, and set_time lands
+    within a hair of the instant asked for rather than exactly on it. Postgres also still reports
+    transaction start time, so a long transaction sees its own start rather than a later add_time.
+    """
+
+    def __init__(self) -> None:
+        self.offset = timedelta()
+        self._open_transactions: set[Connection] = set()
+
+    def now(self) -> datetime:
+        return datetime.now(tz=UTC) + self.offset
+
+    def set_time(self, when: datetime) -> None:
+        if when.tzinfo is None:
+            raise ValueError("timewarp needs an aware datetime, this one has no timezone")
+        self._refuse_mid_transaction()
+        self.offset = when - datetime.now(tz=UTC)
+
+    def add_time(self, delta: timedelta) -> None:
+        """Advances the clock, or rewinds it if delta is negative."""
+        self._refuse_mid_transaction()
+        self.offset += delta
+
+    def reset(self) -> None:
+        self._refuse_mid_transaction()
+        self.offset = timedelta()
+
+    def _refuse_mid_transaction(self) -> None:
+        if self._open_transactions:
+            raise RuntimeError(
+                "can't move the clock while a transaction is open: postgres fixes now() at "
+                "transaction start, so this would silently do nothing until the next one. Move the "
+                "clock outside the session_scope block."
+            )
+
+
+def _as_interval(delta: timedelta) -> str:
+    # these three are exact and sum to delta, unlike total_seconds() which is a float
+    return f"{delta.days} days {delta.seconds} seconds {delta.microseconds} microseconds"
+
+
+def install_timewarp() -> Generator[Timewarp]:
+    warp = Timewarp()
+    engine = _get_base_engine()
+
+    # postgres reads the clock through mock.now(), which adds this setting to its own clock. It's
+    # set per transaction so it can't leak into another test via a pooled connection.
+    def sync_db_offset(conn: Connection) -> None:
+        warp._open_transactions.add(conn)
+        conn.exec_driver_sql("SELECT set_config('mock.offset', %s, true)", (_as_interval(warp.offset),))
+
+    def transaction_ended(conn: Connection) -> None:
+        warp._open_transactions.discard(conn)
+
+    event.listen(engine, "begin", sync_db_offset)
+    event.listen(engine, "commit", transaction_ended)
+    event.listen(engine, "rollback", transaction_ended)
+    try:
+        with patch.object(utils, "_real_now", warp.now):
+            yield warp
+    finally:
+        event.remove(engine, "begin", sync_db_offset)
+        event.remove(engine, "commit", transaction_ended)
+        event.remove(engine, "rollback", transaction_ended)

--- a/app/backend/src/tests/fixtures/timewarp.py
+++ b/app/backend/src/tests/fixtures/timewarp.py
@@ -2,55 +2,152 @@ from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
-from sqlalchemy import Connection, event
+from sqlalchemy import Connection, event, text
 
 from couchers import utils
 from couchers.db import _get_base_engine
 
+FROZEN_TEST_TIME = datetime(2020, 1, 1, tzinfo=UTC)
 
-class Timewarp:
+
+class Clock:
     """
-    Shifts the clock that both python and postgres read, for tests that need to sit at a particular
-    date or jump around in time.
+    What the `timewarp` and `frozen_timewarp` fixtures below have in common: a clock that python and
+    postgres both read, and that a test moves with advance(timedelta(days=30)), negative to rewind.
 
-        timewarp.set_time(datetime(2024, 2, 29, 12, tzinfo=UTC))
-        timewarp.add_time(timedelta(days=30))
-
-    Both clocks keep running, they're just displaced by an offset. Each side applies that offset to
-    its own clock, so the two stay as (im)perfectly aligned as they normally are, and set_time lands
-    within a hair of the instant asked for rather than exactly on it. Postgres also still reports
-    transaction start time, so a long transaction sees its own start rather than a later add_time.
+    Whether it ticks is a property of the fixture the test asked for rather than something it can
+    turn on and off partway through, so the two are separate clocks rather than one with a mode.
+    Each puts the clock at an instant under its own name, run_from and freeze_at, so a call site
+    says which kind of clock it's talking to.
     """
 
     def __init__(self) -> None:
-        self.offset = timedelta()
         self._open_transactions: set[Connection] = set()
 
     def now(self) -> datetime:
-        return datetime.now(tz=UTC) + self.offset
+        raise NotImplementedError
 
-    def set_time(self, when: datetime) -> None:
-        if when.tzinfo is None:
-            raise ValueError("timewarp needs an aware datetime, this one has no timezone")
-        self._refuse_mid_transaction()
-        self.offset = when - datetime.now(tz=UTC)
-
-    def add_time(self, delta: timedelta) -> None:
-        """Advances the clock, or rewinds it if delta is negative."""
-        self._refuse_mid_transaction()
-        self.offset += delta
-
-    def reset(self) -> None:
-        self._refuse_mid_transaction()
-        self.offset = timedelta()
+    def _db_settings(self) -> tuple[str, str]:
+        """What postgres needs to read this same clock, as (mock.offset, mock.frozen_at)."""
+        raise NotImplementedError
 
     def _refuse_mid_transaction(self) -> None:
         if self._open_transactions:
             raise RuntimeError(
-                "can't move the clock while a transaction is open: postgres fixes now() at "
-                "transaction start, so this would silently do nothing until the next one. Move the "
-                "clock outside the session_scope block."
+                "can't move the clock while a transaction is open: postgres reads the clock as it "
+                "was at transaction start, so this would silently do nothing until the next one. "
+                "Move the clock outside the session_scope block."
             )
+
+
+class Timewarp(Clock):
+    """
+    A clock that keeps running, displaced from the real one by an offset. Each side applies that
+    offset to its own clock, so the two stay as (im)perfectly aligned as they normally are, and
+    run_from lands within a hair of the instant asked for rather than exactly on it. Postgres also
+    still reports transaction start time, so a long transaction sees its own start rather than a
+    later advance.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.offset = timedelta()
+
+    def now(self) -> datetime:
+        return datetime.now(tz=UTC) + self.offset
+
+    def run_from(self, when: datetime) -> None:
+        """Sets the clock to `when` and lets it tick on from there."""
+        _check_aware(when)
+        self._refuse_mid_transaction()
+        self.offset = when - datetime.now(tz=UTC)
+
+    def advance(self, delta: timedelta) -> None:
+        """Moves the clock forwards, or backwards if delta is negative."""
+        self._refuse_mid_transaction()
+        self.offset += delta
+
+    def _db_settings(self) -> tuple[str, str]:
+        return _as_interval(self.offset), ""
+
+
+class FrozenTimewarp(Clock):
+    """
+    A clock stopped dead at one instant, so both sides read back exactly that rather than ticking on
+    from there. freeze_at and advance move it to another standstill.
+    """
+
+    def __init__(self, at: datetime) -> None:
+        super().__init__()
+        _check_aware(at)
+        # utils.now() is UTC-aware everywhere else, and callers do read the tzinfo off it
+        self.frozen_at = at.astimezone(UTC)
+
+    def now(self) -> datetime:
+        return self.frozen_at
+
+    def freeze_at(self, when: datetime) -> None:
+        """Stops the clock at `when` instead of wherever it was stopped before."""
+        _check_aware(when)
+        self._refuse_mid_transaction()
+        self.frozen_at = when.astimezone(UTC)
+
+    def advance(self, delta: timedelta) -> None:
+        """Moves the clock forwards, or backwards if delta is negative."""
+        self._refuse_mid_transaction()
+        self.frozen_at += delta
+
+    def _db_settings(self) -> tuple[str, str]:
+        return "", self.frozen_at.isoformat()
+
+
+def _check_aware(when: datetime) -> None:
+    if when.tzinfo is None:
+        raise ValueError("timewarp needs an aware datetime, this one has no timezone")
+
+
+# mock goes ahead of pg_catalog so that an unqualified now() finds mock.now() first
+MOCK_SEARCH_PATH = "public, mock, pg_catalog"
+
+
+def create_mock_clock(conn: Connection) -> None:
+    """
+    Installs mock.now(), the postgres half of this fixture: the frozen instant if there is one, and
+    otherwise postgres' own clock displaced by the offset. Both settings are read per transaction,
+    and set by install_timewarp below.
+
+    This lives outside create_schema_from_models because it has to exist before *either* way of
+    building the schema runs, and survive drop_database() in between, so that migrations and
+    models bake the same function into their column defaults.
+    """
+    conn.execute(
+        text("""
+        CREATE SCHEMA mock;
+
+        CREATE FUNCTION mock.now() RETURNS timestamptz
+        LANGUAGE sql STABLE AS $$
+          SELECT coalesce(
+            nullif(current_setting('mock.frozen_at', true), '')::timestamptz,
+            pg_catalog.now() + coalesce(
+              nullif(current_setting('mock.offset', true), '')::interval,
+              interval '0'
+            )
+          );
+        $$;
+        """)
+    )
+    conn.commit()
+
+
+def mock_clock_installed(conn: Connection) -> bool:
+    """
+    Whether this database has the mock clock, ie whether shifting it does anything at all. In one
+    built without it, an unqualified now() is still pg_catalog.now() and reports the real time.
+    """
+    installed: bool = conn.exec_driver_sql(
+        "SELECT to_regprocedure('now()') IS NOT DISTINCT FROM to_regprocedure('mock.now()')"
+    ).scalar_one()
+    return installed
 
 
 def _as_interval(delta: timedelta) -> str:
@@ -58,26 +155,37 @@ def _as_interval(delta: timedelta) -> str:
     return f"{delta.days} days {delta.seconds} seconds {delta.microseconds} microseconds"
 
 
-def install_timewarp() -> Generator[Timewarp]:
-    warp = Timewarp()
+def install_timewarp[WarpT: Clock](warp: WarpT) -> Generator[WarpT]:
+    # the engine is only connected to once something runs a query, so this is fine without the db fixture
     engine = _get_base_engine()
 
-    # postgres reads the clock through mock.now(), which adds this setting to its own clock. It's
-    # set per transaction so it can't leak into another test via a pooled connection.
-    def sync_db_offset(conn: Connection) -> None:
+    # postgres reads the clock through mock.now(), which returns mock.frozen_at if there is one and
+    # otherwise adds mock.offset to its own clock. Both are set per transaction so they can't leak
+    # into another test via a pooled connection.
+    def sync_db_clock(conn: Connection) -> None:
+        conn.exec_driver_sql(
+            "SELECT set_config('mock.offset', %s, true), set_config('mock.frozen_at', %s, true)",
+            warp._db_settings(),
+        )
+        if not mock_clock_installed(conn):
+            raise RuntimeError(
+                "timewarp can't move the postgres clock in this database: now() still resolves to "
+                "pg_catalog.now(), so the database would quietly report the real time. mock.now() "
+                "is installed when the test database is built, so request the `db` fixture in any "
+                "test that uses timewarp and touches the database."
+            )
         warp._open_transactions.add(conn)
-        conn.exec_driver_sql("SELECT set_config('mock.offset', %s, true)", (_as_interval(warp.offset),))
 
     def transaction_ended(conn: Connection) -> None:
         warp._open_transactions.discard(conn)
 
-    event.listen(engine, "begin", sync_db_offset)
+    event.listen(engine, "begin", sync_db_clock)
     event.listen(engine, "commit", transaction_ended)
     event.listen(engine, "rollback", transaction_ended)
     try:
-        with patch.object(utils, "_real_now", warp.now):
+        with patch.object(utils, "_mockable_now", warp.now):
             yield warp
     finally:
-        event.remove(engine, "begin", sync_db_offset)
+        event.remove(engine, "begin", sync_db_clock)
         event.remove(engine, "commit", transaction_ended)
         event.remove(engine, "rollback", transaction_ended)

--- a/app/backend/src/tests/test_db.py
+++ b/app/backend/src/tests/test_db.py
@@ -28,6 +28,7 @@ from tests.fixtures.db import (
     generate_user,
     pg_dump_is_available,
     populate_testing_resources,
+    without_mock_clock,
 )
 from tests.test_communities import create_1d_point, get_community_id, testing_communities  # noqa
 
@@ -186,7 +187,8 @@ def strip_leading_whitespace(lines: list[str]) -> list[str]:
 @pytest.fixture
 def restore_db_after_migration_test(db):
     try:
-        yield
+        with without_mock_clock():
+            yield
     finally:
         # Dispose the engine's connection pool since we dropped/recreated PostGIS extension,
         # which invalidates cached operator OIDs in existing connections

--- a/app/backend/src/tests/test_db.py
+++ b/app/backend/src/tests/test_db.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 from google.protobuf import empty_pb2
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.sql import func
 
 from couchers.config import config
@@ -27,8 +27,6 @@ from tests.fixtures.db import (
     drop_database,
     generate_user,
     pg_dump_is_available,
-    populate_testing_resources,
-    without_mock_clock,
 )
 from tests.test_communities import create_1d_point, get_community_id, testing_communities  # noqa
 
@@ -185,25 +183,35 @@ def strip_leading_whitespace(lines: list[str]) -> list[str]:
 
 
 @pytest.fixture
-def restore_db_after_migration_test(db):
-    try:
-        with without_mock_clock():
-            yield
-    finally:
-        # Dispose the engine's connection pool since we dropped/recreated PostGIS extension,
-        # which invalidates cached operator OIDs in existing connections
-        engine = _get_base_engine()
-        engine.dispose()
+def migration_test_db(postgres_conn):
+    """
+    Points everything at a scratch database for the duration of the test.
 
-        # Restore test resources since we destroyed the database
-        # This is needed because setup_testdb is session-scoped and won't run again
-        with engine.connect() as conn:
-            populate_testing_resources(conn)
-            conn.commit()
+    The schemas compared here should look like production's, and testdb doesn't: its column
+    defaults bind mock.now() so the timewarp fixture can shift the clock. Building somewhere else
+    keeps the mock out of both dumps and leaves testdb alone, which this test would otherwise
+    destroy and have to rebuild.
+    """
+    postgres_conn.execute(text("DROP DATABASE IF EXISTS migrationtestdb WITH (FORCE)"))
+    postgres_conn.execute(text("CREATE DATABASE migrationtestdb"))
+
+    previous_dsn = config.DATABASE_CONNECTION_STRING
+    config.DATABASE_CONNECTION_STRING = re.sub(r"/testdb$", "/migrationtestdb", previous_dsn)
+    # the cached engine still points at testdb, and clearing the cache would drop it with its
+    # pooled connections still open
+    _get_base_engine().dispose()
+    _get_base_engine.cache_clear()
+    try:
+        yield
+    finally:
+        _get_base_engine().dispose()
+        config.DATABASE_CONNECTION_STRING = previous_dsn
+        _get_base_engine.cache_clear()
+        postgres_conn.execute(text("DROP DATABASE IF EXISTS migrationtestdb WITH (FORCE)"))
 
 
 @pytest.mark.skipif(not pg_dump_is_available(), reason="Can't run migration tests without pg_dump")
-def test_migrations(db, testconfig: dict[str, Any], restore_db_after_migration_test) -> None:
+def test_migrations(testconfig: dict[str, Any], migration_test_db) -> None:
     """
     Compares the database schema built up from migrations with the
     schema built by models.py. Both scenarios are started from an

--- a/app/backend/src/tests/test_timewarp.py
+++ b/app/backend/src/tests/test_timewarp.py
@@ -1,13 +1,16 @@
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 import pytest
 from sqlalchemy import func, select
 from sqlalchemy.sql import text
 
+import tests.fixtures.timewarp
 from couchers.db import session_scope
 from couchers.models import BackgroundJob
 from couchers.utils import now, now_in_timezone, today
-from tests.fixtures.timewarp import Timewarp
+from tests.fixtures.timewarp import FROZEN_TEST_TIME, FrozenTimewarp, Timewarp, mock_clock_installed
 
 LEAP_DAY = datetime(2024, 2, 29, 12, 0, 0, tzinfo=UTC)
 
@@ -28,41 +31,41 @@ def db_now() -> datetime:
         return session.execute(select(func.now())).scalar_one()
 
 
-def test_set_time_moves_both_clocks(db, timewarp: Timewarp) -> None:
-    timewarp.set_time(LEAP_DAY)
+def test_run_from_moves_both_clocks(db, timewarp: Timewarp) -> None:
+    timewarp.run_from(LEAP_DAY)
     assert_close(now(), LEAP_DAY)
     assert_close(db_now(), LEAP_DAY)
 
 
-def test_add_time_moves_both_clocks(db, timewarp: Timewarp) -> None:
-    timewarp.set_time(LEAP_DAY)
-    timewarp.add_time(timedelta(days=30))
+def test_advance_moves_both_clocks(db, timewarp: Timewarp) -> None:
+    timewarp.run_from(LEAP_DAY)
+    timewarp.advance(timedelta(days=30))
     assert_close(now(), LEAP_DAY + timedelta(days=30))
     assert_close(db_now(), LEAP_DAY + timedelta(days=30))
 
 
-def test_add_time_rewinds(db, timewarp: Timewarp) -> None:
-    timewarp.set_time(LEAP_DAY)
-    timewarp.add_time(-timedelta(hours=6))
+def test_advance_rewinds(db, timewarp: Timewarp) -> None:
+    timewarp.run_from(LEAP_DAY)
+    timewarp.advance(-timedelta(hours=6))
     assert_close(now(), LEAP_DAY - timedelta(hours=6))
     assert_close(db_now(), LEAP_DAY - timedelta(hours=6))
 
 
-def test_add_time_without_set_time_shifts_the_real_clock(db, timewarp: Timewarp) -> None:
+def test_advance_without_setting_a_time_shifts_the_real_clock(db, timewarp: Timewarp) -> None:
     before = datetime.now(tz=UTC)
-    timewarp.add_time(timedelta(days=365))
+    timewarp.advance(timedelta(days=365))
     assert before + timedelta(days=365) <= now() <= datetime.now(tz=UTC) + timedelta(days=365)
 
 
 def test_the_clocks_keep_running(db, timewarp: Timewarp) -> None:
-    timewarp.set_time(LEAP_DAY)
+    timewarp.run_from(LEAP_DAY)
     first, first_db = now(), db_now()
     assert now() > first
     assert db_now() > first_db
 
 
 def test_server_default_respects_the_warp(db, timewarp: Timewarp) -> None:
-    timewarp.set_time(LEAP_DAY)
+    timewarp.run_from(LEAP_DAY)
     with session_scope() as session:
         job = make_job()
         session.add(job)
@@ -73,7 +76,7 @@ def test_server_default_respects_the_warp(db, timewarp: Timewarp) -> None:
 
 def test_warp_persists_across_transactions(db, timewarp: Timewarp) -> None:
     """The setting is per-transaction, so each new session has to pick the offset up again."""
-    timewarp.set_time(LEAP_DAY)
+    timewarp.run_from(LEAP_DAY)
     with session_scope() as session:
         session.add(make_job())
     with session_scope() as session:
@@ -81,10 +84,10 @@ def test_warp_persists_across_transactions(db, timewarp: Timewarp) -> None:
 
 
 def test_rows_inserted_at_different_times_differ(db, timewarp: Timewarp) -> None:
-    timewarp.set_time(LEAP_DAY)
+    timewarp.run_from(LEAP_DAY)
     with session_scope() as session:
         session.add(make_job())
-    timewarp.add_time(timedelta(days=1))
+    timewarp.advance(timedelta(days=1))
     with session_scope() as session:
         session.add(make_job())
     with session_scope() as session:
@@ -95,7 +98,7 @@ def test_rows_inserted_at_different_times_differ(db, timewarp: Timewarp) -> None
 
 def test_two_inserts_in_one_transaction_agree(db, timewarp: Timewarp) -> None:
     """Postgres reports transaction start time, so the clock running doesn't split these apart."""
-    timewarp.set_time(LEAP_DAY)
+    timewarp.run_from(LEAP_DAY)
     with session_scope() as session:
         first, second = make_job(), make_job()
         session.add(first)
@@ -109,30 +112,23 @@ def test_two_inserts_in_one_transaction_agree(db, timewarp: Timewarp) -> None:
 def test_query_time_now_is_warped(db, timewarp: Timewarp) -> None:
     """Unqualified now() in a WHERE clause resolves through search_path too, so hybrid properties
     like BackgroundJob.ready_for_retry see the warped clock."""
-    timewarp.set_time(LEAP_DAY)
+    timewarp.run_from(LEAP_DAY)
     with session_scope() as session:
         session.add(make_job())
 
-    timewarp.add_time(-timedelta(days=1))
+    timewarp.advance(-timedelta(days=1))
     with session_scope() as session:
         assert session.execute(select(BackgroundJob).where(BackgroundJob.ready_for_retry)).all() == []
 
-    timewarp.add_time(timedelta(days=2))
+    timewarp.advance(timedelta(days=2))
     with session_scope() as session:
         assert session.execute(select(BackgroundJob).where(BackgroundJob.ready_for_retry)).one()
 
 
 def test_derived_python_helpers_follow(db, timewarp: Timewarp) -> None:
-    timewarp.set_time(LEAP_DAY)
+    timewarp.run_from(LEAP_DAY)
     assert today() == LEAP_DAY.date()
     assert_close(now_in_timezone("America/New_York"), LEAP_DAY)
-
-
-def test_reset_restores_both_clocks(db, timewarp: Timewarp) -> None:
-    timewarp.set_time(LEAP_DAY)
-    timewarp.reset()
-    assert_close(now(), datetime.now(tz=UTC))
-    assert_close(db_now(), datetime.now(tz=UTC))
 
 
 def test_moving_the_clock_mid_transaction_raises(db, timewarp: Timewarp) -> None:
@@ -140,7 +136,7 @@ def test_moving_the_clock_mid_transaction_raises(db, timewarp: Timewarp) -> None
         with session_scope() as session:
             session.add(make_job())
             session.flush()
-            timewarp.add_time(timedelta(days=1))
+            timewarp.advance(timedelta(days=1))
 
 
 def test_no_complaint_before_the_transaction_touches_the_database(db, timewarp: Timewarp) -> None:
@@ -148,7 +144,7 @@ def test_no_complaint_before_the_transaction_touches_the_database(db, timewarp: 
     now() and the clock is still free to move."""
     with session_scope() as session:
         session.add(make_job())
-        timewarp.set_time(LEAP_DAY)
+        timewarp.run_from(LEAP_DAY)
         session.flush()
         assert_close(session.execute(select(BackgroundJob)).scalar_one().queued, LEAP_DAY)
 
@@ -156,7 +152,7 @@ def test_no_complaint_before_the_transaction_touches_the_database(db, timewarp: 
 def test_the_clock_is_movable_again_after_the_transaction(db, timewarp: Timewarp) -> None:
     with session_scope() as session:
         session.add(make_job())
-    timewarp.set_time(LEAP_DAY)
+    timewarp.run_from(LEAP_DAY)
     assert_close(db_now(), LEAP_DAY)
 
 
@@ -165,13 +161,154 @@ def test_a_rolled_back_transaction_doesnt_wedge_the_clock(db, timewarp: Timewarp
         with session_scope() as session:
             session.add(make_job())
             raise ZeroDivisionError
-    timewarp.set_time(LEAP_DAY)
+    timewarp.run_from(LEAP_DAY)
     assert_close(db_now(), LEAP_DAY)
 
 
 def test_naive_datetime_rejected(timewarp: Timewarp) -> None:
     with pytest.raises(ValueError, match="aware datetime"):
-        timewarp.set_time(datetime(2024, 2, 29, 12, 0, 0))
+        timewarp.run_from(datetime(2024, 2, 29, 12, 0, 0))
+
+
+def test_both_clocks_start_at_the_frozen_test_time(db, frozen_timewarp: FrozenTimewarp) -> None:
+    assert now() == datetime(2020, 1, 1, tzinfo=UTC) == FROZEN_TEST_TIME
+    assert now().tzinfo is UTC
+    assert db_now() == FROZEN_TEST_TIME
+    assert now_in_timezone("Australia/Brisbane").hour == 10
+
+
+def test_a_clock_frozen_at_the_test_time_still_moves(db, frozen_timewarp: FrozenTimewarp) -> None:
+    frozen_timewarp.advance(timedelta(days=1))
+    assert now() == FROZEN_TEST_TIME + timedelta(days=1)
+    assert db_now() == FROZEN_TEST_TIME + timedelta(days=1)
+
+
+def test_freeze_at_moves_both_frozen_clocks(db, frozen_timewarp: FrozenTimewarp) -> None:
+    frozen_timewarp.freeze_at(LEAP_DAY)
+    assert now() == LEAP_DAY
+    assert db_now() == LEAP_DAY
+
+
+def test_a_frozen_clock_doesnt_tick(db, frozen_timewarp: FrozenTimewarp) -> None:
+    frozen_timewarp.freeze_at(LEAP_DAY)
+    assert now() == now() == LEAP_DAY
+    assert db_now() == db_now() == LEAP_DAY
+
+
+def test_advance_while_frozen_stays_frozen(db, frozen_timewarp: FrozenTimewarp) -> None:
+    frozen_timewarp.freeze_at(LEAP_DAY)
+    frozen_timewarp.advance(timedelta(days=30))
+    assert now() == LEAP_DAY + timedelta(days=30)
+    assert db_now() == LEAP_DAY + timedelta(days=30)
+
+
+def test_advance_while_frozen_rewinds(db, frozen_timewarp: FrozenTimewarp) -> None:
+    frozen_timewarp.freeze_at(LEAP_DAY)
+    frozen_timewarp.advance(-timedelta(hours=6))
+    assert now() == LEAP_DAY - timedelta(hours=6)
+    assert db_now() == LEAP_DAY - timedelta(hours=6)
+
+
+def test_server_default_is_frozen(db, frozen_timewarp: FrozenTimewarp) -> None:
+    frozen_timewarp.freeze_at(LEAP_DAY)
+    with session_scope() as session:
+        job = make_job()
+        session.add(job)
+        session.flush()
+        assert job.queued == LEAP_DAY
+
+
+def test_frozen_rows_inserted_at_different_times_differ(db, frozen_timewarp: FrozenTimewarp) -> None:
+    frozen_timewarp.freeze_at(LEAP_DAY)
+    with session_scope() as session:
+        session.add(make_job())
+    frozen_timewarp.advance(timedelta(days=1))
+    with session_scope() as session:
+        session.add(make_job())
+    with session_scope() as session:
+        first, second = session.execute(select(BackgroundJob.queued).order_by(BackgroundJob.queued)).scalars().all()
+    assert first == LEAP_DAY
+    assert second == LEAP_DAY + timedelta(days=1)
+
+
+def test_query_time_now_is_frozen(db, frozen_timewarp: FrozenTimewarp) -> None:
+    frozen_timewarp.freeze_at(LEAP_DAY)
+    with session_scope() as session:
+        session.add(make_job())
+
+    frozen_timewarp.advance(-timedelta(days=1))
+    with session_scope() as session:
+        assert session.execute(select(BackgroundJob).where(BackgroundJob.ready_for_retry)).all() == []
+
+    frozen_timewarp.advance(timedelta(days=2))
+    with session_scope() as session:
+        assert session.execute(select(BackgroundJob).where(BackgroundJob.ready_for_retry)).one()
+
+
+def test_derived_python_helpers_follow_a_frozen_clock(db, frozen_timewarp: FrozenTimewarp) -> None:
+    frozen_timewarp.freeze_at(LEAP_DAY)
+    assert today() == LEAP_DAY.date()
+    assert now_in_timezone("America/New_York") == LEAP_DAY
+
+
+def test_setting_a_frozen_clock_mid_transaction_raises(db, frozen_timewarp: FrozenTimewarp) -> None:
+    with pytest.raises(RuntimeError, match="while a transaction is open"):
+        with session_scope() as session:
+            session.add(make_job())
+            session.flush()
+            frozen_timewarp.freeze_at(LEAP_DAY)
+
+
+def test_moving_a_frozen_clock_mid_transaction_raises(db, frozen_timewarp: FrozenTimewarp) -> None:
+    frozen_timewarp.freeze_at(LEAP_DAY)
+    with pytest.raises(RuntimeError, match="while a transaction is open"):
+        with session_scope() as session:
+            session.add(make_job())
+            session.flush()
+            frozen_timewarp.advance(timedelta(days=1))
+
+
+def test_a_frozen_clock_rejects_naive_datetimes(frozen_timewarp: FrozenTimewarp) -> None:
+    with pytest.raises(ValueError, match="aware datetime"):
+        frozen_timewarp.freeze_at(datetime(2024, 2, 29, 12, 0, 0))
+
+
+def test_a_frozen_clock_reads_back_in_utc(db, frozen_timewarp: FrozenTimewarp) -> None:
+    """Like the real utils.now(), whatever timezone the instant was handed over in."""
+    frozen_timewarp.freeze_at(datetime(2024, 2, 29, 12, tzinfo=ZoneInfo("Australia/Brisbane")))
+    assert now().tzinfo is UTC
+    assert now() == datetime(2024, 2, 29, 2, tzinfo=UTC)
+    assert today() == date(2024, 2, 29)
+
+
+def test_the_clock_moves_without_the_db_fixture(frozen_timewarp: FrozenTimewarp) -> None:
+    """A test that only reads the clock from python doesn't need the database built for it."""
+    frozen_timewarp.freeze_at(LEAP_DAY)
+    assert now() == LEAP_DAY
+
+
+def test_a_database_without_the_mock_clock_is_noticed(db) -> None:
+    """What the `begin` listener checks before letting a warped test talk to the database, since an
+    unwarped now() would silently report the real time."""
+    with session_scope() as session:
+        assert mock_clock_installed(session.connection())
+
+        session.execute(text("SET LOCAL search_path = public, pg_catalog"))
+        assert not mock_clock_installed(session.connection())
+
+        # mock.now() exists but doesn't shadow anything, so unqualified now() is still the real one
+        session.execute(text("SET LOCAL search_path = pg_catalog, mock"))
+        assert not mock_clock_installed(session.connection())
+
+
+def test_touching_a_database_without_the_mock_clock_raises(db, timewarp: Timewarp) -> None:
+    with patch.object(tests.fixtures.timewarp, "mock_clock_installed", lambda conn: False):
+        with pytest.raises(RuntimeError, match="can't move the postgres clock"):
+            db_now()
+
+    # the transaction that never got off the ground isn't left counting as open
+    timewarp.run_from(LEAP_DAY)
+    assert_close(db_now(), LEAP_DAY)
 
 
 def test_clock_is_real_without_the_fixture(db) -> None:

--- a/app/backend/src/tests/test_timewarp.py
+++ b/app/backend/src/tests/test_timewarp.py
@@ -1,0 +1,199 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.sql import text
+
+from couchers.db import session_scope
+from couchers.models import BackgroundJob
+from couchers.utils import now, now_in_timezone, today
+from tests.fixtures.timewarp import Timewarp
+
+LEAP_DAY = datetime(2024, 2, 29, 12, 0, 0, tzinfo=UTC)
+
+# the clocks keep running while a test does its work, and postgres' differs from ours by a hair
+TOLERANCE = timedelta(seconds=1)
+
+
+def assert_close(actual: datetime, expected: datetime) -> None:
+    assert abs(actual - expected) < TOLERANCE, f"{actual} is not within {TOLERANCE} of {expected}"
+
+
+def make_job() -> BackgroundJob:
+    return BackgroundJob(job_type="dummy_job", payload=b"")
+
+
+def db_now() -> datetime:
+    with session_scope() as session:
+        return session.execute(select(func.now())).scalar_one()
+
+
+def test_set_time_moves_both_clocks(db, timewarp: Timewarp) -> None:
+    timewarp.set_time(LEAP_DAY)
+    assert_close(now(), LEAP_DAY)
+    assert_close(db_now(), LEAP_DAY)
+
+
+def test_add_time_moves_both_clocks(db, timewarp: Timewarp) -> None:
+    timewarp.set_time(LEAP_DAY)
+    timewarp.add_time(timedelta(days=30))
+    assert_close(now(), LEAP_DAY + timedelta(days=30))
+    assert_close(db_now(), LEAP_DAY + timedelta(days=30))
+
+
+def test_add_time_rewinds(db, timewarp: Timewarp) -> None:
+    timewarp.set_time(LEAP_DAY)
+    timewarp.add_time(-timedelta(hours=6))
+    assert_close(now(), LEAP_DAY - timedelta(hours=6))
+    assert_close(db_now(), LEAP_DAY - timedelta(hours=6))
+
+
+def test_add_time_without_set_time_shifts_the_real_clock(db, timewarp: Timewarp) -> None:
+    before = datetime.now(tz=UTC)
+    timewarp.add_time(timedelta(days=365))
+    assert before + timedelta(days=365) <= now() <= datetime.now(tz=UTC) + timedelta(days=365)
+
+
+def test_the_clocks_keep_running(db, timewarp: Timewarp) -> None:
+    timewarp.set_time(LEAP_DAY)
+    first, first_db = now(), db_now()
+    assert now() > first
+    assert db_now() > first_db
+
+
+def test_server_default_respects_the_warp(db, timewarp: Timewarp) -> None:
+    timewarp.set_time(LEAP_DAY)
+    with session_scope() as session:
+        job = make_job()
+        session.add(job)
+        session.flush()
+        assert_close(job.queued, LEAP_DAY)
+        assert_close(job.next_attempt_after, LEAP_DAY)
+
+
+def test_warp_persists_across_transactions(db, timewarp: Timewarp) -> None:
+    """The setting is per-transaction, so each new session has to pick the offset up again."""
+    timewarp.set_time(LEAP_DAY)
+    with session_scope() as session:
+        session.add(make_job())
+    with session_scope() as session:
+        assert_close(session.execute(select(BackgroundJob)).scalar_one().queued, LEAP_DAY)
+
+
+def test_rows_inserted_at_different_times_differ(db, timewarp: Timewarp) -> None:
+    timewarp.set_time(LEAP_DAY)
+    with session_scope() as session:
+        session.add(make_job())
+    timewarp.add_time(timedelta(days=1))
+    with session_scope() as session:
+        session.add(make_job())
+    with session_scope() as session:
+        first, second = session.execute(select(BackgroundJob.queued).order_by(BackgroundJob.queued)).scalars().all()
+    assert_close(first, LEAP_DAY)
+    assert_close(second, LEAP_DAY + timedelta(days=1))
+
+
+def test_two_inserts_in_one_transaction_agree(db, timewarp: Timewarp) -> None:
+    """Postgres reports transaction start time, so the clock running doesn't split these apart."""
+    timewarp.set_time(LEAP_DAY)
+    with session_scope() as session:
+        first, second = make_job(), make_job()
+        session.add(first)
+        session.flush()
+        session.add(second)
+        session.flush()
+        assert first.queued == second.queued
+        assert_close(first.queued, LEAP_DAY)
+
+
+def test_query_time_now_is_warped(db, timewarp: Timewarp) -> None:
+    """Unqualified now() in a WHERE clause resolves through search_path too, so hybrid properties
+    like BackgroundJob.ready_for_retry see the warped clock."""
+    timewarp.set_time(LEAP_DAY)
+    with session_scope() as session:
+        session.add(make_job())
+
+    timewarp.add_time(-timedelta(days=1))
+    with session_scope() as session:
+        assert session.execute(select(BackgroundJob).where(BackgroundJob.ready_for_retry)).all() == []
+
+    timewarp.add_time(timedelta(days=2))
+    with session_scope() as session:
+        assert session.execute(select(BackgroundJob).where(BackgroundJob.ready_for_retry)).one()
+
+
+def test_derived_python_helpers_follow(db, timewarp: Timewarp) -> None:
+    timewarp.set_time(LEAP_DAY)
+    assert today() == LEAP_DAY.date()
+    assert_close(now_in_timezone("America/New_York"), LEAP_DAY)
+
+
+def test_reset_restores_both_clocks(db, timewarp: Timewarp) -> None:
+    timewarp.set_time(LEAP_DAY)
+    timewarp.reset()
+    assert_close(now(), datetime.now(tz=UTC))
+    assert_close(db_now(), datetime.now(tz=UTC))
+
+
+def test_moving_the_clock_mid_transaction_raises(db, timewarp: Timewarp) -> None:
+    with pytest.raises(RuntimeError, match="while a transaction is open"):
+        with session_scope() as session:
+            session.add(make_job())
+            session.flush()
+            timewarp.add_time(timedelta(days=1))
+
+
+def test_no_complaint_before_the_transaction_touches_the_database(db, timewarp: Timewarp) -> None:
+    """A session that hasn't emitted any SQL yet has no transaction, so postgres hasn't pinned
+    now() and the clock is still free to move."""
+    with session_scope() as session:
+        session.add(make_job())
+        timewarp.set_time(LEAP_DAY)
+        session.flush()
+        assert_close(session.execute(select(BackgroundJob)).scalar_one().queued, LEAP_DAY)
+
+
+def test_the_clock_is_movable_again_after_the_transaction(db, timewarp: Timewarp) -> None:
+    with session_scope() as session:
+        session.add(make_job())
+    timewarp.set_time(LEAP_DAY)
+    assert_close(db_now(), LEAP_DAY)
+
+
+def test_a_rolled_back_transaction_doesnt_wedge_the_clock(db, timewarp: Timewarp) -> None:
+    with pytest.raises(ZeroDivisionError):
+        with session_scope() as session:
+            session.add(make_job())
+            raise ZeroDivisionError
+    timewarp.set_time(LEAP_DAY)
+    assert_close(db_now(), LEAP_DAY)
+
+
+def test_naive_datetime_rejected(timewarp: Timewarp) -> None:
+    with pytest.raises(ValueError, match="aware datetime"):
+        timewarp.set_time(datetime(2024, 2, 29, 12, 0, 0))
+
+
+def test_clock_is_real_without_the_fixture(db) -> None:
+    before = datetime.now(tz=UTC)
+    assert before <= now() <= datetime.now(tz=UTC)
+    assert_close(db_now(), datetime.now(tz=UTC))
+
+
+def test_nothing_depends_on_the_real_now(db) -> None:
+    """Every column default should have bound mock.now(), not pg_catalog.now(). A dependency on the
+    real function means some DDL resolved before the search_path was in place."""
+    with session_scope() as session:
+        dependants = (
+            session.execute(
+                text("""
+                SELECT pg_describe_object(classid, objid, objsubid)
+                FROM pg_depend
+                WHERE refclassid = 'pg_proc'::regclass
+                  AND refobjid = 'pg_catalog.now()'::regprocedure
+                """)
+            )
+            .scalars()
+            .all()
+        )
+        assert dependants == []


### PR DESCRIPTION
Adds a `timewarp` test fixture that shifts the clock that both python and postgres read:

```python
def test_something(db, timewarp):
    timewarp.set_time(datetime(2024, 2, 29, 12, tzinfo=UTC))
    timewarp.add_time(timedelta(days=30))   # negative rewinds
```

Postgres reads the clock through a `mock.now()` that shadows `pg_catalog.now()` via `search_path`. It has to be installed before any DDL runs, since a column `DEFAULT now()` binds the function identity when the column is created. Python goes through a new `_real_now()` seam in `utils`, which covers the ~42 modules that do `from couchers.utils import now`.

Both clocks keep running — the offset displaces them rather than freezing them, and each side applies it to its own clock. Moving the clock while a transaction is open raises, since postgres fixes `now()` at transaction start.

Also: `servicers/bugs.py` now uses `utils.now()` instead of `datetime.now(UTC)`, and the migration drift test builds its schemas in a scratch database so both dumps stay production-shaped.

## Testing

`src/tests/test_timewarp.py` covers both clocks under set/add/rewind/reset, column defaults, query-time `now()`, the mid-transaction guard, and a `pg_depend` check that nothing still binds the real `pg_catalog.now()`.

`uv run pytest` from `app/backend` — 1243 passed, `make mypy` clean.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._