### PR TITLE
Fix Sentry source map uploads for the web frontend

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -112,6 +112,13 @@ default:
         cache_to="--cache-to type=registry,ref=$cache_tag,mode=max"
       fi
 
+      # The web build uploads source maps to Sentry, which needs the auth token inside
+      # the container. It's a protected variable, so it's absent on unprotected branches.
+      local secrets=""
+      if [ -n "${SENTRY_AUTH_TOKEN:-}" ]; then
+        secrets="--secret id=sentry_auth_token,env=SENTRY_AUTH_TOKEN"
+      fi
+
       # Use buildx, as "docker build" does not work with registry cache.
       docker pull "$cache_tag" || true
       docker context create my-builder
@@ -126,6 +133,7 @@ default:
         --build-arg version="$version" \
         --cache-from "$cache_tag" \
         ${cache_to} \
+        ${secrets} \
         "$@" \
         "app/$path/"
     }

--- a/app/web/Dockerfile.prod
+++ b/app/web/Dockerfile.prod
@@ -35,7 +35,10 @@ ENV NEXT_PUBLIC_COMMIT_SHA=$commit_sha
 ARG commit_timestamp
 ENV NEXT_PUBLIC_COMMIT_TIMESTAMP=$commit_timestamp
 
-RUN yarn build && yarn injectsourcemaps && rm -rf .next/cache node_modules/.cache
+# The secret is absent on unprotected branches; the Sentry plugin then skips the upload.
+RUN --mount=type=secret,id=sentry_auth_token \
+    SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token 2>/dev/null || true)" \
+    yarn build && rm -rf .next/cache node_modules/.cache
 
 FROM node:22-bookworm-slim AS runner
 

--- a/app/web/next.config.js
+++ b/app/web/next.config.js
@@ -101,14 +101,18 @@ module.exports = withSentryConfig(module.exports, {
   // For all available options, see:
   // https://github.com/getsentry/sentry-webpack-plugin#options
   sourcemaps: {
-    disable: process.env.NEXT_PUBLIC_COUCHERS_ENV !== "prod",
+    // The auth token is only present in the deploy builds, and it's what the upload needs.
+    disable: !process.env.SENTRY_AUTH_TOKEN,
+    // productionBrowserSourceMaps serves them from the CDN too; don't pull them out from
+    // under the sourceMappingURL comments webpack leaves in the bundles.
+    deleteSourcemapsAfterUpload: false,
   },
 
   org: "couchers",
   project: "frontend",
 
-  // Only print logs for uploading source maps in CI
-  silent: !process.env.CI,
+  // Also cover the shared chunks, which is where most of our code ends up
+  widenClientFileUpload: true,
 
   // Automatically tree-shake Sentry logger statements to reduce bundle size
   disableLogger: true,

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -7,7 +7,6 @@
   },
   "scripts": {
     "build": "next build",
-    "injectsourcemaps": "sentry-cli sourcemaps inject .next/",
     "dev": "next dev",
     "start": "yarn dev",
     "format": "prettier --write '**/*.{ts,tsx,js,jsx,json,css}' && eslint . --fix",


### PR DESCRIPTION
Source maps have never actually been uploaded to Sentry, so frontend stack traces are all minified.

The web bundle is built inside `docker buildx build`, which doesn't inherit the runner's environment, and `SENTRY_AUTH_TOKEN` was never passed in. The Sentry webpack plugin hit its "No auth token provided. Will not upload source maps" path and exited 0. That warning was invisible because `silent: !process.env.CI` was set, and `CI` isn't set inside the container either. The `yarn injectsourcemaps` step ran *after* `yarn build`, stamping debug IDs into files but never uploading anything.

Changes:

- `app/.gitlab-ci.yml`: pass the token into the build as a BuildKit secret, guarded on the variable being set (it's protected, so it's absent on unprotected branches).
- `Dockerfile.prod`: mount that secret onto the `yarn build` step, and drop the `injectsourcemaps` line.
- `next.config.js`: gate `sourcemaps.disable` on the token rather than `NEXT_PUBLIC_COUCHERS_ENV`, drop `silent` so failures show up in the job log, and restore `widenClientFileUpload: true` — without it only `static/chunks/pages/**` and `static/chunks/app/**` are uploaded and `main-*` is explicitly ignored, so most of our shared-chunk code stays unmapped. Also set `deleteSourcemapsAfterUpload: false`, since the SDK now defaults that to `true` for client builds and would delete the `.map` files that `productionBrowserSourceMaps: true` puts on the CDN.
- `package.json`: remove the now-unused `injectsourcemaps` script.

Note that gating on the token means the `next` preview image uploads too (tagged `environment: preview`), where before it was prod-only. Happy to narrow that back to prod if preferred.

Also needs checking: `SENTRY_AUTH_TOKEN` must exist as a GitLab CI/CD variable with `project:releases` and `org:read` scopes. The mobile OTA jobs already call `npx sentry-expo-upload-sourcemaps`, which needs it in env and it isn't in the YAML, so it's very likely already there.

## Testing

Verified by reading `@sentry/bundler-plugin-core` and `@sentry/nextjs` in `node_modules` to confirm the no-token code path, the `widenClientFileUpload` upload globs, and the `deleteSourcemapsAfterUpload` default; confirmed `next.config.js` still loads, prettier is clean, and the CI YAML parses.

The upload itself can't be exercised locally (no token, and it needs a full prod Docker build). To verify after merge: the `build:web` job on `develop` should now print the Sentry upload lines, and a new frontend error in Sentry should show unminified frames with source context.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._