### PR TITLE
Fix leftover numbered <Trans> tags in translated strings

### DIFF
--- a/app/web/features/auth/locales/cs.json
+++ b/app/web/features/auth/locales/cs.json
@@ -271,8 +271,8 @@
     "title": "Silné ověření",
     "subtitle": "Silné ověření je doplňková bezpečnostní funkce, která ti umožňuje ověřit datum narození a pohlaví pomocí tvého biometrického pasu.",
     "status": {
-      "enabled_message": "Tvůj účet má v <1>tuto chvíli</1> silné ověření.",
-      "disabled_message": "Tvůj účet v <1>tuto chvíli</1> nemá silné ověření."
+      "enabled_message": "Tvůj účet má v <strong>tuto chvíli</strong> silné ověření.",
+      "disabled_message": "Tvůj účet v <strong>tuto chvíli</strong> nemá silné ověření."
     },
     "start_button": "Zahájit silné ověření",
     "complete_title": "Zpracováváme tvůj pokus o silné ověření",

--- a/app/web/features/auth/locales/ja.json
+++ b/app/web/features/auth/locales/ja.json
@@ -1,7 +1,7 @@
 {
   "change_email_form": {
     "title": "メールアドレスを変更する",
-    "current_email_message": "現在のメールアドレスは<2>1{{email}}</2>です。",
+    "current_email_message": "現在のメールアドレスは<strong>{{email}}</strong>です。",
     "current_password": "現在のパスワード",
     "new_email": "新たなメールアドレス",
     "success_message": "メールアドレスの変更が確認されました。新たに使用するアドレスを開き、変更を完了してください。"

--- a/app/web/features/auth/locales/zh_Hans.json
+++ b/app/web/features/auth/locales/zh_Hans.json
@@ -1,7 +1,7 @@
 {
   "change_email_form": {
     "title": "更改邮箱",
-    "current_email_message": "您当前的邮箱地址是：<2>{{email}}</2>。",
+    "current_email_message": "您当前的邮箱地址是：<strong>{{email}}</strong>。",
     "success_message": "您的邮箱更改申请已提交。请查阅邮箱，完成更改。",
     "current_password": "当前密码",
     "new_email": "新邮箱地址",

--- a/app/web/features/dashboard/locales/pt_BR.json
+++ b/app/web/features/dashboard/locales/pt_BR.json
@@ -18,7 +18,7 @@
   "all_communities_intro": "Abaixo você pode navegar por todas as páginas de comunidade que existem até o momento. <strong>Clique no nome de uma comunidade para ver outras comunidades dentro dela.</strong>",
   "welcome": "Bem-vindo ao Couchers.org!",
   "new_pill": "Novo",
-  "landing_text": "Estamos criando novos <featuresLink>recursos</featuresLink>, como eventos, guias locais, moderação e encontros. Agradecemos sua paciência e <3>apoio</3> enquanto trabalhamos nisso.",
+  "landing_text": "Estamos criando novos <featuresLink>recursos</featuresLink>, como eventos, guias locais, moderação e encontros. Agradecemos sua paciência e <supportLink>apoio</supportLink> enquanto trabalhamos nisso.",
   "community_builder_form_text": "Crie sua própria comunidade local",
   "communities_welcome_title": "Bem-vindo a Comunidades",
   "communities_intro": "Para ajudar as pessoas em todo o mundo a organizar eventos, discussões e encontros locais, criamos páginas de comunidades, que estão listadas abaixo. <strong>Você foi adicionado automaticamente a algumas comunidades com base em sua localização, mas pode se juntar a qualquer comunidade!</strong> Suas comunidades estão listadas no painel principal.",

--- a/app/web/features/dashboard/locales/ru.json
+++ b/app/web/features/dashboard/locales/ru.json
@@ -8,7 +8,7 @@
   "no_sub_communities": "Нет подсообществ.",
   "load_more": "Загрузить еще",
   "welcome": "Добро пожаловать в Couchers.org!",
-  "landing_text": "Мы работаем над новыми <featuresLink>функциями</featuresLink>: мероприятиями, путеводителями, модерацией и встречами. Спасибо за ваше терпение и <3>поддержку</3>.",
+  "landing_text": "Мы работаем над новыми <featuresLink>функциями</featuresLink>: мероприятиями, путеводителями, модерацией и встречами. Спасибо за ваше терпение и <supportLink>поддержку</supportLink>.",
   "your_communities_helper_text": "Вы были добавлены во все сообщества, соответствующие вашему местоположению. Вы также можете <browseCommunitiesLink>просматривать сообщества и вступать в них</browseCommunitiesLink> в других местах.",
   "community_builder_form_text": "Создайте свое местное сообщество",
   "become_a_host": "Стать хостом",

--- a/app/web/features/dashboard/locales/tr.json
+++ b/app/web/features/dashboard/locales/tr.json
@@ -23,7 +23,7 @@
   "all_communities_heading": "Tüm topluluklar",
   "no_community": "Şu anda bir topluluğun içinde değilsin.",
   "no_sub_communities": "Alt topluluk yok.",
-  "your_communities_helper_text": "Konumunuza göre var olan tüm topluluklara eklendiniz. Dilerseniz diğer konumlardaki <requestCommunityLinktopluluklara da göz atabilirsiniz</requestCommunityLink>.",
+  "your_communities_helper_text": "Konumunuza göre var olan tüm topluluklara eklendiniz. Dilerseniz diğer konumlardaki <browseCommunitiesLink>topluluklara da göz atabilirsiniz</browseCommunitiesLink>.",
   "find_a_host": "Bir ev sahibi bul",
   "landing_text": "Etkinlikler, yerel rehberler, moderasyon ve buluşmalar gibi yeni <featuresLink>özellikler</featuresLink> geliştiriyoruz. Bunları geliştirirkenki sabrınız ve <supportLink>desteğiniz</supportLink> için teşekkür ederiz.",
   "find_your_community": "Bir topluluk bul",

--- a/app/web/features/dashboard/locales/zh_Hans.json
+++ b/app/web/features/dashboard/locales/zh_Hans.json
@@ -11,7 +11,7 @@
   "load_more": "加载更多",
   "welcome": "欢迎来到Couchers.org！",
   "new_pill": "新",
-  "landing_text": "我们正在开发新的<featuresLink>功能</featuresLink>，如活动、本地指南、管理和聚会。感谢您在我们开发过程中给予的耐心和<3>支持</3>。",
+  "landing_text": "我们正在开发新的<featuresLink>功能</featuresLink>，如活动、本地指南、管理和聚会。感谢您在我们开发过程中给予的耐心和<supportLink>支持</supportLink>。",
   "your_communities_helper_text": "根据您的位置，您已被添加到所有社区。您也可以随时<browseCommunitiesLink>浏览其他位置的社区</browseCommunitiesLink>。",
   "community_builder_form_text": "创建您自己的本地社区",
   "my_communities_heading": "我的社区",

--- a/app/web/features/dashboard/locales/zh_Hant.json
+++ b/app/web/features/dashboard/locales/zh_Hant.json
@@ -11,7 +11,7 @@
   "load_more": "載入更多",
   "welcome": "歡迎來到Couchers.org！",
   "new_pill": "新",
-  "landing_text": "我們正在開發新的<featuresLink>功能</featuresLink>，如活動、本地指南、管理和聚會。感謝您在我們開發過程中給予的耐心和<3>支持</3>。",
+  "landing_text": "我們正在開發新的<featuresLink>功能</featuresLink>，如活動、本地指南、管理和聚會。感謝您在我們開發過程中給予的耐心和<supportLink>支持</supportLink>。",
   "your_communities_helper_text": "根據您的位置，您已被添加到所有社群。您也可以隨時<browseCommunitiesLink>瀏覽其他位置的社群</browseCommunitiesLink>。",
   "community_builder_form_text": "建立您自己的在地社群",
   "my_communities_heading": "我的社群",

--- a/app/web/features/donations/locales/cs.json
+++ b/app/web/features/donations/locales/cs.json
@@ -35,7 +35,7 @@
     "title": "Hodnota daru",
     "body": "Přihlas se, abys mohl přispět a my ti na profilu mohli zobrazit odznak dárce.",
     "login_button": "Přihlas se a daruj",
-    "signup_prompt": "Nemáš účet? <1>Zaregistruj se</1>",
-    "anonymous_donation": "Pokud chceš poskytnout jednorázový dar ve výši ${{ amount }} nebo více, aniž bys jej vázal ke svému účtu, kontaktuj nás na adrese <1>{{ email }}</1>."
+    "signup_prompt": "Nemáš účet? <signupLink>Zaregistruj se</signupLink>",
+    "anonymous_donation": "Pokud chceš poskytnout jednorázový dar ve výši ${{ amount }} nebo více, aniž bys jej vázal ke svému účtu, kontaktuj nás na adrese <emailLink>{{ email }}</emailLink>."
   }
 }


### PR DESCRIPTION
Follow-up to #9510, which renamed the numbered `<Trans>` tags (`<2>` -> `<signupLink>`) across en and every other locale. A handful of non-en strings were missed, so their tags no longer match the `components` keys passed at the call site. An unmatched tag isn't an error — react-i18next silently renders the inner text and drops the element — so this shows up as missing links rather than a crash, and CI was green.

What's broken today:

- `dashboard/tr` `your_communities_helper_text` — the rewrite dropped the `>` off the opening tag and used the wrong name (`<requestCommunityLinktopluluklara da göz atabilirsiniz</requestCommunityLink>`). Turkish users see the raw escaped markup as literal text on the dashboard.
- `donations/cs` `logged_out.signup_prompt` and `logged_out.anonymous_donation` — still `<1>`, so the "sign up" link and the benefactor `mailto:` link render as unclickable plain text in Czech.
- `auth/cs` `strong_verification.status.{enabled,disabled}_message` — still `<1>`, emphasis lost.
- `dashboard/{pt_BR,ru,zh_Hans,zh_Hant}` `landing_text` — half-renamed, `<3>` left behind. No user impact (the key has no call site left), fixed for consistency.

Also converts the two pre-existing numbered tags in `auth/{ja,zh_Hans}` `change_email_form.current_email_message`, so no numbered tags remain anywhere. The Japanese string had a stray `1` inside the tag (`<2>1{{email}}</2>`), an artifact of an earlier tag edit — dropped. Happy to keep it verbatim if a Japanese speaker would rather.

One string is left alone: `dashboard/fr` `landing_text` genuinely omits the second link in the translation. That's a translator omission, pre-existing, and the key is unused.

## Testing
- Verified no numbered tags remain in any locale file, and that every non-en string's tag names now match the corresponding `en` string (only the French `landing_text` above differs).
- Rendered the failing cases through `Trans` in jest to confirm the actual behaviour: an unmatched numbered tag drops the link and keeps the text; the malformed Turkish string renders as literal `&lt;requestCommunityLink...`.
- `yarn prettier --check` clean on the changed files; ran the tests covering the affected screens (Donations, ChangeEmail, StrongVerification, CommunitiesList, AccountForm) — 45 passing.

To see it manually: switch to Czech and open the donate page logged out — "Zaregistruj se" and the contact email should now be links. Switch to Turkish and check the dashboard communities helper text.

Worth considering separately: a CI check asserting every non-en string's tag names match `en` would have caught all of this. Also note these files are Weblate-managed, so a re-sync could reintroduce the old strings if Weblate's copy still has them.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works — verified via jest renders, not by running the app
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._
