### PR TITLE
Increase line-height on email body text to 1.5 (fixes #9217)

### DIFF
--- a/app/backend/templates/v2/blocks.mjml
+++ b/app/backend/templates/v2/blocks.mjml
@@ -3,7 +3,7 @@
     <mj-title>{{ header_subject }}</mj-title>
     <mj-preview>{{ header_preview }}</mj-preview>
     <mj-attributes>
-      <mj-text color="#333" />
+      <mj-text color="#333" line-height="1.4" />
     </mj-attributes>
     <mj-style inline="inline">a { color: #00a398; } .unsub a { color: #777; text-decoration: underline; text-decoration-color: #ccc; }</mj-style>
     <mj-font name="Ubuntu" href="https://cdn.couchers.org/fonts/ubuntu/ubuntu.css" />

--- a/app/backend/templates/v2/generated_html/blocks.html
+++ b/app/backend/templates/v2/generated_html/blocks.html
@@ -179,7 +179,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ text }}</div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1.4;text-align:left;color:#333333;">{{ text }}</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -342,7 +342,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#333333;">{{ text }}</div>
+                                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1.4;text-align:left;color:#333333;">{{ text }}</div>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -388,7 +388,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:1;text-align:center;color:#333333;"><a href="https://couchers.org/donate" style="color: #00a398;">{{ donate_link }}</a> | <a href="https://github.com/Couchers-org/couchers" style="color: #00a398;">GitHub</a> | <a href="https://couchers.org/volunteer" style="color: #00a398;">{{ volunteer_link }}</a> | <a href="https://couchers.org/blog" style="color: #00a398;">{{ blog_link }}</a></div>
+                                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:10px;line-height:1.4;text-align:center;color:#333333;"><a href="https://couchers.org/donate" style="color: #00a398;">{{ donate_link }}</a> | <a href="https://github.com/Couchers-org/couchers" style="color: #00a398;">GitHub</a> | <a href="https://couchers.org/volunteer" style="color: #00a398;">{{ volunteer_link }}</a> | <a href="https://couchers.org/blog" style="color: #00a398;">{{ blog_link }}</a></div>
                                 </td>
                               </tr>
                               <tr>


### PR DESCRIPTION
Increase line-height on email body text to 1.5 (fixes #9217)

## Testing

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [x] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [x] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me