### PR TITLE
Backend: dump sample emails as a single self-contained page

### DIFF
--- a/app/backend/src/couchers/email/dump_emails.py
+++ b/app/backend/src/couchers/email/dump_emails.py
@@ -1,6 +1,10 @@
 """
 Dumps emails subjects and html/plaintext bodies with dummy data in every supported
 locale, plus a browsable HTML index with a locale selector and expandable previews.
+
+Bodies are written as one JSON payload per locale rather than a file per body, which
+keeps the published output to a couple of dozen objects instead of thousands. The
+index inlines the default locale so it also works when opened straight off disk.
 """
 
 import inspect
@@ -57,15 +61,11 @@ class RenderedVariation:
     variation: int
     variation_count: int
     subjects: dict[str, str]  # locale -> subject line
-    name: str  # filename without extension, relative to the locale directory
+    name: str  # key this variation's bodies are stored under in the locale payload
 
-    @property
-    def html_filename(self) -> str:
-        return f"{self.name}.html"
 
-    @property
-    def plaintext_filename(self) -> str:
-        return f"{self.name}.txt"
+def payload_filename(locale: str) -> str:
+    return f"emails-{locale}.json"
 
 
 def _ordered_locales(locales: list[str] | None) -> list[str]:
@@ -75,7 +75,7 @@ def _ordered_locales(locales: list[str] | None) -> list[str]:
 
 
 def dump_all(outdir: Path, *, filter_glob: str = "*", locales: list[str] | None = None) -> list[RenderedVariation]:
-    """Dumps all emails matching the filter to outdir (one subdirectory per locale) and
+    """Dumps all emails matching the filter to outdir (one JSON payload per locale) and
     writes a browsable index.html with a locale selector and expandable previews.
 
     Requires the relevant config (e.g. BASE_URL) to be available, as when run inside the
