### PR TITLE
Cache the viewer's block list per request instead of querying per user

### DIFF
--- a/app/backend/src/couchers/context.py
+++ b/app/backend/src/couchers/context.py
@@ -88,6 +88,11 @@ class CouchersContext:
         self.__cookies: list[str] = []
         self.__response_headers: list[tuple[str, str]] = []
         self._growthbook: GrowthBook | None = None
+        # Per-request snapshot of what stops this context's user seeing others, loaded on first use and
+        # owned by couchers.servicers.blocking, which has the visibility rules. Both are set together,
+        # so _blocked_user_ids being None is what "not loaded yet" means.
+        self._blocked_user_ids: frozenset[int] | None = None
+        self._viewer_is_hidden: bool = False
 
         if self.__is_interactive:
             if not self._grpc_context:

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -56,7 +56,7 @@ from couchers.proto import api_pb2, api_pb2_grpc, media_pb2, notification_data_p
 from couchers.rate_limits.check import process_rate_limits_and_check_abort
 from couchers.rate_limits.definitions import RATE_LIMIT_HOURS
 from couchers.resources import get_badge_dict, language_is_allowed, region_is_allowed
-from couchers.servicers.blocking import is_not_visible
+from couchers.servicers.blocking import is_not_visible_to_viewer
 from couchers.sql import (
     moderation_state_column_visible,
     username_or_id,
@@ -1046,9 +1046,7 @@ def user_model_to_pb(
     # note that this function is sometimes called by a logged out user, in which case context comes from make_logged_out_context
 
     viewer_user_id = context.user_id if context.is_logged_in() else None
-    if not is_admin_see_ghosts and is_not_visible(
-        session, viewer_user_id, db_user.id, ignore_shadow=context.serialize_shadowed
-    ):
+    if not is_admin_see_ghosts and is_not_visible_to_viewer(session, context, db_user):
         # User is not visible (deleted, banned, or blocked)
         if is_get_user_return_ghosts:
             maybe_log_nonvisible_user_access(
@@ -1255,9 +1253,7 @@ def lite_user_to_pb(
     is_admin_see_ghosts: bool = False,
     is_get_user_return_ghosts: bool = False,
 ) -> api_pb2.LiteUser:
-    if not is_admin_see_ghosts and is_not_visible(
-        session, context.user_id, lite_user.id, ignore_shadow=context.serialize_shadowed
-    ):
+    if not is_admin_see_ghosts and is_not_visible_to_viewer(session, context, lite_user):
         # User is not visible (deleted, banned, or blocked)
         if is_get_user_return_ghosts:
             # Return an anonymized "ghost" user profile

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -65,7 +65,7 @@ from couchers.proto import api_pb2, api_pb2_grpc, media_pb2, notification_data_p
 from couchers.rate_limits.check import process_rate_limits_and_check_abort
 from couchers.rate_limits.definitions import RATE_LIMIT_HOURS
 from couchers.resources import get_badge_dict, language_is_allowed, region_is_allowed
-from couchers.servicers.blocking import is_not_visible
+from couchers.servicers.blocking import is_not_visible_to_viewer
 from couchers.sql import (
     moderation_state_column_visible,
     username_or_id,
@@ -1065,9 +1065,7 @@ def user_model_to_pb(
     # note that this function is sometimes called by a logged out user, in which case context comes from make_logged_out_context
 
     viewer_user_id = context.user_id if context.is_logged_in() else None
-    if not is_admin_see_ghosts and is_not_visible(
-        session, viewer_user_id, db_user.id, ignore_shadow=context.serialize_shadowed
-    ):
+    if not is_admin_see_ghosts and is_not_visible_to_viewer(session, context, db_user):
         # User is not visible (deleted, banned, or blocked)
         if is_get_user_return_ghosts:
             maybe_log_nonvisible_user_access(
@@ -1274,9 +1272,7 @@ def lite_user_to_pb(
     is_admin_see_ghosts: bool = False,
     is_get_user_return_ghosts: bool = False,
 ) -> api_pb2.LiteUser:
-    if not is_admin_see_ghosts and is_not_visible(
-        session, context.user_id, lite_user.id, ignore_shadow=context.serialize_shadowed
-    ):
+    if not is_admin_see_ghosts and is_not_visible_to_viewer(session, context, lite_user):
         # User is not visible (deleted, banned, or blocked)
         if is_get_user_return_ghosts:
             # Return an anonymized "ghost" user profile

--- a/app/backend/src/couchers/servicers/blocking.py
+++ b/app/backend/src/couchers/servicers/blocking.py
@@ -6,9 +6,11 @@ from sqlalchemy.sql import not_, or_, union
 
 from couchers import urls
 from couchers.context import CouchersContext
+from couchers.materialized_views import LiteUser
 from couchers.models import Upload, User, UserBlock
 from couchers.models.uploads import get_avatar_photo_subquery
 from couchers.proto import blocking_pb2, blocking_pb2_grpc
+from couchers.utils import not_none
 
 
 def is_not_visible(
@@ -47,6 +49,67 @@ def is_not_visible(
         )
 
 
+def _load_viewer_visibility(session: Session, context: CouchersContext) -> None:
+    """
+    Fill the context's per-request snapshot of who its user can't see: everyone in a block relationship
+    with them either way, plus whether their own account is gone (in which case they see nobody).
+
+    One query, once per request. Blocks change rarely and a single request can check visibility for
+    hundreds of users, so the alternative is that many round trips for an answer that can't change.
+    """
+    if context._blocked_user_ids is not None:
+        return
+
+    viewer_user_id = context.user_id if context.is_logged_in() else None
+    if viewer_user_id is None:
+        # nobody can have blocked a logged out viewer, and they have no account to be banned
+        context._blocked_user_ids = frozenset()
+        context._viewer_is_hidden = False
+        return
+
+    blocked_users = select(UserBlock.blocked_user_id).where(UserBlock.blocking_user_id == viewer_user_id)
+    blocking_users = select(UserBlock.blocking_user_id).where(UserBlock.blocked_user_id == viewer_user_id)
+    # the viewer's own id comes back only if their account is gone: they can't block themselves
+    viewer_hidden = select(User.id).where(User.id == viewer_user_id).where(not_(User.is_visible))
+
+    user_ids = set(session.execute(union(blocked_users, blocking_users, viewer_hidden)).scalars().all())
+
+    context._viewer_is_hidden = viewer_user_id in user_ids
+    context._blocked_user_ids = frozenset(user_ids - {viewer_user_id})
+
+
+def forget_viewer_visibility(context: CouchersContext) -> None:
+    """Drop the cached snapshot, for when a request changes the viewer's own blocks underneath it."""
+    context._blocked_user_ids = None
+    context._viewer_is_hidden = False
+
+
+def is_not_visible_to_viewer(session: Session, context: CouchersContext, user: User | LiteUser) -> bool:
+    """
+    Whether `user` is not visible to the context's user, for a caller that has already loaded the row.
+
+    Same rules as is_not_visible, but answered from that row plus the context's cached blocks, so
+    serializing a page of users doesn't cost a query each. Keep the two in step; they're covered by an
+    equivalence test.
+
+    Note the account state (is_visible, shadowed_at) is read off whatever the caller loaded, so for a
+    LiteUser it's as fresh as the last lite_users refresh rather than live.
+    """
+    viewer_user_id = context.user_id if context.is_logged_in() else None
+
+    if not user.is_visible:
+        return True
+    if user.id == viewer_user_id:
+        # you can't block yourself and you're never shadowed from yourself, so a live account always
+        # sees itself, and nothing below can apply
+        return False
+    if user.shadowed_at is not None and not context.serialize_shadowed:
+        return True
+
+    _load_viewer_visibility(session, context)
+    return context._viewer_is_hidden or user.id in not_none(context._blocked_user_ids)
+
+
 class Blocking(blocking_pb2_grpc.BlockingServicer):
     def BlockUser(
         self, request: blocking_pb2.BlockUserReq, context: CouchersContext, session: Session
@@ -76,6 +139,7 @@ class Blocking(blocking_pb2_grpc.BlockingServicer):
             )
             session.add(user_block)
             session.commit()
+            forget_viewer_visibility(context)
 
         return empty_pb2.Empty()
 
@@ -99,6 +163,7 @@ class Blocking(blocking_pb2_grpc.BlockingServicer):
 
         session.delete(user_block)
         session.commit()
+        forget_viewer_visibility(context)
 
         return empty_pb2.Empty()
 

--- a/app/backend/src/tests/fixtures/misc.py
+++ b/app/backend/src/tests/fixtures/misc.py
@@ -1,11 +1,15 @@
+from collections.abc import Generator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any
 from unittest.mock import patch
 
+from sqlalchemy import event
 from sqlalchemy.orm import Session
 
 from couchers.config import config
+from couchers.db import _get_base_engine
 from couchers.jobs.worker import process_job
 from couchers.models import User
 from couchers.notifications.push import PushNotificationContent
@@ -23,6 +27,27 @@ def process_jobs() -> None:
 
 def now_5_min_in_future() -> datetime:
     return now() + timedelta(minutes=5)
+
+
+@contextmanager
+def count_queries() -> Generator[list[str]]:
+    """
+    Collects the SQL run inside the block, so a test can pin down what something costs in queries.
+
+    Use it to guard against an N+1 creeping back in: assert on how the count scales with the input, or
+    on the queries you care about, rather than on an exact total that any unrelated change would break.
+    """
+    engine = _get_base_engine()
+    statements: list[str] = []
+
+    def listener(conn: Any, cursor: Any, statement: str, *args: Any) -> None:
+        statements.append(statement)
+
+    event.listen(engine, "before_cursor_execute", listener)
+    try:
+        yield statements
+    finally:
+        event.remove(engine, "before_cursor_execute", listener)
 
 
 class EmailCollector:

--- a/app/backend/src/tests/fixtures/misc.py
+++ b/app/backend/src/tests/fixtures/misc.py
@@ -1,10 +1,14 @@
+from collections.abc import Generator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
 from unittest.mock import patch
 
+from sqlalchemy import event
 from sqlalchemy.orm import Session
 
 from couchers.config import config
+from couchers.db import _get_base_engine
 from couchers.jobs.worker import process_job
 from couchers.models import User
 from couchers.notifications.push import PushNotificationContent
@@ -22,6 +26,27 @@ def process_jobs() -> None:
     with query_log.span("job", "process_jobs"):
         while process_job():
             pass
+
+
+@contextmanager
+def count_queries() -> Generator[list[str]]:
+    """
+    Collects the SQL run inside the block, so a test can pin down what something costs in queries.
+
+    Use it to guard against an N+1 creeping back in: assert on how the count scales with the input, or
+    on the queries you care about, rather than on an exact total that any unrelated change would break.
+    """
+    engine = _get_base_engine()
+    statements: list[str] = []
+
+    def listener(conn: Any, cursor: Any, statement: str, *args: Any) -> None:
+        statements.append(statement)
+
+    event.listen(engine, "before_cursor_execute", listener)
+    try:
+        yield statements
+    finally:
+        event.remove(engine, "before_cursor_execute", listener)
 
 
 class EmailCollector:

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -29,7 +29,7 @@ from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_
 from couchers.resources import get_badge_dict
 from couchers.utils import create_coordinate, now, to_aware_datetime
 from tests.fixtures.db import generate_user, make_friends, make_user_block
-from tests.fixtures.misc import EmailCollector, PushCollector
+from tests.fixtures.misc import EmailCollector, PushCollector, count_queries
 from tests.fixtures.sessions import (
     api_session,
     blocking_session,
@@ -553,6 +553,29 @@ def test_GetLiteUsers(db):
             api.GetLiteUsers(api_pb2.GetLiteUsersReq(users=201 * [user1.username]))
         assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
         assert e.value.details() == "You can't request that many users at a time."
+
+
+def test_GetLiteUsers_query_count_does_not_grow_with_users(db):
+    """
+    Visibility used to be checked per user, so a request for 200 users cost 200 extra queries. The
+    context caches the viewer's blocks for the request instead, so the cost must now be flat.
+    """
+    user1, token1 = generate_user()
+    others = [generate_user()[0] for _ in range(10)]
+
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+
+    with api_session(token1) as api:
+        with count_queries() as one_user_queries:
+            api.GetLiteUsers(api_pb2.GetLiteUsersReq(users=[str(others[0].id)]))
+
+    with api_session(token1) as api:
+        with count_queries() as ten_user_queries:
+            res = api.GetLiteUsers(api_pb2.GetLiteUsersReq(users=[str(other.id) for other in others]))
+
+    assert len(res.responses) == 10
+    assert not any(response.not_found for response in res.responses)
+    assert len(ten_user_queries) == len(one_user_queries)
 
 
 def test_update_profile(db):

--- a/app/backend/src/tests/test_blocking.py
+++ b/app/backend/src/tests/test_blocking.py
@@ -3,12 +3,20 @@ import pytest
 from google.protobuf import empty_pb2
 from sqlalchemy import select
 
+from couchers.context import (
+    CouchersContext,
+    make_background_user_context,
+    make_logged_out_context,
+    make_notification_user_context,
+)
 from couchers.db import session_scope
+from couchers.i18n import LocalizationContext
 from couchers.models import User, UserBlock
 from couchers.proto import blocking_pb2
-from couchers.servicers.blocking import is_not_visible
+from couchers.servicers.blocking import forget_viewer_visibility, is_not_visible, is_not_visible_to_viewer
 from couchers.utils import now
 from tests.fixtures.db import generate_user, make_user_block
+from tests.fixtures.misc import count_queries
 from tests.fixtures.sessions import blocking_session
 
 
@@ -302,3 +310,67 @@ def test_is_not_visible(db):
         # Shadowed viewer can still see other (visible) users
         assert not is_not_visible(session, shadowed_user.id, visible_for_shadowed.id)
         assert not is_not_visible(session, shadowed_user.id, None)
+
+
+def test_is_not_visible_to_viewer_agrees_with_is_not_visible(db):
+    """
+    is_not_visible_to_viewer answers from a loaded row and the context's cached blocks rather than by
+    querying per user, so it has to reach the same verdict as is_not_visible for every viewer/target
+    pair. Cover each way a user can be hidden and compare the two exhaustively.
+    """
+    visible1, _ = generate_user()
+    visible2, _ = generate_user()
+    blocker, _ = generate_user()
+    blockee, _ = generate_user()
+    deleted, _ = generate_user()
+    banned, _ = generate_user()
+    shadowed, _ = generate_user()
+
+    make_user_block(blocker, blockee)
+
+    with session_scope() as session:
+        session.get_one(User, deleted.id).deleted_at = now()
+        session.get_one(User, banned.id).banned_at = now()
+        session.get_one(User, shadowed.id).shadowed_at = now()
+        session.commit()
+
+    everyone = [visible1, visible2, blocker, blockee, deleted, banned, shadowed]
+
+    # a fresh context each time, as a fresh request would get; notification contexts are the ones that
+    # serialize shadowed users, so they cover ignore_shadow
+    viewers: list[tuple[CouchersContext, int | None]] = [(make_logged_out_context(LocalizationContext.en_utc()), None)]
+    for user in everyone:
+        viewers.append((make_background_user_context(user_id=user.id), user.id))
+        viewers.append((make_notification_user_context(user_id=user.id), user.id))
+
+    with session_scope() as session:
+        for context, viewer_id in viewers:
+            for target in everyone:
+                expected = is_not_visible(session, viewer_id, target.id, ignore_shadow=context.serialize_shadowed)
+                actual = is_not_visible_to_viewer(session, context, session.get_one(User, target.id))
+                assert actual == expected, (
+                    f"viewer={viewer_id}, target={target.id}, shadowed={context.serialize_shadowed}"
+                )
+
+
+def test_is_not_visible_to_viewer_caches_blocks_for_the_request(db):
+    viewer, _ = generate_user()
+    others = [generate_user()[0] for _ in range(5)]
+
+    context = make_background_user_context(user_id=viewer.id)
+
+    with session_scope() as session:
+        with count_queries() as queries:
+            for other in others:
+                assert not is_not_visible_to_viewer(session, context, session.get_one(User, other.id))
+        # the point of the cache: one block lookup however many users get checked
+        assert sum(1 for query in queries if "user_blocks" in query) == 1
+
+    # the snapshot is taken once, so a block made after it needs dropping to take effect. That's what
+    # BlockUser/UnblockUser call forget_viewer_visibility for
+    make_user_block(viewer, others[0])
+    with session_scope() as session:
+        blocked = session.get_one(User, others[0].id)
+        assert not is_not_visible_to_viewer(session, context, blocked)
+        forget_viewer_visibility(context)
+        assert is_not_visible_to_viewer(session, context, blocked)


### PR DESCRIPTION
Every user serialization ran its own visibility check against the database, so a call that serializes many users paid a query per user. `GetLiteUsers` accepts up to 200 ids, which meant 200 extra round trips for an answer that cannot change within a request — the viewer's blocks are fixed for the duration.

This adds `is_not_visible_to_viewer(session, context, user)`, which:

- reads account state (`is_visible`, `shadowed_at`) off the row the caller already loaded, rather than re-querying for it, and
- consults a per-request snapshot of the viewer's blocks cached on `CouchersContext`, loaded lazily with a single query the first time visibility is checked.

`user_model_to_pb` and `lite_user_to_pb` now use it. `BlockUser`/`UnblockUser` call `forget_viewer_visibility(context)` so a request that changes its own blocks still observes the effect. The original `is_not_visible` stays as-is for callers that only have an id.

The two implementations have to agree, so there's an equivalence test comparing them exhaustively across every viewer/target pair, covering deleted, banned, shadowed, blocker, blockee, logged-out, and shadow-serializing (notification) contexts.

One caveat worth a reviewer's eye: for `LiteUser` the account state comes from the `lite_users` materialized view, so it's as fresh as the last refresh rather than live. That matches what the surrounding lite-user serialization already relies on, but it is a behaviour change from the previous live lookup.

## Testing

- Added `test_is_not_visible_to_viewer_agrees_with_is_not_visible` — exhaustive equivalence against the existing helper.
- Added `test_is_not_visible_to_viewer_caches_blocks_for_the_request` — asserts one `user_blocks` lookup regardless of how many users are checked, and that `forget_viewer_visibility` makes a new block take effect.
- Added `test_GetLiteUsers_query_count_does_not_grow_with_users` — a request for 10 users costs the same number of queries as a request for 1.
- Added a `count_queries()` test fixture that collects SQL executed inside a block, for asserting on query counts without pinning an exact total.
- Full backend suite passes locally (1254 passed); `make format` and `make mypy` clean.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history <!-- no database changes -->

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._