### PR TITLE
Frontend/nav: Change lang picker to icon only

### DIFF
--- a/app/web/components/Navigation/LoggedInMenu.tsx
+++ b/app/web/components/Navigation/LoggedInMenu.tsx
@@ -278,7 +278,7 @@ export default function LoggedInMenu({
     <>
       {!isMobile && (
         <Box sx={{ marginRight: theme.spacing(1) }}>
-          <LanguagePickerSelect />
+          <LanguagePickerSelect displayMode="icon" />
         </Box>
       )}
       <Tooltip title={t("global:nav.notifications")}>

--- a/app/web/components/Navigation/Navigation.tsx
+++ b/app/web/components/Navigation/Navigation.tsx
@@ -406,7 +406,7 @@ export default function Navigation() {
                 gap: 2,
               }}
             >
-              {shouldShowLanguagePickerSelect && <LanguagePickerSelect />}
+              {shouldShowLanguagePickerSelect && <LanguagePickerSelect displayMode="icon" />}
               {!isLoginPage && (
                 <Button
                   variant="outlined"

--- a/app/web/features/translate/LanguagePickerSelect.tsx
+++ b/app/web/features/translate/LanguagePickerSelect.tsx
@@ -1,6 +1,6 @@
 import CheckIcon from "@mui/icons-material/Check";
 import ExpandMoreOutlinedIcon from "@mui/icons-material/ExpandMoreOutlined";
-import TranslateIcon from "@mui/icons-material/Translate";
+import LanguageIcon from "@mui/icons-material/Language";
 import {
   Box,
   FormControl,
@@ -205,7 +205,7 @@ export default function LanguagePickerSelect({ displayMode = "rounded", onNaviga
     );
   };
 
-  // Icon mode shows a generic translate icon instead of the selected language
+  // Icon mode shows a generic language icon instead of the selected language
   const renderIconValue = () => (
     <Box
       sx={{
@@ -215,7 +215,7 @@ export default function LanguagePickerSelect({ displayMode = "rounded", onNaviga
         color: "var(--mui-palette-text-primary)",
       }}
     >
-      <TranslateIcon fontSize="small" />
+      <LanguageIcon fontSize="small" />
     </Box>
   );
 
@@ -235,7 +235,7 @@ export default function LanguagePickerSelect({ displayMode = "rounded", onNaviga
               value={isLoading ? "" : locale || ""}
               displayMode={displayMode}
               onChange={handleChange}
-              // Use renderValue to display the selected language (or, in icon mode, a generic translate icon) in collapsed state
+              // Use renderValue to display the selected language (or, in icon mode, a generic language icon) in collapsed state
               renderValue={displayMode === "icon" ? renderIconValue : renderRoundedValue}
               IconComponent={ExpandMoreOutlinedIcon}
               disabled={isLoading || isChangingLanguage}

--- a/app/web/features/translate/LanguagePickerSelect.tsx
+++ b/app/web/features/translate/LanguagePickerSelect.tsx
@@ -1,5 +1,6 @@
 import CheckIcon from "@mui/icons-material/Check";
 import ExpandMoreOutlinedIcon from "@mui/icons-material/ExpandMoreOutlined";
+import TranslateIcon from "@mui/icons-material/Translate";
 import {
   Box,
   FormControl,
@@ -31,13 +32,13 @@ import { useShowAllLanguages } from "./useShowAllLanguages";
 import { getAvailableLanguages } from "./utils";
 
 interface StyledMuiSelectProps {
-  displayMode?: "round" | "rect";
+  displayMode?: "rounded" | "rect" | "icon";
 }
 
 const StyledSelect = styled(Select, {
   shouldForwardProp: (prop) => prop !== "displayMode",
 })<StyledMuiSelectProps>(({ theme, displayMode }) => ({
-  borderRadius: displayMode === "round" ? 999 : theme.shape.borderRadius,
+  borderRadius: displayMode === "rect" ? theme.shape.borderRadius : displayMode === "icon" ? "50%" : 999,
   backgroundColor: "var(--mui-palette-grey-200)",
   "& .MuiOutlinedInput-notchedOutline": {
     borderColor: "var(--mui-palette-grey-300)",
@@ -54,16 +55,28 @@ const StyledSelect = styled(Select, {
     top: "50%",
     transform: "translateY(-50%)",
     right: 10,
+    ...(displayMode === "icon" && { display: "none" }),
   },
   height: 41.25,
+  ...(displayMode === "icon" && {
+    width: 41.25,
+    minWidth: 41.25,
+    "& .MuiSelect-select": {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      paddingLeft: "0 !important",
+      paddingRight: "0 !important",
+    },
+  }),
 }));
 
 type LanguagePickerSelectProps = {
-  displayMode?: "round" | "rect";
+  displayMode?: "rounded" | "rect" | "icon";
   onNavigate?: () => void;
 };
 
-export default function LanguagePickerSelect({ displayMode = "round", onNavigate }: LanguagePickerSelectProps) {
+export default function LanguagePickerSelect({ displayMode = "rounded", onNavigate }: LanguagePickerSelectProps) {
   const router = useRouter();
   const { asPath, locale, pathname, query } = router;
   const { authState } = useAuthContext();
@@ -174,9 +187,9 @@ export default function LanguagePickerSelect({ displayMode = "round", onNavigate
       });
 
   // renderValue function for what should be rendered after a selection is made
-  const renderValue = (value: unknown) => {
+  const renderRoundedValue = (value: unknown) => {
     const selected = value as string;
-    const selectedDisplay = (
+    return (
       <Box
         sx={{
           display: "flex",
@@ -190,8 +203,21 @@ export default function LanguagePickerSelect({ displayMode = "round", onNavigate
         {LANGUAGE_MAP[selected].nativeName}
       </Box>
     );
-    return selectedDisplay;
   };
+
+  // Icon mode shows a generic translate icon instead of the selected language
+  const renderIconValue = () => (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        color: "var(--mui-palette-text-primary)",
+      }}
+    >
+      <TranslateIcon fontSize="small" />
+    </Box>
+  );
 
   return (
     <>
@@ -200,17 +226,17 @@ export default function LanguagePickerSelect({ displayMode = "round", onNavigate
         <FormControl
           variant="outlined"
           sx={{
-            width: displayMode === "round" ? "fit-content" : !isMobile ? "241px" : "100%",
+            width: displayMode === "rect" ? (!isMobile ? "241px" : "100%") : "fit-content",
           }}
         >
-          {displayMode === "round" ? (
+          {displayMode !== "rect" ? (
             <StyledSelect
               id="language-select"
               value={isLoading ? "" : locale || ""}
               displayMode={displayMode}
               onChange={handleChange}
-              // Use renderValue to display the selected language in collapsed state
-              renderValue={renderValue}
+              // Use renderValue to display the selected language (or, in icon mode, a generic translate icon) in collapsed state
+              renderValue={displayMode === "icon" ? renderIconValue : renderRoundedValue}
               IconComponent={ExpandMoreOutlinedIcon}
               disabled={isLoading || isChangingLanguage}
               open={isOpen}

--- a/app/web/features/translate/LanguagePickerSelect.tsx
+++ b/app/web/features/translate/LanguagePickerSelect.tsx
@@ -242,6 +242,14 @@ export default function LanguagePickerSelect({ displayMode = "rounded", onNaviga
               open={isOpen}
               onOpen={() => setIsOpen(true)}
               onClose={() => setIsOpen(false)}
+              MenuProps={
+                displayMode === "icon"
+                  ? {
+                      anchorOrigin: { vertical: "bottom", horizontal: "right" },
+                      transformOrigin: { vertical: "top", horizontal: "right" },
+                    }
+                  : undefined
+              }
             >
               {menuItems}
               <Box

--- a/app/web/features/translate/LanguagePickerSelect.tsx
+++ b/app/web/features/translate/LanguagePickerSelect.tsx
@@ -200,6 +200,7 @@ export default function LanguagePickerSelect({ displayMode = "rounded", onNaviga
           fontWeight: "bold",
         }}
       >
+        <LanguageIcon fontSize="small" />
         {LANGUAGE_MAP[selected].nativeName}
       </Box>
     );


### PR DESCRIPTION
As suggested by @c-kreuz , using only the standard translation icon for the language picker is less cluttered and just as recognizable if not more.

I kept the pill shape with the language name and dropdown arrow when in mobile menu view.

## Testing
Ran locally:

<img width="862" height="340" alt="image" src="https://github.com/user-attachments/assets/72e8e4dd-a364-4f0e-b288-e430fae83a4b" />

<img width="435" height="391" alt="image" src="https://github.com/user-attachments/assets/7e29cd57-2de3-4c02-a038-fc2a6f3041d5" />

Logged out:
<img width="1013" height="692" alt="image" src="https://github.com/user-attachments/assets/66badb90-512c-45fb-8f7f-baee8dd98c35" />

<img width="761" height="277" alt="image" src="https://github.com/user-attachments/assets/3db9b1a4-217f-456d-8177-63bc00d846da" />

Account settings (unchanged):
<img width="742" height="426" alt="image" src="https://github.com/user-attachments/assets/d77fcf8f-d99c-407d-832b-99230f625647" />

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me