### PR TITLE
Add role-based unread host request counts to Ping

### DIFF
--- a/app/backend/src/couchers/helpers/host_requests.py
+++ b/app/backend/src/couchers/helpers/host_requests.py
@@ -1,0 +1,54 @@
+"""
+Shared host request helpers.
+
+The role-based party predicates below exist because a host request has a fixed direction
+(initiator -> recipient), but the *stay-role* of each party depends on how the request came about:
+
+  - a normal request: the initiator is the surfer, the recipient is the host
+  - a public-trip offer: the roles are reversed — the initiator is offering their couch, so they are
+    the host, and the recipient (the trip owner) is the surfer
+
+So "am I hosting?" is not the same question as "did I receive this?".
+"""
+
+from sqlalchemy.sql import and_, or_
+from sqlalchemy.sql.elements import ColumnElement
+
+from couchers.models import HostRequest
+from couchers.models.notifications import NotificationTopicAction
+
+# topic actions whose notifications are marked seen alongside a host request being read
+HOST_REQUEST_NOTIFICATION_TOPIC_ACTIONS = [
+    NotificationTopicAction.host_request__create,
+    NotificationTopicAction.host_request__accept,
+    NotificationTopicAction.host_request__reject,
+    NotificationTopicAction.host_request__confirm,
+    NotificationTopicAction.host_request__cancel,
+    NotificationTopicAction.host_request__message,
+    NotificationTopicAction.host_request__missed_messages,
+    NotificationTopicAction.host_request__reminder,
+]
+
+
+def is_hosting_party(user_id: int) -> ColumnElement[bool]:
+    """The viewer is the host of the stay: a normal request they received, or an offer they sent."""
+    return or_(
+        and_(HostRequest.public_trip_id.is_(None), HostRequest.recipient_user_id == user_id),
+        and_(HostRequest.public_trip_id.isnot(None), HostRequest.initiator_user_id == user_id),
+    )
+
+
+def is_surfing_party(user_id: int) -> ColumnElement[bool]:
+    """The viewer is the guest of the stay: a normal request they sent, or an offer they received."""
+    return or_(
+        and_(HostRequest.public_trip_id.is_(None), HostRequest.initiator_user_id == user_id),
+        and_(HostRequest.public_trip_id.isnot(None), HostRequest.recipient_user_id == user_id),
+    )
+
+
+def is_public_trip_offer_recipient(user_id: int) -> ColumnElement[bool]:
+    """
+    An offer on one of the viewer's public trips: they own the trip, so they received the offer.
+    A strict subset of is_surfing_party.
+    """
+    return and_(HostRequest.public_trip_id.isnot(None), HostRequest.recipient_user_id == user_id)

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -8,7 +8,7 @@ import grpc
 from google.protobuf import empty_pb2
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
-from sqlalchemy.sql import and_, delete, exists, func, intersect, or_, union
+from sqlalchemy.sql import and_, case, delete, exists, func, intersect, or_, union
 
 from couchers import urls
 from couchers.abuse import maybe_log_nonvisible_user_access
@@ -19,6 +19,7 @@ from couchers.crypto import b64encode, generate_hash_signature, random_hex
 from couchers.event_log import log_event
 from couchers.helpers.completed_profile import has_completed_profile
 from couchers.helpers.group_chats import is_current_subscription, is_unseen
+from couchers.helpers.host_requests import is_hosting_party, is_public_trip_offer_recipient, is_surfing_party
 from couchers.helpers.references import where_reference_user_visible, where_references_not_hidden_by_reciprocity
 from couchers.helpers.strong_verification import get_strong_verification_fields
 from couchers.materialized_views import LiteUser, UserResponseRate
@@ -191,45 +192,54 @@ class API(api_pb2_grpc.APIServicer):
             )
         ).scalar_one()
 
