### PR TITLE
Backend/events: Move event thread to EventOccurrence

### DIFF
--- a/app/backend/src/couchers/migrations/versions/0181_move_event_thread_to_occurrence.py
+++ b/app/backend/src/couchers/migrations/versions/0181_move_event_thread_to_occurrence.py
@@ -1,0 +1,85 @@
+"""Move event comment thread from Event to EventOccurrence
+
+Revision ID: 0181
+Revises: 0180
+Create Date: 2026-08-13 07:21:39.779870
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0181"
+down_revision = "0180"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("event_occurrences", sa.Column("thread_id", sa.BigInteger(), nullable=True))
+
+    # Each event's most recent occurrence keeps the event's existing thread (and its comments):
+    # this is the occurrence that comment/reply notifications were already being generated against.
+    op.execute(
+        """
+        UPDATE event_occurrences eo
+        SET thread_id = e.thread_id
+        FROM events e
+        WHERE eo.event_id = e.id
+          AND eo.id = (SELECT max(eo2.id) FROM event_occurrences eo2 WHERE eo2.event_id = e.id)
+        """
+    )
+
+    # Every other occurrence of a repeating event gets its own fresh, empty thread
+    op.execute(
+        """
+        DO $$
+        DECLARE
+            occ_id BIGINT;
+            new_thread_id BIGINT;
+        BEGIN
+            FOR occ_id IN SELECT id FROM event_occurrences WHERE thread_id IS NULL LOOP
+                INSERT INTO threads DEFAULT VALUES RETURNING id INTO new_thread_id;
+                UPDATE event_occurrences SET thread_id = new_thread_id WHERE id = occ_id;
+            END LOOP;
+        END $$
+        """
+    )
+
+    op.alter_column("event_occurrences", "thread_id", nullable=False)
+    op.create_unique_constraint(op.f("uq_event_occurrences_thread_id"), "event_occurrences", ["thread_id"])
+    op.create_foreign_key(
+        op.f("fk_event_occurrences_thread_id_threads"), "event_occurrences", "threads", ["thread_id"], ["id"]
+    )
+
+    op.drop_constraint(op.f("uq_events_thread_id"), "events", type_="unique")
+    op.drop_constraint(op.f("fk_events_thread_id_threads"), "events", type_="foreignkey")
+    op.drop_column("events", "thread_id")
+
+
+def downgrade() -> None:
+    op.add_column("events", sa.Column("thread_id", sa.BigInteger(), autoincrement=False, nullable=True))
+
+    # Each event reclaims the thread of its most recent occurrence; comments on other
+    # occurrences' threads are orphaned (unreachable from the Event) as a result.
+    op.execute(
+        """
+        UPDATE events e
+        SET thread_id = (
+            SELECT eo.thread_id
+            FROM event_occurrences eo
+            WHERE eo.event_id = e.id
+            ORDER BY eo.id DESC
+            LIMIT 1
+        )
+        """
+    )
+
+    op.alter_column("events", "thread_id", nullable=False)
+    op.create_foreign_key(op.f("fk_events_thread_id_threads"), "events", "threads", ["thread_id"], ["id"])
+    op.create_unique_constraint(op.f("uq_events_thread_id"), "events", ["thread_id"])
+
+    op.drop_constraint(op.f("fk_event_occurrences_thread_id_threads"), "event_occurrences", type_="foreignkey")
+    op.drop_constraint(op.f("uq_event_occurrences_thread_id"), "event_occurrences", type_="unique")
+    op.drop_column("event_occurrences", "thread_id")

--- a/app/backend/src/couchers/migrations/versions/0187_move_event_thread_to_occurrence.py
+++ b/app/backend/src/couchers/migrations/versions/0187_move_event_thread_to_occurrence.py
@@ -1,7 +1,7 @@
 """Move event comment thread from Event to EventOccurrence
 
