### PR TITLE
Fix Sentry source map upload TLS failure and disable telemetry

### DIFF
--- a/app/web/Dockerfile.prod
+++ b/app/web/Dockerfile.prod
@@ -6,6 +6,10 @@ WORKDIR /app
 # disable next.js telemetry
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# node:*-slim ships without a system CA store (node bundles its own), but sentry-cli
+# is a rust binary that uses it, so the source map upload fails TLS verification.
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+
 COPY package.json yarn.lock ./
 # https://github.com/yarnpkg/yarn/issues/8242
 RUN yarn config set network-timeout 300000 && yarn install --frozen-lockfile && yarn cache clean

--- a/app/web/next.config.js
+++ b/app/web/next.config.js
@@ -111,6 +111,8 @@ module.exports = withSentryConfig(module.exports, {
   org: "couchers",
   project: "frontend",
 
+  telemetry: false,
+
   // Also cover the shared chunks, which is where most of our code ends up
   widenClientFileUpload: true,
 


### PR DESCRIPTION
The source map upload added in #9511 got the auth token into the build, but every `sentry-cli` call still failed:

```
error: API request failed
Caused by:
    0: API request failed
    1: [60] SSL peer certificate or SSH remote key was not OK (SSL certificate problem: unable to get local issuer certificate)
```

`node:22-bookworm-slim` ships with no system CA store at all — the node images purge `ca-certificates` after building node, and nothing notices because node bundles its own roots. `sentry-cli` is a rust binary that uses the system store, so it can't verify sentry.io. This installs `ca-certificates` in the builder stage (the runner stage only runs node, so it doesn't need it).

Also sets `telemetry: false` so the Sentry plugin stops sending build telemetry.

## Testing
Confirmed the diagnosis directly in the image:

```
$ docker run --rm node:22-bookworm-slim ls /etc/ssl/certs/
ls: cannot access '/etc/ssl/certs/': No such file or directory

# before: curl: (77) error setting certificate file: /etc/ssl/certs/ca-certificates.crt
# after apt-get install ca-certificates: 200
```

Needs a deploy build to confirm end-to-end: the build log should no longer print the `API request failed` blocks, and the release `develop-<sha>` should show up in Sentry with artifacts attached.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._