### PR TITLE
Compute user metrics in a single pass over the users table

### DIFF
--- a/app/backend/src/couchers/helpers/completed_profile.py
+++ b/app/backend/src/couchers/helpers/completed_profile.py
@@ -1,14 +1,11 @@
 from sqlalchemy import and_, select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import ColumnElement
+from sqlalchemy.sql.selectable import Subquery
 
 from couchers.constants import COMPLETED_PROFILE_MINIMUM_CHAR_LENGTH
 from couchers.models import User
-from couchers.models.uploads import PhotoGalleryItem, has_avatar_photo_expression
-
-# Galleries holding at least one photo. Callers passing prejoined_avatar below must outer join this onto their
-# statement with galleries_with_photos.c.gallery_id == User.profile_gallery_id.
-galleries_with_photos = select(PhotoGalleryItem.gallery_id).distinct().subquery("galleries_with_photos")
+from couchers.models.uploads import has_avatar_photo_expression
 
 
 def has_completed_profile(session: Session, user: User) -> bool:
@@ -20,21 +17,24 @@ def has_completed_profile(session: Session, user: User) -> bool:
     return bool(session.execute(select(has_avatar_photo_expression(user))).scalar())
 
 
-def has_completed_profile_expression(prejoined_avatar: bool = False) -> ColumnElement[bool]:
+def has_completed_profile_expression(galleries_with_photos: Subquery | None = None) -> ColumnElement[bool]:
     """
     Returns a SQL expression for checking if a user has completed their profile.
 
     Use this in SQLAlchemy queries where you need to filter by profile completeness.
 
-    The avatar check is a correlated EXISTS, which the planner flattens into a semi-join in a WHERE clause. Set
-    prejoined_avatar where it can't do that -- inside an aggregate FILTER clause it stays a subplan and runs once
-    per row -- and outer join galleries_with_photos into the statement instead.
+    The avatar is checked with a correlated EXISTS, which the planner flattens into a semi-join in a WHERE clause.
+    Where it can't do that -- inside an aggregate FILTER clause it stays a subplan and runs once per row -- pass a
+    subquery of distinct photo_gallery_items.gallery_id that the statement outer joins on User.profile_gallery_id,
+    and the check reads that join instead.
 
     Usage:
         statement = select(User).where(has_completed_profile_expression())
     """
     return and_(
         User.profile_gallery_id != None,
-        galleries_with_photos.c.gallery_id.isnot(None) if prejoined_avatar else has_avatar_photo_expression(User),
+        has_avatar_photo_expression(User)
+        if galleries_with_photos is None
+        else galleries_with_photos.c.gallery_id.isnot(None),
         User.about_me_length >= COMPLETED_PROFILE_MINIMUM_CHAR_LENGTH,
     )

--- a/app/backend/src/couchers/helpers/completed_profile.py
+++ b/app/backend/src/couchers/helpers/completed_profile.py
@@ -1,10 +1,14 @@
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import ColumnElement
 
 from couchers.constants import COMPLETED_PROFILE_MINIMUM_CHAR_LENGTH
 from couchers.models import User
-from couchers.models.uploads import has_avatar_photo_expression
+from couchers.models.uploads import PhotoGalleryItem, has_avatar_photo_expression
+
+# Galleries holding at least one photo. Callers passing prejoined_avatar below must outer join this onto their
+# statement with galleries_with_photos.c.gallery_id == User.profile_gallery_id.
+galleries_with_photos = select(PhotoGalleryItem.gallery_id).distinct().subquery("galleries_with_photos")
 
 
 def has_completed_profile(session: Session, user: User) -> bool:
@@ -16,17 +20,21 @@ def has_completed_profile(session: Session, user: User) -> bool:
     return bool(session.execute(select(has_avatar_photo_expression(user))).scalar())
 
 
-def has_completed_profile_expression() -> ColumnElement[bool]:
+def has_completed_profile_expression(prejoined_avatar: bool = False) -> ColumnElement[bool]:
     """
     Returns a SQL expression for checking if a user has completed their profile.
 
     Use this in SQLAlchemy queries where you need to filter by profile completeness.
+
+    The avatar check is a correlated EXISTS, which the planner flattens into a semi-join in a WHERE clause. Set
+    prejoined_avatar where it can't do that -- inside an aggregate FILTER clause it stays a subplan and runs once
+    per row -- and outer join galleries_with_photos into the statement instead.
 
     Usage:
         statement = select(User).where(has_completed_profile_expression())
     """
     return and_(
         User.profile_gallery_id != None,
-        has_avatar_photo_expression(User),
-        func.coalesce(func.character_length(User.about_me), 0) >= COMPLETED_PROFILE_MINIMUM_CHAR_LENGTH,
+        galleries_with_photos.c.gallery_id.isnot(None) if prejoined_avatar else has_avatar_photo_expression(User),
+        User.about_me_length >= COMPLETED_PROFILE_MINIMUM_CHAR_LENGTH,
     )

