### PR TITLE
Add UI language preference and user blocks to admin API

### DIFF
--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -49,6 +49,7 @@ from couchers.models import (
     UserActivity,
     UserAdminTag,
     UserBadge,
+    UserBlock,
 )
 from couchers.models.discussions import (
     CommentVersion,
@@ -269,6 +270,7 @@ def _user_to_details(session: Session, user: User) -> admin_pb2.UserDetails:
         admin_actions=action_pbs,
         admin_tags=list(admin_tags),
         mod_score=user.mod_score,
+        ui_language_preference=user.ui_language_preference,
     )
 
 
@@ -1003,6 +1005,46 @@ class Admin(admin_pb2_grpc.AdminServicer):
         return admin_pb2.GetFriendRequestsRes(
             sent=[friend_request_to_pb(rel) for rel in sent],
             received=[friend_request_to_pb(rel) for rel in received],
+        )
+
+    def GetUserBlocks(
+        self, request: admin_pb2.GetUserBlocksReq, context: CouchersContext, session: Session
+    ) -> admin_pb2.GetUserBlocksRes:
+        user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
+        if not user:
+            context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
+
+        def user_block_to_pb(block: UserBlock, other_user: User) -> admin_pb2.AdminUserBlock:
+            return admin_pb2.AdminUserBlock(
+                user=admin_pb2.ChatUserInfo(
+                    user_id=other_user.id,
+                    username=other_user.username,
+                    name=other_user.name,
+                    birthdate=date_to_api(other_user.birthdate),
+                    gender=other_user.gender,
+                ),
+                time_blocked=Timestamp_from_datetime(block.time_blocked),
+            )
+
+        blocked_user = aliased(User)
+        blocked_users = session.execute(
+            select(UserBlock, blocked_user)
+            .join(blocked_user, UserBlock.blocked_user_id == blocked_user.id)
+            .where(UserBlock.blocking_user_id == user.id)
+            .order_by(UserBlock.time_blocked.desc(), UserBlock.id.desc())
+        ).all()
+
+        blocking_user = aliased(User)
+        blocking_users = session.execute(
+            select(UserBlock, blocking_user)
+            .join(blocking_user, UserBlock.blocking_user_id == blocking_user.id)
+            .where(UserBlock.blocked_user_id == user.id)
+            .order_by(UserBlock.time_blocked.desc(), UserBlock.id.desc())
+        ).all()
+
+        return admin_pb2.GetUserBlocksRes(
+            blocked_users=[user_block_to_pb(block, other_user) for block, other_user in blocked_users],
+            blocking_users=[user_block_to_pb(block, other_user) for block, other_user in blocking_users],
         )
 
     def GetNonvisibleUserAccessLog(

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -33,6 +33,7 @@ from couchers.proto import (
     account_pb2,
     admin_pb2,
     auth_pb2,
+    blocking_pb2,
     events_pb2,
     references_pb2,
     reporting_pb2,
@@ -49,6 +50,7 @@ from tests.fixtures.misc import EmailCollector, PushCollector
 from tests.fixtures.sessions import (
     account_session,
     auth_api_session,
+    blocking_session,
     events_session,
     real_admin_session,
     references_session,
@@ -998,6 +1000,50 @@ def test_GetFriendRequests_not_found(db):
     with real_admin_session(super_token) as admin_api:
         with pytest.raises(grpc.RpcError) as e:
             admin_api.GetFriendRequests(admin_pb2.GetFriendRequestsReq(user="nonexistent"))
+        assert e.value.code() == grpc.StatusCode.NOT_FOUND
+
+
+def test_GetUserBlocks(db):
+    super_user, super_token = generate_user(is_superuser=True)
+
+    user1, token1 = generate_user()
+    user2, _ = generate_user()
+    user3, token3 = generate_user()
+    user4, token4 = generate_user()
+
+    with blocking_session(token1) as user_blocks:
+        user_blocks.BlockUser(blocking_pb2.BlockUserReq(username=user2.username))
+
+    with blocking_session(token3) as user_blocks:
+        user_blocks.BlockUser(blocking_pb2.BlockUserReq(username=user1.username))
+
+    with blocking_session(token4) as user_blocks:
+        user_blocks.BlockUser(blocking_pb2.BlockUserReq(username=user1.username))
+
+    with real_admin_session(super_token) as admin_api:
+        res = admin_api.GetUserBlocks(admin_pb2.GetUserBlocksReq(user=user1.username))
+
+    assert len(res.blocked_users) == 1
+    assert res.blocked_users[0].user.user_id == user2.id
+    assert res.blocked_users[0].user.username == user2.username
+    assert res.blocked_users[0].HasField("time_blocked")
+
+    # most recently blocked first
+    assert [block.user.user_id for block in res.blocking_users] == [user4.id, user3.id]
+
+    with real_admin_session(super_token) as admin_api:
+        res = admin_api.GetUserBlocks(admin_pb2.GetUserBlocksReq(user=user2.username))
+
+    assert len(res.blocked_users) == 0
+    assert [block.user.user_id for block in res.blocking_users] == [user1.id]
+
+
+def test_GetUserBlocks_not_found(db):
+    super_user, super_token = generate_user(is_superuser=True)
+
+    with real_admin_session(super_token) as admin_api:
+        with pytest.raises(grpc.RpcError) as e:
+            admin_api.GetUserBlocks(admin_pb2.GetUserBlocksReq(user="nonexistent"))
         assert e.value.code() == grpc.StatusCode.NOT_FOUND
 
 

--- a/app/proto/admin.proto
+++ b/app/proto/admin.proto
@@ -79,6 +79,8 @@ service Admin {
 
   rpc GetFriendRequests(GetFriendRequestsReq) returns (GetFriendRequestsRes) {}
 
+  rpc GetUserBlocks(GetUserBlocksReq) returns (GetUserBlocksRes) {}
+
   rpc GetNonvisibleUserAccessLog(GetNonvisibleUserAccessLogReq) returns (GetNonvisibleUserAccessLogRes) {}
 
   rpc EditDiscussion(EditDiscussionReq) returns (google.protobuf.Empty) {}
@@ -174,6 +176,8 @@ message UserDetails {
   repeated string admin_tags = 19;
 
   double mod_score = 20;
+
+  string ui_language_preference = 23;
 }
 
 message GetUserDetailsReq {
@@ -467,6 +471,24 @@ message GetFriendRequestsRes {
   repeated AdminFriendRequest sent = 1;
   // Friend requests received by the user
   repeated AdminFriendRequest received = 2;
+}
+
+message GetUserBlocksReq {
+  // username, email, or user id
+  string user = 1;
+}
+
+message AdminUserBlock {
+  // the other user in the block, i.e. not the user the request was made for
+  ChatUserInfo user = 1;
+  google.protobuf.Timestamp time_blocked = 2;
+}
+
+message GetUserBlocksRes {
+  // Users that this user has blocked
+  repeated AdminUserBlock blocked_users = 1;
+  // Users that have blocked this user
+  repeated AdminUserBlock blocking_users = 2;
 }
 
 enum NonvisibleUserAccessType {

--- a/app/web/features/mod/ModPanel.tsx
+++ b/app/web/features/mod/ModPanel.tsx
@@ -42,6 +42,10 @@ export default function ModPanel({ userDetails }: ModPanelProps) {
       />
       <LabelAndText label={t("mod:panel.birthdate")} text={<code>{userDetails.birthdate}</code>} />
       <LabelAndText
+        label={t("mod:panel.ui_language_preference")}
+        text={<code>{userDetails.uiLanguagePreference}</code>}
+      />
+      <LabelAndText
         label={t("mod:banned")}
         text={userDetails.banned ? <StyledStrongStatus>{t("mod:banned")}</StyledStrongStatus> : t("global:no")}
       />

--- a/app/web/features/mod/locales/en.json
+++ b/app/web/features/mod/locales/en.json
@@ -17,6 +17,7 @@
     "user_id": "User ID",
     "email": "Email",
     "birthdate": "Birthdate",
+    "ui_language_preference": "UI language",
     "has_strong_verification": "Has strong verification",
     "birthdate_verification_status": "Birthdate verification",
     "gender_verification_status": "Gender verification",


### PR DESCRIPTION
Two small additions to the admin API for moderation:

- `UserDetails` now includes `ui_language_preference` (field 23), populated in `_user_to_details`, so every RPC returning `UserDetails` carries it. It's also displayed as "UI language" in the web mod panel.
- New `GetUserBlocks` admin RPC: given a username/email/user id, returns `blocked_users` (users this user has blocked) and `blocking_users` (users who have blocked this user), each with the other party's `ChatUserInfo` and the `time_blocked`, ordered most recent first. It intentionally includes blocks involving deleted/banned users, since that's relevant for moderation.

## Testing
- `make protos`, `make format`, `make mypy` all pass.
- Added `test_GetUserBlocks` (creates blocks through the real blocking API, asserts both directions and ordering) and `test_GetUserBlocks_not_found`.
- `uv run pytest src/tests/test_admin.py` — 66 passed.
- Web: prettier and eslint clean on the changed files; the mod panel change is a single extra `LabelAndText` row under Birthdate.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history — no schema changes

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._