### PR TITLE
Add MarkAllThreadsSeen

### DIFF
--- a/app/backend/src/couchers/helpers/host_requests.py
+++ b/app/backend/src/couchers/helpers/host_requests.py
@@ -11,10 +11,10 @@ The role-based party predicates below exist because a host request has a fixed d
 So "am I hosting?" is not the same question as "did I receive this?".
 """
 
-from sqlalchemy.sql import and_, or_
+from sqlalchemy.sql import and_, case, exists, or_, select
 from sqlalchemy.sql.elements import ColumnElement
 
-from couchers.models import HostRequest
+from couchers.models import HostRequest, Message
 from couchers.models.notifications import NotificationTopicAction
 
 # topic actions whose notifications are marked seen alongside a host request being read
@@ -52,3 +52,23 @@ def is_public_trip_offer_recipient(user_id: int) -> ColumnElement[bool]:
     A strict subset of is_surfing_party.
     """
     return and_(HostRequest.public_trip_id.isnot(None), HostRequest.recipient_user_id == user_id)
+
+
+def viewer_last_seen_message_id(user_id: int) -> ColumnElement[int]:
+    """The viewer's last-seen message id on a request, whichever side of it they are on."""
+    return case(
+        (HostRequest.initiator_user_id == user_id, HostRequest.initiator_last_seen_message_id),
+        else_=HostRequest.recipient_last_seen_message_id,
+    )
+
+
+def has_unseen_host_request_messages(user_id: int) -> ColumnElement[bool]:
+    """
+    A request carrying at least one message the viewer hasn't seen. This is what the Ping badge
+    counts, so anything clearing the badge has to agree with it.
+    """
+    return exists(
+        select(1)
+        .where(Message.conversation_id == HostRequest.conversation_id)
+        .where(Message.id > viewer_last_seen_message_id(user_id))
+    )

--- a/app/backend/src/couchers/helpers/host_requests.py
+++ b/app/backend/src/couchers/helpers/host_requests.py
@@ -54,11 +54,15 @@ def is_public_trip_offer_recipient(user_id: int) -> ColumnElement[bool]:
     return and_(HostRequest.public_trip_id.isnot(None), HostRequest.recipient_user_id == user_id)
 
 
-def viewer_last_seen_message_id(user_id: int) -> ColumnElement[int]:
-    """The viewer's last-seen message id on a request, whichever side of it they are on."""
+def viewer_last_seen_message_id(user_id: int) -> ColumnElement[int | None]:
+    """
+    The viewer's last-seen message id on a request, whichever side of it they are on, and NULL if
+    they are on neither. NULL rather than an else_ branch so that a user who isn't a party to the
+    request compares false rather than silently reading the other party's column.
+    """
     return case(
         (HostRequest.initiator_user_id == user_id, HostRequest.initiator_last_seen_message_id),
-        else_=HostRequest.recipient_last_seen_message_id,
+        (HostRequest.recipient_user_id == user_id, HostRequest.recipient_last_seen_message_id),
     )
 
 

--- a/app/backend/src/couchers/i18n/locales/en.json
+++ b/app/backend/src/couchers/i18n/locales/en.json
@@ -129,6 +129,7 @@
     "invalid_phone": "Phone number must be in international format without punctuation.",
     "invalid_recipients": "Invalid recipients list.",
     "invalid_region": "Invalid region.",
+    "invalid_thread_category": "Invalid message thread category.",
     "invalid_token": "Invalid token.",
     "invalid_username": "Invalid username.",
     "invalid_website_url": "Invalid website URL or text, make sure URL starts with \"https://\", and that the text is included in the URL.",

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -8,7 +8,7 @@ import grpc
 from google.protobuf import empty_pb2
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
-from sqlalchemy.sql import and_, case, delete, exists, func, intersect, or_, union
+from sqlalchemy.sql import and_, case, delete, func, intersect, or_, union
 
 from couchers import urls
 from couchers.abuse import maybe_log_nonvisible_user_access
@@ -19,7 +19,12 @@ from couchers.crypto import b64encode, generate_hash_signature, random_hex
 from couchers.event_log import log_event
 from couchers.helpers.completed_profile import has_completed_profile
 from couchers.helpers.group_chats import is_newest_subscription, is_unseen
-from couchers.helpers.host_requests import is_hosting_party, is_public_trip_offer_recipient, is_surfing_party
+from couchers.helpers.host_requests import (
+    has_unseen_host_request_messages,
+    is_hosting_party,
+    is_public_trip_offer_recipient,
+    is_surfing_party,
+)
 from couchers.helpers.references import where_reference_user_visible, where_references_not_hidden_by_reciprocity
 from couchers.helpers.strong_verification import get_strong_verification_fields
 from couchers.materialized_views import LiteUser, UserResponseRate
@@ -196,10 +201,6 @@ class API(api_pb2_grpc.APIServicer):
         # direction (sent/received) and by stay-role. The role-based tallies bucket public-trip offers
         # correctly despite the role reversal: the offering host counts under hosting, the traveller
         # under surfing.
-        viewer_last_seen_message_id = case(
-            (HostRequest.initiator_user_id == context.user_id, HostRequest.initiator_last_seen_message_id),
-            else_=HostRequest.recipient_last_seen_message_id,
-        )
         other_party_user_id = case(
             (HostRequest.initiator_user_id == context.user_id, HostRequest.recipient_user_id),
             else_=HostRequest.initiator_user_id,
@@ -219,13 +220,7 @@ class API(api_pb2_grpc.APIServicer):
                     HostRequest.recipient_user_id == context.user_id,
                 )
             )
