### PR TITLE
Add cAdvisor for per-container metrics

### DIFF
--- a/app/docker-compose.prod.yml
+++ b/app/docker-compose.prod.yml
@@ -143,6 +143,9 @@ services:
       - "--housekeeping_interval=15s"
       # the default metric set is very wide, this keeps ingest into victoriametrics sane
       - "--disable_metrics=advtcp,cpu_topology,cpuset,hugetlb,memory_numa,percpu,process,referenced_memory,resctrl,sched,tcp,udp"
+      # otherwise every compose label rides along, including the config hash, which churns series
+      - "--store_container_labels=false"
+      - "--whitelisted_container_labels=com.docker.compose.service"
     privileged: true
     devices:
       - /dev/kmsg

--- a/app/docker-compose.prod.yml
+++ b/app/docker-compose.prod.yml
@@ -132,6 +132,32 @@ services:
     pid: host
     volumes:
       - "/:/host:ro,rslave"
+  # generates prometheus metrics for the containers
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.60.5
+    restart: always
+    stop_grace_period: 5s
+    command:
+      # ignore the host's non-docker cgroups
+      - "--docker_only=true"
+      - "--housekeeping_interval=15s"
+      # the default metric set is very wide, this keeps ingest into victoriametrics sane
+      - "--disable_metrics=advtcp,cpu_topology,cpuset,hugetlb,memory_numa,percpu,process,referenced_memory,resctrl,sched,tcp,udp"
+    privileged: true
+    devices:
+      - /dev/kmsg
+    volumes:
+      - "/:/rootfs:ro"
+      - "/var/run:/var/run:ro"
+      - "/sys:/sys:ro"
+      - "/var/lib/docker/:/var/lib/docker:ro"
+      - "/dev/disk/:/dev/disk:ro"
+    expose:
+      - 8080
+    # cadvisor's RSS creeps over time, don't let it crowd out postgres
+    mem_limit: 512m
+    networks:
+      - cadvisor_prometheus
   prometheus:
     image: registry.gitlab.com/couchers/couchers/prometheus
     restart: always
@@ -142,6 +168,7 @@ services:
       - envoy
       - pgprom
       - node_exporter
+      - cadvisor
     # this allows us to communicate with node_exporter which will be running directly on host networking
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -149,6 +176,7 @@ services:
       - backend_prometheus
       - pgprom_prometheus
       - envoy_prometheus
+      - cadvisor_prometheus
   web:
     image: registry.gitlab.com/couchers/couchers/web
     restart: always
@@ -187,5 +215,8 @@ networks:
     driver: bridge
     enable_ipv6: true
   envoy_prometheus:
+    driver: bridge
+    enable_ipv6: true
+  cadvisor_prometheus:
     driver: bridge
     enable_ipv6: true

--- a/app/prometheus/prometheus.yml
+++ b/app/prometheus/prometheus.yml
@@ -26,6 +26,14 @@ scrape_configs:
     static_configs:
       - targets: ["host.docker.internal:9100"]
 
+  - job_name: "cadvisor"
+    static_configs:
+      - targets: ["cadvisor:8080"]
+    metric_relabel_configs:
+      # the image digest changes on every deploy, which would churn series in victoriametrics
+      - regex: "image"
+        action: labeldrop
+
 remote_write:
   - url: https://victoriametrics.couchershq.org/api/v1/write
     authorization:


### PR DESCRIPTION
Adds cAdvisor to the production stack so we get per-container CPU, memory and network metrics alongside the existing host (`node_exporter`), database (`pgprom`), envoy and backend metrics.

It runs on a dedicated `cadvisor_prometheus` bridge network and is scraped by the existing prometheus, so the metrics are forwarded to VictoriaMetrics by the existing `remote_write` with no changes needed on the VM side. It's a pulled third-party image like `node_exporter` and `pgprom`, so there's no GitLab build/release job and no entry in `build_manifest.sh`, and it needs no `.prod.env` file.

Two knobs worth noting:
- `--disable_metrics=...` trims cAdvisor's very wide default metric set — it is by far the chattiest exporter we'd be running, and `percpu` in particular is expensive on a many-core host.
- The `image` label is dropped in `metric_relabel_configs` because the digest changes on every deploy, which would churn series in VictoriaMetrics. The `id` label churns too but is left alone, since dropping it risks colliding the machine-level and container-level series.

## Testing
Both files are YAML-validated but not otherwise verified locally — I don't have a Docker daemon to run `docker compose config` or `promtool check config` against (and the raw `prometheus.yml` can't pass promtool anyway until the entrypoint substitutes the `{VICTORIAMETRICS_API_KEY}` / `{PROMETHEUS_ENVIRONMENT}` placeholders).

To verify on a host with Docker:

1. `docker compose -f docker-compose.prod.yml config` parses.
2. Bring up `cadvisor` and check `curl http://cadvisor:8080/metrics` from the prometheus container returns `container_*` series.
3. Check the `cadvisor` target is `UP` in prometheus, and that `container_memory_usage_bytes` shows up in Grafana with a `name` label per container.

Two things to confirm on the actual server before merging:

- `privileged: true` plus the `/var/run` mount is the standard cAdvisor deployment, but it gives the container root-equivalent host access. Worth checking whether we can drop `privileged` and narrow the mount to `/var/run/docker.sock:/var/run/docker.sock:ro` — that depends on the host's cgroup v2 and AppArmor setup.
- `/dev/kmsg` must exist on the host or the container won't start.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._