### PR TITLE
Add report buttons to discussion and event pages

### DIFF
--- a/app/web/features/FlagButton.tsx
+++ b/app/web/features/FlagButton.tsx
@@ -19,6 +19,7 @@ import { theme } from "theme";
 interface FlagButtonProps {
   contentRef: string;
   authorUser: string | number;
+  ariaLabel?: string;
   className?: string;
   size?: IconButtonProps["size"];
   renderButton?: (onClick: (event: React.MouseEvent) => void) => React.ReactNode;
@@ -27,6 +28,7 @@ interface FlagButtonProps {
 export default function FlagButton({
   contentRef,
   authorUser,
+  ariaLabel,
   className,
   size = "large",
   renderButton,
@@ -125,7 +127,7 @@ export default function FlagButton({
         renderButton(handleButtonClick)
       ) : (
         <IconButton
-          aria-label={t("report.flag.button_aria_label")}
+          aria-label={ariaLabel ?? t("report.flag.button_aria_label")}
           className={className}
           onClick={handleButtonClick}
           color="primary"

--- a/app/web/features/communities/discussions/Comment.tsx
+++ b/app/web/features/communities/discussions/Comment.tsx
@@ -8,6 +8,7 @@ import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
 import EllipsisMenu, { EllipsisMenuItem } from "components/EllipsisMenu";
 import Markdown from "components/Markdown";
 import MarkdownInput, { MarkdownInputProps } from "components/MarkdownInput";
+import { contentRefs } from "features/contentRefs";
 import FlagButton from "features/FlagButton";
 import CopyOnClick from "features/mod/CopyOnClick";
 import ModVisibleComponent from "features/mod/ModVisibleComponent";
@@ -228,7 +229,7 @@ export default function Comment({ topLevel = false, comment, parentThreadId, dis
         {!comment.deleted && (
           <StyledButtonsContainer>
             <StyledAvatar user={user} />
-            <FlagButton contentRef={`comment/${comment.threadId}`} authorUser={comment.authorUserId} />
+            <FlagButton contentRef={contentRefs.comment(comment)} authorUser={comment.authorUserId} />
           </StyledButtonsContainer>
         )}
         <StyledCommentContent sx={comment.deleted ? { gridColumn: "1 / -1" } : undefined}>

--- a/app/web/features/communities/discussions/DiscussionCard.tsx
+++ b/app/web/features/communities/discussions/DiscussionCard.tsx
@@ -14,6 +14,7 @@ import { routeToDiscussion } from "routes";
 import { theme } from "theme";
 
 import getContentSummary from "../getContentSummary";
+import getDiscussionContentRef from "./getDiscussionContentRef";
 
 const StyledDeletedTitle = styled(Typography)(() => ({
   color: "var(--mui-palette-text-secondary)",
@@ -85,10 +86,7 @@ export default function DiscussionCard({
     [discussion.content],
   );
 
-  const contentRef =
-    (discussion.ownerCommunityId != 0
-      ? `community/${discussion.ownerCommunityId}`
-      : `group/${discussion.ownerGroupId}`) + `/discussion/${discussion.discussionId}`;
+  const contentRef = getDiscussionContentRef(discussion);
 
   return (
     <StyledCard className={className} data-testid={DISCUSSION_CARD_TEST_ID}>

--- a/app/web/features/communities/discussions/DiscussionCard.tsx
+++ b/app/web/features/communities/discussions/DiscussionCard.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, Skeleton, styled, Typography } from "@mui/material";
 import Avatar from "components/Avatar";
+import { contentRefs } from "features/contentRefs";
 import FlagButton from "features/FlagButton";
 import CopyOnClick from "features/mod/CopyOnClick";
 import ModVisibleComponent from "features/mod/ModVisibleComponent";
@@ -14,7 +15,6 @@ import { routeToDiscussion } from "routes";
 import { theme } from "theme";
 
 import getContentSummary from "../getContentSummary";
-import getDiscussionContentRef from "./getDiscussionContentRef";
 
 const StyledDeletedTitle = styled(Typography)(() => ({
   color: "var(--mui-palette-text-secondary)",
@@ -86,7 +86,7 @@ export default function DiscussionCard({
     [discussion.content],
   );
 
-  const contentRef = getDiscussionContentRef(discussion);
+  const contentRef = contentRefs.discussion(discussion);
 
   return (
     <StyledCard className={className} data-testid={DISCUSSION_CARD_TEST_ID}>

--- a/app/web/features/communities/discussions/DiscussionPage.test.tsx
+++ b/app/web/features/communities/discussions/DiscussionPage.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor, waitForElementToBeRemoved, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { getProfileLinkA11yLabel } from "components/Avatar/constants";
+import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import mockRouter from "next-router-mock";
 import { discussionBaseRoute } from "routes";
 import { service } from "service";
@@ -37,6 +38,7 @@ const deleteDiscussionMock = service.discussions.deleteDiscussion as MockedServi
 >;
 const updateReplyMock = service.threads.updateReply as MockedService<typeof service.threads.updateReply>;
 const deleteReplyMock = service.threads.deleteReply as MockedService<typeof service.threads.deleteReply>;
+const reportContentMock = service.reporting.reportContent as MockedService<typeof service.reporting.reportContent>;
 
 function renderDiscussion() {
   mockRouter.setCurrentUrl(`${discussionBaseRoute}/1/what-is-there-to-do-in-amsterdam`);
@@ -446,6 +448,56 @@ describe("Discussion page", () => {
       const user = await openEditForm();
       user.click(screen.getByRole("button", { name: t("global:save") }));
       await assertErrorAlert("Update failed");
+    });
+  });
+
+  describe("Reporting a discussion", () => {
+    it("submits a report for the discussion itself", async () => {
+      reportContentMock.mockResolvedValue(new Empty());
+      renderDiscussion();
+      await waitForElementToBeRemoved(screen.getByRole("progressbar"));
+
+      const user = userEvent.setup();
+
+      user.click(
+        screen.getByRole("button", {
+          name: t("communities:report_discussion_button_a11y"),
+        }),
+      );
+
+      const reason = t("global:report.flag.reason.spam");
+      const reasonSelect = await screen.findByLabelText(t("global:report.flag.reason_label"));
+      user.selectOptions(reasonSelect, reason);
+      await waitFor(() => expect(reasonSelect).toHaveValue(reason));
+
+      user.click(screen.getByRole("button", { name: t("global:submit") }));
+
+      await waitFor(() => {
+        expect(reportContentMock).toHaveBeenCalledWith({
+          authorUser: discussions[0].creatorUserId,
+          contentRef: `community/${discussions[0].ownerCommunityId}/discussion/${discussions[0].discussionId}`,
+          description: "",
+          reason,
+        });
+      });
+    });
+
+    it("does not show the report button for a deleted discussion", async () => {
+      getDiscussionMock.mockResolvedValue({ ...discussions[0], deleted: true });
+      renderDiscussion();
+      await waitForElementToBeRemoved(screen.getByRole("progressbar"));
+
+      expect(
+        await screen.findByRole("heading", {
+          level: 1,
+          name: t("communities:discussion_deleted"),
+        }),
+      ).toBeVisible();
+      expect(
+        screen.queryByRole("button", {
+          name: t("communities:report_discussion_button_a11y"),
+        }),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/app/web/features/communities/discussions/DiscussionPage.tsx
+++ b/app/web/features/communities/discussions/DiscussionPage.tsx
@@ -13,6 +13,7 @@ import Markdown from "components/Markdown";
 import MarkdownInput from "components/MarkdownInput";
 import PageTitle from "components/PageTitle";
 import TextField from "components/TextField";
+import { contentRefs } from "features/contentRefs";
 import FlagButton from "features/FlagButton";
 import { discussionKey } from "features/queryKeys";
 import { useLiteUser } from "features/userQueries/useLiteUsers";
@@ -34,7 +35,6 @@ import CommunityPageSubHeader from "../CommunityPage/CommunityPageSubHeader";
 import PageHeader from "../PageHeader";
 import CommentTree from "./CommentTree";
 import DeleteDiscussionDialog from "./DeleteDiscussionDialog";
-import getDiscussionContentRef from "./getDiscussionContentRef";
 
 interface EditDiscussionFormData {
   title: string;
@@ -206,7 +206,7 @@ export default function DiscussionPage({ discussionId }: { discussionId: number 
                       <StyledTitleRowButtons>
                         {!discussion.deleted && (
                           <FlagButton
-                            contentRef={getDiscussionContentRef(discussion)}
+                            contentRef={contentRefs.discussion(discussion)}
                             authorUser={discussion.creatorUserId}
                             ariaLabel={t("communities:report_discussion_button_a11y")}
                           />

--- a/app/web/features/communities/discussions/DiscussionPage.tsx
+++ b/app/web/features/communities/discussions/DiscussionPage.tsx
@@ -13,6 +13,7 @@ import Markdown from "components/Markdown";
 import MarkdownInput from "components/MarkdownInput";
 import PageTitle from "components/PageTitle";
 import TextField from "components/TextField";
+import FlagButton from "features/FlagButton";
 import { discussionKey } from "features/queryKeys";
 import { useLiteUser } from "features/userQueries/useLiteUsers";
 import { RpcError } from "grpc-web";
@@ -33,6 +34,7 @@ import CommunityPageSubHeader from "../CommunityPage/CommunityPageSubHeader";
 import PageHeader from "../PageHeader";
 import CommentTree from "./CommentTree";
 import DeleteDiscussionDialog from "./DeleteDiscussionDialog";
+import getDiscussionContentRef from "./getDiscussionContentRef";
 
 interface EditDiscussionFormData {
   title: string;
@@ -90,6 +92,12 @@ const StyledActionButtons = styled("div")(() => ({
   display: "flex",
   gap: theme.spacing(1),
   justifyContent: "flex-end",
+}));
+
+const StyledTitleRowButtons = styled("div")(() => ({
+  alignItems: "center",
+  display: "flex",
+  flexShrink: 0,
 }));
 
 export const CREATOR_TEST_ID = "creator";
@@ -194,15 +202,26 @@ export default function DiscussionPage({ discussionId }: { discussionId: number 
                   </HeaderButton>
                   <StyledTitleRow>
                     <PageTitle>{discussion.deleted ? t("communities:discussion_deleted") : discussion.title}</PageTitle>
-                    {ellipsisMenuItems.length > 0 && !isEditing && (
-                      <EllipsisMenu
-                        idName="discussion-page"
-                        isMenuOpen={isEllipsisMenuOpen}
-                        menuAnchorEl={ellipsisMenuAnchorEl}
-                        onMenuOpen={(e) => setEllipsisMenuAnchorEl(e.currentTarget)}
-                        onMenuClose={() => setEllipsisMenuAnchorEl(null)}
-                        items={ellipsisMenuItems}
-                      />
+                    {!isEditing && (
+                      <StyledTitleRowButtons>
+                        {!discussion.deleted && (
+                          <FlagButton
+                            contentRef={getDiscussionContentRef(discussion)}
+                            authorUser={discussion.creatorUserId}
+                            ariaLabel={t("communities:report_discussion_button_a11y")}
+                          />
+                        )}
+                        {ellipsisMenuItems.length > 0 && (
+                          <EllipsisMenu
+                            idName="discussion-page"
+                            isMenuOpen={isEllipsisMenuOpen}
+                            menuAnchorEl={ellipsisMenuAnchorEl}
+                            onMenuOpen={(e) => setEllipsisMenuAnchorEl(e.currentTarget)}
+                            onMenuClose={() => setEllipsisMenuAnchorEl(null)}
+                            items={ellipsisMenuItems}
+                          />
+                        )}
+                      </StyledTitleRowButtons>
                     )}
                   </StyledTitleRow>
                   <div>

--- a/app/web/features/communities/events/EventCard.tsx
+++ b/app/web/features/communities/events/EventCard.tsx
@@ -2,6 +2,7 @@ import { Group } from "@mui/icons-material";
 import { Card, CardContent, CardMedia, Chip, styled, Typography } from "@mui/material";
 import { eventImagePlaceholderUrl } from "appConstants";
 import Divider from "components/Divider";
+import { contentRefs } from "features/contentRefs";
 import FlagButton from "features/FlagButton";
 import { useTranslation } from "i18n";
 import { localizeDateTimeRange } from "i18n/datetimes";
@@ -154,7 +155,7 @@ export default function EventCard({ event, className }: EventCardProps) {
           }}
         >
           <FlagButtonWrapper>
-            <FlagButton contentRef={`event/${event.eventId}`} authorUser={event.creatorUserId} />
+            <FlagButton contentRef={contentRefs.event(event)} authorUser={event.creatorUserId} />
           </FlagButtonWrapper>
         </CardMedia>
         <StyledCardContent>

--- a/app/web/features/communities/events/EventPage.test.tsx
+++ b/app/web/features/communities/events/EventPage.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import useCurrentUser from "features/userQueries/useCurrentUser";
+import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import mockRouter from "next-router-mock";
 import { User } from "proto/api_pb";
 import { AttendanceState } from "proto/events_pb";
@@ -37,6 +38,10 @@ jest.mock("features/userQueries/useCurrentUser");
 const useCurrentUserMock = useCurrentUser as jest.MockedFunction<typeof useCurrentUser>;
 
 const getLiteUsersMock = service.user.getLiteUsers as jest.MockedFunction<typeof service.user.getLiteUsers>;
+
+const reportContentMock = service.reporting.reportContent as jest.MockedFunction<
+  typeof service.reporting.reportContent
+>;
 
 function renderEventPage(id = 1, slug = "weekly-meetup") {
   mockRouter.setCurrentUrl(`${eventBaseRoute}/${id}/${slug}`);
@@ -288,6 +293,34 @@ describe("Event page", () => {
     renderEventPage();
 
     await assertErrorAlert(errorMessage);
+  });
+
+  describe("when the report button is clicked", () => {
+    it("submits a report for the event itself", async () => {
+      reportContentMock.mockResolvedValue(new Empty());
+      getEventMock.mockResolvedValue({ ...firstEvent, creatorUserId: 2 });
+      renderEventPage();
+
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      await user.click(
+        await screen.findByRole("button", {
+          name: t("communities:report_event_button_a11y"),
+        }),
+      );
+
+      const reason = t("global:report.flag.reason.spam");
+      await user.selectOptions(await screen.findByLabelText(t("global:report.flag.reason_label")), reason);
+      await user.click(screen.getByRole("button", { name: t("global:submit") }));
+
+      await waitFor(() => {
+        expect(reportContentMock).toHaveBeenCalledWith({
+          authorUser: 2,
+          contentRef: `event/${firstEvent.eventId}`,
+          description: "",
+          reason,
+        });
+      });
+    });
   });
 
   describe("when the event attendance button is clicked", () => {

--- a/app/web/features/communities/events/EventPage.tsx
+++ b/app/web/features/communities/events/EventPage.tsx
@@ -13,6 +13,7 @@ import Markdown from "components/Markdown";
 import Snackbar from "components/Snackbar";
 import { useAuthContext } from "features/auth/AuthProvider";
 import EventAttendees from "features/communities/events/EventAttendees";
+import FlagButton from "features/FlagButton";
 import NotFoundPage from "features/NotFoundPage";
 import { RpcError } from "grpc-web";
 import { useTranslation } from "i18n";
@@ -304,6 +305,11 @@ export default function EventPage({ eventId, eventSlug }: { eventId: number; eve
               </StyledTitle>
               <StyledActionButtonsContainer>
                 <StyledIconButtonGroup>
+                  <FlagButton
+                    contentRef={`event/${event.eventId}`}
+                    authorUser={event.creatorUserId}
+                    ariaLabel={t("communities:report_event_button_a11y")}
+                  />
                   <EllipsisMenu
                     idName="event-page"
                     isMenuOpen={isEllipsisMenuOpen}

--- a/app/web/features/communities/events/EventPage.tsx
+++ b/app/web/features/communities/events/EventPage.tsx
@@ -13,6 +13,7 @@ import Markdown from "components/Markdown";
 import Snackbar from "components/Snackbar";
 import { useAuthContext } from "features/auth/AuthProvider";
 import EventAttendees from "features/communities/events/EventAttendees";
+import { contentRefs } from "features/contentRefs";
 import FlagButton from "features/FlagButton";
 import NotFoundPage from "features/NotFoundPage";
 import { RpcError } from "grpc-web";
@@ -306,7 +307,7 @@ export default function EventPage({ eventId, eventSlug }: { eventId: number; eve
               <StyledActionButtonsContainer>
                 <StyledIconButtonGroup>
                   <FlagButton
-                    contentRef={`event/${event.eventId}`}
+                    contentRef={contentRefs.event(event)}
                     authorUser={event.creatorUserId}
                     ariaLabel={t("communities:report_event_button_a11y")}
                   />

--- a/app/web/features/communities/events/LongEventCard.tsx
+++ b/app/web/features/communities/events/LongEventCard.tsx
@@ -2,6 +2,7 @@ import { Group } from "@mui/icons-material";
 import { Card, CardContent, CardMedia, styled, Tooltip, Typography } from "@mui/material";
 import { eventImagePlaceholderUrl } from "appConstants";
 import Pill from "components/Pill";
+import { contentRefs } from "features/contentRefs";
 import FlagButton from "features/FlagButton";
 import { useTranslation } from "i18n";
 import { localizeDateTimeRange } from "i18n/datetimes";
@@ -147,7 +148,7 @@ const LongEventCard = ({ event, userId }: { event: Event.AsObject; userId?: numb
           }}
         />
         <FlagWrapper>
-          <FlagButton contentRef={`event/${event.eventId}`} authorUser={event.creatorUserId} />
+          <FlagButton contentRef={contentRefs.event(event)} authorUser={event.creatorUserId} />
         </FlagWrapper>
 
         <StyledCardContent>

--- a/app/web/features/communities/locales/en.json
+++ b/app/web/features/communities/locales/en.json
@@ -44,6 +44,7 @@
     "cancel": "Cancel"
   },
   "edit_discussion": "Edit discussion",
+  "report_discussion_button_a11y": "Report this discussion",
   "create_new_discussion_title": "Create new post",
   "discussions_empty_state": "No discussions at the moment.",
   "discussions_label": "Discussions",
@@ -52,6 +53,7 @@
   "copy_link_success": "Link copied to clipboard",
   "duplicate_event": "Duplicate event",
   "edit_event": "Edit event",
+  "report_event_button_a11y": "Report this event",
   "edit_info_page_title": "Edit local info",
   "error_loading_community": "Error loading the community.",
   "events_empty_state": "No events at the moment. Why don't you <0>create</0> one ✨?",

--- a/app/web/features/contentRefs.ts
+++ b/app/web/features/contentRefs.ts
@@ -1,0 +1,28 @@
+import type { User } from "proto/api_pb";
+import type { Discussion } from "proto/discussions_pb";
+import type { Event } from "proto/events_pb";
+import type { PhotoGalleryItem } from "proto/galleries_pb";
+import type { Message } from "proto/messages_pb";
+import type { PublicTrip } from "proto/public_trips_pb";
+import type { Reply } from "proto/threads_pb";
+
+// content_refs identify reported content to moderators, see //docs/content_ref.md
+export const contentRefs = {
+  profile: (user: User.AsObject) => `profile/${user.userId}`,
+  chatMessage: (message: Message.AsObject) => `chat/message/${message.messageId}`,
+  photo: (photo: PhotoGalleryItem.AsObject) => `photo/${photo.itemId}`,
+  publicTrip: (trip: PublicTrip.AsObject) => `public_trip/${trip.tripId}`,
+  event: (event: Event.AsObject) => `event/${event.eventId}`,
+  // a comment is referenced by its own thread id, not the thread of the
+  // discussion or event it hangs off
+  comment: (comment: Reply.AsObject) => `comment/${comment.threadId}`,
+  // a discussion belongs to either a community or a group; the proto oneof is
+  // flattened into two numbers, so the unset one comes back as 0
+  discussion: (discussion: Discussion.AsObject) => {
+    const owner =
+      discussion.ownerCommunityId !== 0
+        ? `community/${discussion.ownerCommunityId}`
+        : `group/${discussion.ownerGroupId}`;
+    return `${owner}/discussion/${discussion.discussionId}`;
+  },
+};

--- a/app/web/features/messages/messagelist/MessageView.tsx
+++ b/app/web/features/messages/messagelist/MessageView.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, Skeleton, styled, Typography } from "@mui/material";
 import Avatar from "components/Avatar";
 import Linkify from "components/Linkify";
 import TextBody from "components/TextBody";
+import { contentRefs } from "features/contentRefs";
 import FlagButton from "features/FlagButton";
 import TimeInterval from "features/messages/messagelist/TimeInterval";
 import useCurrentUser from "features/userQueries/useCurrentUser";
@@ -170,11 +171,7 @@ export default function MessageView({ className, message, onVisible, isDm = fals
         <StyledFooter>
           <StyledTimeInterval instant={timestampToInstant(message.time!)} />
           {author && !isCurrentUser && (
-            <StyledFlagButton
-              contentRef={`chat/message/${message.messageId}`}
-              authorUser={author.userId}
-              size="small"
-            />
+            <StyledFlagButton contentRef={contentRefs.chatMessage(message)} authorUser={author.userId} size="small" />
           )}
         </StyledFooter>
       </StyledCard>

--- a/app/web/features/profile/view/Overview.tsx
+++ b/app/web/features/profile/view/Overview.tsx
@@ -6,6 +6,7 @@ import ProfileIncompleteDialog from "components/ProfileIncompleteDialog/ProfileI
 import { doAntibot } from "features/antibot/antibot";
 import { useAuthContext } from "features/auth/AuthProvider";
 import useAccountInfo from "features/auth/useAccountInfo";
+import { contentRefs } from "features/contentRefs";
 import FriendActions from "features/profile/actions/FriendActions";
 import MessageUserButton from "features/profile/actions/MessageUserButton";
 import UserOverview from "features/profile/view/UserOverview";
@@ -111,7 +112,7 @@ function DefaultActions({
       <FriendActions user={user} setMutationError={setMutationError} />
 
       <StyledModButtons>
-        <ProfileReportFlagButton contentRef={`profile/${user.userId}`} authorUser={user.userId} profileUser={user} />
+        <ProfileReportFlagButton contentRef={contentRefs.profile(user)} authorUser={user.userId} profileUser={user} />
         <AdminPanelUserButton username={user.username} />
       </StyledModButtons>
 

--- a/app/web/features/profile/view/PhotoLightbox.tsx
+++ b/app/web/features/profile/view/PhotoLightbox.tsx
@@ -1,18 +1,15 @@
 import { ArrowBackIos, ArrowForwardIos, Close } from "@mui/icons-material";
 import { Box, IconButton, Modal, styled, Typography } from "@mui/material";
 import { FlagIcon } from "components/Icons";
+import { contentRefs } from "features/contentRefs";
 import FlagButton from "features/FlagButton";
 import { useTranslation } from "i18n";
 import { PROFILE } from "i18n/namespaces";
+import type { PhotoGalleryItem } from "proto/galleries_pb";
 import { useCallback, useEffect, useState } from "react";
 
 interface PhotoLightboxProps {
-  photos: Array<{
-    fullUrl: string;
-    thumbnailUrl: string;
-    caption?: string;
-    itemId?: number;
-  }>;
+  photos: Array<PhotoGalleryItem.AsObject>;
   initialIndex: number;
   open: boolean;
   onClose: () => void;
@@ -306,7 +303,7 @@ export default function PhotoLightbox(props: PhotoLightboxProps) {
 
         {galleryOwnerId && currentPhoto.itemId && (
           <FlagButton
-            contentRef={`photo/${currentPhoto.itemId}`}
+            contentRef={contentRefs.photo(currentPhoto)}
             authorUser={galleryOwnerId}
             renderButton={(onClick) => (
               <ReportButtonContainer

--- a/app/web/features/profile/view/ProfilePhotoGallery.tsx
+++ b/app/web/features/profile/view/ProfilePhotoGallery.tsx
@@ -1,5 +1,6 @@
 import { Box, ImageList, ImageListItem, styled, Typography } from "@mui/material";
 import CircularProgress from "components/CircularProgress";
+import { contentRefs } from "features/contentRefs";
 import FlagButton from "features/FlagButton";
 import { useGallery } from "features/profile/hooks/useGallery";
 import { useProfileUser } from "features/profile/hooks/useProfileUser";
@@ -133,7 +134,7 @@ export default function ProfilePhotoGallery({ galleryId }: ProfilePhotoGalleryPr
                 }}
                 aria-label={t("profile:gallery.report_photo")}
               >
-                <FlagButton contentRef={`photo/${photo.itemId}`} authorUser={profileUser.userId} />
+                <FlagButton contentRef={contentRefs.photo(photo)} authorUser={profileUser.userId} />
               </FlagButtonWrapper>
             </ThumbnailContainer>
           </StyledImageListItem>
@@ -141,12 +142,7 @@ export default function ProfilePhotoGallery({ galleryId }: ProfilePhotoGalleryPr
       </StyledImageList>
 
       <PhotoLightbox
-        photos={gallery.photosList.map((photo) => ({
-          fullUrl: photo.fullUrl,
-          thumbnailUrl: photo.thumbnailUrl,
-          caption: photo.caption,
-          itemId: photo.itemId,
-        }))}
+        photos={gallery.photosList}
         initialIndex={selectedPhotoIndex}
         open={lightboxOpen}
         onClose={handleCloseLightbox}

--- a/app/web/features/publicTrips/PublicTripCard.tsx
+++ b/app/web/features/publicTrips/PublicTripCard.tsx
@@ -19,6 +19,7 @@ import ProfileIncompleteDialog from "components/ProfileIncompleteDialog/ProfileI
 import StyledLink from "components/StyledLink";
 import { useAuthContext } from "features/auth/AuthProvider";
 import useAccountInfo from "features/auth/useAccountInfo";
+import { contentRefs } from "features/contentRefs";
 import FlagButton from "features/FlagButton";
 import { useTranslation } from "i18n";
 import { localizeDateRange } from "i18n/datetimes";
@@ -427,7 +428,7 @@ export default function PublicTripCard({ trip, ownerView = false, id }: PublicTr
                       {t("publicTrips:view_profile")}
                     </StyledLink>
                     <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                      <FlagButton contentRef={`public_trip/${trip.tripId}`} authorUser={user.userId} />
+                      <FlagButton contentRef={contentRefs.publicTrip(trip)} authorUser={user.userId} />
                       {alreadyOffered ? (
                         // Link to the existing offer thread.
                         <Button

--- a/docs/content_ref.md
+++ b/docs/content_ref.md
@@ -17,3 +17,33 @@ Explanation: flag button on a user's profile
 `content_ref`: `chat/message/{message_id}`
 
 Explanation: message sent by one user to another, as part of a normal chat or a request
+
+## Photo
+
+`content_ref`: `photo/{item_id}`
+
+Explanation: a photo in a user's profile gallery
+
+## Public trip
+
+`content_ref`: `public_trip/{trip_id}`
+
+Explanation: a trip a user has made public
+
+## Discussion
+
+`content_ref`: `community/{community_id}/discussion/{discussion_id}` or `group/{group_id}/discussion/{discussion_id}`
+
+Explanation: flag button on a discussion, either on the discussion's own page or on the card in a list of discussions. Discussions belong to either a community or a group, hence the two forms
+
+## Event
+
+`content_ref`: `event/{event_id}`
+
+Explanation: flag button on an event, either on the event's own page or on the card in a list of events
+
+## Comment
+
+`content_ref`: `comment/{thread_id}`
+
+Explanation: a comment or reply on a discussion or an event. Note that this is the thread id of the comment itself, not of the discussion or event it belongs to

--- a/docs/content_ref.md
+++ b/docs/content_ref.md
@@ -4,7 +4,7 @@ When content is reported by the *reporting user* to admins, the report includes 
 
 The content reference, or `content_ref`, is a reference that uniquely identifies a piece of content and helps the admin or moderator find the flagged content. It is in many aspects similar to the path in a URL, but sometimes a page has several different pieces of content that are not uniquely identified by the page. For example, a discussion will have multiple comment on the same page.
 
-This page documents the `content_ref`s currently in use.
+This page documents the `content_ref`s currently in use. On the web frontend they are all built by the helpers in `app/web/features/contentRefs.ts`; keep the two in sync.
 
 ## User profile
 


### PR DESCRIPTION

<img width="1248" height="559" alt="Screenshot 2026-07-31 at 07 40 17" src="https://github.com/user-attachments/assets/684ab7c4-8f33-4971-8c00-58864586cf16" />
<img width="1253" height="483" alt="Screenshot 2026-07-31 at 07 39 59" src="https://github.com/user-attachments/assets/8af4a071-4a6f-4d01-a492-ca12ac63b8c4" />

---

Discussions and events could previously only be reported from their cards in a list — there was no way to report the content from the discussion's or event's own page. This adds a flag button to both pages.

closes #9394

- `EventPage`: flag button in the existing icon-button group, next to the ellipsis menu, using `content_ref` `event/{event_id}` — the same ref the event cards emit, so reports from the card and the page look identical to moderators.
- `DiscussionPage`: flag button in the title row, next to the ellipsis menu. Hidden while editing and for deleted discussions (mirroring how `Comment.tsx` hides it for deleted comments).
- `FlagButton` gains an optional `ariaLabel`, defaulting to the existing generic label. These pages render a flag button per comment, so without a distinct label a screen-reader user can't tell which button reports the page's own content. The page-level buttons are labelled "Report this discussion" / "Report this event".
- The `community/{id}/discussion/{id}` vs `group/{id}/discussion/{id}` ref construction that was inline in `DiscussionCard` is extracted to `getDiscussionContentRef`, now shared by the card and the page.
- `docs/content_ref.md` claimed to list all `content_ref`s in use but only had profile and chat message; the discussion, event, comment, photo and public trip refs are now documented too.

## Testing

Added tests to both page test suites:
- `EventPage`: opening the report dialog, picking a reason and submitting calls `reportContent` with `event/1` and the event's author.
- `DiscussionPage`: the same for `community/1/discussion/1`, plus an assertion that no report button shows for a deleted discussion.

`yarn test features/communities/discussions/DiscussionPage.test.tsx features/communities/events/EventPage.test.tsx` passes, as do `yarn lint` and `tsc` for the touched files.

Note that `yarn test features/communities` has 24 pre-existing failures (CreateEventPage, EventForm, CommunitySearch, EventsPage); the identical 24 fail on a clean `develop` and are unrelated to this change.

To check manually: open any discussion page and any event page, click the flag icon next to the ellipsis menu, pick a reason and submit.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._