### PR TITLE
Frontend: Tell Claude how to call nvm+yarn

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ make mypy
 - For paginated APIs, use a `next_page_token` string field: an empty token means there are no more pages (don't add a separate `no_more` flag). Encrypt tokens with `encrypt_page_token`/`decrypt_page_token` from `couchers.crypto` so they are opaque to clients
 
 ### Web (TypeScript/React)
-- Uses `nvm` for node version management
+- Uses `nvm` for node version management. In non-interactive shells, use it as `source $HOME/.nvm/nvm.sh && <nvm command>`, and use `yarn` as `source $HOME/.nvm/nvm.sh && nvm use && <yarn command>`.
 - Uses `yarn` (not npm) - run dev server with `yarn start` (not Docker)
 - Run linting with `yarn lint` and auto-fix with `yarn lint:fix`
 - Run tests with `yarn test`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,11 +60,13 @@ make mypy
 - For paginated APIs, use a `next_page_token` string field: an empty token means there are no more pages (don't add a separate `no_more` flag). Encrypt tokens with `encrypt_page_token`/`decrypt_page_token` from `couchers.crypto` so they are opaque to clients
 
 ### Web (TypeScript/React)
-- Uses `nvm` for node version management. In non-interactive shells, use it as `source $HOME/.nvm/nvm.sh && <nvm command>`, and use `yarn` as `source $HOME/.nvm/nvm.sh && nvm use && <yarn command>`.
-- Uses `yarn` (not npm) - run dev server with `yarn start` (not Docker)
+- Uses `nvm` for node version management. Use it as `source $HOME/.nvm/nvm.sh && <nvm command>`.
+- Uses `yarn` (not npm). Use it as `source $HOME/.nvm/nvm.sh && nvm use && <yarn command>`
+- Run the dev server with `yarn start` (not Docker)
 - Run linting with `yarn lint` and auto-fix with `yarn lint:fix`
 - Run tests with `yarn test`
 - Run linting AND formatting with `yarn format`
+- Run type checking with `yarn typecheck`
 - Import aliases: use `components/` not `../../../components/`, `routes` not `../../../routes`
 - Import multiple MUI icons together: `import { Favorite, Star, Public } from "@mui/icons-material"` instead of separate imports
 - No `any` types - explicitly type mock mutations (e.g., `UseMutationResult<...>`)


### PR DESCRIPTION
Everytime Claude tries to run frontend tests on my machine it fails twice before succeeding: the first time because `nvm` isn't available in non-interactive shells, and the second time because `yarn` requires the shell to have run `nvm use` first. These instructions help it get it right.

## Testing
Told Claude "run tests in <some .test.ts file>" before and after.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
