### PR TITLE
Add frontend plumbing for the GetProfile RPC

### DIFF
--- a/app/web/features/queryKeys.ts
+++ b/app/web/features/queryKeys.ts
@@ -28,6 +28,10 @@ export function modUserDetailsKey(user?: string) {
   return user === undefined ? "modUserDetails" : ["modUserDetails", user];
 }
 
+export function profileKey(userId?: number) {
+  return userId === undefined ? ["profile"] : ["profile", userId];
+}
+
 export function liteUserKey(userId?: number) {
   return userId === undefined ? ["liteUser"] : ["liteUser", userId];
 }

--- a/app/web/features/userQueries/useProfile.ts
+++ b/app/web/features/userQueries/useProfile.ts
@@ -1,0 +1,34 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuthContext } from "features/auth/AuthProvider";
+import { profileKey } from "features/queryKeys";
+import { userStaleTime } from "features/userQueries/constants";
+import { RpcError } from "grpc-web";
+import { useRouter } from "next/router";
+import { Profile } from "proto/api_pb";
+import { useEffect } from "react";
+import { loginRoute } from "routes";
+import { service } from "service";
+
+export function useProfile(userId: number | undefined) {
+  return useQuery<Profile.AsObject, RpcError>({
+    queryFn: () => service.user.getProfile(userId!.toString()),
+    queryKey: profileKey(userId),
+    staleTime: userStaleTime,
+    enabled: !!userId,
+  });
+}
+
+export function useCurrentProfile() {
+  const authState = useAuthContext().authState;
+  const profileQuery = useProfile(authState.userId ?? undefined);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!authState.userId) {
+      console.error("No user id available to get current profile.");
+      if (typeof window !== "undefined") router.push(loginRoute);
+    }
+  }, [authState.userId, router]);
+
+  return profileQuery;
+}

--- a/app/web/features/userQueries/useProfileByUsername.ts
+++ b/app/web/features/userQueries/useProfileByUsername.ts
@@ -1,0 +1,67 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { reactQueryRetries } from "appConstants";
+import { profileKey, username2Id } from "features/queryKeys";
+import { username2IdStaleTime, userStaleTime } from "features/userQueries/constants";
+import { RpcError, StatusCode } from "grpc-web";
+import { Profile } from "proto/api_pb";
+import { useEffect } from "react";
+import { service } from "service";
+
+export default function useProfileByUsername(username: string, invalidate = false) {
+  //We look up the userId first from the username, mirroring useUserByUsername.
+  //This shares the username2Id cache entry with it, so it's not an extra query in practice.
+  const usernameQuery = useQuery<{ username: string; userId: number }, RpcError>({
+    gcTime: username2IdStaleTime,
+    queryFn: async () => {
+      const user = await service.user.getUser(username);
+      return {
+        userId: user.userId,
+        username: user.username,
+      };
+    },
+    queryKey: [username2Id, username],
+    retry: (failureCount, error) => {
+      //don't retry if the user isn't found
+      return error.code !== StatusCode.NOT_FOUND && failureCount <= reactQueryRetries;
+    },
+    staleTime: username2IdStaleTime,
+    enabled: !!username,
+  });
+
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    if (invalidate && usernameQuery.data?.userId) {
+      queryClient.invalidateQueries({
+        queryKey: profileKey(usernameQuery.data.userId),
+      });
+    }
+  }, [invalidate, queryClient, usernameQuery.data?.userId]);
+
+  const query = useQuery<Profile.AsObject, RpcError>({
+    enabled: !!usernameQuery.data,
+    queryFn: () => service.user.getProfile(usernameQuery.data?.userId.toString() || ""),
+    queryKey: profileKey(usernameQuery.data?.userId ?? 0),
+    staleTime: userStaleTime,
+  });
+
+  const errors = [];
+  if (usernameQuery.error?.message) {
+    errors.push(usernameQuery.error?.message || "");
+  }
+  if (query.error?.message) {
+    errors.push(query.error?.message || "");
+  }
+
+  const error = errors.join("\n");
+  const isLoading = usernameQuery.isLoading || query.isLoading;
+  const isFetching = usernameQuery.isFetching || query.isFetching;
+  const isError = usernameQuery.isError || query.isError;
+
+  return {
+    data: query.data,
+    error,
+    isError,
+    isFetching,
+    isLoading,
+  };
+}