--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -26,7 +26,7 @@ from sqlalchemy.sql.selectable import Select
 from couchers import experimentation
 from couchers.config import config
 from couchers.db import session_scope
-from couchers.helpers.completed_profile import galleries_with_photos, has_completed_profile_expression
+from couchers.helpers.completed_profile import has_completed_profile_expression
 from couchers.materialized_views import ClusterSubscriptionCount
 from couchers.models import (
     BackgroundJob,
@@ -52,6 +52,7 @@ from couchers.models.moderation import (
     ModerationTrigger,
     ModerationVisibility,
 )
+from couchers.models.uploads import PhotoGalleryItem
 from couchers.perf import PerfResult
 
 tracer = trace.get_tracer(__name__)
@@ -467,59 +468,67 @@ def _active_users_bucket_specs() -> list[tuple[Gauge, str, ColumnElement[bool]]]
     return specs
 
 
-_users_gauge_specs: list[tuple[str, str, ColumnElement[bool] | None]] = [
-    ("couchers_users", "Total number of users", None),
-    *[
+def _make_users_gauges() -> list[Gauge]:
+    # Galleries holding at least one photo, outer joined below so the avatar check in the completed profile spec is a
+    # hash join rather than a subplan run once per user inside the FILTER clause.
+    galleries_with_photos = select(PhotoGalleryItem.gallery_id).distinct().subquery("galleries_with_photos")
+
+    specs: list[tuple[str, str, ColumnElement[bool] | None]] = [
+        ("couchers_users", "Total number of users", None),
+        *[
+            (
+                f"couchers_active_users_{name}",
+                f"Number of active users in the last {description}",
+                _active_users_age < interval,
+            )
+            for name, description, interval in _active_user_periods
+        ],
+        ("couchers_users_man", "Total number of users with gender 'Man'", User.gender == "Man"),
+        ("couchers_users_woman", "Total number of users with gender 'Woman'", User.gender == "Woman"),
+        ("couchers_users_nonbinary", "Total number of users with gender 'Non-binary'", User.gender == "Non-binary"),
         (
-            f"couchers_active_users_{name}",
-            f"Number of active users in the last {description}",
-            _active_users_age < interval,
-        )
-        for name, description, interval in _active_user_periods
-    ],
-    ("couchers_users_man", "Total number of users with gender 'Man'", User.gender == "Man"),
-    ("couchers_users_woman", "Total number of users with gender 'Woman'", User.gender == "Woman"),
-    ("couchers_users_nonbinary", "Total number of users with gender 'Non-binary'", User.gender == "Non-binary"),
-    (
-        "couchers_users_can_host",
-        "Total number of users with hosting status 'can_host'",
-        User.hosting_status == HostingStatus.can_host,
-    ),
-    (
-        "couchers_users_cant_host",
-        "Total number of users with hosting status 'cant_host'",
-        User.hosting_status == HostingStatus.cant_host,
-    ),
-    (
-        "couchers_users_maybe",
-        "Total number of users with hosting status 'maybe'",
-        User.hosting_status == HostingStatus.maybe,
-    ),
-    (
-        "couchers_users_completed_profile",
-        "Total number of users with a completed profile",
-        has_completed_profile_expression(prejoined_avatar=True),
-    ),
-    (
-        "couchers_users_completed_my_home",
-        "Total number of users with a completed my home section",
-        cast(ColumnElement[bool], User.has_completed_my_home),
-    ),
-]
+            "couchers_users_can_host",
+            "Total number of users with hosting status 'can_host'",
+            User.hosting_status == HostingStatus.can_host,
+        ),
+        (
+            "couchers_users_cant_host",
+            "Total number of users with hosting status 'cant_host'",
+            User.hosting_status == HostingStatus.cant_host,
+        ),
+        (
+            "couchers_users_maybe",
+            "Total number of users with hosting status 'maybe'",
+            User.hosting_status == HostingStatus.maybe,
+        ),
+        (
+            "couchers_users_completed_profile",
+            "Total number of users with a completed profile",
+            has_completed_profile_expression(galleries_with_photos),
+        ),
+        (
+            "couchers_users_completed_my_home",
+            "Total number of users with a completed my home section",
+            cast(ColumnElement[bool], User.has_completed_my_home),
+        ),
+    ]
+
+    return _make_gauges_from_single_pass(
+        "couchers_users",
+        lambda columns: (
+            select(*columns)
+            .select_from(User)
+            .outerjoin(galleries_with_photos, galleries_with_photos.c.gallery_id == User.profile_gallery_id)
+            .where(User.is_visible)
+        ),
+        specs,
+        _active_users_bucket_specs(),
+    )
+
 
 # Each of these was its own SELECT count(*) FROM users, which added up to roughly sixteen full scans of the table on
 # every scrape and dominated all sequential tuple reads in the database.
