### PR TITLE
Backend: extract shared message helpers, bulk mark_notifications_seen

### DIFF
--- a/app/backend/src/couchers/helpers/messages.py
+++ b/app/backend/src/couchers/helpers/messages.py
@@ -1,0 +1,79 @@
+"""
+Message serialization shared by the conversations and requests APIs: both surface messages from the
+same table, so they must render every message type identically.
+"""
+
+from couchers.models import HostRequestStatus, Message, MessageType
+from couchers.proto import messages_pb2
+from couchers.utils import Timestamp_from_datetime
+
+hostrequeststatus2api = {
+    HostRequestStatus.pending: messages_pb2.HOST_REQUEST_STATUS_PENDING,
+    HostRequestStatus.accepted: messages_pb2.HOST_REQUEST_STATUS_ACCEPTED,
+    HostRequestStatus.rejected: messages_pb2.HOST_REQUEST_STATUS_REJECTED,
+    HostRequestStatus.confirmed: messages_pb2.HOST_REQUEST_STATUS_CONFIRMED,
+    HostRequestStatus.cancelled: messages_pb2.HOST_REQUEST_STATUS_CANCELLED,
+}
+
+api2hostrequeststatus = {
+    messages_pb2.HOST_REQUEST_STATUS_PENDING: HostRequestStatus.pending,
+    messages_pb2.HOST_REQUEST_STATUS_ACCEPTED: HostRequestStatus.accepted,
+    messages_pb2.HOST_REQUEST_STATUS_REJECTED: HostRequestStatus.rejected,
+    messages_pb2.HOST_REQUEST_STATUS_CONFIRMED: HostRequestStatus.confirmed,
+    messages_pb2.HOST_REQUEST_STATUS_CANCELLED: HostRequestStatus.cancelled,
+}
+
+
+def message_to_pb(message: Message) -> messages_pb2.Message:
+    """
+    Turns the given message to a protocol buffer
+    """
+    if message.is_normal_message:
+        return messages_pb2.Message(
+            message_id=message.id,
+            author_user_id=message.author_id,
+            time=Timestamp_from_datetime(message.time),
+            text=messages_pb2.MessageContentText(text=message.text),
+        )
+    else:
+        return messages_pb2.Message(
+            message_id=message.id,
+            author_user_id=message.author_id,
+            time=Timestamp_from_datetime(message.time),
+            chat_created=(
+                messages_pb2.MessageContentChatCreated() if message.message_type == MessageType.chat_created else None
+            ),
+            chat_edited=(
+                messages_pb2.MessageContentChatEdited() if message.message_type == MessageType.chat_edited else None
+            ),
+            user_invited=(
+                messages_pb2.MessageContentUserInvited(target_user_id=message.target_id)
+                if message.message_type == MessageType.user_invited
+                else None
+            ),
+            user_left=(
+                messages_pb2.MessageContentUserLeft() if message.message_type == MessageType.user_left else None
+            ),
+            user_made_admin=(
+                messages_pb2.MessageContentUserMadeAdmin(target_user_id=message.target_id)
+                if message.message_type == MessageType.user_made_admin
+                else None
+            ),
+            user_removed_admin=(
+                messages_pb2.MessageContentUserRemovedAdmin(target_user_id=message.target_id)
+                if message.message_type == MessageType.user_removed_admin
+                else None
+            ),
+            group_chat_user_removed=(
+                messages_pb2.MessageContentUserRemoved(target_user_id=message.target_id)
+                if message.message_type == MessageType.user_removed
+                else None
+            ),
+            host_request_status_changed=(
+                messages_pb2.MessageContentHostRequestStatusChanged(
+                    status=hostrequeststatus2api[message.host_request_status_target]  # type: ignore[index]
+                )
+                if message.message_type == MessageType.host_request_status_changed
+                else None
+            ),
+        )

--- a/app/backend/src/couchers/notifications/notify.py
+++ b/app/backend/src/couchers/notifications/notify.py
@@ -1,8 +1,9 @@
 import logging
+from collections.abc import Sequence
 
 from google.protobuf import empty_pb2
 from google.protobuf.message import Message
-from sqlalchemy import update
+from sqlalchemy import and_, or_, update
 from sqlalchemy.orm import Session
 
 from couchers.jobs.enqueue import queue_job
