### PR TITLE
Fix emails blowing up when a url ends in "src="

### DIFF
--- a/app/backend/src/couchers/email/smtp.py
+++ b/app/backend/src/couchers/email/smtp.py
@@ -44,7 +44,9 @@ def embed_html_relative_images(
 
         return f'src="cid:{content_id}"'
 
-    html = re.sub(r'src="([^":]+)"', repl=process_relative_src_match, string=html)
+    # The lookbehind keeps us inside a tag: without it a url ending in "src=" (base64 tokens are "=" padded,
+    # so this happens) matches from within its own href across into the following attribute.
+    html = re.sub(r'(?<=\s)src="([^":]+)"', repl=process_relative_src_match, string=html)
     return html, related_parts
 
 

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -66,6 +66,26 @@ def test_signup_verification_email(db, email_collector: EmailCollector):
     assert flow.email_token in email.html
 
 
+def test_signup_verification_email_with_token_ending_in_src(db, email_collector: EmailCollector):
+    """
+    Signup tokens are base64 encoded, so their "=" padding makes roughly one in 65k of them end in "src=".
+    The token goes into the button's `<a href="..." style="...">`, where it must not be mistaken for an image.
+    """
+    request_email = f"{random_hex(12)}@couchers.org.invalid"
+    token = f"{'A' * 40}src="
+
+    flow = SignupFlow(name="Frodo", email=request_email, flow_token="")
+
+    with session_scope() as session:
+        context = make_logged_out_context(LocalizationContext.en_utc())
+        with patch("couchers.tasks.urlsafe_secure_token", return_value=token):
+            send_signup_email(context, session, flow)
+
+    email = email_collector.pop_for_recipient(request_email, last=True)
+    assert flow.email_token == token
+    assert token in email.html
+
+
 def test_report_email(db, email_collector: EmailCollector):
     user_reporter, api_token_author = generate_user()
     user_author, api_token_reported = generate_user()

--- a/app/backend/src/tests/test_email.py
+++ b/app/backend/src/tests/test_email.py
@@ -72,7 +72,7 @@ def test_signup_verification_email_with_token_ending_in_src(db, email_collector:
     The token goes into the button's `<a href="..." style="...">`, where it must not be mistaken for an image.
     """
     request_email = f"{random_hex(12)}@couchers.org.invalid"
-    token = f"{'A' * 40}src="
+    token = "a-token-ending-in-src="
 
     flow = SignupFlow(name="Frodo", email=request_email, flow_token="")
 

--- a/app/backend/src/tests/test_smtp.py
+++ b/app/backend/src/tests/test_smtp.py
@@ -57,3 +57,22 @@ def test_embed_html_relative_images() -> None:
     assert related_part.content_type == 'image/png; name="logo-grey.png"'
     assert related_part.content_disposition == 'inline; filename="logo-grey.png"'
     assert related_part.content_id == f"<{content_id_match.group(1)}>"
+
+
+def test_embed_html_relative_images_ignores_url_ending_in_src() -> None:
+    """
+    Our urls end in base64 tokens, whose "=" padding makes them occasionally end in "src=", which must not
+    be picked up as an image reference spanning into the next attribute.
+    """
+    sig = f"{'A' * 40}src="  # a 32 byte blake2b signature, base64 encoded
+    link = f"https://example.com/quick-link?payload=Zm9v&sig={sig}"
+    html = f"""
+        <a href="{link}" style="color: #777;">unsubscribe</a>
+        <img src="attachment_imgs/logo-grey.png" style="border:0;"/>
+    """
+
+    html, related_parts = embed_html_relative_images(html, base_dir=template_folder, content_id_domain="example.com")
+
+    assert link in html, "Link url was replaced"
+    assert len(related_parts) == 1
+    assert related_parts[0].content_disposition == 'inline; filename="logo-grey.png"'

--- a/app/backend/src/tests/test_smtp.py
+++ b/app/backend/src/tests/test_smtp.py
@@ -1,5 +1,7 @@
 import re
 
+import pytest
+
 from couchers.email.rendering import template_folder
 from couchers.email.smtp import email_proto_to_message, embed_html_relative_images
 from couchers.proto.internal.jobs_pb2 import EmailPart, SendEmailPayload
@@ -59,19 +61,30 @@ def test_embed_html_relative_images() -> None:
     assert related_part.content_id == f"<{content_id_match.group(1)}>"
 
 
-def test_embed_html_relative_images_ignores_url_ending_in_src() -> None:
-    """
-    A url ending in "src=" must not be picked up as an image reference reaching into the next attribute.
-    Our urls end in base64 tokens, whose "=" padding makes them end in "src=" about one time in 65k.
-    """
-    link = "https://example.com/quick-link?payload=Zm9v&sig=src="
-    html = f"""
-        <a href="{link}" style="color: #777;">unsubscribe</a>
-        <img src="attachment_imgs/logo-grey.png" style="border:0;"/>
-    """
+@pytest.mark.parametrize(
+    ("html", "is_image_ref"),
+    [
+        ('<img src="attachment_imgs/logo-grey.png"/>', True),
+        ('<img\n    src="attachment_imgs/logo-grey.png"/>', True),
+        # A url that merely mentions "src=" never yields the `src="` the pattern looks for
+        ('<a href="https://example.com/?src=foo" style="color: #777;">unsubscribe</a>', False),
+        # ...but one that *ends* in "src=" does, and then runs on into the next attribute. Our urls end in
+        # base64 tokens, whose "=" padding makes them end in "src=" about one time in 65k.
+        ('<a href="https://example.com/quick-link?sig=src=" style="color: #777;">unsubscribe</a>', False),
+        # The same url with no attribute following it, so there is no later quote to run the match into
+        ('<a href="https://example.com/quick-link?sig=src=">unsubscribe</a>', False),
+    ],
+)
+def test_embed_html_relative_images_only_matches_src_attributes(html: str, is_image_ref: bool) -> None:
+    """Only a genuine src="" attribute is an image reference, no matter what a url in the markup contains."""
+    embedded_html, related_parts = embed_html_relative_images(
+        html, base_dir=template_folder, content_id_domain="example.com"
+    )
 
-    html, related_parts = embed_html_relative_images(html, base_dir=template_folder, content_id_domain="example.com")
-
-    assert link in html, "Link url was replaced"
-    assert len(related_parts) == 1
-    assert related_parts[0].content_disposition == 'inline; filename="logo-grey.png"'
+    if is_image_ref:
+        assert len(related_parts) == 1
+        assert related_parts[0].content_disposition == 'inline; filename="logo-grey.png"'
+        assert f'src="cid:{related_parts[0].content_id[1:-1]}"' in embedded_html
+    else:
+        assert related_parts == []
+        assert embedded_html == html, "markup was rewritten"

--- a/app/backend/src/tests/test_smtp.py
+++ b/app/backend/src/tests/test_smtp.py
@@ -61,11 +61,10 @@ def test_embed_html_relative_images() -> None:
 
 def test_embed_html_relative_images_ignores_url_ending_in_src() -> None:
     """
-    Our urls end in base64 tokens, whose "=" padding makes them occasionally end in "src=", which must not
-    be picked up as an image reference spanning into the next attribute.
+    A url ending in "src=" must not be picked up as an image reference reaching into the next attribute.
+    Our urls end in base64 tokens, whose "=" padding makes them end in "src=" about one time in 65k.
     """
-    sig = f"{'A' * 40}src="  # a 32 byte blake2b signature, base64 encoded
-    link = f"https://example.com/quick-link?payload=Zm9v&sig={sig}"
+    link = "https://example.com/quick-link?payload=Zm9v&sig=src="
     html = f"""
         <a href="{link}" style="color: #777;">unsubscribe</a>
         <img src="attachment_imgs/logo-grey.png" style="border:0;"/>


### PR DESCRIPTION
Closes #9483.

`embed_html_relative_images` rewrites relative images with `re.sub(r'src="([^":]+)"', ...)` over the whole email body. The pattern isn't anchored to a tag, so it also matches across an attribute boundary: in `blocks.html` every link is `<a href="{{ url }}" style="...">`, and if a url *ends* with the literal `src=` the regex matches `src=" style="`, captures ` style=` as a relative image path, and raises `FileExistsError: HTML references missing relative image: /app/templates/v2/ style=`.

Our urls end in urlsafe base64 of 32 bytes (44 chars, always `=` padded): the signup token in `?token=...`, and the payload/signature in `/quick-link?payload=...&sig=...`. A hit needs the last three data characters to be `s`, `r`, `c`; the final data character only takes 16 values and `c` is one of them, so it's `(1/64)·(1/64)·(1/16)` ≈ **1 in 65k per token-bearing url**. Every signup email has one, every non-critical notification has two to four in the footer.

The consequences are that `SignupFlow` fails with `UNKNOWN` (the user can retry, which mints a new token), and `send_email` jobs fail and re-render with a fresh signature on retry. It also shows up as a rare backend CI flake, e.g. [this `test:backend 1/3` job](https://gitlab.com/couchers/couchers/-/jobs/15797291288), which passed on retry.

The fix is a `(?<=\s)` lookbehind, which keeps the match inside a tag: in an attribute value the `src=` is preceded by a base64 character, never whitespace.

## Testing

Two regression tests are in their own commit, ahead of the fix, and reproduce the exact production error:

```
match = <re.Match object; span=(15197, 15210), match='src=" style="'>
FileExistsError: HTML references missing relative image: .../templates/v2/ style=
```

- `test_smtp.py::test_embed_html_relative_images_ignores_url_ending_in_src` covers the unit directly, with the footer unsubscribe shape (`&sig=<base64>`) next to a genuine relative image.
- `test_email.py::test_signup_verification_email_with_token_ending_in_src` goes end to end through `send_signup_email` with the token patched, so it exercises the real `blocks.html` button markup rather than a hand-written snippet.

The full backend suite passes locally.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._