### PR TITLE
i18n: detect <Trans> markup that doesn't match its string

### DIFF
--- a/app/web/eslint-rules/trans-components.js
+++ b/app/web/eslint-rules/trans-components.js
@@ -1,0 +1,267 @@
+/**
+ * Checks every `<Trans>` call site against the English string it renders.
+ *
+ * A tag in the string that matches nothing in `components` doesn't raise an
+ * error at runtime, it just renders the tag's inner text with the wrapper
+ * silently dropped, so this has to be caught statically.
+ *
+ * See /docs/translation-components.md.
+ */
+
+"use strict";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const fs = require("fs");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const path = require("path");
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const namespaces = require("../i18n/namespaces");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { extractTags, isBasicHtmlTag, localeFilePath, resolveKey } = require("../i18n/transTags");
+
+const ROOT = path.resolve(__dirname, "..");
+const DEFAULT_NAMESPACE = "global";
+
+// `AUTH` -> `"auth"`, so that `ns={AUTH}` and `useTranslation(AUTH)` resolve.
+const NAMESPACE_BY_IDENTIFIER = Object.fromEntries(
+  Object.entries(namespaces).filter(([, value]) => typeof value === "string"),
+);
+
+const bundleCache = new Map();
+
+/** The en bundle for a namespace, reloaded when the file changes. */
+function loadBundle(namespace) {
+  const file = path.join(ROOT, localeFilePath(namespace, "en"));
+  const mtime = fs.statSync(file, { throwIfNoEntry: false })?.mtimeMs;
+  if (mtime === undefined) return null;
+
+  const cached = bundleCache.get(namespace);
+  if (cached?.mtime === mtime) return cached.bundle;
+
+  const bundle = JSON.parse(fs.readFileSync(file, "utf8"));
+  bundleCache.set(namespace, { mtime, bundle });
+  return bundle;
+}
+
+function getAttribute(node, name) {
+  return node.openingElement.attributes.find(
+    (attribute) => attribute.type === "JSXAttribute" && attribute.name.name === name,
+  );
+}
+
+/** Every string an expression can evaluate to, or null if that isn't knowable. */
+function staticStrings(expression) {
+  if (!expression) return null;
+  switch (expression.type) {
+    case "Literal":
+      return typeof expression.value === "string" ? [expression.value] : null;
+    case "TemplateLiteral":
+      return expression.expressions.length === 0 ? [expression.quasis[0].value.cooked] : null;
+    case "ConditionalExpression": {
+      const consequent = staticStrings(expression.consequent);
+      const alternate = staticStrings(expression.alternate);
+      return consequent && alternate ? [...consequent, ...alternate] : null;
+    }
+    default:
+      return null;
+  }
+}
+
+function attributeStrings(attribute) {
+  if (!attribute?.value) return null;
+  if (attribute.value.type === "JSXExpressionContainer") return staticStrings(attribute.value.expression);
+  return staticStrings(attribute.value);
+}
+
+/** Namespaces an expression names, whether by literal, constant or array of either. */
+function namespacesFrom(expression) {
+  if (!expression) return [];
+  if (expression.type === "Identifier") {
+    const value = NAMESPACE_BY_IDENTIFIER[expression.name];
+    return value ? [value] : [];
+  }
+  if (expression.type === "ArrayExpression") {
+    return expression.elements.flatMap((element) => namespacesFrom(element));
+  }
+  return staticStrings(expression) ?? [];
+}
+
+function hasRenderedChildren(node) {
+  return node.children.some((child) => {
+    if (child.type === "JSXText") return child.value.trim() !== "";
+    if (child.type === "JSXExpressionContainer") return child.expression.type !== "JSXEmptyExpression";
+    return child.type === "JSXElement" || child.type === "JSXFragment";
+  });
+}
+
+/**
+ * The tag names `components` provides, or null when the prop isn't a literal
+ * and so can't be checked. An array provides the tags `<0>`, `<1>`, ....
+ */
+function componentTagNames(attribute) {
+  if (!attribute) return [];
+  if (attribute.value?.type !== "JSXExpressionContainer") return null;
+
+  const expression = attribute.value.expression;
+  if (expression.type === "ArrayExpression") return expression.elements.map((element, index) => String(index));
+  if (expression.type !== "ObjectExpression") return null;
+
+  const names = [];
+  for (const property of expression.properties) {
+    if (property.type !== "Property" || property.computed) return null;
+    if (property.key.type === "Identifier") names.push(property.key.name);
+    else if (property.key.type === "Literal") names.push(String(property.key.value));
+    else return null;
+  }
+  return names;
+}
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Keep <Trans> call sites consistent with the strings they render",
+      url: "https://github.com/Couchers-org/couchers/blob/develop/docs/translation-components.md",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          // Files whose call sites are still on the legacy numbered-tag style,
+          // relative to app/web. Only the style reports are waived; a call site
+          // that disagrees with its string is an error wherever it lives.
+          allow: { type: "array", items: { type: "string" } },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      children:
+        "Move this markup into `components`: as children, the tag numbering depends on how this file is formatted, so reformatting it silently breaks every translation. See docs/translation-components.md.",
+      componentsArray: "`components` must be an object keyed by tag name, not an array.",
+      numericTag:
+        "Name this `components` entry instead of numbering it: `{{tag}}` means nothing to a translator and shifts whenever the string gains a tag. See docs/translation-components.md.",
+      missingComponent:
+        "`{{namespace}}:{{key}}` contains <{{tag}}> but `components` has no `{{tag}}` entry, so it will render as bare text with the <{{tag}}> wrapper dropped.",
+      unusedComponent: "`components.{{tag}}` is unused: `{{namespace}}:{{key}}` contains no <{{tag}}> tag.",
+      missingKey: "No string `{{key}}` in the `{{namespace}}` en locale.",
+      unknownNamespace: "Cannot tell which namespace `{{key}}` belongs to; prefix it as `namespace:{{key}}`.",
+    },
+  },
+
+  create(context) {
+    const allow = new Set(context.options[0]?.allow ?? []);
+    const isLegacyFile = allow.has(path.relative(ROOT, context.filename));
+
+    const namespacesInFile = [];
+    const transNodes = [];
+
+    /** Resolves a key to its en string(s), searching the namespaces it could belong to. */
+    function lookup(key, explicitNamespaces) {
+      const [prefix, ...rest] = key.split(":");
+      if (rest.length > 0) {
+        const namespace = prefix;
+        return { namespace, entries: resolveKey(loadBundle(namespace) ?? {}, rest.join(":")) };
+      }
+
+      const candidates =
+        explicitNamespaces.length > 0
+          ? explicitNamespaces
+          : [...namespacesInFile, DEFAULT_NAMESPACE, ...namespaces.NAMESPACES];
+
+      for (const namespace of new Set(candidates)) {
+        const bundle = loadBundle(namespace);
+        if (!bundle) continue;
+        const entries = resolveKey(bundle, key);
+        if (entries.length > 0) return { namespace, entries };
+      }
+      return { namespace: candidates[0] ?? null, entries: [] };
+    }
+
+    function check(node) {
+      const keyAttribute = getAttribute(node, "i18nKey");
+      const keys = attributeStrings(keyAttribute);
+      const componentsAttribute = getAttribute(node, "components");
+      const tagNames = componentTagNames(componentsAttribute);
+      const children = hasRenderedChildren(node);
+      const componentsAreArray = componentsAttribute?.value?.expression?.type === "ArrayExpression";
+
+      if (children && !isLegacyFile) {
+        context.report({ node: node.openingElement, messageId: "children" });
+      }
+
+      if (componentsAreArray && !isLegacyFile) {
+        context.report({ node: componentsAttribute, messageId: "componentsArray" });
+      }
+
+      // An array's tags are numbers by construction; `componentsArray` says so.
+      if (tagNames && !componentsAreArray && !isLegacyFile) {
+        for (const tag of tagNames) {
+          if (/^\d+$/.test(tag)) {
+            context.report({ node: componentsAttribute, messageId: "numericTag", data: { tag } });
+          }
+        }
+      }
+
+      // Children carry their own implicit numbering, which can't be resolved
+      // statically; the `children` report above is the finding for those.
+      if (!keys || children || tagNames === null) return;
+
+      for (const key of keys) {
+        const { namespace, entries } = lookup(key, namespacesFrom(getAttribute(node, "ns")?.value?.expression));
+        const bareKey = key.includes(":") ? key.slice(key.indexOf(":") + 1) : key;
+
+        if (entries.length === 0) {
+          const messageId = namespace ? "missingKey" : "unknownNamespace";
+          context.report({ node: keyAttribute, messageId, data: { namespace, key: bareKey } });
+          continue;
+        }
+
+        const tagsInString = new Set(entries.flatMap(({ value }) => extractTags(value)));
+        const provided = new Set(tagNames);
+
+        for (const tag of tagsInString) {
+          if (!provided.has(tag) && !isBasicHtmlTag(tag)) {
+            context.report({
+              node: componentsAttribute ?? node.openingElement,
+              messageId: "missingComponent",
+              data: { namespace, key: bareKey, tag },
+            });
+          }
+        }
+
+        for (const tag of provided) {
+          if (!tagsInString.has(tag)) {
+            context.report({
+              node: componentsAttribute,
+              messageId: "unusedComponent",
+              data: { namespace, key: bareKey, tag },
+            });
+          }
+        }
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        const callee = node.callee;
+        const name = callee.type === "Identifier" ? callee.name : callee.property?.name;
+        if (name === "useTranslation" || name === "serverSideTranslations" || name === "appGetServerSideProps") {
+          namespacesInFile.push(...node.arguments.flatMap((argument) => namespacesFrom(argument)));
+        }
+      },
+
+      JSXElement(node) {
+        if (node.openingElement.name.type === "JSXIdentifier" && node.openingElement.name.name === "Trans") {
+          transNodes.push(node);
+        }
+      },
+
+      // Deferred so that `useTranslation()` calls below a <Trans> still count.
+      "Program:exit"() {
+        transNodes.forEach(check);
+      },
+    };
+  },
+};