--- a/app/web/service/admin.ts
+++ b/app/web/service/admin.ts
@@ -1,6 +1,6 @@
 import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
 import { GetUserDetailsReq, GetUserReq, ListUserIdsReq, UserDetails } from "proto/admin_pb";
-import { User } from "proto/api_pb";
+import { Profile, User } from "proto/api_pb";
 
 import client from "./client";
 
@@ -10,6 +10,14 @@ export async function getUser(user: string): Promise<User.AsObject> {
     req.setUser(user);
   }
   return (await client.admin.getUser(req)).toObject();
+}
+
+export async function getProfile(user: string): Promise<Profile.AsObject> {
+  const req = new GetUserReq();
+  if (user) {
+    req.setUser(user);
+  }
+  return (await client.admin.getProfile(req)).toObject();
 }
 
 export async function getUserDetails(user: string): Promise<UserDetails.AsObject> {

--- a/app/web/service/user.ts
+++ b/app/web/service/user.ts
@@ -3,12 +3,14 @@ import wrappers from "google-protobuf/google/protobuf/wrappers_pb";
 import {
   GetLiteUserReq,
   GetLiteUsersReq,
+  GetProfileReq,
   GetUserReq,
   LanguageAbility,
   NullableBoolValue,
   NullableStringValue,
   NullableUInt32Value,
   PingReq,
+  Profile,
   RepeatedLanguageAbilityValue,
   RepeatedStringValue,
   UpdateProfileReq,
@@ -90,6 +92,23 @@ export async function getUser(user: string): Promise<User.AsObject> {
   }
 
   const response = await client.api.getUser(userReq);
+
+  return response.toObject();
+}
+
+/**
+ * Returns Profile record by Username or id
+ *
+ * @param {string} user
+ * @returns {Promise<Profile.AsObject>}
+ */
+export async function getProfile(user: string): Promise<Profile.AsObject> {
+  const req = new GetProfileReq();
+  if (user) {
+    req.setUser(user);
+  }
+
+  const response = await client.api.getProfile(req);
 
   return response.toObject();
 }

--- a/app/web/test/fixtures/defaultProfile.json
+++ b/app/web/test/fixtures/defaultProfile.json
@@ -1,0 +1,29 @@
+{
+  "userId": 1,
+  "hometown": "Brisbane",
+  "pronouns": "He/him",
+  "occupation": "Mathematician",
+  "education": "Uni",
+  "aboutMe": "Some generic stuff.",
+  "thingsILike": "hospex",
+  "aboutPlace": "About Aapeli's place",
+  "additionalInformation": "",
+  "hostingStatus": 2,
+  "meetupStatus": 1,
+  "regionsVisitedList": ["AUS"],
+  "regionsLivedList": ["AUS", "FIN", "SWE", "USA"],
+  "languageAbilitiesList": [
+    {
+      "code": "eng",
+      "fluency": 4
+    },
+    {
+      "code": "fin",
+      "fluency": 3
+    }
+  ],
+  "profileGalleryId": 1,
+  "sleepingArrangement": 2,
+  "parkingDetails": 3,
+  "smokingAllowed": 1
+}

--- a/app/web/test/serviceMockDefaults.ts
+++ b/app/web/test/serviceMockDefaults.ts
@@ -1,4 +1,11 @@
-import { BirthdateVerificationStatus, GenderVerificationStatus, GetLiteUsersRes, LiteUser, User } from "proto/api_pb";
+import {
+  BirthdateVerificationStatus,
+  GenderVerificationStatus,
+  GetLiteUsersRes,
+  LiteUser,
+  Profile,
+  User,
+} from "proto/api_pb";
 import { GetBlockedUsersRes } from "proto/blocking_pb";
 import { ListAdminsRes } from "proto/communities_pb";
 import { ListEventAttendeesRes, ListEventOrganizersRes } from "proto/events_pb";
@@ -43,6 +50,12 @@ const liteUserMap: Record<string, LiteUser.AsObject> = {
 
 export async function getUser(userId: string): Promise<User.AsObject> {
   return userMap[userId];
+}
+
+// The users.json fixtures still carry every profile field, since GetUser returns them too.
+// This narrows one to the Profile shape rather than duplicating the fixtures.
+export async function getProfile(userId: string): Promise<Profile.AsObject> {
+  return userMap[userId] as unknown as Profile.AsObject;
 }
 
 export async function getLiteUser(userId: string): Promise<LiteUser.AsObject> {

--- a/app/web/test/setupTests.ts
+++ b/app/web/test/setupTests.ts
@@ -12,6 +12,7 @@ import sentryTestkit from "sentry-testkit";
 import i18n from "test/i18n";
 import { TextDecoder, TextEncoder } from "util";
 
+import profile from "./fixtures/defaultProfile.json";
 import user from "./fixtures/defaultUser.json";
 
 jest.mock("service");
@@ -62,6 +63,7 @@ jest.mock("features/weblate/useWeblateStats", () => ({
 jest.setTimeout(10000);
 
 global.defaultUser = user;
+global.defaultProfile = profile;
 global.localStorage = createWebStorageMock();
 global.sessionStorage = createWebStorageMock();
 
@@ -108,6 +110,7 @@ global.ResizeObserver = class ResizeObserver {
 declare global {
   // Disable the rule for this block
   var defaultUser: typeof user;
+  var defaultProfile: typeof profile;
   var testKit: ReturnType<typeof sentryTestkit>["testkit"];
   // Re-enable the rule
 }


### PR DESCRIPTION
Adds the frontend queries and hooks for the `GetProfile` RPC from #9489. Purely additive — nothing consumes them yet.

- `service.user.getProfile` and `service.admin.getProfile`
- a `profileKey` query key
- `useProfile`, `useCurrentProfile` and `useProfileByUsername` hooks, modelled on the existing `useUsers` / `useUserByUsername` ones
- a `defaultProfile` test fixture and a `getProfile` mock default, so tests can wire it up as consumers appear

Migrating the actual consumers off `User` follows in separate PRs, component by component. `User` still carries all of these fields, so nothing changes behaviourally here.

Extracted from the frontend half of #8603, written against current `develop` rather than cherry-picked. One deliberate difference from the original: `useCurrentProfile` does its login redirect in a `useEffect`, matching `develop`'s `useCurrentUser`, rather than in the render body.

## Testing

- `yarn lint` — clean
- `yarn format` — clean
- `yarn tsc --noEmit` — no new errors
- `yarn test` — 915 passed, 41 failed, 9 suites failed

⚠️ **Those 41 failures are pre-existing on `develop`, not from this PR.** Verified by stashing this branch's changes and re-running on clean `develop`: identical counts (9 suites / 41 tests / 915 passed) and identical 11 `tsc` errors. A MUI Autocomplete bump broke `slotProps` typing, taking out `EditLocationMap`, `LocationAutocomplete`, `CommunitySearch`, the event pages, `CreateGroupChat` and `EditProfilePage`. Worth fixing separately.

To replicate: `yarn test` on this branch and on `develop`, and compare the totals.

Nothing calls this code yet, so there is nothing to click through in a browser.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant — no consumers yet, so no behaviour to cover; the fixture and mock default land here for the migration PRs to use
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._