@@ -69,16 +70,18 @@ def mark_notifications_seen(
     session: Session,
     *,
     user_id: int,
-    key: str,
-    topic_actions: list[NotificationTopicAction],
+    topic_actions_and_keys: Sequence[tuple[Sequence[NotificationTopicAction], Sequence[str]]],
 ) -> None:
     """
-    Marks all unseen notifications for the given user, key, and topic actions as seen.
+    Marks the user's unseen notifications matching any of the given topic action and key groups as seen.
     """
+    clauses = [
+        and_(Notification.topic_action.in_(topic_actions), Notification.key.in_(keys))
+        for topic_actions, keys in topic_actions_and_keys
+        if topic_actions and keys
+    ]
+    if not clauses:
+        return
     session.execute(
-        update(Notification)
-        .values(is_seen=True)
-        .where(Notification.user_id == user_id)
-        .where(Notification.key == key)
-        .where(Notification.topic_action.in_(topic_actions))
+        update(Notification).values(is_seen=True).where(Notification.user_id == user_id).where(or_(*clauses))
     )

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -14,6 +14,7 @@ from couchers.context import CouchersContext, make_background_user_context, make
 from couchers.db import session_scope
 from couchers.event_log import log_event
 from couchers.helpers.completed_profile import has_completed_profile
