### PR TITLE
Use the host request stay role columns where surfer/host is meant

### DIFF
--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -773,8 +773,8 @@ class Admin(admin_pb2_grpc.AdminServicer):
         def get_host_request_pb(host_request: HostRequest) -> admin_pb2.AdminHostRequest:
             return admin_pb2.AdminHostRequest(
                 host_request_id=host_request.conversation_id,
-                surfer=get_chat_user_info(host_request.initiator_user_id),
-                host=get_chat_user_info(host_request.recipient_user_id),
+                surfer=get_chat_user_info(host_request.surfer_user_id),
+                host=get_chat_user_info(host_request.host_user_id),
                 status=host_request.status.name if host_request.status else "",
                 from_date=date_to_api(host_request.from_date),
                 to_date=date_to_api(host_request.to_date),

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -102,8 +102,8 @@ def host_request_to_pb(
 
     return requests_pb2.HostRequest(
         host_request_id=host_request.conversation_id,
-        surfer_user_id=host_request.initiator_user_id,
-        host_user_id=host_request.recipient_user_id,
+        surfer_user_id=host_request.surfer_user_id,
+        host_user_id=host_request.host_user_id,
         status=hostrequeststatus2api[host_request.status],
         created=Timestamp_from_datetime(initial_message.time),
         from_date=date_to_api(host_request.from_date),
@@ -141,10 +141,8 @@ def _possibly_observe_first_response_time(
     ).scalar_one_or_none()
 
     if number_messages_by_host == 0:
-        host_gender = session.execute(select(User.gender).where(User.id == host_request.recipient_user_id)).scalar_one()
-        surfer_gender = session.execute(
-            select(User.gender).where(User.id == host_request.initiator_user_id)
-        ).scalar_one()
+        host_gender = session.execute(select(User.gender).where(User.id == host_request.host_user_id)).scalar_one()
+        surfer_gender = session.execute(select(User.gender).where(User.id == host_request.surfer_user_id)).scalar_one()
         host_request_first_response_histogram.labels(host_gender, surfer_gender, response_type).observe(
             (now() - host_request.conversation.created).total_seconds()
         )
@@ -497,8 +495,8 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             host_requests.append(
                 requests_pb2.HostRequest(
                     host_request_id=result.HostRequest.conversation_id,
-                    surfer_user_id=result.HostRequest.initiator_user_id,
-                    host_user_id=result.HostRequest.recipient_user_id,
+                    surfer_user_id=result.HostRequest.surfer_user_id,
+                    host_user_id=result.HostRequest.host_user_id,
                     status=hostrequeststatus2api[result.HostRequest.status],
                     created=Timestamp_from_datetime(result.Conversation.created),
                     from_date=date_to_api(result.HostRequest.from_date),
@@ -611,10 +609,10 @@ class Requests(requests_pb2_grpc.RequestsServicer):
                 "host_request.accepted",
                 {
                     "host_request_id": host_request.conversation_id,
-                    "surfer_id": host_request.initiator_user_id,
-                    "host_id": host_request.recipient_user_id,
-                    "surfer_gender": host_request.initiator.gender,
-                    "host_gender": host_request.recipient.gender,
+                    "surfer_id": host_request.surfer_user_id,
+                    "host_id": host_request.host_user_id,
+                    "surfer_gender": host_request.surfer.gender,
+                    "host_gender": host_request.host.gender,
                     "from_date": str(host_request.from_date),
                     "to_date": str(host_request.to_date),
                     "host_city": host_request.hosting_city,
@@ -654,10 +652,10 @@ class Requests(requests_pb2_grpc.RequestsServicer):
                 "host_request.rejected",
                 {
                     "host_request_id": host_request.conversation_id,
-                    "surfer_id": host_request.initiator_user_id,
-                    "host_id": host_request.recipient_user_id,
-                    "surfer_gender": host_request.initiator.gender,
-                    "host_gender": host_request.recipient.gender,
+                    "surfer_id": host_request.surfer_user_id,
+                    "host_id": host_request.host_user_id,
+                    "surfer_gender": host_request.surfer.gender,
+                    "host_gender": host_request.host.gender,
                     "from_date": str(host_request.from_date),
                     "to_date": str(host_request.to_date),
                     "host_city": host_request.hosting_city,
@@ -695,10 +693,10 @@ class Requests(requests_pb2_grpc.RequestsServicer):
                 "host_request.confirmed",
                 {
                     "host_request_id": host_request.conversation_id,
-                    "surfer_id": host_request.initiator_user_id,
-                    "host_id": host_request.recipient_user_id,
-                    "surfer_gender": host_request.initiator.gender,
-                    "host_gender": host_request.recipient.gender,
+                    "surfer_id": host_request.surfer_user_id,
+                    "host_id": host_request.host_user_id,
+                    "surfer_gender": host_request.surfer.gender,
+                    "host_gender": host_request.host.gender,
                     "from_date": str(host_request.from_date),
                     "to_date": str(host_request.to_date),
                     "host_city": host_request.hosting_city,
@@ -736,10 +734,10 @@ class Requests(requests_pb2_grpc.RequestsServicer):
                 "host_request.cancelled",
                 {
                     "host_request_id": host_request.conversation_id,
-                    "surfer_id": host_request.initiator_user_id,
-                    "host_id": host_request.recipient_user_id,
-                    "surfer_gender": host_request.initiator.gender,
-                    "host_gender": host_request.recipient.gender,
+                    "surfer_id": host_request.surfer_user_id,
+                    "host_id": host_request.host_user_id,
+                    "surfer_gender": host_request.surfer.gender,
+                    "host_gender": host_request.host.gender,
                     "from_date": str(host_request.from_date),
                     "to_date": str(host_request.to_date),
                     "host_city": host_request.hosting_city,
@@ -886,9 +884,9 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             "host_request.message_sent",
             {
                 "host_request_id": host_request.conversation_id,
-                "surfer_id": host_request.initiator_user_id,
-                "host_id": host_request.recipient_user_id,
-                "role": "host" if context.user_id == host_request.recipient_user_id else "surfer",
+                "surfer_id": host_request.surfer_user_id,
+                "host_id": host_request.host_user_id,
+                "role": "host" if context.user_id == host_request.host_user_id else "surfer",
                 "host_city": host_request.hosting_city,
             },
         )
@@ -1064,8 +1062,8 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             "host_request.feedback_submitted",
             {
                 "host_request_id": host_request.conversation_id,
-                "surfer_id": host_request.initiator_user_id,
-                "host_id": host_request.recipient_user_id,
+                "surfer_id": host_request.surfer_user_id,
+                "host_id": host_request.host_user_id,
                 "request_quality": quality.name if quality else None,
                 "has_decline_reason": bool(request.decline_reason),
                 "host_city": host_request.hosting_city,

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -2311,6 +2311,47 @@ def test_create_request_with_public_trip_hosting_snapshot(db, moderator):
         assert hr.hosting_radius == 22
 
 
+def test_public_trip_offer_stay_roles(db, moderator):
+    """An offer reverses initiator/recipient, but the surfer and host are still the traveller and the host."""
+    surfer, surfer_token = generate_user()
+    host, host_token = generate_user()
+
+    trip_from = today() + timedelta(days=10)
+    trip_to = today() + timedelta(days=20)
+    trip_id = _create_public_trip(surfer.id, trip_from, trip_to)
+
+    with requests_session(host_token) as api:
+        host_request_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=surfer.id,
+                from_date=trip_from.isoformat(),
+                to_date=trip_to.isoformat(),
+                text=valid_request_text(),
+                public_trip_id=trip_id,
+            )
+        ).host_request_id
+
+    moderator.approve_host_request(host_request_id)
+
+    with session_scope() as session:
+        host_request = session.execute(
+            select(HostRequest).where(HostRequest.conversation_id == host_request_id)
+        ).scalar_one()
+        assert host_request.initiator_user_id == host.id
+        assert host_request.recipient_user_id == surfer.id
+        assert host_request.surfer_user_id == surfer.id
+        assert host_request.host_user_id == host.id
+
+    for token in (surfer_token, host_token):
+        with requests_session(token) as api:
+            hr = api.GetHostRequest(requests_pb2.GetHostRequestReq(host_request_id=host_request_id))
+            assert hr.surfer_user_id == surfer.id
+            assert hr.host_user_id == host.id
+
+            listed = api.ListHostRequests(requests_pb2.ListHostRequestsReq()).host_requests
+            assert [(r.surfer_user_id, r.host_user_id) for r in listed] == [(surfer.id, host.id)]
+
+
 def test_create_request_with_public_trip_dates_out_of_range(db):
     """Offered dates outside the trip window are rejected."""
     surfer, _ = generate_user()


### PR DESCRIPTION
Now off `develop` — #9476, which adds the generated `surfer_user_id` / `host_user_id` columns, has landed. This PR is just the one-for-one substitutions on the read paths: every site here already meant *whose couch is it* and was reading the conversation columns instead.

For a normal host request the two axes coincide, so nothing changes. For an offer on a public trip they're reversed (the host initiates, the traveller responds), and these were silently inverted.

**`servicers/requests.py`**
- `host_request_to_pb` and `ListHostRequests` — the `surfer_user_id` / `host_user_id` fields on the wire were the initiator/recipient, so clients saw the two swapped for offers. Nothing compensates for this on `develop` — `HostRequestView` reads `surferUserId` / `hostUserId` straight, so the request view shows the two sides swapped on an offer. (The unmerged `na/web/messages-pub-trips` branch re-derives them; that swap can come out once this lands.)
- `_possibly_observe_first_response_time` — gender labels.
- The six `log_event` payloads — `surfer_id`, `host_id`, `surfer_gender`, `host_gender`, `role`.

**`servicers/admin.py`** — the `surfer` / `host` fields on `AdminHostRequest`.

The one write-path change — `CreateHostRequest` snapshotting `hosting_city` / `hosting_location` / `hosting_radius` from the recipient, i.e. the traveller's home city for an offer — is split out into #9491 so it can be reviewed on its own. The places where the *logic* branches on the wrong axis rather than just reading the wrong column — reference types, reference reminders, `am_host` — are in #9480 on top of this.

Deliberately left on the conversation axis, because that's genuinely what they mean: the status state machine, unread/archive tracking, the `didnt_meetup` and reminder-counter columns, request rate limiting, and the decline-feedback flow (only the recipient can reject, so only they leave feedback).

Not addressed anywhere in this stack, since each needs a decision rather than a column swap:
- `UserResponseRate` measures how fast the recipient replies, and is surfaced on profiles as a hosting signal. Swapping it to `host_user_id` would be wrong (the host sends the first message on an offer, so it'd read as instant). It probably wants to exclude offers instead, which means a matview migration.
- `HostRequestReminder.surfer`, `RespondToHostRequestReminder.surfer_user` and `ConfirmHostRequestReminder.host_user` carry the *other* party but are named by stay role. Fixing the naming is a proto change.
- The mod-email columns in `rate_limits/definitions.py` are labelled "host ..." but are really the recipient.

No data repair needed: there are no host requests with a `public_trip_id` in production, so nothing has been written with the roles inverted, and the generated columns derive surfer/host from `public_trip_id` so they're correct for any row.

## Testing
`test_requests.py::test_public_trip_offer_stay_roles` covers the `surfer_user_id` / `host_user_id` fields on `GetHostRequest` and `ListHostRequests` from both sides of an offer, and pins the underlying initiator/recipient columns. Verified to fail on `develop` — it returned the two ids swapped.

Full backend suite passes, `make format` and `make mypy` clean.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._
