### PR TITLE
Backend: count references from deleted authors, matching the referenc…

### DIFF
--- a/app/backend/src/couchers/servicers/public.py
+++ b/app/backend/src/couchers/servicers/public.py
@@ -18,7 +18,6 @@ from couchers.models import (
     InvoiceType,
     Node,
     ProfilePublicVisibility,
-    Reference,
     User,
     Volunteer,
 )
@@ -26,7 +25,13 @@ from couchers.models.uploads import get_avatar_upload
 from couchers.proto import api_pb2, public_pb2, public_pb2_grpc
 from couchers.proto.google.api import httpbody_pb2
 from couchers.resources import get_static_badge_dict
-from couchers.servicers.api import fluency2api, hostingstatus2api, meetupstatus2api, user_model_to_pb
+from couchers.servicers.api import (
+    fluency2api,
+    get_num_references,
+    hostingstatus2api,
+    meetupstatus2api,
+    user_model_to_pb,
+)
 from couchers.servicers.gis import _statement_to_geojson_response
 from couchers.sql import users_visible
 from couchers.utils import Timestamp_from_datetime, not_none, now
@@ -213,13 +218,10 @@ class Public(public_pb2_grpc.PublicServicer):
                 full_user=user_model_to_pb(user, session, make_logged_out_context(localization=context.localization))
             )
 
-        num_references = session.execute(
-            select(func.count())
-            .select_from(Reference)
-            .join(User, User.id == Reference.from_user_id)
-            .where(users_visible(context, User))
-            .where(Reference.to_user_id == user.id)
-        ).scalar_one()
+        # use the shared count so public profiles agree with the reference list and profile count
+        num_references = get_num_references(
+            session, make_logged_out_context(localization=context.localization), [user.id]
+        ).get(user.id, 0)
 
         if user.public_visibility == ProfilePublicVisibility.limited:
             return public_pb2.GetPublicUserRes(

--- a/app/backend/src/tests/test_public.py
+++ b/app/backend/src/tests/test_public.py
@@ -1,12 +1,12 @@
 import json
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 from math import sqrt
 from unittest.mock import patch
 
 import grpc
 import pytest
 from google.protobuf import empty_pb2
-from sqlalchemy import select
+from sqlalchemy import func, select, update
 
 from couchers.db import session_scope
 from couchers.jobs.enqueue import queue_job
@@ -29,6 +29,7 @@ from couchers.utils import now
 from tests.fixtures.db import generate_user, make_volunteer
 from tests.fixtures.misc import process_jobs
 from tests.fixtures.sessions import public_session
+from tests.test_references import create_friend_reference, create_host_reference
 
 
 @pytest.fixture(autouse=True)
@@ -631,3 +632,32 @@ def test_GetPublicUser_full_visibility(db):
         assert res.full_user.city == "Testing city"
         # Full user should have all the fields from the complete user profile
         assert res.full_user.hosting_status == api_pb2.HOSTING_STATUS_CANT_HOST
+
+
+def test_GetPublicUser_num_references_visibility_rules(db):
+    """The public reference count follows the same visibility rules as the reference list"""
+    user, _ = generate_user(public_visibility=ProfilePublicVisibility.limited)
+    friend_referrer, _ = generate_user()
+    recent_guest, _ = generate_user()
+    deleted_referrer1, _ = generate_user()
+    deleted_referrer2, _ = generate_user()
+    shadowed_referrer, _ = generate_user()
+
+    with session_scope() as session:
+        # counted: a normal friend reference
+        create_friend_reference(session, friend_referrer.id, user.id, timedelta(days=15))
+        # not counted: a recent stay where the reciprocal reference hasn't been written yet
+        create_host_reference(session, recent_guest.id, user.id, timedelta(days=3), surfing=False)
+        # counted: references from deleted users remain visible (two of them, so that miscounting
+        # deleted authors can't coincidentally cancel out against the hidden recent stay above)
+        create_friend_reference(session, deleted_referrer1.id, user.id, timedelta(days=16))
+        create_host_reference(session, deleted_referrer2.id, user.id, timedelta(days=30), surfing=False)
+        # not counted: references from shadowed users are hidden from others
+        create_friend_reference(session, shadowed_referrer.id, user.id, timedelta(days=17))
+        for deleted in (deleted_referrer1, deleted_referrer2):
+            session.execute(update(User).where(User.username == deleted.username).values(deleted_at=func.now()))
+        session.execute(update(User).where(User.username == shadowed_referrer.username).values(shadowed_at=func.now()))
+
+    with public_session() as public:
+        res = public.GetPublicUser(public_pb2.GetPublicUserReq(user=user.username))
+        assert res.limited_user.num_references == 3

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -540,6 +540,14 @@ def test_ListReference_blocked_shadowed_users(db):
     with api_session(token1) as api:
         assert api.GetUser(api_pb2.GetUserReq(user=user1.username)).num_references == 1
 
+    # the shadowed author still sees their own reference in both, so the shadow ban isn't leaked
+    with references_session(token3) as api:
+        refs_rec = api.ListReferences(references_pb2.ListReferencesReq(to_user_id=user1.id)).references
+        assert len(refs_rec) == 2
+
+    with api_session(token3) as api:
+        assert api.GetUser(api_pb2.GetUserReq(user=user1.username)).num_references == 2
+
 
 def test_WriteFriendReference(db, moderator):
     user1, token1 = generate_user()


### PR DESCRIPTION
Before:

<img width="1036" height="917" alt="image" src="https://github.com/user-attachments/assets/3b855375-7f94-42a2-9fc2-5b7923f533bf" />

After:

<img width="1033" height="918" alt="image" src="https://github.com/user-attachments/assets/b248d0c0-83ea-4506-acc4-7d3cc9f06725" />

Bug discovered in #9162 

The reference list (ListReferences) deliberately keeps showing references written by deleted users (rendered as an anonymized deactivated account), but get_num_references filtered authors on User.is_visible, which excludes deleted users - so a profile's reference count could be lower than the list it sits next to.

Align get_num_references' author-visibility rule with ListReferences: references by banned authors are hidden, ones by shadowed authors are visible only to the shadowed author themselves, and ones by deleted or blocked authors stay counted.

Also replace GetPublicUser's own inline reference count with get_num_references: it applied neither this rule, nor the reciprocal reference hiding rule, nor moderation visibility, so public profiles could show yet another count.

Enables the previously commented-out assert from #9162 as the regression test.

## Testing

- The assert that was left commented out in #9162 is now enabled and acts as the
  regression test: on develop it fails (the count says 0 while the list shows 1),
  with this fix it passes.
- Added `test_ListReference_shadowed_users`: both the list and the count hide a
  shadowed user's reference from other users, while the shadowed author still sees
  their own reference in both (so the shadow ban isn't leaked to them).
- Added `test_GetPublicUser_num_references_visibility_rules`: the public profile
  count follows the same rules as the list (references hidden by the reciprocity
  window aren't counted, references from deleted users are, references from
  shadowed users aren't).
- Full backend test suite passes locally, `make format` and `make mypy` clean.
- Verified manually in the local dev stack: gave a user some references and set
  `deleted_at` on one of the authors. On develop the profile badge shows a lower
  count than the list next to it; with this branch they agree.

To replicate manually: create a few references to a user, set `deleted_at` on one
of the authors in the db, and compare the count badge with the references list on
their profile.

**Backend checklist**

- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] ~~Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history~~ (no changes)

## For maintainers

- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