-users_gauges: list[Gauge] = _make_gauges_from_single_pass(
-    "couchers_users",
-    lambda columns: (
-        select(*columns)
-        .select_from(User)
-        .outerjoin(galleries_with_photos, galleries_with_photos.c.gallery_id == User.profile_gallery_id)
-        .where(User.is_visible)
-    ),
-    _users_gauge_specs,
-    _active_users_bucket_specs(),
-)
+users_gauges: list[Gauge] = _make_users_gauges()
 
 # Number of users per community, labeled by community name. Only includes communities at the region level or
 # broader (world, macroregion, region).

--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -1,6 +1,6 @@
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from typing import Any, cast
@@ -17,15 +17,16 @@ from prometheus_client import (
     multiprocess,
 )
 from prometheus_client.registry import CollectorRegistry
-from sqlalchemy import Engine, and_, case, select
+from sqlalchemy import Engine, and_, select
 from sqlalchemy.pool import QueuePool
 from sqlalchemy.sql import distinct, func
+from sqlalchemy.sql.elements import ColumnElement
 from sqlalchemy.sql.selectable import Select
 
 from couchers import experimentation
 from couchers.config import config
 from couchers.db import session_scope
-from couchers.helpers.completed_profile import has_completed_profile_expression
+from couchers.helpers.completed_profile import galleries_with_photos, has_completed_profile_expression
 from couchers.materialized_views import ClusterSubscriptionCount
 from couchers.models import (
     BackgroundJob,
@@ -359,15 +360,11 @@ def _make_labeled_gauge_from_query(
     description: str,
     labelname: str,
     statement: Select[Any],
-    default_label_values: list[str] | None = None,
 ) -> Gauge:
     """
     Given a name, description, label name and statement, creates a gauge with one label set from the statement.
 
     statement should be a sqlalchemy SELECT statement that returns rows of (label_value, count).
-
-    default_label_values, if given, are seeded to zero before the query results are applied, so that label
-    values with no matching rows are still emitted.
     """
 
     gauge = Gauge(name, description, labelnames=[labelname], multiprocess_mode="mostrecent")
@@ -376,13 +373,54 @@ def _make_labeled_gauge_from_query(
         with tracer.start_as_current_span(f"metric.{name}"):
             with session_scope() as session:
                 rows = session.execute(statement).all()
-        for label_value in default_label_values or []:
-            g.labels(label_value).set(0)
         for label_value, count in rows:
             g.labels(str(label_value)).set(count)
 
     _set_hacky_labeled_gauges_funcs.append((gauge, f))
     return gauge
+
+
+# list of functions that each run one query and populate several gauges from the single result row
+_set_hacky_multi_gauges_funcs: list[Callable[[], None]] = []
+
+
+def _make_gauges_from_single_pass(
+    span_name: str,
+    make_statement: Callable[[list[Any]], Select[Any]],
+    specs: Sequence[tuple[str, str, ColumnElement[bool] | None]],
+    labeled_specs: Sequence[tuple[Gauge, str, ColumnElement[bool]]] = (),
+) -> list[Gauge]:
+    """
+    Creates a gauge per spec, plus label values on already-created labeled gauges, all from one pass over the table.
+
+    Each spec is (name, description, condition) and counts the rows matching that condition, or every row if it is
+    None; each labeled spec is (gauge, label value, condition). make_statement is handed the count columns and
+    returns the statement to run them in, so the caller owns the FROM and any joins.
+
+    Counting with count(*) FILTER in a single statement rather than one statement per gauge is the whole point: as
+    separate queries these were a full sequential scan of the table each, on every scrape.
+    """
+    conditions = [condition for _, _, condition in specs] + [condition for _, _, condition in labeled_specs]
+    keys = [f"c{i}" for i in range(len(conditions))]
+    statement = make_statement(
+        [
+            (func.count() if condition is None else func.count().filter(condition)).label(key)
+            for key, condition in zip(keys, conditions)
+        ]
+    )
+    gauges = [Gauge(name, description, multiprocess_mode="mostrecent") for name, description, _ in specs]
+
+    def f() -> None:
+        with tracer.start_as_current_span(f"metric.{span_name}"):
+            with session_scope() as session:
+                row = session.execute(statement).one()._mapping
+        for gauge, key in zip(gauges, keys):
+            gauge.set(row[key])
+        for (labeled_gauge, label_value, _), labeled_key in zip(labeled_specs, keys[len(specs) :]):
+            labeled_gauge.labels(label_value).set(row[labeled_key])
+
+    _set_hacky_multi_gauges_funcs.append(f)
+    return gauges
 
 
 _active_user_periods: list[tuple[str, str, timedelta]] = [
@@ -394,17 +432,93 @@ _active_user_periods: list[tuple[str, str, timedelta]] = [
     ("12month", "12 months", timedelta(days=365)),
 ]
 
-active_users_gauges: list[Gauge] = [
-    _make_gauge_from_query(
-        f"couchers_active_users_{name}",
-        f"Number of active users in the last {description}",
-        (select(func.count()).select_from(User).where(User.is_visible).where(User.last_active > func.now() - interval)),
-    )
-    for name, description, interval in _active_user_periods
+# Number of users bucketed by how recently they were last active. Ordered upper bounds, made mutually exclusive by
+# _active_users_bucket_specs so every bucket can be counted in the same pass.
+_active_users_buckets: list[tuple[str, timedelta | None]] = [
+    ("<1d", timedelta(days=1)),
+    ("1d-1w", timedelta(days=7)),
+    ("1w-1m", timedelta(weeks=4)),
+    ("1m-6m", timedelta(weeks=26)),
+    ("6m-12m", timedelta(days=365)),
+    ("12m-24m", timedelta(days=730)),
+    ("24m+", None),
+]
+_active_users_age = func.now() - User.last_active
+
+active_users_by_recency_gauge: Gauge = Gauge(
+    "couchers_active_users_by_recency",
+    "Number of users bucketed by how recently they were last active",
+    labelnames=["period"],
+    multiprocess_mode="mostrecent",
+)
+
+
+def _active_users_bucket_specs() -> list[tuple[Gauge, str, ColumnElement[bool]]]:
+    specs = []
+    lower: timedelta | None = None
+    for label, upper in _active_users_buckets:
+        bounds = []
+        if lower is not None:
+            bounds.append(_active_users_age >= lower)
+        if upper is not None:
+            bounds.append(_active_users_age < upper)
+        specs.append((active_users_by_recency_gauge, label, and_(*bounds)))
+        lower = upper
+    return specs
+
+
+_users_gauge_specs: list[tuple[str, str, ColumnElement[bool] | None]] = [
+    ("couchers_users", "Total number of users", None),
+    *[
+        (
+            f"couchers_active_users_{name}",
+            f"Number of active users in the last {description}",
+            _active_users_age < interval,
+        )
+        for name, description, interval in _active_user_periods
+    ],
+    ("couchers_users_man", "Total number of users with gender 'Man'", User.gender == "Man"),
+    ("couchers_users_woman", "Total number of users with gender 'Woman'", User.gender == "Woman"),
+    ("couchers_users_nonbinary", "Total number of users with gender 'Non-binary'", User.gender == "Non-binary"),
+    (
+        "couchers_users_can_host",
+        "Total number of users with hosting status 'can_host'",
+        User.hosting_status == HostingStatus.can_host,
+    ),
+    (
+        "couchers_users_cant_host",
+        "Total number of users with hosting status 'cant_host'",
+        User.hosting_status == HostingStatus.cant_host,
+    ),
+    (
+        "couchers_users_maybe",
+        "Total number of users with hosting status 'maybe'",
+        User.hosting_status == HostingStatus.maybe,
+    ),
+    (
+        "couchers_users_completed_profile",
+        "Total number of users with a completed profile",
+        has_completed_profile_expression(prejoined_avatar=True),
+    ),
+    (
+        "couchers_users_completed_my_home",
+        "Total number of users with a completed my home section",
+        cast(ColumnElement[bool], User.has_completed_my_home),
+    ),
 ]
 
-users_gauge: Gauge = _make_gauge_from_query(
-    "couchers_users", "Total number of users", select(func.count()).select_from(User).where(User.is_visible)
+# Each of these was its own SELECT count(*) FROM users, which added up to roughly sixteen full scans of the table on
+# every scrape and dominated all sequential tuple reads in the database.
+users_gauges: list[Gauge] = _make_gauges_from_single_pass(
+    "couchers_users",
+    lambda columns: (
+        select(*columns)
+        .select_from(User)
+        .outerjoin(galleries_with_photos, galleries_with_photos.c.gallery_id == User.profile_gallery_id)
+        .where(User.is_visible)
+    ),
+    _users_gauge_specs,
+    _active_users_bucket_specs(),
 )
 
 # Number of users per community, labeled by community name. Only includes communities at the region level or
@@ -420,36 +534,6 @@ users_per_community_gauge: Gauge = _make_labeled_gauge_from_query(
         .outerjoin(ClusterSubscriptionCount, ClusterSubscriptionCount.cluster_id == Cluster.id)
         .where(Node.node_type <= NodeType.region)
     ),
-)
-
-# Number of users bucketed by how recently they were last active.
-_active_users_buckets: list[tuple[str, timedelta | None]] = [
-    ("<1d", timedelta(days=1)),
-    ("1d-1w", timedelta(days=7)),
-    ("1w-1m", timedelta(weeks=4)),
-    ("1m-6m", timedelta(weeks=26)),
-    ("6m-12m", timedelta(days=365)),
-    ("12m-24m", timedelta(days=730)),
-    ("24m+", None),
-]
-_active_users_age = func.now() - User.last_active
-active_users_by_recency_gauge: Gauge = _make_labeled_gauge_from_query(
-    "couchers_active_users_by_recency",
-    "Number of users bucketed by how recently they were last active",
-    "period",
-    (
-        select(
-            case(
-                *[(_active_users_age < interval, label) for label, interval in _active_users_buckets if interval],
-                else_=_active_users_buckets[-1][0],
-            ).label("period"),
-            func.count(),
-        )
-        .select_from(User)
-        .where(User.is_visible)
-        .group_by("period")
-    ),
-    default_label_values=[label for label, _ in _active_users_buckets],
 )
 
 # Window for the per-platform daily-active-user metrics. Kept to 24h so the user_activity scan stays cheap (an index
@@ -508,54 +592,6 @@ def _set_active_users_by_platform(gauge: Gauge) -> None:
 
 
 _set_hacky_labeled_gauges_funcs.append((active_users_by_platform_gauge, _set_active_users_by_platform))
-
-man_gauge: Gauge = _make_gauge_from_query(
-    "couchers_users_man",
-    "Total number of users with gender 'Man'",
-    select(func.count()).select_from(User).where(User.is_visible).where(User.gender == "Man"),
-)
-
-woman_gauge: Gauge = _make_gauge_from_query(
-    "couchers_users_woman",
-    "Total number of users with gender 'Woman'",
-    select(func.count()).select_from(User).where(User.is_visible).where(User.gender == "Woman"),
-)
-
-nonbinary_gauge: Gauge = _make_gauge_from_query(
-    "couchers_users_nonbinary",
-    "Total number of users with gender 'Non-binary'",
-    select(func.count()).select_from(User).where(User.is_visible).where(User.gender == "Non-binary"),
-)
-
-can_host_gauge: Gauge = _make_gauge_from_query(
-    "couchers_users_can_host",
-    "Total number of users with hosting status 'can_host'",
-    select(func.count()).select_from(User).where(User.is_visible).where(User.hosting_status == HostingStatus.can_host),
-)
-
-cant_host_gauge: Gauge = _make_gauge_from_query(
-    "couchers_users_cant_host",
-    "Total number of users with hosting status 'cant_host'",
-    select(func.count()).select_from(User).where(User.is_visible).where(User.hosting_status == HostingStatus.cant_host),
-)
-
-maybe_gauge: Gauge = _make_gauge_from_query(
-    "couchers_users_maybe",
-    "Total number of users with hosting status 'maybe'",
-    select(func.count()).select_from(User).where(User.is_visible).where(User.hosting_status == HostingStatus.maybe),
-)
-
-completed_profile_gauge: Gauge = _make_gauge_from_query(
-    "couchers_users_completed_profile",
-    "Total number of users with a completed profile",
-    select(func.count()).select_from(User).where(User.is_visible).where(has_completed_profile_expression()),
-)
-
-completed_my_home_gauge: Gauge = _make_gauge_from_query(
-    "couchers_users_completed_my_home",
-    "Total number of users with a completed my home section",
-    select(func.count()).select_from(User).where(User.is_visible).where(User.has_completed_my_home),
-)
 
 sent_message_gauge: Gauge = _make_gauge_from_query(
     "couchers_users_sent_message",
@@ -1150,6 +1186,8 @@ def create_prometheus_server(port: int) -> Any:
             gauge.set(f())
         for gauge, labeled_f in _set_hacky_labeled_gauges_funcs:
             labeled_f(gauge)
+        for multi_f in _set_hacky_multi_gauges_funcs:
+            multi_f()
 
         data = generate_latest(registry)
         start_response("200 OK", [("Content-type", CONTENT_TYPE_LATEST), ("Content-Length", str(len(data)))])

--- a/app/backend/src/couchers/migrations/versions/0176_add_generated_about_me_length_column.py
+++ b/app/backend/src/couchers/migrations/versions/0176_add_generated_about_me_length_column.py
@@ -1,0 +1,110 @@
+"""Add generated about_me_length column
+
+Revision ID: 0176
+Revises: 0175
+Create Date: 2026-08-01 10:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0176"
+down_revision = "0175"
+branch_labels = None
+depends_on = None
+
+
+# lite_users is recreated here purely to change how profile completeness is computed, so the definition is shared
+# between upgrade and downgrade with just that expression swapped out
+def _create_lite_users(completed_profile: str) -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS lite_users")
+    op.execute(f"""
+        CREATE MATERIALIZED VIEW lite_users AS
+        SELECT
+            users.id,
+            users.username,
+            users.name,
+            users.city,
+            date_part('year', age(users.birthdate)) AS age,
+            users.geom,
+            users.geom_radius AS radius,
+            (users.banned_at IS NULL AND users.deleted_at IS NULL) AS is_visible,
+            users.shadowed_at,
+            uploads.filename AS avatar_filename,
+            ((users.profile_gallery_id IS NOT NULL)
+                AND EXISTS (SELECT 1 AS anon_1 FROM photo_gallery_items WHERE photo_gallery_items.gallery_id = users.profile_gallery_id)
+                AND {completed_profile}) AS has_completed_profile,
+            ((users.max_guests IS NOT NULL) AND (users.sleeping_arrangement IS NOT NULL) AND ((users.about_place IS NOT NULL) OR (users.other_host_info IS NOT NULL) OR (users.sleeping_details IS NOT NULL) OR (users.area IS NOT NULL) OR (users.house_rules IS NOT NULL))) AS has_completed_my_home,
+            COALESCE(sv_subquery."true", false) AS has_strong_verification,
+            CAST(json_build_object(
+                'type', 'Feature',
+                'geometry', CAST(ST_AsGeoJSON(users.geom, 5) AS json),
+                'properties', json_build_object('id', users.id, 'has_completed_profile',
+                    ((users.profile_gallery_id IS NOT NULL)
+                        AND EXISTS (SELECT 1 AS anon_2 FROM photo_gallery_items WHERE photo_gallery_items.gallery_id = users.profile_gallery_id)
+                        AND {completed_profile}))
+            ) AS text) AS geojson
+        FROM users
+        LEFT OUTER JOIN (
+            SELECT DISTINCT ON (photo_gallery_items.gallery_id)
+                photo_gallery_items.gallery_id,
+                photo_gallery_items.upload_key
+            FROM photo_gallery_items
+            ORDER BY photo_gallery_items.gallery_id, photo_gallery_items.position
+        ) avatar_photo ON avatar_photo.gallery_id = users.profile_gallery_id
+        LEFT OUTER JOIN uploads ON uploads.key = avatar_photo.upload_key
+        LEFT OUTER JOIN
+            (SELECT DISTINCT
+                users_1.id,
+                true AS "true"
+            FROM strong_verification_attempts, users users_1
+            WHERE
+                ((strong_verification_attempts.status = 'succeeded')
+                AND COALESCE(timezone('Etc/UTC', strong_verification_attempts.passport_expiry_date::timestamp without time zone) >= now(), false)
+                AND strong_verification_attempts.passport_date_of_birth = users_1.birthdate
+                AND (
+                    (users_1.gender = 'Woman' AND strong_verification_attempts.passport_sex = 'female')
+                    OR (users_1.gender = 'Man' AND strong_verification_attempts.passport_sex = 'male')
+                    OR strong_verification_attempts.passport_sex = 'unspecified'
+                    OR users_1.has_passport_sex_gender_exception = true
+                ))
+            ) sv_subquery
+        ON sv_subquery.id = users.id
+    """)
+    op.execute("CREATE UNIQUE INDEX uq_lite_users_id ON lite_users(id)")
+    op.execute("CREATE UNIQUE INDEX uq_lite_users_username ON lite_users(username)")
+    op.execute("CREATE INDEX ix_lite_users_id_visible ON lite_users USING hash (id) WHERE is_visible")
+    op.execute("CREATE INDEX ix_lite_users_username_visible ON lite_users USING hash (username) WHERE is_visible")
+    op.execute("CREATE INDEX idx_lite_users_geom ON lite_users USING gist (geom)")
+
+
+def upgrade() -> None:
+    # dropped up front so the table rewrite below doesn't rebuild an index that's about to be replaced anyway
+    op.execute("DROP INDEX ix_users_visible_with_about_me")
+    # rewrites the table under an ACCESS EXCLUSIVE lock, and detoasts every about_me one final time
+    op.execute("""
+        ALTER TABLE users ADD COLUMN about_me_length integer NOT NULL
+        GENERATED ALWAYS AS (COALESCE(character_length(about_me), 0)) STORED
+    """)
+    op.execute("""
+        CREATE INDEX ix_users_visible_with_about_me ON users (id)
+        WHERE banned_at IS NULL
+          AND deleted_at IS NULL
+          AND profile_gallery_id IS NOT NULL
+          AND about_me_length >= 150
+    """)
+    _create_lite_users("users.about_me_length >= 150")
+
+
+def downgrade() -> None:
+    _create_lite_users("COALESCE(character_length(users.about_me), 0) >= 150")
+    op.execute("DROP INDEX ix_users_visible_with_about_me")
+    op.execute("ALTER TABLE users DROP COLUMN about_me_length")
+    op.execute("""
+        CREATE INDEX ix_users_visible_with_about_me ON users (id)
+        WHERE banned_at IS NULL
+          AND deleted_at IS NULL
+          AND profile_gallery_id IS NOT NULL
+          AND COALESCE(character_length((about_me)::text), 0) >= 150
+    """)

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
+    Computed,
     Date,
     DateTime,
     Enum,
@@ -176,6 +177,11 @@ class User(Base, kw_only=True):
 
     # "Who I am" under "About Me" tab
     about_me: Mapped[str | None] = mapped_column(String, default=None)  # CommonMark without images
+    # kept in sync by the database so profile-completeness checks never detoast about_me; doing so was the dominant
+    # cost of both the lite_users refresh and the profile metrics, which scan every user several times a minute
+    about_me_length: Mapped[int] = mapped_column(
+        Integer, Computed("coalesce(character_length(about_me), 0)", persisted=True), init=False
+    )
     # "What I do in my free time" under "About Me" tab
     things_i_like: Mapped[str | None] = mapped_column(String, default=None)  # CommonMark without images
     # "About my home" under "My Home" tab
@@ -402,7 +408,7 @@ class User(Base, kw_only=True):
                 banned_at.is_(None),
                 deleted_at.is_(None),
                 profile_gallery_id.isnot(None),
-                func.coalesce(func.character_length(about_me), 0) >= COMPLETED_PROFILE_MINIMUM_CHAR_LENGTH,
+                about_me_length >= COMPLETED_PROFILE_MINIMUM_CHAR_LENGTH,
             ),
         ),
         # There are two possible states for new_email_token, new_email_token_created, and new_email_token_expiry

--- a/app/backend/src/tests/test_metrics.py
+++ b/app/backend/src/tests/test_metrics.py
@@ -8,13 +8,15 @@ from couchers.db import session_scope
 from couchers.materialized_views import refresh_materialized_views
 from couchers.metrics import (
     _set_hacky_labeled_gauges_funcs,
+    _set_hacky_multi_gauges_funcs,
     active_users_by_platform_gauge,
     active_users_by_platform_statement,
     active_users_by_recency_gauge,
     active_users_mobile_fraction_gauge,
+    users_gauges,
     users_per_community_gauge,
 )
-from couchers.models import ClientPlatform, User, UserActivity
+from couchers.models import ClientPlatform, HostingStatus, User, UserActivity
 from couchers.utils import now
 from tests.fixtures.db import generate_user
 from tests.test_communities import create_community
@@ -33,9 +35,20 @@ def _populate(gauge):
     raise AssertionError("gauge is not a registered labeled gauge")
 
 
+def _populate_single_pass():
+    for f in _set_hacky_multi_gauges_funcs:
+        f()
+
+
 def _sample_values(gauge):
     return {
         sample.labels[gauge._labelnames[0]]: sample.value for metric in gauge.collect() for sample in metric.samples
+    }
+
+
+def _users_gauge_values():
+    return {
+        sample.name: sample.value for gauge in users_gauges for metric in gauge.collect() for sample in metric.samples
     }
 
 
@@ -82,11 +95,59 @@ def test_active_users_by_recency_gauge(db):
         for bucket, age in ages.items():
             session.execute(update(User).where(User.id == user_ids_by_bucket[bucket]).values(last_active=now() - age))
 
-    _populate(active_users_by_recency_gauge)
+    _populate_single_pass()
     values = _sample_values(active_users_by_recency_gauge)
 
     for bucket in ages:
         assert values[bucket] == 1
+
+
+def test_active_users_by_recency_gauge_emits_empty_buckets(db):
+    generate_user()
+
+    _populate_single_pass()
+    values = _sample_values(active_users_by_recency_gauge)
+
+    # every bucket is always emitted, even the ones with no users in them
+    assert set(values) == {"<1d", "1d-1w", "1w-1m", "1m-6m", "6m-12m", "12m-24m", "24m+"}
+    assert values["<1d"] == 1
+    assert values["24m+"] == 0
+
+
+def test_users_gauges(db):
+    generate_user(gender="Man", hosting_status=HostingStatus.can_host)
+    generate_user(gender="Woman", hosting_status=HostingStatus.cant_host)
+    generate_user(gender="Non-binary", hosting_status=HostingStatus.maybe)
+    generate_user(gender="Woman", hosting_status=HostingStatus.can_host, delete_user=True)
+
+    _populate_single_pass()
+    values = _users_gauge_values()
+
+    # the deleted user is excluded from every count
+    assert values["couchers_users"] == 3
+    assert values["couchers_active_users_5m"] == 3
+    assert values["couchers_users_man"] == 1
+    assert values["couchers_users_woman"] == 1
+    assert values["couchers_users_nonbinary"] == 1
+    assert values["couchers_users_can_host"] == 1
+    assert values["couchers_users_cant_host"] == 1
+    assert values["couchers_users_maybe"] == 1
+
+
+def test_users_completed_profile_gauge(db):
+    generate_user()
+    generate_user()
+    short_about_me, _ = generate_user()
+    # a long enough about me isn't sufficient on its own, there has to be a photo in the profile gallery too
+    generate_user(complete_profile=False, about_me="x" * 150)
+
+    # ...and neither is a photo without a long enough about me
+    with session_scope() as session:
+        session.execute(update(User).where(User.id == short_about_me.id).values(about_me="too short"))
+
+    _populate_single_pass()
+
+    assert _users_gauge_values()["couchers_users_completed_profile"] == 2
 
 
 def _add_activity(user_id: int, client_platform: ClientPlatform | None, age: timedelta = timedelta(minutes=1)) -> None:


### PR DESCRIPTION
Performance improvement for the Prometheus metrics scrape.

The ~16 `couchers_users_*` gauges (total, active-by-period, gender, hosting status, completed profile, completed my home) were each their own `SELECT count(*) FROM users`, which added up to roughly sixteen full sequential scans of the `users` table on every scrape and dominated all sequential tuple reads in the database. They're now counted with `count(*) FILTER (WHERE ...)` in a single statement, along with the `couchers_active_users_by_recency` buckets, via a new `_make_gauges_from_single_pass` helper.

Two supporting changes:

- **`users.about_me_length`**: a stored generated column (`coalesce(character_length(about_me), 0)`), so profile-completeness checks never have to detoast `about_me`. That detoasting was the dominant cost of both the `lite_users` refresh and the profile metrics, which scan every user several times a minute. The partial index `ix_users_visible_with_about_me` and the `lite_users` materialized view are rebuilt against the new column.
- **`has_completed_profile_expression(prejoined_avatar=True)`**: the avatar check is normally a correlated `EXISTS`, which the planner flattens into a semi-join in a `WHERE` clause. Inside an aggregate `FILTER` clause it stays a subplan and runs once per row, so the metrics query outer joins a `galleries_with_photos` subquery instead and the expression tests that instead. All other callers are unchanged.

`_make_labeled_gauge_from_query`'s `default_label_values` parameter is dropped — the by-recency gauge was its only user, and the single-pass version always emits every bucket.

Note the migration rewrites the `users` table under an `ACCESS EXCLUSIVE` lock (adding a stored generated column) and detoasts every `about_me` one final time.

## Testing

`make format`, `make mypy` (clean), and the following pass locally:

- `uv run pytest src/tests/test_metrics.py` — includes new tests for the single-pass user gauges, the completed-profile gauge, and that every recency bucket is emitted even when empty
- `uv run pytest src/tests/test_db.py` — the schema-from-migrations vs. schema-from-models comparison covers the new column, index and materialized view
- `uv run pytest src/tests/test_models.py src/tests/test_model_constraints.py src/tests/test_search.py src/tests/test_bg_jobs.py` — the other callers of `has_completed_profile_expression()`

Worth confirming on staging that the `couchers_users_*` and `couchers_active_users_*` series are unchanged in value after deploy, and that scrape duration and `seq_tup_read` on `users` drop.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._