### PR TITLE
Attempt to fix the 'replay' freeze on expanding the map search results left pane

### DIFF
--- a/app/web/components/ResizeableDrawer.tsx
+++ b/app/web/components/ResizeableDrawer.tsx
@@ -7,6 +7,8 @@ import React from "react";
 import IconButton from "./IconButton";
 
 export const DEFAULT_DRAWER_WIDTH = 420;
+/** Keep in sync with CSS width transitions on the map search layout. */
+export const DRAWER_WIDTH_TRANSITION_MS = 200;
 
 interface ResizeableDrawerProps {
   children: React.ReactNode;

--- a/app/web/features/search/MapSearchContent.tsx
+++ b/app/web/features/search/MapSearchContent.tsx
@@ -1,5 +1,8 @@
 import { styled } from "@mui/material";
-import { DEFAULT_DRAWER_WIDTH } from "components/ResizeableDrawer";
+import {
+  DEFAULT_DRAWER_WIDTH,
+  DRAWER_WIDTH_TRANSITION_MS,
+} from "components/ResizeableDrawer";
 import { RpcError } from "grpc-web";
 import { SearchUser } from "proto/search_pb";
 import { LngLatLike, MapRef } from "react-map-gl/maplibre";
@@ -16,6 +19,7 @@ interface MapSearchContentProps {
   drawerWidth: number;
   hasPreviousPage: boolean | undefined;
   hasNextPage: boolean | undefined;
+  isDrawerResizing: boolean;
   isLoading: boolean;
   mapRef: React.RefObject<MapRef | null>;
   mapView: MapViewOptions;
@@ -47,6 +51,7 @@ const SearchResultsContainer = styled("div", {
   display: "flex",
   height: "100%",
   width: isListOnlyView ? "100%" : `${drawerWidth}px`,
+  transition: `width ${DRAWER_WIDTH_TRANSITION_MS}ms ease-in-out`,
 
   ...(!isListOnlyView && {
     [theme.breakpoints.down("md")]: {
@@ -56,6 +61,7 @@ const SearchResultsContainer = styled("div", {
       order: 2,
       boxShadow: "0px -2px 4px rgba(0,0,0,0.1)",
       overflow: "hidden",
+      transition: "none",
     },
   }),
 }));
@@ -68,18 +74,21 @@ const MapContainer = styled("div", {
   position: "relative",
   display: "flex",
   alignItems: "center",
+  transition: `width ${DRAWER_WIDTH_TRANSITION_MS}ms ease-in-out`,
   ...(isListOnlyView && {
     width: 0,
     height: 0,
     overflow: "hidden",
     position: "absolute",
     pointerEvents: "none",
+    transition: "none",
   }),
 
   [theme.breakpoints.down("md")]: {
     width: "100%",
     height: "55%",
     order: 1,
+    transition: "none",
     ...(isListOnlyView && {
       width: 0,
       height: 0,
@@ -92,6 +101,7 @@ const MapSearchContent = ({
   drawerWidth,
   hasPreviousPage,
   hasNextPage,
+  isDrawerResizing,
   isLoading,
   mapRef,
   mapView,
@@ -131,7 +141,12 @@ const MapSearchContent = ({
 
   return (
     <Wrapper>
-      <SearchResultsContainer drawerWidth={drawerWidth} isListOnlyView={mapView === MapViews.LIST_ONLY}>
+      <SearchResultsContainer
+        drawerWidth={drawerWidth}
+        isListOnlyView={mapView === MapViews.LIST_ONLY}
+        // Default Replay block selector; skips serializing list mutations during expand/collapse.
+        {...(isDrawerResizing ? { "data-sentry-block": true } : {})}
+      >
         <MapSearchResultsList
           error={error}
           drawerWidth={drawerWidth}

--- a/app/web/features/search/MapSearchContent.tsx
+++ b/app/web/features/search/MapSearchContent.tsx
@@ -1,8 +1,5 @@
 import { styled } from "@mui/material";
-import {
-  DEFAULT_DRAWER_WIDTH,
-  DRAWER_WIDTH_TRANSITION_MS,
-} from "components/ResizeableDrawer";
+import { DEFAULT_DRAWER_WIDTH, DRAWER_WIDTH_TRANSITION_MS } from "components/ResizeableDrawer";
 import { RpcError } from "grpc-web";
 import { SearchUser } from "proto/search_pb";
 import { LngLatLike, MapRef } from "react-map-gl/maplibre";

--- a/app/web/features/search/SearchControls.tsx
+++ b/app/web/features/search/SearchControls.tsx
@@ -1,4 +1,5 @@
 import { styled, useMediaQuery } from "@mui/material";
+import { DRAWER_WIDTH_TRANSITION_MS } from "components/ResizeableDrawer";
 import { useState } from "react";
 import { LngLatLike, MapRef } from "react-map-gl/maplibre";
 import { theme } from "theme";
@@ -41,6 +42,7 @@ const MapControlsWrapper = styled("div", {
 
   ...(!isMobile &&
     isDualView && {
+      transition: `width ${DRAWER_WIDTH_TRANSITION_MS}ms ease-in-out, left ${DRAWER_WIDTH_TRANSITION_MS}ms ease-in-out, right ${DRAWER_WIDTH_TRANSITION_MS}ms ease-in-out`,
       ...(drawerWidth > window.innerWidth / 2
         ? { left: 0, width: `${drawerWidth}px` }
         : { right: 0, width: `calc(100% - ${drawerWidth}px)` }),

--- a/app/web/features/search/SearchPage.tsx
+++ b/app/web/features/search/SearchPage.tsx
@@ -1,6 +1,6 @@
 import { styled } from "@mui/material";
 import HtmlMeta from "components/HtmlMeta";
-import { DEFAULT_DRAWER_WIDTH } from "components/ResizeableDrawer";
+import { DEFAULT_DRAWER_WIDTH, DRAWER_WIDTH_TRANSITION_MS } from "components/ResizeableDrawer";
 import { useLogEvent } from "features/analytics/hooks";
 import { SearchAnalyticsProvider } from "features/analytics/searchAnalyticsContext";
 import { getOrCreateSearchSessionId } from "features/analytics/searchAttribution";
@@ -77,7 +77,9 @@ export default function SearchPage() {
   const mapRef = useRef<MapRef | null>(null);
 
   const [drawerWidth, setDrawerWidth] = useState<number>(DEFAULT_DRAWER_WIDTH);
+  const [isDrawerResizing, setIsDrawerResizing] = useState(false);
   const [mapView, setMapView] = useState<MapViewOptions>(MapViews.MAP_AND_LIST);
+  const drawerResizeTimeoutRef = useRef<number | undefined>(undefined);
 
   const mapSearchState = useMapSearchState();
   const { setPageNumber, setMapQueryArea, setMoveMapUIOnly, setShowSearchThisAreaButton, setSelectedUserId } =
@@ -156,8 +158,19 @@ export default function SearchPage() {
   };
 
   const handleDrawerWidthChange = (width: number) => {
+    setIsDrawerResizing(true);
     setDrawerWidth(width);
+    window.clearTimeout(drawerResizeTimeoutRef.current);
+    drawerResizeTimeoutRef.current = window.setTimeout(() => {
+      setIsDrawerResizing(false);
+    }, DRAWER_WIDTH_TRANSITION_MS);
   };
+
+  useEffect(() => {
+    return () => {
+      window.clearTimeout(drawerResizeTimeoutRef.current);
+    };
+  }, []);
 
   const handleSetMapView = (view: MapViewOptions) => {
     setMapView(view);
@@ -223,6 +236,7 @@ export default function SearchPage() {
             drawerWidth={drawerWidth}
             hasPreviousPage={hasPreviousPage}
             hasNextPage={hasNextPage}
+            isDrawerResizing={isDrawerResizing}
             isLoading={isLoading}
             mapRef={mapRef}
             mapView={mapView}

--- a/app/web/instrumentation-client.ts
+++ b/app/web/instrumentation-client.ts
@@ -29,6 +29,9 @@ Sentry.init({
       maskAllText: true,
       maskAllInputs: true,
       blockAllMedia: true,
+      // MapLibre (and other canvases) produce huge mutation storms on resize;
+      // block them so Replay's processMutation doesn't freeze the UI.
+      block: [".maplibregl-map", "canvas"],
     }),
   ],
   // Note: if you want to override the automatic release value, do not set a


### PR DESCRIPTION
Investigating the freezes in the map search page.
Performed some profiling on prod.
Seems they happen within sentry/replay, which was recently enabled in https://github.com/Couchers-org/couchers/pull/9104.

> Why processMutation blocks
> Sentry Replay (rrweb) watches the DOM with a MutationObserver. On that expand, it gets a huge mutation batch and serializes it synchronously on the main thread in processMutation.

Attempts to address:
#9521
#9524

Changes by Cursor Grok 4.5.

## Testing
I tested that the map search page still behaves normally in locadev using the Next backend.
However, due to the lower number of users on that environment, I wasn't having the freeze. I only had it on prod.

**Web frontend checklist**
- [X] There are no console warnings when running the app
- [ ] Added tests where relevant
- [X] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