@@ -93,64 +93,67 @@ def dump_all(outdir: Path, *, filter_glob: str = "*", locales: list[str] | None 
     filter_regex = re.compile(re.escape(filter_glob).replace(r"\*", ".*?"))
 
     rendered: list[RenderedVariation] = []
+    # locale -> variation name -> {"html": ..., "txt": ...}
+    bodies: dict[str, dict[str, dict[str, str]]] = {locale: {} for locale in locales}
     # Iterate over all email classes and dump their test instances if they match the filter
     for _, klass in inspect.getmembers(couchers.email.emails, lambda o: inspect.isclass(o) and o.__base__ == EmailBase):
         email_class: type[EmailBase] = klass
         if filter_regex.fullmatch(email_class.__name__):
             test_instances = email_class.test_instances()
             for i in range(len(test_instances)):
-                filename_no_ext = email_class.__name__
+                name = email_class.__name__
                 if len(test_instances) > 1:
-                    filename_no_ext += f"_{i}"
+                    name += f"_{i}"
                 print(f"Dumping email class {email_class.__name__} ({len(locales)} locale(s))")
                 subjects = {}
                 for locale in locales:
                     loc_context = LocalizationContext(locale=locale, timezone=UTC)
-                    subjects[locale] = dump_email(
-                        test_instances[i], footer, loc_context, outdir / locale / filename_no_ext
-                    )
+                    email = render_email(test_instances[i], footer, loc_context, embed_images=False)
+                    subjects[locale] = email.subject
+                    bodies[locale][name] = {"html": email.body_html, "txt": email.body_plaintext}
                 rendered.append(
                     RenderedVariation(
                         email_class=email_class.__name__,
                         variation=i,
                         variation_count=len(test_instances),
                         subjects=subjects,
-                        name=filename_no_ext,
+                        name=name,
                     )
                 )
 
+    outdir.mkdir(parents=True, exist_ok=True)
     if rendered:
         shutil.copytree(template_folder / "attachment_imgs", outdir / "attachment_imgs", dirs_exist_ok=True)
 
-    write_index(outdir / "index.html", rendered, locales)
+    for locale in locales:
+        (outdir / payload_filename(locale)).write_text(json.dumps(bodies[locale], ensure_ascii=False))
+
+    # the index inlines the first locale so it renders without fetch(), which a browser
+    # blocks on file:// - the others are fetched on demand
+    write_index(outdir / "index.html", rendered, locales, bodies[locales[0]])
     return rendered
 
 
-def dump_email(email: EmailBase, footer: EmailFooter, loc_context: LocalizationContext, filepath_no_ext: Path) -> str:
-    """Dumps an email's subject and plaintext+html body to a file, returning the subject line."""
-    rendered = render_email(email, footer, loc_context, embed_images=False)
-    html = rendered.body_html.replace("attachment_imgs/", "../attachment_imgs/")
-
-    filepath_no_ext.parent.mkdir(parents=True, exist_ok=True)
-    filepath_no_ext.with_suffix(".html").write_text(html)
-    filepath_no_ext.with_suffix(".txt").write_text(rendered.body_plaintext)
-
-    return rendered.subject
-
-
-def write_index(index_path: Path, rendered: list[RenderedVariation], locales: list[str]) -> None:
+def write_index(
+    index_path: Path, rendered: list[RenderedVariation], locales: list[str], inlined_bodies: dict[str, dict[str, str]]
+) -> None:
     """Writes a browsable HTML index with a locale selector and an accordion entry per
     rendered email variation, expanding to side-by-side HTML and plaintext previews."""
     rendered = sorted(rendered, key=lambda r: (r.email_class, r.variation))
-    # Guard against a literal "</script>" in subject lines breaking out of the script tag
-    subjects_json = json.dumps({r.name: r.subjects for r in rendered}, ensure_ascii=False).replace("</", "<\\/")
+
+    def embed(value: object) -> Markup:
+        # Guard against a literal "</script>" in the data breaking out of the script tag
+        return Markup(json.dumps(value, ensure_ascii=False).replace("</", "<\\/"))
+
     template = Jinja2Template(source=(Path(__file__).parent / "dump_emails_index.html.jinja2").read_text(), html=True)
     index_html = template.render(
         {
             "rendered": rendered,
             "locales": locales,
             "class_count": len({r.email_class for r in rendered}),
-            "subjects_json": Markup(subjects_json),
+            "subjects_json": embed({r.name: r.subjects for r in rendered}),
+            "inlined_locale_json": embed(locales[0]),
+            "inlined_bodies_json": embed(inlined_bodies),
         }
     )
     index_path.parent.mkdir(parents=True, exist_ok=True)

--- a/app/backend/src/couchers/email/dump_emails_index.html.jinja2
+++ b/app/backend/src/couchers/email/dump_emails_index.html.jinja2
@@ -51,12 +51,12 @@
 </summary>
 <div class="panes">
   <section>
-    <h2>HTML <a data-href="{{ r.html_filename }}" target="_blank">open</a></h2>
-    <iframe data-file="{{ r.html_filename }}" loading="lazy"></iframe>
+    <h2>HTML <a data-kind="html" target="_blank">open</a></h2>
+    <iframe data-kind="html" loading="lazy"></iframe>
   </section>
   <section>
-    <h2>Plaintext <a data-href="{{ r.plaintext_filename }}" target="_blank">open</a></h2>
-    <iframe data-file="{{ r.plaintext_filename }}" loading="lazy"></iframe>
+    <h2>Plaintext <a data-kind="txt" target="_blank">open</a></h2>
+    <iframe data-kind="txt" loading="lazy"></iframe>
   </section>
 </div>
 </details>
@@ -64,10 +64,33 @@
 </main>
 <script>
 const SUBJECTS = {{ subjects_json }};
+const BODIES = new Map([[{{ inlined_locale_json }}, {{ inlined_bodies_json }}]]);
 const select = document.getElementById("locale");
 
 const requested = new URLSearchParams(location.search).get("locale");
 if (requested && SUBJECTS[Object.keys(SUBJECTS)[0]][requested] !== undefined) select.value = requested;
+
+async function bodies(locale) {
+  if (!BODIES.has(locale)) {
+    const resp = await fetch("emails-" + locale + ".json");
+    if (!resp.ok) throw new Error(resp.status + " fetching " + locale);
+    BODIES.set(locale, await resp.json());
+  }
+  return BODIES.get(locale);
+}
+
+const escapeHtml = (s) => s.replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c]);
+
+// srcdoc resolves relative URLs against this document's base, so attachment_imgs/ is
+// already right; a blob: document has an opaque base and needs them made absolute
+const absolutise = (html) => html.replaceAll("attachment_imgs/", new URL("attachment_imgs/", location.href).href);
+
+function docFor(kind, body) {
+  return kind === "html"
+    ? body.html
+    : '<pre style="white-space:pre-wrap;font:13px/1.5 ui-monospace,monospace;margin:0;padding:8px">' +
+        escapeHtml(body.txt) + "</pre>";
+}
 
 function refresh() {
   const locale = select.value;
@@ -78,13 +101,23 @@ function refresh() {
   }
 }
 
