### PR TITLE
Backend: index messages (conversation_id, id) for the unread counts

### DIFF
--- a/app/backend/src/couchers/migrations/versions/0177_index_messages_conversation_id_id.py
+++ b/app/backend/src/couchers/migrations/versions/0177_index_messages_conversation_id_id.py
@@ -1,0 +1,82 @@
+"""Index messages(conversation_id, id) for unread counts, and cover time in the text-only index
+
+Revision ID: 0177
+Revises: 0176
+Create Date: 2026-08-02 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0177"
+down_revision = "0176"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # both are created under new names so they can be built by hand ahead of the deploy without this
+    # migration then dropping and rebuilding them
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_messages_conversation_id_id",
+            "messages",
+            ["conversation_id", "id"],
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.create_index(
+            "ix_messages_conversation_id_id_time_text_only",
+            "messages",
+            ["conversation_id", "id"],
+            postgresql_include=["time"],
+            postgresql_where="message_type = 'text'",
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        # superseded by ix_messages_conversation_id_id_time_text_only
+        op.drop_index(
+            "ix_messages_conversation_id_id_text_only",
+            table_name="messages",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        # superseded by ix_messages_conversation_id, which leads with the same column
+        op.drop_index(
+            "ix_messages_conversation_id",
+            table_name="messages",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_messages_conversation_id",
+            "messages",
+            ["conversation_id"],
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.create_index(
+            "ix_messages_conversation_id_id_text_only",
+            "messages",
+            ["conversation_id", "id"],
+            postgresql_where="message_type = 'text'",
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.drop_index(
+            "ix_messages_conversation_id_id_time_text_only",
+            table_name="messages",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.drop_index(
+            "ix_messages_conversation_id_id",
+            table_name="messages",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/app/backend/src/couchers/models/conversations.py
+++ b/app/backend/src/couchers/models/conversations.py
@@ -142,10 +142,16 @@ class Message(Base, kw_only=True):
 
     __tablename__ = "messages"
     __table_args__ = (
+        # serves "is there anything in this conversation newer than X", which the unread badge counts ask
+        # once per host request. can't be the partial index below: those counts include control messages
+        Index("ix_messages_conversation_id_id", "conversation_id", "id"),
+        # send_request_notifications only wakes users for text messages; time is included so it can decide
+        # the "older than 5 minutes" cutoff without leaving the index
         Index(
-            "ix_messages_conversation_id_id_text_only",
+            "ix_messages_conversation_id_id_time_text_only",
             "conversation_id",
             "id",
+            postgresql_include=["time"],
             postgresql_where=text("message_type = 'text'"),
         ),
     )
@@ -153,7 +159,7 @@ class Message(Base, kw_only=True):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
     # which conversation the message belongs in
-    conversation_id: Mapped[int] = mapped_column(ForeignKey("conversations.id"), index=True)
+    conversation_id: Mapped[int] = mapped_column(ForeignKey("conversations.id"))
 
     # the user that sent the message/command
     author_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)


### PR DESCRIPTION
The unread badge counts in `Ping` ask "is there anything in this conversation newer than X" once per host request. `ix_messages_conversation_id` doesn't contain `id`, so each probe had to heap-fetch every message in the conversation just to evaluate that filter — on a heavy user's `Ping` (315 host requests) that was 2359 of 2723 buffer hits, 87% of the query.

- Adds a non-partial `(conversation_id, id)` index for those counts. They include control messages (an accepted request should light up the badge), so they can't use the existing text-only partial index.
- Extends the text-only index with `INCLUDE (time)` and renames it accordingly, so `send_request_notifications` can apply its unseen-long-enough cutoff without leaving the index. `message_type` is deliberately not added — the partial predicate already pins it.
- Drops `ix_messages_conversation_id`, which the new composite supersedes (same leading column), keeping `messages` at two conversation indexes rather than three.

`time` is an `INCLUDE` rather than a key column on purpose: `id >` is an inequality, so a trailing key column can never narrow the scan boundaries. Benchmarked at 2.4M messages, both shapes come out at the same index size and buffer count, with the key-column version measuring slightly slower.

The migration creates both indexes under new names so they can be built by hand ahead of the deploy without the migration then dropping and rebuilding them. All four operations use `autocommit_block()` with `postgresql_concurrently=True`.

## Testing

- `test_migrations` passes, so the schema built from migrations diffs clean against the schema built from the models — the `INCLUDE (time)`, the partial predicate and both drops all round-trip.
- `make mypy` clean, `make format` clean.
- `test_db`, `test_bg_jobs`, `test_conversations` and `test_requests` pass locally (127 tests).
- Index shapes were compared with `EXPLAIN (ANALYZE, BUFFERS)` against a synthetic 2.4M-row messages table; the motivating plan is a production `EXPLAIN` of the `Ping` host-request count query.

To replicate the benchmark, `EXPLAIN (ANALYZE, BUFFERS)` the unread-count probe against `messages` before and after, and confirm the `messages` node goes from `Index Scan` with `Filter: (id > ...)` and non-zero `Rows Removed by Filter` to an `Index Only Scan` with both predicates as index conditions.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._