### PR TITLE
Fix icon size for event and reference notification settings

### DIFF
--- a/app/web/components/Icons/PenIcon.tsx
+++ b/app/web/components/Icons/PenIcon.tsx
@@ -1,6 +1,6 @@
 import { SvgIcon, SvgIconProps } from "@mui/material";
 
-export default function EventIcon(props: SvgIconProps) {
+export default function PenIcon(props: SvgIconProps) {
   return (
     <SvgIcon {...props} viewBox="0 0 37 37" xmlns="http://www.w3.org/2000/svg">
       <svg

--- a/app/web/features/notifications/utils/constants.tsx
+++ b/app/web/features/notifications/utils/constants.tsx
@@ -34,8 +34,8 @@ const mapNotificationSettingsTypeToIcon: { [key: string]: JSX.Element } = {
     <NotificationsActiveIcon fontSize="large" color="action" />
   ),
   chat: <ChatBubbleIcon fontSize="large" color="action" />,
-  event: <EventIcon />,
-  reference: <PenIcon />,
+  event: <EventIcon fontSize="large" color="action" />,
+  reference: <PenIcon fontSize="large" color="action" />,
   friend_request: <SinglePersonIcon fontSize="large" color="action" />,
   host_request: <CouchFilledIcon fontSize="large" color="action" />,
   discussion: <CommentIcon fontSize="large" color="action" />,


### PR DESCRIPTION
before:
<img width="536" height="603" alt="Screenshot 2026-07-27 at 22 26 38" src="https://github.com/user-attachments/assets/e42c80b0-db39-4f6c-8113-f0e3bf28e7e1" />


after:

<img width="545" height="627" alt="Screenshot 2026-07-27 at 22 26 58" src="https://github.com/user-attachments/assets/93f8e5d0-d761-4d10-af1b-e3174f19bfae" />
