### PR TITLE
Scope the remaining group chat reads to the newest subscription

### DIFF
--- a/app/backend/src/couchers/helpers/group_chats.py
+++ b/app/backend/src/couchers/helpers/group_chats.py
@@ -25,8 +25,9 @@ def was_subscribed_at(
 
 def is_unseen(message: type[Message], subscription: type[GroupChatSubscription]) -> ColumnElement[bool]:
     """
-    Unseen by the subscriber and still within their reach: a message they can never open, because it
-    was sent while they were out of the chat, is not unread.
+    Unseen by the subscriber, over the window this subscription covers. Nothing outside it is unread:
+    either the subscriber wasn't in the chat, or it belongs to a subscription they abandoned on
+    rejoining, which marking seen can never advance.
     """
     return and_(
         was_subscribed_at(subscription, message.time),

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -7,7 +7,7 @@ import grpc
 from google.protobuf import empty_pb2
 from sqlalchemy import select
 from sqlalchemy.orm import Session, contains_eager
-from sqlalchemy.sql import func, not_, or_
+from sqlalchemy.sql import and_, func, not_, or_
 
 from couchers.constants import DATETIME_INFINITY, DATETIME_MINUS_INFINITY
 from couchers.context import CouchersContext, make_background_user_context, make_notification_user_context
@@ -318,6 +318,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             )
             .join(Message, Message.conversation_id == GroupChatSubscription.group_chat_id)
             .where(GroupChatSubscription.user_id == context.user_id)
+            .where(is_newest_subscription(context.user_id))
             .where(was_subscribed_at(GroupChatSubscription, Message.time))
             .where(
                 or_(
@@ -396,6 +397,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
                 .options(contains_eager(GroupChat.conversation))
                 .where(GroupChatSubscription.user_id == context.user_id)
                 .where(GroupChatSubscription.group_chat_id == request.group_chat_id)
+                .where(is_newest_subscription(context.user_id))
                 .where(was_subscribed_at(GroupChatSubscription, Message.time))
                 .order_by(Message.id.desc())
                 .limit(1),
@@ -453,6 +455,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
                 .options(contains_eager(GroupChat.conversation))
                 .where(GroupChatSubscription.user_id == context.user_id)
                 .where(GroupChatSubscription.group_chat_id == GroupChat.conversation_id)
+                .where(is_newest_subscription(context.user_id))
                 .where(was_subscribed_at(GroupChatSubscription, Message.time))
                 .order_by(Message.id.desc())
                 .limit(1),
@@ -532,7 +535,13 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
                     .where(was_subscribed_at(GroupChatSubscription, Message.time))
                     .where(or_(Message.id < request.last_message_id, to_bool(request.last_message_id == 0)))
                     .where(
-                        or_(Message.id > GroupChatSubscription.last_seen_message_id, to_bool(request.only_unseen == 0))
+                        or_(
+                            and_(
+                                is_newest_subscription(context.user_id),
+                                is_unseen(Message, GroupChatSubscription),
+                            ),
+                            to_bool(request.only_unseen == 0),
+                        )
                     )
                     .order_by(Message.id.desc())
                     .limit(page_size + 1),

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -1823,6 +1823,81 @@ def test_rejoined_group_chat_ping_reads_newest_subscription(db, moderator):
         assert api.Ping(api_pb2.PingReq()).unseen_message_count == 0
 
 
+def test_rejoined_group_chat_only_unseen_matches_the_badge(db, moderator):
+    """
+    GetGroupChatMessages matched only_unseen against every one of the viewer's subscriptions, so the
+    abandoned one served up its unread messages even though the badge no longer counts them.
+    """
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
+    make_friends(user1, user2)
+    make_friends(user2, user3)
+
+    with conversations_session(token2) as c:
+        group_chat_id = c.CreateGroupChat(
+            conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user1.id, user3.id])
+        ).group_chat_id
+        moderator.approve_group_chat(group_chat_id)
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="hi"))
+        c.RemoveGroupChatUser(conversations_pb2.RemoveGroupChatUserReq(group_chat_id=group_chat_id, user_id=user1.id))
+        c.InviteToGroupChat(conversations_pb2.InviteToGroupChatReq(group_chat_id=group_chat_id, user_id=user1.id))
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="welcome back"))
+
+    with api_session(token1) as api:
+        assert api.Ping(api_pb2.PingReq()).unseen_message_count == 2
+
+    with conversations_session(token1) as c:
+        unseen = c.GetGroupChatMessages(
+            conversations_pb2.GetGroupChatMessagesReq(group_chat_id=group_chat_id, only_unseen=True)
+        ).messages
+        assert [m.WhichOneof("content") for m in unseen] == ["text", "user_invited"]
+        assert unseen[0].text.text == "welcome back"
+
+        # the earlier stint is still readable, it just isn't unread
+        all_messages = c.GetGroupChatMessages(
+            conversations_pb2.GetGroupChatMessagesReq(group_chat_id=group_chat_id)
+        ).messages
+        assert [m.text.text for m in all_messages if m.WhichOneof("content") == "text"] == ["welcome back", "hi"]
+
+
+def test_rejoined_group_chat_archived_filter_reads_newest_subscription(db, moderator):
+    """
+    ListGroupChats applied the archived filter before picking the newest subscription, so a chat
+    archived before the viewer was removed stayed in their archived list off the abandoned
+    subscription, where nothing could ever mark it seen.
+    """
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+    user3, token3 = generate_user()
+    make_friends(user1, user2)
+    make_friends(user2, user3)
+
+    with conversations_session(token2) as c:
+        group_chat_id = c.CreateGroupChat(
+            conversations_pb2.CreateGroupChatReq(recipient_user_ids=[user1.id, user3.id])
+        ).group_chat_id
+        moderator.approve_group_chat(group_chat_id)
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="hi"))
+
+    with conversations_session(token1) as c:
+        c.SetGroupChatArchiveStatus(
+            conversations_pb2.SetGroupChatArchiveStatusReq(group_chat_id=group_chat_id, is_archived=True)
+        )
+
+    with conversations_session(token2) as c:
+        c.RemoveGroupChatUser(conversations_pb2.RemoveGroupChatUserReq(group_chat_id=group_chat_id, user_id=user1.id))
+        c.InviteToGroupChat(conversations_pb2.InviteToGroupChatReq(group_chat_id=group_chat_id, user_id=user1.id))
+
+    with conversations_session(token1) as c:
+        archived = c.ListGroupChats(conversations_pb2.ListGroupChatsReq(only_archived=True)).group_chats
+        assert [gc.group_chat_id for gc in archived] == []
+
+        (listed,) = c.ListGroupChats(conversations_pb2.ListGroupChatsReq(only_archived=False)).group_chats
+        assert listed.group_chat_id == group_chat_id
+        assert not listed.is_archived
+
+
 def test_regression_ListGroupChats_pagination(db, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()


### PR DESCRIPTION
Follow-up to #9462 / #9473 / #9477, closing the loose ends that stack left behind. Rejoining a chat leaves the earlier subscription behind, and `is_newest_subscription` was applied to Ping, the notification job, `_get_visible_message_subscription` and `MarkAllThreadsSeen` — but not to the remaining group chat reads, which each inferred the newest subscription instead, or didn't scope to one at all.

- **`ListGroupChats` applied the archived filter before `max(GroupChatSubscription.id)`**, so a chat archived before the viewer was removed stayed in their archived list off the abandoned subscription — where the count is unclearable, since marking seen only ever advances the newest one. This also makes it agree with `MarkAllThreadsSeen`, whose `_build_group_chat_select_query` already narrows to the newest subscription before filtering archived.
- **`GetGroupChatMessages` matched `only_unseen` against every one of the viewer's subscriptions**, so "unread only" served up the abandoned stint's messages even though the badge no longer counts them. It now uses `is_unseen` on the newest subscription, matching Ping exactly. Reading the full thread is unchanged: a rejoined viewer still sees both stints.
- `GetGroupChat` and `GetDirectMessage` picked the subscription emergently, via `ORDER BY Message.id DESC LIMIT 1`. That lands on the right row today only because every subscription-creating path also writes a control message in the same transaction, so it's now stated rather than inferred. All five group chat subscription-selection sites use one rule.

Two docstring corrections in `couchers.helpers.group_chats`, no logic change:

- `is_unseen` claimed an out-of-window message is one the viewer "can never open". That's true for a departed viewer, but not for a rejoined one — `GetGroupChatMessages` unions every stint, so those messages are still readable. The real reason they aren't unread is that they belong to a subscription that can never be advanced.
- `was_subscribed_at` now records that its inclusive bounds are load-bearing: joining and leaving each write a control message in the same transaction, so the notice carries exactly the `joined`/`left` timestamp, and tightening either bound would silently drop those notices out of every window.

## Testing
Added two regression tests (`test_rejoined_group_chat_only_unseen_matches_the_badge`, `test_rejoined_group_chat_archived_filter_reads_newest_subscription`); both fail on the unfixed code and pass with the fix. `make format` and `make mypy` pass. `test_conversations.py`, `test_message_threads.py` and `test_bg_jobs.py` (90 tests) and `test_api.py` (50 tests) pass locally.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history (no db changes)

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._