-Revision ID: 0181
-Revises: 0180
+Revision ID: 0187
+Revises: 0186
 Create Date: 2026-08-13 07:21:39.779870
 
 """
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "0181"
-down_revision = "0180"
+revision = "0187"
+down_revision = "0186"
 branch_labels = None
 depends_on = None
 

--- a/app/backend/src/couchers/models/events.py
+++ b/app/backend/src/couchers/models/events.py
@@ -75,12 +75,10 @@ class Event(Base, kw_only=True):
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     owner_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), index=True, default=None)
     owner_cluster_id: Mapped[int | None] = mapped_column(ForeignKey("clusters.id"), index=True, default=None)
-    thread_id: Mapped[int] = mapped_column(ForeignKey("threads.id"), unique=True)
 
     parent_node: Mapped[Node] = relationship(
         init=False, backref="child_events", remote_side="Node.id", foreign_keys="Event.parent_node_id"
     )
-    thread: Mapped[Thread] = relationship(init=False, backref="event", uselist=False)
     subscribers: DynamicMapped[User] = relationship(
         init=False, backref="subscribed_events", secondary="event_subscriptions", lazy="dynamic", viewonly=True
     )
@@ -121,6 +119,7 @@ class EventOccurrence(Base, kw_only=True):
     )
     event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), index=True)
     moderation_state_id: Mapped[int] = mapped_column(ForeignKey("moderation_states.id"), index=True)
+    thread_id: Mapped[int] = mapped_column(ForeignKey("threads.id"), unique=True)
 
     # the user that created this particular occurrence of a repeating event (same as event.creator_user_id if single event)
     creator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
@@ -148,6 +147,7 @@ class EventOccurrence(Base, kw_only=True):
     creator_user: Mapped[User] = relationship(
         init=False, backref="created_event_occurrences", foreign_keys="EventOccurrence.creator_user_id"
     )
+    thread: Mapped[Thread] = relationship(init=False, backref="event_occurrence", uselist=False)
     event: Mapped[Event] = relationship(
         init=False,
         back_populates="occurrences",

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -542,13 +542,14 @@ class Events(events_pb2_grpc.EventsServicer):
         session.add(event)
         session.flush()
 
+        thread = Thread()
+        session.add(thread)
+        session.flush()
+
         occurrence: EventOccurrence | None = None
 
         def create_occurrence(moderation_state_id: int) -> int:
             nonlocal occurrence
-            thread = Thread()
-            session.add(thread)
-            session.flush()
             occurrence = EventOccurrence(
                 event_id=event.id,
                 content=request.content,
@@ -669,13 +670,14 @@ class Events(events_pb2_grpc.EventsServicer):
         ):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "event_cant_overlap")
 
+        thread = Thread()
+        session.add(thread)
+        session.flush()
+
         new_occurrence: EventOccurrence | None = None
 
         def create_occurrence(moderation_state_id: int) -> int:
             nonlocal new_occurrence
-            thread = Thread()
-            session.add(thread)
-            session.flush()
             new_occurrence = EventOccurrence(
                 event_id=event.id,
                 content=request.content,

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -188,7 +188,7 @@ def event_to_pb(session: Session, occurrence: EventOccurrence, context: Couchers
         owner_user_id=event.owner_user_id,
         owner_community_id=owner_community_id,
         owner_group_id=owner_group_id,
-        thread=thread_to_pb(session, context, event.thread_id),
+        thread=thread_to_pb(session, context, occurrence.thread_id),
         can_edit=can_edit,
         can_moderate=can_moderate,
     )
@@ -533,15 +533,10 @@ class Events(events_pb2_grpc.EventsServicer):
         ):
             context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "photo_not_found")
 
-        thread = Thread()
-        session.add(thread)
-        session.flush()
-
         event = Event(
             title=request.title,
             parent_node_id=parent_node.id,
             owner_user_id=context.user_id,
-            thread_id=thread.id,
             creator_user_id=context.user_id,
         )
         session.add(event)
@@ -551,6 +546,9 @@ class Events(events_pb2_grpc.EventsServicer):
 
         def create_occurrence(moderation_state_id: int) -> int:
             nonlocal occurrence
+            thread = Thread()
+            session.add(thread)
+            session.flush()
             occurrence = EventOccurrence(
                 event_id=event.id,
                 content=request.content,
@@ -561,6 +559,7 @@ class Events(events_pb2_grpc.EventsServicer):
                 during=TimestamptzRange(start_datetime, end_datetime),
                 creator_user_id=context.user_id,
                 moderation_state_id=moderation_state_id,
+                thread_id=thread.id,
             )
             session.add(occurrence)
             session.flush()
@@ -674,6 +673,9 @@ class Events(events_pb2_grpc.EventsServicer):
 
         def create_occurrence(moderation_state_id: int) -> int:
             nonlocal new_occurrence
+            thread = Thread()
+            session.add(thread)
+            session.flush()
             new_occurrence = EventOccurrence(
                 event_id=event.id,
                 content=request.content,
@@ -684,6 +686,7 @@ class Events(events_pb2_grpc.EventsServicer):
                 during=during,
                 creator_user_id=context.user_id,
                 moderation_state_id=moderation_state_id,
+                thread_id=thread.id,
             )
             session.add(new_occurrence)
             session.flush()

--- a/app/backend/src/couchers/servicers/threads.py
+++ b/app/backend/src/couchers/servicers/threads.py
@@ -14,7 +14,6 @@ from couchers.jobs.enqueue import queue_job
 from couchers.models import (
     Comment,
     Discussion,
-    Event,
     EventOccurrence,
     ModerationObjectType,
     Reply,
@@ -109,14 +108,16 @@ def generate_reply_notifications(payload: jobs_pb2.GenerateReplyNotificationsPay
                 created_time=Timestamp_from_datetime(comment.created),
                 num_replies=0,
             )
-            # figure out if the thread is related to an event or discussion
-            event = session.execute(select(Event).where(Event.thread_id == thread.id)).scalar_one_or_none()
+            # figure out if the thread is related to an event occurrence or discussion
+            occurrence = session.execute(
+                select(EventOccurrence).where(EventOccurrence.thread_id == thread.id)
+            ).scalar_one_or_none()
             discussion = session.execute(
                 select(Discussion).where(Discussion.thread_id == thread.id)
             ).scalar_one_or_none()
-            if event:
-                # thread is an event thread
-                occurrence = event.occurrences.order_by(EventOccurrence.id.desc()).limit(1).one()
+            if occurrence:
+                # thread is an event occurrence thread
+                event = occurrence.event
                 subscribed_user_ids = [user.id for user in event.subscribers]
                 attending_user_ids = [user.user_id for user in occurrence.attendances]
 
@@ -199,15 +200,14 @@ def generate_reply_notifications(payload: jobs_pb2.GenerateReplyNotificationsPay
                 num_replies=0,
             )
 
-            event = session.execute(
-                select(Event).where(Event.thread_id == parent_comment.thread_id)
+            occurrence = session.execute(
+                select(EventOccurrence).where(EventOccurrence.thread_id == parent_comment.thread_id)
             ).scalar_one_or_none()
             discussion = session.execute(
                 select(Discussion).where(Discussion.thread_id == parent_comment.thread_id)
             ).scalar_one_or_none()
-            if event:
-                # thread is an event thread
-                occurrence = event.occurrences.order_by(EventOccurrence.id.desc()).limit(1).one()
+            if occurrence:
+                # thread is an event occurrence thread
                 for user_id in user_ids_to_notify:
                     context = make_notification_user_context(user_id=user_id)
                     notify(

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -396,7 +396,7 @@ def test_ScheduleEvent(db, frozen_timewarp):
     end_time = start_time + timedelta(hours=3)
 
     with events_session(token) as api:
-        res = api.CreateEvent(
+        create_res = api.CreateEvent(
             events_pb2.CreateEventReq(
                 title="Dummy Title",
                 content="Dummy content.",
@@ -414,9 +414,9 @@ def test_ScheduleEvent(db, frozen_timewarp):
         new_start_time = now() + timedelta(hours=6)
         new_end_time = new_start_time + timedelta(hours=2)
 
-        res = api.ScheduleEvent(
+        schedule_res = api.ScheduleEvent(
             events_pb2.ScheduleEventReq(
-                event_id=res.event_id,
+                event_id=create_res.event_id,
                 content="New event occurrence",
                 location=events_pb2.EventLocation(
                     address="A bit further but still near Null Island",
@@ -428,7 +428,11 @@ def test_ScheduleEvent(db, frozen_timewarp):
             )
         )
 
-        res = api.GetEvent(events_pb2.GetEventReq(event_id=res.event_id))
+        # Each occurrence is independent and has an independent thread
+        assert schedule_res.event_id != create_res.event_id
+        assert schedule_res.thread.thread_id != create_res.thread.thread_id
+
+        res = api.GetEvent(events_pb2.GetEventReq(event_id=schedule_res.event_id))
 
         assert not res.is_next
         assert res.title == "Dummy Title"

--- a/app/backend/src/tests/test_hybrid_properties.py
+++ b/app/backend/src/tests/test_hybrid_properties.py
@@ -335,6 +335,7 @@ def _populate_event_occurrences() -> None:
             node_type=NodeType.world,
         )
         session.add(node)
+        session.flush()
         event = Event(
             parent_node_id=node.id,
             title="Testing event",

--- a/app/backend/src/tests/test_hybrid_properties.py
+++ b/app/backend/src/tests/test_hybrid_properties.py
@@ -335,15 +335,11 @@ def _populate_event_occurrences() -> None:
             node_type=NodeType.world,
         )
         session.add(node)
-        thread = Thread()
-        session.add(thread)
-        session.flush()
         event = Event(
             parent_node_id=node.id,
             title="Testing event",
             creator_user_id=creator.id,
             owner_user_id=creator.id,
-            thread_id=thread.id,
         )
         session.add(event)
         session.flush()
@@ -352,7 +348,11 @@ def _populate_event_occurrences() -> None:
         for days, hours in [(1, 2), (10, 3)]:
             start = now() + timedelta(days=days)
 
-            def create_occurrence(moderation_state_id: int, start=start, hours=hours) -> int:
+            thread = Thread()
+            session.add(thread)
+            session.flush()
+
+            def create_occurrence(moderation_state_id: int, start=start, hours=hours, thread=thread) -> int:
                 occurrence = EventOccurrence(
                     event_id=event.id,
                     moderation_state_id=moderation_state_id,
@@ -362,6 +362,7 @@ def _populate_event_occurrences() -> None:
                     address="Somewhere",
                     timezone="Etc/UTC",
                     during=TimestamptzRange(start, start + timedelta(hours=hours)),
+                    thread_id=thread.id,
                 )
                 session.add(occurrence)
                 session.flush()


### PR DESCRIPTION
Part of supporting recurring events, every occurrence should have an independent thread rather than a shared one at the series level (occurrences mostly look like individual events to non-organizers).

All events today should have a single occurrence since we don't support recurrence yet, but for resiliency the database migration moves the thread to the latest occurrence and creates empty threads on others.

Fixes #9547

## Testing
Nuked database, then ran local backend + frontend before changes, created an event and added a comment. Synced to this branch and reran backend + frontend, observed that the event still has its comment.

Updated `test_ScheduleEvent` to verify that each occurrence has its own thread.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me