### PR TITLE
Make the PR skill write shorter, clearer descriptions

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -101,7 +101,7 @@ Append the following note as the very last line of the PR body, after the "For m
 
 Read the draft description once more as if you had no context on the change and were a busy person with other PRs to get through. Ask what could be dropped and what needs clarifying: a sentence they would skip, a phrase they would have to re-read, a term they would have to look up.
 
-Then make one more editing pass. You may only prune and reword — the description must not get longer.
+Then make one more editing pass for simplification and clarification. You may only prune and reword — the description must not get longer.
 
 ### 8. Create the PR
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -116,4 +116,4 @@ EOF
 
 ### 9. Report back
 
-Tell the user the PR URL when done. If the change alters the UI, say that screenshots are still needed — you can't take them.
+Tell the user the PR URL when done.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -63,19 +63,41 @@ Write a concise commit message (1-2 sentences) that describes what changed and w
 git push -u origin <branch-name>
 ```
 
-### 6. Create the PR
+### 6. Write the PR description
 
-Read the PR template from `.github/pull_request_template.md` in this repo. Fill it in based on the actual changes:
+Read the PR template from `.github/pull_request_template.md` and fill it in.
 
-- Fill in the description at the top (what and why)
-- Fill in the Testing section with what was done or what should be done
-- Include the appropriate checklist(s) — backend, web, or both — based on which areas were changed. Remove checklists that don't apply.
-- Keep the "For maintainers" section as-is
-- Append the following note as the very last line of the PR body, after the "For maintainers" section (separated by a blank line):
+The description has one job: give a reviewer who context-switches in enough to understand what the change is about and why it exists, without reading the code. Nothing else.
+
+**Shape.** One paragraph. Open with high-level context — which subsystem this touches, what it is for, why it matters — so a reviewer who may be familiar with this area but did not drive the session is oriented. Then what is wrong, missing, or needed, and what the change does about it. Add a second short paragraph only for a behaviour change reviewers need to know about, a stacking or follow-up relationship to another PR, or a human-directed decision (see below). Most descriptions should be well under 150 words.
+
+**Stay above the code.** Write in terms a reviewer can follow without opening a file — the authentication system, the notification emails, the search page — rather than the private helpers, local variables and internal functions that implement them. Nobody remembers what those do, including whoever wrote them. Identifiers are fine where a reviewer would recognise them from outside: RPC and service names, database tables, proto messages, settings and env vars, feature flags, URLs.
+
+**Tone.** You are describing the change and the human's decisions about it. You are not an engineer offering your take. Never write anything that reads as your own engineering judgement or as an invitation to discuss it — no "worth a reviewer's opinion", no "happy to change this", no flagged concerns, no recommendations, no notes to reviewers. If something genuinely needs discussion, raise it with the user instead.
+
+**Never include:**
+
+- Anything about tests, formatting, linting, type checking, or CI. It all runs automatically, so there is nothing to report — no test names, no pass counts, no "`make mypy` clean", no "verified to fail before the fix".
+- *How* the change is implemented. The diff shows that. No per-file or per-function walkthrough, no lists of the fields/files/keys/symbols added, no tables.
+- Any narration of the session: what you tried first, what you ruled out, what you deliberately left alone, what you couldn't run locally, environment problems.
+- Design or implementation choices that were yours rather than the user's, however much work went into them.
+- Annotations on checklist items. Tick or leave unticked.
+- Headings, tables, or bold sub-headings beyond the template's own.
+- A first sentence that restates the title.
+
+**The one exception.** If the user explicitly directed a design or implementation decision during the session, and it is consequential and looks wrong on its face — or was picked after real work on an alternative — record it in a sentence or two as their decision. Nothing you decided on your own ever qualifies.
+
+**Testing section.** Leave it out unless a human has to do something by hand to exercise the change that isn't obvious; then give one line of steps. Never test results.
+
+**Checklists.** Include the checklist(s) — backend, web, or both — matching the areas changed, and remove the ones that don't apply. Tick honestly, annotate never. Keep the "For maintainers" section as-is.
+
+Append the following note as the very last line of the PR body, after the "For maintainers" section (separated by a blank line):
 
   ```
   _This PR was created with the Couchers PR skill._
   ```
+
+### 7. Create the PR
 
 ```bash
 gh pr create --base develop --title "<short title>" --body "$(cat <<'EOF'
@@ -86,6 +108,6 @@ EOF
 )"
 ```
 
-### 7. Report back
+### 8. Report back
 
-Tell the user the PR URL when done.
+Tell the user the PR URL when done. If the change alters the UI, say that screenshots are still needed — you can't take them.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -97,7 +97,13 @@ Append the following note as the very last line of the PR body, after the "For m
   _This PR was created with the Couchers PR skill._
   ```
 
-### 7. Create the PR
+### 7. Prune the description
+
+Read the draft description once more as if you had no context on the change and were a busy person with other PRs to get through. Ask what could be dropped and what needs clarifying: a sentence they would skip, a phrase they would have to re-read, a term they would have to look up.
+
+Then make one more editing pass. You may only prune and reword — the description must not get longer.
+
+### 8. Create the PR
 
 ```bash
 gh pr create --base develop --title "<short title>" --body "$(cat <<'EOF'
@@ -108,6 +114,6 @@ EOF
 )"
 ```
 
-### 8. Report back
+### 9. Report back
 
 Tell the user the PR URL when done. If the change alters the UI, say that screenshots are still needed — you can't take them.


### PR DESCRIPTION
The repo ships a Claude Code skill that opens pull requests and writes their descriptions. Those descriptions ran to several hundred words of test and lint results, implementation walkthroughs, and asides about how the session had gone — all of it either visible in the diff or reported by CI. The skill now says what a description is for: high-level context that orients a reviewer who did not drive the session, and the change itself described without needing a file open. Everything else goes, including any decision the agent made on its own rather than the human driving.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._