### PR TITLE
Frontend/i18n: Don't use Trans innerHtml

### DIFF
--- a/app/web/components/CookieBanner.tsx
+++ b/app/web/components/CookieBanner.tsx
@@ -66,14 +66,11 @@ export default function CookieBanner() {
       </StyledCloseButton>
       <div className="content">
         <Typography variant="body2">
-          <Trans t={t} i18nKey="cookie_message">
-            We use cookies to ensure that we give you the best experience on our website. If you continue to use this
-            site, we will assume that you are happy with it. You can read more about our
-            <StyledLink href={tosRoute} sx={{ color: "var(--mui-palette-secondary-light)" }}>
-              Terms of Service
-            </StyledLink>
-            .
-          </Trans>
+          <Trans
+            t={t}
+            i18nKey="cookie_message"
+            components={{ 1: <StyledLink href={tosRoute} sx={{ color: "var(--mui-palette-secondary-light)" }} /> }}
+          />
         </Typography>
       </div>
     </StyledWrapper>

--- a/app/web/components/Footer/Footer.tsx
+++ b/app/web/components/Footer/Footer.tsx
@@ -262,17 +262,11 @@ export default function Footer({ bottomMargin }: { bottomMargin?: string }) {
                 version: version_text,
                 updated_ago: updated_ago_text,
               }}
-            >
-              Version{" "}
-              <VersionLink href={version_link} target="_blank" rel="noopener noreferrer">
-                {version_text}
-              </VersionLink>
-              , last updated{" "}
-              <VersionLink href={updated_ago_link} target="_blank" rel="noopener noreferrer">
-                {updated_ago_text}
-              </VersionLink>
-              .
-            </Trans>
+              components={{
+                2: <VersionLink href={version_link} target="_blank" rel="noopener noreferrer" />,
+                5: <VersionLink href={updated_ago_link} target="_blank" rel="noopener noreferrer" />,
+              }}
+            />
           </Typography>
         </StyledLowerContainer>
       </StyledLowerOuterContainer>

