### PR TITLE
Frontend/i18n: Cleanup i18n datetimes functions

### DIFF
--- a/app/web/features/auth/InviteCodesPage.tsx
+++ b/app/web/features/auth/InviteCodesPage.tsx
@@ -148,8 +148,7 @@ export default function InviteCodesPage() {
                       {c.created?.seconds && (
                         <>
                           {t("global:invites.created_datetime", {
-                            datetime: localizeDateTime(timestampToPlainDateTime(c.created), {
-                              locale: locale,
+                            datetime: localizeDateTime(timestampToPlainDateTime(c.created), locale, {
                               abbreviate: true,
                             }),
                           })}
@@ -159,8 +158,7 @@ export default function InviteCodesPage() {
                         <>
                           {" • "}
                           {t("global:invites.disabled_datetime", {
-                            datetime: localizeDateTime(timestampToPlainDateTime(c.disabled), {
-                              locale,
+                            datetime: localizeDateTime(timestampToPlainDateTime(c.disabled), locale, {
                               abbreviate: true,
                             }),
                           })}

--- a/app/web/features/auth/jail/ModNoteCard.tsx
+++ b/app/web/features/auth/jail/ModNoteCard.tsx
@@ -34,8 +34,7 @@ export default function ModNoteCard({ note, updateJailed }: ModNoteCardProps) {
   const [acknowledged, setAcknowledged] = useState(false);
   const [loading, setLoading] = useState(false);
 
-  const formattedTime = localizeDateTime(timestampToPlainDateTime(note.created!), {
-    locale,
+  const formattedTime = localizeDateTime(timestampToPlainDateTime(note.created!), locale, {
     abbreviate: true,
   });
 

--- a/app/web/features/auth/logins/LoginCard.tsx
+++ b/app/web/features/auth/logins/LoginCard.tsx
@@ -6,7 +6,7 @@ import { CalendarIcon, ClockIcon, InfoIcon, LocationIcon } from "components/Icon
 import IconText from "components/IconText";
 import { activeLoginsKey } from "features/queryKeys";
 import { Trans } from "i18n";
-import { localizeDateTime, localizeRelativeTime } from "i18n/datetimes";
+import { localizeDateOnly, localizeDateTime, localizeRelativeTime } from "i18n/datetimes";
 import { AUTH, GLOBAL } from "i18n/namespaces";
 import { useTranslation } from "next-i18next";
 import { ActiveSession } from "proto/account_pb";
@@ -25,14 +25,10 @@ export default function LoginsPage({ session }: { session: ActiveSession.AsObjec
   } = useTranslation([GLOBAL, AUTH]);
 
   const lastSeenDisplay = localizeRelativeTime(session.lastSeen!, locale);
-  const createdDisplay = localizeDateTime(timestampToPlainDateTime(session.created!), {
-    locale,
+  const createdDisplay = localizeDateTime(timestampToPlainDateTime(session.created!), locale, {
     includeSeconds: true,
   });
-  const expiryDisplay = localizeDateTime(timestampToPlainDateTime(session.expiry!), {
-    locale,
-    includeTime: false,
-  });
+  const expiryDisplay = localizeDateOnly(timestampToPlainDateTime(session.expiry!), locale);
   const queryClient = useQueryClient();
 
   const {

--- a/app/web/features/auth/timezone/Timezone.tsx
+++ b/app/web/features/auth/timezone/Timezone.tsx
@@ -1,6 +1,6 @@
 import { Typography } from "@mui/material";
 import { Trans, useTranslation } from "i18n";
-import { localizeDateTime } from "i18n/datetimes";
+import { localizeTimeOnly } from "i18n/datetimes";
 import { AUTH } from "i18n/namespaces";
 import { Temporal } from "temporal-polyfill";
 
@@ -28,10 +28,7 @@ export default function Timezone({ className, timezone }: TimezoneProps) {
           }}
           values={{
             timezone: timezone,
-            time: localizeDateTime(Temporal.Now.plainDateTimeISO(timezone), {
-              locale,
-              includeDate: false,
-            }),
+            time: localizeTimeOnly(Temporal.Now.plainDateTimeISO(timezone), locale),
           }}
         />
       </Typography>

--- a/app/web/features/communities/discussions/DiscussionPage.tsx
+++ b/app/web/features/communities/discussions/DiscussionPage.tsx
@@ -17,7 +17,7 @@ import { discussionKey } from "features/queryKeys";
 import { useLiteUser } from "features/userQueries/useLiteUsers";
 import { RpcError } from "grpc-web";
 import { useTranslation } from "i18n";
-import { localizeDateTime, localizeRelativeTime } from "i18n/datetimes";
+import { localizeDateOnly, localizeRelativeTime } from "i18n/datetimes";
 import { COMMUNITIES, GLOBAL } from "i18n/namespaces";
 import { useRouter } from "next/router";
 import { Discussion } from "proto/discussions_pb";
@@ -254,10 +254,7 @@ export default function DiscussionPage({ discussionId }: { discussionId: number 
                             ) : (
                               <Typography variant="body2">
                                 {t("communities:discussion_creation_date", {
-                                  dateOnly: localizeDateTime(timestampToPlainDateTime(discussion.created!), {
-                                    locale,
-                                    includeTime: false,
-                                  }),
+                                  dateOnly: localizeDateOnly(timestampToPlainDateTime(discussion.created!), locale),
                                 })}
                               </Typography>
                             )}

--- a/app/web/features/communities/events/EventCard.tsx
+++ b/app/web/features/communities/events/EventCard.tsx
@@ -124,8 +124,8 @@ export default function EventCard({ event, className }: EventCardProps) {
   const dateTimeRangeText = localizeDateTimeRange(
     timestampToPlainDateTime(event.startTime!, event.timezone),
     timestampToPlainDateTime(event.endTime!, event.timezone),
+    locale,
     {
-      locale,
       includeYear: "auto",
       includeDayOfWeek: true,
       abbreviate: true,

--- a/app/web/features/communities/events/EventPage.tsx
+++ b/app/web/features/communities/events/EventPage.tsx
@@ -361,8 +361,8 @@ export default function EventPage({ eventId, eventSlug }: { eventId: number; eve
                   {localizeDateTimeRange(
                     timestampToPlainDateTime(event.startTime!, event.timezone),
                     timestampToPlainDateTime(event.endTime!, event.timezone),
+                    locale,
                     {
-                      locale,
                       includeYear: "auto",
                       includeDayOfWeek: true,
                       capitalize: true,

--- a/app/web/features/communities/events/LongEventCard.tsx
+++ b/app/web/features/communities/events/LongEventCard.tsx
@@ -122,11 +122,10 @@ const LongEventCard = ({ event, userId }: { event: Event.AsObject; userId?: numb
   const dateTimeRangeText = localizeDateTimeRange(
     timestampToPlainDateTime(event.startTime!, event.timezone),
     timestampToPlainDateTime(event.endTime!, event.timezone),
+    locale,
     {
-      locale,
       includeYear: "auto",
       includeDayOfWeek: true,
-      includeTime: true,
       capitalize: true,
     },
   );

--- a/app/web/features/dashboard/DashboardPublicTripCard.tsx
+++ b/app/web/features/dashboard/DashboardPublicTripCard.tsx
@@ -10,7 +10,7 @@ import Avatar from "components/Avatar";
 import { useCommunity } from "features/communities/hooks";
 import { PublicTrip } from "features/publicTrips/useListPublicTrips";
 import { useTranslation } from "i18n";
-import { localizeDateTimeRange, localizeRelativeTimeUnit } from "i18n/datetimes";
+import { localizeDateRange, localizeRelativeTimeUnit } from "i18n/datetimes";
 import { DASHBOARD, PUBLIC_TRIPS } from "i18n/namespaces";
 import Link from "next/link";
 import { myPublicTripsRoute, routeToCommunity } from "routes";
@@ -187,10 +187,11 @@ export function DashboardPublicTripCard({
 
   const { data: community, isLoading: communityLoading } = useCommunity(communityMode ? 0 : trip.communityId);
 
-  const dateRange = localizeDateTimeRange(
+  const dateRange = localizeDateRange(
     Temporal.PlainDateTime.from(trip.fromDate),
     Temporal.PlainDateTime.from(trip.toDate),
-    { locale, includeTime: false, abbreviate: true },
+    locale,
+    { abbreviate: true },
   );
 
   const hasFooter = !communityMode && (offersCount !== undefined || trip.sameGenderOnly);

--- a/app/web/features/dashboard/EventListRow.tsx
+++ b/app/web/features/dashboard/EventListRow.tsx
@@ -1,7 +1,7 @@
 import { ChevronRight, Group, Place, Schedule } from "@mui/icons-material";
 import { Skeleton, styled } from "@mui/material";
 import { useTranslation } from "i18n";
-import { localizeDateTime, localizeMonthAbbreviation } from "i18n/datetimes";
+import { localizeMonthName, localizeTimeOnly } from "i18n/datetimes";
 import { DASHBOARD } from "i18n/namespaces";
 import Link from "next/link";
 import { Event } from "proto/events_pb";
@@ -176,17 +176,13 @@ export default function EventListRow({ event }: EventListRowProps) {
   const nowLabel = t("dashboard:now_label");
   const chipLabel = isOngoing ? nowLabel : todayLabel;
   const chipFontSize = chipLabel.length <= 5 ? 9 : chipLabel.length <= 7 ? 8 : 7;
-  const month = localizeMonthAbbreviation(startDate.toPlainDate(), {
-    locale,
+  const month = localizeMonthName(startDate.month, locale, {
+    abbreviate: true,
     capitalize: true,
   });
   const day = startDate.day;
 
-  const timeStr = localizeDateTime(startDate, {
-    locale,
-    includeDate: false,
-    includeTime: true,
-  });
+  const timeStr = localizeTimeOnly(startDate, locale);
 
   return (
     <RowLink href={routeToEvent(event.eventId, event.slug)}>

--- a/app/web/features/dashboard/UpcomingStayCard.tsx
+++ b/app/web/features/dashboard/UpcomingStayCard.tsx
@@ -5,7 +5,7 @@ import Avatar from "components/Avatar";
 import { useAuthContext } from "features/auth/AuthProvider";
 import { useLiteUser } from "features/userQueries/useLiteUsers";
 import { useTranslation } from "i18n";
-import { localizeDateTimeRange, localizeRelativeTimeUnit } from "i18n/datetimes";
+import { localizeDateRange, localizeRelativeTimeUnit } from "i18n/datetimes";
 import { DASHBOARD } from "i18n/namespaces";
 import Link from "next/link";
 import { HostRequest } from "proto/requests_pb";
@@ -134,10 +134,8 @@ export default function UpcomingStayCard({ hostRequest }: UpcomingStayCardProps)
     capitalize: true,
   });
 
-  const dateRange = localizeDateTimeRange(fromDate, toDate, {
-    locale,
+  const dateRange = localizeDateRange(fromDate, toDate, locale, {
     includeYear: "auto",
-    includeTime: false,
     abbreviate: true,
   });
 

--- a/app/web/features/messages/requests/HostRequestListItem.tsx
+++ b/app/web/features/messages/requests/HostRequestListItem.tsx
@@ -12,7 +12,7 @@ import useCurrentUser from "features/userQueries/useCurrentUser";
 import { useLiteUser } from "features/userQueries/useLiteUsers";
 import { RpcError } from "grpc-web";
 import { useTranslation } from "i18n";
-import { localizeDateTimeRange } from "i18n/datetimes";
+import { localizeDateRange } from "i18n/datetimes";
 import { MESSAGES } from "i18n/namespaces";
 import { HostRequest } from "proto/requests_pb";
 import React, { useState } from "react";
@@ -204,13 +204,12 @@ export default function HostRequestListItem({ hostRequest, className, isArchived
                     display: "inline",
                   }}
                 >
-                  {localizeDateTimeRange(
+                  {localizeDateRange(
                     Temporal.PlainDateTime.from(hostRequest.fromDate),
                     Temporal.PlainDateTime.from(hostRequest.toDate),
+                    locale,
                     {
-                      locale,
                       includeYear: "auto",
-                      includeTime: false,
                     },
                   )}
                 </Typography>

--- a/app/web/features/messages/requests/HostRequestUserSummarySection.tsx
+++ b/app/web/features/messages/requests/HostRequestUserSummarySection.tsx
@@ -2,7 +2,7 @@ import { Skeleton, styled, Tooltip, Typography, useMediaQuery } from "@mui/mater
 import Avatar from "components/Avatar";
 import UserSummary from "components/UserSummary";
 import { useTranslation } from "i18n";
-import { localizeDateTimeRange } from "i18n/datetimes";
+import { localizeDateRange } from "i18n/datetimes";
 import { MESSAGES } from "i18n/namespaces";
 import { LiteUser } from "proto/api_pb";
 import { HostRequest } from "proto/requests_pb";
@@ -80,13 +80,12 @@ const HostRequestUserSummarySection = ({
         </Typography>
         {hostRequest && (
           <Typography component="p" variant="h3" sx={{ paddingRight: theme.spacing(1) }}>
-            {localizeDateTimeRange(
+            {localizeDateRange(
               Temporal.PlainDateTime.from(hostRequest.fromDate),
               Temporal.PlainDateTime.from(hostRequest.toDate),
+              locale,
               {
-                locale,
                 includeYear: "auto",
-                includeTime: false,
                 abbreviate: true,
               },
             )}
@@ -102,13 +101,12 @@ const HostRequestUserSummarySection = ({
         {hostRequest && (
           <StyledRequestedDatesWrapper>
             <Typography component="p" variant="h3" sx={{ paddingRight: theme.spacing(1) }}>
-              {localizeDateTimeRange(
+              {localizeDateRange(
                 Temporal.PlainDateTime.from(hostRequest.fromDate),
                 Temporal.PlainDateTime.from(hostRequest.toDate),
+                locale,
                 {
-                  locale,
                   includeYear: "auto",
-                  includeTime: false,
                 },
               )}
             </Typography>

--- a/app/web/features/profile/view/ReferenceListItem.tsx
+++ b/app/web/features/profile/view/ReferenceListItem.tsx
@@ -56,8 +56,7 @@ export default function ReferenceListItem({ isReceived, user, reference }: Refer
           {isReceived && <Pill variant="rounded">{referenceBadgeLabel(t)[reference.referenceType]}</Pill>}
           {reference.writtenTime && (
             <Pill variant="rounded">
-              {localizeYearMonth(timestampToPlainDateTime(reference.writtenTime).toPlainDate(), {
-                locale,
+              {localizeYearMonth(timestampToPlainDateTime(reference.writtenTime), locale, {
                 abbreviate: true,
                 capitalize: true,
               })}

--- a/app/web/features/profile/view/userLabels.tsx
+++ b/app/web/features/profile/view/userLabels.tsx
@@ -4,9 +4,9 @@ import LabelAndText from "components/LabelAndText";
 import { useLanguages } from "features/profile/hooks/useLanguages";
 import { useTranslation } from "i18n";
 import {
-  localizeDateTime,
   localizeDuration,
   localizeRelativeTime,
+  localizeTimeOnly,
   localizeTimeZone,
   localizeYearMonth,
 } from "i18n/datetimes";
@@ -220,8 +220,7 @@ export const RemainingAboutLabels = ({ user }: Props) => {
         label={t("profile:heading.joined")}
         text={
           user.joined
-            ? localizeYearMonth(timestampToPlainDateTime(user.joined).toPlainDate(), {
-                locale,
+            ? localizeYearMonth(timestampToPlainDateTime(user.joined), locale, {
                 capitalize: true,
               })
             : ""
@@ -234,10 +233,7 @@ export const RemainingAboutLabels = ({ user }: Props) => {
             <Trans
               i18nKey="profile:local_time_with_time_zone_text"
               values={{
-                time: localizeDateTime(Temporal.Now.plainDateTimeISO(user.timezone), {
-                  locale,
-                  includeDate: false,
-                }),
+                time: localizeTimeOnly(Temporal.Now.plainDateTimeISO(user.timezone), locale),
               }}
               components={{
                 timeZone: (

--- a/app/web/features/publicTrips/PublicTripCard.tsx
+++ b/app/web/features/publicTrips/PublicTripCard.tsx
@@ -21,7 +21,7 @@ import { useAuthContext } from "features/auth/AuthProvider";
 import useAccountInfo from "features/auth/useAccountInfo";
 import FlagButton from "features/FlagButton";
 import { useTranslation } from "i18n";
-import { localizeDateTimeRange } from "i18n/datetimes";
+import { localizeDateRange } from "i18n/datetimes";
 import { PUBLIC_TRIPS } from "i18n/namespaces";
 import Link from "next/link";
 import { PublicTripStatus } from "proto/public_trips_pb";
@@ -324,12 +324,11 @@ export default function PublicTripCard({ trip, ownerView = false, id }: PublicTr
             <MetaRow>
               <MetaItem>
                 <CalendarIcon />
-                {localizeDateTimeRange(
+                {localizeDateRange(
                   Temporal.PlainDateTime.from(trip.fromDate),
                   Temporal.PlainDateTime.from(trip.toDate),
+                  locale,
                   {
-                    locale,
-                    includeTime: false,
                     abbreviate: true,
                   },
                 )}

--- a/app/web/i18n/datetimes.test.ts
+++ b/app/web/i18n/datetimes.test.ts
@@ -1,11 +1,15 @@
 import {
   getMuiDateFormat,
   getMuiTimeFormat,
+  localizeDateOnly,
   localizeDateTime,
   localizeDuration,
+  localizeMonthName,
   localizeRelativeTime,
   localizeTimeOffset,
+  localizeTimeOnly,
   localizeTimeZone,
+  localizeYearMonth,
 } from "i18n/datetimes";
 import { TFunction } from "i18next";
 import { Temporal } from "temporal-polyfill";
@@ -19,14 +23,9 @@ describe("localizeDateTime", () => {
   });
 
   it("excludes dates when specified", () => {
+    expect(localizeDateTime(janFirst2000, "en")).toContain("2000");
     expect(
-      localizeDateTime(janFirst2000, {
-        locale: "en",
-      }),
-    ).toContain("2000");
-    expect(
-      localizeDateTime(janFirst2000, {
-        locale: "en",
+      localizeDateTime(janFirst2000, "en", {
         includeDate: false,
       }),
     ).not.toContain("2000");
@@ -34,14 +33,12 @@ describe("localizeDateTime", () => {
 
   it("supports all includeYear modes", () => {
     expect(
-      localizeDateTime(janFirst2000, {
-        locale: "en",
+      localizeDateTime(janFirst2000, "en", {
         includeYear: true,
       }),
     ).toContain("2000");
     expect(
-      localizeDateTime(janFirst2000, {
-        locale: "en",
+      localizeDateTime(janFirst2000, "en", {
         includeYear: false,
       }),
     ).not.toContain("2000");
@@ -50,28 +47,21 @@ describe("localizeDateTime", () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date("2001-01-01T00:00:00Z"));
     expect(
-      localizeDateTime(janFirst2000, {
-        locale: "en",
+      localizeDateTime(janFirst2000, "en", {
         includeYear: "auto",
       }),
     ).toContain("2000");
     expect(
-      localizeDateTime(Temporal.PlainDateTime.from("2001-01-01"), {
-        locale: "en",
+      localizeDateTime(Temporal.PlainDateTime.from("2001-01-01"), "en", {
         includeYear: "auto",
       }),
     ).not.toContain("2001");
   });
 
   it("honors abbreviated month names", () => {
+    expect(localizeDateTime(janFirst2000, "en")).toContain("January");
     expect(
-      localizeDateTime(janFirst2000, {
-        locale: "en",
-      }),
-    ).toContain("January");
-    expect(
-      localizeDateTime(janFirst2000, {
-        locale: "en",
+      localizeDateTime(janFirst2000, "en", {
         abbreviate: true,
       }),
     ).not.toContain("uary");
@@ -79,20 +69,17 @@ describe("localizeDateTime", () => {
 
   it("includes the day of week when specified", () => {
     expect(
-      localizeDateTime(janFirst2000, {
-        locale: "en",
+      localizeDateTime(janFirst2000, "en", {
         includeDayOfWeek: false,
       }),
     ).not.toContain("Sat");
     expect(
-      localizeDateTime(janFirst2000, {
-        locale: "en",
+      localizeDateTime(janFirst2000, "en", {
         includeDayOfWeek: true,
       }),
     ).toContain("Saturday");
     expect(
-      localizeDateTime(janFirst2000, {
-        locale: "en",
+      localizeDateTime(janFirst2000, "en", {
         includeDayOfWeek: true,
         abbreviate: true,
       }),
@@ -100,14 +87,9 @@ describe("localizeDateTime", () => {
   });
 
   it("excludes times when specified", () => {
+    expect(localizeDateTime(janFirst2000.add({ hours: 11 }), "en")).toContain("11");
     expect(
-      localizeDateTime(janFirst2000.add({ hours: 11 }), {
-        locale: "en",
-      }),
-    ).toContain("11");
-    expect(
-      localizeDateTime(janFirst2000.add({ hours: 11 }), {
-        locale: "en",
+      localizeDateTime(janFirst2000.add({ hours: 11 }), "en", {
         includeTime: false,
       }),
     ).not.toContain("11");
@@ -115,66 +97,31 @@ describe("localizeDateTime", () => {
 
   it("includes seconds when specified", () => {
     expect(
-      localizeDateTime(janFirst2000.add({ seconds: 42 }), {
-        locale: "en",
+      localizeDateTime(janFirst2000.add({ seconds: 42 }), "en", {
         includeSeconds: false,
       }),
     ).not.toContain("42");
     expect(
-      localizeDateTime(janFirst2000.add({ seconds: 42 }), {
-        locale: "en",
+      localizeDateTime(janFirst2000.add({ seconds: 42 }), "en", {
         includeSeconds: true,
       }),
     ).toContain("42");
   });
 
   it("honors the locale", () => {
-    expect(
-      localizeDateTime(janFirst2000, {
-        locale: "en",
-      }),
-    ).toContain("January");
-    expect(
-      localizeDateTime(janFirst2000, {
-        locale: "en-US",
-      }),
-    ).toContain("January");
-    expect(
-      localizeDateTime(janFirst2000, {
-        locale: "es",
-      }),
-    ).toContain("enero");
-    expect(
-      localizeDateTime(janFirst2000, {
-        locale: "de",
-      }),
-    ).toContain("Januar");
-    expect(
-      localizeDateTime(janFirst2000, {
-        locale: "pt-BR",
-      }),
-    ).toContain("janeiro");
-    expect(
-      localizeDateTime(janFirst2000, {
-        locale: "ca",
-      }),
-    ).toContain("gener");
-    expect(
-      localizeDateTime(janFirst2000, {
-        locale: "zh-Hans",
-      }),
-    ).toContain("1月");
-    expect(
-      localizeDateTime(janFirst2000, {
-        locale: "zh-Hant",
-      }),
-    ).toContain("1月");
+    expect(localizeDateTime(janFirst2000, "en")).toContain("January");
+    expect(localizeDateTime(janFirst2000, "en-US")).toContain("January");
+    expect(localizeDateTime(janFirst2000, "es")).toContain("enero");
+    expect(localizeDateTime(janFirst2000, "de")).toContain("Januar");
+    expect(localizeDateTime(janFirst2000, "pt-BR")).toContain("janeiro");
+    expect(localizeDateTime(janFirst2000, "ca")).toContain("gener");
+    expect(localizeDateTime(janFirst2000, "zh-Hans")).toContain("1月");
+    expect(localizeDateTime(janFirst2000, "zh-Hant")).toContain("1月");
   });
 
   it("does not capitalize day/month names by default (assumed mid-sentence)", () => {
     // Spanish weekday + month stay lowercase when the date may be part of a sentence.
-    const formatted = localizeDateTime(janFirst2000, {
-      locale: "es",
+    const formatted = localizeDateTime(janFirst2000, "es", {
       includeDayOfWeek: true,
       includeTime: false,
     });
@@ -183,8 +130,7 @@ describe("localizeDateTime", () => {
   });
 
   it("capitalizes only the first letter when capitalize is set (standalone date)", () => {
-    const formatted = localizeDateTime(janFirst2000, {
-      locale: "es",
+    const formatted = localizeDateTime(janFirst2000, "es", {
       includeDayOfWeek: true,
       includeTime: false,
       capitalize: true,
@@ -196,12 +142,32 @@ describe("localizeDateTime", () => {
 
   it("leaves a non-letter first grapheme unchanged when capitalize is set", () => {
     // Spanish dates without a weekday start with the day number.
-    const formatted = localizeDateTime(janFirst2000, {
-      locale: "es",
+    const formatted = localizeDateTime(janFirst2000, "es", {
       includeTime: false,
       capitalize: true,
     });
     expect(formatted).toMatch(/^1 de enero/);
+  });
+});
+
+describe("localizeDateTime-derived helpers", () => {
+  // Sanity check. Testing is otherwise covered by localizeDateTime, which these functions delegate to.
+  it("localizeDateOnly", () => {
+    expect(localizeDateOnly(janFirst2000.add({ hours: 7 }), "en")).toBe("January 1, 2000");
+  });
+
+  it("localizeTimeOnly", () => {
+    expect(localizeTimeOnly(janFirst2000.add({ hours: 7 }), "en")).toBe("7:00 AM");
+  });
+
+  // Sanity check. Testing is otherwise covered by localizeDateTime, which these functions delegate to.
+  it("localizeYearMonth", () => {
+    expect(localizeYearMonth(new Temporal.PlainYearMonth(2000, 2), "en")).toBe("February 2000");
+  });
+
+  // Sanity check. Testing is otherwise covered by localizeDateTime, which it delegates to.
+  it("localizeMonthName", () => {
+    expect(localizeMonthName(2, "en")).toBe("February");
   });
 });
 

--- a/app/web/i18n/datetimes.ts
+++ b/app/web/i18n/datetimes.ts
@@ -3,7 +3,7 @@ import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
 import { capitalizeFirstLetter } from "i18n/casing";
 import { TFunction } from "i18next";
 import { Temporal } from "temporal-polyfill";
-import { approxDateDuration, timestampToInstant } from "utils/date";
+import { approxDateDuration, timestampToInstant, UTC_TIMEZONE } from "utils/date";
 import dayjs, { i18nToDayjsLocale } from "utils/dayjs";
 
 /// Converts a Temporal date/time object to a Date
@@ -18,26 +18,18 @@ function toDateForUTCDisplay(temporal: Temporal.ZonedDateTime | Temporal.PlainDa
   if (temporal instanceof Temporal.PlainDate) {
     temporal = temporal.toPlainDateTime();
   }
-  const zoned = temporal.toZonedDateTime("Etc/UTC");
+  const zoned = temporal.toZonedDateTime(UTC_TIMEZONE);
   return new Date(zoned.epochMilliseconds);
 }
 
-interface LocalizeDateTimeParams {
-  /// The locale to localize in.
-  locale: string;
-  /// Whether to include the date (defaults to true).
-  includeDate?: boolean;
+interface LocalizeDateOptions {
   /// Whether to include the year (defaults to true).
   /// "auto" omits the year if it matches the current year (browser timezone).
   includeYear?: boolean | "auto";
-  /// If including the date, whether to include the day (defaults to true).
+  /// Whether to include the day (defaults to true).
   includeDay?: boolean;
-  /// If including the date, whether to include the day of week (defaults to false).
+  /// Whether to include the day of week (defaults to false).
   includeDayOfWeek?: boolean;
-  /// Whether to include the time (defaults to true).
-  includeTime?: boolean;
-  /// If including the time, whether to include seconds (defaults to false).
-  includeSeconds?: boolean;
   /// Whether to abbreviate days of the week and month names (defaults to false).
   abbreviate?: boolean;
   /// Whether to uppercase the first letter (defaults to false). Set this only when
@@ -46,118 +38,183 @@ interface LocalizeDateTimeParams {
   capitalize?: boolean;
 }
 
-/// Localizes a date and time, optionally with the day of the week.
+interface LocalizeTimeOptions {
+  /// Whether to include seconds (defaults to false).
+  includeSeconds?: boolean;
+}
+interface LocalizeDateTimeOptions extends LocalizeDateOptions, LocalizeTimeOptions {
+  /// Whether to include the date (defaults to true).
+  includeDate?: boolean;
+  /// Whether to include the time (defaults to true).
+  includeTime?: boolean;
+}
+
+/// Localizes a date and time, in full or partially (specific components),
+/// optionally with the day of the week and seconds.
 export function localizeDateTime(
-  date: Temporal.ZonedDateTime | Temporal.PlainDateTime | Temporal.PlainDate,
-  args: LocalizeDateTimeParams,
+  date: Temporal.PlainDateTime | Temporal.ZonedDateTime,
+  locale: string,
+  options?: LocalizeDateTimeOptions,
 ): string {
-  const format = getIntlDateTimeFormatUTC(args, { year: date.year });
+  const format = getIntlDateTimeFormatUTC(locale, options, { year: date.year });
   const formatted = format.format(toDateForUTCDisplay(date));
-  return args.capitalize ? capitalizeFirstLetter(formatted, args.locale) : formatted;
+  return options?.capitalize ? capitalizeFirstLetter(formatted, locale) : formatted;
+}
+
+/// Localizes a date only (no time), optionally with the day of the week.
+export function localizeDateOnly(
+  date: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime,
+  locale: string,
+  options?: LocalizeDateOptions,
+): string {
+  if (date instanceof Temporal.PlainDate) {
+    date = date.toPlainDateTime();
+  }
+  return localizeDateTime(date, locale, { ...options, includeTime: false });
+}
+
+/// Localizes a time only (no date), optionally with seconds.
+export function localizeTimeOnly(
+  time: Temporal.PlainTime | Temporal.PlainDateTime | Temporal.ZonedDateTime,
+  locale: string,
+  options?: LocalizeTimeOptions,
+): string {
+  if (time instanceof Temporal.PlainTime) {
+    time = new Temporal.PlainDate(2000, 1, 1).toPlainDateTime(time);
+  }
+  return localizeDateTime(time, locale, { ...options, includeDate: false });
 }
 
 /// Localizes only the year and month of a date.
 export function localizeYearMonth(
-  date: Temporal.PlainDate,
-  args: {
-    locale: string;
-    abbreviate?: boolean;
-    capitalize?: boolean;
+  date: Temporal.PlainYearMonth | Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime,
+  locale: string,
+  options?: {
+    abbreviate?: boolean; // Defaults to false
+    capitalize?: boolean; // Defaults to false
   },
 ): string {
-  return localizeDateTime(date.toPlainDateTime(), {
-    locale: args.locale,
-    abbreviate: args.abbreviate,
-    capitalize: args.capitalize,
+  if (date instanceof Temporal.PlainYearMonth) {
+    date = date.toPlainDate({ day: 1 });
+  }
+
+  return localizeDateOnly(date, locale, {
+    ...options,
     includeDay: false,
-    includeTime: false,
+  });
+}
+
+/// Localizes the name of a month (e.g. "January", "May" in German).
+export function localizeMonthName(
+  month: number | Temporal.PlainYearMonth | Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime,
+  locale: string,
+  options?: {
+    abbreviate?: boolean; // Defaults to false
+    capitalize?: boolean; // Defaults to false
+  },
+): string {
+  if (typeof month !== "number") {
+    month = month.month;
+  }
+  const dummyDate = new Temporal.PlainDate(2000, month, 1);
+  return localizeDateOnly(dummyDate, locale, {
+    ...options,
+    includeYear: false,
+    includeDay: false,
   });
 }
 
 /// Localizes a range of date and times as a string.
 export function localizeDateTimeRange(
-  start: Temporal.ZonedDateTime | Temporal.PlainDateTime | Temporal.PlainDate,
-  end: Temporal.ZonedDateTime | Temporal.PlainDateTime | Temporal.PlainDate,
-  args: LocalizeDateTimeParams,
+  start: Temporal.PlainDateTime | Temporal.ZonedDateTime,
+  end: Temporal.PlainDateTime | Temporal.ZonedDateTime,
+  locale: string,
+  options?: LocalizeDateTimeOptions,
 ): string {
-  const format = getIntlDateTimeFormatUTC(args, {
+  const format = getIntlDateTimeFormatUTC(locale, options, {
     year: start.year == end.year ? start.year : undefined,
   });
   const formatted = format.formatRange(toDateForUTCDisplay(start), toDateForUTCDisplay(end));
-  return args.capitalize ? capitalizeFirstLetter(formatted, args.locale) : formatted;
+  return options?.capitalize ? capitalizeFirstLetter(formatted, locale) : formatted;
+}
+
+/// Localizes a range of dates (no times) as a string.
+export function localizeDateRange(
+  start: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime,
+  end: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime,
+  locale: string,
+  options?: LocalizeDateOptions,
+): string {
+  if (start instanceof Temporal.PlainDate) {
+    start = start.toPlainDateTime();
+  }
+  if (end instanceof Temporal.PlainDate) {
+    end = end.toPlainDateTime();
+  }
+  return localizeDateTimeRange(start, end, locale, {
+    ...options,
+    includeTime: false,
+  });
 }
 
 // Creating Intl.DateTimeFormat every time is 40x slower.
+// Key: stringified (Intl.DateTimeFormatOptions & { locale: string })
 const intlDateTimeFormatCache = new Map<string, Intl.DateTimeFormat>();
 
-/// Gets an Intl.DateTimeFormat based on params.
+/// Gets an Intl.DateTimeFormat based on options.
 function getIntlDateTimeFormatUTC(
-  args: LocalizeDateTimeParams,
-  options: { year: number | undefined },
+  locale: string,
+  options?: LocalizeDateTimeOptions,
+  dateComponents?: { year?: number },
 ): Intl.DateTimeFormat {
-  // Resolve the auto option since the Intl.DateTimeFormat needs a boolean.
-  if (args.includeYear === "auto") {
-    args = {
-      ...args,
-      includeYear: options.year === undefined || options.year != new Date().getFullYear(),
-    };
+  const intlOptions = getIntlDateTimeFormatOptionsUTC(options, dateComponents);
+  const cacheKey = JSON.stringify({ ...intlOptions, locale });
+  let format = intlDateTimeFormatCache.get(cacheKey);
+  if (!format) {
+    format = new Intl.DateTimeFormat(locale, intlOptions);
+    intlDateTimeFormatCache.set(cacheKey, format);
   }
-
-  // We can't use args as the Map key as it uses reference equality.
-  // Convert it to a json string.
-  const cacheKey = JSON.stringify(args);
-  const cached = intlDateTimeFormatCache.get(cacheKey);
-  if (cached) return cached;
-
-  const format = createIntlDateTimeFormatUTC(args);
-  intlDateTimeFormatCache.set(cacheKey, format);
   return format;
 }
 
 /// Creates a new Intl.DateTimeFormat object based on params.
-function createIntlDateTimeFormatUTC(args: LocalizeDateTimeParams): Intl.DateTimeFormat {
-  const options: Intl.DateTimeFormatOptions = {};
-  if (args.includeDate !== false) {
-    if (args.includeYear !== false) {
-      options.year = "numeric";
+function getIntlDateTimeFormatOptionsUTC(
+  options?: LocalizeDateTimeOptions,
+  dateComponents?: { year?: number },
+): Intl.DateTimeFormatOptions {
+  const intlOptions: Intl.DateTimeFormatOptions = {};
+  if (options?.includeDate !== false) {
+    if (options?.includeYear === undefined || options?.includeYear === true) {
+      intlOptions.year = "numeric";
+    } else if (
+      options?.includeYear === "auto" &&
+      dateComponents?.year !== undefined &&
+      dateComponents.year != new Date().getFullYear()
+    ) {
+      intlOptions.year = "numeric";
     }
-    options.month = args.abbreviate ? "short" : "long";
-    if (args.includeDay !== false) {
-      options.day = "numeric";
-    }
-    if (args.includeDayOfWeek) {
-      options.weekday = args.abbreviate ? "short" : "long";
-    }
-  }
-  if (args.includeTime !== false) {
-    options.hour = "numeric";
-    options.minute = "numeric";
-    if (args.includeSeconds) {
-      options.second = "numeric";
-    }
-  }
-  options.timeZone = "Etc/UTC";
-  return Intl.DateTimeFormat(args.locale, options);
-}
 
-/// Localizes just the abbreviated month name of a date (e.g. "Jan", "Mai" in German).
-export function localizeMonthAbbreviation(
-  date: Temporal.PlainDate,
-  args: {
-    locale: string;
-    capitalize?: boolean;
-  },
-): string {
-  const cacheKey = JSON.stringify(args);
-  let format = intlDateTimeFormatCache.get(cacheKey);
-  if (!format) {
-    const options: Intl.DateTimeFormatOptions = { month: "short" };
-    options.timeZone = "Etc/UTC";
-    format = Intl.DateTimeFormat(args.locale, options);
-    intlDateTimeFormatCache.set(cacheKey, format);
+    intlOptions.month = options?.abbreviate ? "short" : "long";
+
+    if (options?.includeDay !== false) {
+      intlOptions.day = "numeric";
+    }
+
+    if (options?.includeDayOfWeek) {
+      intlOptions.weekday = options.abbreviate ? "short" : "long";
+    }
   }
-  const formatted = format.format(toDateForUTCDisplay(date));
-  return args.capitalize ? capitalizeFirstLetter(formatted, args.locale) : formatted;
+
+  if (options?.includeTime !== false) {
+    intlOptions.hour = "numeric";
+    intlOptions.minute = "numeric";
+    if (options?.includeSeconds) {
+      intlOptions.second = "numeric";
+    }
+  }
+
+  intlOptions.timeZone = UTC_TIMEZONE;
+  return intlOptions;
 }
 
 const timeZoneNameCache = new Map<string, string>();

--- a/app/web/utils/date.ts
+++ b/app/web/utils/date.ts
@@ -2,6 +2,8 @@ import { Duration as DurationPb } from "google-protobuf/google/protobuf/duration
 import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
 import { Temporal } from "temporal-polyfill";
 
+export const UTC_TIMEZONE = "Etc/UTC";
+
 /// Computes the number of days/nights between two dates.
 /// E.g. there's one day/night between 2020-01-01 and 2020-01-02.
 export function daysBetween(date1: Temporal.PlainDate, date2: Temporal.PlainDate): number {


### PR DESCRIPTION
Normalizes the shape of i18n date/time `localize***` functions. No functional changes.

- Rename "-Params" to "-Options" per typescript conventions
- Make `locale` a mandatory positional parameter, and `options`... optional, like `localizeRelativeTime`, `localizeTimeZone`, etc.
- Make all date/time localization functions funnel down to `localizeDateTime[Range]`
  - So `localizeMonthAbbreviation` becomes `localizeMonthName` and doesn't require its own caching mechanism.
- Add helpers to localize only dates or only times
- Update argument types to accept the exact type or anything that is a superset (e.g. PlainDateTime > PlainDate)

## Testing
Compared dashboard, events, profiles and invites in Vercel preview with NEXT and saw no difference in date/times.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me