-function load(details, locale) {
-  for (const iframe of details.querySelectorAll("iframe")) {
-    const src = locale + "/" + iframe.dataset.file;
-    if (iframe.getAttribute("src") !== src) iframe.src = src;
+async function load(details, locale) {
+  let body;
+  try {
+    body = (await bodies(locale))[details.dataset.key];
+  } catch (e) {
+    for (const iframe of details.querySelectorAll("iframe")) iframe.srcdoc = "<p>" + escapeHtml(String(e)) + "</p>";
+    return;
   }
-  for (const link of details.querySelectorAll("a[data-href]")) {
-    link.href = locale + "/" + link.dataset.href;
+  // a slow fetch may land after the user has moved on to another locale
+  if (select.value !== locale) return;
+  for (const iframe of details.querySelectorAll("iframe")) iframe.srcdoc = docFor(iframe.dataset.kind, body);
+  for (const link of details.querySelectorAll("a[data-kind]")) {
+    const html = link.dataset.kind === "html";
+    if (link.href.startsWith("blob:")) URL.revokeObjectURL(link.href);
+    link.href = URL.createObjectURL(
+      new Blob([html ? absolutise(body.html) : body.txt], { type: html ? "text/html" : "text/plain;charset=utf-8" })
+    );
   }
 }
 

--- a/app/backend/src/tests/test_dump_emails.py
+++ b/app/backend/src/tests/test_dump_emails.py
@@ -5,9 +5,10 @@ Output is written to test_artifacts/emails/ (gitignored) and picked up by CI, wh
 publishes the browsable index.html to the preview environment.
 """
 
+import json
 from pathlib import Path
 
-from couchers.email.dump_emails import dump_all
+from couchers.email.dump_emails import dump_all, payload_filename
 
 
 def test_dump_email_samples(testconfig):
@@ -18,8 +19,26 @@ def test_dump_email_samples(testconfig):
     index = output_path / "index.html"
     assert index.exists()
     assert (output_path / "attachment_imgs" / "logo-with-couchers.org-small.png").exists()
-    for variation in rendered:
-        assert variation.subjects
-        for locale in variation.subjects:
-            assert (output_path / locale / variation.html_filename).exists()
-            assert (output_path / locale / variation.plaintext_filename).exists()
+
+    locales = {locale for variation in rendered for locale in variation.subjects}
+    assert locales
+    for locale in locales:
+        bodies = json.loads((output_path / payload_filename(locale)).read_text())
+        for variation in rendered:
+            assert variation.subjects[locale]
+            assert bodies[variation.name]["html"]
+            assert bodies[variation.name]["txt"]
+
+
+def test_dump_email_index_inlines_default_locale(testconfig, tmp_path):
+    """The index has to render off disk, where a browser blocks fetch()."""
+    rendered = dump_all(tmp_path, locales=["de", "en"])
+
+    index_html = (tmp_path / "index.html").read_text()
+    # _ordered_locales puts the default locale first, and that's the one inlined
+    inlined = json.loads((tmp_path / payload_filename("en")).read_text())
+    other = json.loads((tmp_path / payload_filename("de")).read_text())
+    for body, present in ((inlined[rendered[0].name], True), (other[rendered[0].name], False)):
+        # matches how write_index embeds the payload into the script tag
+        encoded = json.dumps(body["html"], ensure_ascii=False).replace("</", "<\\/")
+        assert (encoded in index_html) is present


### PR DESCRIPTION
The backend can render a sample of every notification email in every supported locale, and CI publishes the browsable index to the preview environment. Writing an HTML and a plaintext body per email per locale put a few thousand small files into that output, all of which CI uploads to the preview bucket on every pipeline. The bodies are now gzipped and inlined into the index itself, leaving a single page plus the attachment images; inlining every locale rather than fetching payloads on demand is deliberate, as the index is opened every few weeks and its page weight matters far less than the per-pipeline S3 cost.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._