--- a/app/web/features/NotFoundPage.tsx
+++ b/app/web/features/NotFoundPage.tsx
@@ -34,10 +34,11 @@ export default function NotFoundPage() {
         <StyledImg src={Graphic.src} alt={t("not_found_alt")} />
         <Typography>{t("not_found_text_1")}</Typography>
         <Typography>
-          <Trans t={t} i18nKey="not_found_text_2">
-            Do you just want to
-            <StyledLink href={!authenticated || !isMounted ? baseRoute : dashboardRoute}>go home?</StyledLink>
-          </Trans>
+          <Trans
+            t={t}
+            i18nKey="not_found_text_2"
+            components={{ 1: <StyledLink href={!authenticated || !isMounted ? baseRoute : dashboardRoute} /> }}
+          />
         </Typography>
       </StyledWrapper>
     </>

--- a/app/web/features/auth/deletion/DeleteAccount.tsx
+++ b/app/web/features/auth/deletion/DeleteAccount.tsx
@@ -66,11 +66,12 @@ export default function DeleteAccount({ className, username }: DeleteAccountProp
         {isDeleteAccountSuccess && <Alert severity="success">{t("auth:delete_account.request.success_message")}</Alert>}
         <StyledForm onSubmit={onSubmit}>
           <Typography variant="subtitle1" sx={{ paddingBottom: 2 }}>
-            <Trans t={t} i18nKey="auth:delete_account.request.confirm_username_explanation" values={{ username }}>
-              {`Your username is `}
-              <strong>{username}</strong>
-              {`, please type it in below to confirm account deletion.`}
-            </Trans>
+            <Trans
+              t={t}
+              i18nKey="auth:delete_account.request.confirm_username_explanation"
+              values={{ username }}
+              components={{ 1: <strong /> }}
+            />
           </Typography>
           <TextField
             id="confirmUsername"

--- a/app/web/features/auth/email/DoNotEmail.tsx
+++ b/app/web/features/auth/email/DoNotEmail.tsx
@@ -60,9 +60,8 @@ export default function DoNotEmail() {
                   ? "do_not_email.status.no_emails_enabled_message"
                   : "do_not_email.status.no_emails_disabled_message"
               }
-            >
-              Emails are currently <strong>disabled/enabled</strong> for your account.
-            </Trans>
+              components={{ 1: <strong /> }}
+            />
           </Typography>
           <Typography variant="body1">
             <Button onClick={() => toggleDoNotEmail()} loading={mutation.isPending}>

--- a/app/web/features/auth/jail/ModNoteCard.tsx
+++ b/app/web/features/auth/jail/ModNoteCard.tsx
@@ -1,7 +1,7 @@
 import { Card, styled, Typography } from "@mui/material";
 import Button from "components/Button";
 import Markdown from "components/Markdown";
-import { Trans, useTranslation } from "i18n";
+import { useTranslation } from "i18n";
 import { localizeDateTime } from "i18n/datetimes";
 import { AUTH, GLOBAL } from "i18n/namespaces";
 import { ModNote } from "proto/account_pb";
@@ -52,9 +52,7 @@ export default function ModNoteCard({ note, updateJailed }: ModNoteCardProps) {
 
   return (
     <StyledNoteContainer key={note.noteId}>
-      <Typography variant="h3">
-        <Trans t={t} i18nKey="auth:jail.mod_note_section.note_title" values={{ time: formattedTime }} />
-      </Typography>
+      <Typography variant="h3">{t("auth:jail.mod_note_section.note_title", { time: formattedTime })}</Typography>
       <StyledNoteCard>
         <Markdown source={note.noteContent} topHeaderLevel={3} />
       </StyledNoteCard>

--- a/app/web/features/auth/jail/ModNoteCard.tsx
+++ b/app/web/features/auth/jail/ModNoteCard.tsx
@@ -53,9 +53,7 @@ export default function ModNoteCard({ note, updateJailed }: ModNoteCardProps) {
   return (
     <StyledNoteContainer key={note.noteId}>
       <Typography variant="h3">
-        <Trans t={t} i18nKey="auth:jail.mod_note_section.note_title">
-          Moderator note received on {{ time: formattedTime }}:
-        </Trans>
+        <Trans t={t} i18nKey="auth:jail.mod_note_section.note_title" values={{ time: formattedTime }} />
       </Typography>
       <StyledNoteCard>
         <Markdown source={note.noteContent} topHeaderLevel={3} />

--- a/app/web/features/auth/jail/TOSSection.tsx
+++ b/app/web/features/auth/jail/TOSSection.tsx
@@ -31,9 +31,7 @@ export default function TOSSection({ updateJailed, className }: TOSSectionProps)
   return (
     <div className={className}>
       <Typography variant="body1">
-        <Trans t={t} i18nKey="auth:jail.terms_of_service_section.description">
-          We've update our Terms of Service. To continue, please read and accept the new <TOSLink />
-        </Trans>
+        <Trans t={t} i18nKey="auth:jail.terms_of_service_section.description" components={{ 1: <TOSLink /> }} />
       </Typography>
       <Button loading={loading} onClick={accept} disabled={completed}>
         {completed ? t("global:thanks") : t("global:accept")}

--- a/app/web/features/auth/login/Login.tsx
+++ b/app/web/features/auth/login/Login.tsx
@@ -83,7 +83,7 @@ export default function Login() {
               components={{
                 2: <StyledLink href={signupRoute} />,
               }}
-            ></Trans>
+            />
           </Typography>
         </StyledFormWrapper>
       </StyledContent>

--- a/app/web/features/auth/logins/LoginCard.tsx
+++ b/app/web/features/auth/logins/LoginCard.tsx
@@ -51,9 +51,7 @@ export default function LoginsPage({ session }: { session: ActiveSession.AsObjec
     <StyledCard>
       <CardContent>
         <Typography variant="h2">
-          <Trans t={t} i18nKey="auth:active_logins.login_header">
-            Login on {{ login_datetime: createdDisplay }}
-          </Trans>
+          <Trans t={t} i18nKey="auth:active_logins.login_header" values={{ login_datetime: createdDisplay }} />
         </Typography>
         {error && <Alert severity="error">{error.message}</Alert>}
         <IconText
@@ -63,27 +61,30 @@ export default function LoginsPage({ session }: { session: ActiveSession.AsObjec
               t={t}
               i18nKey="auth:active_logins.location"
               values={{ approximate_location: session.approximateLocation }}
-            >
-              {`Near `}
-              <strong>{session.approximateLocation}</strong>
-            </Trans>
+              components={{ 2: <strong /> }}
+            />
           }
         />
         <IconText
           icon={ClockIcon}
           text={
-            <Trans t={t} i18nKey="auth:active_logins.last_activity" values={{ last_activity_ago: lastSeenDisplay }}>
-              Last activity <strong>{lastSeenDisplay}</strong>
-            </Trans>
+            <Trans
+              t={t}
+              i18nKey="auth:active_logins.last_activity"
+              values={{ last_activity_ago: lastSeenDisplay }}
+              components={{ 2: <strong /> }}
+            />
           }
         />
         <IconText
           icon={CalendarIcon}
           text={
-            <Trans t={t} i18nKey="auth:active_logins.expiry" values={{ expiry_datetime: expiryDisplay }}>
-              {`Expires on `}
-              <strong>{expiryDisplay}</strong>
-            </Trans>
+            <Trans
+              t={t}
+              i18nKey="auth:active_logins.expiry"
+              values={{ expiry_datetime: expiryDisplay }}
+              components={{ 1: <strong /> }}
+            />
           }
         />
         <IconText

--- a/app/web/features/auth/logins/LoginCard.tsx
+++ b/app/web/features/auth/logins/LoginCard.tsx
@@ -50,9 +50,7 @@ export default function LoginsPage({ session }: { session: ActiveSession.AsObjec
   return (
     <StyledCard>
       <CardContent>
-        <Typography variant="h2">
-          <Trans t={t} i18nKey="auth:active_logins.login_header" values={{ login_datetime: createdDisplay }} />
-        </Typography>
+        <Typography variant="h2">{t("auth:active_logins.login_header", { login_datetime: createdDisplay })}</Typography>
         {error && <Alert severity="error">{error.message}</Alert>}
         <IconText
           icon={LocationIcon}

--- a/app/web/features/auth/phone/ChangePhone.tsx
+++ b/app/web/features/auth/phone/ChangePhone.tsx
@@ -164,11 +164,8 @@ export default function ChangePhone({ className, accountInfo }: ChangePhoneProps
                   t={t}
                   i18nKey="auth:change_phone.phone_not_verified_description"
                   values={{ phone: formatPhoneNumberIntl(accountInfo.phone) }}
-                >
-                  We sent you a code to{` `}
-                  <b>{formatPhoneNumberIntl(accountInfo.phone)}</b>.
-                  {`To verify your number, please enter the code below:`}
-                </Trans>
+                  components={{ 2: <b /> }}
+                />
               </Typography>
               <TextField
                 id="code"
@@ -192,12 +189,8 @@ export default function ChangePhone({ className, accountInfo }: ChangePhoneProps
                   t={t}
                   i18nKey="auth:change_phone.remove_phone_description"
                   values={{ phone: formatPhoneNumberIntl(accountInfo.phone) }}
-                >
-                  Your phone number is currently{` `}
-                  <b>{formatPhoneNumberIntl(accountInfo.phone)}</b>.
-                  {` You can remove your phone number below, but you will loose
-                  verification.`}
-                </Trans>
+                  components={{ 2: <b /> }}
+                />
               </Typography>
               <Button fullWidth={!isMdOrWider} loading={isRemoveLoading} onClick={() => removePhone()}>
                 {t("auth:change_phone.remove_button_text")}

--- a/app/web/features/auth/username/Username.tsx
+++ b/app/web/features/auth/username/Username.tsx
@@ -14,11 +14,12 @@ export default function Username({ className, username }: UsernameProps) {
     <div className={className}>
       <Typography variant="h2">{t("account_settings_page.username_section.title")}</Typography>
       <Typography variant="body1">
-        <Trans t={t} i18nKey="account_settings_page.username_section.description" values={{ username }}>
-          {`Your username is `}
-          <strong>{username}</strong>
-          {`.`}
-        </Trans>
+        <Trans
+          t={t}
+          i18nKey="account_settings_page.username_section.description"
+          values={{ username }}
+          components={{ 1: <strong /> }}
+        />
       </Typography>
       <Typography variant="body1">{t("account_settings_page.username_section.explanation")}</Typography>
     </div>

--- a/app/web/features/auth/verification/StrongVerification.tsx
+++ b/app/web/features/auth/verification/StrongVerification.tsx
@@ -29,9 +29,8 @@ export default function StrongVerification({ className, accountInfo }: StrongVer
               ? "strong_verification.status.enabled_message"
               : "strong_verification.status.disabled_message"
           }
-        >
-          You <strong>are currently</strong> verified with Strong Verification.
-        </Trans>
+          components={{ 1: <strong /> }}
+        />
       </Typography>
       <Typography
         variant="body1"

--- a/app/web/features/auth/volunteer/VolunteerManagement.tsx
+++ b/app/web/features/auth/volunteer/VolunteerManagement.tsx
@@ -32,10 +32,7 @@ export default function VolunteerManagement({ className, accountInfo }: Voluntee
             components={{
               1: <StyledLink href={volunteerNotAVolunteerFormUrl} />,
             }}
-          >
-            According to our records you are not a current or past volunteer. If this is incorrect, please let us know
-            by filling in <StyledLink href={volunteerNotAVolunteerFormUrl}>this form</StyledLink>.
-          </Trans>
+          />
         </Typography>
       </div>
     );


### PR DESCRIPTION
The reason `<Trans>` supports inner text is that some loc systems will use that text as the string key. We have explicit string keys so the inner text gets ignored, which is confusing and results in worse placeholder names (e.g. `<1>`)

## Testing
Spot checked most instances using Vercel preview.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me