### PR TITLE
Add ListMessageThreads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ make mypy
 - For URLs, use `from couchers import urls` and then `urls.whatever()`
 - Avoid inline imports whenever possible
 - To filter out invisible users (deleted/banned/blocked), use the helper functions from `couchers.sql`: `where(users_visible(context))` when User is already joined, `where(users_column_visible(context, column))` when you have a user_id column, or `where(users_visible_to_each_other(user1, user2))` for mutual visibility. Never use `User.is_visible` directly in queries
+- For paginated APIs, use a `next_page_token` string field: an empty token means there are no more pages (don't add a separate `no_more` flag). Encrypt tokens with `encrypt_page_token`/`decrypt_page_token` from `couchers.crypto` so they are opaque to clients
 
 ### Web (TypeScript/React)
 - Uses `nvm` for node version management

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -37,7 +37,7 @@ from couchers.proto.internal import jobs_pb2
 from couchers.rate_limits.check import process_rate_limits_and_check_abort
 from couchers.rate_limits.definitions import RATE_LIMIT_HOURS
 from couchers.servicers.api import user_model_to_pb
-from couchers.servicers.message_threads import mark_all_threads_seen
+from couchers.servicers.message_threads import list_message_threads, mark_all_threads_seen
 from couchers.sql import to_bool, users_visible, where_moderated_content_visible, where_users_column_visible
 from couchers.utils import Timestamp_from_datetime, now
 
@@ -48,6 +48,8 @@ DEFAULT_PAGINATION_LENGTH = 20
 MAX_PAGE_SIZE = 50
 
 
+# TODO(#7722): remove with the legacy conversations endpoints; the ListMessageThreads path filters
+# preloaded subscriptions with message_threads._member_visible_to_viewer instead
 def _get_visible_members_for_subscription(subscription: GroupChatSubscription) -> list[int]:
     """
     If a user leaves a group chat, they shouldn't be able to see who's added
@@ -288,11 +290,17 @@ def _unseen_message_count(session: Session, subscription_id: int) -> int:
 
 
 class Conversations(conversations_pb2_grpc.ConversationsServicer):
+    def ListMessageThreads(
+        self, request: conversations_pb2.ListMessageThreadsReq, context: CouchersContext, session: Session
+    ) -> conversations_pb2.ListMessageThreadsRes:
+        return list_message_threads(request, context, session)
+
     def MarkAllThreadsSeen(
         self, request: conversations_pb2.MarkAllThreadsSeenReq, context: CouchersContext, session: Session
     ) -> empty_pb2.Empty:
         return mark_all_threads_seen(request, context, session)
 
+    # TODO(#7722): remove after FE migrates to ListMessageThreads
     def ListGroupChats(
         self, request: conversations_pb2.ListGroupChatsReq, context: CouchersContext, session: Session
     ) -> conversations_pb2.ListGroupChatsRes:

--- a/app/backend/src/couchers/servicers/message_threads.py
+++ b/app/backend/src/couchers/servicers/message_threads.py
@@ -94,14 +94,6 @@ def _resolve_thread_filters(
     )
 
 
-def _latest_host_request_message_id() -> ColumnElement[int]:
-    """
-    The newest message on a request. Correlated, so it resolves per row of the enclosing query, and
-    never NULL, because creating a request writes its first message.
-    """
-    return select(func.max(Message.id)).where(Message.conversation_id == HostRequest.conversation_id).scalar_subquery()
-
-
 def _build_group_chat_select_query(
     context: CouchersContext, only_archived: bool | None, unread: bool
 ) -> Select[tuple[int, int, str]]:
@@ -112,10 +104,11 @@ def _build_group_chat_select_query(
     The message join is windowed to the viewer's subscription, so a chat they were removed from ends
     at the last message they could read rather than at the chat's newest.
     """
-    group_chats = where_moderated_content_visible(
+    return where_moderated_content_visible(
         select(
             GroupChatSubscription.group_chat_id.label("conversation_id"),
             func.max(Message.id).label("latest_message_id"),
+            literal(_KIND_GROUP_CHAT).label("kind"),
         )
         .join(Message, Message.conversation_id == GroupChatSubscription.group_chat_id)
         .join(GroupChat, GroupChat.conversation_id == GroupChatSubscription.group_chat_id)
@@ -128,11 +121,6 @@ def _build_group_chat_select_query(
         context,
         GroupChat,
         is_list_operation=True,
-    ).subquery()
-    return select(
-        group_chats.c.conversation_id,
-        group_chats.c.latest_message_id,
-        literal(_KIND_GROUP_CHAT).label("kind"),
     )
 
 
@@ -149,7 +137,12 @@ def _build_host_request_select_query(
     query = (
         select(
             HostRequest.conversation_id.label("conversation_id"),
-            _latest_host_request_message_id().label("latest_message_id"),
+            # correlated, so it resolves per row, and never NULL: creating a request writes its
+            # first message
+            select(func.max(Message.id))
+            .where(Message.conversation_id == HostRequest.conversation_id)
+            .scalar_subquery()
+            .label("latest_message_id"),
             literal(_KIND_HOST_REQUEST).label("kind"),
         )
         .where(
@@ -462,7 +455,11 @@ def mark_all_threads_seen(
         # the viewer's last-seen column depends on their role, so one update per role
         # (a user is never both initiator and recipient of the same request, so these are disjoint)
         matching_ids = select(host_request_query.subquery().c.conversation_id)
-        latest_message_id = _latest_host_request_message_id()
+        # correlated, so it resolves per row of the update: every request advances to its own newest
+        # message without listing them out
+        latest_message_id = (
+            select(func.max(Message.id)).where(Message.conversation_id == HostRequest.conversation_id).scalar_subquery()
+        )
         marked_conversation_ids: list[int] = []
         for user_id_column, last_seen_column in (
             (HostRequest.initiator_user_id, HostRequest.initiator_last_seen_message_id),

--- a/app/backend/src/couchers/servicers/message_threads.py
+++ b/app/backend/src/couchers/servicers/message_threads.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 
 import grpc
 from google.protobuf import empty_pb2
-from sqlalchemy import ColumnElement, Row, Select, select, union_all, update
+from sqlalchemy import ColumnElement, Row, Select, exists, select, union_all, update
 from sqlalchemy.dialects.postgresql import aggregate_order_by
 from sqlalchemy.orm import Session, aliased
 from sqlalchemy.sql import and_, case, func, literal, or_
@@ -38,6 +38,8 @@ from couchers.models import (
     GroupChatRole,
     GroupChatSubscription,
     HostRequest,
+    HostRequestFeedback,
+    HostRequestStatus,
     Message,
 )
 from couchers.models.notifications import NotificationTopicAction
@@ -188,36 +190,19 @@ def _build_host_request_role_filter(user_id: int, categories: frozenset[int]) ->
     return or_(*clauses) if clauses else None
 
 
-def _member_visible_to_viewer(member: type[GroupChatSubscription]) -> ColumnElement[bool]:
-    """
-    Whether `member` is visible to the viewer, whose own subscription is the unaliased
-    GroupChatSubscription of the enclosing query. Same rule as
-    _get_visible_members_for_subscription / _get_visible_admins_for_subscription in the conversations
-    servicer: a viewer still in the chat sees everyone currently in it, and one who has left sees the
-    roster frozen at the moment they left.
-    """
-    return case(
-        (GroupChatSubscription.left.is_(None), member.left.is_(None)),
-        # the else_ branch only runs where left is non-NULL, which the annotation can't express
-        else_=was_subscribed_at(member, GroupChatSubscription.left),  # type: ignore[arg-type]
-    )
-
-
 def _host_request_thread_to_pb(
     host_request: HostRequest,
     conversation: Conversation,
     message: Message,
     user_id: int,
     unseen_message_count: int,
+    need_host_request_feedback: bool,
 ) -> requests_pb2.HostRequest:
     """
     Build the HostRequest protobuf for the unified thread list. Mirrors ListHostRequests (batched, so
     no per-request queries like host_request_to_pb), with the same semantics: surfer = initiator,
     host = recipient, even for public-trip offers.
     """
-    # need_host_request_feedback is omitted: only the detail view (GetHostRequest) reads it.
-    # TODO(#9347): its recipient-based logic is wrong for public-trip offers, where the recipient is
-    # the traveller rather than the host — same for the response-rate observation.
     lat, lng = get_coordinates(host_request.hosting_location)
     return requests_pb2.HostRequest(
         host_request_id=host_request.conversation_id,
@@ -237,6 +222,7 @@ def _host_request_thread_to_pb(
         hosting_lat=lat,
         hosting_lng=lng,
         hosting_radius=host_request.hosting_radius,
+        need_host_request_feedback=need_host_request_feedback,
         is_archived=(
             host_request.is_initiator_archived
             if host_request.initiator_user_id == user_id
@@ -277,6 +263,14 @@ def _build_group_chats_pb(
     # known) and its visible roster, in one query
     member = aliased(GroupChatSubscription)
     member_user_ids = func.array_agg(aggregate_order_by(member.user_id, member.user_id))
+    # same roster rule as _get_visible_members_for_subscription / _get_visible_admins_for_subscription
+    # in the conversations servicer: a viewer still in the chat sees everyone currently in it, and one
+    # who has left sees the roster frozen at the moment they left
+    member_visible = case(
+        (GroupChatSubscription.left.is_(None), member.left.is_(None)),
+        # the else_ branch only runs where left is non-NULL, which the annotation can't express
+        else_=was_subscribed_at(member, GroupChatSubscription.left),  # type: ignore[arg-type]
+    )
     rows = session.execute(
         select(
             GroupChat,
@@ -289,7 +283,7 @@ def _build_group_chats_pb(
         .join(Conversation, Conversation.id == GroupChat.conversation_id)
         .join(GroupChatSubscription, GroupChatSubscription.group_chat_id == GroupChat.conversation_id)
         .join(Message, and_(Message.conversation_id == GroupChat.conversation_id, Message.id.in_(latest_message_ids)))
-        .join(member, and_(member.group_chat_id == GroupChat.conversation_id, _member_visible_to_viewer(member)))
+        .join(member, and_(member.group_chat_id == GroupChat.conversation_id, member_visible))
         .where(GroupChat.conversation_id.in_(group_chat_ids))
         .where(GroupChatSubscription.user_id == context.user_id)
         .where(is_newest_subscription(context.user_id))
@@ -326,14 +320,28 @@ def _build_host_request_threads_pb(
     host_request_ids = [thread.conversation_id for thread in threads]
     latest_message_ids = [thread.latest_message_id for thread in threads]
 
-    # the request, its conversation, its latest message (id already known) and its unseen count, in
-    # one query
+    # same rule as host_request_to_pb: the host is asked for feedback once they've rejected a request
+    # and haven't given any yet.
+    # TODO(#9347): the recipient-based logic is wrong for public-trip offers, where the recipient is
+    # the traveller rather than the host — same for the response-rate observation.
+    need_host_request_feedback = and_(
+        HostRequest.recipient_user_id == context.user_id,
+        HostRequest.status == HostRequestStatus.rejected,
+        ~exists()
+        .where(HostRequestFeedback.from_user_id == context.user_id)
+        .where(HostRequestFeedback.host_request_id == HostRequest.conversation_id)
+        .correlate(HostRequest),
+    )
+
+    # the request, its conversation, its latest message (id already known), its unseen count and
+    # whether it's owed feedback, in one query
     rows = session.execute(
         select(
             HostRequest,
             Conversation,
             Message,
             unseen_host_request_message_count(context.user_id),
+            need_host_request_feedback,
         )
         .join(Conversation, Conversation.id == HostRequest.conversation_id)
         .join(Message, and_(Message.conversation_id == HostRequest.conversation_id, Message.id.in_(latest_message_ids)))
@@ -341,9 +349,9 @@ def _build_host_request_threads_pb(
     ).all()
     return {
         host_request.conversation_id: _host_request_thread_to_pb(
-            host_request, conversation, message, context.user_id, unseen_message_count
+            host_request, conversation, message, context.user_id, unseen_message_count, needs_feedback
         )
-        for host_request, conversation, message, unseen_message_count in rows
+        for host_request, conversation, message, unseen_message_count, needs_feedback in rows
     }
 
 

--- a/app/backend/src/couchers/servicers/message_threads.py
+++ b/app/backend/src/couchers/servicers/message_threads.py
@@ -12,13 +12,13 @@ protobufs, batched per kind. MarkAllThreadsSeen consumes the same queries as UPD
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import datetime
 
 import grpc
 from google.protobuf import empty_pb2
-from sqlalchemy import ColumnElement, Select, select, union_all, update
-from sqlalchemy.orm import Session, contains_eager
-from sqlalchemy.sql import and_, func, literal, or_
+from sqlalchemy import ColumnElement, Row, Select, select, union_all, update
+from sqlalchemy.dialects.postgresql import aggregate_order_by
+from sqlalchemy.orm import Session, aliased
+from sqlalchemy.sql import and_, case, func, literal, or_
 
 from couchers.context import CouchersContext
 from couchers.crypto import decrypt_page_token, encrypt_page_token
@@ -54,6 +54,9 @@ MAX_PAGE_SIZE = 50
 # discriminator on the unioned rows, telling us which table a conversation_id came from
 _KIND_GROUP_CHAT = "group_chat"
 _KIND_HOST_REQUEST = "host_request"
+
+# one thread as the select queries yield it: (conversation_id, latest_message_id, kind)
+_ThreadRow = Row[tuple[int, int, str]]
 
 
 @dataclass(frozen=True)
@@ -192,25 +195,25 @@ def _build_host_request_role_filter(user_id: int, categories: frozenset[int]) ->
     return or_(*clauses) if clauses else None
 
 
-def _member_visible_to_viewer(subscription: GroupChatSubscription, viewer_left: datetime | None) -> bool:
+def _member_visible_to_viewer(member: type[GroupChatSubscription]) -> ColumnElement[bool]:
     """
-    Whether `subscription`'s user is visible to a viewer whose own subscription left the chat at
-    `viewer_left` (None if the viewer is still in the chat). Same rule as
+    Whether `member` is visible to the viewer, whose own subscription is the unaliased
+    GroupChatSubscription of the enclosing query. Same rule as
     _get_visible_members_for_subscription / _get_visible_admins_for_subscription in the conversations
-    servicer, expressed as a pure predicate so a list of preloaded subscriptions can be filtered
-    without a per-chat query.
+    servicer: a viewer still in the chat sees everyone currently in it, and one who has left sees the
+    roster frozen at the moment they left.
     """
-    if viewer_left is None:
-        # still in the chat: see everyone with a current subscription
-        return subscription.left is None
-    # left the chat: see everyone who was in it at the moment the viewer left
-    return subscription.joined <= viewer_left and (subscription.left is None or subscription.left >= viewer_left)
+    return case(
+        (GroupChatSubscription.left.is_(None), member.left.is_(None)),
+        # the else_ branch only runs where left is non-NULL, which the annotation can't express
+        else_=was_subscribed_at(member, GroupChatSubscription.left),  # type: ignore[arg-type]
+    )
 
 
 def _host_request_thread_to_pb(
     host_request: HostRequest,
     conversation: Conversation,
-    message: Message | None,
+    message: Message,
     user_id: int,
     unseen_message_count: int,
 ) -> requests_pb2.HostRequest:
@@ -236,7 +239,7 @@ def _host_request_thread_to_pb(
             if host_request.initiator_user_id == user_id
             else host_request.recipient_last_seen_message_id
         ),
-        latest_message=message_to_pb(message) if message else None,
+        latest_message=message_to_pb(message),
         hosting_city=host_request.hosting_city,
         hosting_lat=lat,
         hosting_lng=lng,
@@ -252,119 +255,91 @@ def _host_request_thread_to_pb(
 
 
 def _build_group_chats_pb(
-    session: Session,
-    context: CouchersContext,
-    group_chat_ids: list[int],
-    latest_message_id_by_conversation: dict[int, int],
+    session: Session, context: CouchersContext, threads: Sequence[_ThreadRow]
 ) -> dict[int, conversations_pb2.GroupChat]:
     """
-    Build GroupChat protobufs (with unseen counts) for a page of group-chat ids.
+    Build GroupChat protobufs (with unseen counts) for the group chats on a page.
 
-    Latest-message ids come from the caller's paging pass, so they're reused rather than recomputed
-    here (mirrors _build_host_request_threads_pb).
+    Each row already carries the id of the chat's latest message, windowed to the viewer's
+    subscription, so that rule doesn't have to be restated here.
     """
-    if not group_chat_ids:
+    if not threads:
         return {}
+    group_chat_ids = [thread.conversation_id for thread in threads]
+    latest_message_ids = [thread.latest_message_id for thread in threads]
 
-    # all subscriptions for the page's chats in one query: members/admins are computed in Python
-    # (instead of two lazy queries per chat), and it also gives us the viewer's own subscription
-    # without a group-wise-max subquery
-    subscriptions_by_group_chat: dict[int, list[GroupChatSubscription]] = {}
-    for subscription in (
-        session.execute(
-            select(GroupChatSubscription)
-            .where(GroupChatSubscription.group_chat_id.in_(group_chat_ids))
-            .order_by(GroupChatSubscription.id)
-        )
-        .scalars()
-        .all()
-    ):
-        subscriptions_by_group_chat.setdefault(subscription.group_chat_id, []).append(subscription)
-
-    # the viewer's current subscription per chat = their highest-id subscription (handles rejoin)
-    viewer_subscription_by_group_chat: dict[int, GroupChatSubscription] = {}
-    for group_chat_id, subscriptions in subscriptions_by_group_chat.items():
-        viewer_subscriptions = [s for s in subscriptions if s.user_id == context.user_id]
-        if viewer_subscriptions:
-            viewer_subscription_by_group_chat[group_chat_id] = viewer_subscriptions[-1]
-
-    # the group chat + its latest message (id already known) + conversation, in one query
-    latest_message_ids = [latest_message_id_by_conversation[group_chat_id] for group_chat_id in group_chat_ids]
-    row_by_group_chat = {
-        row.GroupChat.conversation_id: row
-        for row in session.execute(
-            select(GroupChat, Message)
-            .join(Message, Message.conversation_id == GroupChat.conversation_id)
-            .join(Conversation, Conversation.id == GroupChat.conversation_id)
-            .where(GroupChat.conversation_id.in_(group_chat_ids))
-            .where(Message.id.in_(latest_message_ids))
-            .options(contains_eager(GroupChat.conversation))
-        ).all()
-    }
-
-    viewer_subscription_ids = [subscription.id for subscription in viewer_subscription_by_group_chat.values()]
-    unseen_count_by_subscription: dict[int, int] = dict(
+    unseen_count_by_group_chat: dict[int, int] = dict(
         session.execute(  # type: ignore[arg-type]
-            select(GroupChatSubscription.id, func.count(Message.id))
+            select(GroupChatSubscription.group_chat_id, func.count(Message.id))
             .join(Message, Message.conversation_id == GroupChatSubscription.group_chat_id)
-            .where(GroupChatSubscription.id.in_(viewer_subscription_ids))
+            .where(GroupChatSubscription.group_chat_id.in_(group_chat_ids))
+            .where(GroupChatSubscription.user_id == context.user_id)
+            .where(is_newest_subscription(context.user_id))
             .where(is_unseen(Message, GroupChatSubscription))
-            .group_by(GroupChatSubscription.id)
+            .group_by(GroupChatSubscription.group_chat_id)
         ).all()
     )
 
-    result: dict[int, conversations_pb2.GroupChat] = {}
-    for group_chat_id in group_chat_ids:
-        row = row_by_group_chat.get(group_chat_id)
-        viewer_subscription = viewer_subscription_by_group_chat.get(group_chat_id)
-        if row is None or viewer_subscription is None:
-            continue
-        group_chat = row.GroupChat
-        visible_members = [
-            subscription
-            for subscription in subscriptions_by_group_chat.get(group_chat_id, [])
-            if _member_visible_to_viewer(subscription, viewer_subscription.left)
-        ]
-        result[group_chat_id] = conversations_pb2.GroupChat(
-            group_chat_id=group_chat_id,
+    # the chat, its conversation, the viewer's own subscription, its latest message (id already
+    # known) and its visible roster, in one query
+    member = aliased(GroupChatSubscription)
+    member_user_ids = func.array_agg(aggregate_order_by(member.user_id, member.user_id))
+    rows = session.execute(
+        select(
+            GroupChat,
+            Conversation,
+            GroupChatSubscription,
+            Message,
+            member_user_ids,
+            member_user_ids.filter(member.role == GroupChatRole.admin),
+        )
+        .join(Conversation, Conversation.id == GroupChat.conversation_id)
+        .join(GroupChatSubscription, GroupChatSubscription.group_chat_id == GroupChat.conversation_id)
+        .join(Message, and_(Message.conversation_id == GroupChat.conversation_id, Message.id.in_(latest_message_ids)))
+        .join(member, and_(member.group_chat_id == GroupChat.conversation_id, _member_visible_to_viewer(member)))
+        .where(GroupChat.conversation_id.in_(group_chat_ids))
+        .where(GroupChatSubscription.user_id == context.user_id)
+        .where(is_newest_subscription(context.user_id))
+        .group_by(GroupChat.conversation_id, Conversation.id, GroupChatSubscription.id, Message.id)
+    ).all()
+
+    return {
+        group_chat.conversation_id: conversations_pb2.GroupChat(
+            group_chat_id=group_chat.conversation_id,
             title=group_chat.title,  # TODO: proper title for DMs, etc
-            member_user_ids=[subscription.user_id for subscription in visible_members],
-            admin_user_ids=[
-                subscription.user_id for subscription in visible_members if subscription.role == GroupChatRole.admin
-            ],
+            member_user_ids=members,
+            # array_agg over an empty filter is NULL rather than an empty array
+            admin_user_ids=admins or [],
             only_admins_invite=group_chat.only_admins_invite,
             is_dm=group_chat.is_dm,
-            created=Timestamp_from_datetime(group_chat.conversation.created),
-            unseen_message_count=unseen_count_by_subscription.get(viewer_subscription.id, 0),
-            last_seen_message_id=viewer_subscription.last_seen_message_id,
-            latest_message=message_to_pb(row.Message) if row.Message else None,
-            mute_info=mute_info(viewer_subscription),
+            created=Timestamp_from_datetime(conversation.created),
+            unseen_message_count=unseen_count_by_group_chat.get(group_chat.conversation_id, 0),
+            last_seen_message_id=subscription.last_seen_message_id,
+            latest_message=message_to_pb(message),
+            mute_info=mute_info(subscription),
             # can_message omitted: list view doesn't use it, and it's a DM-only extra query
-            is_archived=viewer_subscription.is_archived,
+            is_archived=subscription.is_archived,
         )
-    return result
+        for group_chat, conversation, subscription, message, members, admins in rows
+    }
 
 
 def _build_host_request_threads_pb(
-    session: Session,
-    context: CouchersContext,
-    host_request_ids: list[int],
-    latest_message_id_by_conversation: dict[int, int],
+    session: Session, context: CouchersContext, threads: Sequence[_ThreadRow]
 ) -> dict[int, requests_pb2.HostRequest]:
-    """Build HostRequest protobufs (with unseen counts) for a page of host-request threads."""
-    if not host_request_ids:
+    """Build HostRequest protobufs (with unseen counts) for the host requests on a page."""
+    if not threads:
         return {}
+    host_request_ids = [thread.conversation_id for thread in threads]
+    latest_message_ids = [thread.latest_message_id for thread in threads]
+
+    # the request + its latest message (id already known) + conversation, in one query
     host_request_rows = session.execute(
-        select(HostRequest, Conversation)
+        select(HostRequest, Conversation, Message)
         .join(Conversation, Conversation.id == HostRequest.conversation_id)
+        .join(Message, and_(Message.conversation_id == HostRequest.conversation_id, Message.id.in_(latest_message_ids)))
         .where(HostRequest.conversation_id.in_(host_request_ids))
     ).all()
-
-    latest_message_ids = [latest_message_id_by_conversation[conversation_id] for conversation_id in host_request_ids]
-    message_by_id = {
-        message.id: message
-        for message in session.execute(select(Message).where(Message.id.in_(latest_message_ids))).scalars().all()
-    }
 
     unseen_count_by_conversation: dict[int, int] = dict(
         session.execute(  # type: ignore[arg-type]
@@ -379,7 +354,7 @@ def _build_host_request_threads_pb(
         row.HostRequest.conversation_id: _host_request_thread_to_pb(
             row.HostRequest,
             row.Conversation,
-            message_by_id.get(latest_message_id_by_conversation[row.HostRequest.conversation_id]),
+            row.Message,
             context.user_id,
             unseen_count_by_conversation.get(row.HostRequest.conversation_id, 0),
         )
@@ -421,14 +396,12 @@ def list_message_threads(
     # rows are ordered by latest_message_id desc, so the last one on the page is the cursor
     next_page_token = encrypt_page_token(str(page_rows[-1].latest_message_id)) if has_more else ""
 
-    latest_message_id_by_conversation = {row.conversation_id: row.latest_message_id for row in page_rows}
-    group_chat_ids = [row.conversation_id for row in page_rows if row.kind == _KIND_GROUP_CHAT]
-    host_request_ids = [row.conversation_id for row in page_rows if row.kind == _KIND_HOST_REQUEST]
-
     # hydrate each kind in a batch, then re-assemble in the paginated order
-    group_chats_by_id = _build_group_chats_pb(session, context, group_chat_ids, latest_message_id_by_conversation)
+    group_chats_by_id = _build_group_chats_pb(
+        session, context, [row for row in page_rows if row.kind == _KIND_GROUP_CHAT]
+    )
     host_request_threads_by_id = _build_host_request_threads_pb(
-        session, context, host_request_ids, latest_message_id_by_conversation
+        session, context, [row for row in page_rows if row.kind == _KIND_HOST_REQUEST]
     )
 
     message_threads = []

--- a/app/backend/src/couchers/servicers/message_threads.py
+++ b/app/backend/src/couchers/servicers/message_threads.py
@@ -29,7 +29,7 @@ from couchers.helpers.host_requests import (
     is_hosting_party,
     is_public_trip_offer_recipient,
     is_surfing_party,
-    viewer_last_seen_message_id,
+    unseen_host_request_message_count,
 )
 from couchers.helpers.messages import hostrequeststatus2api, message_to_pb
 from couchers.models import (
@@ -333,32 +333,24 @@ def _build_host_request_threads_pb(
     host_request_ids = [thread.conversation_id for thread in threads]
     latest_message_ids = [thread.latest_message_id for thread in threads]
 
-    # the request + its latest message (id already known) + conversation, in one query
-    host_request_rows = session.execute(
-        select(HostRequest, Conversation, Message)
+    # the request, its conversation, its latest message (id already known) and its unseen count, in
+    # one query
+    rows = session.execute(
+        select(
+            HostRequest,
+            Conversation,
+            Message,
+            unseen_host_request_message_count(context.user_id),
+        )
         .join(Conversation, Conversation.id == HostRequest.conversation_id)
         .join(Message, and_(Message.conversation_id == HostRequest.conversation_id, Message.id.in_(latest_message_ids)))
         .where(HostRequest.conversation_id.in_(host_request_ids))
     ).all()
-
-    unseen_count_by_conversation: dict[int, int] = dict(
-        session.execute(  # type: ignore[arg-type]
-            select(HostRequest.conversation_id, func.count(Message.id))
-            .join(Message, Message.conversation_id == HostRequest.conversation_id)
-            .where(HostRequest.conversation_id.in_(host_request_ids))
-            .where(Message.id > viewer_last_seen_message_id(context.user_id))
-            .group_by(HostRequest.conversation_id)
-        ).all()
-    )
     return {
-        row.HostRequest.conversation_id: _host_request_thread_to_pb(
-            row.HostRequest,
-            row.Conversation,
-            row.Message,
-            context.user_id,
-            unseen_count_by_conversation.get(row.HostRequest.conversation_id, 0),
+        host_request.conversation_id: _host_request_thread_to_pb(
+            host_request, conversation, message, context.user_id, unseen_message_count
         )
-        for row in host_request_rows
+        for host_request, conversation, message, unseen_message_count in rows
     }
 
 

--- a/app/backend/src/couchers/servicers/message_threads.py
+++ b/app/backend/src/couchers/servicers/message_threads.py
@@ -260,7 +260,7 @@ def _build_group_chats_pb(
     )
 
     # the chat, its conversation, the viewer's own subscription, its latest message (id already
-    # known) and its visible roster, in one query
+    # known), its visible roster and whether the viewer can message it, in one query
     member = aliased(GroupChatSubscription)
     member_user_ids = func.array_agg(aggregate_order_by(member.user_id, member.user_id))
     # same roster rule as _get_visible_members_for_subscription / _get_visible_admins_for_subscription
@@ -271,6 +271,23 @@ def _build_group_chats_pb(
         # the else_ branch only runs where left is non-NULL, which the annotation can't express
         else_=was_subscribed_at(member, GroupChatSubscription.left),  # type: ignore[arg-type]
     )
+    # same rule as _user_can_message in the conversations servicer: a true group chat can always be
+    # messaged, a DM only while the other party is still in it and visible to the viewer
+    other_party = aliased(GroupChatSubscription)
+    can_message = or_(
+        ~GroupChat.is_dm,
+        where_users_column_visible(
+            select(1)
+            .select_from(other_party)
+            .where(other_party.group_chat_id == GroupChat.conversation_id)
+            .where(other_party.user_id != context.user_id)
+            .where(other_party.left.is_(None)),
+            context,
+            other_party.user_id,
+        )
+        .exists()
+        .correlate(GroupChat),
+    )
     rows = session.execute(
         select(
             GroupChat,
@@ -279,6 +296,7 @@ def _build_group_chats_pb(
             Message,
             member_user_ids,
             member_user_ids.filter(member.role == GroupChatRole.admin),
+            can_message,
         )
         .join(Conversation, Conversation.id == GroupChat.conversation_id)
         .join(GroupChatSubscription, GroupChatSubscription.group_chat_id == GroupChat.conversation_id)
@@ -304,10 +322,10 @@ def _build_group_chats_pb(
             last_seen_message_id=subscription.last_seen_message_id,
             latest_message=message_to_pb(message),
             mute_info=mute_info(subscription),
-            # can_message omitted: list view doesn't use it, and it's a DM-only extra query
+            can_message=can_message,
             is_archived=subscription.is_archived,
         )
-        for group_chat, conversation, subscription, message, members, admins in rows
+        for group_chat, conversation, subscription, message, members, admins, can_message in rows
     }
 
 

--- a/app/backend/src/couchers/servicers/message_threads.py
+++ b/app/backend/src/couchers/servicers/message_threads.py
@@ -200,14 +200,15 @@ def _host_request_thread_to_pb(
 ) -> requests_pb2.HostRequest:
     """
     Build the HostRequest protobuf for the unified thread list. Mirrors ListHostRequests (batched, so
-    no per-request queries like host_request_to_pb), with the same semantics: surfer = initiator,
-    host = recipient, even for public-trip offers.
+    no per-request queries like host_request_to_pb), with the same semantics: surfer/host are the
+    stay roles, which a public-trip offer reverses, while last_seen and archived key off the
+    conversation roles.
     """
     lat, lng = get_coordinates(host_request.hosting_location)
     return requests_pb2.HostRequest(
         host_request_id=host_request.conversation_id,
-        surfer_user_id=host_request.initiator_user_id,
-        host_user_id=host_request.recipient_user_id,
+        surfer_user_id=host_request.surfer_user_id,
+        host_user_id=host_request.host_user_id,
         status=hostrequeststatus2api[host_request.status],
         created=Timestamp_from_datetime(conversation.created),
         from_date=date_to_api(host_request.from_date),

--- a/app/backend/src/couchers/servicers/message_threads.py
+++ b/app/backend/src/couchers/servicers/message_threads.py
@@ -1,39 +1,59 @@
 """
-Bulk operations over the viewer's message threads — group chats, DMs, host requests and public-trip
-offers — selected by category (Conversations.MarkAllThreadsSeen).
+The unified message thread list (Conversations.ListMessageThreads / MarkAllThreadsSeen): one
+paginated list of all the viewer's conversations — group chats, DMs, host requests and public-trip
+offers — ordered by latest message.
+
+Each kind of conversation has its own select query, yielding one row per thread carrying only
+(conversation_id, latest_message_id, kind). ListMessageThreads unions them, so a single cursor on
+latest_message_id pages through all kinds as one list, then hydrates the page's worth of rows into
+protobufs, batched per kind. MarkAllThreadsSeen consumes the same queries as UPDATE targets.
 """
 
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import datetime
 
 import grpc
 from google.protobuf import empty_pb2
-from sqlalchemy import ColumnElement, Select, select, update
-from sqlalchemy.orm import Session
-from sqlalchemy.sql import and_, func, or_
+from sqlalchemy import ColumnElement, Select, select, union_all, update
+from sqlalchemy.orm import Session, contains_eager
+from sqlalchemy.sql import and_, func, literal, or_
 
 from couchers.context import CouchersContext
-from couchers.helpers.group_chats import is_newest_subscription, is_unseen, was_subscribed_at
+from couchers.crypto import decrypt_page_token, encrypt_page_token
+from couchers.helpers.group_chats import is_newest_subscription, is_unseen, mute_info, was_subscribed_at
 from couchers.helpers.host_requests import (
     HOST_REQUEST_NOTIFICATION_TOPIC_ACTIONS,
     has_unseen_host_request_messages,
     is_hosting_party,
     is_public_trip_offer_recipient,
     is_surfing_party,
+    viewer_last_seen_message_id,
 )
+from couchers.helpers.messages import hostrequeststatus2api, message_to_pb
 from couchers.models import (
+    Conversation,
     GroupChat,
+    GroupChatRole,
     GroupChatSubscription,
     HostRequest,
     Message,
 )
 from couchers.models.notifications import NotificationTopicAction
 from couchers.notifications.notify import mark_notifications_seen
-from couchers.proto import conversations_pb2
+from couchers.proto import conversations_pb2, requests_pb2
 from couchers.sql import to_bool, where_moderated_content_visible, where_users_column_visible
+from couchers.utils import Timestamp_from_datetime, date_to_api, get_coordinates
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_PAGINATION_LENGTH = 20
+MAX_PAGE_SIZE = 50
+
+# discriminator on the unioned rows, telling us which table a conversation_id came from
+_KIND_GROUP_CHAT = "group_chat"
+_KIND_HOST_REQUEST = "host_request"
 
 
 @dataclass(frozen=True)
@@ -44,7 +64,8 @@ class _ThreadFilters:
 
 
 def _resolve_thread_filters(
-    context: CouchersContext, request: conversations_pb2.MarkAllThreadsSeenReq
+    context: CouchersContext,
+    request: conversations_pb2.ListMessageThreadsReq | conversations_pb2.MarkAllThreadsSeenReq,
 ) -> _ThreadFilters:
     """
     An empty category list means all categories. MY_PUBLIC_TRIPS is dropped when the public-trips
@@ -70,15 +91,29 @@ def _resolve_thread_filters(
     )
 
 
+def _latest_host_request_message_id() -> ColumnElement[int]:
+    """
+    The newest message on a request. Correlated, so it resolves per row of the enclosing query, and
+    never NULL, because creating a request writes its first message.
+    """
+    return select(func.max(Message.id)).where(Message.conversation_id == HostRequest.conversation_id).scalar_subquery()
+
+
 def _build_group_chat_select_query(
     context: CouchersContext, only_archived: bool | None, unread: bool
-) -> Select[tuple[int]]:
+) -> Select[tuple[int, int, str]]:
     """
-    The ids of the group chats (including DMs) the viewer should see, narrowed by the request's
-    archived and unread filters.
+    The group chats (including DMs) the viewer should see, narrowed by the request's archived and
+    unread filters, along with the id of the newest message each one shows them.
+
+    The message join is windowed to the viewer's subscription, so a chat they were removed from ends
+    at the last message they could read rather than at the chat's newest.
     """
-    return where_moderated_content_visible(
-        select(GroupChatSubscription.group_chat_id.label("conversation_id"))
+    group_chats = where_moderated_content_visible(
+        select(
+            GroupChatSubscription.group_chat_id.label("conversation_id"),
+            func.max(Message.id).label("latest_message_id"),
+        )
         .join(Message, Message.conversation_id == GroupChatSubscription.group_chat_id)
         .join(GroupChat, GroupChat.conversation_id == GroupChatSubscription.group_chat_id)
         .where(GroupChatSubscription.user_id == context.user_id)
@@ -90,21 +125,30 @@ def _build_group_chat_select_query(
         context,
         GroupChat,
         is_list_operation=True,
+    ).subquery()
+    return select(
+        group_chats.c.conversation_id,
+        group_chats.c.latest_message_id,
+        literal(_KIND_GROUP_CHAT).label("kind"),
     )
 
 
 def _build_host_request_select_query(
     context: CouchersContext, role_filter: ColumnElement[bool], only_archived: bool | None, unread: bool
-) -> Select[tuple[int]]:
+) -> Select[tuple[int, int, str]]:
     """
-    The ids of the host requests and public-trip offers the viewer should see, narrowed by the
-    request's archived and unread filters.
+    The host requests and public-trip offers the viewer should see, narrowed by the request's
+    archived and unread filters, along with the id of each one's newest message.
 
     role_filter picks which side of the request the viewer is on: hosting, surfing, or offers on
     their own public trips.
     """
     query = (
-        select(HostRequest.conversation_id.label("conversation_id"))
+        select(
+            HostRequest.conversation_id.label("conversation_id"),
+            _latest_host_request_message_id().label("latest_message_id"),
+            literal(_KIND_HOST_REQUEST).label("kind"),
+        )
         .where(
             or_(
                 HostRequest.initiator_user_id == context.user_id,
@@ -148,6 +192,259 @@ def _build_host_request_role_filter(user_id: int, categories: frozenset[int]) ->
     return or_(*clauses) if clauses else None
 
 
+def _member_visible_to_viewer(subscription: GroupChatSubscription, viewer_left: datetime | None) -> bool:
+    """
+    Whether `subscription`'s user is visible to a viewer whose own subscription left the chat at
+    `viewer_left` (None if the viewer is still in the chat). Same rule as
+    _get_visible_members_for_subscription / _get_visible_admins_for_subscription in the conversations
+    servicer, expressed as a pure predicate so a list of preloaded subscriptions can be filtered
+    without a per-chat query.
+    """
+    if viewer_left is None:
+        # still in the chat: see everyone with a current subscription
+        return subscription.left is None
+    # left the chat: see everyone who was in it at the moment the viewer left
+    return subscription.joined <= viewer_left and (subscription.left is None or subscription.left >= viewer_left)
+
+
+def _host_request_thread_to_pb(
+    host_request: HostRequest,
+    conversation: Conversation,
+    message: Message | None,
+    user_id: int,
+    unseen_message_count: int,
+) -> requests_pb2.HostRequest:
+    """
+    Build the HostRequest protobuf for the unified thread list. Mirrors ListHostRequests (batched, so
+    no per-request queries like host_request_to_pb), with the same semantics: surfer = initiator,
+    host = recipient, even for public-trip offers.
+    """
+    # need_host_request_feedback is omitted: only the detail view (GetHostRequest) reads it.
+    # TODO(#9347): its recipient-based logic is wrong for public-trip offers, where the recipient is
+    # the traveller rather than the host — same for the response-rate observation.
+    lat, lng = get_coordinates(host_request.hosting_location)
+    return requests_pb2.HostRequest(
+        host_request_id=host_request.conversation_id,
+        surfer_user_id=host_request.initiator_user_id,
+        host_user_id=host_request.recipient_user_id,
+        status=hostrequeststatus2api[host_request.status],
+        created=Timestamp_from_datetime(conversation.created),
+        from_date=date_to_api(host_request.from_date),
+        to_date=date_to_api(host_request.to_date),
+        last_seen_message_id=(
+            host_request.initiator_last_seen_message_id
+            if host_request.initiator_user_id == user_id
+            else host_request.recipient_last_seen_message_id
+        ),
+        latest_message=message_to_pb(message) if message else None,
+        hosting_city=host_request.hosting_city,
+        hosting_lat=lat,
+        hosting_lng=lng,
+        hosting_radius=host_request.hosting_radius,
+        is_archived=(
+            host_request.is_initiator_archived
+            if host_request.initiator_user_id == user_id
+            else host_request.is_recipient_archived
+        ),
+        public_trip_id=host_request.public_trip_id,
+        unseen_message_count=unseen_message_count,
+    )
+
+
+def _build_group_chats_pb(
+    session: Session,
+    context: CouchersContext,
+    group_chat_ids: list[int],
+    latest_message_id_by_conversation: dict[int, int],
+) -> dict[int, conversations_pb2.GroupChat]:
+    """
+    Build GroupChat protobufs (with unseen counts) for a page of group-chat ids.
+
+    Latest-message ids come from the caller's paging pass, so they're reused rather than recomputed
+    here (mirrors _build_host_request_threads_pb).
+    """
+    if not group_chat_ids:
+        return {}
+
+    # all subscriptions for the page's chats in one query: members/admins are computed in Python
+    # (instead of two lazy queries per chat), and it also gives us the viewer's own subscription
+    # without a group-wise-max subquery
+    subscriptions_by_group_chat: dict[int, list[GroupChatSubscription]] = {}
+    for subscription in (
+        session.execute(
+            select(GroupChatSubscription)
+            .where(GroupChatSubscription.group_chat_id.in_(group_chat_ids))
+            .order_by(GroupChatSubscription.id)
+        )
+        .scalars()
+        .all()
+    ):
+        subscriptions_by_group_chat.setdefault(subscription.group_chat_id, []).append(subscription)
+
+    # the viewer's current subscription per chat = their highest-id subscription (handles rejoin)
+    viewer_subscription_by_group_chat: dict[int, GroupChatSubscription] = {}
+    for group_chat_id, subscriptions in subscriptions_by_group_chat.items():
+        viewer_subscriptions = [s for s in subscriptions if s.user_id == context.user_id]
+        if viewer_subscriptions:
+            viewer_subscription_by_group_chat[group_chat_id] = viewer_subscriptions[-1]
+
+    # the group chat + its latest message (id already known) + conversation, in one query
+    latest_message_ids = [latest_message_id_by_conversation[group_chat_id] for group_chat_id in group_chat_ids]
+    row_by_group_chat = {
+        row.GroupChat.conversation_id: row
+        for row in session.execute(
+            select(GroupChat, Message)
+            .join(Message, Message.conversation_id == GroupChat.conversation_id)
+            .join(Conversation, Conversation.id == GroupChat.conversation_id)
+            .where(GroupChat.conversation_id.in_(group_chat_ids))
+            .where(Message.id.in_(latest_message_ids))
+            .options(contains_eager(GroupChat.conversation))
+        ).all()
+    }
+
+    viewer_subscription_ids = [subscription.id for subscription in viewer_subscription_by_group_chat.values()]
+    unseen_count_by_subscription: dict[int, int] = dict(
+        session.execute(  # type: ignore[arg-type]
+            select(GroupChatSubscription.id, func.count(Message.id))
+            .join(Message, Message.conversation_id == GroupChatSubscription.group_chat_id)
+            .where(GroupChatSubscription.id.in_(viewer_subscription_ids))
+            .where(is_unseen(Message, GroupChatSubscription))
+            .group_by(GroupChatSubscription.id)
+        ).all()
+    )
+
+    result: dict[int, conversations_pb2.GroupChat] = {}
+    for group_chat_id in group_chat_ids:
+        row = row_by_group_chat.get(group_chat_id)
+        viewer_subscription = viewer_subscription_by_group_chat.get(group_chat_id)
+        if row is None or viewer_subscription is None:
+            continue
+        group_chat = row.GroupChat
+        visible_members = [
+            subscription
+            for subscription in subscriptions_by_group_chat.get(group_chat_id, [])
+            if _member_visible_to_viewer(subscription, viewer_subscription.left)
+        ]
+        result[group_chat_id] = conversations_pb2.GroupChat(
+            group_chat_id=group_chat_id,
+            title=group_chat.title,  # TODO: proper title for DMs, etc
+            member_user_ids=[subscription.user_id for subscription in visible_members],
+            admin_user_ids=[
+                subscription.user_id for subscription in visible_members if subscription.role == GroupChatRole.admin
+            ],
+            only_admins_invite=group_chat.only_admins_invite,
+            is_dm=group_chat.is_dm,
+            created=Timestamp_from_datetime(group_chat.conversation.created),
+            unseen_message_count=unseen_count_by_subscription.get(viewer_subscription.id, 0),
+            last_seen_message_id=viewer_subscription.last_seen_message_id,
+            latest_message=message_to_pb(row.Message) if row.Message else None,
+            mute_info=mute_info(viewer_subscription),
+            # can_message omitted: list view doesn't use it, and it's a DM-only extra query
+            is_archived=viewer_subscription.is_archived,
+        )
+    return result
+
+
+def _build_host_request_threads_pb(
+    session: Session,
+    context: CouchersContext,
+    host_request_ids: list[int],
+    latest_message_id_by_conversation: dict[int, int],
+) -> dict[int, requests_pb2.HostRequest]:
+    """Build HostRequest protobufs (with unseen counts) for a page of host-request threads."""
+    if not host_request_ids:
+        return {}
+    host_request_rows = session.execute(
+        select(HostRequest, Conversation)
+        .join(Conversation, Conversation.id == HostRequest.conversation_id)
+        .where(HostRequest.conversation_id.in_(host_request_ids))
+    ).all()
+
+    latest_message_ids = [latest_message_id_by_conversation[conversation_id] for conversation_id in host_request_ids]
+    message_by_id = {
+        message.id: message
+        for message in session.execute(select(Message).where(Message.id.in_(latest_message_ids))).scalars().all()
+    }
+
+    unseen_count_by_conversation: dict[int, int] = dict(
+        session.execute(  # type: ignore[arg-type]
+            select(HostRequest.conversation_id, func.count(Message.id))
+            .join(Message, Message.conversation_id == HostRequest.conversation_id)
+            .where(HostRequest.conversation_id.in_(host_request_ids))
+            .where(Message.id > viewer_last_seen_message_id(context.user_id))
+            .group_by(HostRequest.conversation_id)
+        ).all()
+    )
+    return {
+        row.HostRequest.conversation_id: _host_request_thread_to_pb(
+            row.HostRequest,
+            row.Conversation,
+            message_by_id.get(latest_message_id_by_conversation[row.HostRequest.conversation_id]),
+            context.user_id,
+            unseen_count_by_conversation.get(row.HostRequest.conversation_id, 0),
+        )
+        for row in host_request_rows
+    }
+
+
+def list_message_threads(
+    request: conversations_pb2.ListMessageThreadsReq, context: CouchersContext, session: Session
+) -> conversations_pb2.ListMessageThreadsRes:
+    filters = _resolve_thread_filters(context, request)
+
+    queries = []
+    if conversations_pb2.MESSAGE_THREAD_CATEGORY_CHATS in filters.categories:
+        queries.append(_build_group_chat_select_query(context, filters.only_archived, filters.only_unread))
+    role_filter = _build_host_request_role_filter(context.user_id, filters.categories)
+    if role_filter is not None:
+        queries.append(
+            _build_host_request_select_query(context, role_filter, filters.only_archived, filters.only_unread)
+        )
+
+    # nothing to include: only reachable when MY_PUBLIC_TRIPS is requested alone and the
+    # public-trips flag is off. TODO: remove once public trips is live (flag always on)
+    if not queries:
+        return conversations_pb2.ListMessageThreadsRes()
+
+    page_size = min(request.page_size or DEFAULT_PAGINATION_LENGTH, MAX_PAGE_SIZE)
+
+    # unioned, so one cursor on latest_message_id pages through both kinds as a single list
+    threads = (queries[0] if len(queries) == 1 else union_all(*queries)).subquery()
+    page_query = select(threads.c.conversation_id, threads.c.latest_message_id, threads.c.kind)
+    if request.page_token:
+        page_query = page_query.where(threads.c.latest_message_id < int(decrypt_page_token(request.page_token)))
+    page_query = page_query.order_by(threads.c.latest_message_id.desc()).limit(page_size + 1)
+    rows = session.execute(page_query).all()
+
+    page_rows = rows[:page_size]
+    has_more = len(rows) > page_size
+    # rows are ordered by latest_message_id desc, so the last one on the page is the cursor
+    next_page_token = encrypt_page_token(str(page_rows[-1].latest_message_id)) if has_more else ""
+
+    latest_message_id_by_conversation = {row.conversation_id: row.latest_message_id for row in page_rows}
+    group_chat_ids = [row.conversation_id for row in page_rows if row.kind == _KIND_GROUP_CHAT]
+    host_request_ids = [row.conversation_id for row in page_rows if row.kind == _KIND_HOST_REQUEST]
+
+    # hydrate each kind in a batch, then re-assemble in the paginated order
+    group_chats_by_id = _build_group_chats_pb(session, context, group_chat_ids, latest_message_id_by_conversation)
+    host_request_threads_by_id = _build_host_request_threads_pb(
+        session, context, host_request_ids, latest_message_id_by_conversation
+    )
+
+    message_threads = []
+    for row in page_rows:
+        if row.kind == _KIND_GROUP_CHAT:
+            group_chat = group_chats_by_id.get(row.conversation_id)
+            if group_chat is not None:
+                message_threads.append(conversations_pb2.MessageThread(group_chat=group_chat))
+        else:
+            host_request_thread = host_request_threads_by_id.get(row.conversation_id)
+            if host_request_thread is not None:
+                message_threads.append(conversations_pb2.MessageThread(host_request=host_request_thread))
+
+    return conversations_pb2.ListMessageThreadsRes(threads=message_threads, next_page_token=next_page_token)
+
+
 def mark_all_threads_seen(
     request: conversations_pb2.MarkAllThreadsSeenReq, context: CouchersContext, session: Session
 ) -> empty_pb2.Empty:
@@ -161,7 +458,7 @@ def mark_all_threads_seen(
         # correlated, so it resolves per row of the update: every subscription advances to its own
         # chat's newest message without listing them out. windowed, so a subscription the viewer
         # has left advances only to the last message they could read, matching its unseen count
-        latest_message_id = (
+        latest_reachable_message_id = (
             select(func.max(Message.id))
             .where(Message.conversation_id == GroupChatSubscription.group_chat_id)
             .where(was_subscribed_at(GroupChatSubscription, Message.time))
@@ -173,8 +470,8 @@ def mark_all_threads_seen(
                 .where(GroupChatSubscription.user_id == context.user_id)
                 .where(is_newest_subscription(context.user_id))
                 .where(GroupChatSubscription.group_chat_id.in_(select(chat_query.subquery().c.conversation_id)))
-                .where(GroupChatSubscription.last_seen_message_id < latest_message_id)
-                .values(last_seen_message_id=latest_message_id)
+                .where(GroupChatSubscription.last_seen_message_id < latest_reachable_message_id)
+                .values(last_seen_message_id=latest_reachable_message_id)
                 .returning(GroupChatSubscription.group_chat_id)
                 .execution_options(synchronize_session=False)
             )
@@ -200,9 +497,7 @@ def mark_all_threads_seen(
         # the viewer's last-seen column depends on their role, so one update per role
         # (a user is never both initiator and recipient of the same request, so these are disjoint)
         matching_ids = select(host_request_query.subquery().c.conversation_id)
-        latest_message_id = (
-            select(func.max(Message.id)).where(Message.conversation_id == HostRequest.conversation_id).scalar_subquery()
-        )
+        latest_message_id = _latest_host_request_message_id()
         marked_conversation_ids: list[int] = []
         for user_id_column, last_seen_column in (
             (HostRequest.initiator_user_id, HostRequest.initiator_last_seen_message_id),

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -398,6 +398,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
 
         return host_request_to_pb(host_request, session, context)
 
+    # TODO(#7722): remove after FE migrates to ListMessageThreads
     def ListHostRequests(
         self, request: requests_pb2.ListHostRequestsReq, context: CouchersContext, session: Session
     ) -> requests_pb2.ListHostRequestsRes:

--- a/app/backend/src/tests/test_message_threads.py
+++ b/app/backend/src/tests/test_message_threads.py
@@ -350,11 +350,10 @@ def test_list_message_threads_public_trip_offer_role_based(db, moderator):
         assert hr.host_request_id == request_id
         assert hr.HasField("public_trip_id")
         assert hr.public_trip_id == trip_id
-        # payload keeps the Requests API semantics: surfer = initiator (the offering
-        # host), host = recipient (the traveller); display roles derived client-side
-        # from public_trip_id being set
-        assert hr.surfer_user_id == host.id
-        assert hr.host_user_id == traveler.id
+        # payload keeps the Requests API semantics: surfer/host are the stay roles, which an
+        # offer reverses — the offering host is the host, the trip's traveller is the surfer
+        assert hr.surfer_user_id == traveler.id
+        assert hr.host_user_id == host.id
 
         # not under SURFING for the host
         res = c.ListMessageThreads(
@@ -362,15 +361,20 @@ def test_list_message_threads_public_trip_offer_role_based(db, moderator):
         )
         assert len(res.threads) == 0
 
+    # the same request served by the Requests API has to agree on who's who
+    with requests_session(host_token) as api:
+        from_requests_api = api.GetHostRequest(requests_pb2.GetHostRequestReq(host_request_id=request_id))
+    assert (from_requests_api.surfer_user_id, from_requests_api.host_user_id) == (hr.surfer_user_id, hr.host_user_id)
+
     # From the traveller's view: appears under SURFING and MY_PUBLIC_TRIPS (role-based filters)
     with conversations_session(traveler_token) as c:
         res = c.ListMessageThreads(
             conversations_pb2.ListMessageThreadsReq(categories=[conversations_pb2.MESSAGE_THREAD_CATEGORY_SURFING])
         )
         assert [t.host_request.host_request_id for t in res.threads] == [request_id]
-        # same initiator/recipient-based payload regardless of viewer
-        assert res.threads[0].host_request.surfer_user_id == host.id
-        assert res.threads[0].host_request.host_user_id == traveler.id
+        # same payload regardless of viewer
+        assert res.threads[0].host_request.surfer_user_id == traveler.id
+        assert res.threads[0].host_request.host_user_id == host.id
 
         res = c.ListMessageThreads(
             conversations_pb2.ListMessageThreadsReq(

--- a/app/backend/src/tests/test_message_threads.py
+++ b/app/backend/src/tests/test_message_threads.py
@@ -110,6 +110,45 @@ def test_list_message_threads_latest_status_change_message(db, moderator):
     )
 
 
+def test_list_message_threads_need_host_request_feedback(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    request_id = _create_host_request(token2, user1.id, moderator)
+
+    def host_request_thread(token: str) -> requests_pb2.HostRequest:
+        with conversations_session(token) as c:
+            res = c.ListMessageThreads(conversations_pb2.ListMessageThreadsReq())
+        thread: requests_pb2.HostRequest = next(
+            t.host_request for t in res.threads if t.host_request.host_request_id == request_id
+        )
+        return thread
+
+    assert not host_request_thread(token1).need_host_request_feedback
+
+    with requests_session(token1) as api:
+        api.RespondHostRequest(
+            requests_pb2.RespondHostRequestReq(
+                host_request_id=request_id,
+                status=messages_pb2.HOST_REQUEST_STATUS_REJECTED,
+            )
+        )
+
+    assert host_request_thread(token1).need_host_request_feedback
+    # only the host is asked for feedback
+    assert not host_request_thread(token2).need_host_request_feedback
+
+    with requests_session(token1) as api:
+        api.SendHostRequestFeedback(
+            requests_pb2.SendHostRequestFeedbackReq(
+                host_request_id=request_id,
+                host_request_quality=requests_pb2.HOST_REQUEST_QUALITY_LOW,
+            )
+        )
+
+    assert not host_request_thread(token1).need_host_request_feedback
+
+
 def test_list_message_threads_interleaves_chats_and_requests(db, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()

--- a/app/backend/src/tests/test_message_threads.py
+++ b/app/backend/src/tests/test_message_threads.py
@@ -12,7 +12,7 @@ from couchers.jobs.handlers import send_message_notifications
 from couchers.models import HostRequest, NotificationTopicAction, User
 from couchers.proto import api_pb2, conversations_pb2, messages_pb2, notifications_pb2, requests_pb2
 from couchers.utils import today
-from tests.fixtures.db import generate_user
+from tests.fixtures.db import generate_user, make_user_block
 from tests.fixtures.misc import now_5_min_in_future, process_jobs
 from tests.fixtures.sessions import (
     conversations_session,
@@ -147,6 +147,30 @@ def test_list_message_threads_need_host_request_feedback(db, moderator):
         )
 
     assert not host_request_thread(token1).need_host_request_feedback
+
+
+def test_list_message_threads_can_message(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
+
+    blocked_dm_id = _create_group_chat(token1, [user2.id], moderator)
+    departed_dm_id = _create_group_chat(token1, [user3.id], moderator)
+    chat_id = _create_group_chat(token1, [user2.id, user3.id], moderator)
+
+    def can_message_by_chat(token: str) -> dict[int, bool]:
+        with conversations_session(token) as c:
+            res = c.ListMessageThreads(conversations_pb2.ListMessageThreadsReq())
+        return {t.group_chat.group_chat_id: t.group_chat.can_message for t in res.threads}
+
+    assert can_message_by_chat(token1) == {blocked_dm_id: True, departed_dm_id: True, chat_id: True}
+
+    make_user_block(user2, user1)
+    with conversations_session(token3) as c:
+        c.LeaveGroupChat(conversations_pb2.LeaveGroupChatReq(group_chat_id=departed_dm_id))
+
+    # a DM whose other party is blocked or gone can't be messaged; a true group chat always can
+    assert can_message_by_chat(token1) == {blocked_dm_id: False, departed_dm_id: False, chat_id: True}
 
 
 def test_list_message_threads_interleaves_chats_and_requests(db, moderator):

--- a/app/backend/src/tests/test_message_threads.py
+++ b/app/backend/src/tests/test_message_threads.py
@@ -188,6 +188,36 @@ def test_list_message_threads_chats_filter_excludes_host_requests(db, moderator)
     assert res.threads[0].group_chat.group_chat_id == chat_id
 
 
+def test_list_message_threads_roster_is_frozen_for_a_departed_viewer(db, moderator):
+    """
+    A viewer who was removed from a chat sees its roster as it was when they left, so anyone added
+    afterwards is invisible to them.
+    """
+    admin, admin_token = generate_user()
+    viewer, viewer_token = generate_user()
+    member, _member_token = generate_user()
+    latecomer, _latecomer_token = generate_user()
+
+    chat_id = _create_group_chat(admin_token, [viewer.id, member.id], moderator)
+
+    with conversations_session(admin_token) as c:
+        c.RemoveGroupChatUser(conversations_pb2.RemoveGroupChatUserReq(group_chat_id=chat_id, user_id=viewer.id))
+        c.InviteToGroupChat(conversations_pb2.InviteToGroupChatReq(group_chat_id=chat_id, user_id=latecomer.id))
+
+    with conversations_session(viewer_token) as c:
+        res = c.ListMessageThreads(conversations_pb2.ListMessageThreadsReq())
+    departed_view = res.threads[0].group_chat
+    assert set(departed_view.member_user_ids) == {admin.id, viewer.id, member.id}
+    assert list(departed_view.admin_user_ids) == [admin.id]
+    # chat created, "hi" and the removal notice; the invite notice is out of reach
+    assert departed_view.unseen_message_count == 3
+
+    with conversations_session(admin_token) as c:
+        res = c.ListMessageThreads(conversations_pb2.ListMessageThreadsReq())
+    admin_view = res.threads[0].group_chat
+    assert set(admin_view.member_user_ids) == {admin.id, member.id, latecomer.id}
+
+
 def test_list_message_threads_rejects_unspecified_category(db):
     _user1, token1 = generate_user()
 

--- a/app/backend/src/tests/test_message_threads.py
+++ b/app/backend/src/tests/test_message_threads.py
@@ -9,8 +9,8 @@ from sqlalchemy import select
 from couchers.db import session_scope
 from couchers.helpers.host_requests import has_unseen_host_request_messages
 from couchers.jobs.handlers import send_message_notifications
-from couchers.models import HostRequest, NotificationTopicAction
-from couchers.proto import api_pb2, conversations_pb2, notifications_pb2, requests_pb2
+from couchers.models import HostRequest, NotificationTopicAction, User
+from couchers.proto import api_pb2, conversations_pb2, messages_pb2, notifications_pb2, requests_pb2
 from couchers.utils import today
 from tests.fixtures.db import generate_user
 from tests.fixtures.misc import now_5_min_in_future, process_jobs
@@ -20,12 +20,22 @@ from tests.fixtures.sessions import (
     real_api_session,
     requests_session,
 )
+from tests.test_communities import create_community
+from tests.test_public_trips import _create_trip_directly
 from tests.test_requests import valid_request_text
 
 
 @pytest.fixture(autouse=True)
 def _(testconfig):
     pass
+
+
+def _make_trip(user: User) -> tuple[int, int]:
+    """Create a community + an active public trip for the given traveller."""
+    with session_scope() as session:
+        node_id = create_community(session, 0, 2, "Test community", [user], [], None).id
+    trip_id = _create_trip_directly(user.id, node_id, today() + timedelta(days=5), today() + timedelta(days=10))
+    return node_id, trip_id
 
 
 def _create_group_chat(token: str, recipient_ids: list[int], moderator, text: str = "hi") -> int:
@@ -36,7 +46,7 @@ def _create_group_chat(token: str, recipient_ids: list[int], moderator, text: st
     return int(res.group_chat_id)
 
 
-def _create_host_request(surfer_token: str, host_id: int, moderator) -> int:
+def _create_host_request(surfer_token: str, host_id: int, moderator, public_trip_id: int | None = None) -> int:
     with requests_session(surfer_token) as api:
         res = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
@@ -44,6 +54,7 @@ def _create_host_request(surfer_token: str, host_id: int, moderator) -> int:
                 from_date=(today() + timedelta(days=5)).isoformat(),
                 to_date=(today() + timedelta(days=10)).isoformat(),
                 text=valid_request_text(),
+                public_trip_id=public_trip_id,
             )
         )
     moderator.approve_host_request(res.host_request_id)
@@ -69,6 +80,230 @@ def test_has_unseen_host_request_messages_is_false_for_a_non_party(db, moderator
 
     assert unseen_for[user1.id] == conversation_id
     assert unseen_for[outsider.id] is None
+
+
+def test_list_message_threads_latest_status_change_message(db, moderator):
+    # Regression: a thread whose latest message is a host-request status change
+    # must serialize with its content set (not an empty control message).
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    request_id = _create_host_request(token2, user1.id, moderator)
+
+    # user1 (the host) accepts, so the latest message becomes a status change
+    with requests_session(token1) as api:
+        api.RespondHostRequest(
+            requests_pb2.RespondHostRequestReq(
+                host_request_id=request_id,
+                status=messages_pb2.HOST_REQUEST_STATUS_ACCEPTED,
+                text="",
+            )
+        )
+
+    with conversations_session(token1) as c:
+        res = c.ListMessageThreads(conversations_pb2.ListMessageThreadsReq())
+    thread = next(t for t in res.threads if t.WhichOneof("thread") == "host_request")
+    assert thread.host_request.latest_message.WhichOneof("content") == "host_request_status_changed"
+    assert (
+        thread.host_request.latest_message.host_request_status_changed.status
+        == messages_pb2.HOST_REQUEST_STATUS_ACCEPTED
+    )
+
+
+def test_list_message_threads_interleaves_chats_and_requests(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    chat_id = _create_group_chat(token1, [user2.id], moderator)
+    # user2 sends a host request to user1 (user1 is the host)
+    request_id = _create_host_request(token2, user1.id, moderator)
+
+    with conversations_session(token1) as c:
+        res = c.ListMessageThreads(conversations_pb2.ListMessageThreadsReq())
+
+    kinds = [t.WhichOneof("thread") for t in res.threads]
+    assert "group_chat" in kinds
+    assert "host_request" in kinds
+    ids = {
+        (t.group_chat.group_chat_id if t.WhichOneof("thread") == "group_chat" else t.host_request.host_request_id)
+        for t in res.threads
+    }
+    assert ids == {chat_id, request_id}
+    # The host request was created after the group chat, so it sorts first (latest message).
+    assert res.threads[0].WhichOneof("thread") == "host_request"
+
+
+def test_list_message_threads_single_cursor_pagination_across_kinds(db, moderator):
+    user1, token1 = generate_user()
+    others = [generate_user() for _ in range(6)]
+
+    # track the two kinds separately so we verify each id comes back as the right kind
+    expected_chat_ids = set()
+    expected_request_ids = set()
+    # interleave creating group chats and host requests so both kinds straddle page boundaries
+    for other, other_token in others:
+        expected_chat_ids.add(_create_group_chat(token1, [other.id], moderator))
+        expected_request_ids.add(_create_host_request(other_token, user1.id, moderator))
+
+    collected_chat_ids: list[int] = []
+    collected_request_ids: list[int] = []
+    latest_ids: list[int] = []
+    page_token = ""
+    while True:
+        with conversations_session(token1) as c:
+            res = c.ListMessageThreads(conversations_pb2.ListMessageThreadsReq(page_size=3, page_token=page_token))
+        for t in res.threads:
+            if t.WhichOneof("thread") == "group_chat":
+                collected_chat_ids.append(t.group_chat.group_chat_id)
+                latest_ids.append(t.group_chat.latest_message.message_id)
+            else:
+                collected_request_ids.append(t.host_request.host_request_id)
+                latest_ids.append(t.host_request.latest_message.message_id)
+        if not res.next_page_token:
+            break
+        page_token = res.next_page_token
+
+    # every thread appears exactly once as its correct kind, none missing or duplicated
+    assert sorted(collected_chat_ids) == sorted(expected_chat_ids)
+    assert sorted(collected_request_ids) == sorted(expected_request_ids)
+    assert len(collected_chat_ids) == len(set(collected_chat_ids))
+    assert len(collected_request_ids) == len(set(collected_request_ids))
+    # globally ordered by latest message id, descending, with no straddling across pages
+    assert latest_ids == sorted(latest_ids, reverse=True)
+
+
+def test_list_message_threads_chats_filter_excludes_host_requests(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    chat_id = _create_group_chat(token1, [user2.id], moderator)
+    _create_host_request(token2, user1.id, moderator)
+
+    with conversations_session(token1) as c:
+        res = c.ListMessageThreads(
+            conversations_pb2.ListMessageThreadsReq(categories=[conversations_pb2.MESSAGE_THREAD_CATEGORY_CHATS])
+        )
+
+    assert [t.WhichOneof("thread") for t in res.threads] == ["group_chat"]
+    assert res.threads[0].group_chat.group_chat_id == chat_id
+
+
+def test_list_message_threads_rejects_unspecified_category(db):
+    _user1, token1 = generate_user()
+
+    with conversations_session(token1) as c:
+        with pytest.raises(grpc.RpcError) as e:
+            c.ListMessageThreads(
+                conversations_pb2.ListMessageThreadsReq(
+                    categories=[conversations_pb2.MESSAGE_THREAD_CATEGORY_UNSPECIFIED]
+                )
+            )
+        assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+
+def test_list_message_threads_unread_filter(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    # user2 sends a request to user1 -> user1 has unseen messages
+    request_id = _create_host_request(token2, user1.id, moderator)
+
+    with conversations_session(token1) as c:
+        res = c.ListMessageThreads(conversations_pb2.ListMessageThreadsReq(only_unread=True))
+        assert [t.host_request.host_request_id for t in res.threads] == [request_id]
+
+        # after marking everything seen, the unread filter is empty
+        c.MarkAllThreadsSeen(conversations_pb2.MarkAllThreadsSeenReq())
+        res = c.ListMessageThreads(conversations_pb2.ListMessageThreadsReq(only_unread=True))
+        assert len(res.threads) == 0
+
+
+def test_list_message_threads_archived_is_orthogonal(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    chat_id = _create_group_chat(token1, [user2.id], moderator)
+
+    with conversations_session(token1) as c:
+        # archive the chat
+        c.SetGroupChatArchiveStatus(
+            conversations_pb2.SetGroupChatArchiveStatusReq(group_chat_id=chat_id, is_archived=True)
+        )
+
+        # default (non-archived) excludes it
+        res = c.ListMessageThreads(conversations_pb2.ListMessageThreadsReq(only_archived=False))
+        assert len(res.threads) == 0
+
+        # only_archived=True includes it
+        res = c.ListMessageThreads(conversations_pb2.ListMessageThreadsReq(only_archived=True))
+        assert [t.group_chat.group_chat_id for t in res.threads] == [chat_id]
+
+
+def test_list_message_threads_public_trip_offer_role_based(db, moderator):
+    traveler, traveler_token = generate_user()
+    host, host_token = generate_user()
+    _, trip_id = _make_trip(traveler)
+
+    # host offers to host the traveller's public trip (role reversal)
+    request_id = _create_host_request(host_token, traveler.id, moderator, public_trip_id=trip_id)
+
+    # From the offering host's view: appears under HOSTING (role-based filter)
+    with conversations_session(host_token) as c:
+        res = c.ListMessageThreads(
+            conversations_pb2.ListMessageThreadsReq(categories=[conversations_pb2.MESSAGE_THREAD_CATEGORY_HOSTING])
+        )
+        assert len(res.threads) == 1
+        hr = res.threads[0].host_request
+        assert hr.host_request_id == request_id
+        assert hr.HasField("public_trip_id")
+        assert hr.public_trip_id == trip_id
+        # payload keeps the Requests API semantics: surfer = initiator (the offering
+        # host), host = recipient (the traveller); display roles derived client-side
+        # from public_trip_id being set
+        assert hr.surfer_user_id == host.id
+        assert hr.host_user_id == traveler.id
+
+        # not under SURFING for the host
+        res = c.ListMessageThreads(
+            conversations_pb2.ListMessageThreadsReq(categories=[conversations_pb2.MESSAGE_THREAD_CATEGORY_SURFING])
+        )
+        assert len(res.threads) == 0
+
+    # From the traveller's view: appears under SURFING and MY_PUBLIC_TRIPS (role-based filters)
+    with conversations_session(traveler_token) as c:
+        res = c.ListMessageThreads(
+            conversations_pb2.ListMessageThreadsReq(categories=[conversations_pb2.MESSAGE_THREAD_CATEGORY_SURFING])
+        )
+        assert [t.host_request.host_request_id for t in res.threads] == [request_id]
+        # same initiator/recipient-based payload regardless of viewer
+        assert res.threads[0].host_request.surfer_user_id == host.id
+        assert res.threads[0].host_request.host_user_id == traveler.id
+
+        res = c.ListMessageThreads(
+            conversations_pb2.ListMessageThreadsReq(
+                categories=[conversations_pb2.MESSAGE_THREAD_CATEGORY_MY_PUBLIC_TRIPS]
+            )
+        )
+        assert [t.host_request.host_request_id for t in res.threads] == [request_id]
+
+        # also present in ALL
+        res = c.ListMessageThreads(conversations_pb2.ListMessageThreadsReq())
+        assert request_id in {t.host_request.host_request_id for t in res.threads}
+
+
+def test_list_message_threads_public_trips_filter_gated_by_flag(db, moderator, feature_flags):
+    feature_flags.set("public_trips_enabled", False)
+
+    traveler, traveler_token = generate_user()
+
+    with conversations_session(traveler_token) as c:
+        res = c.ListMessageThreads(
+            conversations_pb2.ListMessageThreadsReq(
+                categories=[conversations_pb2.MESSAGE_THREAD_CATEGORY_MY_PUBLIC_TRIPS]
+            )
+        )
+        assert len(res.threads) == 0
+        assert not res.next_page_token
 
 
 def test_mark_all_threads_seen_rejects_unspecified_category(db):
@@ -140,11 +375,11 @@ def test_mark_all_threads_seen_respects_unread_and_archived_filters(db, moderato
     assert unseen_chat_messages() == 0
 
 
-def test_mark_all_threads_seen_clears_departed_group_chat(db, moderator):
+def test_departed_group_chat_unseen_count_agrees_with_ping_and_clears(db, moderator):
     """
-    A viewer who was removed from a chat can only reach the messages sent before they left, so
-    marking everything seen has to advance them to that message rather than to the chat's newest —
-    otherwise the badge never clears.
+    Regression test: the per-thread unseen count used to include messages sent after the viewer left
+    the chat, which the Ping badge never counted, and MarkAllThreadsSeen skipped departed chats
+    entirely — so the list showed unread messages the viewer couldn't read and couldn't clear.
 
     The viewer is removed rather than leaving, because leaving posts a message of your own, which
     marks everything up to it seen.
@@ -160,22 +395,28 @@ def test_mark_all_threads_seen_clears_departed_group_chat(db, moderator):
         for _ in range(3):
             c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=chat_id, text="after you left"))
 
-    def unseen_chat_messages() -> int:
+    def unseen_counts() -> tuple[int, int]:
         with real_api_session(token1) as api:
-            return int(api.Ping(api_pb2.PingReq()).unseen_message_count)
+            ping_count = api.Ping(api_pb2.PingReq()).unseen_message_count
+        with conversations_session(token1) as c:
+            res = c.ListMessageThreads(conversations_pb2.ListMessageThreadsReq())
+        thread = next(t for t in res.threads if t.group_chat.group_chat_id == chat_id)
+        return thread.group_chat.unseen_message_count, ping_count
 
     # chat created, "hi", and the removal notice; the three messages sent afterwards are out of reach
-    assert unseen_chat_messages() == 3
+    assert unseen_counts() == (3, 3)
 
     with conversations_session(token1) as c:
         c.MarkAllThreadsSeen(conversations_pb2.MarkAllThreadsSeenReq())
-    assert unseen_chat_messages() == 0
+    assert unseen_counts() == (0, 0)
 
 
-def test_mark_all_threads_seen_advances_the_current_subscription(db, moderator):
+def test_rejoined_group_chat_reads_the_current_subscription(db, moderator):
     """
-    Rejoining a chat leaves the earlier subscription behind with its own last-seen state. Only the
-    current subscription is advanced, and the stale one must not hold the chat unread afterwards.
+    Regression test: rejoining a chat leaves the earlier subscription behind, with its own last-seen
+    state. The unread filter and the Ping badge used to match on any of the viewer's subscriptions,
+    so the stale one held the chat unread and kept the badge up, while the count the list showed and
+    the row MarkAllThreadsSeen advanced came from the current subscription and could never clear it.
     """
     user1, token1 = generate_user()
     _user2, token2 = generate_user()
@@ -190,16 +431,29 @@ def test_mark_all_threads_seen_advances_the_current_subscription(db, moderator):
         c.InviteToGroupChat(conversations_pb2.InviteToGroupChatReq(group_chat_id=chat_id, user_id=user1.id))
         c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=chat_id, text="welcome back"))
 
-    def unseen_chat_messages() -> int:
+    def unread_chat_ids() -> list[int]:
+        with conversations_session(token1) as c:
+            res = c.ListMessageThreads(conversations_pb2.ListMessageThreadsReq(only_unread=True))
+        return [t.group_chat.group_chat_id for t in res.threads]
+
+    def unseen_counts() -> tuple[int, int]:
         with real_api_session(token1) as api:
-            return int(api.Ping(api_pb2.PingReq()).unseen_message_count)
+            ping_count = api.Ping(api_pb2.PingReq()).unseen_message_count
+        with conversations_session(token1) as c:
+            res = c.ListMessageThreads(conversations_pb2.ListMessageThreadsReq())
+        threads = [t for t in res.threads if t.group_chat.group_chat_id == chat_id]
+        # the two subscriptions must not surface the chat twice
+        assert len(threads) == 1
+        return threads[0].group_chat.unseen_message_count, ping_count
 
     # only the invite notice and "welcome back" are in reach; the first stint's messages are not
-    assert unseen_chat_messages() == 2
+    assert unseen_counts() == (2, 2)
+    assert unread_chat_ids() == [chat_id]
 
     with conversations_session(token1) as c:
         c.MarkAllThreadsSeen(conversations_pb2.MarkAllThreadsSeenReq())
-    assert unseen_chat_messages() == 0
+    assert unseen_counts() == (0, 0)
+    assert unread_chat_ids() == []
 
 
 def test_mark_all_threads_seen_clears_missed_messages_notification(db, moderator):

--- a/app/proto/conversations.proto
+++ b/app/proto/conversations.proto
@@ -159,10 +159,9 @@ enum MessageThreadCategory {
 message MessageThread {
   oneof thread {
     GroupChat group_chat = 1;
-    // Same shape and semantics as the Requests API: surfer_user_id is the
-    // request's initiator and host_user_id its recipient, even for a
-    // public-trip offer (where the initiator is the one offering to host);
-    // clients derive display roles from public_trip_id being set.
+    // Same shape and semantics as the Requests API: surfer_user_id and
+    // host_user_id are the stay roles, so a public-trip offer reverses them
+    // relative to who initiated the conversation.
     org.couchers.api.requests.HostRequest host_request = 2;
   }
 }

--- a/app/proto/conversations.proto
+++ b/app/proto/conversations.proto
@@ -168,13 +168,13 @@ message MessageThread {
 }
 
 message ListMessageThreadsReq {
-  // which categories to include; empty means all categories
-  repeated MessageThreadCategory categories = 1;
-  // orthogonal: when present, restrict to archived (true) or non-archived (false)
-  optional bool only_archived = 2;
-  uint32 page_size = 3;
+  uint32 page_size = 1;
   // pagination cursor; pass back the next_page_token from the previous response, or empty for the first page
-  string page_token = 4;
+  string page_token = 2;
+  // which categories to include; empty means all categories
+  repeated MessageThreadCategory categories = 3;
+  // orthogonal: when present, restrict to archived (true) or non-archived (false)
+  optional bool only_archived = 4;
   // orthogonal: when true, restrict to unread threads
   bool only_unread = 5;
 }

--- a/app/proto/conversations.proto
+++ b/app/proto/conversations.proto
@@ -9,12 +9,20 @@ import "google/protobuf/wrappers.proto";
 
 import "annotations.proto";
 import "messages.proto";
+import "requests.proto";
 
 service Conversations {
   option (auth_level) = AUTH_LEVEL_SECURE;
 
   rpc ListGroupChats(ListGroupChatsReq) returns (ListGroupChatsRes) {
     // Retrieves list of group chats (ordered by last message), paginated
+    // TODO(#7722): remove after FE migrates to ListMessageThreads
+  }
+
+  rpc ListMessageThreads(ListMessageThreadsReq) returns (ListMessageThreadsRes) {
+    // Unified list of all message threads (group chats, DMs, host requests and
+    // public-trip offers) ordered by latest message, paginated with a single
+    // global cursor. Filterable by all/unread/chats/hosting/surfing/public_trips.
   }
 
   rpc MarkAllThreadsSeen(MarkAllThreadsSeenReq) returns (google.protobuf.Empty) {
@@ -136,9 +144,9 @@ message ListGroupChatsRes {
   bool no_more = 3;
 }
 
-// Categories of message thread. Combinable in MarkAllThreadsSeen: an empty list means all
-// categories. Read-state (only_unread) and archived (only_archived) are separate, orthogonal
-// filters.
+// Categories of message thread. Combinable in ListMessageThreads / MarkAllThreadsSeen: an empty
+// list means all categories. Read-state (only_unread) and archived (only_archived) are separate,
+// orthogonal filters.
 enum MessageThreadCategory {
   MESSAGE_THREAD_CATEGORY_UNSPECIFIED = 0;
   MESSAGE_THREAD_CATEGORY_CHATS = 1; // group chats + DMs
@@ -146,6 +154,34 @@ enum MessageThreadCategory {
   MESSAGE_THREAD_CATEGORY_SURFING = 3; // role-based: I am the guest/traveller
   // incoming offers on my public trips (I'm the traveller); a subset of SURFING
   MESSAGE_THREAD_CATEGORY_MY_PUBLIC_TRIPS = 4;
+}
+
+message MessageThread {
+  oneof thread {
+    GroupChat group_chat = 1;
+    // Same shape and semantics as the Requests API: surfer_user_id is the
+    // request's initiator and host_user_id its recipient, even for a
+    // public-trip offer (where the initiator is the one offering to host);
+    // clients derive display roles from public_trip_id being set.
+    org.couchers.api.requests.HostRequest host_request = 2;
+  }
+}
+
+message ListMessageThreadsReq {
+  // which categories to include; empty means all categories
+  repeated MessageThreadCategory categories = 1;
+  // orthogonal: when present, restrict to archived (true) or non-archived (false)
+  optional bool only_archived = 2;
+  uint32 page_size = 3;
+  // pagination cursor; pass back the next_page_token from the previous response, or empty for the first page
+  string page_token = 4;
+  // orthogonal: when true, restrict to unread threads
+  bool only_unread = 5;
+}
+
+message ListMessageThreadsRes {
+  repeated MessageThread threads = 1;
+  string next_page_token = 2;
 }
 
 message MarkAllThreadsSeenReq {


### PR DESCRIPTION
Last in the stack breaking up #9219, on top of #9477. Adds the unified message thread list; #9477 below it holds `MarkAllThreadsSeen` and the thread-selection machinery both endpoints share.

**New RPC on the Conversations service:** `ListMessageThreads` — one paginated list of all the viewer's message threads (group chats, DMs, host requests and public-trip offers) ordered by latest message. Same filters as `MarkAllThreadsSeen`: category (`CHATS` / `HOSTING` / `SURFING` / `MY_PUBLIC_TRIPS`, role-based per #9464's predicates), and orthogonally unread and archived state.

**How it works:** each kind's candidate query gains the two columns paging needs — the id of the conversation's newest message, and a tag marking which table the row came from. A `UNION ALL` of those lets a single encrypted cursor on `latest_message_id` page through all kinds as one list, and only the page's worth of rows is hydrated into protobufs, batched per kind (no per-thread queries).

**Also:**
- `HostRequest.unseen_message_count` proto field (populated only by `ListMessageThreads`)
- `MY_PUBLIC_TRIPS` is gated by the `public_trips_enabled` flag; offers still appear under `SURFING`/all when it's off
- the legacy `ListGroupChats` / `ListHostRequests` endpoints are marked for removal once the frontend migrates (#7722)
- a drive-by test that `ListPublicTripsByUser`'s `offers_count` excludes cancelled offers

## Testing
Adds to `test_message_threads.py`: interleaving of the two kinds, single-cursor pagination across kinds, the category/unread/archived filters, role-based bucketing of public-trip offers, flag gating, a status-change message as a thread's latest, and the per-thread unseen count agreeing with the Ping badge on departed and rejoined chats. `make mypy` passes; `test_message_threads.py`, `test_conversations.py`, `test_requests.py` and `test_public_trips.py` pass locally (150 passed).

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history (no db changes)

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me