### PR TITLE
CI: only publish coverage previews on develop by default

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -18,6 +18,8 @@ stages:
 variables:
   # whether to do checks or only build & deploy
   DO_CHECKS: "true"
+  # whether to publish coverage reports to S3 (always on for the release branch)
+  DO_COVERAGE: "false"
   # whether to build web since it's very slow
   BUILD_WEB: "true"
   BUILD_MOBILE: "true"
@@ -764,11 +766,18 @@ preview:backend:
         python3 app/scripts/schema_diff_html.py develop-schema.sql artifacts/schema_dumps/schema.sql artifacts/schema_dumps/diff.html
       fi
     # Upload coverage report to S3
-    - aws s3 rm s3://$AWS_PREVIEW_BUCKET/bcov/$CI_COMMIT_SHORT_SHA/ --recursive
-    - aws s3 cp htmlcov s3://$AWS_PREVIEW_BUCKET/bcov/$CI_COMMIT_SHORT_SHA/ --recursive
-    - aws s3 rm s3://$AWS_PREVIEW_BUCKET/bcov/$CI_COMMIT_REF_SLUG/ --recursive
-    - aws s3 cp htmlcov s3://$AWS_PREVIEW_BUCKET/bcov/$CI_COMMIT_REF_SLUG/ --recursive
-    - echo "Done, coverage report available at https://$CI_COMMIT_SHORT_SHA--bcov.$PREVIEW_DOMAIN/ and https://$CI_COMMIT_REF_SLUG--bcov.$PREVIEW_DOMAIN/"
+    - |
+      BACKEND_ITEMS=schema,schema-diff,emails
+      if [ "$CI_COMMIT_BRANCH" = "$RELEASE_BRANCH" ] || [ "$DO_COVERAGE" = "true" ]; then
+        aws s3 rm s3://$AWS_PREVIEW_BUCKET/bcov/$CI_COMMIT_SHORT_SHA/ --recursive
+        aws s3 cp htmlcov s3://$AWS_PREVIEW_BUCKET/bcov/$CI_COMMIT_SHORT_SHA/ --recursive
+        aws s3 rm s3://$AWS_PREVIEW_BUCKET/bcov/$CI_COMMIT_REF_SLUG/ --recursive
+        aws s3 cp htmlcov s3://$AWS_PREVIEW_BUCKET/bcov/$CI_COMMIT_REF_SLUG/ --recursive
+        echo "Done, coverage report available at https://$CI_COMMIT_SHORT_SHA--bcov.$PREVIEW_DOMAIN/ and https://$CI_COMMIT_REF_SLUG--bcov.$PREVIEW_DOMAIN/"
+        BACKEND_ITEMS=$BACKEND_ITEMS,bcov
+      else
+        echo "Skipping bcov upload, set DO_COVERAGE=true to publish it"
+      fi
     # Upload schema dumps
     - aws s3 rm s3://$AWS_PREVIEW_BUCKET/schema/$CI_COMMIT_SHORT_SHA/ --recursive
     - aws s3 cp artifacts/schema_dumps s3://$AWS_PREVIEW_BUCKET/schema/$CI_COMMIT_SHORT_SHA/ --recursive
@@ -783,7 +792,7 @@ preview:backend:
     - echo "Done, test artifacts available at https://$CI_COMMIT_SHORT_SHA--test-artifacts.$PREVIEW_DOMAIN/ and https://$CI_COMMIT_REF_SLUG--test-artifacts.$PREVIEW_DOMAIN/"
     - echo "Sample emails index at https://$CI_COMMIT_SHORT_SHA--test-artifacts.$PREVIEW_DOMAIN/emails/index.html and https://$CI_COMMIT_REF_SLUG--test-artifacts.$PREVIEW_DOMAIN/emails/index.html"
     # write the backend items into the sticky PR comment (no-op off a PR)
-    - python3 app/scripts/pr_preview_comment.py --items schema,schema-diff,emails,bcov
+    - python3 app/scripts/pr_preview_comment.py --items $BACKEND_ITEMS
   artifacts:
     paths:
       - artifacts/schema_dumps
@@ -855,7 +864,7 @@ preview:wcov:
     - python3 app/scripts/pr_preview_comment.py --items wcov
   rules:
     - if: ($BUILD_WEB == "true") && ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH == $RELEASE_BRANCH)
-    - if: ($BUILD_WEB == "true") && ($DO_CHECKS == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
+    - if: ($BUILD_WEB == "true") && ($DO_CHECKS == "true") && ($DO_COVERAGE == "true") && ($CI_COMMIT_BRANCH != $RELEASE_BRANCH)
       changes:
         - app/proto/**/*
         - app/web/**/*


### PR DESCRIPTION
The backend and web HTML coverage reports are each made up of a large number of small files, and every pipeline uploads both of them to the preview bucket twice (once under the commit SHA, once under the branch slug). That's the bulk of what CI writes to `couchers-dev-assets`, and it's rarely looked at on a feature branch.

This adds a `DO_COVERAGE` pipeline variable, defaulting to `"false"`, that gates the `bcov` and `wcov` uploads:

- on `develop` they always publish, so the links in `docs/cicd.md` keep working
- on any other branch they're skipped unless you run the pipeline with `DO_COVERAGE=true`

`preview:wcov` does nothing but upload, so it's gated at the job level via `rules:`. `preview:backend` also publishes the schema dumps, schema diff and sample emails, so only the four `bcov` lines are gated there; `BACKEND_ITEMS` picks up `bcov` only when the upload actually ran, so the sticky PR comment doesn't link a report that isn't there.

Coverage is still *computed* on every pipeline — `preview:backend-coverage` and `preview:web-coverage` are untouched — so GitLab's MR coverage percentage, the cobertura reports, `test_durations.json`, and the `htmlcov` / `lcov-report` job artifacts are all unaffected. On a PR without the flag you can still browse the report from the job's artifacts page.

## Testing

CI config only, so this is validated by the pipeline on this PR:

- this branch is not `develop` and `DO_COVERAGE` is unset, so `preview:wcov` should not appear in the pipeline, and `preview:backend` should log `Skipping bcov upload, set DO_COVERAGE=true to publish it`
- the preview comment on this PR should still show the schema, schema diff and sample email links, with no backend/web coverage entries
- re-running with `DO_COVERAGE=true` should restore both coverage jobs and both comment links
- the YAML was checked to still parse, and `preview:backend` still declares its `preview:backend-coverage` dependency

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._