### PR TITLE
Set up swap on deployment hosts

### DIFF
--- a/app/deployment/deps.sh
+++ b/app/deployment/deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # works on ubuntu 24.04, tested on AWS
-# installs docker, docker-compose, aws-cli, age
+# installs docker, docker-compose, aws-cli, age; sets up swap
 
 set -e
 
@@ -10,6 +10,15 @@ sudo apt-get -y update
 sudo apt-get -y dist-upgrade
 
 sudo apt-get install -y age
+
+# set up swap
+sudo fallocate -l 4G /swapfile
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+echo 'vm.swappiness=10' | sudo tee /etc/sysctl.d/99-swap.conf
+sudo sysctl --system
 
 # install docker
 sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common


### PR DESCRIPTION
Adds swap setup to the deployment host bootstrap script (`app/deployment/deps.sh`): a 4G swapfile, made persistent via `/etc/fstab`, with `vm.swappiness=10` so it's only used under real memory pressure. This gives deployment hosts headroom for memory spikes instead of getting OOM-killed.

## Testing
Not run against a live host as part of this PR. To replicate, on a fresh Ubuntu 24.04 host (as the script targets), run `app/deployment/deps.sh` and verify:

- `swapon --show` lists `/swapfile` at 4G
- `cat /etc/fstab` contains the `/swapfile none swap sw 0 0` line
- `sysctl vm.swappiness` returns `10`
- rebooting brings swap back up automatically

Note that the script is not idempotent for swap: re-running it on a host that already has `/swapfile` will fail at `fallocate` (the script runs with `set -e`), which matches the existing one-shot bootstrap usage.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._