### PR TITLE
Fetch Profile alongside User on profile-rendering pages

### DIFF
--- a/app/web/features/dashboard/DashboardUserProfileSummary.tsx
+++ b/app/web/features/dashboard/DashboardUserProfileSummary.tsx
@@ -5,6 +5,7 @@ import CenteredSpinner from "components/CenteredSpinner/CenteredSpinner";
 import { ProfileUserProvider } from "features/profile/hooks/useProfileUser";
 import UserOverview from "features/profile/view/UserOverview";
 import useCurrentUser from "features/userQueries/useCurrentUser";
+import { useCurrentProfile } from "features/userQueries/useProfile";
 import { DASHBOARD } from "i18n/namespaces";
 import Link from "next/link";
 import { useTranslation } from "next-i18next";
@@ -28,15 +29,17 @@ function DashboardUserProfileSummaryActions() {
 
 export default function DashboardUserProfileSummary() {
   const { data: user, error, isLoading } = useCurrentUser();
+  const { data: profile, error: profileError, isLoading: isProfileLoading } = useCurrentProfile();
   const desktopMode = useMediaQuery((theme: Theme) => theme.breakpoints.up("sm"));
   return (
     <>
       {error && <Alert severity="error">{error}</Alert>}
-      {isLoading ? (
+      {profileError && <Alert severity="error">{profileError.message}</Alert>}
+      {isLoading || isProfileLoading ? (
         <CenteredSpinner />
-      ) : user ? (
+      ) : user && profile ? (
         desktopMode ? (
-          <ProfileUserProvider user={user}>
+          <ProfileUserProvider user={user} profile={profile}>
             <UserOverview actions={<DashboardUserProfileSummaryActions />} showHostAndMeetAvailability />
           </ProfileUserProvider>
         ) : (

--- a/app/web/features/mod/ModUserPage.tsx
+++ b/app/web/features/mod/ModUserPage.tsx
@@ -51,7 +51,7 @@ function BanDeleteBanner({ userDetails }: { userDetails: UserDetails.AsObject })
 export default function ModUserPage({ username, tab = "about" }: { username: string; tab?: UserTab }) {
   const router = useRouter();
 
-  const { user, userDetails, isLoading, error } = useUserWithDetails(username);
+  const { user, profile, userDetails, isLoading, error } = useUserWithDetails(username);
 
   return (
     <>
@@ -59,9 +59,9 @@ export default function ModUserPage({ username, tab = "about" }: { username: str
       {error && <Alert severity="error">{error}</Alert>}
       {isLoading ? (
         <CenteredSpinner />
-      ) : user && userDetails ? (
+      ) : user && profile && userDetails ? (
         <ModUserDetails userDetails={userDetails}>
-          <ProfileUserProvider user={user}>
+          <ProfileUserProvider user={user} profile={profile}>
             <BanDeleteBanner userDetails={userDetails} />
             <StyledProfileRoot>
               <UserOverview showHostAndMeetAvailability actions={<AdminActions username={user.username} />} />

--- a/app/web/features/mod/hooks.ts
+++ b/app/web/features/mod/hooks.ts
@@ -1,9 +1,9 @@
 import { InfiniteData, useInfiniteQuery, useQuery } from "@tanstack/react-query";
-import { modUserDetailsKey, modUserKey, newUsersListKey } from "features/queryKeys";
+import { modProfileKey, modUserDetailsKey, modUserKey, newUsersListKey } from "features/queryKeys";
 import { userStaleTime } from "features/userQueries/constants";
 import { RpcError } from "grpc-web";
 import { ListUserIdsRes, UserDetails } from "proto/admin_pb";
-import { User } from "proto/api_pb";
+import { Profile, User } from "proto/api_pb";
 import { service } from "service";
 
 export const useNewUsers = () => {
@@ -37,6 +37,12 @@ export default function useUserWithDetails(user: string) {
     staleTime: userStaleTime,
   });
 
+  const profileQuery = useQuery<Profile.AsObject, RpcError>({
+    queryFn: () => service.admin.getProfile(user),
+    queryKey: [modProfileKey(user)],
+    staleTime: userStaleTime,
+  });
+
   const detailsQuery = useQuery<UserDetails.AsObject, RpcError>({
     queryFn: () => service.admin.getUserDetails(user),
     queryKey: [modUserDetailsKey(user)],
@@ -47,17 +53,21 @@ export default function useUserWithDetails(user: string) {
   if (query.error?.message) {
     errors.push(query.error?.message || "");
   }
+  if (profileQuery.error?.message) {
+    errors.push(profileQuery.error?.message || "");
+  }
   if (detailsQuery.error?.message) {
     errors.push(detailsQuery.error?.message || "");
   }
 
   const error = errors.join("\n");
-  const isLoading = query.isLoading || detailsQuery.isLoading;
-  const isFetching = query.isFetching || detailsQuery.isFetching;
-  const isError = query.isError || detailsQuery.isError;
+  const isLoading = query.isLoading || profileQuery.isLoading || detailsQuery.isLoading;
+  const isFetching = query.isFetching || profileQuery.isFetching || detailsQuery.isFetching;
+  const isError = query.isError || profileQuery.isError || detailsQuery.isError;
 
   return {
     user: query.data,
+    profile: profileQuery.data,
     userDetails: detailsQuery.data,
     error,
     isError,

--- a/app/web/features/profile/ProfileSheet.tsx
+++ b/app/web/features/profile/ProfileSheet.tsx
@@ -7,6 +7,7 @@ import NewHostRequest from "features/profile/view/NewHostRequest";
 import NewMessage from "features/profile/view/NewMessage";
 import Overview from "features/profile/view/Overview";
 import UserCard from "features/profile/view/UserCard";
+import { useProfile } from "features/userQueries/useProfile";
 import { useUser } from "features/userQueries/useUsers";
 import { useTranslation } from "i18n";
 import { CONNECTIONS, GLOBAL, PROFILE } from "i18n/namespaces";
@@ -94,6 +95,7 @@ export default function ProfileSheet() {
   } = useProfileSheet();
   const router = useRouter();
   const { data: user, isLoading } = useUser(openProfileUserId ?? undefined);
+  const { data: profile, isLoading: isProfileLoading } = useProfile(openProfileUserId ?? undefined);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [tab, setTab] = useState<UserTab>("about");
   const [isRequesting, setIsRequesting] = useState(false);
@@ -220,9 +222,9 @@ export default function ProfileSheet() {
       ) : (
         <ScrollContent ref={scrollRef}>
           {isSuccessRequest && <Snackbar severity="success">{t("profile:request_form.success")}</Snackbar>}
-          {isLoading && <ProfileSheetSkeleton />}
-          {user && (
-            <ProfileUserProvider user={user}>
+          {(isLoading || isProfileLoading) && <ProfileSheetSkeleton />}
+          {user && profile && (
+            <ProfileUserProvider user={user} profile={profile}>
               <Overview setIsRequesting={setIsRequesting} setIsMessaging={setIsMessaging} tab={tab} isInSheet />
               <UserCard
                 tab={tab}

--- a/app/web/features/profile/hooks/useProfileUser.tsx
+++ b/app/web/features/profile/hooks/useProfileUser.tsx
@@ -1,16 +1,24 @@
-import { User } from "proto/api_pb";
+import { Profile, User } from "proto/api_pb";
 import * as React from "react";
 
 const ProfileUserContext = React.createContext<User.AsObject>({} as User.AsObject);
 ProfileUserContext.displayName = "ProfileUserContext";
 
+const ProfileDataContext = React.createContext<Profile.AsObject>({} as Profile.AsObject);
+ProfileDataContext.displayName = "ProfileDataContext";
+
 interface ProfileUserProviderProps {
   children?: React.ReactNode;
   user: User.AsObject;
+  profile: Profile.AsObject;
 }
 
-export function ProfileUserProvider({ children, user }: ProfileUserProviderProps) {
-  return <ProfileUserContext.Provider value={user}>{children}</ProfileUserContext.Provider>;
+export function ProfileUserProvider({ children, user, profile }: ProfileUserProviderProps) {
+  return (
+    <ProfileUserContext.Provider value={user}>
+      <ProfileDataContext.Provider value={profile}>{children}</ProfileDataContext.Provider>
+    </ProfileUserContext.Provider>
+  );
 }
 
 export function useProfileUser() {
@@ -19,4 +27,12 @@ export function useProfileUser() {
     throw new Error("No ProfileUserContext provided!");
   }
   return profileUser;
+}
+
+export function useProfileData() {
+  const profileData = React.useContext(ProfileDataContext);
+  if (profileData === null) {
+    throw new Error("No ProfileDataContext provided!");
+  }
+  return profileData;
 }

--- a/app/web/features/profile/view/NewHostRequest.test.tsx
+++ b/app/web/features/profile/view/NewHostRequest.test.tsx
@@ -43,7 +43,7 @@ const LONG_TEXT = "a".repeat(250);
 
 function renderNewHostRequest() {
   render(
-    <ProfileUserProvider user={hostUser}>
+    <ProfileUserProvider user={hostUser} profile={defaultProfile}>
       <NewHostRequest setIsRequestSuccess={jest.fn()} setIsRequesting={jest.fn()} />
     </ProfileUserProvider>,
     { wrapper },
@@ -101,7 +101,7 @@ describe("NewHostRequest", () => {
 
     createHostRequestMock.mockResolvedValue(1);
     render(
-      <ProfileUserProvider user={hostUser}>
+      <ProfileUserProvider user={hostUser} profile={defaultProfile}>
         <NewHostRequest setIsRequestSuccess={jest.fn()} setIsRequesting={jest.fn()} />
       </ProfileUserProvider>,
       { wrapper },
@@ -146,7 +146,7 @@ describe("NewHostRequest", () => {
     createHostRequestMock.mockResolvedValue(1);
     const hostBehindTimezone = { ...users[1], timezone: "America/Los_Angeles" };
     render(
-      <ProfileUserProvider user={hostBehindTimezone}>
+      <ProfileUserProvider user={hostBehindTimezone} profile={defaultProfile}>
         <NewHostRequest setIsRequestSuccess={jest.fn()} setIsRequesting={jest.fn()} />
       </ProfileUserProvider>,
       { wrapper },

--- a/app/web/features/profile/view/Overview.test.tsx
+++ b/app/web/features/profile/view/Overview.test.tsx
@@ -48,7 +48,7 @@ describe("Overview", () => {
     getAccountInfoMock.mockResolvedValue(incompleteAccountInfo);
 
     render(
-      <ProfileUserProvider user={mockUsers[1]}>
+      <ProfileUserProvider user={mockUsers[1]} profile={defaultProfile}>
         <Overview setIsRequesting={jest.fn()} setIsMessaging={jest.fn()} tab="about" />
       </ProfileUserProvider>,
       { wrapper },

--- a/app/web/features/profile/view/ProfilePage.test.tsx
+++ b/app/web/features/profile/view/ProfilePage.test.tsx
@@ -8,7 +8,7 @@ import defaultUser from "test/fixtures/defaultUser.json";
 import galleryFixtures from "test/fixtures/gallery.json";
 import wrapper from "test/hookWrapper";
 import i18n from "test/i18n";
-import { getAccountInfo, getLanguages, getRegions, getUser } from "test/serviceMockDefaults";
+import { getAccountInfo, getLanguages, getProfile, getRegions, getUser } from "test/serviceMockDefaults";
 import { addDefaultUser, MockedService } from "test/utils";
 
 import ProfilePage from "./ProfilePage";
@@ -20,6 +20,7 @@ jest.mock("features/userQueries/useCurrentUser");
 jest.mock("react-simple-maps");
 
 const getUserMock = service.user.getUser as MockedService<typeof service.user.getUser>;
+const getProfileMock = service.user.getProfile as MockedService<typeof service.user.getProfile>;
 const reportContentMock = service.reporting.reportContent as MockedService<typeof service.reporting.reportContent>;
 
 const getLanguagesMock = service.resources.getLanguages as jest.MockedFunction<typeof service.resources.getLanguages>;
@@ -44,6 +45,7 @@ describe("Profile page", () => {
 
   beforeEach(() => {
     getUserMock.mockImplementation(getUser);
+    getProfileMock.mockImplementation(getProfile);
     getLanguagesMock.mockImplementation(getLanguages);
     getRegionsMock.mockImplementation(getRegions);
     getAccountInfoMock.mockImplementation(getAccountInfo);

--- a/app/web/features/profile/view/ProfilePage.tsx
+++ b/app/web/features/profile/view/ProfilePage.tsx
@@ -5,6 +5,7 @@ import HtmlMeta from "components/HtmlMeta";
 import { ProfileUserProvider } from "features/profile/hooks/useProfileUser";
 import Overview from "features/profile/view/Overview";
 import useCurrentUser from "features/userQueries/useCurrentUser";
+import { useCurrentProfile } from "features/userQueries/useProfile";
 import { useTranslation } from "i18n";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
 import { useRouter } from "next/router";
@@ -35,15 +36,17 @@ export default function ProfilePage({ tab = "about" }: { tab?: UserTab }) {
   const router = useRouter();
 
   const { data: user, error, isLoading } = useCurrentUser();
+  const { data: profile, error: profileError, isLoading: isProfileLoading } = useCurrentProfile();
 
   return (
     <>
       <HtmlMeta title={t("global:nav.profile")} />
       {error && <Alert severity="error">{error}</Alert>}
-      {isLoading ? (
+      {profileError && <Alert severity="error">{profileError.message}</Alert>}
+      {isLoading || isProfileLoading ? (
         <CenteredSpinner />
-      ) : user ? (
-        <ProfileUserProvider user={user}>
+      ) : user && profile ? (
+        <ProfileUserProvider user={user} profile={profile}>
           <StyledWrapper>
             <Overview tab={tab} />
             <UserCard

--- a/app/web/features/profile/view/References.test.tsx
+++ b/app/web/features/profile/view/References.test.tsx
@@ -33,7 +33,7 @@ function assertDateBadgeIsVisible(reference: ReturnType<typeof within>) {
 
 function renderReferences() {
   render(
-    <ProfileUserProvider user={users[0]}>
+    <ProfileUserProvider user={users[0]} profile={defaultProfile}>
       <References />
     </ProfileUserProvider>,
     { wrapper },

--- a/app/web/features/profile/view/UserOverview.test.tsx
+++ b/app/web/features/profile/view/UserOverview.test.tsx
@@ -18,7 +18,7 @@ describe("UserOverview", () => {
   describe("when user is loaded and provided via context", () => {
     it("should display the user name", () => {
       render(
-        <ProfileUserProvider user={defaultUser}>
+        <ProfileUserProvider user={defaultUser} profile={defaultProfile}>
           <UserOverview showHostAndMeetAvailability={false} />
         </ProfileUserProvider>,
         { wrapper },
@@ -28,7 +28,7 @@ describe("UserOverview", () => {
 
     it("should display the user username with a leading @", () => {
       render(
-        <ProfileUserProvider user={defaultUser}>
+        <ProfileUserProvider user={defaultUser} profile={defaultProfile}>
           <UserOverview showHostAndMeetAvailability={false} />
         </ProfileUserProvider>,
         { wrapper },
@@ -38,7 +38,7 @@ describe("UserOverview", () => {
 
     it("should display the user location", () => {
       render(
-        <ProfileUserProvider user={defaultUser}>
+        <ProfileUserProvider user={defaultUser} profile={defaultProfile}>
           <UserOverview showHostAndMeetAvailability={false} />
         </ProfileUserProvider>,
         { wrapper },
@@ -52,7 +52,7 @@ describe("UserOverview", () => {
 
       it("should display the hosting and meeting status when showHostAndMeetAvailability is true", () => {
         render(
-          <ProfileUserProvider user={defaultUser}>
+          <ProfileUserProvider user={defaultUser} profile={defaultProfile}>
             <UserOverview showHostAndMeetAvailability />
           </ProfileUserProvider>,
           { wrapper },
@@ -63,7 +63,7 @@ describe("UserOverview", () => {
 
       it("should not display the hosting and meeting status when showHostAndMeetAvailability is false", () => {
         render(
-          <ProfileUserProvider user={defaultUser}>
+          <ProfileUserProvider user={defaultUser} profile={defaultProfile}>
             <UserOverview showHostAndMeetAvailability={false} />
           </ProfileUserProvider>,
           { wrapper },
@@ -83,7 +83,7 @@ describe("UserOverview", () => {
       const expectedLabelVerification = t("global:verification_score");
 
       render(
-        <ProfileUserProvider user={defaultUser}>
+        <ProfileUserProvider user={defaultUser} profile={defaultProfile}>
           <UserOverview showHostAndMeetAvailability={false} />
         </ProfileUserProvider>,
         { wrapper },
@@ -97,7 +97,7 @@ describe("UserOverview", () => {
 
     it("should render the action buttons", () => {
       render(
-        <ProfileUserProvider user={defaultUser}>
+        <ProfileUserProvider user={defaultUser} profile={defaultProfile}>
           <UserOverview
             showHostAndMeetAvailability={false}
             actions={
@@ -114,7 +114,7 @@ describe("UserOverview", () => {
 
     it("should not show badge when no strong verification", () => {
       render(
-        <ProfileUserProvider user={{ ...defaultUser, hasStrongVerification: false }}>
+        <ProfileUserProvider user={{ ...defaultUser, hasStrongVerification: false }} profile={defaultProfile}>
           <UserOverview showHostAndMeetAvailability={false} />
         </ProfileUserProvider>,
         { wrapper },
@@ -126,7 +126,7 @@ describe("UserOverview", () => {
 
     it("should show badge when user has strong verification", () => {
       render(
-        <ProfileUserProvider user={{ ...defaultUser, hasStrongVerification: true }}>
+        <ProfileUserProvider user={{ ...defaultUser, hasStrongVerification: true }} profile={defaultProfile}>
           <UserOverview showHostAndMeetAvailability={false} />
         </ProfileUserProvider>,
         { wrapper },

--- a/app/web/features/profile/view/UserPage.test.tsx
+++ b/app/web/features/profile/view/UserPage.test.tsx
@@ -10,7 +10,7 @@ import { service } from "service";
 import mockUsers from "test/fixtures/users.json";
 import wrapper from "test/hookWrapper";
 import i18n from "test/i18n";
-import { getLanguages, getRegions, getUser } from "test/serviceMockDefaults";
+import { getLanguages, getProfile, getRegions, getUser } from "test/serviceMockDefaults";
 import { addDefaultUser, MockedService } from "test/utils";
 
 import { sectionLabels } from "./UserCard";
@@ -22,6 +22,7 @@ jest.mock("features/userQueries/useCurrentUser");
 jest.mock("react-simple-maps");
 
 const getUserMock = service.user.getUser as MockedService<typeof service.user.getUser>;
+const getProfileMock = service.user.getProfile as MockedService<typeof service.user.getProfile>;
 const reportContentMock = service.reporting.reportContent as MockedService<typeof service.reporting.reportContent>;
 
 const blockUserMock = service.blocking.blockUser as MockedService<typeof service.blocking.blockUser>;
@@ -44,6 +45,7 @@ describe("User page", () => {
 
   beforeEach(() => {
     getUserMock.mockImplementation(getUser);
+    getProfileMock.mockImplementation(getProfile);
     reportContentMock.mockResolvedValue(new Empty());
     getLanguagesMock.mockImplementation(getLanguages);
     getRegionsMock.mockImplementation(getRegions);

--- a/app/web/features/profile/view/UserPage.tsx
+++ b/app/web/features/profile/view/UserPage.tsx
@@ -10,6 +10,7 @@ import { ProfileUserProvider } from "features/profile/hooks/useProfileUser";
 import NewHostRequest from "features/profile/view/NewHostRequest";
 import NewMessage from "features/profile/view/NewMessage";
 import Overview from "features/profile/view/Overview";
+import useProfileByUsername from "features/userQueries/useProfileByUsername";
 import useUserByUsername from "features/userQueries/useUserByUsername";
 import { useTranslation } from "i18n";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
@@ -72,6 +73,7 @@ export default function UserPage({ username, tab = "about" }: { username: string
   const router = useRouter();
 
   const { data: user, isLoading, error } = useUserByUsername(username, true);
+  const { data: profile, isLoading: isProfileLoading, error: profileError } = useProfileByUsername(username, true);
 
   const [isRequesting, setIsRequesting] = useState(false);
   const [isSuccessRequest, setIsSuccessRequest] = useState(false);
@@ -91,10 +93,11 @@ export default function UserPage({ username, tab = "about" }: { username: string
       <HtmlMeta title={user?.name} />
       {isSuccessRequest && <Snackbar severity="success">{t("request_form.success")}</Snackbar>}
       {error && <Alert severity="error">{error}</Alert>}
-      {isLoading ? (
+      {profileError && <Alert severity="error">{profileError}</Alert>}
+      {isLoading || isProfileLoading ? (
         <CenteredSpinner />
-      ) : user ? (
-        <ProfileUserProvider user={user}>
+      ) : user && profile ? (
+        <ProfileUserProvider user={user} profile={profile}>
           <StyledProfileRoot>
             <Overview setIsRequesting={setIsRequesting} setIsMessaging={setIsMessaging} tab={tab} />
             <UserCard

--- a/app/web/features/profile/view/leaveReference/LeaveReferencePage.test.tsx
+++ b/app/web/features/profile/view/leaveReference/LeaveReferencePage.test.tsx
@@ -5,7 +5,7 @@ import { leaveReferenceBaseRoute, ReferenceStep } from "routes";
 import { service } from "service";
 import wrapper from "test/hookWrapper";
 import i18n from "test/i18n";
-import { getAvailableReferences, getUser } from "test/serviceMockDefaults";
+import { getAvailableReferences, getProfile, getUser } from "test/serviceMockDefaults";
 import { MockedService } from "test/utils";
 
 import LeaveReferencePage from "./LeaveReferencePage";
@@ -16,6 +16,7 @@ const getAvailableReferencesMock = service.references.getAvailableReferences as 
   typeof service.references.getAvailableReferences
 >;
 const getUserMock = service.user.getUser as MockedService<typeof service.user.getUser>;
+const getProfileMock = service.user.getProfile as MockedService<typeof service.user.getProfile>;
 const getHostRequestReferenceStatusMock = service.references
   .getHostRequestReferenceStatus as unknown as jest.MockedFunction<
   (hostRequestId: number) => Promise<GetHostRequestReferenceStatusRes.AsObject>
@@ -54,6 +55,7 @@ function renderLeaveRequestReferencePage(
 describe("LeaveReferencePage", () => {
   beforeEach(() => {
     getUserMock.mockImplementation(getUser);
+    getProfileMock.mockImplementation(getProfile);
     getAvailableReferencesMock.mockImplementation(getAvailableReferences);
     getHostRequestReferenceStatusMock.mockResolvedValue({
       hasGiven: false,

--- a/app/web/features/profile/view/leaveReference/LeaveReferencePage.tsx
+++ b/app/web/features/profile/view/leaveReference/LeaveReferencePage.tsx
@@ -7,6 +7,7 @@ import { ProfileUserProvider } from "features/profile/hooks/useProfileUser";
 import ReferenceForm from "features/profile/view/leaveReference/ReferenceForm";
 import UserOverview from "features/profile/view/UserOverview";
 import { hasGivenHostRequestReferenceKey } from "features/queryKeys";
+import { useProfile } from "features/userQueries/useProfile";
 import { useUser } from "features/userQueries/useUsers";
 import { useTranslation } from "i18n";
 import { GLOBAL, PROFILE } from "i18n/namespaces";
@@ -67,6 +68,7 @@ export default function LeaveReferencePage({
   });
 
   const { data: user, isLoading: isUserLoading, error: userError } = useUser(userId);
+  const { data: profile, isLoading: isProfileLoading, error: profileError } = useProfile(userId);
   const {
     data: availableReferences,
     isLoading: isAvailableReferencesLoading,
@@ -79,10 +81,12 @@ export default function LeaveReferencePage({
     return <Alert severity="error">{t("profile:leave_reference.invalid_reference_type")}</Alert>;
   }
 
-  if (userError || availableReferencesError) {
-    return <Alert severity="error">{userError || availableReferencesError?.message || ""}</Alert>;
+  if (userError || profileError || availableReferencesError) {
+    return (
+      <Alert severity="error">{userError || profileError?.message || availableReferencesError?.message || ""}</Alert>
+    );
   }
-  if (isUserLoading || isAvailableReferencesLoading) {
+  if (isUserLoading || isProfileLoading || isAvailableReferencesLoading) {
     return <CenteredSpinner />;
   }
 
@@ -131,7 +135,7 @@ export default function LeaveReferencePage({
 
   return (
     <StyledRoot>
-      <ProfileUserProvider user={user!}>
+      <ProfileUserProvider user={user!} profile={profile!}>
         {!isMobile && <UserOverview showHostAndMeetAvailability={false} />}
         <StyledFormWrapper>
           <ReferenceForm hostRequestId={hostRequestId} referenceType={referenceType} userId={userId} step={step} />

--- a/app/web/features/queryKeys.ts
+++ b/app/web/features/queryKeys.ts
@@ -27,6 +27,9 @@ export function modUserKey(user?: string) {
 export function modUserDetailsKey(user?: string) {
   return user === undefined ? "modUserDetails" : ["modUserDetails", user];
 }
+export function modProfileKey(user?: string) {
+  return user === undefined ? "modProfile" : ["modProfile", user];
+}
 
 export function profileKey(userId?: number) {
   return userId === undefined ? ["profile"] : ["profile", userId];


### PR DESCRIPTION
Based on #9492 — review that first, and merge it before this.

`ProfileUserProvider` now takes a `profile` as well as a `user`, and exposes it through a new `useProfileData` hook alongside the existing `useProfileUser`. All six call sites fetch it:

| Surface | Fetched via |
| --- | --- |
| `ProfilePage` | `useCurrentProfile` |
| `UserPage` | `useProfileByUsername` |
| `ProfileSheet` | `useProfile` |
| `DashboardUserProfileSummary` | `useCurrentProfile` |
| `LeaveReferencePage` | `useProfile` |
| `ModUserPage` | `Admin.GetProfile`, via `useUserWithDetails` |

Each of these now also surfaces the profile query's error and folds its loading state into the existing spinner condition.

Nothing calls `useProfileData` yet — the view and edit components still read these fields off `User`, which still carries all of them. So this should be behaviour-neutral. It lands separately so that the per-component migrations that follow are small diffs against a provider that already has the data.

Also adds a `modProfileKey` to `queryKeys.ts`, to match the neighbouring `modUserKey` / `modUserDetailsKey` rather than inlining the key.

Note that `profile` is a required prop, so this touches four test files that render the provider directly (`UserOverview`, `References`, `Overview`, `NewHostRequest`) — they pass the `defaultProfile` fixture added in #9492. Three page tests (`ProfilePage`, `UserPage`, `LeaveReferencePage`) needed the `getProfile` mock wired up, since those pages now gate rendering on the profile having loaded.

## Testing

- `yarn lint` — clean
- `yarn tsc --noEmit` — no new errors
- `yarn test` — 915 passed, 41 failed, 9 suites failed

⚠️ **Those 41 failures are pre-existing on `develop`, not from this PR.** Verified by stashing and re-running on clean `develop`: identical counts (9 suites / 41 tests / 915 passed) and identical 11 `tsc` errors, from a MUI Autocomplete bump that broke `slotProps` typing. I also confirmed the affected profile suites specifically: before wiring the `getProfile` mocks they went to 4 failed / 23 tests, and after wiring them back to 1 failed / 5 tests, which is exactly `develop`'s baseline for those directories (the one being the pre-existing `EditProfilePage` failure).

Not clicked through in a browser yet. Because the provider now gates rendering on `profile`, the thing worth checking manually is that each of the six surfaces above still renders rather than hanging on a spinner.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant — existing suites updated for the new required prop and the new mock; no new behaviour to cover yet
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._