### PR TITLE
Add generated surfer/host columns to host requests

### DIFF
--- a/app/backend/src/couchers/migrations/versions/0180_add_generated_host_request_role_columns.py
+++ b/app/backend/src/couchers/migrations/versions/0180_add_generated_host_request_role_columns.py
@@ -1,0 +1,43 @@
+"""Add generated surfer/host columns to host_requests
+
+Revision ID: 0180
+Revises: 0179
+Create Date: 2026-08-08 10:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0180"
+down_revision = "0179"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # both columns are added in one statement so the table is only rewritten once (under an ACCESS EXCLUSIVE lock)
+    op.execute("""
+        ALTER TABLE host_requests
+        ADD COLUMN surfer_user_id bigint NOT NULL
+            GENERATED ALWAYS AS (case when public_trip_id is null then initiator_user_id else recipient_user_id end) STORED,
+        ADD COLUMN host_user_id bigint NOT NULL
+            GENERATED ALWAYS AS (case when public_trip_id is null then recipient_user_id else initiator_user_id end) STORED
+    """)
+    op.create_foreign_key(
+        op.f("fk_host_requests_surfer_user_id_users"), "host_requests", "users", ["surfer_user_id"], ["id"]
+    )
+    op.create_foreign_key(
+        op.f("fk_host_requests_host_user_id_users"), "host_requests", "users", ["host_user_id"], ["id"]
+    )
+    op.create_index(op.f("ix_host_requests_surfer_user_id"), "host_requests", ["surfer_user_id"], unique=False)
+    op.create_index(op.f("ix_host_requests_host_user_id"), "host_requests", ["host_user_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_host_requests_host_user_id"), table_name="host_requests")
+    op.drop_index(op.f("ix_host_requests_surfer_user_id"), table_name="host_requests")
+    op.drop_constraint(op.f("fk_host_requests_host_user_id_users"), "host_requests", type_="foreignkey")
+    op.drop_constraint(op.f("fk_host_requests_surfer_user_id_users"), "host_requests", type_="foreignkey")
+    op.drop_column("host_requests", "host_user_id")
+    op.drop_column("host_requests", "surfer_user_id")

--- a/app/backend/src/couchers/models/host_requests.py
+++ b/app/backend/src/couchers/models/host_requests.py
@@ -3,7 +3,20 @@ from datetime import date, datetime
 from typing import TYPE_CHECKING, Any
 
 from geoalchemy2 import Geometry
-from sqlalchemy import BigInteger, Boolean, Date, DateTime, Enum, Float, ForeignKey, Index, String, func, text
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Computed,
+    Date,
+    DateTime,
+    Enum,
+    Float,
+    ForeignKey,
+    Index,
+    String,
+    func,
+    text,
+)
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, column_property, mapped_column, relationship
 from sqlalchemy.sql import expression
@@ -37,7 +50,15 @@ class HostRequest(Base, kw_only=True):
     """
     A request to stay with a host.
 
-    In a normal host request, initiator = surfer and recipient = host.
+    There are two independent role axes here, and they only coincide for a normal host request:
+
+    * initiator/recipient is the conversation role: who proposed the stay and who responds to it. The whole
+      status state machine, unread tracking and archiving key off this axis.
+    * surfer/host is the stay role: whose couch it is. References, feedback, response rates and metrics key
+      off this axis.
+
+    An offer on a public trip reverses them: the host initiates and the traveller responds. surfer_user_id
+    and host_user_id are generated from that so the stay role can never drift out of sync.
     """
 
     __tablename__ = "host_requests"
@@ -47,6 +68,19 @@ class HostRequest(Base, kw_only=True):
     conversation_id: Mapped[int] = mapped_column("id", ForeignKey("conversations.id"), primary_key=True)
     initiator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
     recipient_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+
+    surfer_user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id"),
+        Computed("case when public_trip_id is null then initiator_user_id else recipient_user_id end", persisted=True),
+        index=True,
+        init=False,
+    )
+    host_user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id"),
+        Computed("case when public_trip_id is null then recipient_user_id else initiator_user_id end", persisted=True),
+        index=True,
+        init=False,
+    )
 
     # Unified Moderation System
     moderation_state_id: Mapped[int] = mapped_column(ForeignKey("moderation_states.id"), index=True)
@@ -98,6 +132,9 @@ class HostRequest(Base, kw_only=True):
     recipient: Mapped[User] = relationship(
         init=False, backref="host_requests_received", foreign_keys="HostRequest.recipient_user_id"
     )
+    # viewonly since the underlying columns are generated and can't be written through
+    surfer: Mapped[User] = relationship(init=False, foreign_keys="HostRequest.surfer_user_id", viewonly=True)
+    host: Mapped[User] = relationship(init=False, foreign_keys="HostRequest.host_user_id", viewonly=True)
     conversation: Mapped[Conversation] = relationship(init=False)
     moderation_state: Mapped[ModerationState] = relationship(init=False)
     public_trip: Mapped[PublicTrip | None] = relationship(init=False, back_populates="host_requests")


### PR DESCRIPTION
Host requests carry two independent role axes:

* **initiator/recipient** — the conversation role: who proposed the stay, and who responds to it. The status state machine, unread tracking and archiving all key off this axis.
* **surfer/host** — the stay role: whose couch it is. References, feedback, response rates and metrics all key off this axis.

They coincide for a normal host request, but an offer on a public trip reverses them — the host initiates and the traveller responds. Since migration `0140` renamed the columns to `initiator`/`recipient`, the stay role has had nowhere to live, so every consumer that cares about it has to re-derive it from `public_trip_id IS NULL`.

This adds `surfer_user_id` and `host_user_id` as **stored generated columns**, so the stay role is always present and can't drift out of sync with the conversation role. Both get a FK to `users` and an index, and there are matching `viewonly` `surfer` / `host` relationships.

Nothing reads the new columns yet — this is inert groundwork, safe to land and deploy on its own. Switching the call sites over is a follow-up, where each one becomes a visible one-line change with the schema already in place.

Follows the `users.about_me_length` precedent from `0176`.

## Testing

* `test_db.py::test_migrations` passes — the migrated schema and the model-built schema are byte-identical under `pg_dump`, confirming the migration and model agree on columns, FK names and index names.
* `test_requests.py`, `test_public_trips.py`, `test_references.py` — 105 tests pass, confirming the new columns don't disturb the existing insert paths.
* `make mypy` and `make format` clean.
* Verified directly against PG 18.3 that a stored generated column accepts both a FK and an index, and that SQLAlchemy populates the attribute via `RETURNING` immediately after `flush()`:
  ```
  offer  -> surfer_user_id = 2  (reversed, correct)
  normal -> surfer_user_id = 1  (correct)
  ```

Note that `ALTER TABLE ... ADD COLUMN ... GENERATED ALWAYS AS ... STORED` rewrites `host_requests` under an `ACCESS EXCLUSIVE` lock. Both columns are added in a single statement so the table is only rewritten once.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug — no new tests; the pre-existing `test_migrations` schema comparison covers the new columns automatically
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._
