### PR TITLE
Derive surfer/host roles where the logic branched on the wrong axis

### DIFF
--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -22,7 +22,6 @@ from sqlalchemy.sql import (
     exists,
     extract,
     func,
-    literal,
     not_,
     or_,
     union_all,
@@ -309,7 +308,7 @@ def send_request_notifications(payload: empty_pb2.Empty) -> None:
     with session_scope() as session:
         # Get all candidate users who might have unseen request messages.
         # Drive from host_requests/messages (selective) rather than scanning all users (expensive).
-        surfer_ids = (
+        initiator_ids = (
             select(User.id)
             .join(HostRequest, HostRequest.initiator_user_id == User.id)
             .join(Message, Message.conversation_id == HostRequest.conversation_id)
@@ -319,7 +318,7 @@ def send_request_notifications(payload: empty_pb2.Empty) -> None:
             .where(_message_unseen_long_enough(User.id))
             .where(Message.message_type == MessageType.text)
         )
-        host_ids = (
+        recipient_ids = (
             select(User.id)
             .join(HostRequest, HostRequest.recipient_user_id == User.id)
             .join(Message, Message.conversation_id == HostRequest.conversation_id)
@@ -329,13 +328,13 @@ def send_request_notifications(payload: empty_pb2.Empty) -> None:
             .where(_message_unseen_long_enough(User.id))
             .where(Message.message_type == MessageType.text)
         )
-        candidate_user_ids = session.execute(union_all(surfer_ids, host_ids)).scalars().unique().all()
+        candidate_user_ids = session.execute(union_all(initiator_ids, recipient_ids)).scalars().unique().all()
 
         for user_id in candidate_user_ids:
             context = make_notification_user_context(user_id=user_id)
 
-            # requests where this user is surfing
-            surfing_reqs = session.execute(
+            # requests this user initiated
+            initiated_reqs = session.execute(
                 where_users_column_visible(
                     where_moderated_content_visible_to_user_column(
                         select(User, HostRequest, func.max(Message.id))
@@ -355,8 +354,8 @@ def send_request_notifications(payload: empty_pb2.Empty) -> None:
                 .group_by(User, HostRequest)  # type: ignore[arg-type]
             ).all()
 
-            # where this user is hosting
-            hosting_reqs = session.execute(
+            # requests this user received
+            received_reqs = session.execute(
                 where_users_column_visible(
                     where_moderated_content_visible_to_user_column(
                         select(User, HostRequest, func.max(Message.id))
@@ -376,7 +375,7 @@ def send_request_notifications(payload: empty_pb2.Empty) -> None:
                 .group_by(User, HostRequest)  # type: ignore[arg-type]
             ).all()
 
-            for user, host_request, max_message_id in surfing_reqs:
+            for user, host_request, max_message_id in initiated_reqs:
                 user.last_notified_request_message_id = max(user.last_notified_request_message_id, max_message_id)
                 session.flush()
 
@@ -388,11 +387,11 @@ def send_request_notifications(payload: empty_pb2.Empty) -> None:
                     data=notification_data_pb2.HostRequestMissedMessages(
                         host_request=host_request_to_pb(host_request, session, context),
                         user=user_model_to_pb(host_request.recipient, session, context),
-                        am_host=False,
+                        am_host=host_request.host_user_id == user.id,
                     ),
                 )
 
-            for user, host_request, max_message_id in hosting_reqs:
+            for user, host_request, max_message_id in received_reqs:
                 user.last_notified_request_message_id = max(user.last_notified_request_message_id, max_message_id)
                 session.flush()
 
@@ -431,7 +430,7 @@ def send_request_notifications(payload: empty_pb2.Empty) -> None:
                     data=notification_data_pb2.HostRequestMissedMessages(
                         host_request=host_request_to_pb(host_request, session, context),
                         user=user_model_to_pb(host_request.initiator, session, context),
-                        am_host=True,
+                        am_host=host_request.host_user_id == user.id,
                     ),
                 )
 
@@ -508,16 +507,19 @@ def send_reference_reminders(payload: empty_pb2.Empty) -> None:
         for reminder_number, reminder_time, reminder_days_left in reversed(reference_reminder_schedule):
             user = aliased(User)
             other_user = aliased(User)
-            # surfers needing to write a ref
+            # the two halves split on the conversation role, since that's the axis the reminder counters and
+            # didnt_meetup columns live on
+            surfed_col = (HostRequest.surfer_user_id == user.id).label("surfed")
+            # initiators needing to write a ref
             q1 = (
-                select(literal(True), HostRequest, user, other_user)
+                select(surfed_col, HostRequest, user, other_user)
                 .join(user, user.id == HostRequest.initiator_user_id)
                 .join(other_user, other_user.id == HostRequest.recipient_user_id)
                 .outerjoin(
                     Reference,
                     and_(
                         Reference.host_request_id == HostRequest.conversation_id,
-                        # if no reference is found in this join, then the surfer has not written a ref
+                        # if no reference is found in this join, then the initiator has not written a ref
                         Reference.from_user_id == HostRequest.initiator_user_id,
                     ),
                 )
@@ -529,16 +531,16 @@ def send_reference_reminders(payload: empty_pb2.Empty) -> None:
                 .where(users_visible_to_each_other(self_user=user, other_user=other_user))
             )
 
-            # hosts needing to write a ref
+            # recipients needing to write a ref
             q2 = (
-                select(literal(False), HostRequest, user, other_user)
+                select(surfed_col, HostRequest, user, other_user)
                 .join(user, user.id == HostRequest.recipient_user_id)
                 .join(other_user, other_user.id == HostRequest.initiator_user_id)
                 .outerjoin(
                     Reference,
                     and_(
                         Reference.host_request_id == HostRequest.conversation_id,
-                        # if no reference is found in this join, then the host has not written a ref
+                        # if no reference is found in this join, then the recipient has not written a ref
                         Reference.from_user_id == HostRequest.recipient_user_id,
                     ),
                 )
@@ -579,7 +581,7 @@ def send_reference_reminders(payload: empty_pb2.Empty) -> None:
                         days_left=reminder_days_left,
                     ),
                 )
-                if surfed:
+                if user.id == host_request.initiator_user_id:
                     host_request.initiator_sent_reference_reminders = reminder_number
                 else:
                     host_request.recipient_sent_reference_reminders = reminder_number

--- a/app/backend/src/couchers/servicers/references.py
+++ b/app/backend/src/couchers/servicers/references.py
@@ -11,7 +11,7 @@ import grpc
 from google.protobuf import empty_pb2
 from sqlalchemy import select
 from sqlalchemy.orm import Session, aliased
-from sqlalchemy.sql import and_, literal, or_, union_all
+from sqlalchemy.sql import and_, or_, union_all
 
 from couchers.context import CouchersContext, make_notification_user_context
 from couchers.db import are_friends
@@ -88,9 +88,9 @@ def get_host_req_and_check_can_write_ref(
     ).scalar_one_or_none():
         context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "reference_already_given")
 
-    surfed = host_request.initiator_user_id == context.user_id
+    surfed = host_request.surfer_user_id == context.user_id
 
-    if surfed:
+    if host_request.initiator_user_id == context.user_id:
         my_reason = host_request.initiator_reason_didnt_meetup
     else:
         my_reason = host_request.recipient_reason_didnt_meetup
@@ -117,8 +117,11 @@ def check_valid_reference(
 def get_pending_references_to_write(
     session: Session, context: CouchersContext
 ) -> list[tuple[int, ReferenceType, datetime, LiteUser]]:
+    # the two halves split on the conversation role, since that's the axis the didnt_meetup columns live on
+    surfed_col = (HostRequest.surfer_user_id == context.user_id).label("surfed")
+
     q1 = (
-        select(literal(True), HostRequest, LiteUser)
+        select(surfed_col, HostRequest, LiteUser)
         .outerjoin(
             Reference,
             and_(
@@ -136,7 +139,7 @@ def get_pending_references_to_write(
     q1 = q1.where(HostRequest.initiator_reason_didnt_meetup == None)
 
     q2 = (
-        select(literal(False), HostRequest, LiteUser)
+        select(surfed_col, HostRequest, LiteUser)
         .outerjoin(
             Reference,
             and_(
@@ -309,15 +312,13 @@ class References(references_pb2_grpc.ReferencesServicer):
         reference_text = request.text.strip()
 
         if surfed:
-            # we requested to surf with someone
+            # we surfed with someone
             reference_type = ReferenceType.surfed
-            to_user_id = host_request.recipient_user_id
-            assert context.user_id == host_request.initiator_user_id
+            to_user_id = host_request.host_user_id
         else:
             # we hosted someone
             reference_type = ReferenceType.hosted
-            to_user_id = host_request.initiator_user_id
-            assert context.user_id == host_request.recipient_user_id
+            to_user_id = host_request.surfer_user_id
 
         reference: Reference | None = None
 
@@ -425,8 +426,11 @@ class References(references_pb2_grpc.ReferencesServicer):
             ).scalar_one_or_none()
         ) is None
 
+        # the two halves split on the conversation role, since that's the axis the didnt_meetup columns live on
+        surfed_col = (HostRequest.surfer_user_id == context.user_id).label("surfed")
+
         q1 = (
-            select(literal(True), HostRequest)
+            select(surfed_col, HostRequest)
             .outerjoin(
                 Reference,
                 and_(
@@ -442,7 +446,7 @@ class References(references_pb2_grpc.ReferencesServicer):
         )
 
         q2 = (
-            select(literal(False), HostRequest)
+            select(surfed_col, HostRequest)
             .outerjoin(
                 Reference,
                 and_(

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -865,7 +865,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
                     host_request=host_request_to_pb(host_request, session, recipient_context),
                     user=user_model_to_pb(host_request.initiator, session, recipient_context),
                     text=request.text,
-                    am_host=True,
+                    am_host=host_request.host_user_id == host_request.recipient_user_id,
                 ),
                 moderation_state_id=host_request.moderation_state_id,
             )
@@ -883,7 +883,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
                     host_request=host_request_to_pb(host_request, session, recipient_context),
                     user=user_model_to_pb(host_request.recipient, session, recipient_context),
                     text=request.text,
-                    am_host=False,
+                    am_host=host_request.host_user_id == host_request.initiator_user_id,
                 ),
                 moderation_state_id=host_request.moderation_state_id,
             )

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -1294,6 +1294,33 @@ def test_send_reference_reminders(db):
                 assert find in html, f"Expected to find string {find} in HTML email {subject} to {address}, didn't"
 
 
+def test_send_reference_reminders_public_trip_offer(db):
+    """An offer reverses initiator/recipient, so the reminders have to be picked by the stay role."""
+    surfer, _ = generate_user(email="surfer@couchers.org.invalid", name="Surfer")
+    host, _ = generate_user(email="host@couchers.org.invalid", name="Host")
+
+    with session_scope() as session:
+        create_host_request(session, surfer.id, host.id, timedelta(days=4), is_offer=True)
+
+    send_reference_reminders(empty_pb2.Empty())
+
+    while process_job():
+        pass
+
+    with session_scope() as session:
+        emails = {
+            email.recipient: (email.subject, email.plain) for email in session.execute(select(Email)).scalars().all()
+        }
+
+    assert set(emails) == {"surfer@couchers.org.invalid", "host@couchers.org.invalid"}
+    surfer_subject, surfer_plain = emails["surfer@couchers.org.invalid"]
+    assert surfer_subject == "[TEST] You have 14 days to write a reference for Host"
+    assert "from when you surfed with them" in surfer_plain
+    host_subject, host_plain = emails["host@couchers.org.invalid"]
+    assert host_subject == "[TEST] You have 14 days to write a reference for Surfer"
+    assert "from when you hosted them" in host_plain
+
+
 def test_send_host_request_reminders(db, moderator):
     user1, token1 = generate_user(email="user1@couchers.org.invalid", name="User 1")
     user2, token2 = generate_user(email="user2@couchers.org.invalid", name="User 2")

--- a/app/backend/src/tests/test_references.py
+++ b/app/backend/src/tests/test_references.py
@@ -19,13 +19,16 @@ from couchers.models import (
     ModerationObjectType,
     ModerationState,
     ModerationVisibility,
+    Node,
+    NodeType,
     Reference,
     ReferenceType,
     User,
 )
+from couchers.models.public_trips import PublicTrip, PublicTripStatus
 from couchers.moderation.utils import create_moderation
 from couchers.proto import api_pb2, messages_pb2, moderation_pb2, references_pb2, requests_pb2
-from couchers.utils import create_coordinate, now, to_aware_datetime, today
+from couchers.utils import create_coordinate, create_polygon_lat_lng, now, to_aware_datetime, to_multi, today
 from tests.fixtures.db import generate_user, make_friends, make_user_block
 from tests.fixtures.misc import EmailCollector, PushCollector
 from tests.fixtures.sessions import (
@@ -43,6 +46,37 @@ def _(testconfig):
     pass
 
 
+def create_public_trip(session: Session, user_id: int, from_date: date, to_date: date) -> int:
+    node = session.execute(select(Node).limit(1)).scalar_one_or_none()
+    if node is None:
+        node = Node(
+            geom=to_multi(create_polygon_lat_lng([[0, 0], [0, 2], [2, 2], [2, 0], [0, 0]])),
+            node_type=NodeType.locality,
+        )
+        session.add(node)
+        session.flush()
+    moderation_state = ModerationState(
+        object_type=ModerationObjectType.public_trip,
+        object_id=0,
+        visibility=ModerationVisibility.visible,
+    )
+    session.add(moderation_state)
+    session.flush()
+    trip = PublicTrip(
+        user_id=user_id,
+        node_id=node.id,
+        from_date=from_date,
+        to_date=to_date,
+        description="Looking for a host!",
+        status=PublicTripStatus.searching_for_host,
+        moderation_state_id=moderation_state.id,
+    )
+    session.add(trip)
+    session.flush()
+    moderation_state.object_id = trip.id
+    return trip.id
+
+
 def create_host_request(
     session: Session,
     surfer_user_id: int,
@@ -51,20 +85,33 @@ def create_host_request(
     status: HostRequestStatus = HostRequestStatus.confirmed,
     host_reason_didnt_meetup: str | None = None,
     surfer_reason_didnt_meetup: str | None = None,
+    is_offer: bool = False,
 ) -> int:
     """
     Create a host request that's `host_request_age` old
+
+    If `is_offer`, it's an offer on a public trip, so the host initiated it and the surfer received it.
     """
     from_date = today() - host_request_age - timedelta(days=2)
     to_date = today() - host_request_age
     fake_created = now() - host_request_age - timedelta(days=3)
+
+    if is_offer:
+        initiator_user_id, recipient_user_id = host_user_id, surfer_user_id
+        initiator_reason, recipient_reason = host_reason_didnt_meetup, surfer_reason_didnt_meetup
+    else:
+        initiator_user_id, recipient_user_id = surfer_user_id, host_user_id
+        initiator_reason, recipient_reason = surfer_reason_didnt_meetup, host_reason_didnt_meetup
+
+    public_trip_id = create_public_trip(session, surfer_user_id, from_date, to_date) if is_offer else None
+
     conversation = Conversation()
     session.add(conversation)
     session.flush()
 
     msg1 = Message(
         conversation_id=conversation.id,
-        author_id=surfer_user_id,
+        author_id=initiator_user_id,
         message_type=MessageType.chat_created,
     )
     msg1.time = fake_created + timedelta(seconds=1)
@@ -72,8 +119,8 @@ def create_host_request(
 
     msg2 = Message(
         conversation_id=conversation.id,
-        author_id=surfer_user_id,
-        text="Hi, I'm requesting to be hosted.",
+        author_id=initiator_user_id,
+        text="Hi, I'm requesting to be hosted." if not is_offer else "Hi, I'd love to host you.",
         message_type=MessageType.text,
     )
     msg2.time = fake_created + timedelta(seconds=2)
@@ -84,23 +131,24 @@ def create_host_request(
         session,
         ModerationObjectType.host_request,
         conversation.id,
-        surfer_user_id,
+        initiator_user_id,
     )
 
     host_request = HostRequest(
         conversation_id=conversation.id,
-        initiator_user_id=surfer_user_id,
-        recipient_user_id=host_user_id,
+        initiator_user_id=initiator_user_id,
+        recipient_user_id=recipient_user_id,
         from_date=from_date,
         to_date=to_date,
         status=status,
         initiator_last_seen_message_id=msg2.id,
-        recipient_reason_didnt_meetup=host_reason_didnt_meetup,
-        initiator_reason_didnt_meetup=surfer_reason_didnt_meetup,
+        recipient_reason_didnt_meetup=recipient_reason,
+        initiator_reason_didnt_meetup=initiator_reason,
         hosting_city="Test City",
         hosting_location=create_coordinate(0, 0),
         hosting_radius=10,
         moderation_state_id=moderation_state.id,
+        public_trip_id=public_trip_id,
     )
     session.add(host_request)
     session.commit()
@@ -801,6 +849,65 @@ def test_host_request_states_references(db, moderator):
             )
         assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
         assert e.value.details() == "You can't write a reference for that host request, or it wasn't found."
+
+
+def test_public_trip_offer_reference_roles(db, moderator):
+    """An offer reverses initiator/recipient, so the reference types have to come from the stay role."""
+    surfer, surfer_token = generate_user()
+    host, host_token = generate_user()
+
+    with session_scope() as session:
+        host_request_id = create_host_request(session, surfer.id, host.id, timedelta(days=7), is_offer=True)
+
+    moderator.approve_host_request(host_request_id)
+    # ListPendingReferencesToWrite reads the other user out of the LiteUser matview
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+
+    with references_session(surfer_token) as api:
+        available = api.AvailableWriteReferences(
+            references_pb2.AvailableWriteReferencesReq(to_user_id=host.id)
+        ).available_write_references
+        assert [r.reference_type for r in available] == [references_pb2.REFERENCE_TYPE_SURFED]
+        pending = api.ListPendingReferencesToWrite(empty_pb2.Empty()).pending_references
+        assert [r.reference_type for r in pending] == [references_pb2.REFERENCE_TYPE_SURFED]
+
+        api.WriteHostRequestReference(
+            references_pb2.WriteHostRequestReferenceReq(
+                host_request_id=host_request_id,
+                text="Thanks for having me!",
+                was_appropriate=True,
+                rating=0.9,
+            )
+        )
+
+    with references_session(host_token) as api:
+        available = api.AvailableWriteReferences(
+            references_pb2.AvailableWriteReferencesReq(to_user_id=surfer.id)
+        ).available_write_references
+        assert [r.reference_type for r in available] == [references_pb2.REFERENCE_TYPE_HOSTED]
+        pending = api.ListPendingReferencesToWrite(empty_pb2.Empty()).pending_references
+        assert [r.reference_type for r in pending] == [references_pb2.REFERENCE_TYPE_HOSTED]
+
+        api.WriteHostRequestReference(
+            references_pb2.WriteHostRequestReferenceReq(
+                host_request_id=host_request_id,
+                text="Great guest!",
+                was_appropriate=True,
+                rating=0.9,
+            )
+        )
+
+    with session_scope() as session:
+        references = {
+            reference.from_user_id: reference
+            for reference in session.execute(
+                select(Reference).where(Reference.host_request_id == host_request_id)
+            ).scalars()
+        }
+        assert references[surfer.id].reference_type == ReferenceType.surfed
+        assert references[surfer.id].to_user_id == host.id
+        assert references[host.id].reference_type == ReferenceType.hosted
+        assert references[host.id].to_user_id == surfer.id
 
 
 def test_WriteHostRequestReference(db, moderator):


### PR DESCRIPTION
These are the places where the *logic* asked the wrong question: a stay-role decision was made by looking at who started the conversation. Public trip offers reverse that, so these came out backwards.

**`servicers/references.py`** — `surfed` now comes from the stay role, so an offer produces a `hosted` reference from the host and a `surfed` one from the traveller rather than the other way round, and `to_user_id` points at the right person. The query halves still split on the conversation role, since that's the axis `initiator_reason_didnt_meetup` / `recipient_reason_didnt_meetup` live on — only the role each half reports changes. The two `assert`s in `WriteHostRequestReference` are gone because they restated the definition of `surfed`.

**`jobs/handlers.py`** — same for reference reminders (`reference__reminder_surfed` vs `reference__reminder_hosted`); the reminder counter it bumps moves explicitly onto the conversation axis, which is where those columns live. Also `am_host` on missed-message notifications. Renamed the locals in `send_request_notifications` that were called surfer/host but were always the conversation axis.

**`servicers/requests.py`** — `am_host` on `host_request__message` notifications, which was hardcoded `True` / `False` per branch. It feeds `from_host = not am_host` in the email templates.

## Testing
Two regression tests, both verified to fail against the previous behaviour:

- `test_references.py::test_public_trip_offer_reference_roles` — both sides of an offer write a reference; previously the traveller's came out as `hosted` and the host's as `surfed`, pointing at the wrong `to_user_id`.
- `test_bg_jobs.py::test_send_reference_reminders_public_trip_offer` — previously the traveller got the "from when you hosted them" reminder and the host got "surfed with them".

`create_host_request` in `test_references.py` gains an `is_offer` flag that builds the reversed request against a real public trip. Existing callers are unaffected.

Full backend suite passes (1456 tests), `make format` and `make mypy` clean.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._
