### PR TITLE
Make open profile more obvious on mobile

### DIFF
--- a/app/web/components/ProfileLink/ProfileLink.test.tsx
+++ b/app/web/components/ProfileLink/ProfileLink.test.tsx
@@ -40,7 +40,7 @@ describe("ProfileLink", () => {
     expect(screen.getByRole("link")).toBeInTheDocument();
   });
 
-  it("renders a button on native when userId is provided", () => {
+  it("renders a link to the profile on native so it can be opened directly too", () => {
     (useIsNativeEmbed as jest.Mock).mockReturnValue(true);
     render(
       <ProfileLink userId={1} username="testuser">
@@ -48,7 +48,7 @@ describe("ProfileLink", () => {
       </ProfileLink>,
       { wrapper },
     );
-    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/user/testuser");
   });
 
   it("opens profile sheet with correct userId when clicked on native", async () => {
@@ -59,13 +59,14 @@ describe("ProfileLink", () => {
       </ProfileLink>,
       { wrapper },
     );
-    await userEvent.click(screen.getByRole("button"));
+    await userEvent.click(screen.getByRole("link"));
     expect(mockOpenProfileSheet).toHaveBeenCalledWith(42);
   });
 
-  it("renders a link on native when userId is not provided", () => {
+  it("navigates instead of opening the sheet on native when userId is not provided", async () => {
     (useIsNativeEmbed as jest.Mock).mockReturnValue(true);
     render(<ProfileLink username="testuser">Test</ProfileLink>, { wrapper });
-    expect(screen.getByRole("link")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("link"));
+    expect(mockOpenProfileSheet).not.toHaveBeenCalled();
   });
 });

--- a/app/web/components/ProfileLink/ProfileLink.tsx
+++ b/app/web/components/ProfileLink/ProfileLink.tsx
@@ -1,6 +1,9 @@
-import { ButtonBase } from "@mui/material";
+import { styled, Tooltip } from "@mui/material";
+import { ChevronRightIcon, OpenInNewIcon } from "components/Icons";
 import StyledLink from "components/StyledLink";
 import { useProfileSheet } from "features/profile/ProfileSheetContext";
+import { useTranslation } from "i18n";
+import { PROFILE } from "i18n/namespaces";
 import { MouseEvent, ReactNode } from "react";
 import { routeToUser } from "routes";
 import { useIsNativeEmbed } from "utils/nativeLink";
@@ -9,12 +12,33 @@ import useIsScreenSizeOrSmaller from "utils/useIsScreenSizeOrSmaller";
 interface ProfileLinkProps {
   userId?: number;
   username: string;
-  children: ReactNode;
+  children?: ReactNode;
   className?: string;
   openInNewTab?: boolean;
+  showOpenIcon?: boolean;
   "aria-label"?: string;
   style?: React.CSSProperties;
 }
+
+const trailingIcon = {
+  display: "block",
+  flexShrink: 0,
+  height: "1.25rem",
+  width: "1.25rem",
+};
+
+const StyledChevronRightIcon = styled(ChevronRightIcon)(({ theme }) => ({
+  ...trailingIcon,
+  marginInlineStart: theme.spacing(0.5),
+}));
+
+const StyledOpenInNewIcon = styled(OpenInNewIcon)(({ theme }) => ({
+  ...trailingIcon,
+  marginInlineStart: theme.spacing(0.5),
+  "&:hover": {
+    color: "var(--mui-palette-primary-dark)",
+  },
+}));
 
 export default function ProfileLink({
   userId,
@@ -22,40 +46,57 @@ export default function ProfileLink({
   children,
   className,
   openInNewTab,
+  showOpenIcon = false,
   style,
   "aria-label": ariaLabel,
 }: ProfileLinkProps) {
   const isNativeEmbed = useIsNativeEmbed();
   const isMobile = useIsScreenSizeOrSmaller("mobile");
   const { openProfileSheet } = useProfileSheet();
-  if ((isNativeEmbed || isMobile) && userId !== undefined) {
-    return (
-      <ButtonBase
-        component="span"
-        className={className}
-        style={style}
-        aria-label={ariaLabel}
-        onClick={(e: MouseEvent) => {
-          e.stopPropagation();
-          openProfileSheet(userId);
-        }}
-        sx={{ cursor: "pointer", position: "static" }}
-      >
-        {children}
-      </ButtonBase>
-    );
-  }
+  const { t } = useTranslation(PROFILE);
+  const opensSheet = (isNativeEmbed || isMobile) && userId !== undefined;
+  const opensNewTab = !opensSheet && !!openInNewTab;
+
+  const handleClick = (e: MouseEvent) => {
+    // Opening the profile always wins over whatever row or card this sits inside
+    e.stopPropagation();
+    if (!opensSheet) return;
+    // Stays a real link when it opens the sheet, so it looks and behaves like one
+    // (link styling, long press, ctrl/cmd-click) and falls back to the profile page.
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
+    e.preventDefault();
+    openProfileSheet(userId!);
+  };
+
+  // Only looked up when the icon shows, so pages without the PROFILE namespace
+  // can still render a plain ProfileLink.
+  const iconLabel = !showOpenIcon
+    ? undefined
+    : opensNewTab
+      ? t("profile:open_profile_new_tab")
+      : t("profile:open_profile_a11y");
 
   return (
     <StyledLink
       href={routeToUser(username)}
       className={className}
       style={style}
-      aria-label={ariaLabel}
-      target={openInNewTab ? "_blank" : undefined}
-      rel={openInNewTab ? "noopener noreferrer" : undefined}
+      aria-label={ariaLabel ?? (children ? undefined : iconLabel)}
+      onClick={handleClick}
+      target={opensNewTab ? "_blank" : undefined}
+      rel={opensNewTab ? "noopener noreferrer" : undefined}
     >
       {children}
+      {showOpenIcon &&
+        // The sheet slides over the page rather than navigating away, so it gets
+        // a "drill in" chevron instead of the new tab icon.
+        (opensNewTab ? (
+          <Tooltip title={iconLabel}>
+            <StyledOpenInNewIcon />
+          </Tooltip>
+        ) : (
+          <StyledChevronRightIcon />
+        ))}
     </StyledLink>
   );
 }

--- a/app/web/components/UserSummary.tsx
+++ b/app/web/components/UserSummary.tsx
@@ -2,7 +2,7 @@ import { Box, ListItemAvatar, ListItemText, Skeleton, Tooltip, Typography } from
 import { styled } from "@mui/system";
 import Avatar from "components/Avatar";
 import EllipsisMenu, { EllipsisMenuItem } from "components/EllipsisMenu";
-import { OpenInNewIcon, PinIcon } from "components/Icons";
+import { PinIcon } from "components/Icons";
 import ProfileLink from "components/ProfileLink/ProfileLink";
 import { LiteUser } from "proto/api_pb";
 import { BlockedUser } from "proto/blocking_pb";
@@ -24,13 +24,6 @@ const StyledWrapper = styled("div")({
   alignItems: "center",
   wordBreak: "break-word",
 });
-
-const StyledOpenInNewIcon = styled(OpenInNewIcon)(({ theme }) => ({
-  display: "block",
-  marginInlineStart: theme.spacing(0.5),
-  height: "1.25rem",
-  width: "1.25rem",
-}));
 
 const StyledListItemText = styled(ListItemText, {
   shouldForwardProp: (prop) => prop !== "isSmallAvatar",
@@ -164,6 +157,7 @@ export default function UserSummary({
               userId={"userId" in user ? user.userId : undefined}
               username={user.username}
               openInNewTab={!isMobile}
+              showOpenIcon={!isMobile}
               style={{
                 display: "flex",
                 alignItems: "center",
@@ -172,7 +166,6 @@ export default function UserSummary({
               }}
             >
               {title}
-              {!isMobile && <StyledOpenInNewIcon />}
             </ProfileLink>
           ) : (
             title

--- a/app/web/features/profile/locales/en.json
+++ b/app/web/features/profile/locales/en.json
@@ -285,6 +285,7 @@
     "no_people": "There are no people with that badge!",
     "not_found": "Badge not found"
   },
+  "open_profile_a11y": "Open profile",
   "open_profile_new_tab": "Open profile in new tab",
   "reference_amounts": {
     "no_references": "No references",

--- a/app/web/features/search/SeachResultUserCard.tsx
+++ b/app/web/features/search/SeachResultUserCard.tsx
@@ -1,10 +1,8 @@
 import { styled, Tooltip, Typography } from "@mui/material";
 import { FlexboxProps, useMediaQuery } from "@mui/system";
 import Avatar from "components/Avatar";
-import { OpenInNewIcon } from "components/Icons";
 import ProfileLink from "components/ProfileLink/ProfileLink";
 import StrongVerificationBadge from "components/StrongVerificationBadge";
-import StyledLink from "components/StyledLink";
 import { useImpressionRef, useLogEvent } from "features/analytics/hooks";
 import { useSearchAnalytics } from "features/analytics/searchAnalyticsContext";
 import { makeResultId, setSearchReferrer } from "features/analytics/searchAttribution";
@@ -16,10 +14,8 @@ import { TFunction } from "i18next";
 import { SearchUser } from "proto/search_pb";
 import { MouseEvent } from "react";
 import LinesEllipsis from "react-lines-ellipsis";
-import { routeToUser } from "routes";
 import { theme } from "theme";
 import { timestampToInstant } from "utils/date";
-import { useIsNativeEmbed } from "utils/nativeLink";
 import stripMarkdown from "utils/stripMarkdown";
 
 import HostMeetupReferenceStatus from "./HostMeetupReferenceStatus";
@@ -94,11 +90,6 @@ const StyledBottomContent = styled("div")(({ theme }) => ({
   [theme.breakpoints.down("sm")]: {
     fontSize: ".82rem",
   },
-}));
-
-const StyledOpenInNewIcon = styled(OpenInNewIcon)(() => ({
-  height: "1rem",
-  width: "1rem",
 }));
 
 const FlexRow = styled("div")<{
@@ -186,7 +177,6 @@ const SearchResultUserCard = ({
   user,
 }: SearchResultUserCardProps) => {
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
-  const isNativeEmbed = useIsNativeEmbed();
   const {
     t,
     i18n: { language: locale },
@@ -258,7 +248,6 @@ const SearchResultUserCard = ({
               <ProfileLink
                 userId={user.userId}
                 username={user.username}
-                aria-label={t("profile:open_profile_new_tab")}
                 openInNewTab
                 style={{ fontSize: "1.1rem", overflow: "hidden" }}
               >
@@ -276,25 +265,7 @@ const SearchResultUserCard = ({
               </ProfileLink>
               {user.hasStrongVerification && <StrongVerificationBadge />}
             </FlexRow>
-            {!isNativeEmbed && !isMobile && (
-              <StyledLink
-                aria-label={t("profile:open_profile_new_tab")}
-                href={routeToUser(user.username)}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <Tooltip title={t("profile:open_profile_new_tab")}>
-                  <StyledOpenInNewIcon
-                    sx={{
-                      "&:hover": {
-                        color: "var(--mui-palette-primary-dark)",
-                      },
-                    }}
-                  />
-                </Tooltip>
-              </StyledLink>
-            )}
+            <ProfileLink userId={user.userId} username={user.username} openInNewTab showOpenIcon />
           </FlexRow>
 
           <FlexRow justifyContent="space-between">


### PR DESCRIPTION
Closes [couchers/bugs#326 ](https://github.com/Couchers-org/bugs/issues/326)

We're getting multiple support (and instagram ) help requests that people can't tell how to open profiles from mobile map search. This PR hopefully makes it more obvious.

I decided to refactor `ProfileLink` to handle this better as I think it's relevant anywhere it's used, the profile sheet vs new tab behavior etc. That cut down on the conditional code.

I also decided to use the right chevron icon for mobile as the "open in new tab" icon has a specific meaning "opens it somewhere else" and on mobile it's not opening in the browser.

<img width="375" height="598" alt="Screenshot 2026-08-10 at 19 49 12" src="https://github.com/user-attachments/assets/852dcf4d-fb26-4012-9516-8270d04878e3" />

## Testing
- Go to mobile responsive view in browser
- Search a location
- Should be able to open the profile by either clicking the avatar, the name, or the right chevron icon
<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
