### PR TITLE
Frontend: Disable sentry replay due to perf impact

### DIFF
--- a/app/web/instrumentation-client.ts
+++ b/app/web/instrumentation-client.ts
@@ -20,17 +20,6 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
   sendDefaultPii: true,
 
-  // Buffer mode: don't continuously record, only upload on an error or when a bug
-  // report flushes the buffer (service/bugs.ts). Mask everything given the PII here.
-  replaysSessionSampleRate: 0,
-  replaysOnErrorSampleRate: 1.0,
-  integrations: [
-    Sentry.replayIntegration({
-      maskAllText: true,
-      maskAllInputs: true,
-      blockAllMedia: true,
-    }),
-  ],
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
   // that it will also get attached to your source maps


### PR DESCRIPTION
#9104 appears to have caused a user-noticeable perf regression and freezes when doing searches with tons of results. Until we figure this out, disabling to prevent user impact.

## Testing
Ran Vercel preview, but it's not immediately clear if it's faster with NEXT's dataset.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
