### PR TITLE
Frontend/i18n: Don't show event minutes if 00

### DIFF
--- a/app/web/features/communities/events/EventCard.test.tsx
+++ b/app/web/features/communities/events/EventCard.test.tsx
@@ -38,7 +38,7 @@ describe("Event card", () => {
     expect(screen.getByRole("heading", { name: secondEvent.title })).toBeVisible();
     expect(screen.getByText(secondEvent.location!.address)).toBeVisible();
     expect(
-      screen.getByText("Tue, Jun 29, 2021, 11:00 PM – Wed, Jun 30, 2021, 4:00 AM", {
+      screen.getByText("Tue, Jun 29, 2021, 11 PM – Wed, Jun 30, 2021, 4 AM", {
         normalizer: (x) => x, // Match non-breaking spaces and en dashes exactly
       }),
     ).toBeVisible();

--- a/app/web/features/communities/events/EventCard.tsx
+++ b/app/web/features/communities/events/EventCard.tsx
@@ -128,6 +128,7 @@ export default function EventCard({ event, className }: EventCardProps) {
     {
       includeYear: "auto",
       includeDayOfWeek: true,
+      includeMinutes: "auto",
       abbreviate: true,
       capitalize: true,
     },

--- a/app/web/features/communities/events/EventPage.test.tsx
+++ b/app/web/features/communities/events/EventPage.test.tsx
@@ -110,7 +110,7 @@ describe("Event page", () => {
     renderEventPage(secondEvent.eventId, secondEvent.slug);
 
     expect(
-      await screen.findByText("Tuesday, June 29 at 11:00 PM – Wednesday, June 30 at 4:00 AM", {
+      await screen.findByText("Tuesday, June 29 at 11 PM – Wednesday, June 30 at 4 AM", {
         normalizer: (x) => x, // Match non-breaking spaces and en dashes exactly
       }),
     ).toBeVisible();

--- a/app/web/features/communities/events/EventPage.tsx
+++ b/app/web/features/communities/events/EventPage.tsx
@@ -365,6 +365,7 @@ export default function EventPage({ eventId, eventSlug }: { eventId: number; eve
                     {
                       includeYear: "auto",
                       includeDayOfWeek: true,
+                      includeMinutes: "auto",
                       capitalize: true,
                     },
                   )}

--- a/app/web/features/communities/events/LongEventCard.tsx
+++ b/app/web/features/communities/events/LongEventCard.tsx
@@ -126,6 +126,7 @@ const LongEventCard = ({ event, userId }: { event: Event.AsObject; userId?: numb
     {
       includeYear: "auto",
       includeDayOfWeek: true,
+      includeMinutes: "auto",
       capitalize: true,
     },
   );

--- a/app/web/i18n/datetimes.test.ts
+++ b/app/web/i18n/datetimes.test.ts
@@ -95,6 +95,33 @@ describe("localizeDateTime", () => {
     ).not.toContain("11");
   });
 
+  it("includes minutes when specified", () => {
+    const tenAM = janFirst2000.add({ hours: 10 });
+
+    expect(
+      localizeDateTime(tenAM, "en", {
+        includeMinutes: true,
+      }),
+    ).toContain("10:00");
+    expect(
+      localizeDateTime(tenAM, "en", {
+        includeMinutes: false,
+      }),
+    ).not.toContain("10:00");
+
+    // includeMinutes: "auto" depends on minutes == 0
+    expect(
+      localizeDateTime(tenAM, "en", {
+        includeMinutes: "auto",
+      }),
+    ).not.toContain("10:00");
+    expect(
+      localizeDateTime(tenAM.add({ minutes: 1 }), "en", {
+        includeMinutes: "auto",
+      }),
+    ).toContain("10:01");
+  });
+
   it("includes seconds when specified", () => {
     expect(
       localizeDateTime(janFirst2000.add({ seconds: 42 }), "en", {

--- a/app/web/i18n/datetimes.test.ts
+++ b/app/web/i18n/datetimes.test.ts
@@ -120,6 +120,12 @@ describe("localizeDateTime", () => {
         includeMinutes: "auto",
       }),
     ).toContain("10:01");
+    expect(
+      localizeDateTime(tenAM, "en", {
+        includeMinutes: "auto",
+        includeSeconds: true,
+      }),
+    ).toContain("10:00:00");
   });
 
   it("includes seconds when specified", () => {

--- a/app/web/i18n/datetimes.ts
+++ b/app/web/i18n/datetimes.ts
@@ -39,6 +39,9 @@ interface LocalizeDateOptions {
 }
 
 interface LocalizeTimeOptions {
+  /// Whether to include minutes (defaults to true).
+  /// "auto" omits minutes if it is 00.
+  includeMinutes?: boolean | "auto";
   /// Whether to include seconds (defaults to false).
   includeSeconds?: boolean;
 }
@@ -56,7 +59,11 @@ export function localizeDateTime(
   locale: string,
   options?: LocalizeDateTimeOptions,
 ): string {
-  const format = getIntlDateTimeFormatUTC(locale, options, { year: date.year });
+  const format = getIntlDateTimeFormatUTC(locale, options, {
+    year: date.year,
+    minutes: date.minute,
+    seconds: date.second,
+  });
   const formatted = format.format(toDateForUTCDisplay(date));
   return options?.capitalize ? capitalizeFirstLetter(formatted, locale) : formatted;
 }
@@ -133,6 +140,8 @@ export function localizeDateTimeRange(
 ): string {
   const format = getIntlDateTimeFormatUTC(locale, options, {
     year: start.year == end.year ? start.year : undefined,
+    minutes: start.minute == end.minute ? start.minute : undefined,
+    seconds: start.second == end.second ? start.second : undefined,
   });
   const formatted = format.formatRange(toDateForUTCDisplay(start), toDateForUTCDisplay(end));
   return options?.capitalize ? capitalizeFirstLetter(formatted, locale) : formatted;
@@ -165,7 +174,7 @@ const intlDateTimeFormatCache = new Map<string, Intl.DateTimeFormat>();
 function getIntlDateTimeFormatUTC(
   locale: string,
   options?: LocalizeDateTimeOptions,
-  dateComponents?: { year?: number },
+  dateComponents?: { year?: number; minutes?: number; seconds?: number },
 ): Intl.DateTimeFormat {
   const intlOptions = getIntlDateTimeFormatOptionsUTC(options, dateComponents);
   const cacheKey = JSON.stringify({ ...intlOptions, locale });
@@ -180,10 +189,11 @@ function getIntlDateTimeFormatUTC(
 /// Creates a new Intl.DateTimeFormat object based on params.
 function getIntlDateTimeFormatOptionsUTC(
   options?: LocalizeDateTimeOptions,
-  dateComponents?: { year?: number },
+  dateComponents?: { year?: number; minutes?: number; seconds?: number },
 ): Intl.DateTimeFormatOptions {
   const intlOptions: Intl.DateTimeFormatOptions = {};
   if (options?.includeDate !== false) {
+    // Year has three modes: include (default), omit, or auto (omit if current year).
     if (options?.includeYear === undefined || options?.includeYear === true) {
       intlOptions.year = "numeric";
     } else if (
@@ -207,7 +217,17 @@ function getIntlDateTimeFormatOptionsUTC(
 
   if (options?.includeTime !== false) {
     intlOptions.hour = "numeric";
-    intlOptions.minute = "numeric";
+
+    // Minutes have three modes: include (default), omit, or auto (omit if 00).
+    if (options?.includeMinutes === undefined || options?.includeMinutes === true) {
+      intlOptions.minute = "numeric";
+    } else if (
+      options?.includeMinutes === "auto" &&
+      (dateComponents?.minutes !== 0 || (dateComponents?.seconds ?? 0) !== 0)
+    ) {
+      intlOptions.minute = "numeric";
+    }
+
     if (options?.includeSeconds) {
       intlOptions.second = "numeric";
     }

--- a/app/web/i18n/datetimes.ts
+++ b/app/web/i18n/datetimes.ts
@@ -62,7 +62,6 @@ export function localizeDateTime(
   const format = getIntlDateTimeFormatUTC(locale, options, {
     year: date.year,
     minutes: date.minute,
-    seconds: date.second,
   });
   const formatted = format.format(toDateForUTCDisplay(date));
   return options?.capitalize ? capitalizeFirstLetter(formatted, locale) : formatted;
@@ -141,7 +140,6 @@ export function localizeDateTimeRange(
   const format = getIntlDateTimeFormatUTC(locale, options, {
     year: start.year == end.year ? start.year : undefined,
     minutes: start.minute == end.minute ? start.minute : undefined,
-    seconds: start.second == end.second ? start.second : undefined,
   });
   const formatted = format.formatRange(toDateForUTCDisplay(start), toDateForUTCDisplay(end));
   return options?.capitalize ? capitalizeFirstLetter(formatted, locale) : formatted;
@@ -174,7 +172,7 @@ const intlDateTimeFormatCache = new Map<string, Intl.DateTimeFormat>();
 function getIntlDateTimeFormatUTC(
   locale: string,
   options?: LocalizeDateTimeOptions,
-  dateComponents?: { year?: number; minutes?: number; seconds?: number },
+  dateComponents?: { year?: number; minutes?: number },
 ): Intl.DateTimeFormat {
   const intlOptions = getIntlDateTimeFormatOptionsUTC(options, dateComponents);
   const cacheKey = JSON.stringify({ ...intlOptions, locale });
@@ -189,15 +187,24 @@ function getIntlDateTimeFormatUTC(
 /// Creates a new Intl.DateTimeFormat object based on params.
 function getIntlDateTimeFormatOptionsUTC(
   options?: LocalizeDateTimeOptions,
-  dateComponents?: { year?: number; minutes?: number; seconds?: number },
+  dateComponents?: { year?: number; minutes?: number },
 ): Intl.DateTimeFormatOptions {
+  // Apply defaults
+  const includeDate = options?.includeDate ?? true;
+  const includeYear = options?.includeYear ?? true;
+  const includeDay = options?.includeDay ?? true;
+  const includeDayOfWeek = options?.includeDayOfWeek ?? false;
+  const includeTime = options?.includeTime ?? true;
+  const includeMinutes = options?.includeMinutes ?? true;
+  const includeSeconds = options?.includeSeconds ?? false;
+
   const intlOptions: Intl.DateTimeFormatOptions = {};
-  if (options?.includeDate !== false) {
+  if (includeDate) {
     // Year has three modes: include (default), omit, or auto (omit if current year).
-    if (options?.includeYear === undefined || options?.includeYear === true) {
+    if (includeYear === true) {
       intlOptions.year = "numeric";
     } else if (
-      options?.includeYear === "auto" &&
+      includeYear === "auto" &&
       dateComponents?.year !== undefined &&
       dateComponents.year != new Date().getFullYear()
     ) {
@@ -206,29 +213,26 @@ function getIntlDateTimeFormatOptionsUTC(
 
     intlOptions.month = options?.abbreviate ? "short" : "long";
 
-    if (options?.includeDay !== false) {
+    if (includeDay) {
       intlOptions.day = "numeric";
     }
 
-    if (options?.includeDayOfWeek) {
-      intlOptions.weekday = options.abbreviate ? "short" : "long";
+    if (includeDayOfWeek) {
+      intlOptions.weekday = options?.abbreviate ? "short" : "long";
     }
   }
 
-  if (options?.includeTime !== false) {
+  if (includeTime) {
     intlOptions.hour = "numeric";
 
     // Minutes have three modes: include (default), omit, or auto (omit if 00).
-    if (options?.includeMinutes === undefined || options?.includeMinutes === true) {
+    if (includeMinutes === true || includeSeconds) {
       intlOptions.minute = "numeric";
-    } else if (
-      options?.includeMinutes === "auto" &&
-      (dateComponents?.minutes !== 0 || (dateComponents?.seconds ?? 0) !== 0)
-    ) {
+    } else if (includeMinutes === "auto" && dateComponents?.minutes !== 0) {
       intlOptions.minute = "numeric";
     }
 
-    if (options?.includeSeconds) {
+    if (includeSeconds) {
       intlOptions.second = "numeric";
     }
   }


### PR DESCRIPTION
Event datetime ranges can get quite verbose, but we can save some brain cells when they start at minute 0 of the hour by not showing the minutes field.

Fixes #9358

## Testing
Vercel preview:

<img width="1485" height="507" alt="image" src="https://github.com/user-attachments/assets/80ee23f2-210b-4465-a564-0392c4765f55" />

Next:

<img width="1472" height="482" alt="image" src="https://github.com/user-attachments/assets/dc6c8b21-586b-45b0-b2fa-af1c7c51992e" />


Other examples from Vercel preview:

<img width="1475" height="477" alt="image" src="https://github.com/user-attachments/assets/e28c1c12-199e-4296-ba34-1dbd02ade300" />

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
