### PR TITLE
Backend/i18n: Support en-US locale, without a dedicated translation

### DIFF
--- a/app/backend/src/couchers/email/calendar_events.py
+++ b/app/backend/src/couchers/email/calendar_events.py
@@ -155,7 +155,7 @@ def _set_datetime_with_timezone(event: Event, name: str, dt: datetime) -> None:
 
 def ics_event_to_calendar(event: Event, method: str | None, loc_context: LocalizationContext) -> Calendar:
     # PRODID is mandatory and generally follows "-//[Organization]//[Product Name]//[Language]"
-    calendar = Calendar(creator=f"-//Couchers.org//Couchers//{loc_context.locale.upper()}")
+    calendar = Calendar(creator=f"-//Couchers.org//Couchers//{loc_context.preferred_locale.upper()}")
     if method:
         calendar.method = method
     calendar.events.add(event)

--- a/app/backend/src/couchers/email/dump_emails.py
+++ b/app/backend/src/couchers/email/dump_emails.py
@@ -24,7 +24,7 @@ from couchers.email.blocks import (
 )
 from couchers.email.rendering import render_email, template_folder
 from couchers.i18n import LocalizationContext
-from couchers.i18n.locales import DEFAULT_LOCALE, get_supported_locales
+from couchers.i18n.locales import DEFAULT_LOCALE, get_locales_with_translations
 from couchers.templating import Jinja2Template
 
 
@@ -70,7 +70,7 @@ class RenderedVariation:
 
 def _ordered_locales(locales: list[str] | None) -> list[str]:
     if locales is None:
-        locales = get_supported_locales()
+        locales = get_locales_with_translations()
     return sorted(locales, key=lambda locale: (locale != DEFAULT_LOCALE, locale))
 
 

