### PR TITLE
Add unseen_message_count to HostRequest

### DIFF
--- a/app/backend/src/couchers/helpers/group_chats.py
+++ b/app/backend/src/couchers/helpers/group_chats.py
@@ -7,6 +7,8 @@ from datetime import datetime
 from sqlalchemy import ColumnElement, SQLColumnExpression, and_, func, or_, select
 
 from couchers.models import GroupChatSubscription, Message
+from couchers.proto import conversations_pb2
+from couchers.utils import Timestamp_from_datetime
 
 
 def was_subscribed_at(
@@ -47,3 +49,11 @@ def is_newest_subscription(user_id: SQLColumnExpression[int] | int) -> ColumnEle
         .correlate_except(GroupChatSubscription)
     )
     return GroupChatSubscription.id.in_(newest_per_chat)
+
+
+def mute_info(subscription: GroupChatSubscription) -> conversations_pb2.MuteInfo:
+    (muted, muted_until) = subscription.muted_display()
+    return conversations_pb2.MuteInfo(
+        muted=muted,
+        muted_until=Timestamp_from_datetime(muted_until) if muted_until else None,
+    )

--- a/app/backend/src/couchers/helpers/host_requests.py
+++ b/app/backend/src/couchers/helpers/host_requests.py
@@ -11,7 +11,7 @@ The role-based party predicates below exist because a host request has a fixed d
 So "am I hosting?" is not the same question as "did I receive this?".
 """
 
-from sqlalchemy.sql import and_, case, exists, or_, select
+from sqlalchemy.sql import and_, case, exists, func, or_, select
 from sqlalchemy.sql.elements import ColumnElement
 
 from couchers.models import HostRequest, Message
@@ -75,4 +75,21 @@ def has_unseen_host_request_messages(user_id: int) -> ColumnElement[bool]:
         select(1)
         .where(Message.conversation_id == HostRequest.conversation_id)
         .where(Message.id > viewer_last_seen_message_id(user_id))
+    )
+
+
+def unseen_host_request_message_count(user_id: int) -> ColumnElement[int]:
+    """
+    How many messages on a request the viewer hasn't seen; the count behind has_unseen_host_request
+    _messages. Correlated, so it resolves per row of the enclosing query, and zero for a user who
+    isn't a party to the request.
+    """
+    return (
+        select(func.count(Message.id))
+        .where(Message.conversation_id == HostRequest.conversation_id)
+        .where(Message.id > viewer_last_seen_message_id(user_id))
+        # only the request correlates: an enclosing query that joins Message of its own would
+        # otherwise auto-correlate this one's away and leave it with no FROM at all
+        .correlate(HostRequest)
+        .scalar_subquery()
     )

--- a/app/backend/src/couchers/servicers/conversations.py
+++ b/app/backend/src/couchers/servicers/conversations.py
@@ -14,7 +14,7 @@ from couchers.context import CouchersContext, make_background_user_context, make
 from couchers.db import session_scope
 from couchers.event_log import log_event
 from couchers.helpers.completed_profile import has_completed_profile
-from couchers.helpers.group_chats import is_newest_subscription, is_unseen, was_subscribed_at
+from couchers.helpers.group_chats import is_newest_subscription, is_unseen, mute_info, was_subscribed_at
 from couchers.helpers.messages import message_to_pb
 from couchers.jobs.enqueue import queue_job
 from couchers.metrics import sent_messages_counter
@@ -287,14 +287,6 @@ def _unseen_message_count(session: Session, subscription_id: int) -> int:
     return session.execute(query).scalar_one()
 
 
-def _mute_info(subscription: GroupChatSubscription) -> conversations_pb2.MuteInfo:
-    (muted, muted_until) = subscription.muted_display()
-    return conversations_pb2.MuteInfo(
-        muted=muted,
-        muted_until=Timestamp_from_datetime(muted_until) if muted_until else None,
-    )
-
-
 class Conversations(conversations_pb2_grpc.ConversationsServicer):
     def MarkAllThreadsSeen(
         self, request: conversations_pb2.MarkAllThreadsSeenReq, context: CouchersContext, session: Session
@@ -372,7 +364,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
                     unseen_message_count=unseen_counts.get(result.GroupChatSubscription.id, 0),
                     last_seen_message_id=result.GroupChatSubscription.last_seen_message_id,
                     latest_message=message_to_pb(result.Message) if result.Message else None,
-                    mute_info=_mute_info(result.GroupChatSubscription),
+                    mute_info=mute_info(result.GroupChatSubscription),
                     can_message=_user_can_message(session, context, result.GroupChat),
                     is_archived=result.GroupChatSubscription.is_archived,
                 )
@@ -419,7 +411,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             unseen_message_count=_unseen_message_count(session, result.GroupChatSubscription.id),
             last_seen_message_id=result.GroupChatSubscription.last_seen_message_id,
             latest_message=message_to_pb(result.Message) if result.Message else None,
-            mute_info=_mute_info(result.GroupChatSubscription),
+            mute_info=mute_info(result.GroupChatSubscription),
             can_message=_user_can_message(session, context, result.GroupChat),
             is_archived=result.GroupChatSubscription.is_archived,
         )
@@ -476,7 +468,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             unseen_message_count=_unseen_message_count(session, result.GroupChatSubscription.id),
             last_seen_message_id=result.GroupChatSubscription.last_seen_message_id,
             latest_message=message_to_pb(result.Message) if result.Message else None,
-            mute_info=_mute_info(result.GroupChatSubscription),
+            mute_info=mute_info(result.GroupChatSubscription),
             can_message=_user_can_message(session, context, result.GroupChat),
             is_archived=result.GroupChatSubscription.is_archived,
         )
@@ -751,7 +743,7 @@ class Conversations(conversations_pb2_grpc.ConversationsServicer):
             only_admins_invite=group_chat.only_admins_invite,
             is_dm=group_chat.is_dm,
             created=Timestamp_from_datetime(group_chat.conversation.created),
-            mute_info=_mute_info(your_subscription),
+            mute_info=mute_info(your_subscription),
             can_message=True,
         )
 

--- a/app/backend/src/couchers/servicers/requests.py
+++ b/app/backend/src/couchers/servicers/requests.py
@@ -12,7 +12,7 @@ from couchers.context import CouchersContext, make_notification_user_context
 from couchers.db import can_moderate_node
 from couchers.event_log import log_event
 from couchers.helpers.completed_profile import has_completed_profile
-from couchers.helpers.host_requests import HOST_REQUEST_NOTIFICATION_TOPIC_ACTIONS
+from couchers.helpers.host_requests import HOST_REQUEST_NOTIFICATION_TOPIC_ACTIONS, unseen_host_request_message_count
 from couchers.helpers.messages import api2hostrequeststatus, hostrequeststatus2api, message_to_pb
 from couchers.materialized_views import UserResponseRate
 from couchers.metrics import (
@@ -87,6 +87,12 @@ def host_request_to_pb(
         .limit(1)
     ).scalar_one()
 
+    unseen_message_count = session.execute(
+        select(unseen_host_request_message_count(context.user_id)).where(
+            HostRequest.conversation_id == host_request.conversation_id
+        )
+    ).scalar_one()
+
     lat, lng = get_coordinates(host_request.hosting_location)
 
     need_feedback = False
@@ -125,6 +131,7 @@ def host_request_to_pb(
             else host_request.is_initiator_archived
         ),
         public_trip_id=host_request.public_trip_id,
+        unseen_message_count=unseen_message_count,
     )
 
 
@@ -407,7 +414,12 @@ class Requests(requests_pb2_grpc.RequestsServicer):
         statement = where_moderated_content_visible(
             where_users_column_visible(
                 where_users_column_visible(
-                    select(Message, HostRequest, Conversation)
+                    select(
+                        Message,
+                        HostRequest,
+                        Conversation,
+                        unseen_host_request_message_count(context.user_id).label("unseen_message_count"),
+                    )
                     .outerjoin(
                         message_2, and_(Message.conversation_id == message_2.conversation_id, Message.id < message_2.id)
                     )
@@ -511,6 +523,7 @@ class Requests(requests_pb2_grpc.RequestsServicer):
                     hosting_lat=lat,
                     hosting_lng=lng,
                     hosting_radius=result.HostRequest.hosting_radius,
+                    unseen_message_count=result.unseen_message_count,
                 )
             )
 

--- a/app/backend/src/tests/test_public_trips.py
+++ b/app/backend/src/tests/test_public_trips.py
@@ -20,6 +20,7 @@ from couchers.models import (
     NodeType,
     User,
 )
+from couchers.models.host_requests import HostRequest, HostRequestStatus
 from couchers.models.public_trips import PublicTrip, PublicTripStatus
 from couchers.proto import public_trips_pb2, requests_pb2
 from couchers.utils import create_polygon_lat_lng, now, to_multi, today
@@ -1005,6 +1006,47 @@ def test_list_public_trips_by_user_offers_count_not_set_for_others(db):
         res = api.ListPublicTripsByUser(public_trips_pb2.ListPublicTripsByUserReq(user_id=traveler.id))
         assert len(res.public_trips) == 1
         assert not res.public_trips[0].HasField("offers_count")
+
+
+def test_list_public_trips_by_user_offers_count_excludes_cancelled(db):
+    traveler, traveler_token = generate_user()
+    hosts = [generate_user() for _ in range(5)]
+    node_id = _make_node()
+
+    trip_id = _create_trip_directly(traveler.id, node_id, today() + timedelta(days=5), today() + timedelta(days=10))
+
+    for _host, host_token in hosts:
+        with requests_session(host_token) as api:
+            api.CreateHostRequest(
+                requests_pb2.CreateHostRequestReq(
+                    host_user_id=traveler.id,
+                    from_date=(today() + timedelta(days=5)).isoformat(),
+                    to_date=(today() + timedelta(days=10)).isoformat(),
+                    text=_valid_request_text(),
+                    public_trip_id=trip_id,
+                )
+            )
+
+    # Set one offer per status, so we cover every status the count has to consider.
+    with session_scope() as session:
+        offers = (
+            session.execute(
+                select(HostRequest).where(HostRequest.public_trip_id == trip_id).order_by(HostRequest.conversation_id)
+            )
+            .scalars()
+            .all()
+        )
+        offers[0].status = HostRequestStatus.pending
+        offers[1].status = HostRequestStatus.accepted
+        offers[2].status = HostRequestStatus.confirmed
+        offers[3].status = HostRequestStatus.rejected
+        offers[4].status = HostRequestStatus.cancelled
+
+    with public_trips_session(traveler_token) as api:
+        res = api.ListPublicTripsByUser(public_trips_pb2.ListPublicTripsByUserReq(user_id=traveler.id))
+        trip = next(t for t in res.public_trips if t.trip_id == trip_id)
+        # pending, accepted, confirmed and rejected all count; cancelled does not
+        assert trip.offers_count == 4
 
 
 def test_viewer_host_request_id_reflects_viewers_own_offer(db):

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -1482,6 +1482,50 @@ def test_archive_host_request(db, moderator):
         assert res.is_archived
 
 
+def test_host_request_unseen_message_count(db, moderator):
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    with requests_session(token1) as api:
+        host_request_id = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=user2.id,
+                from_date=(today() + timedelta(days=2)).isoformat(),
+                to_date=(today() + timedelta(days=3)).isoformat(),
+                text=valid_request_text(),
+            )
+        ).host_request_id
+    moderator.approve_host_request(host_request_id)
+
+    with requests_session(token1) as api:
+        api.SendHostRequestMessage(
+            requests_pb2.SendHostRequestMessageReq(host_request_id=host_request_id, text="and one more thing")
+        )
+        # sending marks your own messages seen
+        res = api.GetHostRequest(requests_pb2.GetHostRequestReq(host_request_id=host_request_id))
+        assert res.unseen_message_count == 0
+
+    with requests_session(token2) as api:
+        listed = api.ListHostRequests(requests_pb2.ListHostRequestsReq()).host_requests[0]
+        # the request's control message, its text, and the follow-up
+        assert listed.unseen_message_count == 3
+        assert (
+            api.GetHostRequest(requests_pb2.GetHostRequestReq(host_request_id=host_request_id)).unseen_message_count
+            == 3
+        )
+
+        api.MarkLastSeenHostRequest(
+            requests_pb2.MarkLastSeenHostRequestReq(
+                host_request_id=host_request_id, last_seen_message_id=listed.latest_message.message_id
+            )
+        )
+        assert api.ListHostRequests(requests_pb2.ListHostRequestsReq()).host_requests[0].unseen_message_count == 0
+        assert (
+            api.GetHostRequest(requests_pb2.GetHostRequestReq(host_request_id=host_request_id)).unseen_message_count
+            == 0
+        )
+
+
 def test_mark_last_seen(db, moderator):
     user1, token1 = generate_user()
     user2, token2 = generate_user()

--- a/app/proto/requests.proto
+++ b/app/proto/requests.proto
@@ -81,6 +81,8 @@ message HostRequest {
   bool is_archived = 15;
   // If set, this host request was created in response to a public trip
   optional int64 public_trip_id = 16;
+  // number of messages on this request the viewer hasn't seen yet
+  uint32 unseen_message_count = 17;
 }
 
 message GetHostRequestReq {


### PR DESCRIPTION
Groundwork split out of #9472 (ListMessageThreads), so that PR is only the new endpoint.

- adds `unseen_message_count` to the `HostRequest` proto, backed by a new
  `unseen_host_request_message_count` clause helper, and populates it in `GetHostRequest` and
  `ListHostRequests` — the group chat side already had the equivalent field
- moves `_mute_info` out of the conversations servicer into `helpers/group_chats.py`, so callers
  outside that servicer can build a `MuteInfo` without importing from it
- adds a test that a public trip's `offers_count` excludes cancelled offers (existing behaviour,
  previously untested)

## Testing
`uv run pytest src/tests/test_requests.py src/tests/test_conversations.py src/tests/test_public_trips.py` — 139 passed. New `test_host_request_unseen_message_count` covers the count for both parties and that `MarkLastSeenHostRequest` clears it.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
