### PR TITLE
Backend: run the background job dequeue at READ COMMITTED

### DIFF
--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -70,7 +70,7 @@ def _get_base_engine() -> Engine:
         poolclass=QueuePool,
         # each process keeps its own pool, so total connections ~= process count * pool_size, kept under postgres
         # max_connections. ~2 per thread since a thread can hold two connections at once (handler + _store_log,
-        # or worker_repeatable_read + the handler's own session_scope).
+        # or the jobs worker's own session_scope + the handler's).
         pool_size=DB_POOL_SIZE,
         max_overflow=0,
     )
@@ -105,42 +105,6 @@ def session_scope() -> Generator[Session]:
             finally:
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.debug(f"SScope: closed {backend_pid=}")
-
-
-@contextmanager
-def worker_repeatable_read_session_scope() -> Generator[Session]:
-    """
-    This is a separate session scope that is isolated from the main one since otherwise we end up nesting transactions,
-    this causes two different connections to be used
-
-    This operates in a `REPEATABLE READ` isolation level so that we can do a `SELECT ... FOR UPDATE SKIP LOCKED` in the
-    background worker, effectively using postgres as a queueing system.
-    """
-    with tracer.start_as_current_span("worker_session_scope") as rollspan:
-        with Session(_get_base_engine().execution_options(isolation_level="REPEATABLE READ")) as session:
-            session.begin()
-            try:
-                if logger.isEnabledFor(logging.DEBUG):
-                    try:
-                        frame = inspect.stack()[2]
-                        filename_line = f"{frame.filename}:{frame.lineno}"
-                    except Exception as e:
-                        filename_line = "{unknown file}"
-                    backend_pid = session.execute(text("SELECT pg_backend_pid();")).scalar_one()
-                    logger.debug(f"SScope (worker): got {backend_pid=} at {filename_line}")
-                    rollspan.set_attribute("db.backend_pid", backend_pid)
-                    rollspan.set_attribute("db.filename_line", filename_line)
-                rollspan.set_attribute("rpc.thread", get_ident())
-                rollspan.set_attribute("rpc.pid", getpid())
-
-                yield session
-                session.commit()
-            except:
-                session.rollback()
-                raise
-            finally:
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.debug(f"SScope (worker): closed {backend_pid=}")
 
 
 def db_post_fork() -> None:

--- a/app/backend/src/couchers/jobs/worker.py
+++ b/app/backend/src/couchers/jobs/worker.py
@@ -13,13 +13,12 @@ from time import monotonic, perf_counter_ns, sleep
 from typing import Any
 
 import sentry_sdk
-import sqlalchemy.exc
 from google.protobuf import empty_pb2
 from opentelemetry import trace
 from sqlalchemy import select
 
 from couchers.config import config
-from couchers.db import db_post_fork, session_scope, worker_repeatable_read_session_scope
+from couchers.db import db_post_fork, session_scope
 from couchers.experimentation import setup_experimentation
 from couchers.i18n.locales import get_main_i18next
 from couchers.jobs.definitions import JOBS, Job
@@ -27,7 +26,6 @@ from couchers.jobs.enqueue import queue_job
 from couchers.metrics import (
     background_jobs_got_job_counter,
     background_jobs_no_jobs_counter,
-    background_jobs_serialization_errors_counter,
     jobs_queued_histogram,
     observe_in_jobs_duration_histogram,
 )
