### PR TITLE
Announce release-note-worthy PRs to Slack

### DIFF
--- a/.github/llm-bot/pr_release_notes.py
+++ b/.github/llm-bot/pr_release_notes.py
@@ -12,9 +12,12 @@ import re
 from typing import Optional, List, Dict, Any
 from enum import Enum
 
+import requests
 from pydantic import BaseModel, Field
 from a5.ai import LLM
 from github import Github, Auth
+
+from slack import send_slack_message
 
 
 # ============================================================================
@@ -324,7 +327,6 @@ class PRReleaseNotesBot:
         """Get the PR diff, truncated if necessary."""
         # Get the diff using the GitHub API
         # We need to make a raw request with the diff media type
-        import requests
         headers = {
             'Authorization': f'token {os.environ["GITHUB_TOKEN"]}',
             'Accept': 'application/vnd.github.v3.diff'
@@ -498,12 +500,23 @@ This PR does not need to be included in release notes.
 
         print(f"\n✅ Successfully processed PR #{self.pr_number}")
 
+    def announce_to_slack(self, decision: BotDecision):
+        """Announce an included PR to Slack."""
+
+        if decision.decision != ReleaseNotesDecision.INCLUDE or not decision.release_note:
+            return
+
+        send_slack_message(
+            f"{decision.release_note}\n\n"
+            f"<{self.pr.html_url}|#{self.pr_number}: {self.pr.title}> by {self.pr.user.login}"
+        )
+
     def run(self):
         """Main execution flow."""
-        try:
-            if not self.should_process():
-                return
+        if not self.should_process():
+            return
 
+        try:
             decision = self.analyze_pr()
             self.apply_decision(decision)
         except Exception as e:
@@ -517,6 +530,10 @@ This PR does not need to be included in release notes.
                 f"Error: `{type(e).__name__}: {str(e)}`"
             )
             sys.exit(1)
+
+        # Outside the handler above: the labelling and comment have already landed, so a
+        # Slack failure should fail the job loudly rather than claim the PR needs a human
+        self.announce_to_slack(decision)
 
 
 # ============================================================================

--- a/.github/llm-bot/pyproject.toml
+++ b/.github/llm-bot/pyproject.toml
@@ -8,4 +8,5 @@ dependencies = [
     "openai>=2.7.1",
     "pydantic>=2.12.4",
     "pygithub>=2.8.1",
+    "requests>=2.32.5",
 ]

--- a/.github/llm-bot/slack.py
+++ b/.github/llm-bot/slack.py
@@ -1,0 +1,24 @@
+"""
+Slack posting for the GitHub LLM bots.
+
+Standalone rather than reusing couchers.slack: the bots run in GitHub Actions and
+can't import backend code. This posts via an incoming webhook, which has the
+channel baked into the URL and takes mrkdwn (so links are `<url|text>`).
+"""
+
+import os
+
+import requests
+
+
+def send_slack_message(text: str) -> None:
+    webhook_url = os.environ.get("SLACK_WEBHOOK_URL")
+    if not webhook_url:
+        # Forks and misconfigured setups have no webhook; don't fail the job over it
+        print(f"No Slack webhook set, would have sent: {text}")
+        return
+
+    # Webhooks answer with a plain-text "ok" body, so there's no JSON status to check
+    response = requests.post(webhook_url, json={"text": text}, timeout=10)
+    response.raise_for_status()
+    print(f"Posted to Slack: {text}")

--- a/.github/llm-bot/uv.lock
+++ b/.github/llm-bot/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation != 'PyPy'",
@@ -221,6 +221,7 @@ dependencies = [
     { name = "openai" },
     { name = "pydantic" },
     { name = "pygithub" },
+    { name = "requests" },
 ]
 
 [package.metadata]
@@ -229,6 +230,7 @@ requires-dist = [
     { name = "openai", specifier = ">=2.7.1" },
     { name = "pydantic", specifier = ">=2.12.4" },
     { name = "pygithub", specifier = ">=2.8.1" },
+    { name = "requests", specifier = ">=2.32.5" },
 ]
 
 [[package]]

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -31,6 +31,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LLM_API_KEY: ${{ secrets.BOT_LLM_API_KEY }}
           LLM_MODEL: ${{ secrets.BOT_LLM_MODEL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.BOT_SLACK_RELEASE_NOTES_WEBHOOK_URL }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
         run: uv run pr_release_notes.py


### PR DESCRIPTION
When the release notes bot decides a PR should be included in the release notes, it now posts the suggested note and a link to the PR into Slack, alongside the existing label and PR comment.

- New `.github/llm-bot/slack.py` posts to a Slack incoming webhook. Standalone rather than reusing `couchers.slack` because the bots run in GitHub Actions and can't import backend code. It no-ops when `SLACK_WEBHOOK_URL` is unset, so forks are unaffected.
- `announce_to_slack()` fires for every `include` decision, on the merge trigger and the manual `release notes: evaluate` label alike.
- The Slack call sits outside the existing `try`/`except` in `run()`. By that point the label and comment have already landed, so a Slack failure should fail the job loudly rather than post the "a human maintainer will review this" comment, which would be misleading. `should_process()` moved out of the same `try` — it does no I/O, and hoisting it makes the `decision` binding unambiguous.
- `requests` is now a declared dependency rather than a transitive one via pygithub, and its inline import inside `_get_pr_diff` moved to the top of the file.

Two details of the webhook API worth noting, both confirmed against Slack's docs:

- Incoming webhooks accept `text` and `blocks`, **not** the `markdown_text` field that `chat.postMessage` takes. So the link is mrkdwn `<url|text>`, not Markdown `[text](url)`.
- A successful webhook post returns HTTP 200 with a plain-text `ok` body, not JSON. There's therefore no `{"ok": ...}` to inspect and `raise_for_status()` is the whole check — parsing the response as JSON would raise on success.

Note that `uv lock` bumped the lockfile format `revision` from 2 to 3 (newer local uv than whatever wrote it originally). `setup-uv@v6` installs latest uv so CI reads it fine, but happy to revert that line if you'd rather keep it at 2.

**Requires one secret before it does anything:** `BOT_SLACK_RELEASE_NOTES_WEBHOOK_URL`, set to the incoming webhook URL for the target channel. Until it's set the bot behaves exactly as it does today.

## Testing

`.github/llm-bot` isn't covered by the backend ruff config and isn't ruff-formatted, so `make format` was deliberately not run over it.

Verified locally against a stub HTTP server that mimics a webhook, returning a plain-text `ok` body, with no real Slack or GitHub I/O:

- `exclude` decision → nothing sent.
- `include` with no webhook configured → skipped with a log line, no request.
- `include` with a webhook set → exactly one POST, body `{"text": "Added a thing\n\n<https://gh/pr/42|#42: Add a thing> by dev"}`, and the plain-text response parses without error.

The real Slack endpoint is **untested** — that needs the actual webhook URL. Suggested check once the secret is set: add the `release notes: evaluate` label to a PR that has neither release-notes label yet, and confirm one message lands in the channel and the link renders.

Unrelated but noticed while doing this: `couchers/slack.py` in the backend passes mrkdwn-style `<url|text>` links into `chat.postMessage`'s `markdown_text` field, which expects standard Markdown. Might be worth checking whether those links render in the donations channel.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._