### PR TITLE
Eagerly load User.timezone in auth interceptor and Ping

### DIFF
--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -19,6 +19,7 @@ from google.protobuf.message import Message
 from opentelemetry import trace
 from sqlalchemy import Function, literal_column, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import undefer
 from sqlalchemy.sql import func
 
 from couchers.config import config
@@ -113,6 +114,9 @@ def _try_get_and_update_user_details(
             .where(UserSession.token == token)
             .where(UserSession.is_valid)
             .where(UserSession.is_api_key == is_api_key)
+            # User.timezone is deferred and read below for every authenticated call, so load it here rather
+            # than paying a second round trip for its ST_Contains against timezone_areas
+            .options(undefer(User.timezone))
         ).one_or_none()
 
         if not result:

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -7,7 +7,7 @@ import google.protobuf.message
 import grpc
 from google.protobuf import empty_pb2
 from sqlalchemy import select
-from sqlalchemy.orm import Session, selectinload
+from sqlalchemy.orm import Session, selectinload, undefer
 from sqlalchemy.sql import and_, case, delete, func, intersect, or_, union
 
 from couchers import urls
@@ -194,6 +194,9 @@ class API(api_pb2_grpc.APIServicer):
                 selectinload(User.regions_visited),
                 selectinload(User.regions_lived),
                 selectinload(User.language_abilities),
+                # deferred, and user_model_to_pb below reads it; loading it here saves a round trip on
+                # what is the most frequently polled endpoint we have
+                undefer(User.timezone),
             )
         ).scalar_one()
 


### PR DESCRIPTION
`User.timezone` is a deferred column backed by an `ST_Contains` against `timezone_areas`, so touching it after the owning `User` has already been loaded costs an extra query round trip.

Two hot paths read it on essentially every call:

- `_try_get_and_update_user_details` in `interceptors.py` — runs for every authenticated request
- `Ping` in `servicers/api.py` — passes the user through `user_model_to_pb`, and is the most frequently polled endpoint we have

Both now `undefer(User.timezone)` so it comes back with the row they were already fetching. No behaviour change, just one fewer round trip per call on these two paths.

## Testing
- `uv run pytest src/tests/test_interceptors.py` — 62 passed
- `uv run pytest src/tests/test_api.py` — 50 passed
- `make format` and `make mypy` clean

No new tests: this is a loader-strategy change with no behavioural difference, and existing coverage already exercises both paths (every authenticated test call goes through the interceptor, and `test_ping` asserts on the resulting `PingRes`). Reviewers can sanity-check by enabling SQL echo and confirming the separate `SELECT ... ST_Contains(...)` for the timezone no longer fires after a `Ping`.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._