### PR TITLE
Backfill emails.id and make it the primary key

### DIFF
--- a/app/backend/src/couchers/migrations/versions/0175_emails_id_primary_key.py
+++ b/app/backend/src/couchers/migrations/versions/0175_emails_id_primary_key.py
@@ -1,0 +1,85 @@
+"""Backfill emails.id and make it the primary key
+
+Revision ID: 0175
+Revises: 0174
+Create Date: 2026-08-01 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0175"
+down_revision = "0174"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # takes the lowest unused ids rather than counting from 1, so a partly filled table can't collide
+    op.execute("""
+        WITH pending AS (
+            SELECT message_id, row_number() OVER (ORDER BY time, message_id) AS rn
+            FROM emails
+            WHERE id IS NULL
+        ), free AS (
+            SELECT i, row_number() OVER (ORDER BY i) AS rn
+            FROM generate_series(1, (SELECT count(*) FROM emails)) AS i
+            WHERE NOT EXISTS (SELECT 1 FROM emails WHERE emails.id = i)
+        )
+        UPDATE emails
+        SET id = free.i
+        FROM pending JOIN free USING (rn)
+        WHERE emails.message_id = pending.message_id
+    """)
+
+    op.alter_column("emails", "id", nullable=False)
+
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_emails_id",
+            "emails",
+            ["id"],
+            unique=True,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.create_index(
+            "uq_emails_message_id",
+            "emails",
+            ["message_id"],
+            unique=True,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.create_index(
+            "ix_emails_recipient_time",
+            "emails",
+            ["recipient", sa.text("time DESC")],
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+    op.execute("ALTER TABLE emails DROP CONSTRAINT pk_emails")
+    # postgres renames the index to the constraint name
+    op.execute("ALTER TABLE emails ADD CONSTRAINT pk_emails PRIMARY KEY USING INDEX ix_emails_id")
+    op.execute("ALTER TABLE emails ADD CONSTRAINT uq_emails_message_id UNIQUE USING INDEX uq_emails_message_id")
+    # matches what a bigserial column would have
+    op.execute("ALTER SEQUENCE emails_id_seq OWNED BY emails.id")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_emails_recipient_time",
+            table_name="emails",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+
+    op.execute("ALTER SEQUENCE emails_id_seq OWNED BY NONE")
+    op.execute("ALTER TABLE emails DROP CONSTRAINT uq_emails_message_id")
+    op.execute("ALTER TABLE emails DROP CONSTRAINT pk_emails")
+    op.execute("ALTER TABLE emails ADD CONSTRAINT pk_emails PRIMARY KEY (message_id)")
+    op.alter_column("emails", "id", nullable=True)

--- a/app/backend/src/couchers/models/base.py
+++ b/app/backend/src/couchers/models/base.py
@@ -26,7 +26,5 @@ class Base(MappedAsDataclass, DeclarativeBase):
 
 communities_seq = Sequence("communities_seq")
 moderation_seq = Sequence("moderation_seq", start=2_000_000)
-# named as postgres would for a bigserial, so emails.id can become a normal pkey once backfilled
-emails_id_seq = Sequence("emails_id_seq")
 
 Geom = WKBElement | WKTElement

--- a/app/backend/src/couchers/models/rest.py
+++ b/app/backend/src/couchers/models/rest.py
@@ -28,7 +28,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import expression
 
 from couchers.constants import GUIDELINES_VERSION
-from couchers.models.base import Base, Geom, emails_id_seq
+from couchers.models.base import Base, Geom
 from couchers.models.moderation import ModerationObjectType
 from couchers.models.users import HostingStatus
 from couchers.utils import now
@@ -374,12 +374,10 @@ class Email(Base, kw_only=True):
 
     __tablename__ = "emails"
 
-    # the X-Couchers-ID header of the sent email
-    message_id: Mapped[str] = mapped_column(String, primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
-    id: Mapped[int | None] = mapped_column(
-        BigInteger, emails_id_seq, server_default=emails_id_seq.next_value(), init=False
-    )
+    # the X-Couchers-ID header of the sent email
+    message_id: Mapped[str] = mapped_column(String, unique=True)
 
     # timezone should always be UTC
     time: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False, index=True)
@@ -395,6 +393,8 @@ class Email(Base, kw_only=True):
 
     list_unsubscribe_header: Mapped[str | None] = mapped_column(String, default=None)
     source_data: Mapped[str | None] = mapped_column(String, default=None)
+
+    __table_args__ = (Index("ix_emails_recipient_time", recipient, time.desc()),)
 
 
 class SMS(Base, kw_only=True):


### PR DESCRIPTION
Follow-up to #9403, which gave `emails` a sequential `id` and reserved the range `1..count` for the rows that predate the sequence. This fills that range in `time` order, then makes `id` the primary key. `message_id` keeps its uniqueness, as a plain unique constraint rather than by being the primary key. Also adds an index on `(recipient, time DESC)`.

The backfill takes the lowest still-unused ids rather than counting from 1, so it converges to the same result whether the table is untouched, partly filled, or already done — the bulk can be filled in ahead of the deploy and the migration only mops up what's left. Every id it hands out is `<=` the row count, and the sequence's next value is always above that, so it can't collide with an existing row or a future insert.

The sequence ends up owned by the column, so `emails.id` is now just a plain `bigserial` in the model and the standalone `emails_id_seq` cruft is gone.

All three indexes are built `CONCURRENTLY` with `IF NOT EXISTS` and attached to their constraints with `USING INDEX`, so they can be pre-built by hand on prod and the migration is left doing nothing but catalog updates — no scan, no rewrite, no index build. Verified on a 200k-row table: with the not-null constraint in place the planner proves the backfill's `WHERE id IS NULL` impossible (`One-Time Filter: false`) and never executes the `count(*)`, `generate_series` or anti-join.

## Testing
`test_db.py` passes, which replays the full migration chain and diffs the result against the models — that covers the not-null constraint, the primary key, the unique constraint, the sequence ownership and all three indexes matching what the models generate.

Checked the upgrade/downgrade round trip by hand: migrate to head, insert emails, downgrade past this revision, insert another email under the old schema, upgrade again. Data and ids survive, duplicate `message_id`s are rejected at head, and the schema comes back identical.

No test was added for the backfill itself, since the migration tests run against an empty database. The SQL was instead checked by hand against Postgres over the scenarios that matter, verifying in each case that no nulls remain, that ids are unique, and that the next insert doesn't collide:

| scenario | result |
|---|---|
| 0174 deployed earlier, emails sent since, nothing pre-filled | old rows → 1–5, newer rows keep 6, 7 |
| 0174 and this applied in the same deploy | 1–5 |
| pre-filled 3 of 5 | remaining rows → 4, 5, order intact |
| pre-filled completely | no-op |
| run twice, from either state | idempotent |
| a numbered row deleted part-way through | unique, no collision (a freed id gets reused) |
| empty table | no-op |

`test_auth.py`, `test_bg_jobs.py`, `test_email.py` and `test_smtp.py` pass.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._