### PR TITLE
Web/bugfix/deleteaccountplaceholder

### DIFF
--- a/app/web/features/auth/deletion/DeleteAccount.tsx
+++ b/app/web/features/auth/deletion/DeleteAccount.tsx
@@ -69,7 +69,7 @@ export default function DeleteAccount({ className, username }: DeleteAccountProp
             <Trans t={t} i18nKey="auth:delete_account.request.confirm_username_explanation" values={{ username }} />
           </Typography>
           <TextField
-            sx={{ width: 300, display: 'inline-flex'}}
+            sx={{ width: 360, display: 'inline-flex'}}
             id="confirmUsername"
             {...register("confirmUsername", { required: true })}
             label={t("auth:delete_account.request.confirm_username_label")}

--- a/app/web/features/auth/deletion/DeleteAccount.tsx
+++ b/app/web/features/auth/deletion/DeleteAccount.tsx
@@ -69,6 +69,7 @@ export default function DeleteAccount({ className, username }: DeleteAccountProp
             <Trans t={t} i18nKey="auth:delete_account.request.confirm_username_explanation" values={{ username }} />
           </Typography>
           <TextField
+            sx={{ width: 300, display: 'inline-flex'}}
             id="confirmUsername"
             {...register("confirmUsername", { required: true })}
             label={t("auth:delete_account.request.confirm_username_label")}

--- a/app/web/features/auth/deletion/DeleteAccount.tsx
+++ b/app/web/features/auth/deletion/DeleteAccount.tsx
@@ -10,6 +10,7 @@ import { AUTH, GLOBAL } from "i18n/namespaces";
 import { useForm } from "react-hook-form";
 import { service } from "service";
 import { theme } from "theme";
+import { useRef, useState, useLayoutEffect } from "react";
 import { lowercaseAndTrimField } from "utils/validation";
 
 const StyledForm = styled("form")(() => ({
@@ -57,6 +58,27 @@ export default function DeleteAccount({ className, username }: DeleteAccountProp
     },
   });
 
+  //the placeholder label for "confirm_username" can be very long when translated so 
+  //add a hidden element to measure the translated text & extend the box as needed
+  const labelUsername = t("auth:delete_account.request.confirm_username_label");
+  
+  const labelRef = useRef<HTMLSpanElement>(null);
+  const [usernameWidth, setUsernameWidth] = useState(200);
+
+  useLayoutEffect(() => {
+    if (labelRef.current) {
+      setUsernameWidth(labelRef.current.offsetWidth + 48); 
+    }
+  }, [labelUsername]);
+
+  const measureUsernamePlaceholder = (
+    <span
+      ref={labelRef}
+      style={{ visibility: "hidden" }}
+    >
+      {labelUsername}
+    </span>
+  );
   return (
     <div className={className}>
       <Typography variant="h2">{t("auth:delete_account.request.title")}</Typography>
@@ -69,12 +91,15 @@ export default function DeleteAccount({ className, username }: DeleteAccountProp
             <Trans t={t} i18nKey="auth:delete_account.request.confirm_username_explanation" values={{ username }} />
           </Typography>
           <TextField
-            sx={{ width: 360, display: 'inline-flex'}}
+            sx={{
+              display: "inline-flex",
+              width: isMdOrWider ? usernameWidth : '100%',
+            }}
             id="confirmUsername"
             {...register("confirmUsername", { required: true })}
-            label={t("auth:delete_account.request.confirm_username_label")}
-            fullWidth={!isMdOrWider}
+            label={labelUsername}
           />
+          {measureUsernamePlaceholder}
           <Typography variant="subtitle1" sx={{ paddingTop: 2, paddingBottom: 2 }}>
             {t("auth:delete_account.request.reason_explanation")}
           </Typography>

--- a/app/web/features/auth/deletion/DeleteAccount.tsx
+++ b/app/web/features/auth/deletion/DeleteAccount.tsx
@@ -7,10 +7,10 @@ import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { RpcError } from "grpc-web";
 import { Trans, useTranslation } from "i18n";
 import { AUTH, GLOBAL } from "i18n/namespaces";
+import { useLayoutEffect,useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { service } from "service";
 import { theme } from "theme";
-import { useRef, useState, useLayoutEffect } from "react";
 import { lowercaseAndTrimField } from "utils/validation";
 
 const StyledForm = styled("form")(() => ({

--- a/app/web/features/auth/deletion/DeleteAccount.tsx
+++ b/app/web/features/auth/deletion/DeleteAccount.tsx
@@ -7,7 +7,7 @@ import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { RpcError } from "grpc-web";
 import { Trans, useTranslation } from "i18n";
 import { AUTH, GLOBAL } from "i18n/namespaces";
-import { useLayoutEffect,useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { service } from "service";
 import { theme } from "theme";
@@ -58,24 +58,21 @@ export default function DeleteAccount({ className, username }: DeleteAccountProp
     },
   });
 
-  //the placeholder label for "confirm_username" can be very long when translated so 
+  //the placeholder label for "confirm_username" can be very long when translated so
   //add a hidden element to measure the translated text & extend the box as needed
   const labelUsername = t("auth:delete_account.request.confirm_username_label");
-  
+
   const labelRef = useRef<HTMLSpanElement>(null);
   const [usernameWidth, setUsernameWidth] = useState(200);
 
   useLayoutEffect(() => {
     if (labelRef.current) {
-      setUsernameWidth(labelRef.current.offsetWidth + 48); 
+      setUsernameWidth(labelRef.current.offsetWidth + 48);
     }
   }, [labelUsername]);
 
   const measureUsernamePlaceholder = (
-    <span
-      ref={labelRef}
-      style={{ visibility: "hidden" }}
-    >
+    <span ref={labelRef} style={{ visibility: "hidden" }}>
       {labelUsername}
     </span>
   );
@@ -93,7 +90,7 @@ export default function DeleteAccount({ className, username }: DeleteAccountProp
           <TextField
             sx={{
               display: "inline-flex",
-              width: isMdOrWider ? usernameWidth : '100%',
+              width: isMdOrWider ? usernameWidth : "100%",
             }}
             id="confirmUsername"
             {...register("confirmUsername", { required: true })}

--- a/app/web/features/auth/deletion/DeleteAccount.tsx
+++ b/app/web/features/auth/deletion/DeleteAccount.tsx
@@ -7,12 +7,12 @@ import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { RpcError } from "grpc-web";
 import { Trans, useTranslation } from "i18n";
 import { AUTH, GLOBAL } from "i18n/namespaces";
-import { useLayoutEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { service } from "service";
 import { theme } from "theme";
 import { lowercaseAndTrimField } from "utils/validation";
 
+const DEFAULT_TEXTFIELD_WIDTH = '15.5rem';
 const StyledForm = styled("form")(() => ({
   marginBottom: theme.spacing(2),
   "& > * + *": {
@@ -58,24 +58,8 @@ export default function DeleteAccount({ className, username }: DeleteAccountProp
     },
   });
 
-  //the placeholder label for "confirm_username" can be very long when translated so
-  //add a hidden element to measure the translated text & extend the box as needed
-  const labelUsername = t("auth:delete_account.request.confirm_username_label");
+  const labelConfirmUsername = t("auth:delete_account.request.confirm_username_label");
 
-  const labelRef = useRef<HTMLSpanElement>(null);
-  const [usernameWidth, setUsernameWidth] = useState(200);
-
-  useLayoutEffect(() => {
-    if (labelRef.current) {
-      setUsernameWidth(labelRef.current.offsetWidth + 48);
-    }
-  }, [labelUsername]);
-
-  const measureUsernamePlaceholder = (
-    <span ref={labelRef} style={{ visibility: "hidden" }}>
-      {labelUsername}
-    </span>
-  );
   return (
     <div className={className}>
       <Typography variant="h2">{t("auth:delete_account.request.title")}</Typography>
@@ -90,13 +74,12 @@ export default function DeleteAccount({ className, username }: DeleteAccountProp
           <TextField
             sx={{
               display: "inline-flex",
-              width: isMdOrWider ? usernameWidth : "100%",
+              width: isMdOrWider ? `max(${DEFAULT_TEXTFIELD_WIDTH}, ${labelConfirmUsername.length}ch)` : "100%",
             }}
             id="confirmUsername"
             {...register("confirmUsername", { required: true })}
-            label={labelUsername}
+            label={labelConfirmUsername}
           />
-          {measureUsernamePlaceholder}
           <Typography variant="subtitle1" sx={{ paddingTop: 2, paddingBottom: 2 }}>
             {t("auth:delete_account.request.reason_explanation")}
           </Typography>

--- a/app/web/features/auth/deletion/DeleteAccount.tsx
+++ b/app/web/features/auth/deletion/DeleteAccount.tsx
@@ -12,7 +12,7 @@ import { service } from "service";
 import { theme } from "theme";
 import { lowercaseAndTrimField } from "utils/validation";
 
-const DEFAULT_TEXTFIELD_WIDTH = '15.5rem';
+const DEFAULT_TEXTFIELD_WIDTH = "15.5rem";
 const StyledForm = styled("form")(() => ({
   marginBottom: theme.spacing(2),
   "& > * + *": {


### PR DESCRIPTION
Closes #9452. This PR addresses a problem with placeholder text overrunning the length of a textbox. I added a hidden element to the page to help us measure the length of the translated "Confirm Username" placeholder label and then adjust the textbox's width accordingly.

## Testing
Tested different screen sizes and languages. This issue could also affect other text boxes with long placeholder text labels, so I poked around some other languages and parts of the site but didn't find any other places with issues.

|  | Before | After |
| -- | ----- | ---- |
| English | <img width="602" height="390" alt="Screenshot From 2026-08-07 11-16-43" src="https://github.com/user-attachments/assets/f460e715-af13-49b9-8454-f8a0f79aef51" /> | <img width="602" height="390" alt="Screenshot From 2026-08-07 11-16-17" src="https://github.com/user-attachments/assets/07b71576-dbcd-48eb-bdb0-586093cb21ee" /> |
| Français | <img width="602" height="390" alt="Screenshot From 2026-08-07 11-16-31" src="https://github.com/user-attachments/assets/4e191fdc-cf3d-4c1e-b416-fb979f6747bf" /> | <img width="602" height="390" alt="Screenshot From 2026-08-07 11-16-54" src="https://github.com/user-attachments/assets/5abcb76d-eda0-4fac-aa03-a1d2429cca4c" />

Small screen behavior (width = 100%) is unchanged.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [X] There are no console warnings when running the app
- [ ] Added tests where relevant
- [X] Clicked around my changes running locally and it works
- [X] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