--- a/app/web/eslint-rules/trans-components.test.ts
+++ b/app/web/eslint-rules/trans-components.test.ts
@@ -1,0 +1,56 @@
+import { Rule, RuleTester } from "eslint";
+
+import transComponents from "./trans-components";
+
+// RuleTester validates its config with structuredClone, which jsdom doesn't
+// expose. Everything it clones here is plain JSON.
+globalThis.structuredClone ??= ((value: unknown) => JSON.parse(JSON.stringify(value))) as typeof structuredClone;
+
+const ruleTester = new RuleTester({
+  languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+});
+
+// `global:what_is_cs.is_it_safe.description_2` is "...who don't follow our
+// <guidelines>community guidelines</guidelines>", and
+// `profile:leave_reference.did_stay_explanation` carries a bare <strong>.
+ruleTester.run("trans-components", transComponents as unknown as Rule.RuleModule, {
+  valid: [
+    '<Trans i18nKey="profile:leave_reference.did_stay_explanation" />',
+    '<Trans ns={GLOBAL} i18nKey="what_is_cs.is_it_safe.description_2" components={{ guidelines: <a /> }} />',
+    // A legacy file keeps its numbering until it is migrated.
+    {
+      code: '<Trans i18nKey="profile:leave_reference.did_stay_explanation" components={{ 1: <a /> }}>hi</Trans>',
+      filename: "features/legacy/Thing.tsx",
+      options: [{ allow: ["features/legacy/Thing.tsx"] }],
+    },
+  ],
+  invalid: [
+    {
+      code: '<Trans i18nKey="profile:leave_reference.did_stay_explanation">Select <b>No</b></Trans>',
+      errors: [{ messageId: "children" }],
+    },
+    {
+      code: '<Trans ns={GLOBAL} i18nKey="what_is_cs.is_it_safe.description_2" />',
+      errors: [{ messageId: "missingComponent" }],
+    },
+    {
+      code: '<Trans i18nKey="global:what_is_cs.is_it_safe.description_2" components={{ 1: <a /> }} />',
+      errors: [{ messageId: "numericTag" }, { messageId: "missingComponent" }, { messageId: "unusedComponent" }],
+    },
+    {
+      code: '<Trans i18nKey="global:what_is_cs.is_it_safe.description_2" components={[<a key="x" />]} />',
+      errors: [{ messageId: "componentsArray" }, { messageId: "missingComponent" }, { messageId: "unusedComponent" }],
+    },
+    {
+      code: '<Trans i18nKey="global:no_string_by_this_name" />',
+      errors: [{ messageId: "missingKey" }],
+    },
+    // A legacy file is still held to agreeing with the string it renders.
+    {
+      code: '<Trans i18nKey="global:what_is_cs.is_it_safe.description_2" components={{ 1: <a /> }} />',
+      filename: "features/legacy/Thing.tsx",
+      options: [{ allow: ["features/legacy/Thing.tsx"] }],
+      errors: [{ messageId: "missingComponent" }, { messageId: "unusedComponent" }],
+    },
+  ],
+});

