### PR TITLE
Remove issue link from bug report success toast

### DIFF
--- a/app/web/components/Navigation/ReportButton.test.tsx
+++ b/app/web/components/Navigation/ReportButton.test.tsx
@@ -238,9 +238,8 @@ describe("ReportButton", () => {
       );
 
       const successAlert = await screen.findByRole("alert");
-      const bugLink = await within(successAlert).findByRole("link");
-      expect(bugLink).toBeVisible();
-      expect(bugLink).toHaveTextContent("#1");
+      expect(within(successAlert).getByText("#1")).toBeVisible();
+      expect(within(successAlert).queryByRole("link")).not.toBeInTheDocument();
       expect(reportBugMock).toHaveBeenCalledTimes(1);
       expect(reportBugMock).toHaveBeenCalledWith({
         description: "Log in is broken",

--- a/app/web/components/Navigation/ReportDialog.tsx
+++ b/app/web/components/Navigation/ReportDialog.tsx
@@ -10,7 +10,6 @@ import {
   DialogTitle,
 } from "components/Dialog";
 import Snackbar from "components/Snackbar";
-import StyledLink from "components/StyledLink";
 import TextField from "components/TextField";
 import { RpcError } from "grpc-web";
 import { useTranslation } from "i18n";
@@ -105,11 +104,7 @@ export default function ReportDialog({ open, onClose }: DialogProps) {
             i18nKey="report.bug.success_message2"
             t={t}
             components={{
-              id: (
-                <StyledLink variant="body2" href={bug.bugUrl}>
-                  {bug.bugId}
-                </StyledLink>
-              ),
+              id: <span>{bug.bugId}</span>,
             }}
           />
         </Snackbar>


### PR DESCRIPTION
Since the bugs repo is not public, this removes the link to it.

Related to https://github.com/Couchers-org/couchers/issues/9398

---

No locale changes were needed: every language's `report.bug.success_message2` keeps the same `<id/>` placeholder, which now renders as a plain `<span>` instead of a `StyledLink`. `bug_url` remains in the RPC response but is no longer used by the web frontend.

## Testing
`yarn test ReportButton` passes (11 tests). The success-toast test was updated to assert the bug ID text is visible and that the alert contains no link.

To check manually: open the report dialog from the nav bar, choose "Report a bug", submit the form, and confirm the success toast shows the bug ID as plain, unclickable text.

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._