-            .where(
-                exists(
-                    select(1)
-                    .where(Message.conversation_id == HostRequest.conversation_id)
-                    .where(Message.id > viewer_last_seen_message_id)
-                )
-            )
+            .where(has_unseen_host_request_messages(context.user_id))
         )
         unseen_host_request_counts_query = where_users_column_visible(
             unseen_host_request_counts_query, context, other_party_user_id

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -37,6 +37,7 @@ from couchers.proto.internal import jobs_pb2
 from couchers.rate_limits.check import process_rate_limits_and_check_abort
 from couchers.rate_limits.definitions import RATE_LIMIT_HOURS
 from couchers.servicers.api import user_model_to_pb
+from couchers.servicers.message_threads import mark_all_threads_seen
 from couchers.sql import to_bool, users_visible, where_moderated_content_visible, where_users_column_visible
 from couchers.utils import Timestamp_from_datetime, now
 
@@ -295,6 +296,11 @@ def _mute_info(subscription: GroupChatSubscription) -> conversations_pb2.MuteInf
 
 
 class Conversations(conversations_pb2_grpc.ConversationsServicer):
+    def MarkAllThreadsSeen(
+        self, request: conversations_pb2.MarkAllThreadsSeenReq, context: CouchersContext, session: Session
+    ) -> empty_pb2.Empty:
+        return mark_all_threads_seen(request, context, session)
+
     def ListGroupChats(
         self, request: conversations_pb2.ListGroupChatsReq, context: CouchersContext, session: Session
     ) -> conversations_pb2.ListGroupChatsRes:

--- a/app/backend/src/couchers/servicers/message_threads.py
+++ b/app/backend/src/couchers/servicers/message_threads.py
@@ -1,10 +1,6 @@
 """
 Bulk operations over the viewer's message threads — group chats, DMs, host requests and public-trip
 offers — selected by category (Conversations.MarkAllThreadsSeen).
-
-A request's categories resolve into one query per kind of conversation, each selecting the ids of
-the conversations of that kind the request matches. MarkAllThreadsSeen consumes them as UPDATE
-targets.
 """
 
 import logging
@@ -53,7 +49,6 @@ def _build_group_chat_select_query(
         .where(is_newest_subscription(context.user_id))
         .where(was_subscribed_at(GroupChatSubscription, Message.time))
         .where(or_(to_bool(only_archived is None), GroupChatSubscription.is_archived == only_archived))
-        # restrict to chats with at least one message newer than the user's last-seen
         .where(or_(to_bool(not unread), Message.id > GroupChatSubscription.last_seen_message_id))
         .group_by(GroupChatSubscription.group_chat_id),
         context,
@@ -66,13 +61,11 @@ def _build_host_request_select_query(
     context: CouchersContext, role_filter: ColumnElement[bool], only_archived: bool | None, unread: bool
 ) -> Select[tuple[int]]:
     """
-    The host-request half of the same idea as _build_group_chat_select_query: the ids of the host
-    requests and public-trip offers the request covers.
+    The ids of the host requests and public-trip offers the viewer should see, narrowed by the
+    request's archived and unread filters.
 
-    role_filter decides which requests belong in this view — the ones the viewer is hosting, the ones
-    they're surfing, or offers on their public trips. Requests the viewer shouldn't see are dropped
-    here too: ones involving deleted or blocked users, ones hidden by moderation, and — when the
-    caller asks for it — archived or already-read ones.
+    role_filter picks which side of the request the viewer is on: hosting, surfing, or offers on
+    their own public trips.
     """
     viewer_last_seen_message_id = case(
         (HostRequest.initiator_user_id == context.user_id, HostRequest.initiator_last_seen_message_id),
@@ -114,13 +107,9 @@ def _build_thread_select_queries(
     context: CouchersContext, request: conversations_pb2.MarkAllThreadsSeenReq
 ) -> tuple[Select[tuple[int]] | None, Select[tuple[int]] | None]:
     """
-    Resolve a request into the conversation-id subqueries it matches — one for group chats, one for
-    host requests, each None if that kind isn't included.
-
-    An empty category list means all categories, and MY_PUBLIC_TRIPS is dropped when the public-trips
-    flag is off (offers still show under SURFING / all, as before). The host-request categories are
-    role-based and OR'd together; MY_PUBLIC_TRIPS is a subset of SURFING, so requesting both is
-    redundant but harmless — grouping by conversation dedupes.
+    An empty category list means all categories. MY_PUBLIC_TRIPS is dropped when the public-trips
+    flag is off; those offers still show up under SURFING. MY_PUBLIC_TRIPS is also a subset of
+    SURFING, so asking for both is redundant but harmless — grouping by conversation dedupes.
     """
     categories = set(request.categories)
     if conversations_pb2.MESSAGE_THREAD_CATEGORY_UNSPECIFIED in categories:

--- a/app/backend/src/couchers/servicers/message_threads.py
+++ b/app/backend/src/couchers/servicers/message_threads.py
@@ -138,12 +138,13 @@ def _build_host_request_role_filter(user_id: int, categories: frozenset[int]) ->
     The stay-roles the selected categories cover, or None if none of them is a host request category.
     MY_PUBLIC_TRIPS is a subset of SURFING, so asking for both is redundant but harmless.
     """
-    role_filters = {
-        conversations_pb2.MESSAGE_THREAD_CATEGORY_HOSTING: is_hosting_party,
-        conversations_pb2.MESSAGE_THREAD_CATEGORY_SURFING: is_surfing_party,
-        conversations_pb2.MESSAGE_THREAD_CATEGORY_MY_PUBLIC_TRIPS: is_public_trip_offer_recipient,
-    }
-    clauses = [role_filter(user_id) for category, role_filter in role_filters.items() if category in categories]
+    clauses = []
+    if conversations_pb2.MESSAGE_THREAD_CATEGORY_HOSTING in categories:
+        clauses.append(is_hosting_party(user_id))
+    if conversations_pb2.MESSAGE_THREAD_CATEGORY_SURFING in categories:
+        clauses.append(is_surfing_party(user_id))
+    if conversations_pb2.MESSAGE_THREAD_CATEGORY_MY_PUBLIC_TRIPS in categories:
+        clauses.append(is_public_trip_offer_recipient(user_id))
     return or_(*clauses) if clauses else None
 
 

--- a/app/backend/src/couchers/servicers/message_threads.py
+++ b/app/backend/src/couchers/servicers/message_threads.py
@@ -1,0 +1,239 @@
+"""
+Bulk operations over the viewer's message threads — group chats, DMs, host requests and public-trip
+offers — selected by category (Conversations.MarkAllThreadsSeen).
+
+A request's categories resolve into candidate queries, one per kind of conversation, each yielding
+the ids of the conversations of that kind the request covers. MarkAllThreadsSeen consumes them as
+UPDATE targets.
+"""
+
+import logging
+from collections.abc import Sequence
+
+import grpc
+from google.protobuf import empty_pb2
+from sqlalchemy import ColumnElement, Select, select, update
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import and_, case, func, or_
+
+from couchers.context import CouchersContext
+from couchers.helpers.group_chats import is_newest_subscription, was_subscribed_at
+from couchers.helpers.host_requests import (
+    HOST_REQUEST_NOTIFICATION_TOPIC_ACTIONS,
+    is_hosting_party,
+    is_public_trip_offer_recipient,
+    is_surfing_party,
+)
+from couchers.models import (
+    GroupChat,
+    GroupChatSubscription,
+    HostRequest,
+    Message,
+)
+from couchers.models.notifications import NotificationTopicAction
+from couchers.notifications.notify import mark_notifications_seen
+from couchers.proto import conversations_pb2
+from couchers.sql import where_moderated_content_visible, where_users_column_visible
+
+logger = logging.getLogger(__name__)
+
+
+def _group_chat_candidate_query(
+    context: CouchersContext, only_archived: bool | None, unread: bool
+) -> Select[tuple[int]]:
+    """
+    The ids of the group chats (including DMs) the viewer should see, narrowed by the request's
+    archived and unread filters.
+    """
+    group_chat_ids = (
+        select(GroupChatSubscription.group_chat_id.label("conversation_id"))
+        .join(Message, Message.conversation_id == GroupChatSubscription.group_chat_id)
+        .join(GroupChat, GroupChat.conversation_id == GroupChatSubscription.group_chat_id)
+        .where(GroupChatSubscription.user_id == context.user_id)
+        .where(is_newest_subscription(context.user_id))
+        .where(was_subscribed_at(GroupChatSubscription, Message.time))
+        .group_by(GroupChatSubscription.group_chat_id)
+    )
+    if only_archived is not None:
+        group_chat_ids = group_chat_ids.where(GroupChatSubscription.is_archived == only_archived)
+    if unread:
+        # restrict to chats with at least one message newer than the user's last-seen
+        group_chat_ids = group_chat_ids.where(Message.id > GroupChatSubscription.last_seen_message_id)
+    return where_moderated_content_visible(group_chat_ids, context, GroupChat, is_list_operation=True)
+
+
+def _host_request_candidate_query(
+    context: CouchersContext, role_filter: ColumnElement[bool], only_archived: bool | None, unread: bool
+) -> Select[tuple[int]]:
+    """
+    The host-request half of the same idea as _group_chat_candidate_query: the ids of the host
+    requests and public-trip offers the request covers.
+
+    role_filter decides which requests belong in this view — the ones the viewer is hosting, the ones
+    they're surfing, or offers on their public trips. Requests the viewer shouldn't see are dropped
+    here too: ones involving deleted or blocked users, ones hidden by moderation, and — when the
+    caller asks for it — archived or already-read ones.
+    """
+    viewer_last_seen_message_id = case(
+        (HostRequest.initiator_user_id == context.user_id, HostRequest.initiator_last_seen_message_id),
+        else_=HostRequest.recipient_last_seen_message_id,
+    )
+    candidate_query = (
+        select(HostRequest.conversation_id.label("conversation_id"))
+        .join(Message, Message.conversation_id == HostRequest.conversation_id)
+        .where(
+            or_(
+                HostRequest.initiator_user_id == context.user_id,
+                HostRequest.recipient_user_id == context.user_id,
+            )
+        )
+        .where(role_filter)
+        .group_by(HostRequest.conversation_id)
+    )
+    if only_archived is not None:
+        candidate_query = candidate_query.where(
+            or_(
+                and_(
+                    HostRequest.initiator_user_id == context.user_id,
+                    HostRequest.is_initiator_archived == only_archived,
+                ),
+                and_(
+                    HostRequest.recipient_user_id == context.user_id,
+                    HostRequest.is_recipient_archived == only_archived,
+                ),
+            )
+        )
+    if unread:
+        candidate_query = candidate_query.having(func.max(Message.id) > viewer_last_seen_message_id)
+    candidate_query = where_users_column_visible(candidate_query, context, HostRequest.initiator_user_id)
+    candidate_query = where_users_column_visible(candidate_query, context, HostRequest.recipient_user_id)
+    candidate_query = where_moderated_content_visible(candidate_query, context, HostRequest, is_list_operation=True)
+    return candidate_query
+
+
+def _thread_candidate_queries(
+    context: CouchersContext, request: conversations_pb2.MarkAllThreadsSeenReq
+) -> tuple[Select[tuple[int]] | None, Select[tuple[int]] | None]:
+    """
+    Resolve a request into its candidate conversation-id subqueries — one for group chats, one for
+    host requests, each None if that kind isn't included.
+
+    An empty category list means all categories, and MY_PUBLIC_TRIPS is dropped when the public-trips
+    flag is off (offers still show under SURFING / all, as before). The host-request categories are
+    role-based and OR'd together; MY_PUBLIC_TRIPS is a subset of SURFING, so requesting both is
+    redundant but harmless — grouping by conversation dedupes.
+    """
+    categories = set(request.categories)
+    if conversations_pb2.MESSAGE_THREAD_CATEGORY_UNSPECIFIED in categories:
+        context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_thread_category")
+    if not categories:
+        categories = {
+            conversations_pb2.MESSAGE_THREAD_CATEGORY_CHATS,
+            conversations_pb2.MESSAGE_THREAD_CATEGORY_HOSTING,
+            conversations_pb2.MESSAGE_THREAD_CATEGORY_SURFING,
+            conversations_pb2.MESSAGE_THREAD_CATEGORY_MY_PUBLIC_TRIPS,
+        }
+    if not context.get_boolean_value("public_trips_enabled", False):
+        categories.discard(conversations_pb2.MESSAGE_THREAD_CATEGORY_MY_PUBLIC_TRIPS)
+
+    only_archived = request.only_archived if request.HasField("only_archived") else None
+    only_unread = request.only_unread
+
+    chat_query = (
+        _group_chat_candidate_query(context, only_archived, only_unread)
+        if conversations_pb2.MESSAGE_THREAD_CATEGORY_CHATS in categories
+        else None
+    )
+
+    role_clauses = []
+    if conversations_pb2.MESSAGE_THREAD_CATEGORY_HOSTING in categories:
+        role_clauses.append(is_hosting_party(context.user_id))
+    if conversations_pb2.MESSAGE_THREAD_CATEGORY_SURFING in categories:
+        role_clauses.append(is_surfing_party(context.user_id))
+    if conversations_pb2.MESSAGE_THREAD_CATEGORY_MY_PUBLIC_TRIPS in categories:
+        role_clauses.append(is_public_trip_offer_recipient(context.user_id))
+    host_request_query = (
+        _host_request_candidate_query(context, or_(*role_clauses), only_archived, only_unread) if role_clauses else None
+    )
+    return chat_query, host_request_query
+
+
+def mark_all_threads_seen(
+    request: conversations_pb2.MarkAllThreadsSeenReq, context: CouchersContext, session: Session
+) -> empty_pb2.Empty:
+    chat_query, host_request_query = _thread_candidate_queries(context, request)
+
+    # (topic actions, keys) groups for the notifications owned by the threads we mark seen
+    notification_groups: list[tuple[Sequence[NotificationTopicAction], Sequence[str]]] = []
+
+    if chat_query is not None:
+        # correlated, so it resolves per row of the update: every subscription advances to its own
+        # chat's newest message without listing them out. windowed, so a subscription the viewer
+        # has left advances only to the last message they could read, matching its unseen count
+        latest_message_id = (
+            select(func.max(Message.id))
+            .where(Message.conversation_id == GroupChatSubscription.group_chat_id)
+            .where(was_subscribed_at(GroupChatSubscription, Message.time))
+            .scalar_subquery()
+        )
+        marked_group_chat_ids = (
+            session.execute(
+                update(GroupChatSubscription)
+                .where(GroupChatSubscription.user_id == context.user_id)
+                .where(is_newest_subscription(context.user_id))
+                .where(GroupChatSubscription.group_chat_id.in_(select(chat_query.subquery().c.conversation_id)))
+                .where(GroupChatSubscription.last_seen_message_id < latest_message_id)
+                .values(last_seen_message_id=latest_message_id)
+                .returning(GroupChatSubscription.group_chat_id)
+                .execution_options(synchronize_session=False)
+            )
+            .scalars()
+            .all()
+        )
+        if marked_group_chat_ids:
+            notification_groups.append(
+                (
+                    [NotificationTopicAction.chat__message],
+                    [str(group_chat_id) for group_chat_id in marked_group_chat_ids],
+                )
+            )
+            # chat__missed_messages is a summary across all chats, so it's keyed with an empty
+            # string rather than a chat id (same as MarkLastSeenGroupChat)
+            notification_groups.append(([NotificationTopicAction.chat__missed_messages], [""]))
+
+    if host_request_query is not None:
+        # the viewer's last-seen column depends on their role, so one update per role
+        # (a user is never both initiator and recipient of the same request, so these are disjoint)
+        candidate_ids = select(host_request_query.subquery().c.conversation_id)
+        latest_message_id = (
+            select(func.max(Message.id)).where(Message.conversation_id == HostRequest.conversation_id).scalar_subquery()
+        )
+        marked_conversation_ids: list[int] = []
+        for user_id_column, last_seen_column in (
+            (HostRequest.initiator_user_id, HostRequest.initiator_last_seen_message_id),
+            (HostRequest.recipient_user_id, HostRequest.recipient_last_seen_message_id),
+        ):
+            marked_conversation_ids += (
+                session.execute(
+                    update(HostRequest)
+                    .where(user_id_column == context.user_id)
+                    .where(HostRequest.conversation_id.in_(candidate_ids))
+                    .where(last_seen_column < latest_message_id)
+                    .values({last_seen_column: latest_message_id})
+                    .returning(HostRequest.conversation_id)
+                    .execution_options(synchronize_session=False)
+                )
+                .scalars()
+                .all()
+            )
+        if marked_conversation_ids:
+            notification_groups.append(
+                (
+                    HOST_REQUEST_NOTIFICATION_TOPIC_ACTIONS,
+                    [str(conversation_id) for conversation_id in marked_conversation_ids],
+                )
+            )
+
+    mark_notifications_seen(session, user_id=context.user_id, topic_actions_and_keys=notification_groups)
+
+    return empty_pb2.Empty()

--- a/app/backend/src/couchers/servicers/message_threads.py
+++ b/app/backend/src/couchers/servicers/message_threads.py
@@ -2,9 +2,9 @@
 Bulk operations over the viewer's message threads — group chats, DMs, host requests and public-trip
 offers — selected by category (Conversations.MarkAllThreadsSeen).
 
-A request's categories resolve into candidate queries, one per kind of conversation, each yielding
-the ids of the conversations of that kind the request covers. MarkAllThreadsSeen consumes them as
-UPDATE targets.
+A request's categories resolve into one query per kind of conversation, each selecting the ids of
+the conversations of that kind the request matches. MarkAllThreadsSeen consumes them as UPDATE
+targets.
 """
 
 import logging
@@ -38,7 +38,7 @@ from couchers.sql import to_bool, where_moderated_content_visible, where_users_c
 logger = logging.getLogger(__name__)
 
 
-def _group_chat_candidate_query(
+def _build_group_chat_select_query(
     context: CouchersContext, only_archived: bool | None, unread: bool
 ) -> Select[tuple[int]]:
     """
@@ -62,11 +62,11 @@ def _group_chat_candidate_query(
     )
 
 
-def _host_request_candidate_query(
+def _build_host_request_select_query(
     context: CouchersContext, role_filter: ColumnElement[bool], only_archived: bool | None, unread: bool
 ) -> Select[tuple[int]]:
     """
-    The host-request half of the same idea as _group_chat_candidate_query: the ids of the host
+    The host-request half of the same idea as _build_group_chat_select_query: the ids of the host
     requests and public-trip offers the request covers.
 
     role_filter decides which requests belong in this view — the ones the viewer is hosting, the ones
@@ -78,7 +78,7 @@ def _host_request_candidate_query(
         (HostRequest.initiator_user_id == context.user_id, HostRequest.initiator_last_seen_message_id),
         else_=HostRequest.recipient_last_seen_message_id,
     )
-    candidate_query = (
+    query = (
         select(HostRequest.conversation_id.label("conversation_id"))
         .join(Message, Message.conversation_id == HostRequest.conversation_id)
         .where(
@@ -104,17 +104,17 @@ def _host_request_candidate_query(
         .group_by(HostRequest.conversation_id)
         .having(or_(to_bool(not unread), func.max(Message.id) > viewer_last_seen_message_id))
     )
-    candidate_query = where_users_column_visible(candidate_query, context, HostRequest.initiator_user_id)
-    candidate_query = where_users_column_visible(candidate_query, context, HostRequest.recipient_user_id)
-    candidate_query = where_moderated_content_visible(candidate_query, context, HostRequest, is_list_operation=True)
-    return candidate_query
+    query = where_users_column_visible(query, context, HostRequest.initiator_user_id)
+    query = where_users_column_visible(query, context, HostRequest.recipient_user_id)
+    query = where_moderated_content_visible(query, context, HostRequest, is_list_operation=True)
+    return query
 
 
-def _thread_candidate_queries(
+def _build_thread_select_queries(
     context: CouchersContext, request: conversations_pb2.MarkAllThreadsSeenReq
 ) -> tuple[Select[tuple[int]] | None, Select[tuple[int]] | None]:
     """
-    Resolve a request into its candidate conversation-id subqueries — one for group chats, one for
+    Resolve a request into the conversation-id subqueries it matches — one for group chats, one for
     host requests, each None if that kind isn't included.
 
     An empty category list means all categories, and MY_PUBLIC_TRIPS is dropped when the public-trips
@@ -139,7 +139,7 @@ def _thread_candidate_queries(
     only_unread = request.only_unread
 
     chat_query = (
-        _group_chat_candidate_query(context, only_archived, only_unread)
+        _build_group_chat_select_query(context, only_archived, only_unread)
         if conversations_pb2.MESSAGE_THREAD_CATEGORY_CHATS in categories
         else None
     )
@@ -152,7 +152,9 @@ def _thread_candidate_queries(
     if conversations_pb2.MESSAGE_THREAD_CATEGORY_MY_PUBLIC_TRIPS in categories:
         role_clauses.append(is_public_trip_offer_recipient(context.user_id))
     host_request_query = (
-        _host_request_candidate_query(context, or_(*role_clauses), only_archived, only_unread) if role_clauses else None
+        _build_host_request_select_query(context, or_(*role_clauses), only_archived, only_unread)
+        if role_clauses
+        else None
     )
     return chat_query, host_request_query
 
@@ -160,7 +162,7 @@ def _thread_candidate_queries(
 def mark_all_threads_seen(
     request: conversations_pb2.MarkAllThreadsSeenReq, context: CouchersContext, session: Session
 ) -> empty_pb2.Empty:
-    chat_query, host_request_query = _thread_candidate_queries(context, request)
+    chat_query, host_request_query = _build_thread_select_queries(context, request)
 
     # (topic actions, keys) groups for the notifications owned by the threads we mark seen
     notification_groups: list[tuple[Sequence[NotificationTopicAction], Sequence[str]]] = []
@@ -203,7 +205,7 @@ def mark_all_threads_seen(
     if host_request_query is not None:
         # the viewer's last-seen column depends on their role, so one update per role
         # (a user is never both initiator and recipient of the same request, so these are disjoint)
-        candidate_ids = select(host_request_query.subquery().c.conversation_id)
+        matching_ids = select(host_request_query.subquery().c.conversation_id)
         latest_message_id = (
             select(func.max(Message.id)).where(Message.conversation_id == HostRequest.conversation_id).scalar_subquery()
         )
@@ -216,7 +218,7 @@ def mark_all_threads_seen(
                 session.execute(
                     update(HostRequest)
                     .where(user_id_column == context.user_id)
-                    .where(HostRequest.conversation_id.in_(candidate_ids))
+                    .where(HostRequest.conversation_id.in_(matching_ids))
                     .where(last_seen_column < latest_message_id)
                     .values({last_seen_column: latest_message_id})
                     .returning(HostRequest.conversation_id)

--- a/app/backend/src/couchers/servicers/message_threads.py
+++ b/app/backend/src/couchers/servicers/message_threads.py
@@ -10,12 +10,13 @@ import grpc
 from google.protobuf import empty_pb2
 from sqlalchemy import ColumnElement, Select, select, update
 from sqlalchemy.orm import Session
-from sqlalchemy.sql import and_, case, func, or_
+from sqlalchemy.sql import and_, func, or_
 
 from couchers.context import CouchersContext
-from couchers.helpers.group_chats import is_newest_subscription, was_subscribed_at
+from couchers.helpers.group_chats import is_newest_subscription, is_unseen, was_subscribed_at
 from couchers.helpers.host_requests import (
     HOST_REQUEST_NOTIFICATION_TOPIC_ACTIONS,
+    has_unseen_host_request_messages,
     is_hosting_party,
     is_public_trip_offer_recipient,
     is_surfing_party,
@@ -49,7 +50,7 @@ def _build_group_chat_select_query(
         .where(is_newest_subscription(context.user_id))
         .where(was_subscribed_at(GroupChatSubscription, Message.time))
         .where(or_(to_bool(only_archived is None), GroupChatSubscription.is_archived == only_archived))
-        .where(or_(to_bool(not unread), Message.id > GroupChatSubscription.last_seen_message_id))
+        .where(or_(to_bool(not unread), is_unseen(Message, GroupChatSubscription)))
         .group_by(GroupChatSubscription.group_chat_id),
         context,
         GroupChat,
@@ -67,13 +68,8 @@ def _build_host_request_select_query(
     role_filter picks which side of the request the viewer is on: hosting, surfing, or offers on
     their own public trips.
     """
-    viewer_last_seen_message_id = case(
-        (HostRequest.initiator_user_id == context.user_id, HostRequest.initiator_last_seen_message_id),
-        else_=HostRequest.recipient_last_seen_message_id,
-    )
     query = (
         select(HostRequest.conversation_id.label("conversation_id"))
-        .join(Message, Message.conversation_id == HostRequest.conversation_id)
         .where(
             or_(
                 HostRequest.initiator_user_id == context.user_id,
@@ -94,8 +90,7 @@ def _build_host_request_select_query(
                 ),
             )
         )
-        .group_by(HostRequest.conversation_id)
-        .having(or_(to_bool(not unread), func.max(Message.id) > viewer_last_seen_message_id))
+        .where(or_(to_bool(not unread), has_unseen_host_request_messages(context.user_id)))
     )
     query = where_users_column_visible(query, context, HostRequest.initiator_user_id)
     query = where_users_column_visible(query, context, HostRequest.recipient_user_id)
@@ -109,7 +104,7 @@ def _build_thread_select_queries(
     """
     An empty category list means all categories. MY_PUBLIC_TRIPS is dropped when the public-trips
     flag is off; those offers still show up under SURFING. MY_PUBLIC_TRIPS is also a subset of
-    SURFING, so asking for both is redundant but harmless — grouping by conversation dedupes.
+    SURFING, so asking for both is redundant but harmless — the role clauses are OR'd together.
     """
     categories = set(request.categories)
     if conversations_pb2.MESSAGE_THREAD_CATEGORY_UNSPECIFIED in categories:

--- a/app/backend/src/couchers/servicers/message_threads.py
+++ b/app/backend/src/couchers/servicers/message_threads.py
@@ -5,6 +5,7 @@ offers — selected by category (Conversations.MarkAllThreadsSeen).
 
 import logging
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 import grpc
 from google.protobuf import empty_pb2
@@ -33,6 +34,40 @@ from couchers.proto import conversations_pb2
 from couchers.sql import to_bool, where_moderated_content_visible, where_users_column_visible
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _ThreadFilters:
+    categories: frozenset[int]
+    only_archived: bool | None
+    only_unread: bool
+
+
+def _resolve_thread_filters(
+    context: CouchersContext, request: conversations_pb2.MarkAllThreadsSeenReq
+) -> _ThreadFilters:
+    """
+    An empty category list means all categories. MY_PUBLIC_TRIPS is dropped when the public-trips
+    flag is off; those offers still show up under SURFING.
+    """
+    all_categories = frozenset(
+        {
+            conversations_pb2.MESSAGE_THREAD_CATEGORY_CHATS,
+            conversations_pb2.MESSAGE_THREAD_CATEGORY_HOSTING,
+            conversations_pb2.MESSAGE_THREAD_CATEGORY_SURFING,
+            conversations_pb2.MESSAGE_THREAD_CATEGORY_MY_PUBLIC_TRIPS,
+        }
+    )
+    if conversations_pb2.MESSAGE_THREAD_CATEGORY_UNSPECIFIED in request.categories:
+        context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_thread_category")
+    categories = frozenset(request.categories) or all_categories
+    if not context.get_boolean_value("public_trips_enabled", False):
+        categories -= {conversations_pb2.MESSAGE_THREAD_CATEGORY_MY_PUBLIC_TRIPS}
+    return _ThreadFilters(
+        categories=categories,
+        only_archived=request.only_archived if request.HasField("only_archived") else None,
+        only_unread=request.only_unread,
+    )
 
 
 def _build_group_chat_select_query(
@@ -98,60 +133,30 @@ def _build_host_request_select_query(
     return query
 
 
-def _build_thread_select_queries(
-    context: CouchersContext, request: conversations_pb2.MarkAllThreadsSeenReq
-) -> tuple[Select[tuple[int]] | None, Select[tuple[int]] | None]:
+def _build_host_request_role_filter(user_id: int, categories: frozenset[int]) -> ColumnElement[bool] | None:
     """
-    An empty category list means all categories. MY_PUBLIC_TRIPS is dropped when the public-trips
-    flag is off; those offers still show up under SURFING. MY_PUBLIC_TRIPS is also a subset of
-    SURFING, so asking for both is redundant but harmless — the role clauses are OR'd together.
+    The stay-roles the selected categories cover, or None if none of them is a host request category.
+    MY_PUBLIC_TRIPS is a subset of SURFING, so asking for both is redundant but harmless.
     """
-    categories = set(request.categories)
-    if conversations_pb2.MESSAGE_THREAD_CATEGORY_UNSPECIFIED in categories:
-        context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_thread_category")
-    if not categories:
-        categories = {
-            conversations_pb2.MESSAGE_THREAD_CATEGORY_CHATS,
-            conversations_pb2.MESSAGE_THREAD_CATEGORY_HOSTING,
-            conversations_pb2.MESSAGE_THREAD_CATEGORY_SURFING,
-            conversations_pb2.MESSAGE_THREAD_CATEGORY_MY_PUBLIC_TRIPS,
-        }
-    if not context.get_boolean_value("public_trips_enabled", False):
-        categories.discard(conversations_pb2.MESSAGE_THREAD_CATEGORY_MY_PUBLIC_TRIPS)
-
-    only_archived = request.only_archived if request.HasField("only_archived") else None
-    only_unread = request.only_unread
-
-    chat_query = (
-        _build_group_chat_select_query(context, only_archived, only_unread)
-        if conversations_pb2.MESSAGE_THREAD_CATEGORY_CHATS in categories
-        else None
-    )
-
-    role_clauses = []
-    if conversations_pb2.MESSAGE_THREAD_CATEGORY_HOSTING in categories:
-        role_clauses.append(is_hosting_party(context.user_id))
-    if conversations_pb2.MESSAGE_THREAD_CATEGORY_SURFING in categories:
-        role_clauses.append(is_surfing_party(context.user_id))
-    if conversations_pb2.MESSAGE_THREAD_CATEGORY_MY_PUBLIC_TRIPS in categories:
-        role_clauses.append(is_public_trip_offer_recipient(context.user_id))
-    host_request_query = (
-        _build_host_request_select_query(context, or_(*role_clauses), only_archived, only_unread)
-        if role_clauses
-        else None
-    )
-    return chat_query, host_request_query
+    role_filters = {
+        conversations_pb2.MESSAGE_THREAD_CATEGORY_HOSTING: is_hosting_party,
+        conversations_pb2.MESSAGE_THREAD_CATEGORY_SURFING: is_surfing_party,
+        conversations_pb2.MESSAGE_THREAD_CATEGORY_MY_PUBLIC_TRIPS: is_public_trip_offer_recipient,
+    }
+    clauses = [role_filter(user_id) for category, role_filter in role_filters.items() if category in categories]
+    return or_(*clauses) if clauses else None
 
 
 def mark_all_threads_seen(
     request: conversations_pb2.MarkAllThreadsSeenReq, context: CouchersContext, session: Session
 ) -> empty_pb2.Empty:
-    chat_query, host_request_query = _build_thread_select_queries(context, request)
+    filters = _resolve_thread_filters(context, request)
 
     # (topic actions, keys) groups for the notifications owned by the threads we mark seen
     notification_groups: list[tuple[Sequence[NotificationTopicAction], Sequence[str]]] = []
 
-    if chat_query is not None:
+    if conversations_pb2.MESSAGE_THREAD_CATEGORY_CHATS in filters.categories:
+        chat_query = _build_group_chat_select_query(context, filters.only_archived, filters.only_unread)
         # correlated, so it resolves per row of the update: every subscription advances to its own
         # chat's newest message without listing them out. windowed, so a subscription the viewer
         # has left advances only to the last message they could read, matching its unseen count
@@ -186,7 +191,11 @@ def mark_all_threads_seen(
             # string rather than a chat id (same as MarkLastSeenGroupChat)
             notification_groups.append(([NotificationTopicAction.chat__missed_messages], [""]))
 
-    if host_request_query is not None:
+    role_filter = _build_host_request_role_filter(context.user_id, filters.categories)
+    if role_filter is not None:
+        host_request_query = _build_host_request_select_query(
+            context, role_filter, filters.only_archived, filters.only_unread
+        )
         # the viewer's last-seen column depends on their role, so one update per role
         # (a user is never both initiator and recipient of the same request, so these are disjoint)
         matching_ids = select(host_request_query.subquery().c.conversation_id)

--- a/app/backend/src/couchers/servicers/message_threads.py
+++ b/app/backend/src/couchers/servicers/message_threads.py
@@ -33,7 +33,7 @@ from couchers.models import (
 from couchers.models.notifications import NotificationTopicAction
 from couchers.notifications.notify import mark_notifications_seen
 from couchers.proto import conversations_pb2
-from couchers.sql import where_moderated_content_visible, where_users_column_visible
+from couchers.sql import to_bool, where_moderated_content_visible, where_users_column_visible
 
 logger = logging.getLogger(__name__)
 
@@ -45,21 +45,21 @@ def _group_chat_candidate_query(
     The ids of the group chats (including DMs) the viewer should see, narrowed by the request's
     archived and unread filters.
     """
-    group_chat_ids = (
+    return where_moderated_content_visible(
         select(GroupChatSubscription.group_chat_id.label("conversation_id"))
         .join(Message, Message.conversation_id == GroupChatSubscription.group_chat_id)
         .join(GroupChat, GroupChat.conversation_id == GroupChatSubscription.group_chat_id)
         .where(GroupChatSubscription.user_id == context.user_id)
         .where(is_newest_subscription(context.user_id))
         .where(was_subscribed_at(GroupChatSubscription, Message.time))
-        .group_by(GroupChatSubscription.group_chat_id)
-    )
-    if only_archived is not None:
-        group_chat_ids = group_chat_ids.where(GroupChatSubscription.is_archived == only_archived)
-    if unread:
+        .where(or_(to_bool(only_archived is None), GroupChatSubscription.is_archived == only_archived))
         # restrict to chats with at least one message newer than the user's last-seen
-        group_chat_ids = group_chat_ids.where(Message.id > GroupChatSubscription.last_seen_message_id)
-    return where_moderated_content_visible(group_chat_ids, context, GroupChat, is_list_operation=True)
+        .where(or_(to_bool(not unread), Message.id > GroupChatSubscription.last_seen_message_id))
+        .group_by(GroupChatSubscription.group_chat_id),
+        context,
+        GroupChat,
+        is_list_operation=True,
+    )
 
 
 def _host_request_candidate_query(

--- a/app/backend/src/couchers/servicers/message_threads.py
+++ b/app/backend/src/couchers/servicers/message_threads.py
@@ -88,11 +88,9 @@ def _host_request_candidate_query(
             )
         )
         .where(role_filter)
-        .group_by(HostRequest.conversation_id)
-    )
-    if only_archived is not None:
-        candidate_query = candidate_query.where(
+        .where(
             or_(
+                to_bool(only_archived is None),
                 and_(
                     HostRequest.initiator_user_id == context.user_id,
                     HostRequest.is_initiator_archived == only_archived,
@@ -103,8 +101,9 @@ def _host_request_candidate_query(
                 ),
             )
         )
-    if unread:
-        candidate_query = candidate_query.having(func.max(Message.id) > viewer_last_seen_message_id)
+        .group_by(HostRequest.conversation_id)
+        .having(or_(to_bool(not unread), func.max(Message.id) > viewer_last_seen_message_id))
+    )
     candidate_query = where_users_column_visible(candidate_query, context, HostRequest.initiator_user_id)
     candidate_query = where_users_column_visible(candidate_query, context, HostRequest.recipient_user_id)
     candidate_query = where_moderated_content_visible(candidate_query, context, HostRequest, is_list_operation=True)

--- a/app/backend/src/couchers/servicers/message_threads.py
+++ b/app/backend/src/couchers/servicers/message_threads.py
@@ -50,17 +50,17 @@ def _resolve_thread_filters(
     An empty category list means all categories. MY_PUBLIC_TRIPS is dropped when the public-trips
     flag is off; those offers still show up under SURFING.
     """
-    all_categories = frozenset(
-        {
+    if conversations_pb2.MESSAGE_THREAD_CATEGORY_UNSPECIFIED in request.categories:
+        context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_thread_category")
+    categories = frozenset(
+        request.categories
+        or {
             conversations_pb2.MESSAGE_THREAD_CATEGORY_CHATS,
             conversations_pb2.MESSAGE_THREAD_CATEGORY_HOSTING,
             conversations_pb2.MESSAGE_THREAD_CATEGORY_SURFING,
             conversations_pb2.MESSAGE_THREAD_CATEGORY_MY_PUBLIC_TRIPS,
         }
     )
-    if conversations_pb2.MESSAGE_THREAD_CATEGORY_UNSPECIFIED in request.categories:
-        context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_thread_category")
-    categories = frozenset(request.categories) or all_categories
     if not context.get_boolean_value("public_trips_enabled", False):
         categories -= {conversations_pb2.MESSAGE_THREAD_CATEGORY_MY_PUBLIC_TRIPS}
     return _ThreadFilters(

--- a/app/backend/src/tests/test_message_threads.py
+++ b/app/backend/src/tests/test_message_threads.py
@@ -1,0 +1,226 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+import grpc
+import pytest
+from google.protobuf import empty_pb2
+
+from couchers.jobs.handlers import send_message_notifications
+from couchers.models import NotificationTopicAction
+from couchers.proto import api_pb2, conversations_pb2, notifications_pb2, requests_pb2
+from couchers.utils import today
+from tests.fixtures.db import generate_user
+from tests.fixtures.misc import now_5_min_in_future, process_jobs
+from tests.fixtures.sessions import (
+    conversations_session,
+    notifications_session,
+    real_api_session,
+    requests_session,
+)
+from tests.test_requests import valid_request_text
+
+
+@pytest.fixture(autouse=True)
+def _(testconfig):
+    pass
+
+
+def _create_group_chat(token: str, recipient_ids: list[int], moderator, text: str = "hi") -> int:
+    with conversations_session(token) as c:
+        res = c.CreateGroupChat(conversations_pb2.CreateGroupChatReq(recipient_user_ids=recipient_ids))
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=res.group_chat_id, text=text))
+    moderator.approve_group_chat(res.group_chat_id)
+    return int(res.group_chat_id)
+
+
+def _create_host_request(surfer_token: str, host_id: int, moderator) -> int:
+    with requests_session(surfer_token) as api:
+        res = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=host_id,
+                from_date=(today() + timedelta(days=5)).isoformat(),
+                to_date=(today() + timedelta(days=10)).isoformat(),
+                text=valid_request_text(),
+            )
+        )
+    moderator.approve_host_request(res.host_request_id)
+    return int(res.host_request_id)
+
+
+def test_mark_all_threads_seen_rejects_unspecified_category(db):
+    _user1, token1 = generate_user()
+
+    with conversations_session(token1) as c:
+        with pytest.raises(grpc.RpcError) as e:
+            c.MarkAllThreadsSeen(
+                conversations_pb2.MarkAllThreadsSeenReq(
+                    categories=[conversations_pb2.MESSAGE_THREAD_CATEGORY_UNSPECIFIED]
+                )
+            )
+        assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+
+def test_mark_all_threads_seen_respects_categories(db, moderator):
+    user1, token1 = generate_user()
+    _user2, token2 = generate_user()
+
+    # an unread group chat and an unread host request, both from user2
+    _create_group_chat(token2, [user1.id], moderator, text="hello there")
+    _create_host_request(token2, user1.id, moderator)
+
+    def unseen() -> tuple[int, int]:
+        with real_api_session(token1) as api:
+            res = api.Ping(api_pb2.PingReq())
+        return res.unseen_message_count, res.unseen_received_host_request_count
+
+    assert unseen() == (2, 1)
+
+    with conversations_session(token1) as c:
+        c.MarkAllThreadsSeen(
+            conversations_pb2.MarkAllThreadsSeenReq(categories=[conversations_pb2.MESSAGE_THREAD_CATEGORY_CHATS])
+        )
+    # the chat is now read; the host request is untouched
+    assert unseen() == (0, 1)
+
+    with conversations_session(token1) as c:
+        c.MarkAllThreadsSeen(conversations_pb2.MarkAllThreadsSeenReq())
+    assert unseen() == (0, 0)
+
+
+def test_mark_all_threads_seen_respects_unread_and_archived_filters(db, moderator):
+    user1, token1 = generate_user()
+    _user2, token2 = generate_user()
+    _user3, token3 = generate_user()
+
+    archived_chat_id = _create_group_chat(token2, [user1.id], moderator, text="archived")
+    _create_group_chat(token3, [user1.id], moderator, text="not archived")
+
+    with conversations_session(token1) as c:
+        c.SetGroupChatArchiveStatus(
+            conversations_pb2.SetGroupChatArchiveStatusReq(group_chat_id=archived_chat_id, is_archived=True)
+        )
+
+    def unseen_chat_messages() -> int:
+        with real_api_session(token1) as api:
+            return int(api.Ping(api_pb2.PingReq()).unseen_message_count)
+
+    # two messages in each chat: the creation notice and the text
+    assert unseen_chat_messages() == 4
+
+    with conversations_session(token1) as c:
+        c.MarkAllThreadsSeen(conversations_pb2.MarkAllThreadsSeenReq(only_archived=True))
+    assert unseen_chat_messages() == 2
+
+    with conversations_session(token1) as c:
+        c.MarkAllThreadsSeen(conversations_pb2.MarkAllThreadsSeenReq(only_unread=True))
+    assert unseen_chat_messages() == 0
+
+
+def test_mark_all_threads_seen_clears_departed_group_chat(db, moderator):
+    """
+    A viewer who was removed from a chat can only reach the messages sent before they left, so
+    marking everything seen has to advance them to that message rather than to the chat's newest —
+    otherwise the badge never clears.
+
+    The viewer is removed rather than leaving, because leaving posts a message of your own, which
+    marks everything up to it seen.
+    """
+    user1, token1 = generate_user()
+    _user2, token2 = generate_user()
+    user3, _token3 = generate_user()
+
+    chat_id = _create_group_chat(token2, [user1.id, user3.id], moderator)
+
+    with conversations_session(token2) as c:
+        c.RemoveGroupChatUser(conversations_pb2.RemoveGroupChatUserReq(group_chat_id=chat_id, user_id=user1.id))
+        for _ in range(3):
+            c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=chat_id, text="after you left"))
+
+    def unseen_chat_messages() -> int:
+        with real_api_session(token1) as api:
+            return int(api.Ping(api_pb2.PingReq()).unseen_message_count)
+
+    # chat created, "hi", and the removal notice; the three messages sent afterwards are out of reach
+    assert unseen_chat_messages() == 3
+
+    with conversations_session(token1) as c:
+        c.MarkAllThreadsSeen(conversations_pb2.MarkAllThreadsSeenReq())
+    assert unseen_chat_messages() == 0
+
+
+def test_mark_all_threads_seen_advances_the_current_subscription(db, moderator):
+    """
+    Rejoining a chat leaves the earlier subscription behind with its own last-seen state. Only the
+    current subscription is advanced, and the stale one must not hold the chat unread afterwards.
+    """
+    user1, token1 = generate_user()
+    _user2, token2 = generate_user()
+    user3, _token3 = generate_user()
+
+    chat_id = _create_group_chat(token2, [user1.id, user3.id], moderator)
+
+    # removed rather than leaving, so user1's first subscription is left behind with unread messages
+    with conversations_session(token2) as c:
+        c.RemoveGroupChatUser(conversations_pb2.RemoveGroupChatUserReq(group_chat_id=chat_id, user_id=user1.id))
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=chat_id, text="while you were away"))
+        c.InviteToGroupChat(conversations_pb2.InviteToGroupChatReq(group_chat_id=chat_id, user_id=user1.id))
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=chat_id, text="welcome back"))
+
+    def unseen_chat_messages() -> int:
+        with real_api_session(token1) as api:
+            return int(api.Ping(api_pb2.PingReq()).unseen_message_count)
+
+    # only the invite notice and "welcome back" are in reach; the first stint's messages are not
+    assert unseen_chat_messages() == 2
+
+    with conversations_session(token1) as c:
+        c.MarkAllThreadsSeen(conversations_pb2.MarkAllThreadsSeenReq())
+    assert unseen_chat_messages() == 0
+
+
+def test_mark_all_threads_seen_clears_missed_messages_notification(db, moderator):
+    """
+    Regression test: chat__missed_messages is a summary keyed with "" rather than a chat id, so it
+    needs its own (topic actions, keys) group instead of being pooled with the per-chat keys.
+    """
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    # this notification is email-only by default, and the in-app feed only shows push-enabled ones
+    with notifications_session(token2) as n:
+        n.SetNotificationSettings(
+            notifications_pb2.SetNotificationSettingsReq(
+                preferences=[
+                    notifications_pb2.SingleNotificationPreference(
+                        topic=NotificationTopicAction.chat__missed_messages.topic,
+                        action=NotificationTopicAction.chat__missed_messages.action,
+                        delivery_method="push",
+                        enabled=True,
+                    )
+                ]
+            )
+        )
+
+    _create_group_chat(token1, [user2.id], moderator, text="hello there")
+
+    # the job only picks up messages that have been unseen for five minutes
+    with patch("couchers.jobs.handlers.now", now_5_min_in_future):
+        send_message_notifications(empty_pb2.Empty())
+        process_jobs()
+
+    def unseen_missed_messages():
+        with notifications_session(token2) as n:
+            res = n.ListNotifications(notifications_pb2.ListNotificationsReq(only_unread=True))
+        return [
+            notification
+            for notification in res.notifications
+            if notification.topic == NotificationTopicAction.chat__missed_messages.topic
+            and notification.action == NotificationTopicAction.chat__missed_messages.action
+        ]
+
+    assert len(unseen_missed_messages()) == 1
+
+    with conversations_session(token2) as c:
+        c.MarkAllThreadsSeen(conversations_pb2.MarkAllThreadsSeenReq())
+
+    assert unseen_missed_messages() == []

--- a/app/backend/src/tests/test_message_threads.py
+++ b/app/backend/src/tests/test_message_threads.py
@@ -4,9 +4,12 @@ from unittest.mock import patch
 import grpc
 import pytest
 from google.protobuf import empty_pb2
+from sqlalchemy import select
 
+from couchers.db import session_scope
+from couchers.helpers.host_requests import has_unseen_host_request_messages
 from couchers.jobs.handlers import send_message_notifications
-from couchers.models import NotificationTopicAction
+from couchers.models import HostRequest, NotificationTopicAction
 from couchers.proto import api_pb2, conversations_pb2, notifications_pb2, requests_pb2
 from couchers.utils import today
 from tests.fixtures.db import generate_user
@@ -45,6 +48,27 @@ def _create_host_request(surfer_token: str, host_id: int, moderator) -> int:
         )
     moderator.approve_host_request(res.host_request_id)
     return int(res.host_request_id)
+
+
+def test_has_unseen_host_request_messages_is_false_for_a_non_party(db, moderator):
+    user1, _token1 = generate_user()
+    _user2, token2 = generate_user()
+    outsider, _token3 = generate_user()
+
+    conversation_id = _create_host_request(token2, user1.id, moderator)
+
+    with session_scope() as session:
+        unseen_for = {
+            user_id: session.execute(
+                select(HostRequest.conversation_id)
+                .where(HostRequest.conversation_id == conversation_id)
+                .where(has_unseen_host_request_messages(user_id))
+            ).scalar_one_or_none()
+            for user_id in (user1.id, outsider.id)
+        }
+
+    assert unseen_for[user1.id] == conversation_id
+    assert unseen_for[outsider.id] is None
 
 
 def test_mark_all_threads_seen_rejects_unspecified_category(db):

--- a/app/proto/conversations.proto
+++ b/app/proto/conversations.proto
@@ -17,6 +17,11 @@ service Conversations {
     // Retrieves list of group chats (ordered by last message), paginated
   }
 
+  rpc MarkAllThreadsSeen(MarkAllThreadsSeenReq) returns (google.protobuf.Empty) {
+    // Marks every message thread matching the given filter as seen (server-side
+    // bulk mark-all-read).
+  }
+
   rpc GetGroupChat(GetGroupChatReq) returns (GroupChat) {
     // Retrieves group chat info by id
   }
@@ -129,6 +134,27 @@ message ListGroupChatsRes {
   repeated GroupChat group_chats = 1;
   uint64 last_message_id = 2;
   bool no_more = 3;
+}
+
+// Categories of message thread. Combinable in MarkAllThreadsSeen: an empty list means all
+// categories. Read-state (only_unread) and archived (only_archived) are separate, orthogonal
+// filters.
+enum MessageThreadCategory {
+  MESSAGE_THREAD_CATEGORY_UNSPECIFIED = 0;
+  MESSAGE_THREAD_CATEGORY_CHATS = 1; // group chats + DMs
+  MESSAGE_THREAD_CATEGORY_HOSTING = 2; // role-based: I am the host of the stay
+  MESSAGE_THREAD_CATEGORY_SURFING = 3; // role-based: I am the guest/traveller
+  // incoming offers on my public trips (I'm the traveller); a subset of SURFING
+  MESSAGE_THREAD_CATEGORY_MY_PUBLIC_TRIPS = 4;
+}
+
+message MarkAllThreadsSeenReq {
+  // which categories to include; empty means all categories
+  repeated MessageThreadCategory categories = 1;
+  // orthogonal: when present, restrict to archived (true) or non-archived (false)
+  optional bool only_archived = 2;
+  // orthogonal: when true, restrict to unread threads
+  bool only_unread = 3;
 }
 
 message GetUpdatesReq {


### PR DESCRIPTION
Splits the unified thread list (#9472) in two: this PR is the bulk mark-all-read plus the thread-selection machinery it needs, and #9472 becomes the read endpoint on top of it.

**New RPC on the Conversations service:** `MarkAllThreadsSeen` — server-side bulk mark-all-read over the viewer's message threads, selected by category (`CHATS` / `HOSTING` / `SURFING` / `MY_PUBLIC_TRIPS`, role-based per #9464's predicates) and orthogonally by unread and archived state.

**How it works:** each kind of conversation contributes a candidate query yielding the ids of the conversations the request covers; the RPC consumes those as UPDATE targets, one statement per last-seen column (a user is never both initiator and recipient of the same request, so the two host request updates are disjoint). The group chat update is correlated and windowed, so:

- a subscription the viewer has *left* advances only to the last message they could read, matching the unseen count Ping shows — otherwise a departed chat's badge could never clear
- only the *current* subscription of a rejoined chat is touched, so the abandoned one can't hold the chat unread

Notifications owned by the marked threads are marked seen in the same pass; `chat__missed_messages` is a summary keyed with `""` rather than a chat id, so it gets its own group.

The machinery lives in its own module, `couchers.servicers.message_threads`, with a thin delegating RPC method on the servicer.

`MY_PUBLIC_TRIPS` is gated by the `public_trips_enabled` flag; offers still fall under `SURFING`/all when it's off.

## Testing
New `test_message_threads.py` covers category selection, the unread and archived filters, invalid categories, clearing a departed chat, advancing only the current subscription after a rejoin, and clearing the missed-messages notification — all observed through the Ping badge, which is the counter these updates have to agree with. `make mypy` passes; `test_message_threads.py`, `test_conversations.py`, `test_requests.py` and `test_bg_jobs.py` pass locally.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history (no db changes)

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me