--- a/app/web/eslint.config.mjs
+++ b/app/web/eslint.config.mjs
@@ -6,6 +6,9 @@ import jsonc from "eslint-plugin-jsonc";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 import unusedImports from "eslint-plugin-unused-imports";
 
+import transComponents from "./eslint-rules/trans-components.js";
+import legacyTransFiles from "./i18n/legacyTransFiles.js";
+
 const compat = new FlatCompat({
   baseDirectory: import.meta.dirname,
   recommendedConfig: js.configs.recommended,
@@ -41,8 +44,12 @@ const config = [
     plugins: {
       "simple-import-sort": simpleImportSort,
       "unused-imports": unusedImports,
+      couchers: { rules: { "trans-components": transComponents } },
     },
     rules: {
+      // ~~~ settings for local couchers rules ~~~
+      "couchers/trans-components": ["error", { allow: legacyTransFiles }],
+
       // ~~~ settings for simple import sort plugin ~~~
       "simple-import-sort/imports": "warn",
       "simple-import-sort/exports": "warn",

--- a/app/web/features/landing/CouchersIntroduction.tsx
+++ b/app/web/features/landing/CouchersIntroduction.tsx
@@ -99,12 +99,7 @@ const CouchersIntroduction = () => {
             fontSize: "1.3rem",
           }}
         >
-          <Trans
-            i18nKey="landing:introduction_subtitle"
-            components={{
-              bold: <strong style={{ fontWeight: 700 }} />,
-            }}
-          />
+          <Trans i18nKey="landing:introduction_subtitle" />
         </Typography>
         <Typography
           sx={{

--- a/app/web/features/profile/view/leaveReference/formSteps/DidStay.tsx
+++ b/app/web/features/profile/view/leaveReference/formSteps/DidStay.tsx
@@ -156,7 +156,7 @@ const DidStay = ({ referenceData, referenceType, hostRequestId, setReferenceValu
           </Button>
         </StyledButtonContainer>
         <StyledTextBody sx={{ marginTop: theme.spacing(3) }}>
-          <Trans i18nKey="profile:leave_reference.did_stay_explanation" components={{ bold: <strong /> }} />
+          <Trans i18nKey="profile:leave_reference.did_stay_explanation" />
         </StyledTextBody>
         {didStay === false && (
           <StyledReasonContainer>

--- a/app/web/i18n/knownTagMismatches.js
+++ b/app/web/i18n/knownTagMismatches.js
@@ -1,0 +1,41 @@
+/**
+ * Translations that already carry different markup to their English source, as
+ * "namespace/locale:key". Each one renders wrong today: a dropped link, a
+ * translated tag name, an unclosed tag.
+ *
+ * Nothing may be added here. These are fixed in Weblate, not in the repo, and
+ * an entry comes off as its translation is corrected.
+ *
+ * Consumed by `i18n/locales.test.ts`.
+ */
+const knownTagMismatches = [
+  "auth/ca:strong_verification.instructions.step7",
+  "auth/fr:strong_verification.instructions.step7",
+  "auth/ja:change_email_form.current_email_message",
+  "auth/pt-BR:strong_verification.instructions.step7",
+  "auth/pt-BR:volunteer_management.not_a_volunteer_message",
+  "auth/ru:strong_verification.status.disabled_message",
+  "auth/ru:strong_verification.status.enabled_message",
+  "auth/zh-Hans:change_email_form.current_email_message",
+  "auth/zh-Hans:strong_verification.instructions.step7",
+  "auth/zh-Hant:strong_verification.instructions.step7",
+  "communities/pt:events_empty_state",
+  "dashboard/fr:landing_text",
+  "donations/hi:donations_box.helper_text",
+  "donations/ja:donations_box.helper_text",
+  "donations/nb-NO:donations_box.helper_text",
+  "donations/pt:donations_box.helper_text",
+  "donations/ru:donations_box.helper_text",
+  "global/fr:cookie_message",
+  "global/zh-Hans:what_is_cs.is_it_safe.description_2",
+  "global/zh-Hant:what_is_cs.is_it_safe.description_2",
+  "landing/pt-BR:signup_description2_one",
+  "landing/pt-BR:signup_description2_other",
+  "messages/zh-Hans:host_pending_request_help_text",
+  "messages/zh-Hans:surfer_declined_request_help_text",
+  "messages/zh-Hant:host_pending_request_help_text",
+  "messages/zh-Hant:surfer_declined_request_help_text",
+  "profile/tr:complete_profile_dialog.description_1",
+];
+
+module.exports = knownTagMismatches;

--- a/app/web/i18n/legacyTransFiles.js
+++ b/app/web/i18n/legacyTransFiles.js
@@ -1,0 +1,62 @@
+/**
+ * Files whose `<Trans>` call sites predate /docs/translation-components.md:
+ * they pass their markup as children, number their `components` entries, or
+ * pass `components` as an array.
+ *
+ * Nothing may be added here. Entries come off as call sites are migrated to
+ * named tags, and the file goes away with the last one. Being listed only
+ * waives the style rules — a call site that disagrees with the string it
+ * renders is an error here as much as anywhere else.
+ *
+ * Consumed by the `couchers/trans-components` ESLint rule.
+ */
+const legacyTransFiles = [
+  "components/CookieBanner.tsx",
+  "components/Footer/Footer.tsx",
+  "components/ProfileIncompleteDialog/ProfileIncompleteDialog.tsx",
+  "features/NotFoundPage.tsx",
+  "features/auth/deletion/DeleteAccount.tsx",
+  "features/auth/email/ChangeEmail.tsx",
+  "features/auth/email/DoNotEmail.tsx",
+  "features/auth/jail/ModNoteCard.tsx",
+  "features/auth/jail/TOSSection.tsx",
+  "features/auth/login/Login.tsx",
+  "features/auth/logins/LoginCard.tsx",
+  "features/auth/phone/ChangePhone.tsx",
+  "features/auth/signup/AccountForm.tsx",
+  "features/auth/signup/ResendVerificationEmailForm.tsx",
+  "features/auth/signup/Signup.tsx",
+  "features/auth/signup/SignupFormContent.tsx",
+  "features/auth/timezone/Timezone.tsx",
+  "features/auth/username/Username.tsx",
+  "features/auth/verification/StrongVerification.tsx",
+  "features/auth/verification/StrongVerificationPage.tsx",
+  "features/auth/visibility/ProfileVisibility.tsx",
+  "features/auth/volunteer/VolunteerManagement.tsx",
+  "features/communities/CommunitiesPage/CommunitiesPage.tsx",
+  "features/communities/CommunitiesPage/CommunitySearch.tsx",
+  "features/communities/CommunityPage/SubCommunitiesDropdown.tsx",
+  "features/communities/events/CommunityEventsList.tsx",
+  "features/communities/events/DiscoverEventsList.tsx",
+  "features/communities/events/EventsSection.tsx",
+  "features/communities/events/MyEventsList.tsx",
+  "features/dashboard/CommunitiesList.tsx",
+  "features/dashboard/CommunitiesSection.tsx",
+  "features/dashboard/CommunityEvents.tsx",
+  "features/dashboard/Hero/HeroImageAttribution.tsx",
+  "features/dashboard/MyEvents.tsx",
+  "features/donations/Donations.tsx",
+  "features/donations/DonationsBox.tsx",
+  "features/donations/DonationsLoginPanel.tsx",
+  "features/markdown/MarkdownPage.tsx",
+  "features/messages/requests/HostRequestGuideLinks.tsx",
+  "features/notifications/PushNotificationSettings.tsx",
+  "features/profile/edit/EditProfile.tsx",
+  "features/profile/view/NewHostRequest.tsx",
+  "features/profile/view/leaveReference/formSteps/DidStay.tsx",
+  "features/profile/view/leaveReference/formSteps/PrivateFeedback.tsx",
+  "features/profile/view/leaveReference/formSteps/Text.tsx",
+  "features/profile/view/leaveReference/formSteps/submit/ThankYouReference.tsx",
+];
+
+module.exports = legacyTransFiles;

--- a/app/web/i18n/locales.test.ts
+++ b/app/web/i18n/locales.test.ts
@@ -1,0 +1,94 @@
+import fs from "fs";
+import { allLanguages } from "i18n/allLanguages";
+import knownTagMismatches from "i18n/knownTagMismatches";
+import { NAMESPACES } from "i18n/namespaces";
+import path from "path";
+
+import { extractTags, localeFilePath, tagSignature } from "./transTags";
+
+type Strings = Record<string, string>;
+
+const ROOT = path.resolve(__dirname, "..");
+
+function flatten(node: unknown, prefix = "", into: Strings = {}): Strings {
+  for (const [key, value] of Object.entries(node as object)) {
+    if (typeof value === "string") into[`${prefix}${key}`] = value;
+    else if (value && typeof value === "object") flatten(value, `${prefix}${key}.`, into);
+  }
+  return into;
+}
+
+function loadLocale(namespace: string, locale: string): Strings | null {
+  const file = path.join(ROOT, localeFilePath(namespace, locale));
+  if (!fs.existsSync(file)) return null;
+  return flatten(JSON.parse(fs.readFileSync(file, "utf8")));
+}
+
+const english = new Map(NAMESPACES.map((namespace: string) => [namespace, loadLocale(namespace, "en") ?? {}]));
+
+/**
+ * Keys whose translation carries different markup to its English source: a tag
+ * the call site never passes, a dropped link, an unclosed tag. All of these
+ * render as bare text or as a literal `<tag>`, with no error raised.
+ */
+function tagMismatches(locale: string): string[] {
+  const mismatches: string[] = [];
+  for (const namespace of NAMESPACES) {
+    const strings = loadLocale(namespace, locale);
+    if (!strings) continue;
+    const source = english.get(namespace) ?? {};
+
+    for (const [key, value] of Object.entries(strings)) {
+      if (source[key] === undefined) continue;
+      if (tagSignature(source[key]).join() !== tagSignature(value).join()) {
+        mismatches.push(`${namespace}/${locale}:${key}`);
+      }
+    }
+  }
+  return mismatches;
+}
+
+const translatedLanguages = allLanguages.filter((locale: string) => locale !== "en");
+
+describe("tagSignature", () => {
+  it("ignores where in the sentence the tags fall", () => {
+    expect(tagSignature("Read our <guide>guide</guide> first")).toEqual(tagSignature("<guide>Guide</guide> lesen"));
+  });
+
+  it("distinguishes a dropped tag", () => {
+    expect(tagSignature("currently <strong>{{email}}</strong>")).not.toEqual(tagSignature("currently {{email}}"));
+  });
+
+  it("distinguishes an unclosed tag", () => {
+    expect(tagSignature("<2>Learn more</2>.")).not.toEqual(tagSignature("<2>Saiba mais<2>."));
+  });
+
+  it("distinguishes a translated tag name", () => {
+    expect(tagSignature("our <guidelines>guidelines</guidelines>")).not.toEqual(
+      tagSignature("我们的<指南>准则</指南>"),
+    );
+  });
+
+  it("treats a self-closing tag as needing no closing tag", () => {
+    expect(tagSignature("one<br />two")).toEqual(tagSignature("eins<br/>zwei"));
+  });
+});
+
+describe("extractTags", () => {
+  it("returns one entry per opening tag, attributes and all", () => {
+    expect(extractTags('a <b>c</b> <1 href="x">d</1> <br/>')).toEqual(["b", "1", "br"]);
+  });
+});
+
+// See /docs/translation-components.md.
+describe("translated strings", () => {
+  it.each(translatedLanguages)("%s carries the same markup tags as the English source", (locale: string) => {
+    const known = new Set(knownTagMismatches);
+    expect(tagMismatches(locale).filter((id) => !known.has(id))).toEqual([]);
+  });
+
+  it("has no stale entries in knownTagMismatches", () => {
+    const live = new Set(translatedLanguages.flatMap(tagMismatches));
+    expect(knownTagMismatches.filter((id) => !live.has(id))).toEqual([]);
+  });
+});

--- a/app/web/i18n/transTags.js
+++ b/app/web/i18n/transTags.js
@@ -1,0 +1,83 @@
+/**
+ * Helpers for the markup tags embedded in translated strings, e.g. the
+ * `<signupLink>` in `No account yet? <signupLink>Join us</signupLink>`.
+ *
+ * Shared by the `couchers/trans-components` ESLint rule and by
+ * `i18n/locales.test.ts`, so this file must stay plain CommonJS with no imports
+ * (the ESLint rule loads it outside of any bundler).
+ *
+ * See /docs/translation-components.md.
+ */
+
+// react-i18next renders these as themselves, so they need no `components` entry
+// (transKeepBasicHtmlNodesFor, react-i18next/src/defaults.js).
+const BASIC_HTML_TAGS = ["br", "strong", "i", "p"];
+
+// Unicode CLDR plural categories, as i18next suffixes them onto the key.
+const PLURAL_SUFFIXES = ["zero", "one", "two", "few", "many", "other"];
+
+// `<a>`, `</a>`, `<a />`, `<a href="x">`, `<1>`. A tag name is what
+// react-i18next's html parser accepts.
+const TAG = /<(\/?)([a-zA-Z0-9_-]+)(\s[^>]*?)?\/?>/g;
+
+/** Tag names in a string, in order of appearance, one entry per opening tag. */
+function extractTags(value) {
+  return Array.from(value.matchAll(TAG))
+    .filter(([, closing]) => !closing)
+    .map(([, , name]) => name);
+}
+
+/**
+ * The markup a string carries, as a sorted list of `name`/`/name` tokens, for
+ * comparing a translation against its English source. Sorted rather than
+ * ordered because languages reorder the sentence around the tags.
+ */
+function tagSignature(value) {
+  return Array.from(value.matchAll(TAG), ([, closing, name]) => `${closing}${name}`).sort();
+}
+
+/** Whether the tag renders on its own, with no entry in `components`. */
+function isBasicHtmlTag(tag) {
+  return BASIC_HTML_TAGS.includes(tag);
+}
+
+/** Path of a locale file, relative to app/web (mirrors next-i18next.config.js). */
+function localeFilePath(namespace, locale) {
+  const file = `${locale.replace("-", "_")}.json`;
+  return namespace === "global" ? `resources/locales/${file}` : `features/${namespace}/locales/${file}`;
+}
+
+/**
+ * Resolves a dotted i18next key against a loaded locale bundle.
+ *
+ * Returns every string it resolves to: a key with `{{count}}` resolves to one
+ * string per plural form the bundle defines, and all of them have to agree with
+ * the call site.
+ */
+function resolveKey(bundle, key) {
+  const path = key.split(".");
+  const last = path.pop();
+  let node = bundle;
+  for (const segment of path) {
+    if (typeof node !== "object" || node === null) return [];
+    node = node[segment];
+  }
+  if (typeof node !== "object" || node === null) return [];
+
+  if (typeof node[last] === "string") return [{ key, value: node[last] }];
+
+  return PLURAL_SUFFIXES.filter((suffix) => typeof node[`${last}_${suffix}`] === "string").map((suffix) => ({
+    key: `${key}_${suffix}`,
+    value: node[`${last}_${suffix}`],
+  }));
+}
+
+module.exports = {
+  BASIC_HTML_TAGS,
+  PLURAL_SUFFIXES,
+  extractTags,
+  isBasicHtmlTag,
+  localeFilePath,
+  resolveKey,
+  tagSignature,
+};

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -16,6 +16,7 @@ All user-visible strings should be externalized to `en.json` files as to be loca
 - ✅ **DO** use simple HTML/Markdown sentence-internal markup in the string, rather than breaking it up and concatenating its parts.
   - **Good** 👍: `inactive_label` = `This user is <bold>inactive</bold>`.
   - **Bad** 👎: `inactive_label_start` = `This user is ` and `inactive_label_bold` = `inactive`.
+  - On the web frontend, that markup is rendered with `<Trans>`. See [translation-components.md](translation-components.md) for how to write the tags and wire them up.
 - ❌ **AVOID**: leading/trailing whitespace or commas as they are confusing for translators and they are a sign of concatenation.
 
 ### Choosing string keys

--- a/docs/translation-components.md
+++ b/docs/translation-components.md
@@ -1,0 +1,71 @@
+# Components inside translated strings
+
+Strings that contain a link, some bold text, or any other markup are rendered with i18next's
+[`<Trans>`](https://react.i18next.com/latest/trans-component). The markup lives in the string itself
+(`Read our <guide>guide</guide>`) and `<Trans>` swaps each tag for a React element.
+
+Which element goes with which tag is worked out by name or by position. Positional numbering is
+derived from the JSX source, so reformatting the call site silently renumbers it, and a tag that no
+longer matches anything renders its inner text with the wrapper dropped — no error, no console
+warning. The rules below exist to keep that from happening. They are enforced by the
+`couchers/trans-components` ESLint rule and by `i18n/locales.test.ts`.
+
+See [localization.md](localization.md) for how to write and key the strings themselves.
+
+## 1. Use named tags, never numbers
+
+Tag names are stable and tell the translator what they are wrapping.
+
+```tsx
+// 👍
+<Trans
+  i18nKey="auth:login_page.no_account_prompt"
+  components={{ signupLink: <StyledLink href={signupRoute} /> }}
+/>
+```
+
+```json
+"no_account_prompt": "No account yet? <signupLink>Join us</signupLink>"
+```
+
+```tsx
+// 👎 — the meaning of `2` lives nowhere, and shifts if the string gains a tag
+<Trans i18nKey="auth:login_page.no_account_prompt" components={{ 2: <StyledLink href={signupRoute} /> }} />
+```
+
+A tag number may never be changed without updating every locale file for that key in the same
+commit, so renumbering is not something to do casually.
+
+## 2. Prefer bare `<strong>`, `<i>`, `<p>` and `<br>`
+
+These four tags are rendered as themselves and need no `components` entry at all, which is the least
+that can break:
+
+```json
+"current_email_message": "Your email address is currently <strong>{{email}}</strong>."
+```
+
+```tsx
+<Trans i18nKey="auth:change_email_form.current_email_message" values={{ email }} />
+```
+
+Only reach for `components` when the element needs props — a link target, a styled component, a
+click handler.
+
+## 3. Never pass children to `<Trans>`
+
+Children make the tag numbering a function of how the file happens to be formatted, so a stray
+newline from prettier is enough to break the string. Always write `<Trans />` self-closing, with the
+string coming from `i18nKey` and the elements from `components`.
+
+```tsx
+// 👎
+<Trans i18nKey="auth:login_page.no_account_prompt">
+  No account yet? <StyledLink href={signupRoute}>Join us</StyledLink>
+</Trans>
+```
+
+## Changing an existing string
+
+Adding, removing or renaming a tag changes the contract with every translation of that key. Update
+all locale files for the key in the same commit, or change the key so translators retranslate it.


### PR DESCRIPTION
When a translated string contains a tag that matches nothing in a `<Trans>` call site's `components`, react-i18next renders the tag's inner text and silently drops the wrapper — no error, no console warning. #9446 was exactly that: a reformat renumbered `Login.tsx`'s children, and "Join us" stopped being a link. The numbering is derived from the JSX source, so prettier alone is enough to break a string.

This adds two detectors, and documents the conventions that keep it from happening in the first place. It does not migrate anything yet — that's a follow-up.

- **`couchers/trans-components` ESLint rule** (`app/web/eslint-rules/`). For each `<Trans>` it resolves `i18nKey` against the real `en.json` — handling `ns:` prefixes, `ns={GLOBAL}`, the file's `useTranslation()` namespaces, ternary keys and plural suffixes — and reports tags with no matching component, dead `components` entries, missing keys, JSX children, and numbered or array `components`. Runs in the existing `test:web-linting` job and inline in editors.
- **`app/web/i18n/locales.test.ts`**, asserting that every translation carries the same markup tags as its English source. Catches translator-side drift arriving from Weblate.
- **`docs/translation-components.md`**: use named tags, prefer bare `<strong>`/`<i>`/`<p>`/`<br>` which need no `components` entry at all, never pass children to `<Trans>`.

Two baselines keep this green on today's code, each with a "nothing may be added here" header and both deleted by the migration PR:

- `i18n/legacyTransFiles.js` — 46 call sites still on the old style. Being listed waives only the style rules; a call site that disagrees with its string is an error wherever it lives.
- `i18n/knownTagMismatches.js` — 27 translations that already render wrong. A second test fails if an entry stops being a real mismatch, so the list can't rot.

Also removes two dead `components={{ bold: … }}` entries (`CouchersIntroduction.tsx`, `DidStay.tsx`) whose strings no longer contain a `<bold>` tag. Those were the rule's only findings outside the baseline.

### Follow-ups, not in this PR

- Migrate the 46 call sites to named tags, rewriting the tsx and all 17 locale files together, and delete both baseline files. Best landed while no Weblate PR is open.
- The 27 mismatches are Weblate's to fix, not the repo's. Some are worth a look: `zh-Hans`/`zh-Hant` translated the tag name itself in `what_is_cs.is_it_safe.description_2` (`<指南>` for `<guidelines>`), `pt-BR` and `tr` have unclosed tags, and `donations_box.helper_text` lost its cancellation link in five languages. Worth checking Weblate's `xml-tags` check is enabled on the component.

## Testing

- `yarn lint --max-warnings=0` and `yarn prettier --check` pass; `tsc --noEmit` reports only pre-existing `slotProps` errors in untouched files.
- `yarn test i18n/locales.test.ts eslint-rules/trans-components.test.ts` — 38 tests. The rule has 9 RuleTester cases covering each report and the baseline waiver; the locale test has unit tests for the tag comparison (dropped tag, unclosed tag, translated tag name, reordering).
- Verified the rule catches the #9446 shape by temporarily stripping the `components` prop from `Login.tsx`: "contains `<2>` but `components` has no `2` entry".
- `yarn test features/profile/view/leaveReference` passes after the `DidStay.tsx` change.

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._