@@ -47,27 +45,23 @@ def process_job() -> bool:
     """
     logger.debug("Looking for a job")
 
-    with worker_repeatable_read_session_scope() as session:
-        # a combination of REPEATABLE READ and SELECT ... FOR UPDATE SKIP LOCKED makes sure that only one transaction
-        # will modify the job at a time. SKIP UPDATE means that if the job is locked, then we ignore that row, it's
-        # easier to use SKIP LOCKED vs NOWAIT in the ORM, with NOWAIT you get an ugly exception from deep inside
-        # psycopg2 that's quite annoying to catch and deal with
-        try:
-            job = (
-                session.execute(
-                    select(BackgroundJob)
-                    .where(BackgroundJob.ready_for_retry)
-                    .order_by(BackgroundJob.priority.desc(), BackgroundJob.next_attempt_after.asc())
-                    .limit(1)
-                    .with_for_update(skip_locked=True)
-                )
-                .scalars()
-                .one_or_none()
+    with session_scope() as session:
+        # SELECT ... FOR UPDATE is what makes sure only one worker handles a given job: no two transactions can hold
+        # the row lock at once. SKIP LOCKED means an already-claimed job is passed over rather than waited on, so
+        # workers spread out across the queue. This must run at READ COMMITTED (the default): a stricter isolation
+        # level can't follow the update chain of a row another worker just committed, and aborts the whole dequeue
+        # with a serialization error instead of skipping the row
+        job = (
+            session.execute(
+                select(BackgroundJob)
+                .where(BackgroundJob.ready_for_retry)
+                .order_by(BackgroundJob.priority.desc(), BackgroundJob.next_attempt_after.asc())
+                .limit(1)
+                .with_for_update(skip_locked=True)
             )
-        except sqlalchemy.exc.OperationalError:
-            background_jobs_serialization_errors_counter.inc()
-            logger.debug("Serialization error")
-            return False
+            .scalars()
+            .one_or_none()
+        )
 
         if not job:
             background_jobs_no_jobs_counter.inc()

--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -644,11 +644,6 @@ background_jobs_ready_to_execute_gauge: Gauge = _make_gauge_from_query(
     select(func.count()).select_from(BackgroundJob).where(BackgroundJob.ready_for_retry),
 )
 
-background_jobs_serialization_errors_counter: Counter = Counter(
-    "couchers_background_jobs_serialization_errors_total",
-    "Number of times a bg worker has a serialization error",
-)
-
 background_jobs_no_jobs_counter: Counter = Counter(
     "couchers_background_jobs_no_jobs_total",
     "Number of times a bg worker tries to grab a job but there is none",

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -6,7 +6,7 @@ import pytest
 import requests
 from google.protobuf import empty_pb2
 from google.protobuf.empty_pb2 import Empty
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.sql import delete, func
 
 import couchers.jobs.worker
@@ -504,6 +504,54 @@ def test_job_retry(db):
 
     _check_job_counter("mock_job", "error", "4", "Exception")
     _check_job_counter("mock_job", "failed", "5", "Exception")
+
+
+def test_job_dequeue_steps_over_other_workers_jobs(db):
+    handled = []
+
+    def mock_job(payload: jobs_pb2.SendEmailPayload) -> None:
+        handled.append(payload.subject)
+
+    MOCK_JOBS: dict[str, Job[Any]] = {"mock_job": Job(mock_job)}
+
+    with session_scope() as session:
+        for subject in ["first", "second", "third"]:
+            queue_job(session, job=mock_job, payload=jobs_pb2.SendEmailPayload(subject=subject))
+        session.flush()
+        # queued in one transaction, so they'd otherwise all share a next_attempt_after and tie in the ordering
+        for i, job in enumerate(session.execute(select(BackgroundJob).order_by(BackgroundJob.id)).scalars()):
+            job.next_attempt_after = now() - timedelta(seconds=3 - i)
+
+    # another worker already finished "first" and committed
+    with session_scope() as session:
+        finished = (
+            session.execute(select(BackgroundJob).order_by(BackgroundJob.next_attempt_after).limit(1)).scalars().one()
+        )
+        finished.state = BackgroundJobState.completed
+
+    with session_scope() as holder:
+        # another worker is holding "second", mid-flight
+        held = (
+            holder.execute(
+                select(BackgroundJob)
+                .where(BackgroundJob.ready_for_retry)
+                .order_by(BackgroundJob.next_attempt_after)
+                .limit(1)
+                .with_for_update(skip_locked=True)
+            )
+            .scalars()
+            .one()
+        )
+        assert held.payload == jobs_pb2.SendEmailPayload(subject="second").SerializeToString()
+
+        # the dequeue must run at READ COMMITTED: under a stricter isolation level it can't follow the update chain of
+        # the row the other worker just completed, and aborts the whole transaction rather than stepping over it
+        assert holder.execute(text("show transaction_isolation")).scalar_one() == "read committed"
+
+        with patch("couchers.jobs.worker.JOBS", MOCK_JOBS):
+            assert process_job()
+
+    assert handled == ["third"]
 
 
 def test_no_jobs_no_problem(db):


### PR DESCRIPTION
The background job worker wrapped its `SELECT ... FOR UPDATE SKIP LOCKED` dequeue in a `REPEATABLE READ` transaction, on the stated rationale that "a combination of REPEATABLE READ and SELECT ... FOR UPDATE SKIP LOCKED makes sure that only one transaction will modify the job at a time". That isn't where the guarantee comes from — `FOR UPDATE` is a row lock, and no two transactions can hold it on the same row at any isolation level. The isolation level contributed nothing to mutual exclusion and only removed options.

Under `READ COMMITTED`, when the dequeue scan reaches a row another worker has concurrently updated and committed, Postgres runs EvalPlanQual: it follows the row's update chain to the newest version and re-evaluates the `WHERE` clause against it. A job someone else just completed silently drops out of the result, and the scan carries on. Under `REPEATABLE READ` that chain can't be followed without showing data outside the fixed snapshot, so Postgres has no legal answer and aborts the entire transaction with `40001`. The worker caught that, returned "no job", and `service_jobs` slept for a second — so contention made workers idle rather than making them work.

Changes:

- `process_job` uses `session_scope()`, i.e. the `READ COMMITTED` default. The comment now states what actually provides each property, and that the isolation level is a requirement rather than an incidental default.
- `worker_repeatable_read_session_scope` is deleted. With the isolation override removed it was identical to `session_scope`, and it had no other callers.
- The `except sqlalchemy.exc.OperationalError` around the dequeue is deleted. There are no serialization failures left for it to catch, and what remained was a blanket swallow of connection errors, `admin_shutdown` and deadlocks — all reported to metrics as an idle queue.
- `couchers_background_jobs_serialization_errors_total` is removed. **Note for maintainers:** any dashboard panel or alert rule referencing that metric needs removing too.

Net ~55 lines deleted. No schema change, no migration.

Unrelated known issues in this worker are deliberately left alone here, to keep this reviewable: the retry backoff adding to the stale `next_attempt_after` instead of `now()`, the transaction being held open across the whole handler, the absence of any stuck-job reaping, and there being no purge job for the `background_jobs` table.

## Testing

`make format`, `make mypy` (466 files) and `pytest src/tests/test_bg_jobs.py` (34 tests) all pass locally.

New regression test, `test_job_dequeue_steps_over_other_workers_jobs`: three queued jobs, the first completed and committed by a simulated second worker, the second held under an open `FOR UPDATE` lock by a simulated third, and `process_job()` must run the remaining one. It also asserts `show transaction_isolation` is `read committed`.

To replicate the failure the test guards against, temporarily restore the override in `session_scope`:

```python
with Session(_get_base_engine().execution_options(isolation_level="REPEATABLE READ")) as session:
```

then `uv run pytest src/tests/test_bg_jobs.py -k dequeue`.

One caveat reviewers should know: the isolation assertion is the part that actually pins this fix, and it is what fails on that revert. The behavioural half of the test would most likely still pass under `REPEATABLE READ`, because `process_job` opens its session and the dequeue is the first statement in it, so the snapshot is taken *after* the concurrent commit has already landed. Reproducing the abort deterministically through `process_job()` would need a hook to interleave a commit between session open and dequeue, which didn't seem worth the machinery. The behavioural half documents intent and would catch a `SKIP LOCKED` or ordering regression.

Separately worth checking before merge: what `couchers_background_jobs_serialization_errors_total` currently reads in production, since that quantifies how often this was firing. The window is narrower than it first looks for the snapshot-timing reason above — but it widens with worker count, and it widens a lot with debug logging on, because the debug branch in the session scope issues `SELECT pg_backend_pid()` before the dequeue and moves the snapshot earlier.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._