### PR TITLE
Backend: exclude shadowed users from the public API

### DIFF
--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -1067,7 +1067,7 @@ def user_model_to_pb(
             )
         raise GhostUserSerializationError(
             f"Tried to serialize ghost profile in user_model_to_pb without appropriate flags. "
-            f"Context user_id: {context.user_id}, db_user id: {db_user.id} (username: {db_user.username})"
+            f"Context user_id: {viewer_user_id}, db_user id: {db_user.id} (username: {db_user.username})"
         )
 
     num_references = get_num_references(session, context, [db_user.id]).get(db_user.id, 0)

--- a/app/backend/src/couchers/servicers/public.py
+++ b/app/backend/src/couchers/servicers/public.py
@@ -10,6 +10,7 @@ from sqlalchemy.sql import func, union_all
 
 from couchers import experimentation, urls
 from couchers.context import CouchersContext, make_logged_out_context
+from couchers.i18n import LocalizationContext
 from couchers.materialized_views import LiteUser
 from couchers.models import (
     Cluster,
@@ -27,6 +28,7 @@ from couchers.proto.google.api import httpbody_pb2
 from couchers.resources import get_static_badge_dict
 from couchers.servicers.api import fluency2api, hostingstatus2api, meetupstatus2api, user_model_to_pb
 from couchers.servicers.gis import _statement_to_geojson_response
+from couchers.sql import users_visible
 from couchers.utils import Timestamp_from_datetime, not_none, now
 
 logger = logging.getLogger(__name__)
@@ -50,16 +52,20 @@ def format_volunteer_link(volunteer: Volunteer, username: str) -> dict[str, str]
 
 @cached(cache=TTLCache(maxsize=1, ttl=600), key=lambda _: None, lock=threading.Lock())
 def _get_public_users(session: Session) -> httpbody_pb2.HttpBody:
+    # the response is cached and shared between all callers, so it must not depend on who is asking; logged-in users
+    # get the per-viewer map from Gis.GetUsers instead
+    context = make_logged_out_context(localization=LocalizationContext.en_utc())
+
     with_geom = (
         select(User.username, User.geom)
-        .where(User.is_visible)
+        .where(users_visible(context, User))
         .where(User.public_visibility != ProfilePublicVisibility.nothing)
         .where(User.public_visibility != ProfilePublicVisibility.map_only)
     )
 
     without_geom = (
         select(null(), User.randomized_geom)
-        .where(User.is_visible)
+        .where(users_visible(context, User))
         .where(User.randomized_geom != None)
         .where(User.public_visibility == ProfilePublicVisibility.map_only)
     )
@@ -184,7 +190,7 @@ class Public(public_pb2_grpc.PublicServicer):
     ) -> public_pb2.GetPublicUserRes:
         user = session.execute(
             select(User)
-            .where(User.is_visible)
+            .where(users_visible(context, User))
             .where(User.username == request.user)
             .where(
                 User.public_visibility.in_(
@@ -211,7 +217,7 @@ class Public(public_pb2_grpc.PublicServicer):
             select(func.count())
             .select_from(Reference)
             .join(User, User.id == Reference.from_user_id)
-            .where(User.is_visible)
+            .where(users_visible(context, User))
             .where(Reference.to_user_id == user.id)
         ).scalar_one()
 

--- a/app/backend/src/tests/test_public.py
+++ b/app/backend/src/tests/test_public.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import grpc
 import pytest
 from google.protobuf import empty_pb2
+from sqlalchemy import select
 
 from couchers.db import session_scope
 from couchers.jobs.enqueue import queue_job
@@ -20,9 +21,11 @@ from couchers.models import (
     ProfilePublicVisibility,
     Reference,
     ReferenceType,
+    User,
 )
 from couchers.proto import api_pb2, public_pb2
 from couchers.servicers.public import _get_donation_stats, _get_public_users, _get_signup_page_info, _get_volunteers
+from couchers.utils import now
 from tests.fixtures.db import generate_user, make_volunteer
 from tests.fixtures.misc import process_jobs
 from tests.fixtures.sessions import public_session
@@ -89,6 +92,23 @@ def test_GetPublicMapLayer(db):
                 ydiff = coords[1] - test_user_coordinates[1]
                 dist = sqrt(xdiff**2 + ydiff**2)
                 assert dist > 0.02 and dist < 0.1
+
+
+def test_GetPublicMapLayer_excludes_shadowed(db):
+    """Test GetPublicUsers excludes shadowed users from the public map"""
+
+    _get_public_users.cache_clear()
+
+    generate_user(username="visible", public_visibility=ProfilePublicVisibility.limited)
+    shadowed_user, _ = generate_user(username="shadowed", public_visibility=ProfilePublicVisibility.limited)
+
+    with session_scope() as session:
+        session.execute(select(User).where(User.id == shadowed_user.id)).scalar_one().shadowed_at = now()
+
+    with public_session() as public:
+        data = json.loads(public.GetPublicUsers(empty_pb2.Empty()).data)
+
+    assert {feature["properties"]["username"] for feature in data["features"]} == {"visible"}
 
 
 def test_GetDonationStats_empty(db, feature_flags):
@@ -516,6 +536,19 @@ def test_GetPublicUser_invisible_user(db):
     with public_session() as public:
         with pytest.raises(grpc.RpcError) as exc:
             public.GetPublicUser(public_pb2.GetPublicUserReq(user="deleted"))
+        assert exc.value.code() == grpc.StatusCode.NOT_FOUND
+
+
+def test_GetPublicUser_shadowed_user(db):
+    """Test GetPublicUser returns NOT_FOUND for a shadowed user"""
+    shadowed_user, _ = generate_user(username="shadowed", public_visibility=ProfilePublicVisibility.full)
+
+    with session_scope() as session:
+        session.execute(select(User).where(User.id == shadowed_user.id)).scalar_one().shadowed_at = now()
+
+    with public_session() as public:
+        with pytest.raises(grpc.RpcError) as exc:
+            public.GetPublicUser(public_pb2.GetPublicUserReq(user="shadowed"))
         assert exc.value.code() == grpc.StatusCode.NOT_FOUND
 
 


### PR DESCRIPTION
The public servicer filtered users with `User.is_visible` directly, which doesn't account for shadowed users, so they still showed up on the public map and via `GetPublicUser`. Switch those queries to the `users_visible()` helper.

Since the public API has no logged-in viewer, `users_visible()` now skips the user-blocks subquery when the context isn't logged in. The `_get_public_users` response is cached and shared across all callers, so it deliberately uses a logged-out context rather than the caller's — logged-in users get their per-viewer map from `Gis.GetUsers`.

Also fixes the `GhostUserSerializationError` message in `user_model_to_pb` to report `viewer_user_id` rather than `context.user_id`, which is what the surrounding code actually keys off.

## Testing
Added regression tests: `test_GetPublicMapLayer_excludes_shadowed` (shadowed user absent from the public map layer) and `test_GetPublicUser_shadowed_user` (shadowed user returns `NOT_FOUND`). `uv run pytest src/tests/test_public.py` passes (20 tests), and `make format` / `make mypy` are clean.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._