### PR TITLE
Scope group chat unseen counts to the current subscription window

### DIFF
--- a/app/backend/src/couchers/helpers/group_chats.py
+++ b/app/backend/src/couchers/helpers/group_chats.py
@@ -1,0 +1,49 @@
+"""
+Rules for scoping a user's group chat messages, shared by the conversations API and the Ping badge.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import ColumnElement, SQLColumnExpression, and_, func, or_, select
+
+from couchers.models import GroupChatSubscription, Message
+
+
+def was_subscribed_at(
+    subscription: type[GroupChatSubscription], instant: SQLColumnExpression[datetime] | datetime
+) -> ColumnElement[bool]:
+    """
+    In the chat at the given instant: joined before it and hadn't left yet, or left after it.
+    """
+    return and_(
+        subscription.joined <= instant,
+        or_(subscription.left == None, subscription.left >= instant),
+    )
+
+
+def is_unseen(message: type[Message], subscription: type[GroupChatSubscription]) -> ColumnElement[bool]:
+    """
+    Unseen by the subscriber and still within their reach: a message they can never open, because it
+    was sent while they were out of the chat, is not unread.
+    """
+    return and_(
+        was_subscribed_at(subscription, message.time),
+        message.id > subscription.last_seen_message_id,
+    )
+
+
+def is_current_subscription(user_id: SQLColumnExpression[int] | int) -> ColumnElement[bool]:
+    """
+    Only the user's newest subscription to each chat they've been in. Rejoining a chat leaves the
+    earlier subscription behind, and it's the newest one that carries the archived and last-seen state.
+    """
+    newest_per_chat = (
+        select(func.max(GroupChatSubscription.id))
+        .where(GroupChatSubscription.user_id == user_id)
+        .group_by(GroupChatSubscription.group_chat_id)
+        # not aliased(): rebuilding the ORM proxy index per call is a hotspot, and Ping runs this on
+        # every poll. correlate_except keeps this table local to the subquery so it doesn't bind to
+        # the enclosing query's GroupChatSubscription
+        .correlate_except(GroupChatSubscription)
+    )
+    return GroupChatSubscription.id.in_(newest_per_chat)

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -24,7 +24,6 @@ from sqlalchemy.sql import (
     func,
     literal,
     not_,
-    or_,
     union_all,
     update,
 )
@@ -55,6 +54,7 @@ from couchers.email.smtp import send_smtp_email
 from couchers.event_log import log_event
 from couchers.helpers.badges import user_add_badge, user_remove_badge
 from couchers.helpers.completed_profile import has_completed_profile_expression
+from couchers.helpers.group_chats import is_current_subscription, is_unseen
 from couchers.materialized_views import (
     UserResponseRate,
 )
@@ -217,10 +217,9 @@ def send_message_notifications(payload: empty_pb2.Empty) -> None:
                 )
                 .where(not_(GroupChatSubscription.is_muted))
                 .where(User.is_visible)
-                .where(Message.time >= GroupChatSubscription.joined)
-                .where(or_(Message.time <= GroupChatSubscription.left, GroupChatSubscription.left == None))
+                .where(is_current_subscription(User.id))
+                .where(is_unseen(Message, GroupChatSubscription))
                 .where(Message.id > User.last_notified_message_id)
-                .where(Message.id > GroupChatSubscription.last_seen_message_id)
                 .where(_message_unseen_long_enough(User.id))
                 .where(Message.message_type == MessageType.text)  # TODO: only text messages for now
             )
@@ -248,11 +247,10 @@ def send_message_notifications(payload: empty_pb2.Empty) -> None:
                     )
                     .where(GroupChatSubscription.user_id == user.id)
                     .where(not_(GroupChatSubscription.is_muted))
+                    .where(is_current_subscription(user.id))
                     .where(Message.id > user.last_notified_message_id)
-                    .where(Message.id > GroupChatSubscription.last_seen_message_id)
-                    .where(Message.time >= GroupChatSubscription.joined)
-                    .where(Message.message_type == MessageType.text)  # TODO: only text messages for now
-                    .where(or_(Message.time <= GroupChatSubscription.left, GroupChatSubscription.left == None)),
+                    .where(is_unseen(Message, GroupChatSubscription))
+                    .where(Message.message_type == MessageType.text),  # TODO: only text messages for now
                     context,
                     Message.author_id,
                 )

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -18,6 +18,7 @@ from couchers.context import CouchersContext, make_notification_user_context
 from couchers.crypto import b64encode, generate_hash_signature, random_hex
 from couchers.event_log import log_event
 from couchers.helpers.completed_profile import has_completed_profile
+from couchers.helpers.group_chats import is_current_subscription, is_unseen
 from couchers.helpers.references import where_reference_user_visible, where_references_not_hidden_by_reciprocity
 from couchers.helpers.strong_verification import get_strong_verification_fields
 from couchers.materialized_views import LiteUser, UserResponseRate
@@ -240,9 +241,8 @@ class API(api_pb2_grpc.APIServicer):
         )
         unseen_message_query = (
             unseen_message_query.where(GroupChatSubscription.user_id == context.user_id)
-            .where(Message.time >= GroupChatSubscription.joined)
-            .where(or_(Message.time <= GroupChatSubscription.left, GroupChatSubscription.left == None))
-            .where(Message.id > GroupChatSubscription.last_seen_message_id)
+            .where(is_current_subscription(context.user_id))
+            .where(is_unseen(Message, GroupChatSubscription))
         )
         unseen_message_count = session.execute(unseen_message_query).scalar_one()
 

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -14,6 +14,7 @@ from couchers.context import CouchersContext, make_background_user_context, make
 from couchers.db import session_scope
 from couchers.event_log import log_event
 from couchers.helpers.completed_profile import has_completed_profile
+from couchers.helpers.group_chats import is_unseen, was_subscribed_at
 from couchers.helpers.messages import message_to_pb
 from couchers.jobs.enqueue import queue_job
 from couchers.metrics import sent_messages_counter
@@ -59,8 +60,8 @@ def _get_visible_members_for_subscription(subscription: GroupChatSubscription) -
         return [
             sub.user_id
             for sub in subscription.group_chat.subscriptions.where(
-                GroupChatSubscription.joined <= subscription.left
-            ).where(or_(GroupChatSubscription.left >= subscription.left, GroupChatSubscription.left == None))
+                was_subscribed_at(GroupChatSubscription, subscription.left)
+            )
         ]
 
 
@@ -81,9 +82,9 @@ def _get_visible_admins_for_subscription(subscription: GroupChatSubscription) ->
         # not in chat anymore, see everyone who was in chat when we left
         return [
             sub.user_id
-            for sub in subscription.group_chat.subscriptions.where(GroupChatSubscription.role == GroupChatRole.admin)
-            .where(GroupChatSubscription.joined <= subscription.left)
-            .where(or_(GroupChatSubscription.left >= subscription.left, GroupChatSubscription.left == None))
+            for sub in subscription.group_chat.subscriptions.where(
+                GroupChatSubscription.role == GroupChatRole.admin
+            ).where(was_subscribed_at(GroupChatSubscription, subscription.left))
         ]
 
 
@@ -134,8 +135,7 @@ def generate_message_notifications(payload: jobs_pb2.GenerateMessageNotification
                     select(GroupChatSubscription.user_id)
                     .where(GroupChatSubscription.group_chat_id == message.conversation_id)
                     .where(GroupChatSubscription.user_id != message.author_id)
-                    .where(GroupChatSubscription.joined <= message.time)
-                    .where(or_(GroupChatSubscription.left == None, GroupChatSubscription.left >= message.time))
+                    .where(was_subscribed_at(GroupChatSubscription, message.time))
                     .where(not_(GroupChatSubscription.is_muted)),
                     context=context,
                     column=GroupChatSubscription.user_id,
@@ -276,7 +276,7 @@ def _unseen_message_count(session: Session, subscription_id: int) -> int:
         .select_from(Message)
         .join(GroupChatSubscription, GroupChatSubscription.group_chat_id == Message.conversation_id)
         .where(GroupChatSubscription.id == subscription_id)
-        .where(Message.id > GroupChatSubscription.last_seen_message_id)
+        .where(is_unseen(Message, GroupChatSubscription))
     )
     return session.execute(query).scalar_one()
 
@@ -307,8 +307,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             )
             .join(Message, Message.conversation_id == GroupChatSubscription.group_chat_id)
             .where(GroupChatSubscription.user_id == context.user_id)
-            .where(Message.time >= GroupChatSubscription.joined)
-            .where(or_(Message.time <= GroupChatSubscription.left, GroupChatSubscription.left == None))
+            .where(was_subscribed_at(GroupChatSubscription, Message.time))
             .where(
                 or_(
                     to_bool(request.HasField("only_archived") == False),
@@ -344,7 +343,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
                 select(GroupChatSubscription.id, func.count(Message.id))
                 .join(Message, Message.conversation_id == GroupChatSubscription.group_chat_id)
                 .where(GroupChatSubscription.id.in_(subscription_ids))
-                .where(Message.id > GroupChatSubscription.last_seen_message_id)
+                .where(is_unseen(Message, GroupChatSubscription))
                 .group_by(GroupChatSubscription.id)
             ).all()
         )
@@ -386,8 +385,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
                 .options(contains_eager(GroupChat.conversation))
                 .where(GroupChatSubscription.user_id == context.user_id)
                 .where(GroupChatSubscription.group_chat_id == request.group_chat_id)
-                .where(Message.time >= GroupChatSubscription.joined)
-                .where(or_(Message.time <= GroupChatSubscription.left, GroupChatSubscription.left == None))
+                .where(was_subscribed_at(GroupChatSubscription, Message.time))
                 .order_by(Message.id.desc())
                 .limit(1),
                 context,
@@ -444,8 +442,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
                 .options(contains_eager(GroupChat.conversation))
                 .where(GroupChatSubscription.user_id == context.user_id)
                 .where(GroupChatSubscription.group_chat_id == GroupChat.conversation_id)
-                .where(Message.time >= GroupChatSubscription.joined)
-                .where(or_(Message.time <= GroupChatSubscription.left, GroupChatSubscription.left == None))
+                .where(was_subscribed_at(GroupChatSubscription, Message.time))
                 .order_by(Message.id.desc())
                 .limit(1),
                 context,
@@ -483,8 +480,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
                     .join(GroupChatSubscription, GroupChatSubscription.group_chat_id == Message.conversation_id)
                     .join(GroupChat, GroupChat.conversation_id == Message.conversation_id)
                     .where(GroupChatSubscription.user_id == context.user_id)
-                    .where(Message.time >= GroupChatSubscription.joined)
-                    .where(or_(Message.time <= GroupChatSubscription.left, GroupChatSubscription.left == None))
+                    .where(was_subscribed_at(GroupChatSubscription, Message.time))
                     .where(Message.id > request.newest_message_id)
                     .order_by(Message.id.asc())
                     .limit(DEFAULT_PAGINATION_LENGTH + 1),
@@ -522,8 +518,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
                     .join(GroupChat, GroupChat.conversation_id == Message.conversation_id)
                     .where(GroupChatSubscription.user_id == context.user_id)
                     .where(GroupChatSubscription.group_chat_id == request.group_chat_id)
-                    .where(Message.time >= GroupChatSubscription.joined)
-                    .where(or_(Message.time <= GroupChatSubscription.left, GroupChatSubscription.left == None))
+                    .where(was_subscribed_at(GroupChatSubscription, Message.time))
                     .where(or_(Message.id < request.last_message_id, to_bool(request.last_message_id == 0)))
                     .where(
                         or_(Message.id > GroupChatSubscription.last_seen_message_id, to_bool(request.only_unseen == 0))
@@ -619,8 +614,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
                     .join(GroupChatSubscription, GroupChatSubscription.group_chat_id == Message.conversation_id)
                     .join(GroupChat, GroupChat.conversation_id == Message.conversation_id)
                     .where(GroupChatSubscription.user_id == context.user_id)
-                    .where(Message.time >= GroupChatSubscription.joined)
-                    .where(or_(Message.time <= GroupChatSubscription.left, GroupChatSubscription.left == None))
+                    .where(was_subscribed_at(GroupChatSubscription, Message.time))
                     .where(or_(Message.id < request.last_message_id, to_bool(request.last_message_id == 0)))
                     .where(Message.text.ilike(f"%{request.query}%"))
                     .order_by(Message.id.desc())

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -677,6 +677,56 @@ def test_send_message_notifications_basic(db, moderator):
         )
 
 
+def test_send_message_notifications_ignores_abandoned_subscription(db, moderator):
+    """
+    Rejoining a chat leaves the earlier subscription behind with its own last-seen state, and the job
+    used to notify off that stale one even once the user had caught up on their current subscription.
+    """
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
+
+    make_friends(user1, user2)
+    make_friends(user1, user3)
+    make_friends(user2, user3)
+
+    with conversations_session(token1) as c:
+        group_chat_id = c.CreateGroupChat(
+            conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user2.id, user3.id])
+        ).group_chat_id
+    moderator.approve_group_chat(group_chat_id)
+
+    with conversations_session(token1) as c:
+        # unread and un-notified for user2 when they get removed below
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message 1"))
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message 2"))
+        c.RemoveGroupChatUser(conversations_pb2.RemoveGroupChatUserReq(group_chat_id=group_chat_id, user_id=user2.id))
+        c.InviteToGroupChat(conversations_pb2.InviteToGroupChatReq(group_chat_id=group_chat_id, user_id=user2.id))
+
+    for token in [token2, token3]:
+        with conversations_session(token) as c:
+            latest_message_id = c.GetGroupChat(
+                conversations_pb2.GetGroupChatReq(group_chat_id=group_chat_id)
+            ).latest_message.message_id
+            c.MarkLastSeenGroupChat(
+                conversations_pb2.MarkLastSeenGroupChatReq(
+                    group_chat_id=group_chat_id, last_seen_message_id=latest_message_id
+                )
+            )
+
+    with patch("couchers.jobs.handlers.now", now_5_min_in_future):
+        send_message_notifications(empty_pb2.Empty())
+        process_jobs()
+
+    with session_scope() as session:
+        assert (
+            session.execute(
+                select(func.count()).select_from(BackgroundJob).where(BackgroundJob.job_type == "send_email")
+            ).scalar_one()
+            == 0
+        )
+
+
 def test_send_message_notifications_muted(db, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -1706,6 +1706,80 @@ def test_total_unseen(db, moderator):
         assert api.Ping(api_pb2.PingReq()).unseen_message_count == 13
 
 
+def test_departed_group_chat_unseen_count_excludes_unreachable_messages(db, moderator):
+    """
+    ListGroupChats and GetGroupChat used to count messages sent after the viewer left the chat, which
+    they can never open. The viewer is removed rather than leaving, because leaving posts a message of
+    your own, which marks everything up to it seen.
+    """
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
+    make_friends(user1, user2)
+    make_friends(user2, user3)
+
+    with conversations_session(token2) as c:
+        group_chat_id = c.CreateGroupChat(
+            conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user1.id, user3.id])
+        ).group_chat_id
+        moderator.approve_group_chat(group_chat_id)
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="hi"))
+        c.RemoveGroupChatUser(conversations_pb2.RemoveGroupChatUserReq(group_chat_id=group_chat_id, user_id=user1.id))
+        for _ in range(3):
+            c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="after you left"))
+
+    # chat created, "hi", and the removal notice; the three messages sent afterwards are out of reach
+    with api_session(token1) as api:
+        assert api.Ping(api_pb2.PingReq()).unseen_message_count == 3
+
+    with conversations_session(token1) as c:
+        res = c.ListGroupChats(conversations_pb2.ListGroupChatsReq())
+        (listed,) = [gc for gc in res.group_chats if gc.group_chat_id == group_chat_id]
+        assert listed.unseen_message_count == 3
+        assert c.GetGroupChat(conversations_pb2.GetGroupChatReq(group_chat_id=group_chat_id)).unseen_message_count == 3
+
+
+def test_rejoined_group_chat_ping_reads_current_subscription(db, moderator):
+    """
+    Rejoining a chat leaves the earlier subscription behind with its own last-seen state. Ping used to
+    match on any of the viewer's subscriptions, so the stale one kept the badge up forever.
+    """
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
+    make_friends(user1, user2)
+    make_friends(user2, user3)
+
+    with conversations_session(token2) as c:
+        group_chat_id = c.CreateGroupChat(
+            conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user1.id, user3.id])
+        ).group_chat_id
+        moderator.approve_group_chat(group_chat_id)
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="hi"))
+        # removed rather than leaving, so user1's first subscription is left behind with unread messages
+        c.RemoveGroupChatUser(conversations_pb2.RemoveGroupChatUserReq(group_chat_id=group_chat_id, user_id=user1.id))
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="while you were away"))
+        c.InviteToGroupChat(conversations_pb2.InviteToGroupChatReq(group_chat_id=group_chat_id, user_id=user1.id))
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="welcome back"))
+
+    # only the invite notice and "welcome back" are in reach of the current subscription
+    with api_session(token1) as api:
+        assert api.Ping(api_pb2.PingReq()).unseen_message_count == 2
+
+    with conversations_session(token1) as c:
+        latest_message_id = c.GetGroupChat(
+            conversations_pb2.GetGroupChatReq(group_chat_id=group_chat_id)
+        ).latest_message.message_id
+        c.MarkLastSeenGroupChat(
+            conversations_pb2.MarkLastSeenGroupChatReq(
+                group_chat_id=group_chat_id, last_seen_message_id=latest_message_id
+            )
+        )
+
+    with api_session(token1) as api:
+        assert api.Ping(api_pb2.PingReq()).unseen_message_count == 0
+
+
 def test_regression_ListGroupChats_pagination(db, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()


### PR DESCRIPTION
Second in the stack breaking up #9219 (on top of #9460). Fixes two unread-count bugs around group chats the user was removed from:

- **ListGroupChats and GetGroupChat counted messages sent after the viewer left the chat**, which they can never open — while the Ping badge correctly excluded them, so the per-chat counts and the badge disagreed.
- **Rejoining a chat leaves the earlier subscription behind, and Ping matched on any of the viewer's subscriptions**, so the stale subscription's unread messages kept the badge up even after the viewer read everything on their current subscription (marking seen only ever advances the current one).

The window ("messages sent while the user was in the chat") and current-subscription rules now live in `couchers.helpers.group_chats`, shared by both the conversations API and the Ping badge so all the counts agree. Later in the stack, `ListMessageThreads` / `MarkAllThreadsSeen` build on the same helpers.

## Testing
Added two regression tests (`test_departed_group_chat_unseen_count_excludes_unreachable_messages`, `test_rejoined_group_chat_ping_reads_current_subscription`); both fail on the unfixed code and pass with the fix. `make mypy` passes; `test_conversations.py` and `test_api.py` pass locally.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history (no db changes)

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._