### PR TITLE
Add editor API to list decided event community invite requests

### DIFF
--- a/app/backend/src/couchers/servicers/editor.py
+++ b/app/backend/src/couchers/servicers/editor.py
@@ -191,6 +191,7 @@ class Editor(editor_pb2_grpc.EditorServicer):
         requests = session.execute(query).scalars().all()
 
         def _request_to_pb(req: EventCommunityInviteRequest) -> editor_pb2.DecidedEventCommunityInviteRequest:
+            # these are set together, per the decided_approved check constraint
             assert req.decided is not None and req.decided_by_user_id is not None and req.approved is not None
             return editor_pb2.DecidedEventCommunityInviteRequest(
                 event_community_invite_request_id=req.id,

--- a/app/backend/src/couchers/servicers/editor.py
+++ b/app/backend/src/couchers/servicers/editor.py
@@ -33,6 +33,7 @@ from couchers.utils import (
     date_to_api,
     dt_id_from_page_token,
     dt_id_to_page_token,
+    not_none,
     now,
     parse_date,
 )
@@ -190,29 +191,23 @@ class Editor(editor_pb2_grpc.EditorServicer):
 
         requests = session.execute(query).scalars().all()
 
-        def _request_to_pb(req: EventCommunityInviteRequest) -> editor_pb2.DecidedEventCommunityInviteRequest:
-            # these are set together, per the decided_approved check constraint
-            assert req.decided is not None and req.decided_by_user_id is not None and req.approved is not None
-            return editor_pb2.DecidedEventCommunityInviteRequest(
-                event_community_invite_request_id=req.id,
-                user_id=req.user_id,
-                event_url=urls.event_link(occurrence_id=req.occurrence.id, slug=req.occurrence.event.slug),
-                community_id=req.occurrence.event.parent_node_id,
-                created=Timestamp_from_datetime(req.created),
-                decided=Timestamp_from_datetime(req.decided),
-                decided_by_user_id=req.decided_by_user_id,
-                approved=req.approved,
-            )
-
-        next_page_token = None
-        if len(requests) > page_size:
-            next_req = requests[page_size]
-            assert next_req.decided is not None
-            next_page_token = dt_id_to_page_token(next_req.decided, next_req.id)
-
         return editor_pb2.ListDecidedEventCommunityInviteRequestsRes(
-            requests=[_request_to_pb(req) for req in requests[:page_size]],
-            next_page_token=next_page_token,
+            requests=[
+                editor_pb2.DecidedEventCommunityInviteRequest(
+                    event_community_invite_request_id=req.id,
+                    user_id=req.user_id,
+                    event_url=urls.event_link(occurrence_id=req.occurrence.id, slug=req.occurrence.event.slug),
+                    community_id=req.occurrence.event.parent_node_id,
+                    created=Timestamp_from_datetime(req.created),
+                    decided=Timestamp_from_datetime(not_none(req.decided)),
+                    decided_by_user_id=not_none(req.decided_by_user_id),
+                    approved=not_none(req.approved),
+                )
+                for req in requests[:page_size]
+            ],
+            next_page_token=dt_id_to_page_token(not_none(requests[page_size].decided), requests[page_size].id)
+            if len(requests) > page_size
+            else None,
         )
 
     def DecideEventCommunityInviteRequest(

--- a/app/backend/src/couchers/servicers/editor.py
+++ b/app/backend/src/couchers/servicers/editor.py
@@ -6,7 +6,7 @@ from geoalchemy2.shape import from_shape
 from google.protobuf import empty_pb2
 from shapely.geometry import shape
 from shapely.geometry.base import BaseGeometry
-from sqlalchemy import select
+from sqlalchemy import select, tuple_
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import exists, update
 
@@ -28,7 +28,14 @@ from couchers.servicers.communities import community_to_pb
 from couchers.servicers.events import generate_event_create_notifications, get_users_to_notify_for_new_event
 from couchers.servicers.postal_verification import postalverificationstatus2pb
 from couchers.servicers.public import format_volunteer_link
-from couchers.utils import Timestamp_from_datetime, date_to_api, now, parse_date
+from couchers.utils import (
+    Timestamp_from_datetime,
+    date_to_api,
+    dt_id_from_page_token,
+    dt_id_to_page_token,
+    now,
+    parse_date,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -158,6 +165,53 @@ class Editor(editor_pb2_grpc.EditorServicer):
         return editor_pb2.ListEventCommunityInviteRequestsRes(
             requests=[_request_to_pb(request) for request in requests[:page_size]],
             next_page_token=str(requests[-1].id) if len(requests) > page_size else None,
+        )
+
+    def ListDecidedEventCommunityInviteRequests(
+        self, request: editor_pb2.ListDecidedEventCommunityInviteRequestsReq, context: CouchersContext, session: Session
+    ) -> editor_pb2.ListDecidedEventCommunityInviteRequestsRes:
+        page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
+
+        query = (
+            select(EventCommunityInviteRequest)
+            .where(EventCommunityInviteRequest.decided.is_not(None))
+            .order_by(EventCommunityInviteRequest.decided.desc(), EventCommunityInviteRequest.id.desc())
+            .limit(page_size + 1)
+        )
+
+        if request.HasField("approved"):
+            query = query.where(EventCommunityInviteRequest.approved == request.approved.value)
+
+        if request.page_token:
+            decided, request_id = dt_id_from_page_token(request.page_token)
+            query = query.where(
+                tuple_(EventCommunityInviteRequest.decided, EventCommunityInviteRequest.id) <= (decided, request_id)
+            )
+
+        requests = session.execute(query).scalars().all()
+
+        def _request_to_pb(req: EventCommunityInviteRequest) -> editor_pb2.DecidedEventCommunityInviteRequest:
+            assert req.decided is not None and req.decided_by_user_id is not None and req.approved is not None
+            return editor_pb2.DecidedEventCommunityInviteRequest(
+                event_community_invite_request_id=req.id,
+                user_id=req.user_id,
+                event_url=urls.event_link(occurrence_id=req.occurrence.id, slug=req.occurrence.event.slug),
+                community_id=req.occurrence.event.parent_node_id,
+                created=Timestamp_from_datetime(req.created),
+                decided=Timestamp_from_datetime(req.decided),
+                decided_by_user_id=req.decided_by_user_id,
+                approved=req.approved,
+            )
+
+        next_page_token = None
+        if len(requests) > page_size:
+            next_req = requests[page_size]
+            assert next_req.decided is not None
+            next_page_token = dt_id_to_page_token(next_req.decided, next_req.id)
+
+        return editor_pb2.ListDecidedEventCommunityInviteRequestsRes(
+            requests=[_request_to_pb(req) for req in requests[:page_size]],
+            next_page_token=next_page_token,
         )
 
     def DecideEventCommunityInviteRequest(

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -2423,6 +2423,117 @@ def test_community_invite_requests(db, email_collector: EmailCollector, moderato
         assert err.value.details() == "A community invite has already been sent out for this event."
 
 
+def test_list_decided_community_invite_requests(db, moderator: Moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
+    superuser, superuser_token = generate_user(is_superuser=True)
+
+    with session_scope() as session:
+        w = create_community(session, 0, 2, "World Community", [superuser], [], None)
+        mr = create_community(session, 0, 2, "Macroregion", [superuser], [], w)
+        r = create_community(session, 0, 2, "Region", [superuser], [], mr)
+        c_id = create_community(session, 0, 2, "Community", [user1, user2, user3], [], r).id
+
+    enforce_community_memberships()
+
+    def create_event_and_request_invite(token: str, title: str) -> str:
+        with events_session(token) as api:
+            res = api.CreateEvent(
+                events_pb2.CreateEventReq(
+                    title=title,
+                    content="Dummy content.",
+                    parent_community_id=c_id,
+                    location=events_pb2.EventLocation(
+                        address="Near Null Island",
+                        lat=0.1,
+                        lng=0.2,
+                    ),
+                    start_datetime_iso8601_local=datetime_to_iso8601_local(now() + timedelta(hours=3)),
+                    end_datetime_iso8601_local=datetime_to_iso8601_local(now() + timedelta(hours=4)),
+                )
+            )
+        moderator.approve_event_occurrence(res.event_id)
+        with events_session(token) as api:
+            api.RequestCommunityInvite(events_pb2.RequestCommunityInviteReq(event_id=res.event_id))
+        return f"http://localhost:3000/event/{res.event_id}/{res.slug}"
+
+    event1_url = create_event_and_request_invite(token1, "Approved Event")
+    event2_url = create_event_and_request_invite(token2, "Declined Event")
+    # this one stays pending
+    create_event_and_request_invite(token3, "Pending Event")
+
+    with real_editor_session(superuser_token) as editor:
+        pending = editor.ListEventCommunityInviteRequests(editor_pb2.ListEventCommunityInviteRequestsReq())
+        assert len(pending.requests) == 3
+        by_user = {req.user_id: req.event_community_invite_request_id for req in pending.requests}
+
+        # nothing decided yet
+        res = editor.ListDecidedEventCommunityInviteRequests(editor_pb2.ListDecidedEventCommunityInviteRequestsReq())
+        assert len(res.requests) == 0
+        assert not res.next_page_token
+
+        editor.DecideEventCommunityInviteRequest(
+            editor_pb2.DecideEventCommunityInviteRequestReq(
+                event_community_invite_request_id=by_user[user1.id],
+                approve=True,
+            )
+        )
+        editor.DecideEventCommunityInviteRequest(
+            editor_pb2.DecideEventCommunityInviteRequestReq(
+                event_community_invite_request_id=by_user[user2.id],
+                approve=False,
+            )
+        )
+
+        # the pending one is not returned, and the most recently decided comes first
+        res = editor.ListDecidedEventCommunityInviteRequests(editor_pb2.ListDecidedEventCommunityInviteRequestsReq())
+        assert len(res.requests) == 2
+        assert not res.next_page_token
+
+        declined, approved = res.requests
+
+        assert declined.event_community_invite_request_id == by_user[user2.id]
+        assert declined.user_id == user2.id
+        assert declined.event_url == event2_url
+        assert declined.community_id == c_id
+        assert declined.decided_by_user_id == superuser.id
+        assert not declined.approved
+        assert declined.created.ToDatetime() <= declined.decided.ToDatetime()
+
+        assert approved.event_community_invite_request_id == by_user[user1.id]
+        assert approved.user_id == user1.id
+        assert approved.event_url == event1_url
+        assert approved.community_id == c_id
+        assert approved.decided_by_user_id == superuser.id
+        assert approved.approved
+        assert approved.decided.ToDatetime() <= declined.decided.ToDatetime()
+
+        # filtering
+        res = editor.ListDecidedEventCommunityInviteRequests(
+            editor_pb2.ListDecidedEventCommunityInviteRequestsReq(approved=wrappers_pb2.BoolValue(value=True))
+        )
+        assert [req.event_community_invite_request_id for req in res.requests] == [by_user[user1.id]]
+
+        res = editor.ListDecidedEventCommunityInviteRequests(
+            editor_pb2.ListDecidedEventCommunityInviteRequestsReq(approved=wrappers_pb2.BoolValue(value=False))
+        )
+        assert [req.event_community_invite_request_id for req in res.requests] == [by_user[user2.id]]
+
+        # pagination
+        res = editor.ListDecidedEventCommunityInviteRequests(
+            editor_pb2.ListDecidedEventCommunityInviteRequestsReq(page_size=1)
+        )
+        assert [req.event_community_invite_request_id for req in res.requests] == [by_user[user2.id]]
+        assert res.next_page_token
+
+        res = editor.ListDecidedEventCommunityInviteRequests(
+            editor_pb2.ListDecidedEventCommunityInviteRequestsReq(page_size=1, page_token=res.next_page_token)
+        )
+        assert [req.event_community_invite_request_id for req in res.requests] == [by_user[user1.id]]
+        assert not res.next_page_token
+
+
 def test_community_invite_not_sent_to_attendees_or_organizers(db, moderator: Moderator):
     # Regression: users who already RSVP'd (or organize the event) must not get the
     # community invite notification when it is approved.

--- a/app/proto/editor.proto
+++ b/app/proto/editor.proto
@@ -19,6 +19,8 @@ service Editor {
 
   rpc ListEventCommunityInviteRequests(ListEventCommunityInviteRequestsReq) returns (ListEventCommunityInviteRequestsRes) {}
 
+  rpc ListDecidedEventCommunityInviteRequests(ListDecidedEventCommunityInviteRequestsReq) returns (ListDecidedEventCommunityInviteRequestsRes) {}
+
   rpc DecideEventCommunityInviteRequest(DecideEventCommunityInviteRequestReq) returns (DecideEventCommunityInviteRequestRes) {}
 
   rpc SendBlogPostNotification(SendBlogPostNotificationReq) returns (google.protobuf.Empty) {}
@@ -68,6 +70,34 @@ message EventCommunityInviteRequest {
 
 message ListEventCommunityInviteRequestsRes {
   repeated EventCommunityInviteRequest requests = 1;
+
+  string next_page_token = 2;
+}
+
+message ListDecidedEventCommunityInviteRequestsReq {
+  uint32 page_size = 1;
+  string page_token = 2;
+
+  // if set, only return requests that were approved (true) or declined (false); otherwise return both
+  google.protobuf.BoolValue approved = 3;
+}
+
+message DecidedEventCommunityInviteRequest {
+  int64 event_community_invite_request_id = 1;
+
+  int64 user_id = 2;
+  string event_url = 3;
+  int64 community_id = 4;
+
+  google.protobuf.Timestamp created = 5;
+  google.protobuf.Timestamp decided = 6;
+  int64 decided_by_user_id = 7;
+  bool approved = 8;
+}
+
+message ListDecidedEventCommunityInviteRequestsRes {
+  // most recently decided first
+  repeated DecidedEventCommunityInviteRequest requests = 1;
 
   string next_page_token = 2;
 }


### PR DESCRIPTION
Adds a new editor-level RPC `ListDecidedEventCommunityInviteRequests` that lists event community invite requests that have already been approved or declined, complementing the existing `ListEventCommunityInviteRequests` (which only returns pending ones). This gives editors a view of past decisions.

Details:
- `ListDecidedEventCommunityInviteRequestsReq` takes `page_size`, `page_token`, and an optional `BoolValue approved` filter (unset returns both approved and declined).
- Each `DecidedEventCommunityInviteRequest` returns the request id, `user_id`, `event_url`, `community_id`, `created`, `decided`, `decided_by_user_id` and `approved`.
- Results are ordered most recently decided first, paginated with a keyset cursor on `(decided, id)` using the existing `dt_id_to_page_token`/`dt_id_from_page_token` helpers. A plain id cursor would order by creation rather than decision time, and bulk auto-declines share a `decided` timestamp, hence the id tiebreak.
- `community_id` is taken from the event's `parent_node_id` rather than `get_users_to_notify_for_new_event`, since that query is expensive and its notify count is no longer meaningful once a request is decided.

## Testing
Added `test_list_decided_community_invite_requests` in `src/tests/test_events.py`: it creates three invite requests, decides two of them (one approved, one declined), and asserts that the pending one is excluded, that ordering is newest-decision-first, that all returned fields are correct, that both values of the `approved` filter work, and that two-page pagination works.

To replicate locally, from `/app/backend`:

```
uv run pytest src/tests/test_events.py -k community_invite
```

`make format` and `make mypy` both pass.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._