-        sent_reqs_query = select(HostRequest.conversation_id, HostRequest.initiator_last_seen_message_id).where(
-            HostRequest.initiator_user_id == context.user_id
+        # One pass over the requests the viewer is a party to that have unread messages, tallied both by
+        # direction (sent/received) and by stay-role. The role-based tallies bucket public-trip offers
+        # correctly despite the role reversal: the offering host counts under hosting, the traveller
+        # under surfing.
+        viewer_last_seen_message_id = case(
+            (HostRequest.initiator_user_id == context.user_id, HostRequest.initiator_last_seen_message_id),
+            else_=HostRequest.recipient_last_seen_message_id,
         )
-        sent_reqs_query = where_users_column_visible(sent_reqs_query, context, HostRequest.recipient_user_id)
-        sent_reqs_query = where_moderated_content_visible(sent_reqs_query, context, HostRequest, is_list_operation=True)
-        sent_reqs_last_seen_message_ids = sent_reqs_query.subquery()
-
-        unseen_sent_host_request_count = session.execute(
-            select(func.count())
-            .select_from(sent_reqs_last_seen_message_ids)
+        other_party_user_id = case(
+            (HostRequest.initiator_user_id == context.user_id, HostRequest.recipient_user_id),
+            else_=HostRequest.initiator_user_id,
+        )
+        unseen_host_request_counts_query = (
+            select(
+                func.count().filter(HostRequest.initiator_user_id == context.user_id).label("sent"),
+                func.count().filter(HostRequest.recipient_user_id == context.user_id).label("received"),
+                func.count().filter(is_hosting_party(context.user_id)).label("hosting"),
+                func.count().filter(is_surfing_party(context.user_id)).label("surfing"),
+                func.count().filter(is_public_trip_offer_recipient(context.user_id)).label("public_trip_offer"),
+            )
+            .select_from(HostRequest)
+            .where(
+                or_(
+                    HostRequest.initiator_user_id == context.user_id,
+                    HostRequest.recipient_user_id == context.user_id,
+                )
+            )
             .where(
                 exists(
                     select(1)
-                    .where(Message.conversation_id == sent_reqs_last_seen_message_ids.c.conversation_id)
-                    .where(Message.id > sent_reqs_last_seen_message_ids.c.initiator_last_seen_message_id)
+                    .where(Message.conversation_id == HostRequest.conversation_id)
+                    .where(Message.id > viewer_last_seen_message_id)
                 )
             )
-        ).scalar_one()
-
-        received_reqs_query = select(HostRequest.conversation_id, HostRequest.recipient_last_seen_message_id).where(
-            HostRequest.recipient_user_id == context.user_id
         )
-        received_reqs_query = where_users_column_visible(received_reqs_query, context, HostRequest.initiator_user_id)
-        received_reqs_query = where_moderated_content_visible(
-            received_reqs_query, context, HostRequest, is_list_operation=True
+        unseen_host_request_counts_query = where_users_column_visible(
+            unseen_host_request_counts_query, context, other_party_user_id
         )
-        received_reqs_last_seen_message_ids = received_reqs_query.subquery()
+        unseen_host_request_counts_query = where_moderated_content_visible(
+            unseen_host_request_counts_query, context, HostRequest, is_list_operation=True
+        )
+        unseen_host_request_counts = session.execute(unseen_host_request_counts_query).one()
 
-        unseen_received_host_request_count = session.execute(
-            select(func.count())
-            .select_from(received_reqs_last_seen_message_ids)
-            .where(
-                exists(
-                    select(1)
-                    .where(Message.conversation_id == received_reqs_last_seen_message_ids.c.conversation_id)
-                    .where(Message.id > received_reqs_last_seen_message_ids.c.recipient_last_seen_message_id)
-                )
-            )
-        ).scalar_one()
+        unseen_public_trip_offer_count = (
+            unseen_host_request_counts.public_trip_offer
+            if context.get_boolean_value("public_trips_enabled", False)
+            else 0
+        )
 
         unseen_message_query = (
             select(func.count(Message.id))
@@ -276,8 +286,11 @@ class API(api_pb2_grpc.APIServicer):
         return api_pb2.PingRes(
             user=user_model_to_pb(user, session, context),
             unseen_message_count=unseen_message_count,
-            unseen_sent_host_request_count=unseen_sent_host_request_count,
-            unseen_received_host_request_count=unseen_received_host_request_count,
+            unseen_sent_host_request_count=unseen_host_request_counts.sent,
+            unseen_received_host_request_count=unseen_host_request_counts.received,
+            unseen_hosting_host_request_count=unseen_host_request_counts.hosting,
+            unseen_surfing_host_request_count=unseen_host_request_counts.surfing,
+            unseen_public_trip_offer_count=unseen_public_trip_offer_count,
             pending_friend_request_count=pending_friend_request_count,
             unseen_notification_count=unseen_notification_count,
         )

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -12,6 +12,7 @@ from couchers.context import CouchersContext, make_notification_user_context
 from couchers.db import can_moderate_node
 from couchers.event_log import log_event
 from couchers.helpers.completed_profile import has_completed_profile
+from couchers.helpers.host_requests import HOST_REQUEST_NOTIFICATION_TOPIC_ACTIONS
 from couchers.helpers.messages import api2hostrequeststatus, hostrequeststatus2api, message_to_pb
 from couchers.materialized_views import UserResponseRate
 from couchers.metrics import (
@@ -974,19 +975,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             session,
             user_id=context.user_id,
             topic_actions_and_keys=[
-                (
-                    [
-                        NotificationTopicAction.host_request__create,
-                        NotificationTopicAction.host_request__accept,
-                        NotificationTopicAction.host_request__reject,
-                        NotificationTopicAction.host_request__confirm,
-                        NotificationTopicAction.host_request__cancel,
-                        NotificationTopicAction.host_request__message,
-                        NotificationTopicAction.host_request__missed_messages,
-                        NotificationTopicAction.host_request__reminder,
-                    ],
-                    [str(host_request.conversation_id)],
-                ),
+                (HOST_REQUEST_NOTIFICATION_TOPIC_ACTIONS, [str(host_request.conversation_id)]),
             ],
         )
 

--- a/app/backend/src/couchers/sql.py
+++ b/app/backend/src/couchers/sql.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import ColumnElement, and_, false, or_, select, true
+from sqlalchemy import ColumnElement, SQLColumnExpression, and_, false, or_, select, true
 from sqlalchemy.orm import InstrumentedAttribute, aliased
 from sqlalchemy.sql import Select, exists, union
 
@@ -88,7 +88,7 @@ def users_visible(context: CouchersContext, table: _User = User) -> ColumnElemen
 
 
 def where_users_column_visible[T: tuple[Any, ...]](
-    query: Select[T], context: CouchersContext, column: InstrumentedAttribute[int]
+    query: Select[T], context: CouchersContext, column: SQLColumnExpression[int]
 ) -> Select[T]:
     """
     Filters the given column, not yet joined/selected from

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -41,6 +41,7 @@ from couchers.utils import create_coordinate, create_polygon_lat_lng, now, to_mu
 from tests.fixtures.db import backdate_conversations, generate_user
 from tests.fixtures.misc import EmailCollector, PushCollector
 from tests.fixtures.sessions import api_session, auth_api_session, requests_session
+from tests.test_public_trips import _create_trip_directly, _make_node
 
 
 @pytest.fixture(autouse=True)
@@ -1584,6 +1585,84 @@ def test_mark_last_seen(db, moderator):
     with api_session(token2) as api:
         assert api.Ping(api_pb2.PingReq()).unseen_received_host_request_count == 1
         assert api.Ping(api_pb2.PingReq()).unseen_sent_host_request_count == 1
+
+
+def _create_host_request_via_api(surfer_token: str, host_id: int, moderator, public_trip_id: int | None = None) -> int:
+    with requests_session(surfer_token) as api:
+        res = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=host_id,
+                from_date=(today() + timedelta(days=5)).isoformat(),
+                to_date=(today() + timedelta(days=10)).isoformat(),
+                text=valid_request_text(),
+                public_trip_id=public_trip_id,
+            )
+        )
+    moderator.approve_host_request(res.host_request_id)
+    return int(res.host_request_id)
+
+
+def test_ping_role_based_counts_match_direction_without_offers(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    # user2 surfs with user1 -> user1 is the host of the stay
+    _create_host_request_via_api(token2, user1.id, moderator)
+
+    with api_session(token1) as api:
+        res = api.Ping(api_pb2.PingReq())
+        # with no public-trip offers, role-based counts equal the direction-based ones
+        assert res.unseen_received_host_request_count == 1
+        assert res.unseen_hosting_host_request_count == 1
+        assert res.unseen_sent_host_request_count == 0
+        assert res.unseen_surfing_host_request_count == 0
+        assert res.unseen_public_trip_offer_count == 0
+
+
+def test_ping_counts_public_trip_offer_by_role(db, moderator):
+    traveler, traveler_token = generate_user()
+    host, host_token = generate_user()
+    node_id = _make_node()
+    trip_id = _create_trip_directly(traveler.id, node_id, today() + timedelta(days=5), today() + timedelta(days=10))
+
+    request_id = _create_host_request_via_api(host_token, traveler.id, moderator, public_trip_id=trip_id)
+
+    # the traveller (recipient) has the offer's create message unseen: counts as surfing + public-trip offer
+    with api_session(traveler_token) as api:
+        res = api.Ping(api_pb2.PingReq())
+        assert res.unseen_surfing_host_request_count == 1
+        assert res.unseen_public_trip_offer_count == 1
+        assert res.unseen_hosting_host_request_count == 0
+
+    # the traveller replies, so now the offering host has an unseen message under hosting
+    with requests_session(traveler_token) as api:
+        api.SendHostRequestMessage(
+            requests_pb2.SendHostRequestMessageReq(host_request_id=request_id, text="thanks for the offer")
+        )
+
+    with api_session(host_token) as api:
+        res = api.Ping(api_pb2.PingReq())
+        assert res.unseen_hosting_host_request_count == 1
+        assert res.unseen_surfing_host_request_count == 0
+        assert res.unseen_public_trip_offer_count == 0
+
+
+def test_ping_public_trip_offer_count_gated_by_flag(db, moderator, feature_flags):
+    feature_flags.set("public_trips_enabled", False)
+
+    traveler, traveler_token = generate_user()
+    host, host_token = generate_user()
+    node_id = _make_node()
+    trip_id = _create_trip_directly(traveler.id, node_id, today() + timedelta(days=5), today() + timedelta(days=10))
+
+    _create_host_request_via_api(host_token, traveler.id, moderator, public_trip_id=trip_id)
+
+    with api_session(traveler_token) as api:
+        res = api.Ping(api_pb2.PingReq())
+        # the dedicated offer count is gated off...
+        assert res.unseen_public_trip_offer_count == 0
+        # ...but the offer is a real conversation and still surfaces under surfing
+        assert res.unseen_surfing_host_request_count == 1
 
 
 def test_mark_last_seen_clears_notifications(db, moderator):

--- a/app/proto/api.proto
+++ b/app/proto/api.proto
@@ -121,6 +121,13 @@ message PingRes {
   uint32 pending_friend_request_count = 4;
 
   uint32 unseen_notification_count = 7;
+
+  // Role-based unread host-request counts. Unlike the direction-based
+  // sent/received counts above, these classify by stay-role, so public-trip
+  // offers (role reversal) are bucketed correctly.
+  uint32 unseen_hosting_host_request_count = 8; // I am the host of the stay
+  uint32 unseen_surfing_host_request_count = 9; // I am the guest/traveller
+  uint32 unseen_public_trip_offer_count = 10; // incoming public-trip offers (gated by public_trips_enabled)
 }
 
 message MutualFriend {


### PR DESCRIPTION
Third in the stack breaking up #9219 (on top of #9462). Adds role-based unread host-request counts to `Ping`.

A host request has a fixed direction (initiator → recipient), but the *stay-role* of each party depends on how the request came about: for a normal request the initiator is the surfer; for a public-trip offer the roles are reversed — the initiator is offering their couch, so they are the host. The existing `unseen_sent/received_host_request_count` fields classify by direction, so they bucket offers under the wrong tab.

- New `PingRes` fields: `unseen_hosting_host_request_count`, `unseen_surfing_host_request_count` and `unseen_public_trip_offer_count` (the last gated by the `public_trips_enabled` flag; offers still count under surfing when it's off).
- The role predicates live in `couchers.helpers.host_requests` (shared later in the stack by `ListMessageThreads`), along with the host-request notification topic-action list.
- The five tallies (2 direction-based + 3 role-based) are collapsed into a single pass over the viewer's host requests with unread messages, replacing the two separate count queries.
- `where_users_column_visible` now accepts any `SQLColumnExpression[int]`, since the other-party column is a `case` expression here.

## Testing
Added `test_ping_role_based_counts_match_direction_without_offers`, `test_ping_counts_public_trip_offer_by_role` and `test_ping_public_trip_offer_count_gated_by_flag`. `make mypy` passes; `test_requests.py`, `test_api.py`, `test_conversations.py`, `test_notifications.py` and `test_public_trips.py` pass locally (238 passed).

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history (no db changes)

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._