### PR TITLE
Log API calls rejected before the handler runs

### DIFF
--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -69,7 +69,7 @@ def _get_base_engine() -> Engine:
         # one connection per thread
         poolclass=QueuePool,
         # each process keeps its own pool, so total connections ~= process count * pool_size, kept under postgres
-        # max_connections. ~2 per thread since a thread can hold two connections at once (handler + _store_log,
+        # max_connections. ~2 per thread since a thread can hold two connections at once (handler + _log_call,
         # or the jobs worker's own session_scope + the handler's).
         pool_size=DB_POOL_SIZE,
         max_overflow=0,

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -63,6 +63,10 @@ from couchers.utils import (
 
 logger = logging.getLogger(__name__)
 
+# a call to a method that doesn't exist carries an arbitrary string off the wire, so it's bucketed under this rather
+# than used as a prometheus label; the api_calls row still records what was actually asked for
+NONEXISTENT_METHOD_LABEL = "<nonexistent>"
+
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class UserAuthInfo:
@@ -284,6 +288,7 @@ def _sanitized_bytes(proto: Message | None) -> bytes | None:
 def _log_call(
     *,
     method: str,
+    metric_method: str | None = None,
     start: int,
     perf: PerfResult | None,
     headers: CouchersHeaders | None,
@@ -296,6 +301,7 @@ def _log_call(
     exception: Exception | None = None,
 ) -> None:
     """Record a finished call: one api_calls row, plus the per-call Prometheus observations."""
+    metric_method = metric_method or method
     duration = (perf_counter_ns() - start) / 1e6  # ms
 
     req_bytes = _sanitized_bytes(request)
@@ -332,9 +338,9 @@ def _log_call(
         )
 
     observe_in_servicer_duration_histogram(
-        method, user_id, status_code or "", type(exception).__name__ if exception else "", duration / 1000
+        metric_method, user_id, status_code or "", type(exception).__name__ if exception else "", duration / 1000
     )
-    observe_api_call(method, headers.client_platform if headers else None)
+    observe_api_call(metric_method, headers.client_platform if headers else None)
     logger.debug(f"{user_id=}, {method=}, {duration=} ms")
 
 
@@ -347,6 +353,7 @@ def _abort_and_log[T, R](
     headers: CouchersHeaders | None,
     auth_info: UserAuthInfo | None = None,
     exception: Exception | None = None,
+    nonexistent_method: bool = False,
 ) -> grpc.RpcMethodHandler[T, R]:
     """
     Log a call rejected during auth/setup, then return a handler that terminates it.
@@ -355,8 +362,10 @@ def _abort_and_log[T, R](
     the auth/setup phase, which is all the work the call did.
     """
     perf = read_perf()
+    metric_method = NONEXISTENT_METHOD_LABEL if nonexistent_method else method
     _log_call(
         method=method,
+        metric_method=metric_method,
         start=start,
         perf=perf,
         headers=headers,
@@ -366,7 +375,7 @@ def _abort_and_log[T, R](
         status_code=code.name,
         exception=exception,
     )
-    observe_in_servicer_setup_histogram(method, perf)
+    observe_in_servicer_setup_histogram(metric_method, perf)
     return abort_handler(message, code)
 
 
@@ -426,7 +435,14 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             try:
                 auth_level = find_auth_level(self._pool, method)
             except AbortError as ae:
-                return _abort_and_log(method=method, message=ae.msg, code=ae.code, start=start, headers=headers)
+                return _abort_and_log(
+                    method=method,
+                    message=ae.msg,
+                    code=ae.code,
+                    start=start,
+                    headers=headers,
+                    nonexistent_method=ae.code == grpc.StatusCode.UNIMPLEMENTED,
+                )
 
             auth_info = _try_get_and_update_user_details(
                 headers.token,
@@ -640,6 +656,9 @@ def find_auth_level(pool: DescriptorPool, method: str) -> AuthLevel.ValueType:
 
     try:
         service: ServiceDescriptor = pool.FindServiceByName(service_name)  # type: ignore[no-untyped-call]
+        # checked so a probe for a method that doesn't exist on a real service aborts here, rather than reaching the
+        # missing-handler RuntimeError below and being reported as an internal error
+        service.FindMethodByName(method_name)  # type: ignore[no-untyped-call]
         service_options = service.GetOptions()
     except KeyError:
         raise AbortError(NONEXISTENT_API_CALL_ERROR_MESSAGE, grpc.StatusCode.UNIMPLEMENTED) from None

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -79,6 +79,18 @@ class UserAuthInfo:
     is_api_key: bool
 
 
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CouchersHeaders:
+    token: str | None = field(repr=False)
+    is_api_key: bool
+    ip_address: str | None
+    user_agent: str | None
+    client_platform: ClientPlatform | None
+    ui_lang: str | None
+    user_id: str | None
+    sofa: str | None
+
+
 def _binned_now() -> Function[Any]:
     return func.date_bin(
         literal_column("interval '1 hour'"),
@@ -269,31 +281,32 @@ def _sanitized_bytes(proto: Message | None) -> bytes | None:
     return new_proto.SerializeToString()
 
 
-def _store_log(
+def _log_call(
     *,
     method: str,
-    status_code: str | None = None,
-    duration: float,
+    start: int,
+    perf: PerfResult | None,
+    headers: CouchersHeaders | None,
     user_id: int | None,
     is_api_key: bool,
-    request: Message,
-    response: Message | None,
-    traceback: str | None = None,
-    perf_report: str | None = None,
-    perf: PerfResult | None = None,
-    client_platform: ClientPlatform | None = None,
-    ip_address: str | None,
-    user_agent: str | None,
     sofa: str | None,
+    request: Message | None = None,
+    response: Message | None = None,
+    status_code: str | None = None,
+    exception: Exception | None = None,
 ) -> None:
+    """Record a finished call: one api_calls row, plus the per-call Prometheus observations."""
+    duration = (perf_counter_ns() - start) / 1e6  # ms
+
     req_bytes = _sanitized_bytes(request)
     res_bytes = _sanitized_bytes(response)
+    response_truncated = False
+    truncate_res_bytes_length = 16 * 1024  # 16 kB
+    if res_bytes and len(res_bytes) > truncate_res_bytes_length:
+        res_bytes = res_bytes[:truncate_res_bytes_length]
+        response_truncated = True
+
     with session_scope() as session:
-        response_truncated = False
-        truncate_res_bytes_length = 16 * 1024  # 16 kB
-        if res_bytes and len(res_bytes) > truncate_res_bytes_length:
-            res_bytes = res_bytes[:truncate_res_bytes_length]
-            response_truncated = True
         session.add(
             APICall(
                 is_api_key=is_api_key,
@@ -304,19 +317,57 @@ def _store_log(
                 request=req_bytes,
                 response=res_bytes,
                 response_truncated=response_truncated,
-                traceback=traceback,
-                perf_report=perf_report,
+                traceback="".join(format_exception(type(exception), exception, exception.__traceback__))
+                if exception
+                else None,
                 db_query_count=perf.db_query_count if perf else None,
                 db_write_query_count=perf.db_write_query_count if perf else None,
                 db_time_ms=perf.db_time_ms if perf else None,
                 cpu_ms=perf.cpu_ms if perf else None,
-                client_platform=client_platform,
-                ip_address=ip_address,
-                user_agent=user_agent,
+                client_platform=headers.client_platform if headers else None,
+                ip_address=headers.ip_address if headers else None,
+                user_agent=headers.user_agent if headers else None,
                 sofa=sofa,
             )
         )
+
+    observe_in_servicer_duration_histogram(
+        method, user_id, status_code or "", type(exception).__name__ if exception else "", duration / 1000
+    )
+    observe_api_call(method, headers.client_platform if headers else None)
     logger.debug(f"{user_id=}, {method=}, {duration=} ms")
+
+
+def _abort_and_log[T, R](
+    *,
+    method: str,
+    message: str,
+    code: grpc.StatusCode,
+    start: int,
+    headers: CouchersHeaders | None,
+    auth_info: UserAuthInfo | None = None,
+    exception: Exception | None = None,
+) -> grpc.RpcMethodHandler[T, R]:
+    """
+    Log a call rejected during auth/setup, then return a handler that terminates it.
+
+    The request is never deserialized on these paths, so there are no request bytes to store, and the perf numbers cover
+    the auth/setup phase, which is all the work the call did.
+    """
+    perf = read_perf()
+    _log_call(
+        method=method,
+        start=start,
+        perf=perf,
+        headers=headers,
+        user_id=auth_info.user_id if auth_info else None,
+        is_api_key=headers.is_api_key if headers else False,
+        sofa=headers.sofa if headers else None,
+        status_code=code.name,
+        exception=exception,
+    )
+    observe_in_servicer_setup_histogram(method, perf)
+    return abort_handler(message, code)
 
 
 type Cont[T, R] = Callable[[grpc.HandlerCallDetails], grpc.RpcMethodHandler[T, R] | None]
@@ -351,19 +402,31 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
         # accounting for the auth/setup phase; the handler re-arms its own below
         start_perf()
 
-        try:
-            try:
-                auth_level = find_auth_level(self._pool, method)
-            except AbortError as ae:
-                return abort_handler(ae.msg, ae.code)
+        # bound as setup progresses so the reject paths below, and the catch-all, can log what is known so far
+        maybe_headers: CouchersHeaders | None = None
+        auth_info: UserAuthInfo | None = None
 
+        try:
+            # parsed before anything else so client details are available on every reject path
             try:
                 headers = parse_headers(dict(handler_call_details.invocation_metadata))
             except BadHeaders:
-                return unauthenticated_handler(COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE)
+                return _abort_and_log(
+                    method=method,
+                    message=COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE,
+                    code=grpc.StatusCode.UNAUTHENTICATED,
+                    start=start,
+                    headers=None,
+                )
+            maybe_headers = headers
 
             # if this is not present in prod, it's a Big Bug in config
             assert config.DEV or headers.ip_address is not None
+
+            try:
+                auth_level = find_auth_level(self._pool, method)
+            except AbortError as ae:
+                return _abort_and_log(method=method, message=ae.msg, code=ae.code, start=start, headers=headers)
 
             auth_info = _try_get_and_update_user_details(
                 headers.token,
@@ -377,7 +440,9 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             try:
                 check_permissions(auth_info, auth_level)
             except AbortError as ae:
-                return unauthenticated_handler(ae.msg, ae.code)
+                return _abort_and_log(
+                    method=method, message=ae.msg, code=ae.code, start=start, headers=headers, auth_info=auth_info
+                )
 
             if not (handler := continuation(handler_call_details)):
                 raise RuntimeError(f"No handler in '{method}'")
@@ -402,7 +467,16 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             sentry_sdk.set_tag("context", "servicer_setup")
             sentry_sdk.set_tag("method", method)
             sentry_sdk.capture_exception(e)
-            return abort_handler(UNKNOWN_ERROR_MESSAGE, grpc.StatusCode.INTERNAL)
+            # reported to Sentry first: if the DB is what's broken, logging the call below fails too
+            return _abort_and_log(
+                method=method,
+                message=UNKNOWN_ERROR_MESSAGE,
+                code=grpc.StatusCode.INTERNAL,
+                start=start,
+                headers=maybe_headers,
+                auth_info=auth_info,
+                exception=e,
+            )
 
         def function_without_couchers_stuff(req: Message, grpc_context: grpc.ServicerContext) -> Message | None:
             couchers_context = make_interactive_context(
@@ -420,64 +494,42 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                 session.connection()
                 observe_in_servicer_pool_wait_histogram(method, (perf_counter_ns() - pool_wait_start) / 1e9)
                 start_perf()
+
+                res: Message | None = None
+                exception: Exception | None = None
                 try:
                     _res = prev_function(req, couchers_context, session)  # type: ignore[call-arg, arg-type]
-                    res = cast(Message, _res)
                     # flush so pending ORM writes execute (and are counted) before we snapshot; a handler that only
                     # session.add(...)s and returns would otherwise flush at commit, after read_perf()
                     session.flush()
-                    perf = read_perf()
-                    finished = perf_counter_ns()
-                    duration = (finished - start) / 1e6  # ms
-                    _store_log(
-                        method=method,
-                        duration=duration,
-                        user_id=couchers_context._user_id,
-                        is_api_key=cast(bool, couchers_context._is_api_key),
-                        request=req,
-                        response=res,
-                        perf=perf,
-                        client_platform=headers.client_platform,
-                        ip_address=headers.ip_address,
-                        user_agent=headers.user_agent,
-                        sofa=sofa,
-                    )
-                    observe_in_servicer_duration_histogram(method, couchers_context._user_id, "", "", duration / 1000)
-                    observe_api_call(method, headers.client_platform)
-                    observe_in_servicer_perf_histograms(method, perf)
+                    res = cast(Message, _res)
                 except Exception as e:
-                    perf = read_perf()
-                    finished = perf_counter_ns()
-                    duration = (finished - start) / 1e6  # ms
+                    exception = e
 
-                    if couchers_context._grpc_context:
-                        context_code = couchers_context._grpc_context.code()  # type: ignore[attr-defined]
-                        code = getattr(context_code, "name", None)
-                    else:
-                        code = None
+                perf = read_perf()
 
-                    traceback = "".join(format_exception(type(e), e, e.__traceback__))
-                    _store_log(
-                        method=method,
-                        status_code=code,
-                        duration=duration,
-                        user_id=couchers_context._user_id,
-                        is_api_key=cast(bool, couchers_context._is_api_key),
-                        request=req,
-                        response=None,
-                        traceback=traceback,
-                        perf=perf,
-                        client_platform=headers.client_platform,
-                        ip_address=headers.ip_address,
-                        user_agent=headers.user_agent,
-                        sofa=sofa,
-                    )
-                    observe_in_servicer_duration_histogram(
-                        method, couchers_context._user_id, code or "", type(e).__name__, duration / 1000
-                    )
-                    observe_api_call(method, headers.client_platform)
-                    observe_in_servicer_perf_histograms(method, perf)
+                if exception and couchers_context._grpc_context:
+                    context_code = couchers_context._grpc_context.code()  # type: ignore[attr-defined]
+                    code = getattr(context_code, "name", None)
+                else:
+                    code = None
 
+                _log_call(
+                    method=method,
+                    start=start,
+                    perf=perf,
+                    headers=headers,
+                    user_id=couchers_context._user_id,
+                    is_api_key=cast(bool, couchers_context._is_api_key),
+                    sofa=sofa,
+                    request=req,
+                    response=res,
+                    status_code=code,
+                    exception=exception,
+                )
+                observe_in_servicer_perf_histograms(method, perf)
+
+                if exception:
                     if not code:
                         sentry_sdk.set_tag("context", "servicer")
                         sentry_sdk.set_tag("method", method)
@@ -490,9 +542,9 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                                 "sofa": sofa[:12],
                             }
                         )
-                        sentry_sdk.capture_exception(e)
+                        sentry_sdk.capture_exception(exception)
 
-                    raise e
+                    raise exception
 
             if auth_info and not auth_info.is_api_key:
                 # check the two cookies are in sync & that language preference cookie is correct
@@ -529,18 +581,6 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             request_deserializer=timed_serde(handler.request_deserializer, "deserialize"),
             response_serializer=timed_serde(handler.response_serializer, "serialize"),
         )
-
-
-@dataclass(frozen=True, slots=True, kw_only=True)
-class CouchersHeaders:
-    token: str | None = field(repr=False)
-    is_api_key: bool
-    ip_address: str | None
-    user_agent: str | None
-    client_platform: ClientPlatform | None
-    ui_lang: str | None
-    user_id: str | None
-    sofa: str | None
 
 
 def parse_headers(headers: Mapping[str, str | bytes]) -> CouchersHeaders:

--- a/app/backend/src/couchers/perf.py
+++ b/app/backend/src/couchers/perf.py
@@ -7,7 +7,7 @@ from sqlalchemy import Engine, event
 # Per-request resource accounting. The gRPC server is thread-per-request with synchronous psycopg, so the SQLAlchemy
 # cursor-execute listeners fire on the same thread that runs the handler. We keep a thread-local accumulator that the
 # interceptor arms (start_perf) right before invoking the handler and reads back (read_perf) right after, so the
-# captured numbers cover the handler span only (not auth lookup or the _store_log insert that runs afterwards).
+# captured numbers cover the handler span only (not auth lookup or the _log_call insert that runs afterwards).
 
 _local = threading.local()
 
@@ -36,7 +36,7 @@ def start_perf() -> None:
 def read_perf() -> PerfResult | None:
     """Snapshot and clear the current thread's accumulator, or None if accounting wasn't armed.
 
-    Clearing means queries that run after this (e.g. the _store_log insert, or background work reusing the thread)
+    Clearing means queries that run after this (e.g. the _log_call insert, or background work reusing the thread)
     aren't attributed to the just-finished request.
     """
     acc: _PerfAccumulator | None = getattr(_local, "acc", None)

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -13,6 +13,7 @@ from google.protobuf.descriptor_pool import DescriptorPool
 from sqlalchemy import select, text, update
 
 from couchers.constants import (
+    COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE,
     MISSING_AUTH_LEVEL_ERROR_MESSAGE,
     NONEXISTENT_API_CALL_ERROR_MESSAGE,
     UNKNOWN_ERROR_MESSAGE,
@@ -470,6 +471,13 @@ def test_setup_phase_exception_observed(db):
 
     assert _get_setup_errors_value(method, "ValueError") == val + 1
 
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == method
+        assert trace.status_code == "INTERNAL"
+        assert trace.traceback
+        assert "expected only letters" in trace.traceback
+
 
 def test_tracing_interceptor_abort(db):
     val = _get_histogram_labels_value("/org.couchers.auth.Auth/SignupFlow", "False", "Exception", "FAILED_PRECONDITION")
@@ -853,6 +861,142 @@ def test_auth_levels(db):
             call_rpc(empty_pb2.Empty())
         assert err.value.code() == grpc.StatusCode.INTERNAL
         assert err.value.details() == "Internal authentication error."
+
+
+def test_rejected_call_logged_unauthenticated(db):
+    method = "/org.couchers.api.account.Account/GetAccountInfo"
+    hist_before = _get_histogram_labels_value(method, "False", "", "UNAUTHENTICATED")
+    api_calls_before = _get_api_call_count(method, "unknown")
+
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(
+        TestRpc,
+        interceptors=[CouchersMiddlewareInterceptor()],
+        service_name="org.couchers.api.account.Account",
+        method_name="GetAccountInfo",
+    ) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty())
+        assert e.value.code() == grpc.StatusCode.UNAUTHENTICATED
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == method
+        assert trace.status_code == "UNAUTHENTICATED"
+        assert trace.user_id is None
+        assert not trace.is_api_key
+        # the request is never deserialized on a reject path
+        assert trace.request is None
+        assert trace.response is None
+        assert not trace.traceback
+        assert trace.duration > 0
+
+    assert _get_histogram_labels_value(method, "False", "", "UNAUTHENTICATED") == hist_before + 1
+    assert _get_api_call_count(method, "unknown") == api_calls_before + 1
+
+
+def test_rejected_call_logged_permission_denied(db):
+    """A rejected call from a valid session is attributed to that user."""
+    user, token = generate_user()
+    method = "/org.couchers.admin.Admin/GetUserDetails"
+    hist_before = _get_histogram_labels_value(method, "True", "", "PERMISSION_DENIED")
+
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(
+        TestRpc,
+        interceptors=[CouchersMiddlewareInterceptor()],
+        service_name="org.couchers.admin.Admin",
+        method_name="GetUserDetails",
+    ) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty(), metadata=(cookie_auth(token), ("x-couchers-client-platform", "web_mobile")))
+        assert e.value.code() == grpc.StatusCode.PERMISSION_DENIED
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == method
+        assert trace.status_code == "PERMISSION_DENIED"
+        assert trace.user_id == user.id
+        assert trace.client_platform == ClientPlatform.web_mobile
+        assert not trace.traceback
+
+        # the same call is also counted in the per-user activity table, so the two agree
+        api_calls = session.execute(select(UserActivity.api_calls).where(UserActivity.user_id == user.id)).scalar_one()
+        assert api_calls == 1
+
+    assert _get_histogram_labels_value(method, "True", "", "PERMISSION_DENIED") == hist_before + 1
+
+
+def test_rejected_call_logged_nonexistent_rpc(db):
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(
+        TestRpc,
+        interceptors=[CouchersMiddlewareInterceptor()],
+        service_name="org.couchers.nonexistent.NA",
+        method_name="GetNothing",
+    ) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty(), metadata=(("x-couchers-real-ip", "1.1.1.1"),))
+        assert e.value.code() == grpc.StatusCode.UNIMPLEMENTED
+        assert e.value.details() == NONEXISTENT_API_CALL_ERROR_MESSAGE
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == "/org.couchers.nonexistent.NA/GetNothing"
+        assert trace.status_code == "UNIMPLEMENTED"
+        assert trace.user_id is None
+        # headers are parsed before the method is looked up, so we know who called a method that doesn't exist
+        assert trace.ip_address == "1.1.1.1"
+        assert trace.user_agent is not None
+
+
+def test_rejected_call_logged_missing_auth_level(db):
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(
+        TestRpc,
+        interceptors=[CouchersMiddlewareInterceptor()],
+        service_name="org.couchers.media.Media",
+        method_name="UploadConfirmation",
+    ) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty())
+        assert e.value.code() == grpc.StatusCode.INTERNAL
+        assert e.value.details() == MISSING_AUTH_LEVEL_ERROR_MESSAGE
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == "/org.couchers.media.Media/UploadConfirmation"
+        assert trace.status_code == "INTERNAL"
+
+
+def test_rejected_call_logged_bad_headers(db):
+    _, token = generate_user()
+
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(TestRpc, interceptors=[CouchersMiddlewareInterceptor()]) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty(), metadata=(cookie_auth(token), api_auth(token)))
+        assert e.value.code() == grpc.StatusCode.UNAUTHENTICATED
+        assert e.value.details() == COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == "/org.couchers.auth.Auth/SignupFlow"
+        assert trace.status_code == "UNAUTHENTICATED"
+        assert trace.user_id is None
+        # the headers couldn't be parsed, so nothing is known about the client
+        assert trace.ip_address is None
+        assert trace.user_agent is None
 
 
 def test_parse_headers_with_session_cookie():

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -22,6 +22,7 @@ from couchers.crypto import b64encode, random_hex, simple_encrypt
 from couchers.db import session_scope
 from couchers.descriptor_pool import get_descriptor_pool
 from couchers.interceptors import (
+    NONEXISTENT_METHOD_LABEL,
     AbortError,
     BadHeaders,
     CouchersMiddlewareInterceptor,
@@ -932,6 +933,9 @@ def test_rejected_call_logged_permission_denied(db):
 
 
 def test_rejected_call_logged_nonexistent_rpc(db):
+    hist_before = _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED")
+    api_calls_before = _get_api_call_count(NONEXISTENT_METHOD_LABEL, "unknown")
+
     def TestRpc(request, context, session):
         return empty_pb2.Empty()
 
@@ -954,6 +958,50 @@ def test_rejected_call_logged_nonexistent_rpc(db):
         # headers are parsed before the method is looked up, so we know who called a method that doesn't exist
         assert trace.ip_address == "1.1.1.1"
         assert trace.user_agent is not None
+
+    # the caller picks the method, so it's bucketed in prometheus instead of becoming a label of its own
+    assert _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED") == hist_before + 1
+    assert _get_api_call_count(NONEXISTENT_METHOD_LABEL, "unknown") == api_calls_before + 1
+    assert _get_histogram_labels_value("/org.couchers.nonexistent.NA/GetNothing", "False", "", "UNIMPLEMENTED") == 0
+    assert _get_api_call_count("/org.couchers.nonexistent.NA/GetNothing", "unknown") == 0
+    assert (
+        _get_histogram_count(
+            servicer_setup_db_time_histogram,
+            "couchers_servicer_setup_db_time_seconds_count",
+            method="/org.couchers.nonexistent.NA/GetNothing",
+        )
+        == 0
+    )
+
+
+def test_rejected_call_logged_nonexistent_method_on_real_service(db):
+    """A real service with a method that doesn't exist is rejected too, rather than reported as an internal error."""
+    method = "/org.couchers.api.core.API/GetNothing"
+    hist_before = _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED")
+
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(
+        TestRpc,
+        interceptors=[CouchersMiddlewareInterceptor()],
+        service_name="org.couchers.api.core.API",
+        method_name="GetNothing",
+    ) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty(), metadata=(("x-couchers-real-ip", "1.1.1.1"),))
+        assert e.value.code() == grpc.StatusCode.UNIMPLEMENTED
+        assert e.value.details() == NONEXISTENT_API_CALL_ERROR_MESSAGE
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == method
+        assert trace.status_code == "UNIMPLEMENTED"
+        assert not trace.traceback
+
+    assert _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED") == hist_before + 1
+    assert _get_histogram_labels_value(method, "False", "", "UNIMPLEMENTED") == 0
+    assert _get_setup_errors_value(method, "RuntimeError") == 0
 
 
 def test_rejected_call_logged_missing_auth_level(db):


### PR DESCRIPTION
Calls that the middleware interceptor terminates during auth/setup returned an abort handler directly, so `_store_log` never ran: no `logging.api_calls` row, and no `api_calls_total` / `servicer_duration_seconds` / `servicer_setup_*` observations either. The biggest gap is every rejected permission check — unauthenticated or expired-session calls to secure endpoints, jailed users hitting non-jailed endpoints, non-editors/non-admins hitting editor/admin endpoints.

That also left the counters disagreeing with each other: `_try_get_and_update_user_details` runs *before* the permission check, so a jailed or non-admin user's rejected call already incremented `user_sessions.api_calls` and `logging.user_activity`, but never appeared in `logging.api_calls`.

All four reject paths now go through a `_abort_and_log` helper that writes the row and fires the counters before returning the terminating handler:

| Path | Logged as |
| --- | --- |
| Both `cookie` and `authorization` sent | `UNAUTHENTICATED` |
| `find_auth_level` fails (unknown service, or missing `auth_level` annotation) | `UNIMPLEMENTED` / `INTERNAL` |
| `check_permissions` fails | `UNAUTHENTICATED` / `PERMISSION_DENIED`, attributed to the user when the session was valid |
| Catch-all setup exception | `INTERNAL`, with the traceback |

Rows carry `ip_address`, `user_agent`, `sofa`, `client_platform` and the setup-phase perf numbers — all the work such a call actually does. `request` is null: the abort stub has no deserializer, so the request bytes are never parsed on these paths.

Two supporting changes:

- `parse_headers` now runs before `find_auth_level`, so a call to a nonexistent method has a known IP and user agent to log — exactly the traffic you want to identify. Side effect: a request that is both malformed-headers *and* a nonexistent method now returns `UNAUTHENTICATED` rather than `UNIMPLEMENTED`, which also stops it leaking method existence.
- `CouchersHeaders` moved up beside `UserAuthInfo` so the helper can reference it without a forward reference.

In the catch-all, the Sentry capture deliberately stays before the log write — if the DB is what broke, `_store_log` fails too and the Sentry report shouldn't depend on it.

Worth a reviewer's opinion: this means every unauthenticated request to a secure endpoint now costs an INSERT. Previously a request with no token at all did zero DB work. Bot and scanner traffic is the main exposure. If that volume is unwelcome, the narrow alternative is to keep the metrics for the first three cases and restrict the DB row to the catch-all.

## Testing

Five new tests in `test_interceptors.py`, one per reject path, plus a user-attribution case asserting that `logging.api_calls` and `user_activity` now agree. `test_setup_phase_exception_observed` extended to assert the `INTERNAL` row and its traceback.

- `make mypy` passes (481 files)
- `pytest src/tests/test_interceptors.py` passes 67/67
- `pytest src/tests/test_admin.py src/tests/test_account.py src/tests/test_jail.py src/tests/test_api.py` passes 165/165

The full suite could not be run locally: it dies partway through with `psycopg.errors.DiskFull` on `pg_wal` and everything after cascades into `PendingRollbackError`. That is a local Docker disk problem, not this change — leaving the PR as a draft for CI to run the full suite.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history (no schema changes)

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._