--- a/app/backend/src/couchers/i18n/context.py
+++ b/app/backend/src/couchers/i18n/context.py
@@ -13,7 +13,7 @@ from couchers.i18n.locales import (
     get_babel_locale,
     get_locale_chain,
     get_main_i18next,
-    is_supported_locale,
+    to_supported_locale,
 )
 from couchers.i18n.localize import (
     localize_date,
@@ -30,40 +30,45 @@ class LocalizationContext:
     """
     Specifies regional settings used for localization of strings and date/times.
     Future settings like 12/24h or format preferences would go here as well.
+    Only represents locale we support on the backend.
     """
 
-    # The locale code (e.g. 'en', 'pt-BR'), used to lookup translations and format dates/numbers.
-    # Note that a locale doesn't necessarily specify a region.
-    locale: str
-
-    # The locale code and all of its fallbacks.
+    # The locales to be used from most to least preferred, for example: pt-BR, pt, en.
     locale_list: list[str]
+
+    # Babel objects for the locales in locale_list.
+    # In some cases we might remap locales.
+    # For example "en" could use the "en-001" babel locale for international date formats.
+    babel_locale_list: list[babel.Locale]
 
     # The timezone to use when formatting date-times and instants.
     timezone: tzinfo
 
-    # The Babel locale used for datetime formatting and other Unicode CLDR usage.
-    babel_locale: babel.Locale
-
     def __init__(self, locale: str, timezone: tzinfo) -> None:
-        if not is_supported_locale(locale):
-            raise ValueError(f"Unsupported locale {locale}.")
+        locale = to_supported_locale(locale)
 
-        self.locale = locale
-        self.locale_list = get_locale_chain(self.locale)
+        self.locale_list = get_locale_chain(locale)
+        self.babel_locale_list = list(map(get_babel_locale, self.locale_list))
         self.timezone = timezone
-        self.babel_locale = get_babel_locale(locale)
 
     def __setattr__(self, name: str, value: Any) -> None:
         # Freeze after initialization. We can't use @dataclass(frozen=True) because then
         # we need the default initializer and some of our fields shouldn't be parameters.
-        if hasattr(self, "babel_locale"):
+        if hasattr(self, "timezone"):
             raise FrozenInstanceError(f"Cannot modify attribute {name}.")
         return object.__setattr__(self, name, value)
 
     @property
+    def preferred_locale(self) -> str:
+        return self.locale_list[0]
+
+    @property
+    def preferred_babel_locale(self) -> babel.Locale:
+        return self.babel_locale_list[0]
+
+    @property
     def localized_timezone(self) -> str:
-        return localize_timezone(self.timezone, self.babel_locale)
+        return localize_timezone(self.timezone, self.babel_locale_list)
 
     def localize_string(
         self, key: str, *, i18next: I18Next | None = None, substitutions: SubstitutionDict | None = None
@@ -72,7 +77,7 @@ class LocalizationContext:
         return i18next.localize(key, self.locale_list, substitutions=substitutions)
 
     def localize_list(self, items: Sequence[str]) -> str:
-        return localize_list(items, self.babel_locale)
+        return localize_list(items, self.babel_locale_list)
 
     def localize_date(
         self, value: date | datetime, *, abbrev: bool = False, with_year: bool = True, with_day_of_week: bool = False
@@ -80,7 +85,7 @@ class LocalizationContext:
         if isinstance(value, datetime):
             value = to_timezone(value, self.timezone).date()
         return localize_date(
-            value, self.babel_locale, abbrev=abbrev, with_year=with_year, with_day_of_week=with_day_of_week
+            value, self.preferred_babel_locale, abbrev=abbrev, with_year=with_year, with_day_of_week=with_day_of_week
         )
 
     def localize_date_from_iso(
@@ -117,7 +122,7 @@ class LocalizationContext:
             # By default we display the datetime in the user's timezone.
             # The "timezone" parameter overrides this behavior.
             to_timezone(value, display_timezone or self.timezone),
-            self.babel_locale,
+            self.preferred_babel_locale,
             abbrev=abbrev,
             with_year=with_year,
             with_day_of_week=with_day_of_week,
@@ -127,7 +132,7 @@ class LocalizationContext:
     def localize_time(self, value: datetime | time, *, with_seconds: bool = False) -> str:
         if isinstance(value, datetime):
             value = to_timezone(value, self.timezone).time()
-        return localize_time(value, self.babel_locale, with_seconds=with_seconds)
+        return localize_time(value, self.preferred_babel_locale, with_seconds=with_seconds)
 
     @staticmethod
     def en_utc() -> LocalizationContext:

--- a/app/backend/src/couchers/i18n/locales.py
+++ b/app/backend/src/couchers/i18n/locales.py
@@ -11,26 +11,41 @@ from couchers.i18n.i18next import I18Next
 # Note: "en" is a valid locale even if it doesn't include a region.
 DEFAULT_LOCALE = "en"
 
+# Locales that we support for regional formatting,
+# but don't have dedicated translations.
+NON_TRANSLATED_LOCALES: list[str] = ["en-US"]
+
 # Locale fallbacks (for those that don't fallback to English).
 # If a string is not found in the requested language, we try the provided one before English
 # Some mutually intelligible language variants fallback to each other.
 _LOCALE_FALLBACKS: dict[str, str] = {
     "pt-BR": "pt",
     "pt": "pt-BR",
+    "en-US": "en",
     "es-419": "es",
     "es": "es-419",
     "fr-CA": "fr",
 }
 
 
-def get_supported_locales() -> list[str]:
-    """Gets the list of supported locales (i.e., for which we have translations)."""
+def get_locales_with_translations() -> list[str]:
+    """Gets the list of locales which have translations."""
     return list(get_main_i18next().translations_by_locale.keys())
 
 
-def is_supported_locale(locale: str) -> bool:
-    """Checks if a locale is supported (i.e., if we have translations for it)."""
+def is_locale_with_translations(locale: str) -> bool:
+    """Checks if we have translations for a given locale."""
     return locale in get_main_i18next().translations_by_locale.keys()
+
+
+def get_supported_locales() -> list[str]:
+    """Gets the list of locales supported."""
+    return get_locales_with_translations() + NON_TRANSLATED_LOCALES
+
+
+def is_supported_locale(locale: str) -> bool:
+    """Checks if a locale is supported."""
+    return locale in get_supported_locales()
 
 
 def to_supported_locale(locale: str) -> str:
@@ -77,6 +92,7 @@ def get_babel_locale(locale: str) -> babel.Locale:
     Returns the babel locale object for a given locale string.
     Guaranteed by tests to succeed for supported locales.
     """
+    # TODO(#9184): Once we have en-US available, "en" should return the babel locale for "en-001" (Global English)
     return babel.Locale.parse(locale, sep="-")
 
 

--- a/app/backend/src/couchers/i18n/locales.py
+++ b/app/backend/src/couchers/i18n/locales.py
@@ -21,7 +21,6 @@ NON_TRANSLATED_LOCALES: list[str] = ["en-US"]
 _LOCALE_FALLBACKS: dict[str, str] = {
     "pt-BR": "pt",
     "pt": "pt-BR",
-    "en-US": "en",
     "es-419": "es",
     "es": "es-419",
     "fr-CA": "fr",
@@ -45,7 +44,7 @@ def get_supported_locales() -> list[str]:
 
 def is_supported_locale(locale: str) -> bool:
     """Checks if a locale is supported."""
-    return locale in get_supported_locales()
+    return is_locale_with_translations(locale) or locale in NON_TRANSLATED_LOCALES
 
 
 def to_supported_locale(locale: str) -> str:

--- a/app/backend/src/couchers/i18n/localize.py
+++ b/app/backend/src/couchers/i18n/localize.py
@@ -16,45 +16,58 @@ from babel.lists import format_list
 from couchers.resources import get_region_code_iso3166_alpha3_to_alpha2
 
 
-def localize_list(items: Sequence[str], locale: babel.Locale) -> str:
-    return format_list(items, locale=locale)
+def localize_list(items: Sequence[str], locales: list[babel.Locale]) -> str:
+    for locale in locales:
+        try:
+            return format_list(items, locale=locale)
+        except ValueError:  # Raised if the locale doesn't support list formatting
+            continue
+    return format_list(items, locale=babel.Locale.parse("en"))
 
 
-def try_localize_language_name_from_iso639(code: str, locale: babel.Locale, standalone: bool = False) -> str | None:
+def try_localize_language_name_from_iso639(
+    code: str, locales: list[babel.Locale], standalone: bool = False
+) -> str | None:
     """
     Attempts to localize the name of a language expressed as an ISO639 code.
 
     Args:
         code: The ISO639 language code.
-        locale: The locale to render the language name in.
+        locales: The acceptable locales to render the language name in.
         standalone: The result won't be part of a larger sentence and should be capitalized if the language has capitals.
 
     Returns:
         The localized name, or None if no localized name is available.
     """
-    try:
-        name = babel.Locale.parse(code).get_language_name(locale)
-        if name is None:
-            return None
-        if standalone:
-            # The Unicode CLDR returns a casing that allows embedding in a larger sentence, e.g. "español".
-            # If we're displaying the language name on its own, capitalize its first letter if applicable.
-            # An LLM prompt revealed that this holds for all major languages.
-            # It is a no-op for scripts that don't have capital letters.
-            name = name[:1].title() + name[1:]
-        return name
-    except ValueError, babel.UnknownLocaleError:
-        return None
+    for locale in locales:
+        try:
+            name = babel.Locale.parse(code).get_language_name(locale)
+            if name is None:
+                continue
+            if standalone:
+                # The Unicode CLDR returns a casing that allows embedding in a larger sentence, e.g. "español".
+                # If we're displaying the language name on its own, capitalize its first letter if applicable.
+                # An LLM prompt revealed that this holds for all major languages.
+                # It is a no-op for scripts that don't have capital letters.
+                name = name[:1].title() + name[1:]
+            return name
+        except ValueError, babel.UnknownLocaleError:
+            continue
+    return None
 
 
-def try_localize_region_name_from_iso3166(code: str, locale: babel.Locale) -> str | None:
+def try_localize_region_name_from_iso3166(code: str, locales: list[babel.Locale]) -> str | None:
     """
-    Gets a region name specified as an ISO3166 alpha2 or alpha3 code, localized in the given locale.
+    Gets a region name specified as an ISO3166 alpha2 or alpha3 code,
+    localized in the first acceptable locale provided.
     """
     # The Unicode CLDR uses alpha2 codes as keys (all alpha3 codes have a corresponding alpha2 code)
     code = get_region_code_iso3166_alpha3_to_alpha2().get(code, code)
-    region_name: str | None = locale.territories.get(code, None)
-    return region_name
+    for locale in locales:
+        region_name: str | None = locale.territories.get(code, None)
+        if region_name is not None:
+            return region_name
+    return None
 
 
 def localize_date(
@@ -157,8 +170,10 @@ def _combine_cldr_date_time_patterns(locale: babel.Locale, date_pattern: str, ti
     return combining_format.replace("{1}", date_pattern).replace("{0}", time_pattern)
 
 
-def localize_timezone(timezone: tzinfo, locale: babel.Locale, *, short: bool = False) -> str:
-    return get_timezone_name(timezone, width="short" if short else "long", locale=locale)
+def localize_timezone(timezone: tzinfo, locales: list[babel.Locale], *, short: bool = False) -> str:
+    # From the implementation, get_timezone_name has no failure condition for unsupported locales,
+    # so just used the preferred locale.
+    return get_timezone_name(timezone, width="short" if short else "long", locale=locales[0])
 
 
 def format_phone_number(value: str) -> str:

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -35,7 +35,6 @@ from couchers.context import CouchersContext, make_interactive_context, make_med
 from couchers.db import session_scope
 from couchers.descriptor_pool import get_descriptor_pool
 from couchers.i18n import LocalizationContext
-from couchers.i18n.locales import to_supported_locale
 from couchers.metrics import (
     observe_api_call,
     observe_in_servicer_duration_histogram,
@@ -388,9 +387,8 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             else:
                 sofa, new_sofa_cookie = generate_sofa_cookie()
 
-            locale = to_supported_locale((auth_info.ui_language_preference if auth_info else headers.ui_lang) or "")
             loc_context = LocalizationContext(
-                locale=locale,
+                locale=(auth_info.ui_language_preference if auth_info else headers.ui_lang) or "",
                 timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
             )
 
@@ -480,7 +478,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                         sentry_sdk.set_tag("context", "servicer")
                         sentry_sdk.set_tag("method", method)
                         sentry_sdk.set_tag("user_agent", headers.user_agent)
-                        sentry_sdk.set_tag("ui_lang", loc_context.locale)
+                        sentry_sdk.set_tag("ui_lang", loc_context.preferred_locale)
                         sentry_sdk.set_user(
                             {
                                 "id": couchers_context._user_id,

--- a/app/backend/src/couchers/servicers/bugs.py
+++ b/app/backend/src/couchers/servicers/bugs.py
@@ -197,7 +197,7 @@ class Bugs(bugs_pb2_grpc.BugsServicer):
             f"**Backend version**: `{self._version()}`\n"
             f"**Frontend version**: `{request.frontend_version}`\n"
             f"**User Agent**: `{request.user_agent}`\n"
-            f"**Locale**: `{context.localization.locale}`\n"
+            f"**Locale**: `{context.localization.preferred_locale}`\n"
             f"**Screen resolution**: {request.screen_resolution.width}x{request.screen_resolution.height}\n"
             f"**Page**: {request.page}\n"
             f"**User**: {user_details} / `{(context._sofa or '')[:12]}`"

--- a/app/backend/src/couchers/servicers/resources.py
+++ b/app/backend/src/couchers/servicers/resources.py
@@ -30,7 +30,7 @@ def _get_regions_res(locale: babel.Locale) -> resources_pb2.GetRegionsRes:
         regions=[
             resources_pb2.Region(
                 alpha3=alpha3,
-                name=try_localize_region_name_from_iso3166(alpha3, locale) or english_name,
+                name=try_localize_region_name_from_iso3166(alpha3, [locale]) or english_name,
             )
             for alpha3, english_name in sorted(get_region_dict().items())
         ]
@@ -43,7 +43,7 @@ def _get_languages_res(locale: babel.Locale) -> resources_pb2.GetLanguagesRes:
         languages=[
             resources_pb2.Language(
                 code=code,
-                name=try_localize_language_name_from_iso639(code, locale, standalone=True) or english_name,
+                name=try_localize_language_name_from_iso639(code, [locale], standalone=True) or english_name,
             )
             for code, english_name in sorted(get_language_dict().items())
         ]
@@ -73,12 +73,12 @@ class Resources(resources_pb2_grpc.ResourcesServicer):
     def GetRegions(
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session
     ) -> resources_pb2.GetRegionsRes:
-        return _get_regions_res(context.localization.babel_locale)
+        return _get_regions_res(context.localization.preferred_babel_locale)
 
     def GetLanguages(
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session
     ) -> resources_pb2.GetLanguagesRes:
-        return _get_languages_res(context.localization.babel_locale)
+        return _get_languages_res(context.localization.preferred_babel_locale)
 
     def GetBadges(
         self, request: empty_pb2.Empty, context: CouchersContext, session: Session

--- a/app/backend/src/tests/test_i18n_locales.py
+++ b/app/backend/src/tests/test_i18n_locales.py
@@ -38,8 +38,7 @@ def test_to_supported_locale():
     assert to_supported_locale("zh-Hans") == "zh-Hans"
 
     # Supported locale with no translations
-    assert not is_supported_locale("en-US")
-    assert not is_locale_with_translations("en-US")
+    assert is_supported_locale("en-US") and not is_locale_with_translations("en-US")
     assert to_supported_locale("en-US") == "en-US"
 
     # Bogus locales

--- a/app/backend/src/tests/test_i18n_locales.py
+++ b/app/backend/src/tests/test_i18n_locales.py
@@ -6,6 +6,8 @@ from couchers.i18n.locales import (
     get_locale_chain,
     get_main_i18next,
     get_supported_locales,
+    is_locale_with_translations,
+    is_supported_locale,
     to_supported_locale,
 )
 
@@ -35,6 +37,11 @@ def test_to_supported_locale():
     assert to_supported_locale("fr-CA") == "fr-CA"
     assert to_supported_locale("zh-Hans") == "zh-Hans"
 
+    # Supported locale with no translations
+    assert not is_supported_locale("en-US")
+    assert not is_locale_with_translations("en-US")
+    assert to_supported_locale("en-US") == "en-US"
+
     # Bogus locales
     assert to_supported_locale("") == DEFAULT_LOCALE
     assert to_supported_locale("xx") == DEFAULT_LOCALE
@@ -49,12 +56,24 @@ def test_to_supported_locale():
 
 def test_all_supported_locales_have_babel_locales():
     for locale in get_supported_locales():
-        assert get_babel_locale(locale), f"Locale {locale} does not have a valid Babel locale"
+        babel_locale = get_babel_locale(locale)
+        assert babel_locale, f"Locale {locale} does not have a valid Babel locale"
+
+        # Ensure minimal support for the i18n operations we care about
+        assert babel_locale.date_formats
+        assert babel_locale.datetime_formats
+        assert babel_locale.datetime_skeletons
+        assert babel_locale.list_patterns
+        assert babel_locale.languages
+        assert babel_locale.time_zones
+        assert babel_locale.zone_formats
+        assert babel_locale.territories
 
 
 def test_get_locale_chain():
     """Test that fallbacks are correctly set up"""
     assert get_locale_chain("en") == ["en"]
+    assert get_locale_chain("en-US") == ["en-US", "en"]
     assert get_locale_chain("pl") == ["pl", "en"]
     assert get_locale_chain("xx") == ["xx", "en"]
     assert get_locale_chain("fr-CA") == ["fr-CA", "fr", "en"]

--- a/app/backend/src/tests/test_i18next.py
+++ b/app/backend/src/tests/test_i18next.py
@@ -37,7 +37,7 @@ def test_fallback():
     en = i18next.add_translation("en")
     en.add_string("greeting", "hello")
     i18next.add_translation("fr")
-    assert i18next.localize("greeting", ["fr", "en"]) == "hello"
+    assert i18next.localize("greeting", ["xx", "fr", "en"]) == "hello"
 
 
 def test_mutual_fallback():

--- a/app/backend/src/tests/test_localize.py
+++ b/app/backend/src/tests/test_localize.py
@@ -20,27 +20,27 @@ babel_zh = babel.Locale.parse("zh")
 
 
 def test_localize_language_name() -> None:
-    assert try_localize_language_name_from_iso639("en", babel_en) == "English"
-    assert try_localize_language_name_from_iso639("es", babel_en) == "Spanish"
+    assert try_localize_language_name_from_iso639("en", [babel_en]) == "English"
+    assert try_localize_language_name_from_iso639("es", [babel_en]) == "Spanish"
 
-    assert try_localize_language_name_from_iso639("en", babel_es) == "inglés"
-    assert try_localize_language_name_from_iso639("es", babel_es) == "español"
+    assert try_localize_language_name_from_iso639("en", [babel_es]) == "inglés"
+    assert try_localize_language_name_from_iso639("es", [babel_es]) == "español"
 
-    assert try_localize_language_name_from_iso639("en", babel_es, standalone=True) == "Inglés"  # Sentence case
-    assert try_localize_language_name_from_iso639("eng", babel_es) == "inglés"  # ISO639-3 code
-    assert try_localize_language_name_from_iso639("xx", babel_en) is None
+    assert try_localize_language_name_from_iso639("en", [babel_es], standalone=True) == "Inglés"  # Sentence case
+    assert try_localize_language_name_from_iso639("eng", [babel_es]) == "inglés"  # ISO639-3 code
+    assert try_localize_language_name_from_iso639("xx", [babel_en]) is None
 
 
 def test_localize_region_name() -> None:
-    assert try_localize_region_name_from_iso3166("US", babel_en) == "United States"
-    assert try_localize_region_name_from_iso3166("DE", babel_en) == "Germany"
+    assert try_localize_region_name_from_iso3166("US", [babel_en]) == "United States"
+    assert try_localize_region_name_from_iso3166("DE", [babel_en]) == "Germany"
 
-    assert try_localize_region_name_from_iso3166("US", babel_es) == "Estados Unidos"
-    assert try_localize_region_name_from_iso3166("DE", babel_es) == "Alemania"
+    assert try_localize_region_name_from_iso3166("US", [babel_es]) == "Estados Unidos"
+    assert try_localize_region_name_from_iso3166("DE", [babel_es]) == "Alemania"
 
-    assert try_localize_region_name_from_iso3166("USA", babel_en) == "United States"  # alpha3 code
+    assert try_localize_region_name_from_iso3166("USA", [babel_en]) == "United States"  # alpha3 code
 
-    assert try_localize_region_name_from_iso3166("xx", babel_en) is None
+    assert try_localize_region_name_from_iso3166("xx", [babel_en]) is None
 
 
 def test_localize_date() -> None:
@@ -72,12 +72,12 @@ def test_localize_datetime() -> None:
 
 
 def test_localize_timezone() -> None:
-    assert localize_timezone(ZoneInfo("Europe/London"), babel_en) == "United Kingdom Time"
-    assert localize_timezone(ZoneInfo("Europe/London"), babel_es) == "hora de Reino Unido"
+    assert localize_timezone(ZoneInfo("Europe/London"), [babel_en]) == "United Kingdom Time"
+    assert localize_timezone(ZoneInfo("Europe/London"), [babel_es]) == "hora de Reino Unido"
 
 
 def test_localize_list() -> None:
     abc = ["a", "b", "c"]
-    assert localize_list(abc, babel_en) == "a, b, and c"
-    assert localize_list(abc, babel_es) == "a, b y c"
-    assert localize_list(abc, babel_zh) == "a、b和c"
+    assert localize_list(abc, [babel_en]) == "a, b, and c"
+    assert localize_list(abc, [babel_es]) == "a, b y c"
+    assert localize_list(abc, [babel_zh]) == "a、b和c"


### PR DESCRIPTION
Broadens the concept of supported locales to allow for a first supported locale without dedicated translations: en-US.

Couchers has a lot of international users using the English default language but getting confused by `MM/DD/YYYY` date formats. We want to split into `English (US)` and `English (International)` (default), but not duplicate translations.

The "en" locale follows US regional formats, whereas "en-001" is "English (International)" and uses `DD/MM/YYYY`. However we can't only support "en-US" and "en-001" because we need to support the "en" generic language. My solution will be to special-case "en" to resolve to the "en-001" babel locale, which we use for regional formatting, but I change the "en" behavior until the frontend offers both English variants.

As part of this it becomes more important for i18n operations to support fallbacks. Our string lookup is already setup to take a list, so `["en-US", "en"]` will match "en". I've done something similar for other regional formatting functions, though in practice it seems like Babel/the CLDR has data for all of our current locales doesn't need to fallback.

The frontend doesn't have a way to select en-US so there are no functional changes for now.

Related to #9184

## Testing
Added/updated tests. Ran backend + frontend locally and switched between English and German.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
