### PR TITLE
Revert "Add GetProfile RPC"

### DIFF
--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -62,7 +62,7 @@ from couchers.notifications.notify import notify
 from couchers.proto import admin_pb2, admin_pb2_grpc, api_pb2, notification_data_pb2
 from couchers.proto.internal import jobs_pb2
 from couchers.resources import get_badge_dict
-from couchers.servicers.api import profile_model_to_pb, user_model_to_pb
+from couchers.servicers.api import user_model_to_pb
 from couchers.servicers.auth import create_session
 from couchers.servicers.bugs import _fetch_signed_manifest, _native_ota_manifest_url
 from couchers.servicers.events import generate_event_delete_notifications
@@ -315,12 +315,6 @@ class Admin(admin_pb2_grpc.AdminServicer):
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
         return user_model_to_pb(user, session, context, is_admin_see_ghosts=True)
-
-    def GetProfile(self, request: admin_pb2.GetUserReq, context: CouchersContext, session: Session) -> api_pb2.Profile:
-        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
-        if not user:
-            context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
-        return profile_model_to_pb(user)
 
     def SearchUsers(
         self, request: admin_pb2.SearchUsersReq, context: CouchersContext, session: Session

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -309,25 +309,6 @@ class API(api_pb2_grpc.APIServicer):
 
         return user_model_to_pb(user, session, context, is_get_user_return_ghosts=True)
 
-    def GetProfile(self, request: api_pb2.GetProfileReq, context: CouchersContext, session: Session) -> api_pb2.Profile:
-        user = session.execute(
-            select(User)
-            .where(username_or_id(request.user))
-            .options(
-                selectinload(User.regions_visited),
-                selectinload(User.regions_lived),
-                selectinload(User.language_abilities),
-            )
-        ).scalar_one_or_none()
-
-        if not user:
-            context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
-
-        if is_not_visible(session, context.user_id, user.id):
-            context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
-
-        return profile_model_to_pb(user)
-
     def GetLiteUser(
         self, request: api_pb2.GetLiteUserReq, context: CouchersContext, session: Session
     ) -> api_pb2.LiteUser:
@@ -1275,75 +1256,6 @@ def user_model_to_pb(
         user.camping_ok.value = db_user.camping_ok
 
     return user
-
-
-def profile_model_to_pb(db_user: User) -> api_pb2.Profile:
-    profile = api_pb2.Profile(
-        user_id=db_user.id,
-        hometown=db_user.hometown,
-        pronouns=db_user.pronouns,
-        occupation=db_user.occupation,
-        education=db_user.education,
-        about_me=db_user.about_me,
-        things_i_like=db_user.things_i_like,
-        about_place=db_user.about_place,
-        additional_information=db_user.additional_information,
-        hosting_status=hostingstatus2api[db_user.hosting_status],
-        meetup_status=meetupstatus2api[db_user.meetup_status],
-        regions_visited=[region.code for region in db_user.regions_visited],
-        regions_lived=[region.code for region in db_user.regions_lived],
-        language_abilities=[
-            api_pb2.LanguageAbility(code=ability.language_code, fluency=fluency2api[ability.fluency])
-            for ability in db_user.language_abilities
-        ],
-        profile_gallery_id=db_user.profile_gallery_id,
-        smoking_allowed=smokinglocation2api[db_user.smoking_allowed],
-        sleeping_arrangement=sleepingarrangement2api[db_user.sleeping_arrangement],
-        parking_details=parkingdetails2api[db_user.parking_details],
-    )
-
-    if db_user.max_guests is not None:
-        profile.max_guests.value = db_user.max_guests
-    if db_user.last_minute is not None:
-        profile.last_minute.value = db_user.last_minute
-    if db_user.has_pets is not None:
-        profile.has_pets.value = db_user.has_pets
-    if db_user.accepts_pets is not None:
-        profile.accepts_pets.value = db_user.accepts_pets
-    if db_user.pet_details is not None:
-        profile.pet_details.value = db_user.pet_details
-    if db_user.has_kids is not None:
-        profile.has_kids.value = db_user.has_kids
-    if db_user.accepts_kids is not None:
-        profile.accepts_kids.value = db_user.accepts_kids
-    if db_user.kid_details is not None:
-        profile.kid_details.value = db_user.kid_details
-    if db_user.has_housemates is not None:
-        profile.has_housemates.value = db_user.has_housemates
-    if db_user.housemate_details is not None:
-        profile.housemate_details.value = db_user.housemate_details
-    if db_user.wheelchair_accessible is not None:
-        profile.wheelchair_accessible.value = db_user.wheelchair_accessible
-    if db_user.smokes_at_home is not None:
-        profile.smokes_at_home.value = db_user.smokes_at_home
-    if db_user.drinking_allowed is not None:
-        profile.drinking_allowed.value = db_user.drinking_allowed
-    if db_user.drinks_at_home is not None:
-        profile.drinks_at_home.value = db_user.drinks_at_home
-    if db_user.other_host_info is not None:
-        profile.other_host_info.value = db_user.other_host_info
-    if db_user.sleeping_details is not None:
-        profile.sleeping_details.value = db_user.sleeping_details
-    if db_user.area is not None:
-        profile.area.value = db_user.area
-    if db_user.house_rules is not None:
-        profile.house_rules.value = db_user.house_rules
-    if db_user.parking is not None:
-        profile.parking.value = db_user.parking
-    if db_user.camping_ok is not None:
-        profile.camping_ok.value = db_user.camping_ok
-
-    return profile
 
 
 def lite_user_to_pb(

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -20,7 +20,6 @@ from couchers.models import (
     NonvisibleUserAccessType,
     NonvisibleUserState,
     RateLimitAction,
-    SleepingArrangement,
     User,
     UserBadge,
 )
@@ -183,66 +182,6 @@ def test_get_user(db):
         assert res.user_id == user2.id
         assert res.username == user2.username
         assert res.name == user2.name
-
-
-def test_get_profile(db):
-    user1, token1 = generate_user()
-    user2, _ = generate_user(
-        complete_profile=False,
-        about_me="hello there",
-        things_i_like="long walks",
-        about_place="cozy couch",
-        hometown="Berlin",
-        occupation="Software engineer",
-        max_guests=3,
-        sleeping_arrangement=SleepingArrangement.private,
-    )
-
-    with api_session(token1) as api:
-        res = api.GetProfile(api_pb2.GetProfileReq(user=user2.username))
-        assert res.user_id == user2.id
-        assert res.about_me == "hello there"
-        assert res.things_i_like == "long walks"
-        assert res.about_place == "cozy couch"
-        assert res.hometown == "Berlin"
-        assert res.occupation == "Software engineer"
-        assert res.max_guests.value == 3
-        assert res.sleeping_arrangement == api_pb2.SLEEPING_ARRANGEMENT_PRIVATE
-        assert res.hosting_status in (
-            api_pb2.HOSTING_STATUS_UNKNOWN,
-            api_pb2.HOSTING_STATUS_CAN_HOST,
-            api_pb2.HOSTING_STATUS_MAYBE,
-            api_pb2.HOSTING_STATUS_CANT_HOST,
-        )
-
-    with api_session(token1) as api:
-        res = api.GetProfile(api_pb2.GetProfileReq(user=str(user2.id)))
-        assert res.user_id == user2.id
-
-
-def test_get_profile_not_found(db):
-    _, token1 = generate_user()
-
-    with api_session(token1) as api:
-        with pytest.raises(grpc.RpcError) as e:
-            api.GetProfile(api_pb2.GetProfileReq(user="nonexistent_user_xyz"))
-        assert e.value.code() == grpc.StatusCode.NOT_FOUND
-
-
-@pytest.mark.parametrize("flag", ["deleted_at", "banned_at"])
-def test_get_profile_ghost_user(db, flag):
-    _, token1 = generate_user()
-    user2, _ = generate_user()
-
-    with session_scope() as session:
-        session.execute(update(User).where(User.id == user2.id).values(**{flag: func.now()}))
-
-    refresh_materialized_views_rapid(empty_pb2.Empty())
-
-    with api_session(token1) as api:
-        with pytest.raises(grpc.RpcError) as e:
-            api.GetProfile(api_pb2.GetProfileReq(user=user2.username))
-        assert e.value.code() == grpc.StatusCode.NOT_FOUND
 
 
 @pytest.mark.parametrize("flag", ["deleted_at", "banned_at"])

--- a/app/proto/admin.proto
+++ b/app/proto/admin.proto
@@ -26,10 +26,6 @@ service Admin {
     // Get info about a particular user, ignores the fact that they may be banned/deleted
   }
 
-  rpc GetProfile(GetUserReq) returns (org.couchers.api.core.Profile) {
-    // Get the editable profile of a user, ignores the fact that they may be banned/deleted
-  }
-
   rpc SearchUsers(SearchUsersReq) returns (SearchUsersRes) {}
 
   rpc ChangeUserGender(ChangeUserGenderReq) returns (UserDetails) {}

--- a/app/proto/api.proto
+++ b/app/proto/api.proto
@@ -20,10 +20,6 @@ service API {
     // Get info about a particular user
   }
 
-  rpc GetProfile(GetProfileReq) returns (Profile) {
-    // Get the editable profile (markdown bio, hosting prefs, my-home) for a user
-  }
-
   rpc GetLiteUser(GetLiteUserReq) returns (LiteUser) {
     // Get minimal info about a particular user
   }
@@ -329,56 +325,6 @@ message User {
 
 message GetUserReq {
   string user = 1;
-}
-
-message GetProfileReq {
-  string user = 1;
-}
-
-message Profile {
-  int64 user_id = 1;
-
-  string hometown = 2;
-  string pronouns = 3;
-  string occupation = 4;
-  string education = 5; // CommonMark without images
-  string about_me = 6; // CommonMark without images
-  string things_i_like = 7; // CommonMark without images
-  string about_place = 8; // CommonMark without images
-  string additional_information = 9; // CommonMark without images
-
-  HostingStatus hosting_status = 10;
-  MeetupStatus meetup_status = 11;
-
-  repeated string regions_visited = 12;
-  repeated string regions_lived = 13;
-  repeated LanguageAbility language_abilities = 14;
-
-  uint64 profile_gallery_id = 15;
-
-  google.protobuf.UInt32Value max_guests = 20;
-  google.protobuf.BoolValue last_minute = 21;
-  google.protobuf.BoolValue has_pets = 22;
-  google.protobuf.BoolValue accepts_pets = 23;
-  google.protobuf.StringValue pet_details = 24;
-  google.protobuf.BoolValue has_kids = 25;
-  google.protobuf.BoolValue accepts_kids = 26;
-  google.protobuf.StringValue kid_details = 27;
-  google.protobuf.BoolValue has_housemates = 28;
-  google.protobuf.StringValue housemate_details = 29;
-  google.protobuf.BoolValue wheelchair_accessible = 30;
-  SmokingLocation smoking_allowed = 31;
-  google.protobuf.BoolValue smokes_at_home = 32;
-  google.protobuf.BoolValue drinking_allowed = 33;
-  google.protobuf.BoolValue drinks_at_home = 34;
-  google.protobuf.StringValue other_host_info = 35; // CommonMark without images
-  SleepingArrangement sleeping_arrangement = 36;
-  google.protobuf.StringValue sleeping_details = 37; // CommonMark without images
-  google.protobuf.StringValue area = 38; // CommonMark without images
-  google.protobuf.StringValue house_rules = 39; // CommonMark without images
-  google.protobuf.BoolValue parking = 40;
-  ParkingDetails parking_details = 41;
-  google.protobuf.BoolValue camping_ok = 42;
 }
 
 message LiteUser {


### PR DESCRIPTION
Reverts #9489, which added `API.GetProfile` / `Admin.GetProfile` and the new `Profile` proto message.

That PR was purely additive and nothing consumes the RPC yet, so backing it out is a clean removal: no field numbers are reused, no other code paths touched it, and `GetUser` still returns all of these fields exactly as before.

## Testing

- `make protos`, `make format` — clean
- `make mypy` — success, no issues in 479 source files
- `uv run pytest src/tests/test_api.py src/tests/test_admin.py` — 114 passed (the three `get_profile` tests added in #9489 are removed along with the RPC)

To replicate: run the backend test database, then `uv run pytest src/tests/test_api.py src/tests/test_admin.py` from `app/backend`.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug — n/a, this is a revert; the tests added by the reverted PR are removed with it
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history — n/a, no database changes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._