### PR TITLE
Snapshot the offering host's place on a public trip offer

### DIFF
--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -275,6 +275,9 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             if existing_offer:
                 context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "duplicate_host_request_for_trip")
 
+        # an offer on a public trip reverses the roles: the caller is the host and the recipient is the traveller
+        surfer_user, host_user = (recipient, user) if public_trip_id is not None else (user, recipient)
+
         conversation = Conversation()
         session.add(conversation)
         session.flush()
@@ -315,9 +318,9 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             initiator_last_seen_message_id=message.id,
             # TODO: tz
             # timezone=recipient.timezone,
-            hosting_city=recipient.city,
-            hosting_location=recipient.geom,
-            hosting_radius=recipient.geom_radius,
+            hosting_city=host_user.city,
+            hosting_location=host_user.geom,
+            hosting_radius=host_user.geom_radius,
             public_trip_id=public_trip_id,
         )
         session.add(host_request)
@@ -339,7 +342,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
 
         host_requests_sent_counter.labels(user.gender, recipient.gender).inc()
         sent_messages_counter.labels(user.gender, "host request send").inc()
-        account_age_on_host_request_create_histogram.labels(user.gender, recipient.gender).observe(
+        account_age_on_host_request_create_histogram.labels(surfer_user.gender, host_user.gender).observe(
             (now() - user.joined).total_seconds()
         )
         log_event(
@@ -348,10 +351,11 @@ class Requests(requests_pb2_grpc.RequestsServicer):
             "host_request.created",
             {
                 "host_request_id": host_request.conversation_id,
-                "host_id": recipient.id,
-                "surfer_gender": user.gender,
-                "host_gender": recipient.gender,
-                "city": recipient.city,
+                "surfer_id": surfer_user.id,
+                "host_id": host_user.id,
+                "surfer_gender": surfer_user.gender,
+                "host_gender": host_user.gender,
+                "city": host_user.city,
                 "from_date": str(from_date),
                 "to_date": str(to_date),
                 "nights": (to_date - from_date).days,

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -2281,6 +2281,36 @@ def test_create_request_with_public_trip(db, moderator):
         assert hr.public_trip_id == trip_id
 
 
+def test_create_request_with_public_trip_hosting_snapshot(db, moderator):
+    """An offer snapshots the offering host's place, not the traveller's."""
+    surfer, _ = generate_user(city="Surfer city", geom=create_coordinate(1, 1), geom_radius=11)
+    host, host_token = generate_user(city="Host city", geom=create_coordinate(2, 2), geom_radius=22)
+
+    trip_from = today() + timedelta(days=10)
+    trip_to = today() + timedelta(days=20)
+    trip_id = _create_public_trip(surfer.id, trip_from, trip_to)
+
+    with requests_session(host_token) as api:
+        host_request_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=surfer.id,
+                from_date=trip_from.isoformat(),
+                to_date=trip_to.isoformat(),
+                text=valid_request_text(),
+                public_trip_id=trip_id,
+            )
+        ).host_request_id
+
+    moderator.approve_host_request(host_request_id)
+
+    with requests_session(host_token) as api:
+        hr = api.GetHostRequest(requests_pb2.GetHostRequestReq(host_request_id=host_request_id))
+        assert hr.hosting_city == "Host city"
+        assert round(hr.hosting_lat, 4) == 2
+        assert round(hr.hosting_lng, 4) == 2
+        assert hr.hosting_radius == 22
+
+
 def test_create_request_with_public_trip_dates_out_of_range(db):
     """Offered dates outside the trip window are rejected."""
     surfer, _ = generate_user()


### PR DESCRIPTION
`CreateHostRequest` snapshots the stay's location onto the host request row (`hosting_city` / `hosting_location` / `hosting_radius`), and it took all three from `recipient` — the user being written to.

For a normal request the recipient is the host, so that's the right place. For an offer on a public trip the roles are reversed: the host is the caller and the recipient is the traveller, so the snapshot stored the traveller's home city and coordinates as "where the stay is". The same inversion applied to the `account_age_on_host_request_create_histogram` gender labels and to the `host_request.created` event payload (`host_id`, `surfer_gender`, `host_gender`, `city`); that event also gains a `surfer_id` so it matches the other `host_request.*` events, which already have one.

This is picked out of #9478 so that whoever owns public trips can look at it on its own — it's the only write-path change in that stack, i.e. the only one that changes what gets stored rather than what gets read back.

`initiator_user_id` / `recipient_user_id` are untouched: they are the conversation axis and are correct as they are. The validation above this already guarantees the trip's traveller is the recipient (`public_trip_user_mismatch`), so the two users are unambiguous at this point. The row doesn't exist yet here, so this uses locals rather than the generated `surfer_user_id` / `host_user_id` columns — and it needs the `User` objects for `city` / `geom` / `geom_radius` / `gender`, not just the ids.

No data repair needed: there are no host requests with a `public_trip_id` in production, and the offer flow is unreachable there (every entry point in the web app is gated on `process.env.NODE_ENV !== "production"`).

## Testing
`test_requests.py::test_create_request_with_public_trip_hosting_snapshot` creates an offer on a public trip and checks the snapshot on `GetHostRequest` is the offering host's city, coordinates and radius. Verified to fail on `develop`, where it returns `"Surfer city"`. The plain-request snapshot is already covered by `test_create_request`.

Full `test_requests.py` passes, `make format` and `make mypy` clean.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
