### PR TITLE
Backend/events: Don't notify event updaters/cancelers about their own action

### DIFF
--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -426,7 +426,7 @@ def generate_event_update_notifications(payload: jobs_pb2.GenerateEventUpdateNot
         subscribed_user_ids = [user.id for user in event.subscribers]
         attending_user_ids = [user.user_id for user in occurrence.attendances]
 
-        for user_id in set(subscribed_user_ids + attending_user_ids):
+        for user_id in set(subscribed_user_ids + attending_user_ids) - {updating_user.id}:
             if is_not_visible(session, user_id, updating_user.id):
                 continue
             context = make_notification_user_context(user_id=user_id)
@@ -455,7 +455,7 @@ def generate_event_cancel_notifications(payload: jobs_pb2.GenerateEventCancelNot
         subscribed_user_ids = [user.id for user in event.subscribers]
         attending_user_ids = [user.user_id for user in occurrence.attendances]
 
-        for user_id in set(subscribed_user_ids + attending_user_ids):
+        for user_id in set(subscribed_user_ids + attending_user_ids) - {cancelling_user.id}:
             if is_not_visible(session, user_id, cancelling_user.id):
                 continue
             context = make_notification_user_context(user_id=user_id)

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -3122,16 +3122,16 @@ def test_event_update_and_cancel_notifications_not_sent_to_actor(
     db, push_collector: PushCollector, moderator: Moderator
 ):
     """The user who updates or cancels an event shouldn't be notified about their own action."""
-    user1, token1 = generate_user()
-    user2, token2 = generate_user()
+    organizer_user, organizer_token = generate_user()
+    attendee_user, attendee_token = generate_user()
 
     with session_scope() as session:
-        create_community(session, 0, 2, "Community", [user2], [], None)
+        create_community(session, 0, 2, "Community", [attendee_user], [], None)
 
     start_time = now() + timedelta(hours=2)
     end_time = start_time + timedelta(hours=3)
 
-    with events_session(token1) as api:
+    with events_session(organizer_token) as api:
         res = api.CreateEvent(
             events_pb2.CreateEventReq(
                 title="Actor Test",
@@ -3150,12 +3150,12 @@ def test_event_update_and_cancel_notifications_not_sent_to_actor(
     moderator.approve_event_occurrence(event_id)
     process_jobs()
 
-    # User2 subscribes so there's someone left to notify
-    with events_session(token2) as api:
+    # The attendee subscribes to notifications
+    with events_session(attendee_token) as api:
         api.SetEventSubscription(events_pb2.SetEventSubscriptionReq(event_id=event_id, subscribe=True))
 
-    # User1, the organizer, updates and then cancels their own event
-    with events_session(token1) as api:
+    # The organizer updates and then cancels their own event
+    with events_session(organizer_token) as api:
         api.UpdateEvent(
             events_pb2.UpdateEventReq(
                 event_id=event_id,
@@ -3167,20 +3167,12 @@ def test_event_update_and_cancel_notifications_not_sent_to_actor(
 
     process_jobs()
 
-    with session_scope() as session:
-        actions_for_user1 = [
-            n.topic_action.action
-            for n in session.execute(select(Notification).where(Notification.user_id == user1.id)).scalars().all()
-        ]
-        assert "update" not in actions_for_user1
-        assert "cancel" not in actions_for_user1
+    # The organizer should not receive any notifications
+    assert push_collector.count_for_user(organizer_user.id) == 0
 
-        actions_for_user2 = [
-            n.topic_action.action
-            for n in session.execute(select(Notification).where(Notification.user_id == user2.id)).scalars().all()
-        ]
-        assert "update" in actions_for_user2
-        assert "cancel" in actions_for_user2
+    # But the attendee should receive both the update and cancel notifications
+    assert push_collector.pop_for_user(attendee_user.id).topic_action == NotificationTopicAction.event__update.display
+    assert push_collector.pop_for_user(attendee_user.id).topic_action == NotificationTopicAction.event__cancel.display
 
 
 def test_event_reminder_notification_has_moderation_state(db, push_collector: PushCollector, moderator: Moderator):

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -3118,6 +3118,71 @@ def test_event_cancel_notification_has_moderation_state(db, push_collector: Push
         assert cancel_notifs[0].moderation_state_id == occurrence.moderation_state_id
 
 
+def test_event_update_and_cancel_notifications_not_sent_to_actor(
+    db, push_collector: PushCollector, moderator: Moderator
+):
+    """The user who updates or cancels an event shouldn't be notified about their own action."""
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    with session_scope() as session:
+        create_community(session, 0, 2, "Community", [user2], [], None)
+
+    start_time = now() + timedelta(hours=2)
+    end_time = start_time + timedelta(hours=3)
+
+    with events_session(token1) as api:
+        res = api.CreateEvent(
+            events_pb2.CreateEventReq(
+                title="Actor Test",
+                content="Content.",
+                location=events_pb2.EventLocation(
+                    address="Near Null Island",
+                    lat=0.1,
+                    lng=0.2,
+                ),
+                start_datetime_iso8601_local=datetime_to_iso8601_local(start_time),
+                end_datetime_iso8601_local=datetime_to_iso8601_local(end_time),
+            )
+        )
+        event_id = res.event_id
+
+    moderator.approve_event_occurrence(event_id)
+    process_jobs()
+
+    # User2 subscribes so there's someone left to notify
+    with events_session(token2) as api:
+        api.SetEventSubscription(events_pb2.SetEventSubscriptionReq(event_id=event_id, subscribe=True))
+
+    # User1, the organizer, updates and then cancels their own event
+    with events_session(token1) as api:
+        api.UpdateEvent(
+            events_pb2.UpdateEventReq(
+                event_id=event_id,
+                title=wrappers_pb2.StringValue(value="Updated Title"),
+                should_notify=True,
+            )
+        )
+        api.CancelEvent(events_pb2.CancelEventReq(event_id=event_id))
+
+    process_jobs()
+
+    with session_scope() as session:
+        actions_for_user1 = [
+            n.topic_action.action
+            for n in session.execute(select(Notification).where(Notification.user_id == user1.id)).scalars().all()
+        ]
+        assert "update" not in actions_for_user1
+        assert "cancel" not in actions_for_user1
+
+        actions_for_user2 = [
+            n.topic_action.action
+            for n in session.execute(select(Notification).where(Notification.user_id == user2.id)).scalars().all()
+        ]
+        assert "update" in actions_for_user2
+        assert "cancel" in actions_for_user2
+
+
 def test_event_reminder_notification_has_moderation_state(db, push_collector: PushCollector, moderator: Moderator):
     """Event reminder notifications should carry the event's moderation_state_id for deferral."""
     user1, token1 = generate_user()


### PR DESCRIPTION
## Description

Fixes #9423.

Updating or cancelling your own event sent you a notification about it: the update/cancel fan-outs notified every subscriber and attendee, and the organizer is automatically both. The acting user is now excluded from both.

`event__delete` is deliberately left alone: it's only reachable via the admin API, and the notification must not reveal the deleting admin's identity.

Audited the rest: `event__comment` and `thread__reply` already skip the author, and the event-creation notifications already exclude organizers and attendees via `get_users_to_notify_for_new_event`. No changes needed there.

## Testing

Added `test_event_update_and_cancel_notifications_not_sent_to_actor`, which asserts the organizer receives no update or cancel notification while another subscriber still does. Verified it fails without the fix.

`make format` clean, `make mypy` passes, `test_events.py` passes.

Generated with [Claude Code](https://claude.ai/code)