+from couchers.helpers.messages import message_to_pb
 from couchers.jobs.enqueue import queue_job
 from couchers.metrics import sent_messages_counter
 from couchers.models import (
@@ -30,7 +31,7 @@ from couchers.models import (
 from couchers.models.notifications import NotificationTopicAction
 from couchers.moderation.utils import create_moderation
 from couchers.notifications.notify import mark_notifications_seen, notify
-from couchers.proto import conversations_pb2, conversations_pb2_grpc, messages_pb2, notification_data_pb2
+from couchers.proto import conversations_pb2, conversations_pb2_grpc, notification_data_pb2
 from couchers.proto.internal import jobs_pb2
 from couchers.rate_limits.check import process_rate_limits_and_check_abort
 from couchers.rate_limits.definitions import RATE_LIMIT_HOURS
@@ -43,54 +44,6 @@ logger = logging.getLogger(__name__)
 # TODO: Still needs custom pagination: GetUpdates
 DEFAULT_PAGINATION_LENGTH = 20
 MAX_PAGE_SIZE = 50
-
-
-def _message_to_pb(message: Message) -> messages_pb2.Message:
-    """
-    Turns the given message to a protocol buffer
-    """
-    if message.is_normal_message:
-        return messages_pb2.Message(
-            message_id=message.id,
-            author_user_id=message.author_id,
-            time=Timestamp_from_datetime(message.time),
-            text=messages_pb2.MessageContentText(text=message.text),
-        )
-    else:
-        return messages_pb2.Message(
-            message_id=message.id,
-            author_user_id=message.author_id,
-            time=Timestamp_from_datetime(message.time),
-            chat_created=(
-                messages_pb2.MessageContentChatCreated() if message.message_type == MessageType.chat_created else None
-            ),
-            chat_edited=(
-                messages_pb2.MessageContentChatEdited() if message.message_type == MessageType.chat_edited else None
-            ),
-            user_invited=(
-                messages_pb2.MessageContentUserInvited(target_user_id=message.target_id)
-                if message.message_type == MessageType.user_invited
-                else None
-            ),
-            user_left=(
-                messages_pb2.MessageContentUserLeft() if message.message_type == MessageType.user_left else None
-            ),
-            user_made_admin=(
-                messages_pb2.MessageContentUserMadeAdmin(target_user_id=message.target_id)
-                if message.message_type == MessageType.user_made_admin
-                else None
-            ),
-            user_removed_admin=(
-                messages_pb2.MessageContentUserRemovedAdmin(target_user_id=message.target_id)
-                if message.message_type == MessageType.user_removed_admin
-                else None
-            ),
-            group_chat_user_removed=(
-                messages_pb2.MessageContentUserRemoved(target_user_id=message.target_id)
-                if message.message_type == MessageType.user_removed
-                else None
-            ),
-        )
 
 
 def _get_visible_members_for_subscription(subscription: GroupChatSubscription) -> list[int]:
@@ -408,7 +361,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
                     created=Timestamp_from_datetime(result.GroupChat.conversation.created),
                     unseen_message_count=unseen_counts.get(result.GroupChatSubscription.id, 0),
                     last_seen_message_id=result.GroupChatSubscription.last_seen_message_id,
-                    latest_message=_message_to_pb(result.Message) if result.Message else None,
+                    latest_message=message_to_pb(result.Message) if result.Message else None,
                     mute_info=_mute_info(result.GroupChatSubscription),
                     can_message=_user_can_message(session, context, result.GroupChat),
                     is_archived=result.GroupChatSubscription.is_archived,
@@ -456,7 +409,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             created=Timestamp_from_datetime(result.GroupChat.conversation.created),
             unseen_message_count=_unseen_message_count(session, result.GroupChatSubscription.id),
             last_seen_message_id=result.GroupChatSubscription.last_seen_message_id,
-            latest_message=_message_to_pb(result.Message) if result.Message else None,
+            latest_message=message_to_pb(result.Message) if result.Message else None,
             mute_info=_mute_info(result.GroupChatSubscription),
             can_message=_user_can_message(session, context, result.GroupChat),
             is_archived=result.GroupChatSubscription.is_archived,
@@ -514,7 +467,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             created=Timestamp_from_datetime(result.GroupChat.conversation.created),
             unseen_message_count=_unseen_message_count(session, result.GroupChatSubscription.id),
             last_seen_message_id=result.GroupChatSubscription.last_seen_message_id,
-            latest_message=_message_to_pb(result.Message) if result.Message else None,
+            latest_message=message_to_pb(result.Message) if result.Message else None,
             mute_info=_mute_info(result.GroupChatSubscription),
             can_message=_user_can_message(session, context, result.GroupChat),
             is_archived=result.GroupChatSubscription.is_archived,
@@ -548,7 +501,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             updates=[
                 conversations_pb2.Update(
                     group_chat_id=message.conversation_id,
-                    message=_message_to_pb(message),
+                    message=message_to_pb(message),
                 )
                 for message in sorted(results, key=lambda message: message.id)[:DEFAULT_PAGINATION_LENGTH]
             ],
@@ -587,7 +540,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         )
 
         return conversations_pb2.GetGroupChatMessagesRes(
-            messages=[_message_to_pb(message) for message in results[:page_size]],
+            messages=[message_to_pb(message) for message in results[:page_size]],
             last_message_id=results[-2].id if len(results) > 1 else 0,  # TODO
             no_more=len(results) <= page_size,
         )
@@ -689,7 +642,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             results=[
                 conversations_pb2.MessageSearchResult(
                     group_chat_id=message.conversation_id,
-                    message=_message_to_pb(message),
+                    message=message_to_pb(message),
                 )
                 for message in results[:page_size]
             ],

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -561,16 +561,12 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
         mark_notifications_seen(
             session,
             user_id=context.user_id,
-            key=str(request.group_chat_id),
-            topic_actions=[NotificationTopicAction.chat__message],
-        )
-        # chat__missed_messages is a summary across all chats, so it's keyed with an empty string
-        # rather than a chat id: reading any chat counts as acting on it, and it gets marked seen
-        mark_notifications_seen(
-            session,
-            user_id=context.user_id,
-            key="",
-            topic_actions=[NotificationTopicAction.chat__missed_messages],
+            topic_actions_and_keys=[
+                ([NotificationTopicAction.chat__message], [str(request.group_chat_id)]),
+                # chat__missed_messages is a summary across all chats, so it's keyed with an empty string
+                # rather than a chat id: reading any chat counts as acting on it, and it gets marked seen
+                ([NotificationTopicAction.chat__missed_messages], [""]),
+            ],
         )
 
         return empty_pb2.Empty()

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -12,6 +12,7 @@ from couchers.context import CouchersContext, make_notification_user_context
 from couchers.db import can_moderate_node
 from couchers.event_log import log_event
 from couchers.helpers.completed_profile import has_completed_profile
+from couchers.helpers.messages import api2hostrequeststatus, hostrequeststatus2api, message_to_pb
 from couchers.materialized_views import UserResponseRate
 from couchers.metrics import (
     account_age_on_host_request_create_histogram,
@@ -61,56 +62,11 @@ DEFAULT_PAGINATION_LENGTH = 10
 MAX_PAGE_SIZE = 50
 
 
-hostrequeststatus2api = {
-    HostRequestStatus.pending: messages_pb2.HOST_REQUEST_STATUS_PENDING,
-    HostRequestStatus.accepted: messages_pb2.HOST_REQUEST_STATUS_ACCEPTED,
-    HostRequestStatus.rejected: messages_pb2.HOST_REQUEST_STATUS_REJECTED,
-    HostRequestStatus.confirmed: messages_pb2.HOST_REQUEST_STATUS_CONFIRMED,
-    HostRequestStatus.cancelled: messages_pb2.HOST_REQUEST_STATUS_CANCELLED,
-}
-
-api2hostrequeststatus = {
-    messages_pb2.HOST_REQUEST_STATUS_PENDING: HostRequestStatus.pending,
-    messages_pb2.HOST_REQUEST_STATUS_ACCEPTED: HostRequestStatus.accepted,
-    messages_pb2.HOST_REQUEST_STATUS_REJECTED: HostRequestStatus.rejected,
-    messages_pb2.HOST_REQUEST_STATUS_CONFIRMED: HostRequestStatus.confirmed,
-    messages_pb2.HOST_REQUEST_STATUS_CANCELLED: HostRequestStatus.cancelled,
-}
-
 hostrequestquality2sql = {
     requests_pb2.HOST_REQUEST_QUALITY_UNSPECIFIED: HostRequestQuality.high_quality,
     requests_pb2.HOST_REQUEST_QUALITY_LOW: HostRequestQuality.okay_quality,
     requests_pb2.HOST_REQUEST_QUALITY_OKAY: HostRequestQuality.low_quality,
 }
-
-
-def message_to_pb(message: Message) -> messages_pb2.Message:
-    """
-    Turns the given message to a protocol buffer
-    """
-    if message.is_normal_message:
-        return messages_pb2.Message(
-            message_id=message.id,
-            author_user_id=message.author_id,
-            time=Timestamp_from_datetime(message.time),
-            text=messages_pb2.MessageContentText(text=message.text),
-        )
-    else:
-        return messages_pb2.Message(
-            message_id=message.id,
-            author_user_id=message.author_id,
-            time=Timestamp_from_datetime(message.time),
-            chat_created=(
-                messages_pb2.MessageContentChatCreated() if message.message_type == MessageType.chat_created else None
-            ),
-            host_request_status_changed=(
-                messages_pb2.MessageContentHostRequestStatusChanged(
-                    status=hostrequeststatus2api[message.host_request_status_target]  # type: ignore[index]
-                )
-                if message.message_type == MessageType.host_request_status_changed
-                else None
-            ),
-        )
 
 
 def host_request_to_pb(

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -973,16 +973,20 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         mark_notifications_seen(
             session,
             user_id=context.user_id,
-            key=str(host_request.conversation_id),
-            topic_actions=[
-                NotificationTopicAction.host_request__create,
-                NotificationTopicAction.host_request__accept,
-                NotificationTopicAction.host_request__reject,
-                NotificationTopicAction.host_request__confirm,
-                NotificationTopicAction.host_request__cancel,
-                NotificationTopicAction.host_request__message,
-                NotificationTopicAction.host_request__missed_messages,
-                NotificationTopicAction.host_request__reminder,
+            topic_actions_and_keys=[
+                (
+                    [
+                        NotificationTopicAction.host_request__create,
+                        NotificationTopicAction.host_request__accept,
+                        NotificationTopicAction.host_request__reject,
+                        NotificationTopicAction.host_request__confirm,
+                        NotificationTopicAction.host_request__cancel,
+                        NotificationTopicAction.host_request__message,
+                        NotificationTopicAction.host_request__missed_messages,
+                        NotificationTopicAction.host_request__reminder,
+                    ],
+                    [str(host_request.conversation_id)],
+                ),
             ],
         )
 


### PR DESCRIPTION
First of a stack breaking up #9219 into reviewable pieces. Two refactors with no schema or proto changes:

- **Extract shared message serialization helpers**: the conversations and requests servicers each had their own copy of `message_to_pb`, and each was missing message types the other rendered (conversations' copy didn't handle `host_request_status_changed`, requests' copy didn't handle the group chat control messages). One complete version now lives in `couchers.helpers.messages`, along with the host request status maps.
- **Bulk `mark_notifications_seen`**: takes a list of (topic actions, keys) groups and marks them seen in a single update, instead of one call per group. Needed later in the stack by `MarkAllThreadsSeen`.

## Testing
`make mypy` passes; `test_conversations.py`, `test_requests.py` and `test_notifications.py` pass locally.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug (covered by existing tests)
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history (no db changes)

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._